### PR TITLE
[TECH] Générer en masse des JDD cohérents (production-like).

### DIFF
--- a/high-level-tests/load-testing/README.md
+++ b/high-level-tests/load-testing/README.md
@@ -24,17 +24,21 @@ SIECLE file for 4000 users in file SIECLE-organization-1237457A-4000-users.xml
 ```
 
 ## BDD
+Alimenter le fichier .env à partir de sample.env, notamment USER_COUNT
+Exemple pour 1 million d'utilisateurs
+````
+USER_COUNT=1000000
+````
 
-Alimenter le fichier .env à partir de sample.env
 
-## Local 
+### Local 
 Exécuter `npm run generate-dataset`
 
-## Scalingo
+### Scalingo
 TODO: Créer configuration Scalingo sur high-level-tests  
 Exécuter `scalingo run --region osc-fr1 --app <NOM_APPLICATION> --size M --detached npm run generate-dataset`    
 
-# Exécution des test
+# Exécution des tests
 
 ## Pré-requis :
 

--- a/high-level-tests/load-testing/README.md
+++ b/high-level-tests/load-testing/README.md
@@ -23,6 +23,11 @@ Generating SIECLE file on organization 1237457A for 4000 users
 SIECLE file for 4000 users in file SIECLE-organization-1237457A-4000-users.xml
 ```
 
+## BDD
+
+Alimenter le fichier .env à partir de sample.env
+Exécuter `npm run generate-dataset`
+
 # Exécution des test
 
 ## Pré-requis :

--- a/high-level-tests/load-testing/README.md
+++ b/high-level-tests/load-testing/README.md
@@ -26,7 +26,13 @@ SIECLE file for 4000 users in file SIECLE-organization-1237457A-4000-users.xml
 ## BDD
 
 Alimenter le fichier .env à partir de sample.env
+
+## Local 
 Exécuter `npm run generate-dataset`
+
+## Scalingo
+TODO: Créer configuration Scalingo sur high-level-tests  
+Exécuter `scalingo run --region osc-fr1 --app <NOM_APPLICATION> --size M --detached npm run generate-dataset`    
 
 # Exécution des test
 

--- a/high-level-tests/load-testing/data/bulk-data-generation.js
+++ b/high-level-tests/load-testing/data/bulk-data-generation.js
@@ -1,6 +1,7 @@
 const execa = require('execa');
 
 const databaseConnectionString = process.env.DATABASE_URL;
