### PR TITLE
[FEATURE] Traduction des indices sur la page correction (PIX-795).

### DIFF
--- a/api/lib/domain/services/get-translated-text.js
+++ b/api/lib/domain/services/get-translated-text.js
@@ -1,0 +1,11 @@
+const { ENGLISH_SPOKEN } = require('../../domain/constants').LOCALE;
+
+function getTranslatedText(locale, translations = { frenchText: '', englishText: '' }) {
+  if (locale === ENGLISH_SPOKEN) {
+    return translations.englishText;
+  }
+
+  return translations.frenchText;
+}
+
+module.exports = { getTranslatedText };

--- a/api/lib/infrastructure/datasources/airtable/skill-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/skill-datasource.js
@@ -30,7 +30,6 @@ module.exports = datasource.extend({
     return {
       id: airtableRecord.get('id persistant'),
       name: airtableRecord.get('Nom'),
-      hint: airtableRecord.get('Indice'),
       hintFrFr: airtableRecord.get('Indice fr-fr'),
       hintEnUs: airtableRecord.get('Indice en-us'),
       hintStatus: airtableRecord.get('Statut de l\'indice') || 'no status',

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -7,15 +7,16 @@ const competenceDatasource = require('../datasources/airtable/competence-datasou
 const knowledgeElementRepository = require('./knowledge-element-repository');
 const scoringService = require('../../domain/services/scoring/scoring-service');
 const { NotFoundError } = require('../../domain/errors');
-const { FRENCH_FRANCE, ENGLISH_SPOKEN } = require('../../domain/constants').LOCALE;
+const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
+const { getTranslatedText } = require('../../domain/services/get-translated-text');
 
 const PixOriginName = 'Pix';
 
 function _toDomain({ competenceData, areaDatas, locale }) {
   const areaData = competenceData.areaId && _.find(areaDatas, { id: competenceData.areaId });
-  const translatedCompetenceName = _getTranslatedText(locale, { frenchText: competenceData.nameFrFr, englishText: competenceData.nameEnUs });
-  const translatedCompetenceDescription = _getTranslatedText(locale, { frenchText: competenceData.descriptionFrFr, englishText: competenceData.descriptionEnUs });
-  const translatedAreaTitle = areaData ? _getTranslatedText(locale, { frenchText: areaData.titleFrFr, englishText: areaData.titleEnUs }) : '';
+  const translatedCompetenceName = getTranslatedText(locale, { frenchText: competenceData.nameFrFr, englishText: competenceData.nameEnUs });
+  const translatedCompetenceDescription = getTranslatedText(locale, { frenchText: competenceData.descriptionFrFr, englishText: competenceData.descriptionEnUs });
+  const translatedAreaTitle = areaData ? getTranslatedText(locale, { frenchText: areaData.titleFrFr, englishText: areaData.titleEnUs }) : '';
 
   return new Competence({
     id: competenceData.id,
@@ -31,14 +32,6 @@ function _toDomain({ competenceData, areaDatas, locale }) {
       color: areaData.color,
     }),
   });
-}
-
-function _getTranslatedText(locale, translations = { frenchText: '', englishText: '' }) {
-  if (locale === ENGLISH_SPOKEN) {
-    return translations.englishText;
-  }
-
-  return translations.frenchText;
 }
 
 module.exports = {

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -6,14 +6,14 @@ const challengeDatasource = require('../datasources/airtable/challenge-datasourc
 const skillDatasource = require('../datasources/airtable/skill-datasource');
 const tutorialRepository = require('./tutorial-repository');
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
-const { ENGLISH_SPOKEN } = require('../../domain/constants').LOCALE;
+const { getTranslatedText } = require('../../domain/services/get-translated-text');
 
 module.exports = {
 
   async getByChallengeId({ challengeId, userId, locale }) {
     const challenge = await challengeDatasource.get(challengeId);
     const skills = await _getSkills(challenge);
-    const hints = await _getHints(skills, locale);
+    const hints = await _getHints({ skills, locale });
 
     const tutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'tutorialIds', locale });
     const learningMoreTutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'learningMoreTutorialIds', locale });
@@ -28,9 +28,9 @@ module.exports = {
   }
 };
 
-async function _getHints(skills, locale) {
+async function _getHints({ skills, locale }) {
   const skillsWithHints = await _filterSkillsWithValidatedHint(skills);
-  return _convertSkillsToHints(skillsWithHints, locale);
+  return _convertSkillsToHints({ skillsWithHints, locale });
 }
 
 function _getSkills(challengeDataObject) {
@@ -42,19 +42,11 @@ function _filterSkillsWithValidatedHint(skillDataObjects) {
   return skillDataObjects.filter((skillDataObject) => VALIDATED_HINT_STATUSES.includes(skillDataObject.hintStatus));
 }
 
-function _getTranslatedText(locale, translations = { frenchText: '', englishText: '' }) {
-  if (locale === ENGLISH_SPOKEN) {
-    return translations.englishText;
-  }
-
-  return translations.frenchText;
-}
-
-function _convertSkillsToHints(skillDataObjects, locale) {
-  return skillDataObjects.map((skillDataObject) => {
+function _convertSkillsToHints({ skillsWithHints, locale }) {
+  return skillsWithHints.map((skillsWithHint) => {
     return new Hint({
-      skillName: skillDataObject.name,
-      value: _getTranslatedText(locale, { frenchText: skillDataObject.hintFrFr, englishText: skillDataObject.hintEnUs }),
+      skillName: skillsWithHint.name,
+      value: getTranslatedText(locale, { frenchText: skillsWithHint.hintFrFr, englishText: skillsWithHint.hintEnUs }),
     });
   });
 }

--- a/api/lib/infrastructure/repositories/correction-repository.js
+++ b/api/lib/infrastructure/repositories/correction-repository.js
@@ -6,13 +6,14 @@ const challengeDatasource = require('../datasources/airtable/challenge-datasourc
 const skillDatasource = require('../datasources/airtable/skill-datasource');
 const tutorialRepository = require('./tutorial-repository');
 const VALIDATED_HINT_STATUSES = ['Validé', 'pré-validé'];
+const { ENGLISH_SPOKEN } = require('../../domain/constants').LOCALE;
 
 module.exports = {
 
   async getByChallengeId({ challengeId, userId, locale }) {
     const challenge = await challengeDatasource.get(challengeId);
     const skills = await _getSkills(challenge);
-    const hints = await _getHints(skills);
+    const hints = await _getHints(skills, locale);
 
     const tutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'tutorialIds', locale });
     const learningMoreTutorials = await _getTutorials({ userId, skills, tutorialIdsProperty: 'learningMoreTutorialIds', locale });
@@ -27,9 +28,9 @@ module.exports = {
   }
 };
 
-async function _getHints(skills) {
+async function _getHints(skills, locale) {
   const skillsWithHints = await _filterSkillsWithValidatedHint(skills);
-  return _convertSkillsToHints(skillsWithHints);
+  return _convertSkillsToHints(skillsWithHints, locale);
 }
 
 function _getSkills(challengeDataObject) {
@@ -41,11 +42,19 @@ function _filterSkillsWithValidatedHint(skillDataObjects) {
   return skillDataObjects.filter((skillDataObject) => VALIDATED_HINT_STATUSES.includes(skillDataObject.hintStatus));
 }
 
-function _convertSkillsToHints(skillDataObjects) {
+function _getTranslatedText(locale, translations = { frenchText: '', englishText: '' }) {
+  if (locale === ENGLISH_SPOKEN) {
+    return translations.englishText;
+  }
+
+  return translations.frenchText;
+}
+
+function _convertSkillsToHints(skillDataObjects, locale) {
   return skillDataObjects.map((skillDataObject) => {
     return new Hint({
       skillName: skillDataObject.name,
-      value: skillDataObject.hint
+      value: _getTranslatedText(locale, { frenchText: skillDataObject.hintFrFr, englishText: skillDataObject.hintEnUs }),
     });
   });
 }

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -37,7 +37,8 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       const skill = airtableBuilder.factory.buildSkill({
         id: 'q_first_acquis',
         nom: '@web3',
-        indice: 'Indice web3',
+        indiceFr: 'Geolocaliser ?',
+        indiceEn: 'Geolocate ?',
         statutDeLIndice: 'Validé',
         compétenceViaTube: 'recABCD',
         comprendre: [englishTutorial.id, frenchTutorial.id],
@@ -87,7 +88,7 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
             type: 'corrections',
             attributes: {
               solution: 'fromage',
-              hint: 'Indice web3',
+              hint: 'Geolocaliser ?',
             },
             relationships: {
               tutorials: {

--- a/api/tests/tooling/airtable-builder/factory/build-skill.js
+++ b/api/tests/tooling/airtable-builder/factory/build-skill.js
@@ -1,6 +1,7 @@
 module.exports = function buildSkill({
   id = 'recTIddrkopID28Ep',
-  indice = 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ? Dans quelle condition une application peut-elle utiliser les données de géolocalisation du t...',
+  indiceFr = 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ? Dans quelle condition une application peut-elle utiliser les données de géolocalisation du t...',
+  indiceEn = 'Can we gelocate ?',
   statutDeLIndice = 'Proposé',
   epreuves = [
     'recF2iWmZKIuOsKO1',
@@ -37,7 +38,8 @@ module.exports = function buildSkill({
     id,
     'fields': {
       'id persistant': id,
-      'Indice': indice,
+      'Indice fr-fr': indiceFr,
+      'Indice en-us': indiceEn,
       'Statut de l\'indice': statutDeLIndice,
       'Epreuves': epreuves,
       'Comprendre (id persistant)': comprendre,

--- a/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillAirtableDataObjectFixture.js
@@ -1,9 +1,8 @@
-const { DEFAULT_TUTORIAL_ID, DEFAULT_PIX_VALUE, DEFAULT_NAME, DEFAULT_LEARNING_TUTORIAL_IDS, DEFAULT_COMPETENCE_ID, DEFAULT_STATUS, DEFAULT_HINT_STATUS, DEFAULT_ID, DEFAULT_HINT, DEFAULT_HINT_FR_FR, DEFAULT_HINT_EN_US, DEFAULT_TUBE_ID }  = require('./skillRawAirTableFixture');
+const { DEFAULT_TUTORIAL_ID, DEFAULT_PIX_VALUE, DEFAULT_NAME, DEFAULT_LEARNING_TUTORIAL_IDS, DEFAULT_COMPETENCE_ID, DEFAULT_STATUS, DEFAULT_HINT_STATUS, DEFAULT_ID, DEFAULT_HINT_FR_FR, DEFAULT_HINT_EN_US, DEFAULT_TUBE_ID }  = require('./skillRawAirTableFixture');
 
 module.exports = function SkillAirtableDataObjectFixture({
   id = DEFAULT_ID,
   name = DEFAULT_NAME,
-  hint = DEFAULT_HINT,
   hintEnUs = DEFAULT_HINT_EN_US,
   hintFrFr = DEFAULT_HINT_FR_FR,
   hintStatus = DEFAULT_HINT_STATUS,
@@ -17,7 +16,6 @@ module.exports = function SkillAirtableDataObjectFixture({
   return {
     id,
     name,
-    hint,
     hintEnUs,
     hintFrFr,
     hintStatus,

--- a/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/skillRawAirTableFixture.js
@@ -5,7 +5,6 @@ const COMPETENCE_TUBE_ID = 'Compétence (via Tube) (id persistant)';
 const STATUS = 'Status';
 
 const DEFAULT_ID = 'recSK0X22abcdefgh',
-  DEFAULT_HINT = 'Peut-on géo-localiser un lapin sur la banquise ?',
   DEFAULT_HINT_FR_FR = 'Peut-on géo-localiser un lapin sur la banquise ?',
   DEFAULT_HINT_EN_US = 'Can we geo-locate a rabbit on the ice floe?',
   DEFAULT_HINT_STATUS = 'Validé',
@@ -25,7 +24,6 @@ class SkillRawAirTableFixture extends AirtableRecord {
       'fields': {
         'id persistant': id,
         'Nom': DEFAULT_NAME,
-        'Indice': DEFAULT_HINT,
         'Indice fr-fr': DEFAULT_HINT_FR_FR,
         'Indice en-us': DEFAULT_HINT_EN_US,
         'Statut de l\'indice': DEFAULT_HINT_STATUS,
@@ -80,7 +78,6 @@ function skillRawAirTableFixture({ id } = { id: DEFAULT_ID }) {
 module.exports = {
   skillRawAirTableFixture,
   DEFAULT_ID,
-  DEFAULT_HINT,
   DEFAULT_HINT_FR_FR,
   DEFAULT_HINT_EN_US,
   DEFAULT_HINT_STATUS,

--- a/api/tests/unit/infrastructure/repositories/correction-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/correction-repository_test.js
@@ -20,11 +20,11 @@ describe('Unit | Repository | correction-repository', function() {
 
     const recordId = 'rec-challengeId';
     const userId = 'userId';
-    const locale = 'lang-country';
+    const locale = 'en';
 
     const expectedHints = [
-      domainBuilder.buildHint({ skillName: '@web2', value: 'Peut-on géo-localiser un lapin sur la banquise ?' }),
-      domainBuilder.buildHint({ skillName: '@web3', value: 'Peut-on géo-localiser un lapin sur la banquise ?' }),
+      domainBuilder.buildHint({ skillName: '@web2', value: 'Can we geo-locate a rabbit on the ice floe?' }),
+      domainBuilder.buildHint({ skillName: '@web3', value: 'Can we geo-locate a rabbit on the ice floe?' }),
     ];
 
     const userTutorial = { id: 'userTutorialId', userId, tutorialId: 'recTuto1' };


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible de récupérer les traductions des indices sur les pages de correction des épreuves.

## :robot: Solution
Ajout de la locale en paramètre lors de la récupération des indices

## :100: Pour tester
Passer le site en anglais via le param ?lang=en et terminer un parcours.
Aller sur la page Réponses et tutos pour voir les indices.
