### PR TITLE
[TECH] Ecriture d'un script pour générer les snapshots KE pour des participations partagées (PIX-855)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1338,8 +1338,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -2106,8 +2105,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -2351,46 +2349,46 @@
       "dev": true
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -2634,8 +2632,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3812,8 +3809,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -5645,6 +5641,12 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
         "braces": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -5668,6 +5670,17 @@
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
             "readdirp": "~3.2.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
           }
         },
         "debug": {
@@ -5701,6 +5714,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "is-number": {
           "version": "7.0.0",
@@ -5738,6 +5757,26 @@
             "picomatch": "^2.0.4"
           }
         },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
         "supports-color": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
@@ -5763,6 +5802,35 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
           }
         },
         "yargs-parser": {
@@ -6553,7 +6621,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -6579,8 +6646,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pac-proxy-agent": {
       "version": "2.0.0",
@@ -7324,14 +7390,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.17.0",
@@ -8715,8 +8779,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "wide-align": {
       "version": "1.1.3",
@@ -8792,46 +8855,68 @@
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^5.0.0"
           }
         }
       }
@@ -8971,8 +9056,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yamljs": {
       "version": "0.3.0",
@@ -8984,21 +9068,106 @@
       }
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dev": true,
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "yargs-parser": "^18.1.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9006,6 +9175,17 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -9033,6 +9213,35 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
         "yargs-parser": {
           "version": "13.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
@@ -9043,27 +9252,6 @@
             "decamelize": "^1.2.0"
           }
         }
