### PR TITLE
[BUGFIX] Envoyer les e-mails correspondant à la locale à laquelle ils ont été initié (PIX-1069).

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -33,11 +33,12 @@ export default class Application extends JSONAPIAdapter.extend(DataAdapterMixin)
   }
 
   get _locale() {
-    if (this.intl.get('locale') === 'fr') {
+    const currentLocale = this.intl.get('locale')[0];
+    if (currentLocale === 'fr') {
       return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION ?
         FRENCH_LOCALE
         : FRENCHSPOKEN_LOCALE;
     }
-    return this.intl.get('locale');
+    return currentLocale;
   }
 }

--- a/mon-pix/tests/unit/adapters/application-test.js
+++ b/mon-pix/tests/unit/adapters/application-test.js
@@ -42,7 +42,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
     it('should add Accept-Language header set to fr-fr when the current domain contains pix.fr and locale is "fr"', function() {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');
-      applicationAdapter.intl = { get: () => 'fr' };
+      applicationAdapter.intl = { get: () => ['fr'] };
 
       // When
       applicationAdapter.set('currentDomain', { getExtension() { return 'fr'; } });
@@ -54,7 +54,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
     it('should add Accept-Language header set to fr when the current domain contains pix.digital and locale is "fr"', function() {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');
-      applicationAdapter.intl = { get: () => 'fr' };
+      applicationAdapter.intl = { get: () => ['fr'] };
 
       // When
       applicationAdapter.set('currentDomain', { getExtension() { return 'digital'; } });
@@ -68,7 +68,7 @@ describe('Unit | Adapters | ApplicationAdapter', function() {
       const applicationAdapter = this.owner.lookup('adapter:application');
 
       // When
-      applicationAdapter.intl = { get: () => 'en' };
+      applicationAdapter.intl = { get: () => ['en'] };
 
       // Then
       expect(applicationAdapter.headers['Accept-Language']).to.equal('en');


### PR DESCRIPTION
## :unicorn: Problème
Les mails sont envoyés systématiquement avec la locale `fr` donc les url en `.org` 

L'`application-adapter` cherchait la locale grâce `this.intl.get('locale')`. Cependant, celui-ci retourne un tableau, mais dans les tests la méthode a été stubé comme une chaine et donc l'erreur n'a pas été vu.

## :robot: Solution
Prendre le premier élément du tableau que renvoie la méthode `this.intl.get('locale')`.

## :100: Pour tester
Vérifier que le header `Accept-Language` soit bien `fr-fr` sur pix.fr et `fr` sur pix.org