### PR TITLE
[FEATURE] Rendre plus explicite le message d'erreur lors d'un échec de réconciliation (PIX-957).

### DIFF
--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -142,7 +142,7 @@ export default class JoinRestrictedCampaignController extends Controller {
         return this.set('errorMessage', 'Vous avez déjà rejoint votre établissement avec un autre compte. Retrouvez-le. En cas d’oubli, contactez votre enseignant.');
       }
       if (error.status === '404') {
-        return this.set('errorMessage', 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+        return this.set('errorMessage', 'Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/> <br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
       }
       return this.set('errorMessage', error.detail);
     });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -463,7 +463,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
       // then
       sinon.assert.calledOnce(studentUserAssociation.unloadRecord);
-      expect(controller.get('errorMessage')).to.equal('Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+      expect(controller.get('errorMessage')).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/> <br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
       sinon.assert.notCalled(controller.transitionToRoute);
       expect(controller.get('isLoading')).to.equal(false);
     });


### PR DESCRIPTION
## :unicorn: Problème
Le message lors d'une erreur de réconciliation n'est pas explicite et s'adresse d'abord aux enseignants. 

## :robot: Solution
Changer le message d'erreur. 

## :100: Pour tester
Essayer de faire une réconciliation avec de mauvais nom/prénom et voir le message