### PR TITLE
[FEATURE] Traduction des pages et composants de loading (PIX-1042)

### DIFF
--- a/mon-pix/app/templates/application.hbs
+++ b/mon-pix/app/templates/application.hbs
@@ -5,5 +5,5 @@
   {{outlet}}
 
   <!-- Preloading images -->
-  <img src="{{rootURL}}/images/loader-white.svg" alt="{{t 'common.loading'}}" style="display: none">
+  <img src="{{rootURL}}/images/loader-white.svg" alt="{{t 'common.loading.default'}}" style="display: none">
 </div>

--- a/mon-pix/app/templates/assessments/loading.hbs
+++ b/mon-pix/app/templates/assessments/loading.hbs
@@ -1,1 +1,1 @@
-<Loader @loaderText="En cours de chargement…" />
+<Loader @loaderText={{t "common.loading.default"}} />

--- a/mon-pix/app/templates/assessments/results-loading.hbs
+++ b/mon-pix/app/templates/assessments/results-loading.hbs
@@ -1,1 +1,1 @@
-<Loader @loaderText="Préparation de vos résultats…" />
+<Loader @loaderText={{t "common.loading.results"}} />

--- a/mon-pix/app/templates/assessments/resume-loading.hbs
+++ b/mon-pix/app/templates/assessments/resume-loading.hbs
@@ -1,1 +1,1 @@
-<Loader @loaderText="Votre test est en cours de chargement…" />
+<Loader @loaderText={{t "common.loading.test"}} />

--- a/mon-pix/app/templates/campaigns/loading.hbs
+++ b/mon-pix/app/templates/campaigns/loading.hbs
@@ -1,1 +1,1 @@
-<Loader @loaderText="En cours de chargement…" />
+<Loader @loaderText={{t "common.loading.default"}} />

--- a/mon-pix/app/templates/certifications/start-loading.hbs
+++ b/mon-pix/app/templates/certifications/start-loading.hbs
@@ -6,8 +6,10 @@
       <div class="background-banner"></div>
 
       <div class="app-nested-loader rounded-panel--over-background-banner rounded-panel rounded-panel--strong">
-        <p class="app-loader__image"><img src="/images/interwind.gif"></p>
-        <p class="app-loader__text">Chargement en cours…</p>
+        <p class="app-loader__image">
+          <img src="/images/interwind.gif" alt="" role="presentation" />
+        </p>
+        <p class="app-loader__text">{{t "common.loading.default"}}</p>
       </div>
 
     </div>

--- a/mon-pix/app/templates/components/loader.hbs
+++ b/mon-pix/app/templates/components/loader.hbs
@@ -1,4 +1,6 @@
 <div class="app-loader">
-  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
+  <p class="app-loader__image">
+    <img src="/images/interwind.gif" alt="" role="presentation" />
+  </p>
   <p class="app-loader__text">{{@loaderText}}</p>
 </div>

--- a/mon-pix/app/templates/courses/create-assessment-loading.hbs
+++ b/mon-pix/app/templates/courses/create-assessment-loading.hbs
@@ -1,4 +1,1 @@
-<div class="app-loader">
-  <p class="app-loader__image"><img src="/images/interwind.gif"></p>
-  <p class="app-loader__text">Votre test est en cours de chargement…</p>
-</div>
+<Loader @loaderText={{t "common.loading.default"}} />

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -17,7 +17,11 @@
     },
     "french-republic": "French Republic",
     "level": "level",
-    "loading": "Loading",
+    "loading": {
+      "default": "Loading",
+      "results": "Preparing your results",
+      "test": "Your test is loading"
+    },
     "or": "or",
     "pix": "pix"
   },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -17,7 +17,11 @@
     },
     "french-republic": "République française",
     "level": "niveau",
-    "loading": "Chargement en cours",
+    "loading": {
+      "default": "Chargement en cours",
+      "results": "Préparation de vos résultats",
+      "test": "Votre test est en cours de chargement"
+    },
     "or": "ou",
     "pix": "pix"
   },


### PR DESCRIPTION
## :unicorn: Problème

Les pages et composants de loading ne sont pas traduits

## :robot: Solution

Traduire les pages et composants de loading pour:
- l'application globale
- assessment (global, results, resume)
- campagnes (global)
- certification (global)
- courses (create-assessment)

## :rainbow: Remarques

N/A

## :100: Pour tester

Observer les différentes transitions de loading.