### PR TITLE
[BUGFIX] La barre de progression dans Pix Orga n'a pas la bonne proportion (PIX-1033)

### DIFF
--- a/orga/app/components/progress-bar.js
+++ b/orga/app/components/progress-bar.js
@@ -3,6 +3,6 @@ import { htmlSafe } from '@ember/string';
 
 export default class ProgressBar extends Component {
   get progressBarStyle() {
-    return htmlSafe(`width: ${this.args.value}px`);
+    return htmlSafe(`width: ${this.args.value}%`);
   }
 }

--- a/orga/tests/integration/components/progress-bar-test.js
+++ b/orga/tests/integration/components/progress-bar-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | progress-bar', function(hooks) {
+  setupRenderingTest(hooks);
+
+  module('Component rendering', function() {
+    test('should render the component with the given value', async function(assert) {
+      // given
+      this.set('value', 80);
+
+      // when
+      await render(hbs`<ProgressBar @value={{value}} />`);
+
+      // then
+      assert.dom('.progress-bar--completion').hasAttribute('style', 'width: 80%');
+    });
+
+    test('should render the component with the given children', async function(assert) {
+      // when
+      await render(hbs`<ProgressBar>Text</ProgressBar>`);
+
+      // then
+      assert.contains('Text');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

La barre de progression dans Pix Orga n'a pas la bonne proportion par rapport à la valeur de l'avancement

## :robot: Solution

La largeur de la barre d'avancement était en pixel au lieu d'être en pourcentage.

## :rainbow: Remarques

Un test a été ajouté pour vérifier ce problème.

## :100: Pour tester

1. Se connecter à Pix Orga avec le compte pro@example.net
2. Aller sur une campagne d'évaluation
3. Sélection un participant qui a envoyé ses résultats
4. Vérifier la barre d'avancement en haut à droite
