### PR TITLE
[FEATURE] Renommer la colonne 'Connecté avec' dans PixOrga > Elèves (PIX-1055).

### DIFF
--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -17,7 +17,7 @@
           <Table::Header>Nom</Table::Header>
           <Table::Header>Prénom</Table::Header>
           <Table::Header>Date de naissance</Table::Header>
-          <Table::Header>Connecté avec</Table::Header>
+          <Table::Header>Méthode(s) de connexion</Table::Header>
           <Table::Header @size="small"/>
         </tr>
         <tr>

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -6,7 +6,7 @@ const DASH = '\u2013';
 const SPACING_CHARACTER = '\n';
 
 export const CONNEXION_TYPES = {
-  none: 'Non connecté',
+  none: 'Aucune',
   email: 'Adresse e-mail',
   identifiant: 'Identifiant',
   mediacentre: 'Mediacentre',

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     assert.contains('Nom');
     assert.contains('Prénom');
     assert.contains('Date de naissance');
-    assert.contains('Connecté avec');
+    assert.contains('Méthode(s) de connexion');
   });
 
   test('it should display a list of students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Dans un soucis de cohérence, le titre de la colonne présentant les méthodes de connexion d'un élève doit être modifié.

## :robot: Solution
Dans PixOrga > Elèves:
- Renommer la colonne 'Connecté avec' par 'Méthode(s) de connexion'
- Renommer dans le champ de recherche 'Non connecté' par 'Aucune'
