### PR TITLE
[FEATURE] Ajouter le texte légale sur le formulaire de demande d'administration d'organisation SCO (PIX-910).

### DIFF
--- a/orga/app/components/routes/join-request-form.hbs
+++ b/orga/app/components/routes/join-request-form.hbs
@@ -63,4 +63,10 @@
     </div>
 
   </form>
+
+  <p class="join-request-form__legal-information">
+    Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre à votre établissement scolaire d'accéder à son espace Pix Orga.
+    Elles sont conservées pendant un an. Elles sont destinées à Pix et ne sont pas communiquées à des tiers en dehors d’un envoi par mail à l'adresse électronique du chef de l'établissement dont vous avez saisi l'identifiant UAI/RNE.
+    Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d’accès aux données vous concernant et les faire rectifier en envoyant un mail à <a href="mailto:dpo@pix.fr">dpo@pix.fr</a>
+  </p>
 </div>

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -7,6 +7,15 @@
     margin: 0 0 24px;
   }
 
+  &__legal-information {
+    font-family: $roboto;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+    margin: 16px 0 24px;
+    text-align: center;
+    width: 500px;
+  }
+
   &__back {
     font-size: 1rem;
     text-align: left;

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -20,7 +20,6 @@
     border-radius: 10px;
     display: flex;
     flex-direction: column;
-    align-items: center;
     padding: 32px 10px 40px;
 
     @include device-is('tablet') {


### PR DESCRIPTION
## :unicorn: Problème
Il n'y pas le texte légal sur le formulaire de demande d'administration d'organisation scolaire.

## :robot: Solution
Ajouter le texte. 

## :rainbow: Remarques
Le bouton retour a été remis à la bonne place au passage.

## :100: Pour tester
Se rendre sur la page /demande-administration-sco et voir que le texte légal est bien présent. 
