### PR TITLE
[FEATURE] Ajout des paliers dans les profils cibles d'une campagne (PIX-1048).

### DIFF
--- a/api/db/migrations/20200803144114_create-stages-table.js
+++ b/api/db/migrations/20200803144114_create-stages-table.js
@@ -1,0 +1,18 @@
+const TABLE_NAME = 'stages';
+
+exports.up = (knex) => {
+
+  return knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('id').primary();
+    t.integer('targetProfileId').notNullable().references('target-profiles.id').index();
+    t.string('title').notNullable();
+    t.string('message').notNullable();
+    t.integer('threshold').notNullable().unsigned();
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/db/seeds/data/stages-builder.js
+++ b/api/db/seeds/data/stages-builder.js
@@ -1,0 +1,14 @@
+module.exports = function stagesBuilder({ databaseBuilder }) {
+  const targetProfileId = 2;
+
+  const stages = [
+    { title: 'palier 1', message: 'Tu as le palier 1', threshold: 0, targetProfileId },
+    { title: 'palier 2', message: 'Tu as le palier 2', threshold: 20, targetProfileId },
+    { title: 'palier 3', message: 'Tu as le palier 3', threshold: 40, targetProfileId },
+    { title: 'palier 4', message: 'Tu as le palier 4', threshold: 60, targetProfileId },
+    { title: 'palier 5', message: 'Tu as le palier 5', threshold: 80, targetProfileId }
+  ];
+
+  stages.forEach((stage) => databaseBuilder.factory.buildStage(stage));
+};
+

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -25,6 +25,7 @@ const { pixEmploiTargetProfileBuilder } = require('./data/pix-emploi-target-prof
 const targetProfilesBuilder = require('./data/target-profiles-builder');
 const { usersBuilder } = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
+const stagesBuilder = require('./data/stages-builder');
 
 const SEQUENCE_RESTART_AT_NUMBER = 10000000;
 const SEED_NUMBER = 20110228;
@@ -64,6 +65,7 @@ exports.seed = (knex) => {
   campaignParticipationsBuilder({ databaseBuilder });
   assessmentsBuilder({ databaseBuilder });
   answersBuilder({ databaseBuilder });
+  stagesBuilder({ databaseBuilder });
 
   // Éléments de parcours pour l'utilisateur Pix Aile
   buildPixAileProfile({ databaseBuilder });

--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -1,0 +1,16 @@
+class Stage {
+
+  constructor({
+    id,
+    title,
+    message,
+    threshold,
+  } = {}) {
+    this.id = id;
+    this.title = title;
+    this.message = message;
+    this.threshold = threshold;
+  }
+}
+
+module.exports = Stage;

--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -7,6 +7,7 @@ class TargetProfile {
     outdated,
     // includes
     skills = [],
+    stages,
     // references
     organizationId,
   } = {}) {
@@ -17,6 +18,7 @@ class TargetProfile {
     this.outdated = outdated;
     // includes
     this.skills = skills;
+    this.stages = stages;
     // references
     this.organizationId = organizationId;
   }

--- a/api/lib/infrastructure/adapters/target-profile-adapter.js
+++ b/api/lib/infrastructure/adapters/target-profile-adapter.js
@@ -1,4 +1,5 @@
 const TargetProfile = require('../../domain/models/TargetProfile');
+const Stage = require('../../domain/models/Stage');
 const skillAdapter = require('./skill-adapter');
 
 module.exports = {
@@ -6,6 +7,9 @@ module.exports = {
   fromDatasourceObjects({ bookshelfTargetProfile, associatedSkillAirtableDataObjects }) {
 
     const skills = associatedSkillAirtableDataObjects.map(skillAdapter.fromAirtableDataObject);
+    const targetProfileStages = bookshelfTargetProfile.related('stages');
+    const hasStages = targetProfileStages && targetProfileStages.models;
+    const stages = hasStages ? targetProfileStages.models.map((stage) => new Stage(stage.attributes)) : [];
 
     return new TargetProfile({
       id: bookshelfTargetProfile.get('id'),
@@ -14,6 +18,7 @@ module.exports = {
       organizationId: bookshelfTargetProfile.get('organizationId'),
       outdated: bookshelfTargetProfile.get('outdated'),
       skills,
+      stages,
     });
   },
 };

--- a/api/lib/infrastructure/data/stage.js
+++ b/api/lib/infrastructure/data/stage.js
@@ -1,0 +1,18 @@
+const Bookshelf = require('../bookshelf');
+
+const modelName = 'Stage';
+require('./target-profile');
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'stages',
+  hasTimestamps: ['createdAt', 'updatedAt'],
+  requireFetch: false,
+
+  targetProfile() {
+    return this.belongsTo('TargetProfile', 'targetProfileId');
+  },
+
+}, {
+  modelName
+});

--- a/api/lib/infrastructure/data/target-profile.js
+++ b/api/lib/infrastructure/data/target-profile.js
@@ -1,6 +1,7 @@
 const Bookshelf = require('../bookshelf');
 
 require('./badge');
+require('./stage');
 require('./target-profile-skill');
 
 const modelName = 'TargetProfile';
@@ -19,6 +20,9 @@ module.exports = Bookshelf.model(modelName, {
     return this.belongsTo('Badge', 'targetProfileId');
   },
 
+  stages() {
+    return this.hasMany('Stage', 'targetProfileId');
+  },
 }, {
   modelName
 });

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -20,7 +20,13 @@ module.exports = {
       .query((qb) => qb.innerJoin('campaigns', 'campaigns.targetProfileId', 'target-profiles.id'))
       .query((qb) => qb.innerJoin('target-profiles_skills', 'target-profiles_skills.targetProfileId', 'target-profiles.id'))
       .where({ 'campaigns.id': campaignId })
-      .fetch({ require: true, withRelated: ['skillIds'] });
+      .fetch({ require: true, withRelated: [
+        'skillIds', {
+          stages: function(query) {
+            query.orderBy('threshold', 'ASC');
+          }
+        }]
+      });
 
     return _getWithAirtableSkills(targetProfileBookshelf);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -2,7 +2,7 @@ const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
   serialize(results) {
-    return new Serializer('campaign-participation-result', {
+    return new Serializer('campaign-participation-results', {
       attributes: [
         'masteryPercentage',
         'totalSkillsCount',
@@ -11,7 +11,8 @@ module.exports = {
         'isCompleted',
         'campaignParticipationBadges',
         'competenceResults',
-        'progress'
+        'progress',
+        'reachedStage',
       ],
       campaignParticipationBadges: {
         ref: 'id',
@@ -52,6 +53,18 @@ module.exports = {
           'validatedSkillsCount'
         ],
       },
+      reachedStage: {
+        ref: 'id',
+        attributes: [
+          'title',
+          'message',
+          'threshold',
+          'starCount',
+        ],
+      },
+      typeForAttribute(attribute) {
+        return attribute === 'reachedStage' ? 'reached-stages' : attribute;
+      }
     }).serialize(results);
   },
 };

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -19,7 +19,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
     areas,
     competences;
 
-  let server, badge, badgePartnerCompetence;
+  let server, badge, badgePartnerCompetence, stage;
 
   beforeEach(async () => {
     server = await createServer();
@@ -75,6 +75,14 @@ describe('Acceptance | API | Campaign Participation Result', () => {
       name: 'Pix Emploi',
       color: 'emerald',
       skillIds
+    });
+
+    stage = databaseBuilder.factory.buildStage({
+      id: 1,
+      message: 'Tu as le palier 1',
+      title: 'palier 1',
+      threshold: 20,
+      targetProfileId: targetProfile.id
     });
 
     targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
@@ -197,6 +205,12 @@ describe('Acceptance | API | Campaign Participation Result', () => {
                 type: 'competenceResults',
               }]
             },
+            'reached-stage': {
+              data: {
+                id: `${stage.id}`,
+                type: 'reached-stages',
+              }
+            }
           },
         },
         included: [{
@@ -268,6 +282,15 @@ describe('Acceptance | API | Campaign Participation Result', () => {
             'validated-skills-count': 1,
             'area-color': EMERALD_COLOR,
           },
+        }, {
+          attributes: {
+            'message': 'Tu as le palier 1',
+            'title': 'palier 1',
+            'threshold': 20,
+            'star-count': 1,
+          },
+          id: stage.id.toString(),
+          type: 'reached-stages'
         }],
       };
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -121,6 +121,8 @@ describe('Integration | Repository | Target-profile', () => {
       const skillAssociatedToTargetProfile = { id: skillId, name: '@Acquis2' };
       databaseBuilder.factory.buildTargetProfile();
       databaseBuilder.factory.buildCampaign();
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 40 });
+      databaseBuilder.factory.buildStage({ targetProfileId, threshold: 20 });
       sinon.stub(skillDatasource, 'findOperativeByRecordIds').resolves([skillAssociatedToTargetProfile]);
 
       await databaseBuilder.commit();
@@ -129,8 +131,20 @@ describe('Integration | Repository | Target-profile', () => {
     it('should return the target profile matching the campaign id', async () => {
       // when
       const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+
       // then
       expect(targetProfile.id).to.equal(targetProfileId);
+    });
+
+    it('should return the target profile with the stages ordered by threshold ASC', async () => {
+      // when
+      const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+
+      // then
+      expect(targetProfile.stages).to.exist;
+      expect(targetProfile.stages).to.have.lengthOf(2);
+      expect(targetProfile.stages[0].threshold).to.equal(20);
+      expect(targetProfile.stages[1].threshold).to.equal(40);
     });
   });
 

--- a/api/tests/tooling/database-builder/factory/build-stage.js
+++ b/api/tests/tooling/database-builder/factory/build-stage.js
@@ -1,0 +1,23 @@
+const faker = require('faker');
+const databaseBuffer = require('../database-buffer');
+
+module.exports = function buildStage({
+  id,
+  message = faker.random.words(),
+  title = faker.random.words(),
+  threshold = 20,
+  targetProfileId,
+} = {}) {
+
+  const values = {
+    id,
+    message,
+    title,
+    threshold,
+    targetProfileId,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'stages',
+    values,
+  });
+};

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -32,6 +32,7 @@ module.exports = {
   buildSession: require('./build-session'),
   buildSchoolingRegistration: require('./build-schooling-registration'),
   buildSchoolingRegistrationWithUser: require('./build-schooling-registration-with-user'),
+  buildStage: require('./build-stage'),
   buildTargetProfile: require('./build-target-profile'),
   buildTargetProfileSkill: require('./build-target-profile-skill'),
   buildTargetProfileShare: require('./build-target-profile-share'),

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
@@ -11,6 +11,7 @@ module.exports = function buildCampaignParticipationResult(
     validatedSkillsCount = 5,
     competenceResults = [],
     campaignParticipationBadges,
+    reachedStage = {},
   } = {}) {
 
   return new CampaignParticipationResult({
@@ -21,5 +22,6 @@ module.exports = function buildCampaignParticipationResult(
     validatedSkillsCount,
     competenceResults,
     campaignParticipationBadges,
+    reachedStage,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile.js
@@ -10,6 +10,7 @@ module.exports = function buildTargetProfile({
   organizationId = faker.random.number(),
   organizationsSharedId = [],
   outdated = false,
+  stages = [],
 } = {}) {
   return new TargetProfile({
     id,
@@ -19,5 +20,6 @@ module.exports = function buildTargetProfile({
     organizationId,
     organizationsSharedId,
     outdated,
+    stages,
   });
 };

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -29,6 +29,14 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
       { id: 3, name: 'Démocratie liquide', index: '8.6', skillIds: [5, 6], area: wildStrawberryArea },
     ];
 
+    const stages = [
+      { title: 'palier 1', message: 'Tu as le palier 1', threshold: 0 },
+      { title: 'palier 2', message: 'Tu as le palier 2', threshold: 20 },
+      { title: 'palier 3', message: 'Tu as le palier 3', threshold: 40 },
+      { title: 'palier 4', message: 'Tu as le palier 4', threshold: 60 },
+      { title: 'palier 5', message: 'Tu as le palier 5', threshold: 80 },
+    ];
+
     const targetProfile = {
       id: 1,
       skills,
@@ -41,6 +49,113 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
         return false;
       },
     };
+
+    context('when no stage', function() {
+      it('should add pix competences to the campaign participation results', () => {
+        // when
+        const campaignBadges = [];
+        const acquiredBadgeIds = [];
+        const result = CampaignParticipationResult.buildFrom({
+          campaignParticipationId,
+          assessment,
+          competences,
+          targetProfile,
+          knowledgeElements,
+          campaignBadges,
+          acquiredBadgeIds,
+        });
+
+        // then
+        expect(result).to.be.an.instanceOf(CampaignParticipationResult);
+        expect(result).to.deep.equal({
+          id: campaignParticipationId,
+          isCompleted: false,
+          totalSkillsCount: 4,
+          testedSkillsCount: 2,
+          validatedSkillsCount: 1,
+          knowledgeElementsCount: 2,
+          campaignParticipationBadges: [],
+          reachedStage: null,
+          competenceResults: [{
+            id: 1,
+            name: 'Economie symbiotique',
+            index: '5.1',
+            areaColor: 'jaffa',
+            totalSkillsCount: 1,
+            testedSkillsCount: 1,
+            validatedSkillsCount: 1,
+          }, {
+            id: 2,
+            name: 'Désobéissance civile',
+            index: '6.9',
+            areaColor: 'wild-strawberry',
+            totalSkillsCount: 3,
+            testedSkillsCount: 1,
+            validatedSkillsCount: 0,
+          }],
+        });
+      });
+
+    });
+
+    context('when stages', function() {
+      beforeEach(() => {
+        targetProfile.stages = stages;
+      });
+      afterEach(() => {
+        targetProfile.stages = null;
+      });
+
+      it('when user has reached a stage', () => {
+        // when
+        const campaignBadges = [];
+        const acquiredBadgeIds = [];
+
+        const result = CampaignParticipationResult.buildFrom({
+          campaignParticipationId,
+          assessment,
+          competences,
+          targetProfile,
+          knowledgeElements,
+          campaignBadges,
+          acquiredBadgeIds,
+        });
+
+        // then
+        expect(result).to.deep.equal({
+          id: campaignParticipationId,
+          isCompleted: false,
+          totalSkillsCount: 4,
+          testedSkillsCount: 2,
+          validatedSkillsCount: 1,
+          knowledgeElementsCount: 2,
+          campaignParticipationBadges: [],
+          reachedStage: {
+            title: 'palier 2',
+            message: 'Tu as le palier 2',
+            threshold: 20,
+            starCount: 2
+          },
+          competenceResults: [{
+            id: 1,
+            name: 'Economie symbiotique',
+            index: '5.1',
+            areaColor: 'jaffa',
+            totalSkillsCount: 1,
+            testedSkillsCount: 1,
+            validatedSkillsCount: 1,
+          }, {
+            id: 2,
+            name: 'Désobéissance civile',
+            index: '6.9',
+            areaColor: 'wild-strawberry',
+            totalSkillsCount: 3,
+            testedSkillsCount: 1,
+            validatedSkillsCount: 0,
+          }],
+        });
+      });
+    });
 
     context('when no badge', function() {
 
@@ -69,6 +184,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           validatedSkillsCount: 1,
           knowledgeElementsCount: 2,
           campaignParticipationBadges: [],
+          reachedStage: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -174,6 +290,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
               validatedSkillsCount: 1,
             }],
           }],
+          reachedStage: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -313,6 +430,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             partnerCompetenceResults: [],
             targetProfileId: 1,
           }],
+          reachedStage: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -409,6 +527,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           testedSkillsCount: 2,
           validatedSkillsCount: 1,
           knowledgeElementsCount: 2,
+          reachedStage: null,
           campaignParticipationBadges: [{
             id: 1,
             isAcquired: true,
@@ -552,6 +671,8 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           testedSkillsCount: 2,
           validatedSkillsCount: 1,
           knowledgeElementsCount: 2,
+          reachedStage: null,
+
           campaignParticipationBadges: [{
             id: 1,
             isAcquired: true,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -38,6 +38,13 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
         id: 19,
         partnerCompetenceResults,
       });
+      const reachedStage = {
+        id: 56,
+        title: 'Palier 1',
+        message: 'Vous avez obtenu le palier 1',
+        threshold: 50,
+        starCount: 2
+      };
       const campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({
         isCompleted: true,
         testedSkillsCount,
@@ -45,6 +52,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
         validatedSkillsCount,
         competenceResults,
         campaignParticipationBadges: [campaignParticipationBadge],
+        reachedStage
       });
 
       const expectedSerializedCampaignParticipationResult = {
@@ -76,6 +84,12 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
                   type: 'competenceResults'
                 }
               ]
+            },
+            'reached-stage': {
+              data: {
+                id: reachedStage.id.toString(),
+                type: 'reached-stages'
+              }
             }
           },
           type: 'campaign-participation-results'
@@ -141,6 +155,16 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
             },
             id: competenceResults[1].id.toString(),
             type: 'competenceResults'
+          },
+          {
+            attributes: {
+              title: reachedStage.title,
+              message: reachedStage.message,
+              threshold: reachedStage.threshold,
+              'star-count': reachedStage.starCount,
+            },
+            id: reachedStage.id.toString(),
+            type: 'reached-stages'
           },
         ]
       };

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -1,6 +1,6 @@
 /* eslint ember/no-computed-properties-in-native-classes: 0 */
 
