### PR TITLE
[TECH] Utiliser les snapshots KE dans l'affichage de la liste des participants des campagnes d'évaluation (PIX-1066)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
@@ -82,10 +82,8 @@ async function _buildCampaignAssessmentParticipationSummary(result, targetedSkil
 }
 
 async function _getValidatedTargetSkillIds(userId, limitDate, targetedSkillIds) {
-  const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({
-    userId,
-    limitDate,
-  });
+  const knowledgeElementsByUser = await knowledgeElementRepository.findSnapshotForUsers({ [userId]: limitDate });
+  const knowledgeElements = knowledgeElementsByUser[userId];
 
   const validatedKnowledgeElements = _.filter(knowledgeElements, 'isValidated');
   const validatedSkillIds = _.map(validatedKnowledgeElements, 'skillId');

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -144,6 +144,20 @@ module.exports = {
       knowledgeElementsGroupedByUserIdAndCompetenceId[userId] = _.groupBy(knowledgeElements, 'competenceId');
     }
     return knowledgeElementsGroupedByUserIdAndCompetenceId;
+  },
+
+  async findSnapshotForUsers(userIdsAndDates) {
+    const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
+
+    for (const [strUserId, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
+      const userId = parseInt(strUserId);
+      let knowledgeElements = knowledgeElementsFromSnapshot;
+      if (!knowledgeElements) {
+        knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate: userIdsAndDates[userId] });
+      }
+      knowledgeElementsGroupedByUser[userId] = knowledgeElements;
+    }
+    return knowledgeElementsGroupedByUser;
   }
 };
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -132,32 +132,30 @@ module.exports = {
   },
 
   async findSnapshotGroupedByCompetencesForUsers(userIdsAndDates) {
-    const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
+    const knowledgeElementsGroupedByUser = await this.findSnapshotForUsers(userIdsAndDates);
 
-    const knowledgeElementsGroupedByUserIdAndCompetenceId = {};
-    for (const [strUserId, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
-      const userId = parseInt(strUserId);
-      let knowledgeElements = knowledgeElementsFromSnapshot;
-      if (!knowledgeElements) {
-        knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate: userIdsAndDates[userId] });
-      }
-      knowledgeElementsGroupedByUserIdAndCompetenceId[userId] = _.groupBy(knowledgeElements, 'competenceId');
+    for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
+      knowledgeElementsGroupedByUser[userId] = _.groupBy(knowledgeElements, 'competenceId');
     }
-    return knowledgeElementsGroupedByUserIdAndCompetenceId;
+    return knowledgeElementsGroupedByUser;
   },
 
-  async findSnapshotForUsers(userIdsAndDates) {
-    const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
+  async findSnapshotForUsers(sharedAtDatesByUsers) {
+    const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(sharedAtDatesByUsers);
 
-    for (const [strUserId, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
-      const userId = parseInt(strUserId);
+    for (const [userIdStr, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
+      const userId = parseInt(userIdStr);
       let knowledgeElements = knowledgeElementsFromSnapshot;
       if (!knowledgeElements) {
-        knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate: userIdsAndDates[userId] });
+        knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({
+          userId,
+          limitDate: sharedAtDatesByUsers[userId],
+        });
       }
       knowledgeElementsGroupedByUser[userId] = knowledgeElements;
     }
     return knowledgeElementsGroupedByUser;
   }
+
 };
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-summary-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, sinon } = require('../../../test-helper');
+const { expect, databaseBuilder, sinon, knex } = require('../../../test-helper');
 const campaignAssessmentParticipationSummaryRepository = require('../../../../lib/infrastructure/repositories/campaign-assessment-participation-summary-repository');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const CampaignAssessmentParticipationSummary = require('../../../../lib/domain/read-models/CampaignAssessmentParticipationSummary');
@@ -14,6 +14,7 @@ describe('Integration | Repository | Campaign Assessment Participation Summary',
 
     afterEach(() => {
       skillDatasource.findOperativeByRecordIds.restore();
+      return knex('knowledge-element-snapshots').delete();
     });
 
     let campaign;

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -768,7 +768,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       it('should return the knowledge elements in the snapshot', async () => {
         // given
-        sandbox.spy(knowledgeElementSnapshotRepository);
         const dateUserId1 = new Date('2020-01-03');
         const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId: userId1 });
         databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId: userId1, snappedAt: dateUserId1, snapshot: JSON.stringify([knowledgeElement]) });
@@ -780,10 +779,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         // then
         expect(knowledgeElementsByUserIdAndCompetenceId[userId1][knowledgeElement.competenceId][0]).to.deep.equal(knowledgeElement);
-        expect(knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates).to.have.been.calledWith({ [userId1]: dateUserId1 });
-        await expect(knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates.firstCall.returnValue).to.eventually.deep.equal({
-          [userId1]: [knowledgeElement],
-        });
       });
     });
 
@@ -864,7 +859,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       return knex('knowledge-element-snapshots').delete();
     });
 
-    it('should return knowledge elements within respective dates grouped by userId the competenceId', async () => {
+    it('should return knowledge elements within respective dates and users', async () => {
       // given
       const dateUserId1 = new Date('2020-01-03');
       const dateUserId2 = new Date('2019-01-03');


### PR DESCRIPTION
## :unicorn: Problème
On poursuit l'amélioration des perfs autour de l'ensemble de la navigation dans PixOrga.
Aujourd'hui, c'est affichage de la liste des participants d'une campagne d'évaluation.

## :robot: Solution
On utilise les snapshotsKE dans la récupération de la liste + on les récupère par paquet.

Une étude de l'impact ici -> https://docs.google.com/spreadsheets/d/1XdfbuzEiPUaM5UljXGdLXtOcZ3vOvG1bdZv5mlgLyec/edit?ts=5f2c14fe#gid=1439239740

Perf: 
![perf](https://user-images.githubusercontent.com/48727874/89886339-c00b5180-dbcc-11ea-90ed-cc52a557e5a7.png)

Mémoire : (on reste dans le tunnel donc c'est bon)
![mem](https://user-images.githubusercontent.com/48727874/89886350-c6013280-dbcc-11ea-961d-66f4fca976c4.png)


## :rainbow: Remarques
Dès lors qu'on aura aussi appliquer cette modification sur la liste des participants d'une campagne de collecte de profils, on pourra remettre la pagination à 100 !

## :100: Pour tester
Tester la non régression de l'affichage de la liste et des résultats.
On peut aussi expérimenter la différence de vitesse en essayant en local le avant / après.
Pour cela, créer une campagne de test :
`node pix/api/scripts/generate-campaign-with-participants.js --organizationId 1 --participantCount 150 --campaignType assessment --profileType all`
Puis consulter la page des participants plusieurs fois sans l'amélioration, puis plusieurs fois avec. Ca va beaucoup plus vite avec ;)