-      }
-    },
-    "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
-      "dev": true,
-      "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
       }
     },
     "z-schema": {

--- a/api/package.json
+++ b/api/package.json
@@ -75,7 +75,8 @@
     "xml-crypto": "~1.0.2",
     "xmldom": "0.3.0",
     "xregexp": "^4.3.0",
-    "yamljs": "^0.3.0"
+    "yamljs": "^0.3.0",
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
@@ -59,13 +59,13 @@ async function getEligibleCampaignParticipations(maxSnapshotCount) {
 
 async function generateKnowledgeElementSnapshots(campaignParticipationData, concurrency) {
   return bluebird.map(campaignParticipationData, async (campaignParticipation) => {
-    const { userId, sharedAt: snappedAt } = campaignParticipation;
-    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: snappedAt });
+    const { userId, sharedAt } = campaignParticipation;
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: sharedAt });
     try {
-      await knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
+      await knowledgeElementSnapshotRepository.save({ userId, snappedAt: sharedAt, knowledgeElements });
     } catch (err) {
       if (err instanceof AlreadyExistingEntity) {
-        console.log(`Un snapshot existe déjà pour l'utilisateur ${userId} à la date ${snappedAt}. Ignoré.`);
+        console.log(`Un snapshot existe déjà pour l'utilisateur ${userId} à la date ${sharedAt}. Ignoré.`);
       } else {
         throw err;
       }

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
@@ -1,0 +1,113 @@
+const bluebird = require('bluebird');
+const { knex } = require('../../db/knex-database-connection');
+const knowledgeElementRepository = require('../../lib/infrastructure/repositories/knowledge-element-repository');
+const knowledgeElementSnapshotRepository = require('../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
+
+const DEFAULT_MAX_SNAPSHOT_COUNT = 5000;
+const DEFAULT_CONCURRENCY = 3;
+
+function _printUsage() {
+  console.log(`
+  node generate-knowledge-element-snapshots-for-active-campaigns.js [OPTIONS]
+    --maxSnapshotCount <count>  : Nombre de snapshots max. à générer (doit être supérieur à 0, défaut: ${DEFAULT_MAX_SNAPSHOT_COUNT})
+    --concurrency <count>       : Concurrence (doit être supérieur à 0, limite 10, défaut: ${DEFAULT_CONCURRENCY})
+    --help ou -h                : Affiche l'aide`);
+}
+
+function _validateAndNormalizeArgs(commandLineArgs) {
+  if (commandLineArgs.find((commandLineArg) => (commandLineArg === '--help' || commandLineArg === '-h'))) {
+    _printUsage();
+    process.exit(0);
+  }
+  const commandLineArgsLength = commandLineArgs.length;
+  const maxSnapshotCountIndicatorIndex = commandLineArgs.findIndex((commandLineArg) => commandLineArg === '--maxSnapshotCount');
+  let maxSnapshotCount;
+  if (maxSnapshotCountIndicatorIndex === -1 || maxSnapshotCountIndicatorIndex + 1 >= commandLineArgsLength) {
+    maxSnapshotCount = DEFAULT_MAX_SNAPSHOT_COUNT;
+  } else {
+    maxSnapshotCount = parseInt(commandLineArgs[maxSnapshotCountIndicatorIndex + 1]);
+    if (isNaN(maxSnapshotCount)) {
+      maxSnapshotCount = DEFAULT_MAX_SNAPSHOT_COUNT;
+    }
+    if (maxSnapshotCount <= 0) {
+      throw new Error(`Nombre max de snapshots ${commandLineArgs[maxSnapshotCountIndicatorIndex + 1]} ne peut pas être inférieur à 1.`);
+    }
+  }
+  const concurrencyIndicatorIndex = commandLineArgs.findIndex((commandLineArg) => commandLineArg === '--concurrency');
+  let concurrency;
+  if (concurrencyIndicatorIndex === -1 || concurrencyIndicatorIndex + 1 >= commandLineArgsLength) {
+    concurrency = DEFAULT_CONCURRENCY;
+  } else {
+    concurrency = parseInt(commandLineArgs[concurrencyIndicatorIndex + 1]);
+    if (isNaN(concurrency)) {
+      concurrency = DEFAULT_CONCURRENCY;
+    }
+    if (concurrency <= 0 || concurrency > 10) {
+      throw new Error(`Concurrent ${commandLineArgs[concurrencyIndicatorIndex + 1]} ne peut pas être inférieur à 1 ni supérieur à 10.`);
+    }
+  }
+
+  return {
+    maxSnapshotCount,
+    concurrency,
+  };
+}
+
+async function getEligibleCampaignParticipations(maxSnapshotCount) {
+  return knex('campaign-participations').select('campaign-participations.userId', 'campaign-participations.sharedAt')
+    .leftJoin('knowledge-element-snapshots', 'knowledge-element-snapshots.userId', 'campaign-participations.userId')
+    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+    .whereNull('campaigns.archivedAt')
+    .whereNotNull('campaign-participations.sharedAt')
+    .where((qb) => {
+      qb.whereNull('knowledge-element-snapshots.snappedAt')
+        .orWhereRaw('?? != ??', ['campaign-participations.sharedAt', 'knowledge-element-snapshots.snappedAt']);
+    })
+    .orderBy('campaign-participations.userId')
+    .limit(maxSnapshotCount);
+}
+
+async function generateKnowledgeElementSnapshots(campaignParticipationData, concurrency) {
+  return bluebird.map(campaignParticipationData, async (campaignParticipation) => {
+    const { userId, sharedAt: snappedAt } = campaignParticipation;
+    const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: snappedAt });
+    return knowledgeElementSnapshotRepository.save({ userId, snappedAt, knowledgeElements });
+  }, { concurrency });
+}
+
+async function main() {
+  try {
+    const commandLineArgs = process.argv.slice(2);
+    console.log('Validation des arguments...');
+    const {
+      maxSnapshotCount,
+      concurrency,
+    } = _validateAndNormalizeArgs(commandLineArgs);
+
+    console.log(`Génération de ${maxSnapshotCount} snapshots avec une concurrence de ${concurrency}`);
+    const campaignParticipationData = await getEligibleCampaignParticipations(maxSnapshotCount);
+
+    console.log(`${campaignParticipationData.length} participations récupérées...`);
+    await generateKnowledgeElementSnapshots(campaignParticipationData, concurrency);
+    console.log('FIN');
+  } catch (error) {
+    console.error(error);
+    _printUsage();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  getEligibleCampaignParticipations,
+  generateKnowledgeElementSnapshots,
+};

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
@@ -1,0 +1,123 @@
+const { expect, databaseBuilder, sinon } = require('../../../test-helper');
+const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
+const {
+  getEligibleCampaignParticipations,
+  generateKnowledgeElementSnapshots,
+} = require('../../../../scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns');
+
+describe('Integration | Scripts | generate-knowledge-element-snapshots-for-active-campaigns.js', () => {
+
+  describe('#getEligibleCampaignParticipations', () => {
+
+    it('should avoid returning campaign participations that are not in active campaigns', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: new Date('2020-01-01') }).id;
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(0);
+    });
+
+    it('should avoid returning campaign participations that are not shared', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: null });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(0);
+    });
+
+    it('should avoid returning campaign participations that already have a corresponding snasphot', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: campaignParticipation.sharedAt, userId });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(0);
+    });
+
+    it('should return shared campaign participations from active campaigns that does not have a corresponding snapshot', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const userId2 = databaseBuilder.factory.buildUser().id;
+      const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId: userId1 });
+      const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-02-01'), userId: userId2 });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2019-01-01'), userId: userId2 });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(2);
+      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation1.userId, sharedAt: campaignParticipation1.sharedAt });
+      expect(campaignParticipationData[1]).to.deep.equal({ userId: campaignParticipation2.userId, sharedAt: campaignParticipation2.sharedAt });
+    });
+
+    it('should return maximum campaign participation as set in the parameter', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
+      const userId1 = databaseBuilder.factory.buildUser().id;
+      const userId2 = databaseBuilder.factory.buildUser().id;
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId: userId1 });
+      databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId: userId2 });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(1);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation.userId, sharedAt: campaignParticipation.sharedAt });
+    });
+  });
+
+  describe('#generateKnowledgeElementSnapshots', () => {
+
+    beforeEach(() => {
+      sinon.stub(knowledgeElementRepository, 'findUniqByUserId');
+      sinon.stub(knowledgeElementSnapshotRepository, 'save');
+    });
+
+    afterEach(() => {
+      knowledgeElementRepository.findUniqByUserId.restore();
+      knowledgeElementSnapshotRepository.save.restore();
+    });
+
+    it('should save snapshots', async () => {
+      // given
+      const concurrency = 1;
+      const campaignParticipationData = [{ userId: 1, sharedAt: new Date('2020-01-01') }];
+      const expectedKnowledgeElements = ['someKnowledgeElements'];
+      knowledgeElementRepository.findUniqByUserId
+        .withArgs({ userId: campaignParticipationData[0].userId, limitDate: campaignParticipationData[0].sharedAt })
+        .resolves(expectedKnowledgeElements);
+
+      // when
+      await generateKnowledgeElementSnapshots(campaignParticipationData, concurrency);
+
+      // then
+      expect(knowledgeElementSnapshotRepository.save).to.have.been.calledWithExactly({
+        userId: campaignParticipationData[0].userId,
+        snappedAt: campaignParticipationData[0].sharedAt,
+        knowledgeElements: expectedKnowledgeElements,
+      });
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
@@ -54,20 +54,32 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
     it('should return shared campaign participations from active campaigns that does not have a corresponding snapshot', async () => {
       // given
       const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
-      const userId1 = databaseBuilder.factory.buildUser().id;
-      const userId2 = databaseBuilder.factory.buildUser().id;
-      const campaignParticipation1 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId: userId1 });
-      const campaignParticipation2 = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-02-01'), userId: userId2 });
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2019-01-01'), userId: userId2 });
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-01-01'), userId });
       await databaseBuilder.commit();
 
       // when
       const campaignParticipationData = await getEligibleCampaignParticipations(5);
 
       // then
-      expect(campaignParticipationData.length).to.equal(2);
-      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation1.userId, sharedAt: campaignParticipation1.sharedAt });
-      expect(campaignParticipationData[1]).to.deep.equal({ userId: campaignParticipation2.userId, sharedAt: campaignParticipation2.sharedAt });
+      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation.userId, sharedAt: campaignParticipation.sharedAt });
+    });
+
+    it('should return shared campaign participations from active campaigns even if there is a snapshot from an anterior date that already exists', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-02-01'), userId });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2019-01-01'), userId });
+      await databaseBuilder.commit();
+
+      // when
+      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+
+      // then
+      expect(campaignParticipationData.length).to.equal(1);
+      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation.userId, sharedAt: campaignParticipation.sharedAt });
     });
 
     it('should return maximum campaign participation as set in the parameter', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Depuis peu, la création d'un snapshot KE à l'issue d'une participation à une campagne (plus précisément au partage des résultats) est en production. Dorénavant, les snapshots vont exister pour ces participations-ci.
En revanche, les participations ayant été partagées avant n'ont pas encore de snapshot associé.

## :robot: Solution
Ecrire un script permettant de générer des snapshots pour ces participations. Le nombre de participations pour lesquelles il va falloir créer un snapshot a été compté à environ 500k participations.
Ce script va générer des snapshots pour les participations n'ayant pas un snapshot associé ET concernant une campagne active.

## :rainbow: Remarques
Script paramétrable sur deux points :
- Nombre de snapshots à créer (si jamais on veut le faire en plusieurs temps)
- Valeur de la concurrency pour la création de snapshots (histoire d'accélérer un peu l'affaire)

Une fois en prod, on pourra essayer de lancer le script avec une petite valeur de snapshots à créer histoire de voir le comportement de l'ensemble et l'impact sur les perfs.
Cela dit, je pense que l'impact ne sera pas très gros :
1. On est en vacances
2. On ne fait que de la lecture sur la table `knowledge-elements` (pas de lock)
3. L'écriture est faite sur `knowledge-element-snapshots`, qui n'est pas si sollicitée que ça pendant ces vacances.

+ réfléchir si exclure les campagnes archivées c'est vraiment nécessaire... on n'est plus à ça près.

## :100: Pour tester
Le lancer en local, de préférence il faut disposer de participations partagées n'ayant pas de snapshot pour en voir les effets.