+const userCount = 1000 || process.env.USER_COUNT;
 
 async function run() {
 
@@ -24,7 +25,7 @@ async function getUserCount() {
 
 async function bulkDataGeneration() {
   const scriptPath = './data/generate_mass_data.sql';
-  const launchGenerationScriptCommand = `psql ${databaseConnectionString} -v ON_ERROR_STOP=1 --echo-all --file=${scriptPath}`;
+  const launchGenerationScriptCommand = `psql ${databaseConnectionString} -v ON_ERROR_STOP=1 --echo-all --variable user_count=${userCount} --file=${scriptPath}`;
   await execa.sync(launchGenerationScriptCommand, { stdio: 'inherit', shell: true });
 }
 

--- a/high-level-tests/load-testing/data/bulk-data-generation.js
+++ b/high-level-tests/load-testing/data/bulk-data-generation.js
@@ -1,0 +1,34 @@
+const execa = require('execa');
+
+const databaseConnectionString = process.env.DATABASE_URL;
+
+async function run() {
+
+  const initialUserCount = await getUserCount();
+  await bulkDataGeneration();
+  const finalUserCount = await getUserCount();
+
+  const usersGenerated = finalUserCount - initialUserCount;
+  if (usersGenerated === 0) {
+    console.error('Aucune donnée générée');
+    process.exit(1);
+  } else {
+    console.info(`${usersGenerated} utilisateurs générés`);
+  }
+}
+async function getUserCount() {
+  const dataGenerationQueryCheck = 'SELECT COUNT(1) FROM users';
+  const { stdout } = await execa.sync('psql', [databaseConnectionString, '--tuples-only', '--command', dataGenerationQueryCheck]);
+  return isNaN(parseInt(stdout)) ? 0 : parseInt(stdout);
+}
+
+async function bulkDataGeneration() {
+  const scriptPath = './data/generate_mass_data.sql';
+  const launchGenerationScriptCommand = `psql ${databaseConnectionString} -v ON_ERROR_STOP=1 --echo-all --file=${scriptPath}`;
+  await execa.sync(launchGenerationScriptCommand, { stdio: 'inherit', shell: true });
+}
+
+module.exports = {
+  run,
+};
+

--- a/high-level-tests/load-testing/data/bulk-data-generation.js
+++ b/high-level-tests/load-testing/data/bulk-data-generation.js
@@ -1,13 +1,12 @@
 const execa = require('execa');
 
-const databaseConnectionString = process.env.DATABASE_URL;
-const userCount = 1000 || process.env.USER_COUNT;
-
 async function run() {
 
-  const initialUserCount = await getUserCount();
-  await bulkDataGeneration();
-  const finalUserCount = await getUserCount();
+  const databaseConnectionString = process.env.DATABASE_URL;
+
+  const initialUserCount = await getUserCount(databaseConnectionString);
+  await bulkDataGeneration(databaseConnectionString);
+  const finalUserCount = await getUserCount(databaseConnectionString);
 
   const usersGenerated = finalUserCount - initialUserCount;
   if (usersGenerated === 0) {
@@ -17,16 +16,48 @@ async function run() {
     console.info(`${usersGenerated} utilisateurs générés`);
   }
 }
-async function getUserCount() {
+
+async function getUserCount(databaseConnectionString) {
   const dataGenerationQueryCheck = 'SELECT COUNT(1) FROM users';
   const { stdout } = await execa.sync('psql', [databaseConnectionString, '--tuples-only', '--command', dataGenerationQueryCheck]);
   return isNaN(parseInt(stdout)) ? 0 : parseInt(stdout);
 }
 
-async function bulkDataGeneration() {
+async function bulkDataGeneration(databaseConnectionString) {
   const scriptPath = './data/generate_mass_data.sql';
-  const launchGenerationScriptCommand = `psql ${databaseConnectionString} -v ON_ERROR_STOP=1 --echo-all --variable user_count=${userCount} --file=${scriptPath}`;
+  const variableCommand = getVariableCommand();
+
+  const launchGenerationScriptCommand = `psql ${databaseConnectionString} -v ON_ERROR_STOP=1 --echo-all ${variableCommand} --file=${scriptPath}`;
   await execa.sync(launchGenerationScriptCommand, { stdio: 'inherit', shell: true });
+}
+
+function getVariableCommand() {
+  const configuration = getConfiguration();
+  return  `--variable user_count=${configuration.userCount} \\
+           --variable competence_evaluation_count=${configuration.competence_evaluation_count} \\
+           --variable organization_count=${configuration.organization_count} \\
+           --variable campaign_per_organization_count=${configuration.campaign_per_organization_count} \\
+           --variable participation_per_campaign_count=${configuration.participation_per_campaign_count} \\
+           --variable shared_participation_percentage=${configuration.shared_participation_percentage} \\
+           --variable answer_per_competence_evaluation_assessment_count=${configuration.answer_per_competence_evaluation_assessment_count} \\
+           --variable answer_per_campaign_assessment_count=${configuration.answer_per_campaign_assessment_count} \\
+           --variable validated_knowledge_element_percentage=${configuration.validated_knowledge_element_percentage} \\
+           --variable invalidated_knowledge_element_percentage=${configuration.invalidated_knowledge_element_percentage}`;
+}
+
+function getConfiguration() {
+  return ({
+    userCount: (1000 || process.env.USER_COUNT),
+    competence_evaluation_count: (1000 || process.env.COMPETENCE_EVALUATION_COUNT),
+    organization_count: (0 || process.env.ORGANIZATION_COUNT),
+    campaign_per_organization_count: (3 || process.env.CAMPAIGN_PER_ORGANIZATION_COUNT),
+    participation_per_campaign_count: (150 || process.env.PARTICIPATION_PER_CAMPAIGN_COUNT),
+    shared_participation_percentage: (65 || process.env.SHARED_PARTICIPATION_PERCENTAGE),
+    answer_per_competence_evaluation_assessment_count: (25 || process.env.ANSWER_PER_COMPETENCE_EVALUATION_ASSESSMENT_COUNT),
+    answer_per_campaign_assessment_count: (25 || process.env.ANSWER_PER_CAMPAIGN_ASSESSMENT_COUNT),
+    validated_knowledge_element_percentage: (60 || process.env.VALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE),
+    invalidated_knowledge_element_percentage: (30 || process.env.INVALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE),
+  });
 }
 
 module.exports = {

--- a/high-level-tests/load-testing/data/bulk-data-generation.js
+++ b/high-level-tests/load-testing/data/bulk-data-generation.js
@@ -47,16 +47,16 @@ function getVariableCommand() {
 
 function getConfiguration() {
   return ({
-    userCount: (1000 || process.env.USER_COUNT),
-    competence_evaluation_count: (1000 || process.env.COMPETENCE_EVALUATION_COUNT),
-    organization_count: (0 || process.env.ORGANIZATION_COUNT),
-    campaign_per_organization_count: (3 || process.env.CAMPAIGN_PER_ORGANIZATION_COUNT),
-    participation_per_campaign_count: (150 || process.env.PARTICIPATION_PER_CAMPAIGN_COUNT),
-    shared_participation_percentage: (65 || process.env.SHARED_PARTICIPATION_PERCENTAGE),
-    answer_per_competence_evaluation_assessment_count: (25 || process.env.ANSWER_PER_COMPETENCE_EVALUATION_ASSESSMENT_COUNT),
-    answer_per_campaign_assessment_count: (25 || process.env.ANSWER_PER_CAMPAIGN_ASSESSMENT_COUNT),
-    validated_knowledge_element_percentage: (60 || process.env.VALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE),
-    invalidated_knowledge_element_percentage: (30 || process.env.INVALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE),
+    userCount: (process.env.USER_COUNT || 1000) ,
+    competence_evaluation_count: (process.env.COMPETENCE_EVALUATION_COUNT || 1000),
+    organization_count: (process.env.ORGANIZATION_COUNT || 0),
+    campaign_per_organization_count: (process.env.CAMPAIGN_PER_ORGANIZATION_COUNT || 3),
+    participation_per_campaign_count: (process.env.PARTICIPATION_PER_CAMPAIGN_COUNT || 150),
+    shared_participation_percentage: (process.env.SHARED_PARTICIPATION_PERCENTAGE || 65),
+    answer_per_competence_evaluation_assessment_count: (process.env.ANSWER_PER_COMPETENCE_EVALUATION_ASSESSMENT_COUNT || 25),
+    answer_per_campaign_assessment_count: (process.env.ANSWER_PER_CAMPAIGN_ASSESSMENT_COUNT || 25),
+    validated_knowledge_element_percentage: (process.env.VALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE || 60),
+    invalidated_knowledge_element_percentage: (process.env.INVALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE || 30),
   });
 }
 

--- a/high-level-tests/load-testing/data/db-connection.js
+++ b/high-level-tests/load-testing/data/db-connection.js
@@ -1,0 +1,17 @@
+const { Client } = require('pg');
+
+async function runDBOperation(callback) {
+  const client = new Client({
+    connectionString: process.env.DATABASE_URL,
+  });
+  try {
+    await client.connect();
+    await callback(client);
+  } finally {
+    await client.end();
+  }
+}
+
+module.exports = {
+  runDBOperation,
+};

--- a/high-level-tests/load-testing/data/generate-dataset.js
+++ b/high-level-tests/load-testing/data/generate-dataset.js
@@ -1,0 +1,15 @@
+require('dotenv').config();
+const importReferentialData = require('./import-referential-data');
+const bulkDataGeneration = require('./bulk-data-generation');
+
+(
+  async () => {
+    console.log('Importing referential...');
+    await importReferentialData.run();
+    console.log('Referential imported');
+
+    console.log('Generating dataset...');
+    await bulkDataGeneration.run();
+    console.log('Dataset generated');
+  }
+)();

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -1,6 +1,18 @@
 BEGIN;
 
 -----------------------------------------------------------------------------------------------------
+--				Création d'une table temporaire contenant le référentiel   --------------------------
+-----------------------------------------------------------------------------------------------------
+CREATE TEMPORARY TABLE referentiel (
+  skill_id 		VARCHAR,
+  competence_id VARCHAR,
+  pix_value 	NUMERIC(6,5)
+) ON COMMIT DROP;
+INSERT INTO referentiel(skill_id, competence_id, pix_value)
+VALUES
+-- Ajouter les données du référentiel ici !
+
+-----------------------------------------------------------------------------------------------------
 --				Empêcher la journalisation des tables   ---------------------------------------------
 -----------------------------------------------------------------------------------------------------
 ALTER TABLE "knowledge-elements" SET UNLOGGED;

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -1,6 +1,12 @@
 BEGIN;
 
 -----------------------------------------------------------------------------------------------------
+--				Déclaration de constantes   ---------------------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+SET LOCAL constants.string_count=20000;
+
+
+-----------------------------------------------------------------------------------------------------
 --				Création d'une table temporaire contenant le référentiel   --------------------------
 -----------------------------------------------------------------------------------------------------
 CREATE TEMPORARY TABLE referentiel (
@@ -58,6 +64,26 @@ ALTER TABLE "users" DROP CONSTRAINT "users_samlid_unique";
 ALTER TABLE "users" DROP CONSTRAINT "users_username_unique";
 
 
+-----------------------------------------------------------------------------------------------------
+--				Création et remplissage d'une table de chaînes aléatoires composées de 3 syllabes   -------
+-----------------------------------------------------------------------------------------------------
+CREATE TEMPORARY TABLE random_string (
+  id SERIAL PRIMARY KEY,
+  rand_str VARCHAR
+) ON COMMIT DROP;
+INSERT INTO random_string(id, rand_str)
+SELECT
+  generator AS id,
+	(
+	  SELECT string_agg(x,'')
+		FROM (
+		  SELECT start_arr[ 1 + ( (random() * 25)::int) % 33 ]
+			FROM (
+			  SELECT '{cu,bal,ro,re,pi,co,jho,bo,ba,ja,mi,pe,da,an,en,sy,vir,nath,so,mo,al,che,cha,dia,n,ph,hn,b,t,gh,ri,hen,ng}'::text[] as start_arr
+			) AS syllables_array, generate_series(1, 3 + (generator*0))
+			) AS the_string(x)
+	)
+FROM generate_series(1,current_setting('constants.string_count')::int) as generator;
 
 -----------------------------------------------------------------------------------------------------
 --				Rétablir les contraintes   ----------------------------------------------------------

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -1,0 +1,83 @@
+BEGIN;
+
+-----------------------------------------------------------------------------------------------------
+--				Empêcher la journalisation des tables   ---------------------------------------------
+-----------------------------------------------------------------------------------------------------
+ALTER TABLE "knowledge-elements" SET UNLOGGED;
+ALTER TABLE "competence-marks" SET UNLOGGED;
+ALTER TABLE "feedbacks" SET UNLOGGED;
+ALTER TABLE "answers" SET UNLOGGED;
+ALTER TABLE "assessment-results" SET UNLOGGED;
+ALTER TABLE "competence-evaluations" SET UNLOGGED;
+ALTER TABLE "assessments" SET UNLOGGED;
+ALTER TABLE "certification-challenges" SET UNLOGGED;
+ALTER TABLE "badge-partner-competences" SET UNLOGGED;
+ALTER TABLE "partner-certifications" SET UNLOGGED;
+ALTER TABLE "campaign-participations" SET UNLOGGED;
+ALTER TABLE "badge-acquisitions" SET UNLOGGED;
+ALTER TABLE "badge-criteria" SET UNLOGGED;
+ALTER TABLE "target-profile-shares" SET UNLOGGED;
+ALTER TABLE "badges" SET UNLOGGED;
+ALTER TABLE "campaigns" SET UNLOGGED;
+ALTER TABLE "certification-candidates" SET UNLOGGED;
+ALTER TABLE "certification-courses" SET UNLOGGED;
+ALTER TABLE "target-profiles_skills" SET UNLOGGED;
+ALTER TABLE "stages" SET UNLOGGED;
+ALTER TABLE "users_pix_roles" SET UNLOGGED;
+ALTER TABLE "certification-center-memberships" SET UNLOGGED;
+ALTER TABLE "memberships" SET UNLOGGED;
+ALTER TABLE "organization-invitations" SET UNLOGGED;
+ALTER TABLE "schooling-registrations" SET UNLOGGED;
+ALTER TABLE "sessions" SET UNLOGGED;
+ALTER TABLE "target-profiles" SET UNLOGGED;
+ALTER TABLE "user-orga-settings" SET UNLOGGED;
+ALTER TABLE "certification-centers" SET UNLOGGED;
+ALTER TABLE "user_tutorials" SET UNLOGGED;
+ALTER TABLE "users" SET UNLOGGED;
+ALTER TABLE "tutorial-evaluations" SET UNLOGGED;
+ALTER TABLE "organizations" SET UNLOGGED;
+
+
+-----------------------------------------------------------------------------------------------------
+--				Rétablir la journalisation des tables   ---------------------------------------------
+-----------------------------------------------------------------------------------------------------
+ALTER TABLE "organizations" SET LOGGED;
+ALTER TABLE "tutorial-evaluations" SET LOGGED;
+ALTER TABLE "users" SET LOGGED;
+ALTER TABLE "user_tutorials" SET LOGGED;
+ALTER TABLE "certification-centers" SET LOGGED;
+ALTER TABLE "user-orga-settings" SET LOGGED;
+ALTER TABLE "target-profiles" SET LOGGED;
+ALTER TABLE "sessions" SET LOGGED;
+ALTER TABLE "schooling-registrations" SET LOGGED;
+ALTER TABLE "organization-invitations" SET LOGGED;
+ALTER TABLE "memberships" SET LOGGED;
+ALTER TABLE "certification-center-memberships" SET LOGGED;
+ALTER TABLE "users_pix_roles" SET LOGGED;
+ALTER TABLE "stages" SET LOGGED;
+ALTER TABLE "target-profiles_skills" SET LOGGED;
+ALTER TABLE "certification-courses" SET LOGGED;
+ALTER TABLE "certification-candidates" SET LOGGED;
+ALTER TABLE "campaigns" SET LOGGED;
+ALTER TABLE "badges" SET LOGGED;
+ALTER TABLE "target-profile-shares" SET LOGGED;
+ALTER TABLE "badge-criteria" SET LOGGED;
+ALTER TABLE "badge-acquisitions" SET LOGGED;
+ALTER TABLE "campaign-participations" SET LOGGED;
+ALTER TABLE "partner-certifications" SET LOGGED;
+ALTER TABLE "badge-partner-competences" SET LOGGED;
+ALTER TABLE "certification-challenges" SET LOGGED;
+ALTER TABLE "assessments" SET LOGGED;
+ALTER TABLE "competence-evaluations" SET LOGGED;
+ALTER TABLE "assessment-results" SET LOGGED;
+ALTER TABLE "answers" SET LOGGED;
+ALTER TABLE "feedbacks" SET LOGGED;
+ALTER TABLE "competence-marks" SET LOGGED;
+ALTER TABLE "knowledge-elements" SET LOGGED;
+
+
+
+ROLLBACK;
+
+
+

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -574,8 +574,8 @@ WITH inserted_knowledge_elements_cte AS (
   SELECT
     'direct',
     CASE
-      WHEN id_picker.status_score > (100-current_setting('constants.validated_knowledge_element_percentage')::int) THEN 'validated'
       WHEN id_picker.status_score > (100-current_setting('constants.invalidated_knowledge_element_percentage')::int) THEN 'invalidated'
+      WHEN id_picker.status_score > (100-current_setting('constants.validated_knowledge_element_percentage')::int) THEN 'validated'
       ELSE 'reset'
     END,
     inserted_answers.assessment_id,
@@ -627,8 +627,8 @@ WITH inserted_knowledge_elements_cte AS (
   SELECT
     'direct',
     CASE
-      WHEN id_picker.status_score > (100-current_setting('constants.validated_knowledge_element_percentage')::int) THEN 'validated'
       WHEN id_picker.status_score > (100-current_setting('constants.invalidated_knowledge_element_percentage')::int) THEN 'invalidated'
+      WHEN id_picker.status_score > (100-current_setting('constants.validated_knowledge_element_percentage')::int) THEN 'validated'
       ELSE 'reset'
     END,
     inserted_answers.assessment_id,

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -671,6 +671,25 @@ SELECT
   inserted_knowledge_elements_cte.created_at
 FROM inserted_knowledge_elements_cte;
 
+
+-----------------------------------------------------------------------------------------------------
+--				Ajout des knowledge elements dépendants   -------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+INSERT INTO "knowledge-elements"("source", "status", "assessmentId", "userId", "answerId", "skillId", "earnedPix", "competenceId", "createdAt")
+SELECT
+  'inferred',
+  'validated',
+  inserted_knowledge_elements.assessment_id,
+  inserted_knowledge_elements.user_id,
+  inserted_knowledge_elements.answer_id,
+  skills_dependency.sub_skill_id,
+  skills_dependency.sub_skill_pix_value,
+  inserted_knowledge_elements.competence_id,
+  inserted_knowledge_elements.created_at
+FROM inserted_knowledge_elements
+JOIN skills_dependency ON skills_dependency.skill_id = inserted_knowledge_elements.skill_id
+WHERE inserted_knowledge_elements.status = 'validated';
+
 -----------------------------------------------------------------------------------------------------
 --				Rétablir les contraintes   ----------------------------------------------------------
 -----------------------------------------------------------------------------------------------------

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -51,6 +51,23 @@ ALTER TABLE "organizations" SET UNLOGGED;
 
 
 -----------------------------------------------------------------------------------------------------
+--				Supprimer les contraintes   ---------------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+ALTER TABLE "users" DROP CONSTRAINT "users_email_unique";
+ALTER TABLE "users" DROP CONSTRAINT "users_samlid_unique";
+ALTER TABLE "users" DROP CONSTRAINT "users_username_unique";
+
+
+
+-----------------------------------------------------------------------------------------------------
+--				Rétablir les contraintes   ----------------------------------------------------------
+-----------------------------------------------------------------------------------------------------
+ALTER TABLE "users" ADD CONSTRAINT "users_email_unique" UNIQUE ("email");
+ALTER TABLE "users" ADD CONSTRAINT "users_samlid_unique" UNIQUE ("samlId");
+ALTER TABLE "users" ADD CONSTRAINT "users_username_unique" UNIQUE ("username");
+
+
+-----------------------------------------------------------------------------------------------------
 --				Rétablir la journalisation des tables   ---------------------------------------------
 -----------------------------------------------------------------------------------------------------
 ALTER TABLE "organizations" SET LOGGED;

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -593,7 +593,7 @@ WITH inserted_knowledge_elements_cte AS (
         SELECT (random() * current_setting('constants.answer_per_competence_evaluation_assessment_count')::int*current_setting('constants.competence_evaluation_count')::int)::int + (generator*0) AS picked_answer_rownum
       ),
       (
-        SELECT (random() * 675)::int + (generator*0) AS picked_referentiel_rownum
+        SELECT (random() * 657)::int + (generator*0) AS picked_referentiel_rownum
       ),
       (
         SELECT (random() * 100 + (generator*0))::int AS status_score
@@ -646,7 +646,7 @@ WITH inserted_knowledge_elements_cte AS (
         SELECT (current_setting('constants.answer_per_competence_evaluation_assessment_count')::int*current_setting('constants.competence_evaluation_count')::int + random() * current_setting('constants.campaign_per_organization_count')::int*current_setting('constants.organization_count')::int*current_setting('constants.participation_per_campaign_count')::int*current_setting('constants.answer_per_campaign_assessment_count')::int)::int + (generator*0) AS picked_answer_rownum
       ),
       (
-        SELECT (random() * 675)::int + (generator*0) AS picked_referentiel_rownum
+        SELECT (random() * 657)::int + (generator*0) AS picked_referentiel_rownum
       ),
       (
         SELECT (random() * 100 + (generator*0))::int AS status_score

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -27,7 +27,6 @@ SET LOCAL constants.participation_per_campaign_count=150;
 SET LOCAL constants.shared_participation_percentage=65;
 SET LOCAL constants.answer_per_competence_evaluation_assessment_count=25;
 SET LOCAL constants.answer_per_campaign_assessment_count=25;
-SET LOCAL constants.knowledge_element_per_answer_count=2;
 SET LOCAL constants.validated_knowledge_element_percentage=60; -- Détermine la répartition des statuts des knowledge-elements
 SET LOCAL constants.invalidated_knowledge_element_percentage=30; -- Le reste du pourcentage va constituer les knowledge-elements 'reset'
 
@@ -599,7 +598,7 @@ WITH inserted_knowledge_elements_cte AS (
         SELECT (random() * 100 + (generator*0))::int AS status_score
       ),
         generator AS id
-      FROM generate_series(1,current_setting('constants.answer_per_competence_evaluation_assessment_count')::int*current_setting('constants.competence_evaluation_count')::int*current_setting('constants.knowledge_element_per_answer_count')::int) as generator
+      FROM generate_series(1,current_setting('constants.answer_per_competence_evaluation_assessment_count')::int*current_setting('constants.competence_evaluation_count')::int) as generator
     ) id_picker
   INNER JOIN inserted_answers ON inserted_answers.rownum = id_picker.picked_answer_rownum
   INNER JOIN referentiel ON referentiel.rownum = id_picker.picked_referentiel_rownum
@@ -652,7 +651,7 @@ WITH inserted_knowledge_elements_cte AS (
         SELECT (random() * 100 + (generator*0))::int AS status_score
       ),
         generator AS id
-      FROM generate_series(1,current_setting('constants.campaign_per_organization_count')::int*current_setting('constants.organization_count')::int*current_setting('constants.participation_per_campaign_count')::int*current_setting('constants.answer_per_campaign_assessment_count')::int*current_setting('constants.knowledge_element_per_answer_count')::int) as generator
+      FROM generate_series(1,current_setting('constants.campaign_per_organization_count')::int*current_setting('constants.organization_count')::int*current_setting('constants.participation_per_campaign_count')::int*current_setting('constants.answer_per_campaign_assessment_count')::int) as generator
     ) id_picker
   INNER JOIN inserted_answers ON inserted_answers.rownum = id_picker.picked_answer_rownum
   INNER JOIN referentiel ON referentiel.rownum = id_picker.picked_referentiel_rownum

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -34,12 +34,32 @@ SET LOCAL constants.answer_per_campaign_assessment_count=25;
 CREATE TEMPORARY TABLE referentiel (
   rownum SERIAL PRIMARY KEY,
   skill_id 		VARCHAR,
+  tube_id 		VARCHAR,
   competence_id VARCHAR,
-  pix_value 	NUMERIC(6,5)
+  pix_value 	NUMERIC(6,5),
+  level			INTEGER
 ) ON COMMIT DROP;
-INSERT INTO referentiel(skill_id, competence_id, pix_value)
-VALUES(...);
+INSERT INTO referentiel(skill_id, competence_id, tube_id, pix_value, level)
+VALUES (...);
 -- Ajouter les données du référentiel ici !
+
+
+-----------------------------------------------------------------------------------------------------
+--				Création d'une table temporaire contenant des données de dépendances entre les acquis   ---
+-----------------------------------------------------------------------------------------------------
+CREATE TEMPORARY TABLE skills_dependency (
+  skill_id 		VARCHAR,
+  sub_skill_id 		VARCHAR,
+  sub_skill_pix_value NUMERIC(6,5)
+) ON COMMIT DROP;
+INSERT INTO skills_dependency(skill_id, sub_skill_id, sub_skill_pix_value)
+SELECT
+  referentiel_a.skill_id,
+  referentiel_b.skill_id,
+  referentiel_b.pix_value
+FROM referentiel AS referentiel_a
+JOIN referentiel AS referentiel_b ON referentiel_a.tube_id=referentiel_b.tube_id
+WHERE referentiel_a.level > referentiel_b.level;
 
 -----------------------------------------------------------------------------------------------------
 --				Empêcher la journalisation des tables   ---------------------------------------------

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -200,6 +200,7 @@ ALTER TABLE "target-profiles" SET UNLOGGED;
 ALTER TABLE "user-orga-settings" SET UNLOGGED;
 ALTER TABLE "certification-centers" SET UNLOGGED;
 ALTER TABLE "user_tutorials" SET UNLOGGED;
+ALTER TABLE "authentication-methods" SET UNLOGGED;
 ALTER TABLE "users" SET UNLOGGED;
 ALTER TABLE "tutorial-evaluations" SET UNLOGGED;
 
@@ -848,6 +849,7 @@ ALTER TABLE "organizations" SET LOGGED;
 ALTER TABLE "organization-tags" SET LOGGED;
 ALTER TABLE "tutorial-evaluations" SET LOGGED;
 ALTER TABLE "users" SET LOGGED;
+ALTER TABLE "authentication-methods" SET LOGGED;
 ALTER TABLE "user_tutorials" SET LOGGED;
 ALTER TABLE "certification-centers" SET LOGGED;
 ALTER TABLE "user-orga-settings" SET LOGGED;

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -3,16 +3,16 @@ BEGIN;
 -----------------------------------------------------------------------------------------------------
 --				Recalage des séquences       --------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
-SELECT setval(pg_get_serial_sequence('users','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "users";
-SELECT setval(pg_get_serial_sequence('assessments','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "assessments";
-SELECT setval(pg_get_serial_sequence('organizations','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "organizations";
-SELECT setval(pg_get_serial_sequence('memberships','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "memberships";
-SELECT setval(pg_get_serial_sequence('target-profiles','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "target-profiles";
-SELECT setval(pg_get_serial_sequence('target-profiles_skills','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "target-profiles_skills";
-SELECT setval(pg_get_serial_sequence('campaigns','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "campaigns";
-SELECT setval(pg_get_serial_sequence('campaign-participations','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "campaign-participations";
-SELECT setval(pg_get_serial_sequence('answers','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "answers";
-SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("id"), 1), max("id") IS NOT null) FROM "knowledge-elements";
+SELECT setval(pg_get_serial_sequence('users','id'), coalesce(max("id"), 1)) FROM "users";
+SELECT setval(pg_get_serial_sequence('assessments','id'), coalesce(max("id"), 1)) FROM "assessments";
+SELECT setval(pg_get_serial_sequence('organizations','id'), coalesce(max("id"), 1)) FROM "organizations";
+SELECT setval(pg_get_serial_sequence('memberships','id'), coalesce(max("id"), 1)) FROM "memberships";
+SELECT setval(pg_get_serial_sequence('target-profiles','id'), coalesce(max("id"), 1)) FROM "target-profiles";
+SELECT setval(pg_get_serial_sequence('target-profiles_skills','id'), coalesce(max("id"), 1)) FROM "target-profiles_skills";
+SELECT setval(pg_get_serial_sequence('campaigns','id'), coalesce(max("id"), 1)) FROM "campaigns";
+SELECT setval(pg_get_serial_sequence('campaign-participations','id'), coalesce(max("id"), 1)) FROM "campaign-participations";
+SELECT setval(pg_get_serial_sequence('answers','id'), coalesce(max("id"), 1)) FROM "answers";
+SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("id"), 1)) FROM "knowledge-elements";
 
 
 -----------------------------------------------------------------------------------------------------

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -20,16 +20,15 @@ SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("i
 -----------------------------------------------------------------------------------------------------
 
 SET LOCAL constants.user_count=:user_count;
---SET LOCAL constants.user_count=1000;
-SET LOCAL constants.competence_evaluation_count=1000;
-SET LOCAL constants.organization_count=0;
-SET LOCAL constants.campaign_per_organization_count=3;
-SET LOCAL constants.participation_per_campaign_count=150;
-SET LOCAL constants.shared_participation_percentage=65;
-SET LOCAL constants.answer_per_competence_evaluation_assessment_count=25;
-SET LOCAL constants.answer_per_campaign_assessment_count=25;
-SET LOCAL constants.validated_knowledge_element_percentage=60; -- Détermine la répartition des statuts des knowledge-elements
-SET LOCAL constants.invalidated_knowledge_element_percentage=30; -- Le reste du pourcentage va constituer les knowledge-elements 'reset'
+SET LOCAL constants.competence_evaluation_count=:competence_evaluation_count;
+SET LOCAL constants.organization_count=:organization_count;
+SET LOCAL constants.campaign_per_organization_count=:campaign_per_organization_count;
+SET LOCAL constants.participation_per_campaign_count=:participation_per_campaign_count;
+SET LOCAL constants.shared_participation_percentage=:shared_participation_percentage;
+SET LOCAL constants.answer_per_competence_evaluation_assessment_count=:answer_per_competence_evaluation_assessment_count;
+SET LOCAL constants.answer_per_campaign_assessment_count=:answer_per_campaign_assessment_count;
+SET LOCAL constants.validated_knowledge_element_percentage=:validated_knowledge_element_percentage;
+SET LOCAL constants.invalidated_knowledge_element_percentage=:invalidated_knowledge_element_percentage;
 
 
 -----------------------------------------------------------------------------------------------------

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -19,7 +19,8 @@ SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("i
 --				Déclaration de constantes   ---------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
 
-SET LOCAL constants.user_count=1000;
+SET LOCAL constants.user_count=:user_count;
+--SET LOCAL constants.user_count=1000;
 SET LOCAL constants.competence_evaluation_count=1000;
 SET LOCAL constants.organization_count=0;
 SET LOCAL constants.campaign_per_organization_count=3;

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -19,12 +19,8 @@ SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("i
 --				Déclaration de constantes   ---------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
 
- -- 5 million KE
- -- 200 000 compétences = 200 000 users
- -- aucune orga = parcours libre
-
-SET LOCAL constants.user_count=200000;
-SET LOCAL constants.competence_evaluation_count=200000;
+SET LOCAL constants.user_count=1000;
+SET LOCAL constants.competence_evaluation_count=1000;
 SET LOCAL constants.organization_count=0;
 SET LOCAL constants.campaign_per_organization_count=3;
 SET LOCAL constants.participation_per_campaign_count=150;
@@ -173,6 +169,7 @@ WHERE referentiel_a.level > referentiel_b.level;
 -----------------------------------------------------------------------------------------------------
 --				Empêcher la journalisation des tables   ---------------------------------------------
 -----------------------------------------------------------------------------------------------------
+ALTER TABLE "organization-tags" SET UNLOGGED;
 ALTER TABLE "knowledge-elements" SET UNLOGGED;
 ALTER TABLE "competence-marks" SET UNLOGGED;
 ALTER TABLE "feedbacks" SET UNLOGGED;
@@ -205,6 +202,7 @@ ALTER TABLE "certification-centers" SET UNLOGGED;
 ALTER TABLE "user_tutorials" SET UNLOGGED;
 ALTER TABLE "users" SET UNLOGGED;
 ALTER TABLE "tutorial-evaluations" SET UNLOGGED;
+
 ALTER TABLE "organizations" SET UNLOGGED;
 
 
@@ -229,13 +227,8 @@ ALTER TABLE "knowledge-elements" DROP CONSTRAINT "knowledge_elements_userid_fore
 -----------------------------------------------------------------------------------------------------
 --				Supprimer les index   ---------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
-DROP INDEX "assessment_courseid_index";
 DROP INDEX "assessments_campaignparticipationid_index";
 DROP INDEX "assessments_certificationcourseid_index";
-DROP INDEX "assessments_competenceid_index";
-DROP INDEX "assessments_state_index";
-DROP INDEX "assessments_type_index";
-DROP INDEX "assessments_userid_index";
 DROP INDEX "campaign_participations_userid_index";
 DROP INDEX "answers_assessmentid_index";
 DROP INDEX "knowledge_elements_userid_index";
@@ -823,13 +816,8 @@ ALTER TABLE "knowledge-elements" ADD CONSTRAINT "knowledge_elements_userid_forei
 -----------------------------------------------------------------------------------------------------
 --				Rétablir les index   ---------------------------------------------------------
 -----------------------------------------------------------------------------------------------------
-CREATE INDEX "assessment_courseid_index" ON "assessments"("courseId");
 CREATE INDEX "assessments_campaignparticipationid_index" ON "assessments"("campaignParticipationId");
 CREATE INDEX "assessments_certificationcourseid_index" ON "assessments"("certificationCourseId");
-CREATE INDEX "assessments_competenceid_index" ON "assessments"("competenceId");
-CREATE INDEX "assessments_state_index" ON "assessments"("state");
-CREATE INDEX "assessments_type_index" ON "assessments"("type");
-CREATE INDEX "assessments_userid_index" ON "assessments"("userId");
 CREATE INDEX "campaign_participations_userid_index" ON "campaign-participations"("userId");
 CREATE INDEX "answers_assessmentid_index" ON "answers"("assessmentId");
 CREATE INDEX "knowledge_elements_userid_index" ON "knowledge-elements"("userId");
@@ -857,6 +845,7 @@ DROP FUNCTION IF EXISTS pick_random_date(start_date timestamptz, limit_date time
 --				Rétablir la journalisation des tables   ---------------------------------------------
 -----------------------------------------------------------------------------------------------------
 ALTER TABLE "organizations" SET LOGGED;
+ALTER TABLE "organization-tags" SET LOGGED;
 ALTER TABLE "tutorial-evaluations" SET LOGGED;
 ALTER TABLE "users" SET LOGGED;
 ALTER TABLE "user_tutorials" SET LOGGED;

--- a/high-level-tests/load-testing/data/generate_mass_data.sql
+++ b/high-level-tests/load-testing/data/generate_mass_data.sql
@@ -20,15 +20,16 @@ SELECT setval(pg_get_serial_sequence('knowledge-elements','id'), coalesce(max("i
 -----------------------------------------------------------------------------------------------------
 
 SET LOCAL constants.user_count=:user_count;
-SET LOCAL constants.competence_evaluation_count=:competence_evaluation_count;
-SET LOCAL constants.organization_count=:organization_count;
-SET LOCAL constants.campaign_per_organization_count=:campaign_per_organization_count;
-SET LOCAL constants.participation_per_campaign_count=:participation_per_campaign_count;
-SET LOCAL constants.shared_participation_percentage=:shared_participation_percentage;
-SET LOCAL constants.answer_per_competence_evaluation_assessment_count=:answer_per_competence_evaluation_assessment_count;
-SET LOCAL constants.answer_per_campaign_assessment_count=:answer_per_campaign_assessment_count;
-SET LOCAL constants.validated_knowledge_element_percentage=:validated_knowledge_element_percentage;
-SET LOCAL constants.invalidated_knowledge_element_percentage=:invalidated_knowledge_element_percentage;
+SET LOCAL constants.competence_evaluation_count=1000;
+SET LOCAL constants.organization_count=0;
+SET LOCAL constants.campaign_per_organization_count=3;
+SET LOCAL constants.participation_per_campaign_count=150;
+SET LOCAL constants.shared_participation_percentage=65;
+SET LOCAL constants.answer_per_competence_evaluation_assessment_count=25;
+SET LOCAL constants.answer_per_campaign_assessment_count=25;
+SET LOCAL constants.validated_knowledge_element_percentage=60; -- Détermine la répartition des statuts des knowledge-elements
+SET LOCAL constants.invalidated_knowledge_element_percentage=30; -- Le reste du pourcentage va constituer les knowledge-elements 'reset'
+
 
 
 -----------------------------------------------------------------------------------------------------

--- a/high-level-tests/load-testing/data/import-referential-data.js
+++ b/high-level-tests/load-testing/data/import-referential-data.js
@@ -1,0 +1,164 @@
+'use strict';
+
+const Airtable = require('airtable');
+const _ = require('lodash');
+const format = require('pg-format');
+const { runDBOperation } = require('./db-connection');
+
+const tables = [{
+  name:'areas',
+  airtableName:'Domaines',
+  fields: [
+    { name:'name', type:'text', airtableName:'Nom' },
+  ],
+  airtableId:'id persistant',
+  indices: [],
+},{
+  name:'competences',
+  airtableName:'Competences',
+  fields: [
+    { name:'name', type:'text', airtableName:'Référence' },
+    { name:'code', type:'text', airtableName:'Sous-domaine' },
+    { name:'title', type:'text', airtableName:'Titre' },
+    { name:'areaId', type:'text', airtableName:'Domaine (id persistant)', isArray:false },
+  ],
+  airtableId:'id persistant',
+  indices: ['areaId'],
+},{
+  name:'tubes',
+  airtableName:'Tubes',
+  fields: [
+    { name:'name', type:'text', airtableName:'Nom' },
+    { name:'title', type:'text', airtableName:'Titre' },
+    { name:'competenceId', type:'text', airtableName:'Competences (id persistant)', isArray:false },
+  ],
+  airtableId:'id persistant',
+  indices: ['competenceId'],
+},{
+  name:'skills',
+  airtableName:'Acquis',
+  fields: [
+    { name:'name', type:'text', airtableName:'Nom' },
+    { name:'description', type:'text', airtableName:'Description' },
+    { name:'level', type:'smallint', airtableName:'Level' },
+    { name:'tubeId', type:'text', airtableName:'Tube (id persistant)', isArray:false },
+    { name:'status', type:'text', airtableName:'Status' },
+    { name:'pixValue', type:'numeric(6,5)', airtableName:'PixValue' },
+  ],
+  airtableId:'id persistant',
+  indices: ['tubeId'],
+},{
+  name:'challenges',
+  airtableName:'Epreuves',
+  fields: [
+    { name:'instructions', type:'text', airtableName:'Consigne' },
+    { name:'status', type:'text', airtableName:'Statut' },
+    { name:'type', type:'text', airtableName:'Type d\'épreuve' },
+    { name:'timer', type:'smallint', airtableName:'Timer' },
+    { name:'autoReply', type:'boolean', airtableName:'Réponse automatique' },
+    { name:'skillIds', type:'text []', airtableName:'Acquix (id persistant)', isArray:true },
+    { name:'skillCount', type:'smallint', extractor: (record) => _.size(record.get('Acquix (id persistant)')) },
+    { name:'firstSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 0) },
+    { name:'secondSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 1) },
+    { name:'thirdSkillId', type:'text', extractor: (record) => _.get(record.get('Acquix (id persistant)'), 2) },
+  ],
+  airtableId:'id persistant',
+  indices: ['firstSkillId'],
+}, {
+  name:'courses',
+  airtableName:'Tests',
+  fields: [
+    { name:'name', type:'text', airtableName:'Nom' },
+    { name:'adaptive', type:'boolean', airtableName:'Adaptatif ?' },
+    { name:'competenceId', type:'text', airtableName:'Competence (id persistant)', isArray:false },
+  ],
+  airtableId:'id persistant',
+  indices: ['competenceId'],
+}, {
+  name:'tutorials',
+  airtableName:'Tutoriels',
+  fields: [
+    { name:'title', type:'text', airtableName:'Titre' },
+    { name:'link', type:'text', airtableName:'Lien' },
+  ],
+  airtableId:'id persistant',
+  indices: ['title'],
+},
+];
+
+async function run() {
+  await Promise.all(tables.map(async (table) => {
+    const data = await _getItems(table);
+    await _dropTable(table.name);
+    await _createTable(table);
+    await _saveItems(table, data);
+  }));
+}
+
+async function _dropTable(tableName) {
+  return runDBOperation(async (client) => {
+    const dropQuery = `DROP TABLE IF EXISTS ${format.ident(tableName)} CASCADE`;
+    await client.query(dropQuery);
+  });
+}
+
+async function _createTable(table) {
+  await runDBOperation(async (client) => {
+    const fieldsText = ['"id" text PRIMARY KEY'].concat(table.fields.map((field) => {
+      return format('\t%I\t%s', field.name, field.type + (field.type === 'boolean' ? ' NOT NULL' : ''));
+    })).join(',\n');
+    const createQuery = format('CREATE TABLE %I (%s)', table.name, fieldsText);
+    await client.query(createQuery);
+    for (const index of table.indices) {
+      const indexQuery = format ('CREATE INDEX %I on %I (%I)', `${table.name}_${index}_idx`, table.name, index);
+      await client.query(indexQuery);
+    }
+  });
+}
+
+async function _saveItems(table, items) {
+  await runDBOperation(async (client) => {
+    const fields = ['id'].concat(table.fields.map((field) => field.name));
+    const values = items.map((item) => fields.map((field) => item[field]));
+    const saveQuery = format('INSERT INTO %I (%I) VALUES %L', table.name, fields, values);
+    await client.query(saveQuery);
+  });
+}
+
+function _initAirtable() {
+  return new Airtable({ apiKey: process.env.AIRTABLE_KEY }).base(process.env.AIRTABLE_BASE);
+}
+
+async function _getItems(structure) {
+  const base = _initAirtable();
+  const fields = structure.fields;
+  const airtableFields = _.compact(fields.map((field) => field.airtableName));
+  if (structure.airtableId) {
+    airtableFields.push(structure.airtableId);
+  }
+  const records = await base(structure.airtableName).select({
+    fields: airtableFields,
+  }).all();
+  return records.map((record) => {
+    const item = { id:record.get(structure.airtableId) || record.getId() };
+    fields.forEach((field) => {
+      let value = field.extractor ? field.extractor(record) : record.get(field.airtableName);
+      if (Array.isArray(value)) {
+        if (!field.isArray) {
+          value = value[0];
+        } else {
+          value = `{${value.join(',')}}`;
+        }
+      }
+      if (field.type === 'boolean') {
+        value = Boolean(value);
+      }
+      item[field.name] = value;
+    });
+    return item;
+  });
+}
+
+module.exports = {
+  run,
+};

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -16,11 +16,53 @@
       "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abortcontroller-polyfill": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.5.0.tgz",
+      "integrity": "sha512-O6Xk757Jb4o0LMzMOMdWvxpHWrQzruYBaUruFaIOfAQRnWFxfdXYobw12jrVHGtoXk6WiiyYzc0QWN9aL62HQA==",
+      "dev": true
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
+    },
+    "airtable": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.10.0.tgz",
+      "integrity": "sha512-6gBUG+z1kqvwyHYWlc+y74TfYpc18mvmNuVcefjlvd6MSgLP9Hk47ByyBS6Ke8zdSk6kBTDpdiwCjoJQUpu6yg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^14.0.14",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "4.17.19",
+        "node-fetch": "^2.6.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.14.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
+          "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        }
+      }
     },
     "ajv": {
       "version": "6.10.0",
@@ -311,6 +353,12 @@
         "widest-line": "^2.0.0"
       }
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true
+    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -474,14 +522,14 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
       }
     },
     "crypto-random-string": {
@@ -608,6 +656,73 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
+      "dev": true
+    },
+    "dotenv-cli": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-4.0.0.tgz",
+      "integrity": "sha512-ByKEec+ashePEXthZaA1fif9XDtcaRnkN7eGdBDx3HHRjwZ/rA1go83Cbs4yRrx3JshsCf96FjAyIA2M672+CQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1",
+        "dotenv": "^8.1.0",
+        "dotenv-expand": "^5.1.0",
+        "minimist": "^1.1.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "driftless": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/driftless/-/driftless-2.0.3.tgz",
@@ -637,6 +752,15 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "engine.io-client": {
@@ -746,19 +870,59 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+      "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "^7.0.0",
+        "get-stream": "^5.0.0",
+        "human-signals": "^1.1.1",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.0",
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+          "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        }
       }
     },
     "extend": {
@@ -974,6 +1138,12 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -1240,9 +1410,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "log-symbols": {
@@ -1288,6 +1458,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "mersenne": {
       "version": "0.0.4",
@@ -1340,6 +1516,12 @@
       "integrity": "sha1-KA0nfbkUbspvilcLVyq68qmsx1Q=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "nomnom": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
@@ -1359,12 +1541,12 @@
       }
     },
     "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "^3.0.0"
       }
     },
     "nth-check": {
@@ -1387,6 +1569,15 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "onetime": {
       "version": "2.0.1",
@@ -1456,6 +1647,12 @@
         "semver": "^5.1.0"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
@@ -1490,9 +1687,9 @@
       "dev": true
     },
     "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "performance-now": {
@@ -1500,6 +1697,73 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
+    },
+    "pg": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.4.1.tgz",
+      "integrity": "sha512-NRsH0aGMXmX1z8Dd0iaPCxWUw4ffu+lIAmGm+sTCwuDDWkpEgRCAHZYDwqaNhC5hG5DRMOjSUFasMWhvcmLN1A==",
+      "dev": true,
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.1",
+        "pg-protocol": "^1.3.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ==",
+      "dev": true
+    },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=",
+      "dev": true
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true
+    },
+    "pg-pool": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA==",
+      "dev": true
+    },
+    "pg-protocol": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.3.0.tgz",
+      "integrity": "sha512-64/bYByMrhWULUaCd+6/72c9PMWhiVFs3EVxl9Ct6a3v/U8+rKgqP2w+kKg/BIGgMJyB+Bk/eNivT32Al+Jghw==",
+      "dev": true
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "dev": true,
+      "requires": {
+        "split2": "^3.1.1"
+      }
     },
     "pidusage": {
       "version": "1.2.0",
@@ -1512,6 +1776,33 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "dev": true
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1543,6 +1834,16 @@
       "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1565,6 +1866,17 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "registry-auth-token": {
@@ -1676,18 +1988,18 @@
       }
     },
     "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "signal-exit": {
@@ -1781,6 +2093,15 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "optional": true
+    },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1897,6 +2218,12 @@
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -1919,6 +2246,73 @@
       "dev": true,
       "requires": {
         "execa": "^0.7.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "timed-out": {
@@ -2069,9 +2463,9 @@
       }
     },
     "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2090,6 +2484,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write-file-atomic": {
@@ -2128,6 +2528,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "yallist": {

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -12,12 +12,22 @@
     "preinstall": "npx check-engine",
     "report": "artillery report report/index.json",
     "start": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml",
-    "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js"
+    "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js",
+    "generate-dataset": "npm run db:initialize && npm run actually-generate-dataset",
+    "db:initialize": "cd ../../api && npm run db:prepare",
+    "actually-generate-dataset": "node ./data/generate-dataset.js"
   },
   "license": "ISC",
   "devDependencies": {
+    "airtable": "^0.10.0",
     "artillery": "^1.6.0-27",
     "faker": "^4.1.0",
-    "js2xmlparser": "^4.0.1"
+    "js2xmlparser": "^4.0.1",
+    "dotenv": "^8.2.0",
+    "dotenv-cli": "^4.0.0",
+    "execa": "^4.0.3",
+    "lodash": "^4.17.20",
+    "pg": "^8.4.1",
+    "pg-format": "^1.0.4"
   }
 }

--- a/high-level-tests/load-testing/sample.env
+++ b/high-level-tests/load-testing/sample.env
@@ -44,3 +44,11 @@ AIRTABLE_API_KEY=keyblo10ZCvCqBAJg
 # type: String
 # default: none
 AIRTABLE_BASE=app3fvsqhtHJntXaC
+
+
+# Users to be created
+#
+# presence: facultative
+# type: Integer
+# default: 1000
+USER_COUNT=1000

--- a/high-level-tests/load-testing/sample.env
+++ b/high-level-tests/load-testing/sample.env
@@ -1,0 +1,46 @@
+# This file is the minimal confuguration file used by Dotenv to define the
+# environment variables on localhost.
+#
+# Instructions:
+#   1. copy this file as `.env`
+#   2. edit the `.env` file with working values
+#   3. uncomment the lines to activate or configure associated features
+
+# =========
+# DATABASES
+# =========
+
+# URL of the PostgreSQL database used for storing users data
+#
+# If not present, the script will crash
+#
+# presence: required
+# type: Url
+# default: none
+DATABASE_URL=postgresql://postgres@localhost/pix
+
+# ================
+# LEARNING CONTENT
+# ================
+
+# API key provided in your Airtable personal account used for fetching learning
+# content.
+#
+# If not present and if the Redis cache were not enabled/preloaded, the
+# application will crash during data fetching.
+#
+# presence: required
+# type: String
+# default: none
+AIRTABLE_API_KEY=keyblo10ZCvCqBAJg
+
+# API token provided in your Airtable database configuration used for fetching
+# learning content.
+#
+# If not present and if the Redis cache were not enabled/preloaded, the
+# application will crash during data fetching.
+#
+# presence: required
+# type: String
+# default: none
+AIRTABLE_BASE=app3fvsqhtHJntXaC

--- a/high-level-tests/load-testing/sample.env
+++ b/high-level-tests/load-testing/sample.env
@@ -51,4 +51,70 @@ AIRTABLE_BASE=app3fvsqhtHJntXaC
 # presence: facultative
 # type: Integer
 # default: 1000
-USER_COUNT=1000
+USER_COUNT=
+
+# competence_evaluation_count
+#
+# presence: facultative
+# type: Integer
+# default: 1000
+COMPETENCE_EVALUATION_COUNT=
+
+# ORGANIZATION_COUNT
+#
+# presence: facultative
+# type: Integer
+# default: 0
+ORGANIZATION_COUNT=
+
+# CAMPAIGN_PER_ORGANIZATION_COUNT
+#
+# presence: facultative
+# type: Integer
+# default: 3
+CAMPAIGN_PER_ORGANIZATION_COUNT=
+
+# PARTICIPATION_PER_CAMPAIGN_COUNT
+#
+# presence: facultative
+# type: Integer
+# default: 150
+PARTICIPATION_PER_CAMPAIGN_COUNT=
+
+# SHARED_PARTICIPATION_PERCENTAGE
+#
+# presence: facultative
+# type: Integer
+# default: 65
+SHARED_PARTICIPATION_PERCENTAGE=
+
+# ANSWER_PER_COMPETENCE_EVALUATION_ASSESSMENT_COUNT
+#
+# presence: facultative
+# type: Integer
+# default: 25
+ANSWER_PER_COMPETENCE_EVALUATION_ASSESSMENT_COUNT
+
+
+# ANSWER_PER_CAMPAIGN_ASSESSMENT_COUNT
+#
+# presence: facultative
+# type: Integer
+# default: 25
+ANSWER_PER_CAMPAIGN_ASSESSMENT_COUNT=
+
+
+# Détermine la répartition des statuts des knowledge-elements
+#
+# presence: facultative
+# type: Integer
+# default: 60
+VALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE=
+
+
+# Le reste du pourcentage va constituer les knowledge-elements 'reset'
+#
+# presence: facultative
+# type: Integer
+# default: 30
+INVALIDATED_KNOWLEDGE_ELEMENT_PERCENTAGE=


### PR DESCRIPTION
## :unicorn: Problème
On ne dispose pas de moyen "rapide et efficace" de monter sur pied une base de données contenant un volume de données suffisamment gros pour faire des tests de charge et de trafic sur nos applicatifs. La solution temporaire, utilisée jusqu'à présent, est d'exploiter la base de réplication. Cette solution temporaire nous limite au volume réel de la production et ne nous permet pas d'anticiper un grossissement (comme celui attendu pour la rentrée par exemple). Il existe aussi un script JS dans le dossier api/scripts qui permet de créer des utilisateurs + campagnes + participations + KE de façon automatique. Le problème est que cette solution full-js n'est pas très rapide (environ 5 minutes pour 20k utilisateurs à peu près). On a voulu l'exploiter pour créer une base de 4 millions d'utilisateurs, mais évidemment cela prend beaucoup trop de temps. 

## :robot: Solution
La raison pour laquelle une solution JS n'est pas recevable, c'est qu'il y a un coût à la formulation de la requête via knex -> node-pg -> jusqu'à la base. L'écriture d'un tel script en full SQL nous permettrait d'exploiter plus intensivement les features SQL et PostgreSQL.

Le plan du script SQL est le suivant :

### Etapes préparatoires
- [x] Désactiver la journalisation des tables (`ALTER TABLE ma_table SET UNLOGGED`). C'est un excellent gain en temps car cela désactive l'écriture des opérations réalisées sur les tables dans le WAL. C'est évidemment un mécanisme ESSENTIEL en production, pour une base de données pour laquelle on souhaite garantir la cohérence des données et la récupération en cas de problème sur la base. On n'en a pas besoin ici.
- [x] Désactiver un grand nombre de contraintes déclarées dans les schémas des tables, on pense particulièrement aux contraintes de clé étrangère. En effet, lorsqu'on insère un enregistrement dans une table, si celle-ci présente des contraintes, le moteur s'assure de la non-violation de cette contrainte avant insertion (ou modification ou suppression). Typiquement, on crée un `knowledge-element` déclaré être lié à l'utilisateur d'ID 123, le moteur va vérifier que l'utilisateur 123 existe bel et bien dans la table `users`. Cette vérification est coûteuse, et n'est pas indispensable dans le cadre de génération massive (puisqu'on a la maîtrise des données qu'on insère, bref on se fait confiance).
- [x] Suppression des index et de leur maintenance. Un index doit être mis à jour en permanence dès lors qu'on modifie les données contenues dans une table (ré-organisation logique des feuilles de l'index, etc...).
- [x] Création d'une table qui va contenir les données du référentiel qui vont nous être nécessaires, particulièrement à la création des target-profiles et des knowledge-elements.

### Concepts
On notera quelques "magouilles" particulières pour parvenir à nos fins.

#### Boutons et molettes de configuration
Tout en haut du script, on peut trouver un ensemble de déclarations de variables/constantes. Ces déclarations sont en fait nos boutons à tourner afin de modifier la configuration générale souhaitée de la base de données.
Les modifications mises à disposition sont :
- `constants.user_count`: Nombre d'utilisateurs à créer
- `constants.competence_evaluation_count`: Nombre d'assessments de type COMPETENCE_EVALUATION à créer
- `constants.organization_count`: Nombre d'organisations à créer
- `constants.campaign_per_organization_count`: Nombre de campagnes par organisation à créer
- `constants.participation_per_campaign_count`: Nombre de participations par campagne à créer
- `constants.shared_participation_percentage`: La proportion de participations partagées sur l'ensemble créé
- `constants.answer_per_competence_evaluation_assessment_count`: Le nombre de réponses par assessment de type COMPETENCE_EVALUATION à créer
- `constants.answer_per_campaign_assessment_count`: Le nombre de réponses par assessment de type CAMPAIGN à créer
- `constants.validated_knowledge_element_percentage`: La proportion de knowledge-elements validés
- `constants.invalidated_knowledge_element_percentage`: La proportion de knowledge-elements invalidés (le reste sera du reset)

#### Choix aléatoires d'enregistrement
On va créer un tas de données dans plusieurs tables différence dans l'ordre de la précédence métier logique. Par exemple, seront créés en premier lieu les utilisateurs puisque ceux-ci sont à la base de la création des assessments, et donc des answers, etc... . Considérons la portion de paramétrage suivante :
- `constants.user_count=10`
- `constants.competence_evaluation_count=25`
Cela signifie que pour 10 utilisateurs, on va créer 25 assessments de type COMPETENCE_EVALUATION qu'il va falloir leur assigner. Et l'assignation se fait de façon aléatoire : 
![choix_aléatoire_explication](https://user-images.githubusercontent.com/48727874/89430794-6a075b80-d73f-11ea-8436-f87b888ac61f.png)

### Concrètement, ça fait quoi ?
- Génération d'une table contenant : le référentiel, les dépendances d'acquis et des chaînes aléatoirement consituées
- Génération de `n` utilisateurs
- Génération de `m` assessments de type COMPETENCE_EVALUATION répartis parmi les `n` utilisateurs aléatoirement
- Génération de  `p` answers par assessment de type COMPETENCE_EVALUATION (soit `m * p`) répartis parmi les `m` assessments aléatoirement

- Génération de 3 profils cible (un petit, un moyen et un tout-pix)
- Génération de `q` organisations, ainsi que d'autant d'utilisateurs avec memberships et rôle ADMIN
- Génération de `r` campagnes par organisation (soit `q * r`) réparties aléatoirement parmi les `q` organisations
- Génération de `s` participations par campagnes ( soit `q * r * s`) réparties aléatoirement parmi les `q * r` campagnes et  `n` utilisateurs ainsi que de son assessment (soit `q * r * s`)
- Génération de `t` answers par assessment de type CAMPAIGN (soit  `q * r * s * t`) répartis parmi les `q * r * s` assessments

- Pour chaque answer, crée un knowledge-element (soit `(m * p) + (q * r * s * t)`) auquel on associe un acquis au hasard, ainsi qu'un statut au hasard
- Pour chaque knowledge-element validé (soit une certaine proportion de  `(m * p) + (q * r * s * t)`), on va créer les knowldege-elements inférés correspondant (peut varier de 0 à 6 par knowledge-element initial selon son acquis)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Dès le commit `Add dynamic referential import for AirTable`
Exécuter `npm run generate-dataset`

Créer un schéma vide (structure uniquement)
> npm run db:prepare

Modifier le nombre d'utilisateur à créer
`SET LOCAL constants.user_count=100000;`

Modifier le fichier après la balise `-- Ajouter les données du référentiel ici !` 

Exemple
```
INSERT INTO referentiel
  (skill_id, competence_id, tube_id, pix_value, level)
VALUES
  ('skilla', 'tubea', 'competencea', 1, 1);

INSERT INTO referentiel
  (skill_id, competence_id, tube_id, pix_value, level)
VALUES
  ('skilla', 'tubea', 'competenceb', 2, 2);
```
Supprimer le `ROLBACK` en fin de script et rajouter un `COMMIT`

Exécuter le script
>psql -U postgres -d pix -h localhost -a -f ../high-level-tests/load-testing/data/generate_mass_data.sql > /tmp/db.log

Vérifier le temps écoulé (ex: < 1 minute pour 1 million d'utilisateur)

Vérifier le log (absence de `ERROR`)
>cat /tmp/db.log

Lister les utilisateurs présents
`SELECT email FROM users LIMIT 5`

Mettre à jour les mots de passe à `pix123`
```
UPDATE users 
SET password ='$2a$05$IP2HpgRg180EVjTnnq5yTOAW.42Bt3dIxoRMu6lV1NYHTSJeXO.U.';
```

Démarrer PixApp et effectuer un parcours libre

Désactiver l'authentification des élèves
```
UPDATE organizations
SET "isManagingStudents" = FALSE;
```

Accéder à une campagne
```
SELECT
    'http://localhost:4200/campagnes/' || c.code
FROM
    campaigns c
```

Sélectionner un compte ayant accès à une organisation
```
SELECT
    u.email,
    m."organizationRole",
    o.type,
    o.name
FROM
    memberships m
        INNER JOIN users u on m."userId" = u.id
        INNER JOIN organizations o on m."organizationId" = o.id
```

Démarrer PixOrga et se connecter  sur le compte

Sélectionner un compte PixAdmin
```
SELECT
    u.email,
    pr.name
FROM "users_pix_roles" upr
    INNER JOIN users u on upr.user_id = u.id
    INNER JOIN pix_roles pr on upr.pix_role_id = pr.id
;
```
Démarrer PixAdmin et se connecter  sur le compte

## :construction: Reste à faire
Trucs à faire
- [x] Refaire une passe sur l'ensemble des dates et de la cohérence des dates entre elles
- [x] Réponses pour les assessments de competence_evaluation
- [x] KEs pour les assessments de competence_evaluation
- [x] Réponses pour les assessments de campagne
- [x] KEs pour les assessments de campagne
- [ ] schooling registrations (actuellemnent, les orga sont SCO + managingStudent, mais pas d'élèves présents)
- [ ] admonistrateur (PixAdmin)