### PR TITLE
[FEATURE] Filtrer les tutoriaux en fonction de la langue sélectionnée (PIX-792).

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -47,11 +47,13 @@ module.exports = {
 
   async getCorrection(request) {
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
     const answerId = request.params.id;
 
     const correction = await usecases.getCorrectionForAnswer({
       answerId,
-      userId
+      userId,
+      locale,
     });
 
     return correctionSerializer.serialize(correction);

--- a/api/lib/application/scorecards/scorecard-controller.js
+++ b/api/lib/application/scorecards/scorecard-controller.js
@@ -15,10 +15,11 @@ module.exports = {
   },
 
   findTutorials(request) {
+    const locale = extractLocaleFromRequest(request);
     const authenticatedUserId = request.auth.credentials.userId;
     const scorecardId = request.params.id;
 
-    return usecases.findTutorials({ authenticatedUserId, scorecardId })
+    return usecases.findTutorials({ authenticatedUserId, scorecardId, locale })
       .then(tutorialSerializer.serialize);
   },
 };

--- a/api/lib/domain/usecases/find-tutorials.js
+++ b/api/lib/domain/usecases/find-tutorials.js
@@ -10,6 +10,7 @@ module.exports = async function findTutorials({
   skillRepository,
   tubeRepository,
   tutorialRepository,
+  locale,
 }) {
 
   const { userId, competenceId } = Scorecard.parseId(scorecardId);
@@ -33,14 +34,14 @@ module.exports = async function findTutorials({
   const tubeNamesForTutorials = _.keys(skillsGroupedByTube);
   const tubes = await tubeRepository.findByNames(tubeNamesForTutorials);
 
-  const tutorialsWithTubesList = await _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId);
+  const tutorialsWithTubesList = await _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId, locale);
   return _.orderBy(_.flatten(tutorialsWithTubesList), 'tubeName');
 };
 
-async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId) {
+async function _getTutorialsWithTubesList(easiestSkills, tubes, tutorialRepository, userId, locale) {
   return await Promise.all(_.map(easiestSkills, async (skill) => {
     const tube = _.find(tubes, { name: skill.tubeName });
-    const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: skill.tutorialIds, userId });
+    const tutorials = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: skill.tutorialIds, userId, locale });
     return _.map(tutorials, (tutorial) => {
       tutorial.tubeName = tube.name;
       tutorial.tubePracticalTitle = tube.practicalTitle;

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -6,6 +6,7 @@ module.exports = async function getCorrectionForAnswer({
   correctionRepository,
   answerId,
   userId,
+  locale,
 } = {}) {
   const integerAnswerId = parseInt(answerId);
   if (!Number.isFinite(integerAnswerId)) {
@@ -20,8 +21,7 @@ module.exports = async function getCorrectionForAnswer({
 
   _validateCorrectionIsAccessible(assessment, userId, integerAnswerId);
 
-  return correctionRepository.getByChallengeId({ challengeId: answer.challengeId, userId });
-
+  return correctionRepository.getByChallengeId({ challengeId: answer.challengeId, userId, locale });
 };
 
 function _validateCorrectionIsAccessible(assessment) {

--- a/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tutorial-datasource.js
@@ -14,6 +14,7 @@ module.exports = datasource.extend({
     'Lien',
     'Source',
     'Titre',
+    'Langue'
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -24,6 +25,7 @@ module.exports = datasource.extend({
       link: airtableRecord.get('Lien'),
       source: airtableRecord.get('Source'),
       title: airtableRecord.get('Titre'),
+      locale: airtableRecord.get('Langue'),
     };
   },
 

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -9,13 +9,13 @@ const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
 
 module.exports = {
 
-  async getByChallengeId({ challengeId, userId }) {
+  async getByChallengeId({ challengeId, userId, locale }) {
     const challenge = await challengeDatasource.get(challengeId);
     const skills = await _getSkills(challenge);
     const hints = await _getHints(skills);
 
-    const tutorials = await _getTutorials(userId, skills, 'tutorialIds');
-    const learningMoreTutorials = await _getTutorials(userId, skills, 'learningMoreTutorialIds');
+    const tutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'tutorialIds', locale });
+    const learningMoreTutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'learningMoreTutorialIds', locale });
 
     return new Correction({
       id: challenge.id,
@@ -50,13 +50,13 @@ function _convertSkillsToHints(skillDataObjects) {
   });
 }
 
-async function _getTutorials(userId, skills, tutorialIdsProperty) {
+async function _getTutorials({ userId, skills, tutorialIdsProperty, locale }) {
   const tutorialsIds = _(skills)
     .map((skill) => skill[tutorialIdsProperty])
     .filter((tutorialId) => !_.isEmpty(tutorialId))
     .flatten()
     .uniq()
     .value();
-  return tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialsIds, userId });
+  return tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialsIds, userId, locale });
 }
 

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -1,6 +1,7 @@
 const { expect, generateValidRequestAuthorizationHeader, airtableBuilder, databaseBuilder } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const { FRENCH_FRANCE } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Acceptance | Controller | answer-controller-get-correction', () => {
 
@@ -15,6 +16,8 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
     let assessment = null;
     let answer = null;
     let userId;
+    let englishTutorial;
+    let frenchTutorial;
 
     before(() => {
       const challenge = airtableBuilder.factory.buildChallenge({
@@ -27,17 +30,20 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       });
       airtableBuilder.mockList({ tableName: 'Epreuves' }).returns([challenge]).activate();
 
+      englishTutorial = airtableBuilder.factory.buildTutorial({ id: 'english-tutorial-id', langue: 'en-us' });
+      frenchTutorial = airtableBuilder.factory.buildTutorial({ id: 'french-tutorial-id', langue: 'fr-fr' });
+      airtableBuilder.mockList({ tableName: 'Tutoriels' }).returns([englishTutorial, frenchTutorial]).activate();
+
       const skill = airtableBuilder.factory.buildSkill({
         id: 'q_first_acquis',
         nom: '@web3',
         indice: 'Indice web3',
         statutDeLIndice: 'Validé',
-        compétenceViaTube: 'recABCD'
+        compétenceViaTube: 'recABCD',
+        comprendre: [englishTutorial.id, frenchTutorial.id],
+        enSavoirPlus: [],
       });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([skill]).activate();
-
-      const tutorial = airtableBuilder.factory.buildTutorial();
-      airtableBuilder.mockList({ tableName: 'Tutoriels' }).returns([tutorial]).activate();
     });
 
     after(() => {
@@ -63,42 +69,62 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       await databaseBuilder.commit();
     });
 
-    it('should return the answer correction', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: `/api/answers/${answer.id}/correction`,
-        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
-      };
-
-      const expectedBody = {
-        data: {
-          id: 'q_first_challenge',
-          type: 'corrections',
-          attributes: {
-            solution: 'fromage',
-            hint: 'Indice web3',
+    context('when Accept-Language header is specified', () => {
+      it('should return the answer correction with tutorials restricted to given language', async () => {
+        // given
+        const options = {
+          method: 'GET',
+          url: `/api/answers/${answer.id}/correction`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+            'accept-language': FRENCH_FRANCE
           },
-          relationships: {
-            tutorials: {
-              'data': [],
+        };
+
+        const expectedBody = {
+          data: {
+            id: 'q_first_challenge',
+            type: 'corrections',
+            attributes: {
+              solution: 'fromage',
+              hint: 'Indice web3',
             },
-            'learning-more-tutorials': {
-              'data': [],
-            }
+            relationships: {
+              tutorials: {
+                data: [{
+                  id: frenchTutorial.id,
+                  type: 'tutorials',
+                }],
+              },
+              'learning-more-tutorials': {
+                data: [],
+              }
+            },
           },
-        }
-      };
+          included: [{
+            attributes: {
+              duration: '00:03:31',
+              format: 'vidéo',
+              id: 'french-tutorial-id',
+              link: 'http://www.example.com/this-is-an-example.html',
+              source: 'Source Example, Example',
+              title: 'Communiquer',
+            },
+            id: 'french-tutorial-id',
+            type: 'tutorials',
+          }]
+        };
 
-      // when
-      const response = await server.inject(options);
+        // when
+        const response = await server.inject(options);
 
-      // then
-      expect(response.statusCode).to.equal(200);
-      expect(response.result).to.deep.equal(expectedBody);
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result).to.deep.equal(expectedBody);
+      });
     });
 
-    it('should return 404 when user does not has access to this answer', async () => {
+    it('should return 404 when user does not have access to this answer', async () => {
       // given
       const options = {
         method: 'GET',
@@ -129,3 +155,4 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
     });
   });
 });
+

--- a/api/tests/acceptance/application/scorecard-controller_test.js
+++ b/api/tests/acceptance/application/scorecard-controller_test.js
@@ -1,6 +1,7 @@
 const { airtableBuilder, databaseBuilder, expect, knex, generateValidRequestAuthorizationHeader } = require('../../test-helper');
 const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
 const KnowledgeElement = require('../../../lib/domain/models/KnowledgeElement');
+const { FRENCH_SPOKEN } = require('../../../lib/domain/constants').LOCALE;
 
 const createServer = require('../../../server');
 
@@ -206,23 +207,28 @@ describe('Acceptance | Controller | scorecard-controller', () => {
       const tubeWebId = 'recTubeWeb1';
       const tutorialWebId = 'recTutorial1';
       const tutorialWebId2 = 'recTutorial2';
+      const tutorialWebId3 = 'recTutorial3';
 
       beforeEach(async () => {
         databaseBuilder.factory.buildUserTutorial({ id: 10500, userId, tutorialId: tutorialWebId });
         await databaseBuilder.commit();
 
-        options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+        options.headers = {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+          'accept-language': FRENCH_SPOKEN,
+        };
 
         const tutorials = [
-          airtableBuilder.factory.buildTutorial({ id: tutorialWebId }),
-          airtableBuilder.factory.buildTutorial({ id: tutorialWebId2 }),
+          airtableBuilder.factory.buildTutorial({ id: tutorialWebId, langue: 'fr-fr' }),
+          airtableBuilder.factory.buildTutorial({ id: tutorialWebId2, langue: 'fr-fr' }),
+          airtableBuilder.factory.buildTutorial({ id: tutorialWebId3, langue: 'en-us' }),
         ];
 
         const skills = [
           airtableBuilder.factory.buildSkill({
             id: skillWeb1Id,
             nom: skillWeb1Name,
-            'comprendre': [tutorials[0].id, tutorials[1].id],
+            'comprendre': [tutorials[0].id, tutorials[1].id, tutorials[2].id],
             'compétenceViaTube': [competenceId],
           }),
         ];

--- a/api/tests/tooling/airtable-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tutorial.js
@@ -6,6 +6,7 @@ module.exports = function buildTutorial({
   source = 'Source Example, Example',
   lien = 'http://www.example.com/this-is-an-example.html',
   createdTime = '2018-03-15T14:38:03.000Z',
+  langue = 'en-us',
 } = {}) {
 
   return {
@@ -17,6 +18,7 @@ module.exports = function buildTutorial({
       'Durée': duree,
       'Source': source,
       'Lien': lien,
+      'Langue': langue,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/tooling/fixtures/infrastructure/tutorialAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/tutorialAirtableDataObjectFixture.js
@@ -5,6 +5,7 @@ module.exports = function tutorialAirtableDataObjectFixture({
   link = 'https://youtube.fr',
   source = 'Youtube',
   title = 'Comment dresser un panda',
+  locale = 'fr-fr'
 } = {}) {
   return {
     id,
@@ -13,5 +14,6 @@ module.exports = function tutorialAirtableDataObjectFixture({
     link,
     source,
     title,
+    locale,
   };
 };

--- a/api/tests/tooling/fixtures/infrastructure/tutorialRawAirtableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/tutorialRawAirtableFixture.js
@@ -10,6 +10,7 @@ module.exports = function tutorialRawAirTableFixture({ id } = { id: 'receomyzL0A
       'Lien': 'https://youtube.fr',
       'Source': 'Youtube',
       'Titre':'Comment dresser un panda',
+      'Langue': 'fr-fr'
     },
     'createdTime': '2018-01-31T12:41:07.000Z'
   });

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -15,6 +15,7 @@ describe('Unit | Controller | answer-controller', () => {
     sinon.stub(answerRepository, 'findByChallengeAndAssessment');
     sinon.stub(usecases, 'correctAnswerThenUpdateAssessment');
     sinon.stub(requestResponseUtils, 'extractUserIdFromRequest');
+    sinon.stub(requestResponseUtils, 'extractLocaleFromRequest');
   });
 
   describe('#save', () => {
@@ -140,6 +141,7 @@ describe('Unit | Controller | answer-controller', () => {
 
     const answerId = 1;
     const userId = 'userId';
+    const locale = 'lang-country';
 
     beforeEach(() => {
       sinon.stub(usecases, 'getCorrectionForAnswer');
@@ -149,7 +151,8 @@ describe('Unit | Controller | answer-controller', () => {
     it('should return ok', async () => {
       // given
       requestResponseUtils.extractUserIdFromRequest.returns(userId);
-      usecases.getCorrectionForAnswer.withArgs({ answerId, userId }).resolves({});
+      requestResponseUtils.extractLocaleFromRequest.returns(locale);
+      usecases.getCorrectionForAnswer.withArgs({ answerId, userId, locale }).resolves({});
       correctionSerializer.serialize.withArgs({}).returns('ok');
 
       // when

--- a/api/tests/unit/application/scorecards/scorecard-controller_test.js
+++ b/api/tests/unit/application/scorecards/scorecard-controller_test.js
@@ -8,19 +8,22 @@ const scorecardSerializer = require('../../../../lib/infrastructure/serializers/
 const tutorialSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/tutorial-serializer');
 
 describe('Unit | Controller | scorecard-controller', () => {
+  const authenticatedUserId = '12';
+  const scorecardId = 'foo';
+  const locale = 'fr';
 
   describe('#getScorecard', () => {
+    const authenticatedUserId = '12';
 
     const scorecard = { name: 'Competence1' };
 
     beforeEach(() => {
-      sinon.stub(usecases, 'getScorecard').resolves(scorecard);
+      sinon.stub(usecases, 'getScorecard').withArgs({ authenticatedUserId, scorecardId, locale }).resolves(scorecard);
       sinon.stub(scorecardSerializer, 'serialize').resolvesArg(0);
     });
 
     it('should call the expected usecase', async () => {
       // given
-      const authenticatedUserId = '12';
       const scorecardId = 'foo';
       const locale = 'fr';
 
@@ -40,19 +43,15 @@ describe('Unit | Controller | scorecard-controller', () => {
       const result = await scorecardController.getScorecard(request, hFake);
 
       // then
-      expect(usecases.getScorecard).to.have.been.calledWith({ authenticatedUserId, scorecardId, locale });
       expect(result).to.be.equal(scorecard);
     });
   });
 
   describe('#findTutorials', () => {
-    const authenticatedUserId = '12';
-    const scorecardId = 'foo';
-
     const tutorials = [];
 
     beforeEach(() => {
-      sinon.stub(usecases, 'findTutorials').withArgs({ authenticatedUserId, scorecardId }).resolves(tutorials);
+      sinon.stub(usecases, 'findTutorials').withArgs({ authenticatedUserId, scorecardId, locale }).resolves(tutorials);
       sinon.stub(tutorialSerializer, 'serialize').withArgs(tutorials).resolves('ok');
     });
 
@@ -67,13 +66,13 @@ describe('Unit | Controller | scorecard-controller', () => {
         params: {
           id: scorecardId,
         },
+        headers: { 'accept-language': locale }
       };
 
       // when
       const result = await scorecardController.findTutorials(request, hFake);
 
       // then
-      expect(usecases.findTutorials).to.have.been.calledWith({ authenticatedUserId, scorecardId });
       expect(result).to.be.equal('ok');
     });
   });

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | find-tutorials', () => {
   let tubeRepository;
   let tutorialRepository;
   let userTutorialRepository;
+  let locale;
 
   beforeEach(() => {
     scorecardId = '1_recabC123';
@@ -25,6 +26,7 @@ describe('Unit | UseCase | find-tutorials', () => {
     skillRepository = { findActiveByCompetenceId: sinon.stub() };
     tubeRepository = { findByNames: sinon.stub() };
     tutorialRepository = { findByRecordIdsForCurrentUser: sinon.stub() };
+    locale = 'lang-country';
   });
 
   afterEach(() => {
@@ -51,6 +53,7 @@ describe('Unit | UseCase | find-tutorials', () => {
           skillRepository,
           tubeRepository,
           tutorialRepository,
+          locale,
         });
 
         // then
@@ -103,8 +106,8 @@ describe('Unit | UseCase | find-tutorials', () => {
 
           const inferredTutorialIdList = [inferredTutorial.id];
 
-          tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: tutorialIdList1, userId: authenticatedUserId }).returns([tutorial1, tutorial2]);
-          tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: tutorialIdList2, userId: authenticatedUserId }).returns([tutorial3]);
+          tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: tutorialIdList1, userId: authenticatedUserId, locale }).returns([tutorial1, tutorial2]);
+          tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: tutorialIdList2, userId: authenticatedUserId, locale }).returns([tutorial3]);
 
           tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: inferredTutorialIdList, userId: authenticatedUserId }).returns([inferredTutorial]);
 
@@ -172,6 +175,7 @@ describe('Unit | UseCase | find-tutorials', () => {
             skillRepository,
             tubeRepository,
             tutorialRepository,
+            locale,
           });
 
           //then

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
   const assessmentId = 1;
   const answerId = 2;
   const challengeId = 12;
+  const locale = 'lang-country';
   let answer;
 
   beforeEach(() => {
@@ -41,6 +42,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
           correctionRepository,
           answerId,
           userId: assessment.userId,
+          locale,
         });
 
         // then
@@ -58,7 +60,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
         assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 
         const correction = Symbol('A correction');
-        correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId }).resolves(correction);
+        correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId, locale }).resolves(correction);
 
         // when
         const responseSolution = await getCorrectionForAnswer({
@@ -67,6 +69,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
           correctionRepository,
           answerId,
           userId: assessment.userId,
+          locale,
         });
 
         // then
@@ -84,7 +87,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
         assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 
         const correction = Symbol('A correction');
-        correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId }).resolves(correction);
+        correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId, locale }).resolves(correction);
 
         // when
         const responseSolution = await getCorrectionForAnswer({
@@ -93,6 +96,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
           correctionRepository,
           answerId,
           userId: assessment.userId,
+          locale,
         });
 
         // then
@@ -109,7 +113,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
       assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
 
       const correction = Symbol('A correction');
-      correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId }).resolves(correction);
+      correctionRepository.getByChallengeId.withArgs({ challengeId, userId: assessment.userId, locale }).resolves(correction);
 
       // when
       const result = await getCorrectionForAnswer({
@@ -118,6 +122,7 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
         correctionRepository,
         answerId,
         userId: assessment.userId,
+        locale,
       });
 
       // then

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -20,6 +20,7 @@ describe('Unit | Repository | correction-repository', function() {
 
     const recordId = 'rec-challengeId';
     const userId = 'userId';
+    const locale = 'lang-country';
 
     const expectedHints = [
       domainBuilder.buildHint({ skillName: '@web2', value: 'Peut-on géo-localiser un lapin sur la banquise ?' }),
@@ -82,11 +83,11 @@ describe('Unit | Repository | correction-repository', function() {
 
         challengeDatasource.get.resolves(challengeDataObject);
         skillDatas.forEach((skillData, index) => skillDatasource.get.onCall(index).resolves(skillData));
-        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto1', 'recTuto2'], userId }).resolves(expectedTutorials);
-        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto3', 'recTuto4'], userId }).resolves(expectedLearningMoreTutorials);
+        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto1', 'recTuto2'], userId, locale }).resolves(expectedTutorials);
+        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto3', 'recTuto4'], userId, locale }).resolves(expectedLearningMoreTutorials);
 
         // when
-        promise = correctionRepository.getByChallengeId({ challengeId: recordId, userId });
+        promise = correctionRepository.getByChallengeId({ challengeId: recordId, userId, locale });
       });
 
       it('should return a correction with the solution', function() {
@@ -145,11 +146,11 @@ describe('Unit | Repository | correction-repository', function() {
 
         challengeDatasource.get.resolves(challengeDataObject);
         skillDatas.forEach((skillData, index) => skillDatasource.get.onCall(index).resolves(skillData));
-        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto1'], userId }).resolves([expectedTutorials[0]]);
-        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto3'], userId }).resolves([expectedLearningMoreTutorials[0]]);
+        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto1'], userId, locale }).resolves([expectedTutorials[0]]);
+        tutorialRepository.findByRecordIdsForCurrentUser.withArgs({ ids: ['recTuto3'], userId, locale }).resolves([expectedLearningMoreTutorials[0]]);
 
         // when
-        promise = correctionRepository.getByChallengeId({ challengeId: recordId, userId });
+        promise = correctionRepository.getByChallengeId({ challengeId: recordId, userId, locale });
       });
 
       it('should return a correction with deduplicated tutorials', function() {

--- a/api/tests/unit/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/tutorial-repository_test.js
@@ -25,15 +25,17 @@ describe('Unit | Repository | tutorial-repository', () => {
       link: 'https://youtube.fr',
       source: 'Youtube',
       title: 'Comment dresser un panda',
+      locale: 'fr-fr',
     };
 
     tutorialData2 = {
       id: 'recTutorial2',
       duration: '00:04:30',
       format: 'page',
-      link: 'https://youtube.fr',
+      link: 'https://youtube.com',
       source: 'Youtube',
-      title: 'Comment dresser un lama',
+      title: 'How to raise a lama',
+      locale: 'en-us',
     };
 
     expectedTutorial = new Tutorial({
@@ -49,9 +51,9 @@ describe('Unit | Repository | tutorial-repository', () => {
       id: 'recTutorial2',
       duration: '00:04:30',
       format: 'page',
-      link: 'https://youtube.fr',
+      link: 'https://youtube.com',
       source: 'Youtube',
-      title: 'Comment dresser un lama',
+      title: 'How to raise a lama',
     });
 
     userId = 'userId';
@@ -99,23 +101,46 @@ describe('Unit | Repository | tutorial-repository', () => {
         .resolves([userTutorial]);
     });
 
-    it('should return a list of Domain Tutorial objects', async () => {
-      // given
-      const tutorialIds = ['recTutorial1', 'recTutorial2'];
-      expectedTutorial.tutorialEvaluation = tutorialEvaluation;
-      expectedTutorial.userTutorial = userTutorial;
-      const expectedTutorialList = [
-        expectedTutorial,
-        expectedTutorial2
-      ];
+    context('locale is defined', () => {
+      it('should return a list of Domain Tutorial objects restricted to given locale', async () => {
+        // given
+        const locale = 'en';
+        const tutorialIds = ['recTutorial1', 'recTutorial2'];
+        expectedTutorial.tutorialEvaluation = tutorialEvaluation;
+        expectedTutorial.userTutorial = userTutorial;
+        const expectedTutorialList = [
+          expectedTutorial2
+        ];
 
-      // when
-      const fetchedTutorialList = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialIds, userId });
+        // when
+        const fetchedTutorialList = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialIds, userId, locale });
 
-      // then
-      expect(fetchedTutorialList[0]).to.be.an.instanceOf(Tutorial);
-      expect(fetchedTutorialList[1]).to.be.an.instanceOf(Tutorial);
-      expect(fetchedTutorialList).to.deep.equal(expectedTutorialList);
+        // then
+        expect(fetchedTutorialList[0]).to.be.an.instanceOf(Tutorial);
+        expect(fetchedTutorialList).to.deep.equal(expectedTutorialList);
+      });
+    });
+
+    context('locale is not defined', () => {
+      it('should return a list of Domain Tutorial objects', async () => {
+        // given
+        const locale = undefined;
+        const tutorialIds = ['recTutorial1', 'recTutorial2'];
+        expectedTutorial.tutorialEvaluation = tutorialEvaluation;
+        expectedTutorial.userTutorial = userTutorial;
+        const expectedTutorialList = [
+          expectedTutorial,
+          expectedTutorial2
+        ];
+
+        // when
+        const fetchedTutorialList = await tutorialRepository.findByRecordIdsForCurrentUser({ ids: tutorialIds, userId, locale });
+
+        // then
+        expect(fetchedTutorialList[0]).to.be.an.instanceOf(Tutorial);
+        expect(fetchedTutorialList[1]).to.be.an.instanceOf(Tutorial);
+        expect(fetchedTutorialList).to.deep.equal(expectedTutorialList);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Bien qu'il soit possible de change de langue sur `app.pix.fr`, les tutoriaux proposés ne sont pas restreints à la langue courrante.

## :robot: Solution
Prendre en compte le header `Accept-Language` lors de la récupération des tutoriaux.

## :rainbow: Remarques
Le filtrage des tutoriaux par langue n'est pas effectué sur la page `Mes Tutos`. On laisse la possiblité pour un utilisateur qui aurait enregistré des tutoriaux puis aurait changé de langue de pouvoir les retrouver dans sa  liste.

## :100: Pour tester
Faire une évaluation en français.
Vérifier que les tutos proposés en cas d'échec sont en français.

Faire une évaluation en anglais (en ajoutant `?lang=en` à la fin de l'url).
Vérifier que les tutos proposés en cas d'échec sont en anglais.

Vérifier ques les tutos proposés sur la page de détail de compétences sont dans le même langue que celle choisie.

Tuto en anglais dispo sur:
app-pr1705.review.pix.fr/challenges/rec2T3CyDv6gcfvJg/preview?lang=en
