### PR TITLE
[FEATURE] Traduction de la page où l'on demande l'identifiant externe d'une campagne (PIX-806)

### DIFF
--- a/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
+++ b/mon-pix/app/controllers/campaigns/fill-in-id-pix.js
@@ -1,35 +1,35 @@
-/* eslint ember/no-actions-hash: 0 */
-/* eslint ember/no-classic-classes: 0 */
-
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import Controller from '@ember/controller';
 
-export default Controller.extend({
+export default class FillInIdPix extends Controller {
+  @service intl;
 
-  participantExternalId: null,
-  isLoading: false,
-  errorMessage: null,
+  @tracked participantExternalId = null;
+  @tracked isLoading = false;
+  @tracked errorMessage = null;
 
-  actions: {
+  @action
+  submit() {
+    this.model.errorMessage = null;
 
-    submit() {
-      this.set('model.errorMessage', null);
+    const participantExternalId = this.participantExternalId;
 
-      const participantExternalId = this.participantExternalId;
-
-      if (participantExternalId) {
-        this.set('isLoading', true);
-        return this.transitionToRoute('campaigns.start-or-resume', this.model, { queryParams: { participantExternalId } });
-      } else {
-        return this.set('errorMessage', `Merci de renseigner votre ${ this.model.idPixLabel }.`);
-      }
-    },
-
-    cancel() {
-      this.set('errorMessage', null);
-
-      return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-        queryParams: { hasUserSeenLandingPage: false }
-      });
-    },
+    if (participantExternalId) {
+      this.isLoading = true;
+      return this.transitionToRoute('campaigns.start-or-resume', this.model, { queryParams: { participantExternalId } });
+    } else {
+      return this.errorMessage = this.intl.t('pages.fill-in-id-pix.errors.missing-id-pix-label',  { idPixLabel: this.model.idPixLabel });
+    }
   }
-});
+
+  @action
+  cancel() {
+    this.errorMessage = null;
+
+    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
+      queryParams: { hasUserSeenLandingPage: false }
+    });
+  }
+}

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -18,7 +18,7 @@ export default class FillInCampaignCodeController extends Controller {
 
     if (!this.campaignCode) {
       this.errorMessage = this.intl.t(
-        'pages.fill-in-campaign-code.errors.code-missing'
+        'pages.fill-in-campaign-code.errors.missing-code'
       );
       return;
     }

--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -1,16 +1,16 @@
-{{page-title 'Saisir mon identifiant'}}
+{{page-title (t 'pages.fill-in-id-pix.title')}}
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
-    <h1 class="fill-in-id-pix-text fill-in-id-pix-text__title">Avant de commencer</h1>
+    <h1 class="fill-in-id-pix-text fill-in-id-pix-text__title">{{t 'pages.fill-in-id-pix.first-title'}}</h1>
     <p class="fill-in-id-pix-text fill-in-id-pix-text__announcement">
-      L'organisateur a besoin de l'information ci-dessous pour pouvoir vous accompagner :
+      {{t 'pages.fill-in-id-pix.announcement'}}
     </p>
 
     <form {{action "submit" on="submit"}} class="fill-in-id-pix__form">
       <div class="fill-in-id-pix-form__section">
         <div class="fill-in-id-pix__form-field">
-          <label for="id-pix-label">{{@model.idPixLabel}} :</label>
+          <label for="id-pix-label">{{@model.idPixLabel}}</label>
           <Input required @id="id-pix-label" @value={{this.participantExternalId}} />
         </div>
         {{#if this.isLoading}}
@@ -18,7 +18,7 @@
             <span class="loader-in-button">&nbsp;</span>
           </button>
         {{else}}
-          <button type="submit" class="button button--big">Continuer</button>
+          <button type="submit" class="button button--big">{{t 'pages.fill-in-id-pix.buttons.continue'}}</button>
         {{/if}}
         {{#if this.errorMessage}}
           <div class="fill-in-id-pix__form__error-message">{{errorMessage}}</div>
@@ -27,11 +27,11 @@
 
       {{#if this.isLoading}}
         <button type="button" disabled class="button button--regular button--no-color fill-in-id-pix__cancel-button">
-          Annuler
+          {{t 'pages.fill-in-id-pix.buttons.cancel'}}
         </button>
       {{else}}
         <button type="button" {{action "cancel"}} class="button button--regular button--no-color fill-in-id-pix__cancel-button">
-          Annuler
+          {{t 'pages.fill-in-id-pix.buttons.cancel'}}
         </button>
       {{/if}}
     </form>

--- a/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/fill-in-id-pix-test.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import { setupTest } from 'ember-mocha';
+import setupRenderingTest from '../../../helpers/setup-intl-rendering';
 import sinon from 'sinon';
 
 describe('Unit | Controller | Campaigns | Fill in ParticipantExternalId', function() {
 
-  setupTest();
-
+  setupRenderingTest();
+  
   const model = {
     id: 1243,
     code: 'CODECAMPAIGN',

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -620,14 +620,27 @@
     },
 
     "fill-in-campaign-code": {
-      "title": "J'ai un code",
+      "title": "I have a code",
       "first-title": "Enter your code",
       "description": "This code allows you to start a course'<br>'or to send your profile to an organization.",
-      "start": "Start",
       "errors": {
         "forbidden": "Oops! We can't find you. Check your information to continue or notify the organizer.",
-        "not-found": "Your code is wrong, please check or contact the organizer.",
-        "code-missing": "Please enter a code."
+        "missing-code": "Please enter a code.",
+        "not-found": "Your code is wrong, please check or contact the organizer."
+      },
+      "start": "Start"
+    },
+
+    "fill-in-id-pix": {
+      "title": "Enter my username",
+      "first-title": "Before starting",
+      "announcement": "The organizer needs the following information to be able to accompany you :",
+      "buttons": {
+        "continue": "Continue",
+        "cancel": "Cancel"
+      },
+      "errors": {
+        "missing-id-pix-label": "Please fill in your { idPixLabel }."
       }
     }
   },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -623,11 +623,24 @@
       "title": "J'ai un code",
       "first-title": "Saisissez votre code",
       "description": "Ce code permet de démarrer un parcours'<br>'ou d’envoyer votre profil à une organisation",
-      "start": "Commencer",
       "errors": {
         "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
-        "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur.",
-        "code-missing": "Veuillez saisir un code."
+        "missing-code": "Veuillez saisir un code.",
+        "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur."
+      },
+      "start": "Commencer"
+    },
+
+    "fill-in-id-pix": {
+      "title": "Saisir mon identifiant",
+      "first-title": "Avant de commencer",
+      "announcement": "L'organisateur a besoin de l'information ci-dessous pour pouvoir vous accompagner :",
+      "buttons": {
+        "continue": "Continuer",
+        "cancel": "Annuler"
+      },
+      "errors": {
+        "missing-id-pix-label": "Merci de renseigner votre { idPixLabel }."
       }
     }
   },


### PR DESCRIPTION
## :unicorn: Problème
Traduction de la page identifiant externe indisponible.

## :robot: Solution
Ajout des clés de traduction dans les fichiers en.json et fr.json

## :rainbow: Remarques
Le fichier fill-in-id-pix.js (Controller) a été mis à jour pour Octane également

## :100: Pour tester
Créer une campagne avec identifiant étudiant, ajouter le code sur mon-pix, une page intermédiaire demandera l'identifiant étudiant. 

<img width="1046" alt="Capture d’écran 2020-07-29 à 14 03 00" src="https://user-images.githubusercontent.com/13931126/88797846-432bb100-d1a4-11ea-9f86-cd1054201a58.png">
 