### PR TITLE
[FEATURE] Traduire la page de profil déjà envoyé (PIX-1043)

### DIFF
--- a/mon-pix/app/formats.js
+++ b/mon-pix/app/formats.js
@@ -1,5 +1,9 @@
 export default {
   time: {
+    hhmm: {
+      hour: 'numeric',
+      minute: 'numeric',
+    },
     hhmmss: {
       hour: 'numeric',
       minute: 'numeric',

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -1,20 +1,26 @@
-{{page-title 'Profil déjà envoyé'}}
+{{page-title (t 'pages.profile-already-shared.title')}}
+
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
-    <img class="send-profile-header__image" src="{{rootURL}}/images/bees/fat-bee.svg" alt="Tout ne se passe pas comme prévu">
+    <img class="send-profile-header__image" src="{{rootURL}}/images/bees/fat-bee.svg" alt={{t "pages.profile-already-shared.first-title"}}>
     <div class="send-profile-header__announcement">
       <p class="send-profile-header__instruction">
-        Vous avez déjà envoyé le profil ci-dessous à l'organisation {{this.model.campaign.organizationName}}
-        <br>le {{moment-format this.model.sharedProfile.sharedAt 'LL' locale='fr'}}
-        à {{moment-format this.model.sharedProfile.sharedAt 'HH:mm' locale='fr'}}
+        {{t "pages.profile-already-shared.explanation" organization=this.model.campaign.organizationName date=this.model.sharedProfile.sharedAt hour=this.model.sharedProfile.sharedAt htmlSafe=true}}
       </p>
-      <LinkTo @route="index" class="skill-review-share__back-to-home link">Continuez votre expérience Pix</LinkTo>
+      <LinkTo @route="index" class="skill-review-share__back-to-home link">
+        {{t "pages.profile-already-shared.actions.continue"}}
+      </LinkTo>
     </div>
     <div class="send-profile-header__profile">
       <HexagonScore @pixScore={{this.model.sharedProfile.pixScore}} />
       <div class="send-profile-header__profile__cards">
-        <ProfileScorecards @interactive={{false}} class="send-profile-header__profile__cards" @areasCode={{this.model.sharedProfile.areasCode}} @scorecards={{this.model.sharedProfile.scorecards}}/>
+        <ProfileScorecards
+          class="send-profile-header__profile__cards"
+          @interactive={{false}}
+          @areasCode={{this.model.sharedProfile.areasCode}}
+          @scorecards={{this.model.sharedProfile.scorecards}}
+        />
       </div>
     </div>
   </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -436,6 +436,15 @@
       }
     },
 
+    "profile-already-shared": {
+      "title": "Profile already sent",
+      "first-title": "Everything does not go as planned",
+      "actions": {
+        "continue": "Continue your Pix experience"
+      },
+      "explanation": "You have already sent the profile below to the organization {organization} '<br>' on {date,date,LL} at {hour,time,hhmm}"
+    },
+
     "result-item": {
       "aband": "No answer",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -432,6 +432,15 @@
       }
     },
 
+    "profile-already-shared": {
+      "title": "Profil déjà envoyé",
+      "first-title": "Tout ne se passe pas comme prévu",
+      "actions": {
+        "continue": "Continuez votre expérience Pix"
+      },
+      "explanation": "Vous avez déjà envoyé le profil ci-dessous à l'organisation {organization}'<br>'le {date,date,LL} à {hour,time,hhmm}"
+    },
+
     "levelup-notif": {
       "obtained-level": "Niveau { level } gagné !"
     },


### PR DESCRIPTION
## :unicorn: Problème

La page de profil déjà envoyé n'est pas traduite

## :robot: Solution

Traduire la page de profil déjà envoyé 

## :rainbow: Remarques

On a utilisé le templating de formatage de date et d'heure directement dans le fichier de traduction.

## :100: Pour tester

1. Envoyer un profil sur une campagne (SNAP123)
2. Tenter de renvoyer le profil sur cette campagne => vérifier les traductions