### PR TITLE
[BUGFIX] Correction d'affichage de l'ampoule sur la page "Réponses et tutos" (PIX-1074)

### DIFF
--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -6,9 +6,14 @@
 
 .tutorial-panel__hint-container-body {
   display: flex;
+  flex-direction: column;
   align-items: center;
   margin-bottom: 10px;
   padding: 20px 0 40px;
+
+  @include device-is('tablet') {
+    flex-direction: row;
+  }
 }
 
 .tutorial-panel__hint-container {
@@ -45,7 +50,7 @@
   font-family: $font-open-sans;
 
   & p {
-    padding-top: 12px;
+    padding: 12px 12px 0px 12px;
   }
 }
 
@@ -55,4 +60,5 @@
 
 .tutorial-panel__hint-picto {
   padding: 0 20px;
+  min-width: 100px;
 }

--- a/mon-pix/app/styles/globals/_text.scss
+++ b/mon-pix/app/styles/globals/_text.scss
@@ -22,7 +22,7 @@
    margin-bottom: 20px;
    position: relative;
    z-index: 1;
- 
+
    &:before {
      border-top: 2px solid #dfdfdf;
      content:"";
@@ -32,12 +32,14 @@
      width: 100%;
      z-index: -1;
    }
- 
+
    span {
      background: $color;
-     padding: 0 15px;
+     display: inline;
+     box-shadow: 15px 0 0 $color, -15px 0 0 $color;
+     box-decoration-break: clone;
    }
- 
+
    @include device-is('desktop') {
      font-size: 1.375rem;
      line-height: 26px;


### PR DESCRIPTION
## :unicorn: Problème
Sur l'écran "Réponses et tutos", la taille de l'ampoule "Pour réussir la prochaine fois"change en fonction de la hauteur du texte descriptif. Elle est des fois illisible.

<img width="349" alt="Capture d’écran 2020-08-03 à 11 53 40" src="https://user-images.githubusercontent.com/36371437/89170883-988b0800-d580-11ea-9317-4e7b511a2c06.png">


## :robot: Solution
Correction du display flex du container et ajout de padding afin d'améliorer le centrage en version mobile

<img width="908" alt="Capture d’écran 2020-08-03 à 11 51 16" src="https://user-images.githubusercontent.com/36371437/89171029-d4be6880-d580-11ea-8027-e877fdf2849f.png">

<img width="369" alt="Capture d’écran 2020-08-03 à 11 51 09" src="https://user-images.githubusercontent.com/36371437/89171051-dbe57680-d580-11ea-9440-55e24b7e3394.png">


## :100: Pour tester
Réaliser un parcours et cliquer sur Réponses et tutos dans une page de mi-parcours.
