### PR TITLE
[CLEANUP] Retrait de la route dépréciée pour récupérer la liste des participants à une campagne

### DIFF
--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -144,27 +144,6 @@ exports.register = async function(server) {
       }
     },
     {
-      /**
-       * @deprecated in favor of '/api/campaigns/{id}/profiles-collection-participations',
-       */
-      method: 'GET',
-      path: '/api/campaigns/{id}/profiles-collection/participations',
-      config: {
-        validate: {
-          params: Joi.object({
-            id: Joi.number().integer().required()
-          }),
-        },
-        handler: campaignController.findProfilesCollectionParticipations,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Récupération des profils collectés d\'une campagne par son id',
-          '- Route dépréciée en faveur de "/api/campaigns/{id}/profiles-collection-participations"',
-        ],
-        tags: ['api', 'campaign']
-      }
-    },
-    {
       method: 'GET',
       path: '/api/campaigns/{id}/profiles-collection-participations',
       config: {


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR https://github.com/1024pix/pix/pull/1455, afin d'assurer un fonctionnement continu de l'accès aux participants à une campagne, la vieille version de la route a été conservée. Elle a été marquée "dépreciée" à l'époque, en attendant d'être sûre qu'elle ne soit plus utilisée.

## :robot: Solution
De l'eau a coulé sous les ponts, on peut sereinement supprimer la route !

## :rainbow: Remarques
Aucun appel à cette route (d'après Datadog) ce mois passé

## :100: Pour tester
Non régression de l'accès à la liste des participants sur PixOrga
