### PR TITLE
[FEATURE] Traduction restantes des pages de certifications (Pix-1047)

### DIFF
--- a/mon-pix/app/templates/certifications/results.hbs
+++ b/mon-pix/app/templates/certifications/results.hbs
@@ -1,2 +1,2 @@
-{{page-title 'Avancement de votre certification'}}
+{{page-title (t "pages.certification-results.title")}}
 <CertificationResultsPage @certificationNumber={{@model}} />

--- a/mon-pix/app/templates/components/certification-not-certifiable.hbs
+++ b/mon-pix/app/templates/components/certification-not-certifiable.hbs
@@ -1,10 +1,11 @@
 <PixBlock class="certification-not-certifiable__panel">
   <h3 class="certification-not-certifiable__title">
-      Votre profil n'est pas encore certifiable.
+    {{t "pages.certification-not-certifiable.title"}}
   </h3>
   <p class="certification-not-certifiable__text">
-      Pour faire certifier votre profil, vous devez avoir obtenu un niveau supérieur à 0 dans 5 compétences minimum.
+    {{t "pages.certification-not-certifiable.text"}}
   </p>
-
-  <LinkTo @route="index" class="button button--link button--big button--thin certification-not-certifiable__button">Retour à l'accueil</LinkTo>
+  <LinkTo @route="index" class="button button--link button--big button--thin certification-not-certifiable__button">
+    {{t "pages.certification-not-certifiable.action.back"}}
+  </LinkTo>
 </PixBlock>

--- a/mon-pix/app/templates/components/feedback-certification-section.hbs
+++ b/mon-pix/app/templates/components/feedback-certification-section.hbs
@@ -1,14 +1,14 @@
 <div class="feedback-certification-section__div">
-  Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :
+  {{t "pages.challenge.certification.feedback-panel.description"}}
   <ul>
     <li>
