### PR TITLE
[A11Y] Ajouter l'icône "Lien extérieur" sur les tutoriaux (PIX-1035)

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -7,6 +7,7 @@
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";
 /* globals */
+@import 'globals/a11y';
 @import 'globals/colors';
 @import 'globals/fonts';
 @import 'globals/breakpoints';

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -26,14 +26,7 @@
   }
 
   a::after {
-    content:'';
-    display:inline-block;
-    margin: 0 0.2rem;
-    height:1rem;
-    width:1rem;
-    background-size: 1rem;
-    background-image: url('/images/icons/external-link-alt.svg');
-    background-repeat: no-repeat;
+    @include external-link;
   }
 }
 

--- a/mon-pix/app/styles/components/_tutorial-item.scss
+++ b/mon-pix/app/styles/components/_tutorial-item.scss
@@ -33,6 +33,10 @@
     @include device-is('tablet') {
       font-weight: $font-medium;
     }
+
+    &::after {
+      @include external-link;
+    }
   }
 
   &__description {

--- a/mon-pix/app/styles/globals/_a11y.scss
+++ b/mon-pix/app/styles/globals/_a11y.scss
@@ -9,3 +9,14 @@
   border: 0;
   display: block;
 }
+
+@mixin external-link {
+  content: '';
+  display: inline-block;
+  margin: 0 0.2rem;
+  height: 1rem;
+  width: 1rem;
+  background-size: 1rem;
+  background-image: url('/images/icons/external-link-alt.svg');
+  background-repeat: no-repeat;
+}


### PR DESCRIPTION
## :unicorn: Problème
Les liens des tutoriaux s'ouvrent dans un nouveau lien, ce qui n'est pas toujours visible pour l'utilisateur. Pour une meilleure compréhension, nous souhaitons ajouter une icône après les liens des tutoriaux.

## :robot: Solution
Réutilisation de l'icone du "Lien extérieur" implémentée dans la PR #1636 pour en faire une mixin Sass.

## :100: Pour tester
- Sur une page de résultats: observer que l'icône du lien extérieur s'affiche
