### PR TITLE
[FEATURE] Afficher plus d'informations sur les tutoriels de l'analyse d'une campagne (PIX-1065).

### DIFF
--- a/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
+++ b/orga/app/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row.hbs
@@ -45,6 +45,14 @@
                   <a href={{tutorial.link}} class="link" target="_blank" rel="noopener noreferrer">
                     {{tutorial.title}}
                   </a>
+                  <span class="tube-recommendation-tutorial-table__details">
+                    <strong>·</strong>
+                    Par {{tutorial.source}}
+                    <strong>·</strong>
+                    <span class="tube-recommendation-tutorial-table__format">{{tutorial.format}}</span>
+                    <strong>·</strong>
+                    {{moment-duration tutorial.duration 'minutes'}}
+                  </span>
                 </td>
               </tr>
             {{/each}}

--- a/orga/app/models/tutorial.js
+++ b/orga/app/models/tutorial.js
@@ -3,4 +3,7 @@ import Model, { attr } from '@ember-data/model';
 export default class Tutorial extends Model {
   @attr('string') title;
   @attr('string') link;
+  @attr('string') format;
+  @attr('string') duration;
+  @attr('string') source;
 }

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
@@ -65,4 +65,15 @@
       font-weight: 500;
     }
   }
+
+  &__details {
+    color: $grey-80;
+    font-family: $roboto;
+    font-size: .75rem;
+    font-weight: normal;
+  }
+
+  &__format {
+    text-transform: capitalize;
+  }
 }

--- a/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/details/analysis/tube-recommendation-row-test.js
@@ -17,6 +17,9 @@ module('Integration | Component | routes/authenticated/campaigns/details/analysi
     tutorial1 = store.createRecord('tutorial', {
       title: 'tutorial1',
       link: 'http://link.to.tuto.1',
+      format: 'Vidéo',
+      source: 'Youtube',
+      duration: '00:10:00',
     });
 
     tutorial2 = store.createRecord('tutorial', {
@@ -62,6 +65,9 @@ module('Integration | Component | routes/authenticated/campaigns/details/analysi
     // then
     assert.dom('[aria-hidden="false"]').containsText('1 tuto recommandé par la communauté Pix');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('tutorial1');
+    assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Vidéo');
+    assert.dom('[aria-label="Tutoriel"]:first-child').containsText('10 minutes');
+    assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Par Youtube');
     assert.dom('[aria-expanded="true"]').exists();
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pas d'informations sur les tutoriels dans l'analyse d'une campagne avant de cliquer sur le lien.

## :robot: Solution
Nous avons afficher les détails (source, format et durée) des tutoriels dans l'analyse d'une campagne.

## :100: Pour tester
- Aller sur Pix Orga
- Se connecter avec pro@example.net
- Aller dans la campagne "Campagne 1"
- Aller dans l'onglet "Analyse" et dérouler le sujet "Ouverture avancée de fichiers"
- Constater la présence des détails des tutoriels (source, format et durée)
- Aller dans l'onglet "Participants"
- Cliquer sur "Antoine Boiduvin"
- Aller dans l'onglet "Analyse" et dérouler le sujet "Ouverture avancée de fichiers"
- Constater la présence des détails des tutoriels (source, format et durée)