-import Model, { attr, hasMany } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 import { mapBy, max } from '@ember/object/computed';
 import { computed } from '@ember/object';
 
@@ -15,6 +15,7 @@ export default class CampaignParticipationResult extends Model {
   // includes
   @hasMany('campaignParticipationBadges') campaignParticipationBadges;
   @hasMany('competenceResult') competenceResults;
+  @belongsTo('reachedStage') reachedStage;
 
   // methods
   @mapBy('competenceResults', 'totalSkillsCount') totalSkillsCounts;

--- a/mon-pix/app/models/reached-stage.js
+++ b/mon-pix/app/models/reached-stage.js
@@ -1,0 +1,12 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class ReachedStage extends Model {
+
+  @attr('string') title;
+  @attr('string') message;
+  @attr('number') threshold;
+  @attr('number') starCount;
+
+  @belongsTo('campaign-participation-result') campaignParticipationResult;
+}
+

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -70,6 +70,12 @@
     {{/if}}
     <div class="skill-review-result__dash-line"></div>
 
+    {{#if this.model.campaignParticipation.campaignParticipationResult.reachedStage}}
+      <div class="skill-review__reached-stage">
+        {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.title}}
+      </div>
+    {{/if}}
+
     {{#if this.showBadges}}
       <div class="badge-acquired-container">
         {{#each this.acquiredBadges as |badge|}}

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -11,5 +11,6 @@ export default ApplicationSerializer.extend({
   include: [
     'campaignParticipationBadges',
     'competenceResults',
+    'reachedStage',
   ],
 });

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -167,6 +167,31 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         expect(findAll('.badge-acquired-card').length).to.equal(1);
       });
 
+      it('should display reached stage when campaign has stages', async function() {
+        // given
+        const reachedStage = server.create('reached-stage', {
+          title: 'You reached Stage 1',
+          message: 'You are almost a rock star',
+          threshold: 50,
+          startCount: 2,
+        });
+        campaignParticipationResult.update({ reachedStage });
+
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
+
+        // then
+        expect(find('.skill-review__reached-stage')).to.exist;
+      });
+
+      it('should not display reached stage when campaign has no stages', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
+
+        // then
+        expect(find('.skill-review__reached-stage')).to.not.exist;
+      });
+
       it('should share the results', async function() {
         // when
         await visit(`/campagnes/${campaign.code}`);


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible pour un utilisateur prescrit de positionner son résult (score en pourcentage) sur une échelle.

## :robot: Solution
On introduit le concept de palier.
Une campagne peut avoir ou non plusieurs paliers.
Chaque palier matérialise un seuil en pourcentage que l'utilisateur atteint ou non.
Ainsi, pour une campagne, un utilisateur a un message affichant le palier atteint.

## :rainbow: Remarques
Cette PR constitue la modélisation du concept de palier et l'affichage du titre du palier sur l'écran de résultat de la campagne.

## :100: Pour tester
Passer la campagne AZERTY123.
Vérifier que le titre du palier est affiché sur l'écran de résultats (au-dessus des badges).
Passer une autre campagne.
Vérifier qu'aucun titre de palier n'est affiché.