### PR TITLE
[FEATURE] Filtrer les épreuves dans la langues sélectionnée (PIX-793)

### DIFF
--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const hashInt = require('hash-int');
+const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../constants').LOCALE;
 const UNEXISTING_ITEM = null;
 
 module.exports = {
@@ -9,13 +10,18 @@ module.exports = {
     }
     const key = Math.abs(hashInt(randomSeed));
     const chosenSkill = skills[key % skills.length];
-    const localeChallenges = _.filter(chosenSkill.challenges, ((challenge) => _.includes(challenge.locales, locale)));
-    if (_.isEmpty(localeChallenges)) {
-      return _pickChallengeAtIndex(chosenSkill.challenges, key);
-    }
-    return _pickChallengeAtIndex(localeChallenges, key);
+
+    return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, key)
+        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_SPOKEN, key)
+        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_FRANCE, key);
   }
 };
+
+function _pickLocaleChallengeAtIndex(challenges, locale, index) {
+  const localeChallenges = _.filter(challenges, ((challenge) => _.includes(challenge.locales, locale)));
+  const challenge = _.isEmpty(localeChallenges) ? null : _pickChallengeAtIndex(localeChallenges, index);
+  return challenge;
+}
 
 function _pickChallengeAtIndex(challenges, index) {
   return challenges[index % challenges.length];

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const datasource = require('./datasource');
-const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../domain/constants').LOCALE;
+const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../domain/constants').LOCALE;
 
 const VALIDATED_CHALLENGES = ['validé', 'validé sans test', 'pré-validé'];
 const OPERATIVE_CHALLENGES = [...VALIDATED_CHALLENGES, 'archivé'];
@@ -121,6 +121,8 @@ function _convertLanguagesToLocales(languages) {
 
 function _convertLanguageToLocale(language) {
   switch (language) {
+    case 'Anglais':
+      return ENGLISH_SPOKEN;
     case 'Francophone':
       return FRENCH_SPOKEN;
     case 'Franco Français':

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -251,7 +251,9 @@ buildChallenge.untimed = function buildUntimedChallenge({
   createdTime = '2016-08-24T11:59:02.000Z',
   format = 'petit',
   illustrationAlt = 'texte alternatif à l\'image',
-  langue = 'Francophone',
+  langues = [
+    'Francophone'
+  ],
 } = {}) {
 
   return rawBuildChallenge({
@@ -286,7 +288,7 @@ buildChallenge.untimed = function buildUntimedChallenge({
     createdTime,
     illustrationAlt,
     format,
-    langue,
+    langues,
   });
 };
 
@@ -360,7 +362,7 @@ function rawBuildChallenge({
       'domaines': domaines,
       'Texte alternatif illustration': illustrationAlt,
       'format': format,
-      'Langue': langues,
+      'Langues': langues,
     },
     'createdTime': createdTime,
   };

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -1,11 +1,12 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const pickChallengeService = require('../../../../lib/domain/services/pick-challenge-service');
-const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
+const { ENGLISH_SPOKEN, FRENCH_FRANCE, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 const _ = require('lodash');
 
 describe('Unit | Service | PickChallengeService', () => {
 
   describe('#pickChallenge', () => {
+    const englishSpokenChallenge = domainBuilder.buildChallenge({ locales: [ENGLISH_SPOKEN] });
     const frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
     const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
     const frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
@@ -15,17 +16,17 @@ describe('Unit | Service | PickChallengeService', () => {
 
       it('should return challenge in selected locale', async () => {
         // given
-        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
+        const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, englishSpokenChallenge] }];
 
         // when
         const challenge = await pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: FRENCH_SPOKEN
+          locale: ENGLISH_SPOKEN
         });
 
         // then
-        expect(challenge).to.equal(frenchSpokenChallenge);
+        expect(challenge).to.equal(englishSpokenChallenge);
       });
 
       it('should always return the same challenge in selected locale', async () => {
@@ -44,6 +45,40 @@ describe('Unit | Service | PickChallengeService', () => {
         expect(challenges).to.contains(frenchSpokenChallenge);
         expect(challenges).to.not.contains(otherFrenchSpokenChallenge);
         expect(challenges).to.not.contains(frenchChallenge);
+      });
+
+      context('when no challenge in selected locale', () => {
+        it('should return FR challenge', async () => {
+          // given
+          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
+
+          // when
+          const challenge = await pickChallengeService.pickChallenge({
+            skills,
+            randomSeed,
+            locale: ENGLISH_SPOKEN
+          });
+
+          // then
+          expect(challenge).to.equal(frenchSpokenChallenge);
+        });
+
+        context('and no FR challenge', () => {
+          it('should return FR-FR challenge', async () => {
+            // given
+            const skills = [{ challenges: [frenchChallenge] }];
+
+            // when
+            const challenge = await pickChallengeService.pickChallenge({
+              skills,
+              randomSeed,
+              locale: ENGLISH_SPOKEN
+            });
+
+            // then
+            expect(challenge).to.equal(frenchChallenge);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Bien qu'il soit possible de change de langue sur app.pix.fr, les épreuves affichées ne sont pas restreintes à la langue courante.

## :robot: Solution
S'il n'y a aucune épreuve dans la langue demandée, renvoyer une épreuve francophone.
S'il n'y a aucune épreuve francophone, renvoyer une épreuve franco-française.

## :100: Pour tester
- La RA est connectée à une base Airtable de copie de celle de la prod
- Sur https://app-pr1737.review.pix.fr/campagnes?lang=en, renseigner le code `LOCALE123`
- Vérifier que l'épreuve est bien en anglais
