### PR TITLE
[FEATURE] Permettre la création de centre de certification depuis Pix Admin (PIX-501).

### DIFF
--- a/admin/app/components/certification-center-form.hbs
+++ b/admin/app/components/certification-center-form.hbs
@@ -1,0 +1,52 @@
+<form class="form certification-center-form" {{on "submit" @onSubmit}}>
+
+  <section class="form-section form-section--certification-center">
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="certificationCenterName">Nom : </label>
+      <Input class={{if @certificationCenter.errors.name "form-field__text form-control is-invalid" "form-field__text form-control"}}
+             @id="certificationCenterName"
+             @value={{@certificationCenter.name}} />
+      {{#if @certificationCenter.errors.name}}
+        <div class="form-field__error">
+          {{@certificationCenter.errors.name.[0].message}}
+        </div>
+      {{/if}}
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="certificationCenterType">Type : </label>
+      <div id="certificationCenterTypeSelector" class="form-field__select {{if @certificationCenter.errors.type 'is-invalid' ''}} certification-center-form__select-type">
+        <PowerSelect
+                @options={{this.certificationCenterTypes}}
+                @searchEnabled={{false}}
+                @selected={{this.selectedCertificationCenterType}}
+                @onchange={{this.selectCertificationCenterType}} as |certificationCenterType|>
+          {{certificationCenterType.label}}
+        </PowerSelect>
+      </div>
+      {{#each @certificationCenter.errors.type as |error|}}
+        <div class="form-field__error">
+          {{error.message}}
+        </div>
+      {{/each}}
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="certificationCenterExternalId">Identifiant externe : </label>
+      <Input class={{if @certificationCenter.errors.externalId "form-field__text form-control is-invalid" "form-field__text form-control"}}
+             @id="certificationCenterExternalId"
+             @value={{@certificationCenter.externalId}} />
+      {{#if @certificationCenter.errors.externalId}}
+        <div class="form-field__error">
+          {{@certificationCenter.errors.externalId.[0].message}}
+        </div>
+      {{/if}}
+    </div>
+  </section>
+
+  <section class="form-section form-section--actions">
+    <button class="form-action form-action--cancel btn btn-outline-default btn-thin" type="button" {{on "click" @onCancel}}>Annuler</button>
+    <button class="form-action form-action--submit btn btn-success btn-thin" type="submit">Ajouter</button>
+  </section>
+</form>

--- a/admin/app/components/certification-center-form.js
+++ b/admin/app/components/certification-center-form.js
@@ -1,0 +1,20 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class CertificationCenterForm extends Component {
+
+  certificationCenterTypes = [
+    { value: 'PRO', label: 'Organisation professionnelle' },
+    { value: 'SCO', label: 'Établissement scolaire' },
+    { value: 'SUP', label: 'Établissement supérieur' },
+  ];
+
+  @tracked selectedCertificationCenterType;
+
+  @action
+  selectCertificationCenterType(certificationCenterType) {
+    this.selectedCertificationCenterType = certificationCenterType;
+    this.args.certificationCenter.type = certificationCenterType.value;
+  }
+}

--- a/admin/app/controllers/authenticated/certification-centers/new.js
+++ b/admin/app/controllers/authenticated/certification-centers/new.js
@@ -1,0 +1,30 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class NewController extends Controller {
+
+  @service notifications;
+
+  @action
+  goBackToCertificationCentersList() {
+    this.transitionToRoute('authenticated.certification-centers');
+  }
+
+  @action
+  async addCertificationCenter(event) {
+    event.preventDefault();
+
+    if (!this.model.externalId || !this.model.externalId.trim()) {
+      this.model.externalId = null;
+    }
+
+    try {
+      await this.model.save();
+      this.notifications.success('Le centre de certif a été créé avec succès.');
+      this.transitionToRoute('authenticated.certification-centers.list');
+    } catch (error) {
+      this.notifications.error('Une erreur est survenue.');
+    }
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -40,6 +40,7 @@ Router.map(function() {
     });
 
     this.route('certification-centers', function() {
+      this.route('new');
       this.route('list');
     });
 

--- a/admin/app/routes/authenticated/certification-centers/new.js
+++ b/admin/app/routes/authenticated/certification-centers/new.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class NewRoute extends Route {
+
+  model() {
+    return this.store.createRecord('certification-center');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -31,6 +31,7 @@
 @import 'authenticated/tools';
 
 /* components */
+@import 'components/certification-center-form';
 @import 'components/certification-details-answer';
 @import 'components/certification-details-competence';
 @import 'components/certification-list';

--- a/admin/app/styles/components/certification-center-form.scss
+++ b/admin/app/styles/components/certification-center-form.scss
@@ -1,0 +1,5 @@
+.certification-center-form__select-type {
+    .ember-power-select-trigger {
+        width: 250px;
+    }
+}

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -1,5 +1,10 @@
 <header class="page-header">
   <div class="page-title">Tous les centres de certification</div>
+  <div class="page-actions">
+    <LinkTo @route="authenticated.certification-centers.new" class="btn btn-outline-default btn-thin">
+      <FaIcon @icon="plus"></FaIcon>&nbsp;Nouveau centre de certif
+    </LinkTo>
+  </div>
 </header>
 
 <main class="page-body">

--- a/admin/app/templates/authenticated/certification-centers/new.hbs
+++ b/admin/app/templates/authenticated/certification-centers/new.hbs
@@ -1,0 +1,14 @@
+<header class="page-header">
+  <div class="page-title">
+    Nouveau centre de certification
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <CertificationCenterForm
+            @certificationCenter={{@model}}
+            @onSubmit={{this.addCertificationCenter}}
+            @onCancel={{this.goBackToCertificationCentersList}} />
+  </section>
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -29,6 +29,14 @@ export default function() {
   this.get('/admin/users/:id');
   this.get('/certification-centers');
   this.get('/certification-centers/:id');
+  this.post('/certification-centers', (schema, request) => {
+    const params = JSON.parse(request.requestBody);
+    const name = params.data.attributes.name;
+    const type = params.data.attributes.type;
+    const externalId = params.data.attributes.externalId;
+
+    return schema.certificationCenters.create({ name, type, externalId });
+  });
 
   this.post('/memberships', createMembership);
   this.get('/organizations');

--- a/admin/tests/acceptance/certification-center-form--test.js
+++ b/admin/tests/acceptance/certification-center-form--test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+module('Acceptance | Certification-center Form', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async () => {
+    await createAuthenticateSession({ userId: 1 });
+  });
+
+  test('it should create a certification center', async function(assert) {
+    const name = 'name';
+    const type = { label: 'Organisation professionnelle', value: 'PRO' };
+    const externalId = 'externalId';
+
+    // when
+    await visit('/certification-centers/new');
+
+    await fillIn('#certificationCenterName', name);
+    await selectChoose('#certificationCenterTypeSelector', type.label);
+    await fillIn('#certificationCenterExternalId', externalId);
+
+    await click('button[type=submit]');
+
+    // then
+    assert.equal(currentURL(), '/certification-centers/list');
+    assert.contains(name);
+    assert.contains(type.value);
+    assert.contains(externalId);
+  });
+
+});

--- a/admin/tests/integration/components/certification-center-form-test.js
+++ b/admin/tests/integration/components/certification-center-form-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+import { selectChoose } from 'ember-power-select/test-support/helpers';
+
+module('Integration | Component | certification-center-form', function(hooks) {
+
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.onSubmit = () => {};
+    this.onCancel = () => {};
+    this.certificationCenter = EmberObject.create();
+  });
+
+  test('it renders', async function(assert) {
+    // when
+    await render(hbs`<CertificationCenterForm @certificationCenter={{this.certificationCenter}} @onSubmit={{this.onSubmit}} @onCancel={{this.onCancel}} />`);
+
+    // then
+    assert.dom('.certification-center-form').exists();
+  });
+
+  module('#selectCertificationCenterType', function() {
+
+    test('should update attribute certificationCenter.type', async function(assert) {
+      // given
+      await render(hbs`<CertificationCenterForm @certificationCenter={{this.certificationCenter}} @onSubmit={{this.onSubmit}} @onCancel={{this.onCancel}} />`);
+
+      // when
+      await selectChoose('#certificationCenterTypeSelector', 'Établissement scolaire');
+
+      // then
+      assert.equal(this.certificationCenter.type, 'SCO');
+      assert.dom('.ember-power-select-selected-item').hasText('Établissement scolaire');
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/certification-centers/new', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const controller = this.owner.lookup('controller:authenticated/certification-centers/new');
+    assert.ok(controller);
+  });
+});

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -4,6 +4,8 @@ const HttpErrors = require('./http-errors');
 const DomainErrors = require('../domain/errors');
 const errorSerializer = require('../infrastructure/serializers/jsonapi/error-serializer');
 
+const NOT_VALID_RELATIONSHIPS = ['externalId'];
+
 function _formatAttribute({ attribute, message }) {
   return {
     status: '422',
@@ -39,7 +41,7 @@ function _formatInvalidAttribute({ attribute, message }) {
   if (!attribute) {
     return _formatUndefinedAttribute({ message });
   }
-  if (attribute.endsWith('Id')) {
+  if (attribute.endsWith('Id') && !NOT_VALID_RELATIONSHIPS.includes(attribute)) {
     return _formatRelationship({ attribute, message });
   }
   return _formatAttribute({ attribute, message });

--- a/api/lib/domain/usecases/save-certification-center.js
+++ b/api/lib/domain/usecases/save-certification-center.js
@@ -1,3 +1,6 @@
+const certificationCenterCreationValidator = require('../validators/certification-center-creation-validator');
+
 module.exports = function saveCertificationCenter({ certificationCenter, certificationCenterRepository }) {
+  certificationCenterCreationValidator.validate(certificationCenter);
   return certificationCenterRepository.save(certificationCenter);
 };

--- a/api/lib/domain/validators/certification-center-creation-validator.js
+++ b/api/lib/domain/validators/certification-center-creation-validator.js
@@ -1,0 +1,44 @@
+const Joi = require('@hapi/joi');
+const { EntityValidationError } = require('../errors');
+
+const validationConfiguration = { abortEarly: false, allowUnknown: true };
+
+const certificationCenterlidationJoiSchema = Joi.object({
+
+  name: Joi.string()
+    .max(255)
+    .required()
+    .messages({
+      'string.empty': 'Le nom n’est pas renseigné.',
+      'any.required': 'Le nom n’est pas renseigné.',
+      'string.max': 'Le nom ne doit pas dépasser 255 caractères.'
+    }),
+
+  type: Joi.string()
+    .required()
+    .valid('SCO', 'SUP', 'PRO')
+    .messages({
+      'string.empty': 'Le type n’est pas renseigné.',
+      'any.required': 'Le type n’est pas renseigné.',
+      'any.only': 'Le type du centre de certification doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.',
+    }),
+
+  externalId: Joi.string()
+    .optional()
+    .allow(null)
+    .max(255)
+    .messages({
+      'string.max': 'L‘identifiant externe ne doit pas dépasser 255 caractères.'
+    })
+});
+
+module.exports = {
+
+  validate(certificationCenter) {
+    const { error } = certificationCenterlidationJoiSchema.validate(certificationCenter, validationConfiguration);
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+    return true;
+  }
+};

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -14,7 +14,9 @@ module.exports = {
   deserialize(jsonAPI) {
     return new CertificationCenter({
       id: jsonAPI.data.id,
-      name: jsonAPI.data.attributes.name
+      name: jsonAPI.data.attributes.name,
+      type: jsonAPI.data.attributes.type,
+      externalId: jsonAPI.data.attributes['external-id'],
     });
   },
 };

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -89,7 +89,8 @@ describe('Acceptance | API | Certification Center', () => {
           data: {
             type: 'certification-center',
             attributes: {
-              name: 'Nouveau Centre de Certif'
+              name: 'Nouveau Centre de Certif',
+              type: 'SCO',
             }
           }
         }

--- a/api/tests/unit/domain/validators/certification-center-creation-validator_test.js
+++ b/api/tests/unit/domain/validators/certification-center-creation-validator_test.js
@@ -1,0 +1,171 @@
+const { expect } = require('../../../test-helper');
+const certificationCenterCreationValidator = require('../../../../lib/domain/validators/certification-center-creation-validator');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+const MISSING_VALUE = '';
+
+function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
+  expect(entityValidationErrors).to.be.instanceOf(EntityValidationError);
+  expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
+  expect(entityValidationErrors.invalidAttributes[0]).to.deep.equal(expectedError);
+}
+
+describe('Unit | Domain | Validators | certification-center-validator', function() {
+
+  describe('#validate', () => {
+
+    context('when validation is successful', () => {
+
+      it('should not throw any error', () => {
+        // given
+        const certificationCenterCreationParams = { name: 'ACME', type: 'PRO' };
+
+        // when/then
+        expect(certificationCenterCreationValidator.validate(certificationCenterCreationParams)).to.not.throw;
+      });
+    });
+
+    context('when certification-center data validation fails', () => {
+
+      context('on name attribute', () => {
+
+        it('should reject with error when name is missing', () => {
+          // given
+          const expectedError = {
+            attribute: 'name',
+            message: 'Le nom n’est pas renseigné.'
+          };
+          const certificationCenterCreationParams = { name: MISSING_VALUE, type: 'PRO' };
+
+          try {
+            // when
+            certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
+        it('should reject with error when name is longer than 255 characters', () => {
+          // given
+          const expectedError = {
+            attribute: 'name',
+            message: 'Le nom ne doit pas dépasser 255 caractères.'
+          };
+          const certificationCenterCreationParams = { name: 'a'.repeat(256), type: 'PRO' };
+
+          try {
+            // when
+            certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
+      });
+
+      context('on type attribute', () => {
+
+        it('should reject with error when type is missing', () => {
+          // given
+          const expectedError = [
+            {
+              attribute: 'type',
+              message: 'Le type du centre de certification doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.'
+            },
+            {
+              attribute: 'type',
+              message: 'Le type n’est pas renseigné.'
+            }];
+
+          const certificationCenterCreationParams = { name: 'ACME', type: MISSING_VALUE };
+
+          try {
+            // when
+            certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            expect(errors.invalidAttributes).to.have.length(2);
+            expect(errors.invalidAttributes).to.have.deep.equal(expectedError);
+          }
+        });
+
+        it('should reject with error when type value is not SUP, SCO or PRO', () => {
+          // given
+          const expectedError = {
+            attribute: 'type',
+            message: 'Le type du centre de certification doit avoir l’une des valeurs suivantes: SCO, SUP, PRO.'
+          };
+          const certificationCenterCreationParams = { name: 'ACME', type: 'PTT' };
+
+          try {
+            // when
+            certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            _assertErrorMatchesWithExpectedOne(errors, expectedError);
+          }
+        });
+
+        [
+          'SUP',
+          'SCO',
+          'PRO'
+        ].forEach((type) => {
+          it(`should not throw with ${type} as type`, function() {
+            // given
+            const certificationCenterCreationParams = { name: 'ACME', type };
+
+            // when/then
+            return expect(certificationCenterCreationValidator.validate(certificationCenterCreationParams)).to.not.throw;
+          });
+        });
+
+      });
+
+      context('on externalId attribute', () => {
+
+        it('should reject with error when externalId is longer than 255 characters', () => {
+          // given
+          const expectedError = [
+            {
+              attribute: 'externalId',
+              message: 'L‘identifiant externe ne doit pas dépasser 255 caractères.'
+            }
+          ];
+
+          const certificationCenterCreationParams = { name: 'ACME', type: 'SCO', externalId: 'a'.repeat(256) };
+
+          try {
+            // when
+            certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+            expect.fail('should have thrown an error');
+          } catch (errors) {
+            // then
+            expect(errors.invalidAttributes).to.have.length(1);
+            expect(errors.invalidAttributes).to.have.deep.equal(expectedError);
+          }
+        });
+      });
+
+      it('should reject with errors on all fields (but only once by field) when all fields are missing', () => {
+        // given
+        const certificationCenterCreationParams = { name: MISSING_VALUE, type: MISSING_VALUE, };
+
+        try {
+          // when
+          certificationCenterCreationValidator.validate(certificationCenterCreationParams);
+          expect.fail('should have thrown an error');
+        } catch (errors) {
+          // then
+          expect(errors.invalidAttributes).to.have.lengthOf(3);
+        }
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -7,10 +7,14 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
   let certificationCenterId;
   let certificationCenterName;
   let certificationCenterDate;
+  let certificationCenterType;
+  let certificationCenterExternalId;
 
   beforeEach(() => {
     certificationCenterId = 42;
     certificationCenterName = 'My certification center';
+    certificationCenterType = 'PRO';
+    certificationCenterExternalId = 'Identifiant externe';
     certificationCenterDate = 'Some date';
   });
 
@@ -58,6 +62,8 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
           id: certificationCenterId.toString(),
           attributes: {
             name: certificationCenterName,
+            type: certificationCenterType,
+            'external-id': certificationCenterExternalId,
             'created-at': new Date('2018-02-01T01:02:03Z')
           },
           relationships: {}
@@ -71,9 +77,9 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
       expect(deserializedCertificationCenter).to.be.instanceOf(CertificationCenter);
       expect(deserializedCertificationCenter.id).to.equal(certificationCenterId.toString());
       expect(deserializedCertificationCenter.name).to.equal(certificationCenterName);
+      expect(deserializedCertificationCenter.type).to.equal(certificationCenterType);
+      expect(deserializedCertificationCenter.externalId).to.equal(certificationCenterExternalId);
       expect(deserializedCertificationCenter.createdAt).to.be.undefined;
     });
-
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certifications sont créés à la main en base de donnée ce qui reste délicat d'accéder directement à la base. 

## :robot: Solution
Permettre la création depuis Pix Admin

## :100: Pour tester
Se connecter à Pix Admin et aller dans l'onglet centre de certification et créer un centre. 
