### PR TITLE
[CLEANUP] Résoudre le test non déterministe de `improvement-service`.

### DIFF
--- a/api/lib/domain/services/improvement-service.js
+++ b/api/lib/domain/services/improvement-service.js
@@ -1,16 +1,14 @@
 const constants = require('../constants');
-const _ = require('lodash');
 const moment = require('moment');
 
 function _keepKnowledgeElementsRecentOrValidated({ currentUserKnowledgeElements, assessment }) {
   const startedDateOfAssessment = assessment.createdAt;
 
-  const retriableKnowledgeElements = _.filter(currentUserKnowledgeElements, (knowledgeElement) => {
+  return currentUserKnowledgeElements.filter((knowledgeElement) => {
     const isOldEnoughToBeImproved = moment(startedDateOfAssessment)
-      .diff(knowledgeElement.createdAt, 'days', true) >= constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
-    return knowledgeElement.isInvalidated && isOldEnoughToBeImproved;
+      .diff(knowledgeElement.createdAt, 'days', true) < constants.MINIMUM_DELAY_IN_DAYS_BEFORE_IMPROVING;
+    return knowledgeElement.isValidated || isOldEnoughToBeImproved;
   });
-  return _.difference(currentUserKnowledgeElements, retriableKnowledgeElements);
 }
 
 function filterKnowledgeElementsIfImproving({ knowledgeElements, assessment }) {

--- a/api/tests/unit/domain/services/improvement-service_test.js
+++ b/api/tests/unit/domain/services/improvement-service_test.js
@@ -1,5 +1,4 @@
 const { expect, domainBuilder } = require('../../../test-helper');
-const moment = require('moment');
 const _ = require('lodash');
 
 const improvementService = require('../../../../lib/domain/services/improvement-service');
@@ -24,24 +23,29 @@ describe('Unit | Service | ImprovementService', () => {
     context('when assessment is improving', () => {
       let assessment, oldKnowledgeElementsValidated, oldKnowledgeElementsInvalidated, recentKnowledgeElements;
       beforeEach(() => {
-        assessment = domainBuilder.buildAssessment.ofTypeCampaign({ state: 'started', isImproving: true, createdAt: moment().format() });
+        const assessmentDate = '2020-07-30';
+        const fiveDaysBeforeAssesmentDate = '2020-07-25';
+        const fourDaysBeforeAssesmentDate = '2020-07-26';
+        const twoDaysBeforeAssesmentDate = '2020-07-28';
+        const twoDaysAfterAssesmentDate = '2020-08-02';
+        assessment = domainBuilder.buildAssessment.ofTypeCampaign({ state: 'started', isImproving: true, createdAt: assessmentDate });
         oldKnowledgeElementsValidated = [
-          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: moment().subtract(5, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: moment().subtract(5, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: moment().subtract(5, 'days').format() }),
+          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: fiveDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: fiveDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: fiveDaysBeforeAssesmentDate }),
         ];
 
         oldKnowledgeElementsInvalidated = [
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(5, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(5, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(5, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(4, 'days').format() }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: fiveDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: fiveDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: fiveDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: fourDaysBeforeAssesmentDate }),
         ];
         recentKnowledgeElements = [
-          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: moment().subtract(2, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(2, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().subtract(2, 'days').format() }),
-          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: moment().add(6, 'days').format() }),
+          domainBuilder.buildKnowledgeElement({ status: 'validated', createdAt: twoDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: twoDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: twoDaysBeforeAssesmentDate }),
+          domainBuilder.buildKnowledgeElement({ status: 'invalidated', createdAt: twoDaysAfterAssesmentDate }),
         ];
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Les tests de `improvement-service` ne sont pas déterministe (cf : [ici](https://app.circleci.com/pipelines/github/1024pix/pix/13365/workflows/9e3fe33a-3fed-4c02-9313-b574e2397f11/jobs/127572)) 

## :robot: Solution
Enlever l'utilisation de la librairie moment dans les tests

## :rainbow: Remarques
Un refacto de la méthode `_keepKnowledgeElementsRecentOrValidated` a été fait au passage. 

