### PR TITLE
[BUGFIX] Correction du style de titre sur la page Panel (PIX-1037).

### DIFF
--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -10,13 +10,7 @@
 }
 
 .learning-more-panel__hint-title {
-  // XXX Inspired from https://codepen.io/ericrasch/pen/Irlpm
-  position: relative;
-  z-index: 1;
-
-  span {
-    background: white;
-  }
+  @include tutorial-panel-title(white);
 }
 
 .learning-more-panel__tutorial-info {

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -36,36 +36,8 @@
 }
 
 .tutorial-panel__hint-title {
-  font-family: $font-open-sans;
-  font-size: 1.375rem;
-  text-align: center;
-  color: $grey-80;
-  font-weight: $font-semi-bold;
-  margin-bottom: 20px;
+  @include tutorial-panel-title($grey-10);
 
-  // XXX Inspired from https://codepen.io/ericrasch/pen/Irlpm
-  position: relative;
-  z-index: 1;
-
-  &:before {
-    border-top: 2px solid #dfdfdf;
-    content:"";
-    margin: 0 auto;
-    position: absolute;
-    top: 50%; left: 0; right: 0; bottom: 0;
-    width: 100%;
-    z-index: -1;
-  }
-
-  span {
-    background: $grey-10;
-    padding: 0 15px;
-  }
-
-  @include device-is('desktop') {
-    font-size: 1.375rem;
-    line-height: 26px;
-  }
 }
 
 .tutorial-panel__hint-content {

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -11,3 +11,35 @@
   font-family: $font-open-sans;
   color: $grey-200;
 }
+
+@mixin tutorial-panel-title($color) {
+   // XXX Inspired from https://codepen.io/ericrasch/pen/Irlpm
+   font-family: $font-open-sans;
+   font-size: 1.375rem;
+   text-align: center;
+   color: $grey-80;
+   font-weight: $font-semi-bold;
+   margin-bottom: 20px;
+   position: relative;
+   z-index: 1;
+ 
+   &:before {
+     border-top: 2px solid #dfdfdf;
+     content:"";
+     margin: 0 auto;
+     position: absolute;
+     top: 50%; left: 0; right: 0; bottom: 0;
+     width: 100%;
+     z-index: -1;
+   }
+ 
+   span {
+     background: $color;
+     padding: 0 15px;
+   }
+ 
+   @include device-is('desktop') {
+     font-size: 1.375rem;
+     line-height: 26px;
+   }
+}


### PR DESCRIPTION
## :unicorn: Problème
Sur le checkpoint, lorsqu'on affiche le résultat d'une épreuve, on a une partie "Pour réussir la prochaine fois" et "Pour en apprendre davantage". Les deux titres ont un style différent.

## :robot: Solution
Implémentation d'une mixin afin de partager le style aux deux titres avec couleur du background en paramètre. 

## :100: Pour tester
Réaliser une épreuve et cliquer sur "Réponses en tutos" sur la page checkpoint de l'épreuve