-      votre n° de certification (en haut à droite de l'écran)
+      {{t "pages.challenge.certification.feedback-panel.certification-number"}}
     </li>
     <li>
-      le numéro de la question (en haut à droite de l'écran)
+      {{t "pages.challenge.certification.feedback-panel.question-number"}}
     </li>
     <li>
-      le problème rencontré
+      {{t "pages.challenge.certification.feedback-panel.problem"}}
     </li>
   </ul>
 </div>

--- a/mon-pix/app/templates/components/no-certification-panel.hbs
+++ b/mon-pix/app/templates/components/no-certification-panel.hbs
@@ -1,3 +1,3 @@
 <div class="no-certification-panel">
-  Vous n'avez pas encore de certification.
+  {{t "pages.certifications-list.no-certification.text"}}
 </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -26,13 +26,12 @@
     "pix": "pix"
   },
 
-  "pages" : {
-
+  "pages": {
     "assessment-results": {
       "title": "End of assessment",
       "actions": {
-        "continue-pix-experience" : "Continue my Pix experience",
-        "return-to-homepage" : "Return to homepage"
+        "continue-pix-experience": "Continue my Pix experience",
+        "return-to-homepage": "Return to homepage"
       },
       "answers": {
         "header": "Your answers"
@@ -137,7 +136,16 @@
       }
     },
 
+    "certification-not-certifiable": {
+      "title": "Votre profil n'est pas encore certifiable.",
+      "text": "Pour faire certifier votre profil, vous devez avoir obtenu un niveau supérieur à 0 dans 5 compétences minimum.",
+      "action": {
+        "back": "Retour à l'accueil"
+      }
+    },
+
     "certification-results": {
+      "title": "Avancement de votre certification",
       "action": {
         "confirm": "Je confirme",
         "logout": "Se déconnecter"
@@ -179,6 +187,9 @@
         "score": "score pix",
         "status": "status"
       },
+      "no-certification": {
+        "text": "Vous n'avez pas encore de certification."
+      },
       "statuses": {
         "success": {
           "action": "see results",
@@ -206,6 +217,12 @@
         "title": "Certification {certificationNumber}",
         "banner": {
           "certification-number": "N° of certification"
+        },
+        "feedback-panel": {
+          "description": "Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :",
+          "certification-number": "votre n° de certification (en haut à droite de l'écran)",
+          "question-number": "le numéro de la question (en haut à droite de l'écran)",
+          "problem": "le problème rencontré"
         }
       },
       "embed-simulator": {
@@ -315,9 +332,9 @@
     },
 
     "checkpoint": {
-      "title" : {
+      "title": {
         "assessment-progress": "Assessment progress",
-        "end-of-assessment" : "End of the assessment"
+        "end-of-assessment": "End of the assessment"
       },
       "actions": {
         "next-page": {
@@ -622,9 +639,9 @@
     },
 
     "tutorial": {
-      "next":"Next",
+      "next": "Next",
       "pages": {
-        "page0" : {
+        "page0": {
           "title": "You can look up the Internet for information",
           "icon": "icn-recherche.svg",
           "explanation": "If you don't know the answer to a question,\nit must be somewhere on the Internet."
@@ -639,7 +656,7 @@
           "icon": "icn-temps.svg",
           "explanation": "Go through tutorials to learn more \nabout each question and improve."
         },
-        "page3" : {
+        "page3": {
           "title": "An adaptative level of difficulty",
           "icon": "icn-temps.svg",
           "explanation": "According to your answers, \nPix will adapt the level of difficulty of upcoming questions. "

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -26,13 +26,12 @@
     "pix": "pix"
   },
 
-  "pages" : {
-
+  "pages": {
     "assessment-results": {
       "title": "Fin du test",
       "actions": {
-        "continue-pix-experience" : "Continuer mon expérience Pix",
-        "return-to-homepage" : "Revenir à l'accueil"
+        "continue-pix-experience": "Continuer mon expérience Pix",
+        "return-to-homepage": "Revenir à l'accueil"
       },
       "answers": {
         "header": "Vos réponses"
@@ -137,7 +136,16 @@
       }
     },
 
+    "certification-not-certifiable": {
+      "title": "Votre profil n'est pas encore certifiable.",
+      "text": "Pour faire certifier votre profil, vous devez avoir obtenu un niveau supérieur à 0 dans 5 compétences minimum.",
+      "action": {
+        "back": "Retour à l'accueil"
+      }
+    },
+
     "certification-results": {
+      "title": "Avancement de votre certification",
       "action": {
         "confirm": "Je confirme",
         "logout": "Se déconnecter"
@@ -179,6 +187,9 @@
         "score": "score pix",
         "status": "statut"
       },
+      "no-certification": {
+        "text": "Vous n'avez pas encore de certification."
+      },
       "statuses": {
         "success": {
           "action": "voir les résultats",
@@ -206,6 +217,12 @@
         "title": "Certification {certificationNumber}",
         "banner": {
           "certification-number": "N° de certification"
+        },
+        "feedback-panel": {
+          "description": "Pour signaler un problème, appelez votre surveillant et communiquez-lui les informations suivantes :",
+          "certification-number": "votre n° de certification (en haut à droite de l'écran)",
+          "question-number": "le numéro de la question (en haut à droite de l'écran)",
+          "problem": "le problème rencontré"
         }
       },
       "embed-simulator": {
@@ -315,9 +332,9 @@
     },
 
     "checkpoint": {
-      "title" : {
+      "title": {
         "assessment-progress": "Avancement du parcours",
-        "end-of-assessment" : "Fin de votre évaluation"
+        "end-of-assessment": "Fin de votre évaluation"
       },
       "actions": {
         "next-page": {
@@ -622,9 +639,9 @@
     },
 
     "tutorial": {
-      "next":"Suivant",
+      "next": "Suivant",
       "pages": {
-        "page0" : {
+        "page0": {
           "title": "Vous pouvez rechercher sur internet",
           "icon": "icn-recherche.svg",
           "explanation": "Si vous ignorez une réponse, \nelle se trouve sûrement sur internet."
@@ -639,7 +656,7 @@
           "icon": "icn-tutos.svg",
           "explanation": "Accédez à des tutos pour apprendre davantage \nsur chaque question et progresser."
         },
-        "page3" : {
+        "page3": {
           "title": "Un niveau de difficulté adapté",
           "icon": "icn-algo.svg",
           "explanation": "En fonction de vos réponses,\nPix adapte la difficulté des questions."


### PR DESCRIPTION
## :unicorn: Problème
Le site app.pix.org aura une version en anglais. Les textes doivent être traduit.
Tous les templates liés à la certification ne sont pas traduits.

## :robot: Solution
Les templates à traduire sont : 

- certifications/results
- certification-not-certifiable
- feedback-certifications
- no-certification-panel

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
