### PR TITLE
[BUGFIX] Réduire la taille des noms des compétences dans pix orga à 14px (PIX-1041)

### DIFF
--- a/orga/app/styles/globals/competences.scss
+++ b/orga/app/styles/globals/competences.scss
@@ -8,7 +8,7 @@
     position: relative;
     padding-left: 1rem;
     font-family: $open-sans;
-    font-size: 1rem;
+    font-size: 0.875rem;
     font-weight: 600;
     color: $grey-80;
   }


### PR DESCRIPTION
## :unicorn: Problème
La taille des noms des compétences est trop imposant

## :robot: Solution
Modification de la propriété __name de la classe competences-col dans le fichier competences.scss à 14px

## :rainbow: Remarques
RAS.

## :100: Pour tester
Aller sur Orga > campagne > résultats collectifs et dans les résultats d'un participant ayant terminé son test.
