### PR TITLE
[FEATURE] Préciser le message d'erreur quand l'épreuve est un QROC avec validation auto (PIX-1034).

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -18,7 +18,8 @@ class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    return this.intl.t('pages.challenge.skip-error-message.qroc');
+    const errorMessage = this.challenge.autoReply ? 'pages.challenge.skip-error-message.qroc-auto-reply' : 'pages.challenge.skip-error-message.qroc';
+    return this.intl.t(errorMessage);
   }
 
   _addEventListener() {

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -43,7 +43,7 @@ describe('Acceptance | Displaying a QCM challenge', () => {
 
       // then
       expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner au moins une réponse. Sinon, passer.');
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner au moins une réponse. Sinon, passez.');
     });
 
     it('should hide the alert error after the user interact with checkboxes', async () => {

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -42,7 +42,7 @@ describe('Acceptance | Displaying a QCU challenge', () => {
 
       // then
       expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passer.');
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, sélectionner une réponse. Sinon, passez.');
     });
 
     it('should hide the alert error after the user interact with radio button', async () => {

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -72,7 +72,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         await click('.challenge-actions__action-validate');
-        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passez.');
       });
     });
 
@@ -101,7 +101,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passez.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {
@@ -276,7 +276,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passez.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('L\'épreuve n\'est pas réussie. Essayez encore ou passez.');
       });
 
       it('should go to the next challenge when user validates after finishing successfully the embed', async () => {
@@ -72,7 +72,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         await click('.challenge-actions__action-validate');
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
       });
     });
 
@@ -101,7 +101,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {
@@ -276,7 +276,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('Jouer l’épreuve pour valider. Sinon, passer.');
+        expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir le champ texte. Sinon, passer.');
       });
 
       it('should hide the alert error after the user interact with input text', async () => {

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -42,7 +42,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       await click(find('.challenge-actions__action-validate'));
 
       expect(find('.alert')).to.exist;
-      expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir tous les champs réponse. Sinon, passer.');
+      expect(find('.alert').textContent.trim()).to.equal('Pour valider, veuillez remplir tous les champs réponse. Sinon, passez.');
     });
 
     it('should hide the alert error after the user interact with input text', async () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -291,7 +291,8 @@
       "skip-error-message": {
         "qcm": "Choose at least one answer to validate. Skip otherwise.",
         "qcu": "Choose an answer to validate. Skip otherwise.",
-        "qroc": "Play the challenge to validate. Skip otherwise.",
+        "qroc": "Fill in the answer fields to validate. Skip otherwise.",
+        "qroc-auto-reply": "The challenge is not successful. Try again or skip.",
         "qrocm": "Fill in all the answer fields to validate. Skip otherwise."
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -291,7 +291,8 @@
       "skip-error-message": {
         "qcm": "Pour valider, sélectionner au moins une réponse. Sinon, passer.",
         "qcu": "Pour valider, sélectionner une réponse. Sinon, passer.",
-        "qroc": "Jouer l’épreuve pour valider. Sinon, passer.",
+        "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passer.",
+        "qroc-auto-reply": "L'épreuve n'est pas réussie. Essayez encore ou passez.",
         "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passer."
       }
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -34,7 +34,7 @@
         "header": "Vos réponses"
       }
     },
-  
+
     "campaign": {
       "title": "Parcours",
       "errors": {
@@ -42,7 +42,7 @@
         "no-longer-accessible": "Oups, la page demandée n’est plus accessible."
       }
     },
-  
+
     "campaign-landing": {
       "title": "Présentation",
       "assessment": {
@@ -289,11 +289,11 @@
         "label": "Question"
       },
       "skip-error-message": {
-        "qcm": "Pour valider, sélectionner au moins une réponse. Sinon, passer.",
-        "qcu": "Pour valider, sélectionner une réponse. Sinon, passer.",
-        "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passer.",
+        "qcm": "Pour valider, sélectionner au moins une réponse. Sinon, passez.",
+        "qcu": "Pour valider, sélectionner une réponse. Sinon, passez.",
+        "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passez.",
         "qroc-auto-reply": "L'épreuve n'est pas réussie. Essayez encore ou passez.",
-        "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passer."
+        "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -427,7 +427,7 @@
         "reminder-send-campaign-with-title": "Parcours \"{title}\" terminé. N'oubliez pas de finaliser votre envoi !"
       },
       "total-score-helper": {
-        "title": "Why 1024 pix ?",
+        "title": "Pourquoi 1024 pix ?",
         "explanation": "C’est le nombre maximum de pix qu’on pourra atteindre lorsque les 8 niveaux du référentiel Pix seront disponibles.'<br>'Aujourd’hui, '<span class=\"hexagon-score-information__text--strong\">'le maximum est de 640 pix'</span>', correspondant au niveau 5."
       }
     },


### PR DESCRIPTION
## :unicorn: Problème
- Lorsque l'épreuve est de type QROC, le message d'erreur n'était pas clair. Nous avons aussi besoin d'un message d'erreur plus précis pour le cas où l'épreuve est de type QROC mais que le champ texte est invisible (car validation auto)

## :robot: Solution
- Remettre le texte correctement pour les QROC
- Ajouter une clé de traduction `qroc-auto-reply` pour le cas des Embed QROC avec réponse automatique
- Modifier `_getErrorMessage` pour choisir la bonne clé selon le cas.

## :rainbow: Remarques
-

## :100: Pour tester
Faire Valider et voir le message :
- Epreuve QROC auto : https://app-pr1700.review.pix.fr/challenges/recy37FMPthJpfWmd/preview 
- Epreuve QROC embed avec champ : https://app-pr1700.review.pix.fr/challenges/recleClaoc9hKWBIT/preview 
- Epreuve QROC normal :  https://app-pr1700.review.pix.fr/challenges/recegRLZWI2Y6nzFw/preview 