### PR TITLE
[FEATURE] Traduire la page de campagne archivée (PIX-1000).

### DIFF
--- a/mon-pix/app/templates/campaigns-error.hbs
+++ b/mon-pix/app/templates/campaigns-error.hbs
@@ -1,3 +1,3 @@
 <InaccessibleCampaign>
-  {{t "pages.not-accessible-campaign.message"}}
+  {{t "pages.campaign.errors.not-accessible"}}
 </InaccessibleCampaign>

--- a/mon-pix/app/templates/campaigns/start-or-resume.hbs
+++ b/mon-pix/app/templates/campaigns/start-or-resume.hbs
@@ -1,11 +1,13 @@
 {{#if @model.isLoading }}
   <div class="app-loader">
-    <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+    <p class="app-loader__image">
+      <img src="/images/interwind.gif" alt={{t "common.loading"}} />
+    </p>
   </div>
 {{else}}
   {{#if @model.isArchived }}
     <InaccessibleCampaign>
-      La campagne a été archivée.
+      {{t "pages.campaign.errors.no-longer-accessible"}}
     </InaccessibleCampaign>
   {{/if}}
 {{/if}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -36,7 +36,11 @@
     },
   
     "campaign": {
-      "title": "Path"
+      "title": "Parcours",
+      "errors": {
+        "not-accessible": "Oups, the requested page is not accessible.",
+        "no-longer-accessible": "Oups, the requested page is no longer accessible."
+      }
     },
   
     "campaign-landing": {
@@ -406,10 +410,6 @@
 
     "levelup-notif": {
       "obtained-level": "Level { level } obtained!"
-    },
-
-    "not-accessible-campaign": {
-      "message": "Oups, the requested page is not accessible."
     },
 
     "profile": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -36,7 +36,11 @@
     },
   
     "campaign": {
-      "title": "Parcours"
+      "title": "Parcours",
+      "errors": {
+        "not-accessible": "Oups, la page demandée n’est pas accessible.",
+        "no-longer-accessible": "Oups, la page demandée n’est plus accessible."
+      }
     },
   
     "campaign-landing": {
@@ -402,10 +406,6 @@
     "learning-more": {
       "title": "Pour en apprendre davantage",
       "info": "Ces liens vers les tutos ont été proposés par des utilisateurs de Pix."
-    },
-
-    "not-accessible-campaign": {
-      "message": "Oups, la page demandée n’est pas accessible."
     },
 
     "profile": {


### PR DESCRIPTION
## :unicorn: Problème

la page de campagne archivée n'est pas traduite

## :robot: Solution

Traduire la page de campagne archivée

## :rainbow: Remarques

n/a

## :100: Pour tester
Archiver une campagne puis saisir son code dans pix-app
