### PR TITLE
[FEATURE] Traduction des pages concernant la réinitialisation de mot de passe (PIX-790).

### DIFF
--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -6,8 +6,9 @@ const _ = require('lodash');
 
 @classic
 export default class ResetPasswordRoute extends Route {
-  @service session;
   @service errors;
+  @service intl;
+  @service session;
 
   async model(params) {
     const passwordResetTemporaryKey = params.temporary_key;
@@ -17,7 +18,7 @@ export default class ResetPasswordRoute extends Route {
     } catch (error) {
       const status = _.get(error, 'errors[0].status');
       if (status && (status === 401 || status && 404)) {
-        this.errors.push('Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.');
+        this.errors.push(this.intl.t('pages.reset-password.error'));
         this.replaceWith('password-reset-demand');
       }
     }

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -6,16 +6,16 @@
 
   <div class="sign-form__header">
     {{#unless this.hasSucceeded}}
-      <h1 class="sign-form-title">Mot de passe oublié ?</h1>
+      <h1 class="sign-form-title">{{t 'pages.password-reset-demand.title'}}</h1>
       <div class="sign-form-header__instruction sign-form-header__instruction--short sign-form-subtitle">
-        Entrez votre adresse e-mail ci-dessous, et c'est repartix
+        {{t 'pages.password-reset-demand.subtitle'}}
       </div>
     {{/unless}}
   </div>
 
   {{#if this.hasFailed}}
     <div class="sign-form__notification-message sign-form__notification-message--error" aria-live="polite">
-      Cette adresse e-mail ne correspond à aucun compte
+      {{t 'pages.password-reset-demand.error.message'}}
     </div>
   {{/if}}
 
@@ -26,16 +26,15 @@
   {{/if}}
 
   {{#if this.hasSucceeded}}
-    <div class="sign-form-header__instruction sign-form-subtitle">Demande de réinitialisation de mot de passe</div>
+    <div class="sign-form-header__instruction sign-form-subtitle">{{t 'pages.password-reset-demand.succeed.subtitle'}}</div>
 
     <div class="password-reset-demand-form__body" aria-live="polite">
-      <span class="password-reset-demand-body__text sign-form-text">Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe
-        vous a été envoyé à l’adresse e-mail {{this.email}}.</span>
-      <span class="password-reset-demand-body__text sign-form-text">Si vous ne recevez pas cet e-mail, vérifiez vos courriers indésirables.</span>
+      <span class="password-reset-demand-body__text sign-form-text">{{t 'pages.password-reset-demand.succeed.instructions' email=this.email}}</span>
+      <span class="password-reset-demand-body__text sign-form-text">{{t 'pages.password-reset-demand.succeed.help'}}</span>
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{this.homeUrl}} class="link" title="Lien vers la page d'accueil de Pix">Retour à l'accueil</a>
+      <a href={{this.homeUrl}} class="link" title="Lien vers la page d'accueil de Pix">{{t 'pages.password-reset-demand.actions.back-home'}}</a>
     </div>
   {{else}}
     <form {{on 'submit' this.savePasswordResetDemand}} class="sign-form__body">
@@ -48,7 +47,7 @@
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
         {{#if this.isButtonEnabled}}
           <button type="submit" class="button button--uppercase button--thin button--round">
-            Réinitialiser mon mot de passe
+           {{t 'pages.password-reset-demand.actions.reset'}}
           </button>
         {{else}}
           <button type="button" disabled class="button button--uppercase button--thin button--round button--big">
@@ -56,7 +55,7 @@
           </button>
         {{/if}}
         <LinkTo @route="login" class="link link--grey sign-form-link password-reset-demand-form__cancel-link">
-          Retour à la page de connexion
+          {{t 'pages.password-reset-demand.actions.back-sign-in'}}
         </LinkTo>
       </div>
 

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -8,7 +8,7 @@
     <h1 class="sign-form-title">{{@user.fullName}}</h1>
 
     {{#unless this.hasSucceeded}}
-      <div class="sign-form-header__instruction sign-form-subtitle">Saisissez votre nouveau mot de passe</div>
+      <div class="sign-form-header__instruction sign-form-subtitle">{{t 'pages.reset-password.instruction'}}</div>
     {{/unless}}
   </div>
 
@@ -26,7 +26,7 @@
 
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
         <button type="submit" class="button button--uppercase button--thin button--round button--big">
-          envoyer
+          {{t 'pages.reset-password.actions.submit'}}
         </button>
       </div>
 
@@ -36,11 +36,11 @@
   {{#if this.hasSucceeded}}
     <div class="sign-form__body">
       <div class="password-reset-demand-form__body password-reset-demand-form__body--centered sign-form-text" aria-live="polite">
-        Votre mot de passe a été modifié avec succès.
+        {{t 'pages.reset-password.succeed'}}
       </div>
       <div class="sign-form-body__bottom-button sign-form-body__bottom-button--big">
         <LinkTo @route="login" class="button button--link button--uppercase button--thin button--round">
-          connectez-vous
+          {{t 'pages.reset-password.actions.sign-in'}}
         </LinkTo>
       </div>
     </div>

--- a/mon-pix/app/templates/password-reset-demand.hbs
+++ b/mon-pix/app/templates/password-reset-demand.hbs
@@ -1,4 +1,4 @@
-{{page-title 'Oubli de mot de passe'}}
+{{page-title (t 'pages.password-reset-demand.page-title')}}
 <div class="sign-form-page">
   <PasswordResetDemandForm />
 </div>

--- a/mon-pix/app/templates/reset-password.hbs
+++ b/mon-pix/app/templates/reset-password.hbs
@@ -1,4 +1,4 @@
-{{page-title 'Changer mon mot de passe'}}
+{{page-title (t 'pages.reset-password.title')}}
 <div class="sign-form-page">
   <ResetPasswordForm @user={{@model.user}} @temporaryKey={{@model.temporaryKey}} />
 </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -468,6 +468,17 @@
       "explanation": "You have already sent the profile below to the organization {organization} '<br>' on {date,date,LL} at {hour,time,hhmm}"
     },
 
+    "reset-password": {
+      "title": "Changer mon mot de passe",
+      "actions": {
+        "submit": "Envoyer",
+        "sign-in": "Connectez-vous"
+      },
+      "error": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+      "instruction": "Saisissez votre nouveau mot de passe",
+      "succeed": "Votre mot de passe a été modifié avec succès."
+    },
+
     "result-item": {
       "aband": "No answer",
       "actions": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -417,6 +417,25 @@
       "obtained-level": "Level { level } obtained!"
     },
 
+    "password-reset-demand": {
+      "title": "Mot de passe oublié ?",
+      "actions": {
+        "back-home": "Retour à l'accueil",
+        "back-sign-in": "Retour à la page de connexion",
+        "reset": "Réinitialiser mon mot de passe"
+      },
+      "error": {
+        "message": "Cette adresse e-mail ne correspond à aucun compte"
+      },
+      "page-title": "Oubli de mot de passe",
+      "subtitle": "Entrez votre adresse e-mail ci-dessous, et c'est repartix",
+      "succeed": {
+        "help": "Si vous ne recevez pas cet e-mail, vérifiez vos courriers indésirables.",
+        "instructions": "Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe\n vous a été envoyé à l’adresse e-mail {email}.",
+        "subtitle": "Demande de réinitialisation de mot de passe"
+      }
+    },
+
     "profile": {
       "title": "Your profile",
       "competence-card": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -468,6 +468,17 @@
       "explanation": "Vous avez déjà envoyé le profil ci-dessous à l'organisation {organization}'<br>'le {date,date,LL} à {hour,time,hhmm}"
     },
 
+    "reset-password": {
+      "title": "Changer mon mot de passe",
+      "actions": {
+        "submit": "Envoyer",
+        "sign-in": "Connectez-vous"
+      },
+      "error": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+      "instruction": "Saisissez votre nouveau mot de passe",
+      "succeed": "Votre mot de passe a été modifié avec succès."
+    },
+
     "result-item": {
       "aband": "Sans réponse",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -417,6 +417,25 @@
       "obtained-level": "Niveau { level } gagné !"
     },
 
+    "password-reset-demand": {
+      "title": "Mot de passe oublié ?",
+      "actions": {
+        "back-home": "Retour à l'accueil",
+        "back-sign-in": "Retour à la page de connexion",
+        "reset": "Réinitialiser mon mot de passe"
+      },
+      "error": {
+        "message": "Cette adresse e-mail ne correspond à aucun compte"
+      },
+      "page-title": "Oubli de mot de passe",
+      "subtitle": "Entrez votre adresse e-mail ci-dessous, et c'est repartix",
+      "succeed": {
+        "help": "Si vous ne recevez pas cet e-mail, vérifiez vos courriers indésirables.",
+        "instructions": "Un e-mail contenant la démarche à suivre afin de réinitialiser votre mot de passe\n vous a été envoyé à l’adresse e-mail {email}.",
+        "subtitle": "Demande de réinitialisation de mot de passe"
+      }
+    },
+
     "profile": {
       "title": "Votre profil",
       "competence-card": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -413,6 +413,10 @@
       "info": "Ces liens vers les tutos ont été proposés par des utilisateurs de Pix."
     },
 
+    "levelup-notif": {
+      "obtained-level": "Niveau { level } gagné !"
+    },
+
     "profile": {
       "title": "Votre profil",
       "competence-card": {
@@ -443,10 +447,6 @@
         "continue": "Continuez votre expérience Pix"
       },
       "explanation": "Vous avez déjà envoyé le profil ci-dessous à l'organisation {organization}'<br>'le {date,date,LL} à {hour,time,hhmm}"
-    },
-
-    "levelup-notif": {
-      "obtained-level": "Niveau { level } gagné !"
     },
 
     "result-item": {


### PR DESCRIPTION
## :unicorn: Problème
Les pages concernant la réinitialisation de mot de passe ne sont pas traduites. 

## :robot: Solution
Traduire les pages.

## :rainbow: Pour tester
Vérifier les pages : 
- /mot-de-passe-oublie
- /changer-mot-de-passe

