### PR TITLE
[FEATURE] Modifier le script de remplissage des adresses e-mails des établissements SCO afin qu'il n'échoue pas lorsqu'une organisation n'est pas trouvée (PIX-1081).

### DIFF
--- a/api/scripts/populate-organizations-email.js
+++ b/api/scripts/populate-organizations-email.js
@@ -1,7 +1,5 @@
 const bluebird = require('bluebird');
 
-const { NotFoundError } = require('../lib/domain/errors');
-
 const { parseCsvWithHeader } = require('../scripts/helpers/csvHelpers');
 
 const BookshelfOrganization = require('../lib/infrastructure/data/organization');
@@ -11,8 +9,9 @@ async function updateOrganizationEmailByExternalId(externalId, email) {
     .where({ externalId })
     .save({ email }, { patch: true })
     .catch((err) => {
-      if (err instanceof BookshelfOrganization.NotFoundError) {
-        throw new NotFoundError(`Organization not found for External ID ${externalId}`);
+      if (err instanceof BookshelfOrganization.NoRowsUpdatedError) {
+        console.error(`Organization not found for External ID ${externalId}`);
+        return;
       }
       throw err;
     });

--- a/api/tests/integration/scripts/populate-organizations-email_test.js
+++ b/api/tests/integration/scripts/populate-organizations-email_test.js
@@ -21,6 +21,7 @@ describe('Integration | Scripts | populate-organizations-email.js', () => {
       const csvData = [
         { uai: 'uai1', email: 'uai1@example.net' },
         { uai: 'uai2', email: 'uai2@example.net' },
+        { uai: 'unknown', email: 'unknown@example.net' }
       ];
 
       // when
@@ -28,8 +29,9 @@ describe('Integration | Scripts | populate-organizations-email.js', () => {
 
       // then
       const organizations = await knex('organizations').select('externalId as uai', 'email');
-      expect(organizations).to.have.deep.members(csvData);
+      expect(organizations).to.deep.include(csvData[0]);
+      expect(organizations).to.deep.include(csvData[1]);
+      expect(organizations).to.not.deep.include(csvData[2]);
     });
-
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, le script de remplissage des adresses e-mails des établissements SCO échoue à chaque fois qu'une organisation n'a pas pu être mise à jour (NoRowsUpdated). Or, certaines organisations n'existent pas encore dans notre base de données. 

## :robot: Solution
- Permettre de remplir les adresses e-mail des établissements même si l'un d'entre eux n'a pas été trouvé.
- Logger les UAI des établissements qui n'ont pas été trouvés afin de permettre une investigation.