### PR TITLE
[FEATURE] Rendre plus explicite le message d'erreur lors d'un échec de réconciliation dans la double mire (PIX-956).

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -166,7 +166,7 @@ export default class RegisterForm extends Component {
         this.set('isLoading', false);
         errorResponse.errors.forEach((error) => {
           if (error.status === '404') {
-            return this.set('errorMessage', 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.');
+            return this.set('errorMessage', 'Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant. <br><br> Vous êtes un enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment.');
           }
           if (error.status === '409') {
             return this.set('errorMessage', 'Vous possédez déjà un compte Pix. Veuillez vous connecter.');

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -273,7 +273,7 @@ describe('Integration | Component | routes/register-form', function() {
     });
 
     [
-      { status: '404', errorMessage: 'Vous êtes enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment. <br> <br> Vous êtes un élève ? <br> Vérifiez vos informations afin de continuer ou prévenez l’organisateur de votre parcours.' },
+      { status: '404', errorMessage: 'Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant. <br><br> Vous êtes un enseignant ? <br> L’accès à un parcours n’est pas disponible pour le moment.' },
       { status: '409', errorMessage: 'Vous possédez déjà un compte Pix. Veuillez vous connecter.' },
     ].forEach(({ status, errorMessage }) => {
       it(`should display an error message if user saves with an error response status ${status}`, async function() {


### PR DESCRIPTION
## :unicorn: Problème
Le message lors d'une erreur de réconciliation n'est pas explicite et s'adresse d'abord aux enseignants.

## :robot: Solution
Changer le message d'erreur.

## :100: Pour tester
Se connecter à Pix Orga sur l'organisation SCO (sco@example.net).
Aller sur la liste des élèves et ouvrir l'inspecteur Ember. Dans Data, trouver un ID de student réconcilié.
Supprimer la réconciliation 
`UPDATE "schooling-registrations" SET "userId" = NULL WHERE id=100059`
Essayer de se réconcilier lors de l'inscription avec un mauvais nom/prénom/date de naissance et voir le message;
