### PR TITLE
[FEATURE] Empêcher un élève de se réconcilier qu'il ait un compte utilisateur au sein du même établissement ou ailleurs (PIX-983).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -201,7 +201,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.BadRequestError(error.message);
   }
   if (error instanceof DomainErrors.SchoolingRegistrationAlreadyLinkedToUserError) {
-    return new HttpErrors.ConflictError(error.message);
+    return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }
   if (error instanceof DomainErrors.UserNotAuthorizedToUpdatePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -23,8 +23,10 @@ class PreconditionFailedError extends BaseHttpError {
 }
 
 class ConflictError extends BaseHttpError {
-  constructor(message = 'Conflict between request and server state.') {
+  constructor(message = 'Conflict between request and server state.', code, meta) {
     super(message);
+    this.code = code;
+    this.meta = meta;
     this.title = 'Conflict';
     this.status = 409;
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -1,6 +1,8 @@
 class DomainError extends Error {
-  constructor(message) {
+  constructor(message, code, meta) {
     super(message);
+    this.code = code ;
+    this.meta = meta ;
   }
 }
 
@@ -387,8 +389,10 @@ class UserShouldChangePasswordError extends DomainError {
 }
 
 class SchoolingRegistrationAlreadyLinkedToUserError extends DomainError {
-  constructor(message = 'L\'élève est déjà rattaché à un compte utilisateur.') {
+  constructor(message = 'L\'élève est déjà rattaché à un compte utilisateur.', code, meta) {
     super(message);
+    this.code = code;
+    this.meta = meta;
   }
 }
 

--- a/api/lib/domain/services/obfuscation-service.js
+++ b/api/lib/domain/services/obfuscation-service.js
@@ -1,0 +1,42 @@
+const _ = require('lodash');
+
+const CONNEXION_TYPES = {
+  username: 'username',
+  email: 'email',
+  samlId: 'samlId',
+};
+const ASTERISK_OBFUSCATION = '***';
+const USERNAME_SEPARATOR = '.';
+const EMAIL_SEPARATOR = '@';
+
+const TWO_PARTS = 2;
+
+function getUserAuthenticationMethodWithObfuscation(user) {
+  if (user.samlId) return { authenticatedBy: CONNEXION_TYPES.samlId, value: null };
+
+  if (user.username) {
+    const username = usernameObfuscation(user.username);
+    return { authenticatedBy: CONNEXION_TYPES.username, value: username };
+  }
+  if (user.email) {
+    const email = emailObfuscation(user.email);
+    return { authenticatedBy: CONNEXION_TYPES.email, value: email };
+  }
+}
+
+function emailObfuscation(email) {
+  const parts = _.split(email, EMAIL_SEPARATOR, TWO_PARTS);
+  return `${_.first(email)}${ASTERISK_OBFUSCATION}${EMAIL_SEPARATOR}${_.last(parts)}`;
+}
+
+function usernameObfuscation(username) {
+  const parts = _.split(username, USERNAME_SEPARATOR, TWO_PARTS);
+  const name = _.last(parts);
+  return `${_.first(username)}${ASTERISK_OBFUSCATION}${USERNAME_SEPARATOR}${_.first(name)}${ASTERISK_OBFUSCATION}${_.last(name)}`;
+}
+
+module.exports = {
+  usernameObfuscation,
+  emailObfuscation,
+  getUserAuthenticationMethodWithObfuscation
+};

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -13,15 +13,15 @@ const MAX_ACCEPTABLE_RATIO = 0.25;
 
 const STUDENT_RECONCILIATION_ERRORS = {
   IN_OTHER_ORGANIZATION: {
-    samlId: { displayShortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-    username: { displayShortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-    email: { displayShortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+    samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+    username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+    email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
   }
   ,
   IN_SAME_ORGANIZATION: {
-    samlId: { displayShortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-    username: { displayShortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-    email: { displayShortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+    samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+    username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+    email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
   }
 };
 
@@ -65,9 +65,9 @@ async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSc
     const user = await userRepository.getUserAuthenticationMethods(userId);
     const authentificationMethod = getUserAuthenticationMethodWithObfuscation(user);
 
-    const detail = 'Un compte existe déjà pour l\'élève dans le même établissement.';
+    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
     const error = STUDENT_RECONCILIATION_ERRORS.IN_SAME_ORGANIZATION[authentificationMethod.authenticatedBy];
-    const meta = { displayShortCode: error.displayShortCode, value: authentificationMethod.value };
+    const meta = { shortCode: error.shortCode, value: authentificationMethod.value };
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }
 }
@@ -78,9 +78,9 @@ async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(st
     const user = await userRepository.getUserAuthenticationMethods(userId);
     const authentificationMethod = getUserAuthenticationMethodWithObfuscation(user);
 
-    const detail = 'Un compte existe déjà pour l\'élève dans un autre établissement.';
+    const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
     const error = STUDENT_RECONCILIATION_ERRORS.IN_OTHER_ORGANIZATION[authentificationMethod.authenticatedBy];
-    const meta = { displayShortCode: error.displayShortCode, value: authentificationMethod.value };
+    const meta = { shortCode: error.shortCode, value: authentificationMethod.value };
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }
 }

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -73,7 +73,7 @@ async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSc
 }
 
 async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository) {
-  if (!_.isEmpty(student) && !_.isEmpty(student.account)) {
+  if (_.get(student, 'account')) {
     const userId = student.account.userId;
     const user = await userRepository.getUserAuthenticationMethods(userId);
     const authentificationMethod = getUserAuthenticationMethodWithObfuscation(user);

--- a/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
+++ b/api/lib/domain/usecases/create-and-associate-user-to-schooling-registration.js
@@ -91,7 +91,7 @@ module.exports = async function createAndAssociateUserToSchoolingRegistration({
     throw new CampaignCodeError();
   }
 
-  const schoolingRegistrationId = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId: campaign.organizationId, user: userAttributes, schoolingRegistrationRepository });
+  const matchedSchoolingRegistration = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId: campaign.organizationId, user: userAttributes, schoolingRegistrationRepository, userRepository });
 
   const isUsernameMode = userAttributes.withUsername;
   const cleanedUserAttributes = _emptyOtherMode(isUsernameMode, userAttributes);
@@ -100,7 +100,7 @@ module.exports = async function createAndAssociateUserToSchoolingRegistration({
   const encryptedPassword = await _encryptPassword(cleanedUserAttributes.password, encryptionService);
   const domainUser = _createDomainUser(cleanedUserAttributes, encryptedPassword);
 
-  const userId = await userRepository.createAndAssociateUserToSchoolingRegistration({ domainUser, schoolingRegistrationId });
+  const userId = await userRepository.createAndAssociateUserToSchoolingRegistration({ domainUser, schoolingRegistrationId: matchedSchoolingRegistration.id });
 
   const createdUser = await userRepository.get(userId);
   if (!isUsernameMode) {

--- a/api/lib/domain/usecases/generate-username.js
+++ b/api/lib/domain/usecases/generate-username.js
@@ -13,7 +13,7 @@ module.exports = async function generateUsername({
     throw new CampaignCodeError(`Le code campagne ${campaignCode} n'existe pas.`);
   }
 
-  await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId: campaign.organizationId, user, schoolingRegistrationRepository });
+  await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId: campaign.organizationId, user, schoolingRegistrationRepository, userRepository });
 
   return userReconciliationService.createUsernameByUser({ user , userRepository });
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -56,6 +56,7 @@ const dependencies = {
   sessionAuthorizationService: require('../../domain/services/session-authorization-service'),
   sessionRepository: require('../../infrastructure/repositories/session-repository'),
   schoolingRegistrationRepository: require('../../infrastructure/repositories/schooling-registration-repository'),
+  studentRepository: require('../../infrastructure/repositories/student-repository'),
   schoolingRegistrationsXmlService: require('../../domain/services/schooling-registrations-xml-service'),
   higherEducationRegistrationRepository: require('../../infrastructure/repositories/higher-education-registration-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),

--- a/api/lib/infrastructure/repositories/student-repository.js
+++ b/api/lib/infrastructure/repositories/student-repository.js
@@ -31,4 +31,10 @@ module.exports = {
 
     return this._toStudents(results);
   },
+  async getReconciledStudentByNationalStudentId(nationalStudentId) {
+
+    const result = await this.findReconciledStudentsByNationalStudentId([nationalStudentId]);
+
+    return _.isEmpty(result) ? null : result[0];
+  },
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -32,6 +32,16 @@ function _toUserDetailsForAdminDomain(BookshelfUser) {
   });
 }
 
+function _toUserAuthenticationMethods(BookshelfUser) {
+  const rawUser = BookshelfUser.toJSON();
+  return new User({
+    id: rawUser.id,
+    email: rawUser.email,
+    username: rawUser.username,
+    samlId: rawUser.samlId,
+  });
+}
+
 function _toCertificationCenterMembershipsDomain(certificationCenterMembershipBookshelf) {
   return certificationCenterMembershipBookshelf.map((bookshelf) => {
     return new CertificationCenterMembership({
@@ -171,6 +181,19 @@ module.exports = {
       .where({ id: userId })
       .fetch({ require: true, withRelated: ['userOrgaSettings'] })
       .then((user) => bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user))
+      .catch((err) => {
+        if (err instanceof BookshelfUser.NotFoundError) {
+          throw new UserNotFoundError(`User not found for ID ${userId}`);
+        }
+        throw err;
+      });
+  },
+
+  getUserAuthenticationMethods(userId) {
+    return BookshelfUser
+      .where({ id: userId })
+      .fetch({ require: true, columns: ['id','email','username','samlId', ] })
+      .then((userAuthenticationMethods) => _toUserAuthenticationMethods(userAuthenticationMethods))
       .catch((err) => {
         if (err instanceof BookshelfUser.NotFoundError) {
           throw new UserNotFoundError(`User not found for ID ${userId}`);

--- a/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/error-serializer.js
@@ -5,7 +5,9 @@ module.exports = {
     return JSONAPIError({
       status: `${infrastructureError.status}`,
       title: infrastructureError.title,
-      detail: infrastructureError.message
+      detail: infrastructureError.message,
+      code: infrastructureError.code,
+      meta: infrastructureError.meta,
     });
   }
 };

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -80,7 +80,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
           // then
           expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l\'élève dans le même établissement.');
+          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
         });
       });
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -80,7 +80,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
           // then
           expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal('L\'élève est déjà rattaché à un compte utilisateur.');
+          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l\'élève dans le même établissement.');
         });
       });
 

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -57,7 +57,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
       context('When student is already reconciled in the same organization', () => {
 
-        it('should return a schooling registration already linked error (display short code R31 when account with email)', async () => {
+        it('should return a schooling registration already linked error (short code R31 when account with email)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser();
           userWithEmailOnly.username = null;
@@ -71,8 +71,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R31', value: 'j***@example.net' }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R31', value: 'j***@example.net' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -93,7 +93,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (display short code R32 when connected with username)', async () => {
+        it('should return a schooling registration already linked error (short code R32 when connected with username)', async () => {
           // given
           const userWithUsernameOnly = databaseBuilder.factory.buildUser();
           userWithUsernameOnly.username = 'john.harry0702';
@@ -107,8 +107,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R32', value: 'j***.h***2' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
@@ -129,7 +129,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (display short code R33 when account with samlId)', async () => {
+        it('should return a schooling registration already linked error (short code R33 when account with samlId)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser();
           userWithEmailOnly.username = null;
@@ -143,8 +143,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R33', value: null }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R33', value: null }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -166,9 +166,9 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
         });
       });
 
-      context('When student is already reconciled in others organization', () => {
+      context('When student is already reconciled in another organization', () => {
 
-        it('should return a schooling registration already linked error (display short code R11 when account with email)', async () => {
+        it('should return a schooling registration already linked error (short code R11 when account with email)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser();
           userWithEmailOnly.username = null;
@@ -188,8 +188,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R11', value: 'j***@example.net' }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R11', value: 'j***@example.net' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -210,7 +210,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (display short code R12 when connected with username)', async () => {
+        it('should return a schooling registration already linked error (short code R12 when connected with username)', async () => {
           // given
           const userWithUsernameOnly = databaseBuilder.factory.buildUser();
           userWithUsernameOnly.email = null;
@@ -229,8 +229,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R12', value: 'j***.h***2' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
@@ -251,7 +251,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (display short code R13 when account with samlId)', async () => {
+        it('should return a schooling registration already linked error (short code R13 when account with samlId)', async () => {
           // given
           const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
           userWithSamlIdOnly.email = null;
@@ -270,8 +270,8 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R13', value: null }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R13', value: null }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithSamlIdOnly.id);
@@ -624,7 +624,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
     describe('Error cases', () => {
 
-      context('when no schoolingRegistration found to associate because birthdate does not match', () => {
+      context('when no schoolingRegistration can be associated because birthdate does not match', () => {
 
         it('should respond with a 404 - Not Found', async () => {
           // given
@@ -669,7 +669,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
           // then
           expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal('L\'élève est déjà rattaché à un compte utilisateur.');
+          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
         });
       });
 

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -55,6 +55,244 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
         expect(response.statusCode).to.equal(200);
       });
 
+      context('When student is already reconciled in the same organization', () => {
+
+        it('should return a schooling registration already linked error (display short code R31 when account with email)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = 'john.harry@example.net';
+          userWithEmailOnly.samlId = null;
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithEmailOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R31', value: 'j***@example.net' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (display short code R32 when connected with username)', async () => {
+          // given
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
+          userWithUsernameOnly.username = 'john.harry0702';
+          userWithUsernameOnly.email = null;
+          userWithUsernameOnly.samlId = null;
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithUsernameOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (display short code R33 when account with samlId)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = null;
+          userWithEmailOnly.samlId = '12345689';
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithEmailOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R33', value: null }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+      });
+
+      context('When student is already reconciled in others organization', () => {
+
+        it('should return a schooling registration already linked error (display short code R11 when account with email)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = 'john.harry@example.net';
+          userWithEmailOnly.samlId = null;
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithEmailOnly.id;
+
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R11', value: 'j***@example.net' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (display short code R12 when connected with username)', async () => {
+          // given
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
+          userWithUsernameOnly.email = null;
+          userWithUsernameOnly.username = 'john.harry0702';
+          userWithUsernameOnly.samlId = null;
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithUsernameOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (display short code R13 when account with samlId)', async () => {
+          // given
+          const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
+          userWithSamlIdOnly.email = null;
+          userWithSamlIdOnly.username = null;
+          userWithSamlIdOnly.samlId = '12345678';
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithSamlIdOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R13', value: null }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithSamlIdOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+      });
+
       context('when no schoolingRegistration can be associated because birthdate does not match', () => {
 
         it('should return an 404 NotFoundError error', async () => {
@@ -386,7 +624,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
     describe('Error cases', () => {
 
-      context('when no schoolingRegistration can be associated because birthdate does not match', () => {
+      context('when no schoolingRegistration found to associate because birthdate does not match', () => {
 
         it('should respond with a 404 - Not Found', async () => {
           // given

--- a/api/tests/acceptance/application/student-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/student-dependent-user-controller_test.js
@@ -81,7 +81,7 @@ describe('Acceptance | Controller | Student-dependent-user', () => {
 
           // then
           expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l\'élève dans le même établissement.');
+          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
         });
       });
 

--- a/api/tests/acceptance/application/student-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/student-dependent-user-controller_test.js
@@ -81,7 +81,7 @@ describe('Acceptance | Controller | Student-dependent-user', () => {
 
           // then
           expect(response.statusCode).to.equal(409);
-          expect(response.result.errors[0].detail).to.equal('L\'élève est déjà rattaché à un compte utilisateur.');
+          expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l\'élève dans le même établissement.');
         });
       });
 

--- a/api/tests/integration/infrastructure/repositories/student-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/student-repository_test.js
@@ -34,4 +34,38 @@ describe('Integration | Infrastructure | Repository | student-repository', () =>
       expect(students[1].account).to.deep.equal({ userId: thirdAccount.id, updatedAt: thirdAccount.updatedAt, certificationCount: 0 });
     });
   });
+
+  describe('#getReconciledStudentByNationalStudentId', () => {
+
+    it('should return instance of Student', async () => {
+      // given
+      const nationalStudentId = '123456789AB';
+      const account = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildCertificationCourse({ userId: account.id });
+      databaseBuilder.factory.buildCertificationCourse({ userId: account.id });
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: account.id, nationalStudentId: nationalStudentId });
+
+      await databaseBuilder.commit();
+
+      // when
+      const student = await studentRepository.getReconciledStudentByNationalStudentId(nationalStudentId);
+
+      // then
+      expect(student.nationalStudentId).to.equal(nationalStudentId);
+      expect(student.account).to.deep.equal({ userId: account.id, updatedAt: account.updatedAt, certificationCount: 2 });
+    });
+
+    it('should return null when no student found', async () => {
+      // given
+      const nationalStudentId = '000000999B';
+
+      // when
+      const student = await studentRepository.getReconciledStudentByNationalStudentId(nationalStudentId);
+
+      // then
+      expect(student).to.be.null;
+
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -143,6 +143,39 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
   });
 
+  describe('#getUserAuthenticationMethods', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser(userToInsert);
+      await databaseBuilder.commit();
+    });
+
+    it('should return a domain user with authentication methods only when found', async () => {
+      // when
+      const user = await userRepository.getUserAuthenticationMethods(userInDb.id);
+
+      // then
+      expect(user.samlId).to.equal(userInDb.samlId);
+      expect(user.username).to.equal(userInDb.username);
+      expect(user.email).to.equal(userInDb.email);
+
+    });
+
+    it('should throw an error when user not found', async () => {
+      // given
+      const userIdThatDoesNotExist = '99999';
+
+      // when
+      const result = await catchErr(userRepository.getUserAuthenticationMethods)(userIdThatDoesNotExist);
+
+      // then
+      expect(result).to.be.instanceOf(UserNotFoundError);
+    });
+
+  });
+
   describe('get user', () => {
 
     describe('#get', () => {

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -1,0 +1,130 @@
+const { expect } = require('../../../test-helper');
+const { emailObfuscation, usernameObfuscation, getUserAuthenticationMethodWithObfuscation } = require('../../../../lib/domain/services/obfuscation-service');
+const User = require('../../../../lib/domain/models/User');
+describe('Unit | Service | user-authentication-method-obfuscation-service', () => {
+
+  describe('#emailObfuscation', () => {
+
+    it('should return obfuscated email',() => {
+      // Given
+      const email = 'johnHarry@example.net';
+      // When
+      const value = emailObfuscation(email);
+      //Then
+      expect(value).to.be.equal('j***@example.net');
+    });
+
+  });
+
+  describe('#usernameObfuscation', () => {
+
+    it('should return obfuscated username',() => {
+      // Given
+      const username = 'john.harry0702';
+      // When
+      const value = usernameObfuscation(username);
+      //Then
+      expect(value).to.be.equal('j***.h***2');
+    });
+
+  });
+
+  describe('#getUserAuthenticationMethodWithObfuscation', () => {
+
+    it('should return authenticated with samlId when user is authenticated with samlId only',() => {
+      // Given
+      const samlId = '1234567';
+      const user = new User({ samlId });
+      user.samlId = '1234567';
+
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'samlId',
+        value: null,
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should return authenticated with samlId when user is authenticated with samlId and username',() => {
+      // Given
+      const samlId = '1234567';
+      const username = 'john.harry.0702';
+      const user = new User({ samlId, username });
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'samlId',
+        value: null,
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should return authenticated with samlId when user is authenticated with samlId, username and email',() => {
+      // Given
+      const samlId = '1234567';
+      const username = 'john.harry.0702';
+      const email = 'john.harry@example.net';
+
+      const user = new User({ samlId, username, email });
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'samlId',
+        value: null,
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should return authenticated with username when user is authenticated with username only',() => {
+      // Given
+      const username = 'john.harry0702';
+      const user = new User({ username });
+
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'username',
+        value: 'j***.h***2',
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should return authenticated with username when user is authenticated with username and email',() => {
+      // Given
+      const username = 'john.harry0702';
+      const email = 'john.harry@example.net';
+      const user = new User({ username, email });
+
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'username',
+        value: 'j***.h***2',
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+    it('should return authenticated with username when user is authenticated with email only',() => {
+      // Given
+      const email = 'john.harry@example.net';
+      const user = new User({ email });
+
+      // When
+      const value = getUserAuthenticationMethodWithObfuscation(user);
+      //Then
+      const expectedResult = {
+        authenticatedBy : 'email',
+        value: 'j***@example.net',
+      };
+      expect(value).to.be.deep.equal(expectedResult);
+    });
+
+  });
+
+});

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -328,7 +328,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
 
         context('When schoolingRegistration is not already linked', () => {
 
-          it('should return matchedschoolingRegistration', async () => {
+          it('should return matchedSchoolingRegistration', async () => {
             // when
             const result = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId, user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
 

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -328,12 +328,12 @@ describe('Unit | Service | user-reconciliation-service', () => {
 
         context('When schoolingRegistration is not already linked', () => {
 
-          it('should return schoolingRegistrationId', async () => {
+          it('should return matchedschoolingRegistration', async () => {
             // when
             const result = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId, user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
 
             // then
-            expect(result).to.equal(schoolingRegistrations[0].id);
+            expect(result).to.equal(schoolingRegistrations[0]);
           });
         });
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
@@ -25,13 +25,13 @@ describe('Unit | Serializer | JSONAPI | error-serializer', () => {
 
     it('should convert a conflict error object into JSONAPIError', () => {
       // given
-      const error = new ConflictError('error detail', 'code', { displayShortCode: 'displayShortCode', value: 'value' });
+      const error = new ConflictError('error detail', 'code', { shortCode: 'shortCode', value: 'value' });
       const expectedJSONAPIError = JSONAPIError({
         status: '409',
         title: 'Conflict',
         detail: 'error detail',
         code: 'code',
-        meta: { displayShortCode: 'displayShortCode', value: 'value' },
+        meta: { shortCode: 'shortCode', value: 'value' },
       });
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/error-serializer_test.js
@@ -1,6 +1,6 @@
 const { expect } = require('../../../../test-helper');
 const JSONAPIError = require('jsonapi-serializer').Error;
-const { MissingQueryParamError } = require('../../../../../lib/application/http-errors');
+const { MissingQueryParamError, ConflictError } = require('../../../../../lib/application/http-errors');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/error-serializer');
 
 describe('Unit | Serializer | JSONAPI | error-serializer', () => {
@@ -14,6 +14,24 @@ describe('Unit | Serializer | JSONAPI | error-serializer', () => {
         status: '400',
         title: 'Missing Query Parameter',
         detail: 'Missing assessmentId query parameter.'
+      });
+
+      // when
+      const serializedError = serializer.serialize(error);
+
+      // then
+      expect(serializedError).to.deep.equal(expectedJSONAPIError);
+    });
+
+    it('should convert a conflict error object into JSONAPIError', () => {
+      // given
+      const error = new ConflictError('error detail', 'code', { displayShortCode: 'displayShortCode', value: 'value' });
+      const expectedJSONAPIError = JSONAPIError({
+        status: '409',
+        title: 'Conflict',
+        detail: 'error detail',
+        code: 'code',
+        meta: { displayShortCode: 'displayShortCode', value: 'value' },
       });
 
       // when

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -498,11 +498,11 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R31', value: 'j***@example.net' }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R31', value: 'j***@example.net' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l\'adresse mail j***@example.net.' +
-            '<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R31)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l‘adresse mail <br>j***@example.net.<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br> (Code R31)';
+
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -525,10 +525,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R32', value: 'j***.h***2' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec un identifiant sous la forme j***.h***2.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R32)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l‘identifiant<br>j***.h***2.<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br> (Code R32)';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -551,10 +551,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R33', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R33', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -577,10 +577,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R33', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R33', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -603,10 +603,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R33', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R33', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -629,10 +629,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R33', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R33', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -655,10 +655,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
-            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'R32', value: 'j***.h***2' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec un identifiant sous la forme j***.h***2.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R32)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l‘identifiant<br>j***.h***2.<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br> (Code R32)';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -685,10 +685,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R11', value: 'j***@example.net' }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R11', value: 'j***@example.net' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l’adresse e-mail j***@example.net<br> Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R11)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l’adresse e-mail <br>j***@example.net<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R11)';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -711,10 +711,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R12', value: 'j***.h***2' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant j***.h***2<br> Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant <br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R12)';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -737,10 +737,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R13', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R13', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -763,10 +763,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R13', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R13', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -789,10 +789,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R13', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R13', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -815,10 +815,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R13', value: undefined }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R13', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when
@@ -841,10 +841,10 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
-            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
-            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'R12', value: 'j***.h***2' }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant j***.h***2<br> Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant <br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R12)';
           studentUserAssociation.save.rejects({ errors: [error] });
 
           // when

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -468,20 +468,6 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
       expect(controller.get('isLoading')).to.equal(false);
     });
 
-    it('should display a conflict error', async function() {
-      // given
-      studentUserAssociation.save.rejects({ errors: [{ status: '409' }] });
-
-      // when
-      await controller.actions.attemptNext.call(controller);
-
-      // then
-      sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.');
-      sinon.assert.notCalled(controller.transitionToRoute);
-      expect(controller.get('isLoading')).to.equal(false);
-    });
-
     it('should associate user with student and redirect to campaigns.start-or-resume after failing', async function() {
       // given
       studentUserAssociation.save
@@ -501,5 +487,379 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
       sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
       expect(controller.get('errorMessage')).to.equal(null);
     });
+
+    describe('When student is already reconciled in the same organization', async function() {
+
+      describe('When student account is authenticated by email only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R31)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R31', value: 'j***@example.net' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l\'adresse mail j***@example.net.' +
+            '<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R31)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by username only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R32)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec un identifiant sous la forme j***.h***2.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R32)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R33)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R33', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId and username', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R33)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R33', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId and email', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R33)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R33', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId, email and username', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R33)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R33', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans votre établissement scolaire.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R33)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by email and username', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R32)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans le même établissement.',
+            meta: { displayShortCode: 'R32', value: 'j***.h***2' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec un identifiant sous la forme j***.h***2.<br> Connectez-vous à ce compte sinon demandez de l\'aide à un enseignant. (Code R32)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+    });
+
+    describe('When student is already reconciled in others organization', async function() {
+
+      describe('When student account is authenticated by email only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R11)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R11', value: 'j***@example.net' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l’adresse e-mail j***@example.net<br> Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R11)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by username only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R12)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant j***.h***2<br> Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId only', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R13)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R13', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId and username', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R13)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R13', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId and email', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R13)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R13', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by SamlId, username and email', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R13)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R13', value: undefined }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br> Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l\'aide de Pix Orga.';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+      describe('When student account is authenticated by username and email', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R12)', async function() {
+          // given
+          const error = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l\'élève dans un autre établissement.',
+            meta: { displayShortCode: 'R12', value: 'j***.h***2' }
+          };
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant j***.h***2<br> Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)';
+          studentUserAssociation.save.rejects({ errors: [error] });
+
+          // when
+          await controller.actions.attemptNext.call(controller);
+
+          // then
+          sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
+          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          sinon.assert.notCalled(controller.transitionToRoute);
+          expect(controller.get('isLoading')).to.equal(false);
+        });
+
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Aujourd'hui, lorsqu'un élève tente de rejoindre un parcours restreint, il est invité à s'inscrire ou à se créer un compte. 
Si celui ci décide de se connecter avec un compte qui n'est pas encore réconcilié, un formulaire de réconciliation est affiché lui proposant de remplir son nom, prénom et date de naissance avant de retrouver son inscription dans l'établissement créateur du parcours. 
Un fois cette inscription retrouvée, le compte par lequel il est connecté est lié à l'inscription. Cependant, a aucun moment, nous cherchons à vérifier s'il n'existe pas :

1. Un compte utilisateur qui existe déjà pour cet élève dans un autre établissement.
2. Un compte utilisateur qui existe déjà pour cette élève dans l'établissement actuel 

Le but de ce ticket étant de ne pas favoriser le multi-compte en forçant l'élève à réutiliser un compte existant.

Les différents messages d'erreur ainsi que les règles d’obfuscation de l’adresse email et de l’identifiant sont décrites [ici](https://docs.google.com/document/d/17FnXibce-pMfVfM5QoytSMuDC18zzeiOLwpMHSimuR0/edit).

## :robot: Solution

Ne pas réconcilier l'élève si ce dernier a déjà été réconcilié avec un autre compte.
Afficher des messages d'erreur différents suivant les méthodes de connexion e-mail (et/ou) identifiant (et/ou) GAR) si:
-L'élève possède déjà un compte réconcilié dans un autre établissement.
-L'élève possède déjà un compte réconcilié dans l'établissement actuel.
Afficher dans le message d'erreur, le compte de l'utilisateur avec lequel l'élève devrait se connecter.
Si l'élève possède plusieurs comptes, le compte avec le plus de certification sera choisi sinon on opte pour son compte récent.

Quand un élève à déjà un compte avec plusieurs méthodes d'authentification. On priorise ainsi:
1-GAR 2-username 3-email

## :rainbow: Remarques

**Dans cette PR, la structure de l'objet ERROR renvoyée par l'api a évolué de telle sorte à renvoyer:**
- un code fonctionnel compréhensible par les développeurs.
- un objet meta qui contient des propriétés spécifique au usecase.  Ici, le displayShortCode: un code facile à retenir pour l'élève et qui est demandé par le métier. value: le résultat de l'obfuscation des identifiants.
En restant conforme avec la spécification json-api https://jsonapi.org/format/#errors
![image](https://user-images.githubusercontent.com/10045497/89179132-66cd6d80-d58f-11ea-9993-d8e77fc67bb8.png)

Le message est calculé coté IHM en se basant sur le displayShortCode dans l'objet Meta.

Une ADR a été ouverte à ce sujet https://github.com/1024pix/pix/pull/1730

## :100: Pour tester
Ci-dessous les scénarios possibles:

**1- Elève avec un seul compte utilisateur**
_1.1 Elève déjà réconcilié dans le même établissement uniquement_
-Elève avec compte gar uniquement: 
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte username uniquement:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme XXXXXXXX.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R32)
-Elève avec compte email uniquement :
Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l'adresse mail u***@example.net.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R31)
-Elève avec compte gar, email:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33) 
-Elève avec compte gar, username:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte gar, username, email:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte email, username:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme XXXXXXXX.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R32)

**1.2- Elève déjà réconcilié dans un autre établissement uniquement**
-Elève avec compte gar uniquement:
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Contactez un enseignant qui pourra vous redonner l’accès à ce compte à l'aide de Pix Orga. (Code R13).
-Elève avec compte username uniquement:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme XXXXXXXX.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (code R12)
-Elève avec compte email uniquement:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire avec l'adresse mail XXXXXXXX.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (code R11)
-Elève avec compte gar, email:
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Contactez un enseignant qui pourra vous redonner l’accès à ce compte à l'aide de Pix Orga. (Code R13).
-Elève avec compte gar, username:
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Contactez un enseignant qui pourra vous redonner l’accès à ce compte à l'aide de Pix Orga. (Code R13).
-Elève avec compte gar, username, email:
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Contactez un enseignant qui pourra vous redonner l’accès à ce compte à l'aide de Pix Orga. (Code R13).
-Elève avec compte email , username:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme XXXXXXXX.'
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (code R12)

**1-3 Elève déjà réconcilié dans le même et d’autres établissements ( les deux )**
-Elève avec compte gar uniquement:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte username uniquement:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme XXXXXXXX.'
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R32)
-Elève avec compte email uniquement :
Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l'adresse mail u***@example.net.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R31)
-Elève avec compte gar, email:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33) 
-Elève avec compte gar, username:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte gar, username, email:
Vous possédez déjà un compte Pix via l'ENT dans votre établissement scolaire.
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R33)
-Elève avec compte email , username:
Vous possédez déjà un compte Pix utilisé dans un autre établissement scolaire, avec un identifiant sous la forme 'u***.u***4.'
Connectez-vous à ce compte sinon demandez de l'aide à un enseignant. (Code R32)

**2- Elève avec plusieurs comptes utilisateurs:**
Idem en haut avec le most relevant student suivant les règles métiers :) .
