### PR TITLE
[FEATURE] Dans Pix Orga, générer un identifiant avec mot de passe temporaire pour les utilisateurs qui se connectent uniquement avec le GAR (PIX-1005).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/student.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/student.js
@@ -4,7 +4,7 @@ when(`je veux gérer le compte d'un élève`, () => {
 });
 
 then(`je vois la modale de gestion du compte de l'élève`, () => {
-  cy.contains('Gestion du compte de l\'élève');
+  cy.contains('Gestion du compte Pix de l\'élève');
 });
 
 then('je vois le mot de passe généré', () => {

--- a/orga/app/components/password-reset-modal.hbs
+++ b/orga/app/components/password-reset-modal.hbs
@@ -1,47 +1,84 @@
-<Modal::Dialog @title="Gestion du compte de l'élève" @display={{@display}} @close={{this.closePasswordReset}}>
+<Modal::Dialog @title="Gestion du compte Pix de l'élève" @display={{@display}} @close={{this.closePasswordReset}}>
   <form class="password-reset-window">
-    <Modal::Body>
-      {{#if @student.hasUsername}}
-          <div class="input-container">
-            <label for="username">Identifiant</label>
-            <div class="password-reset-window__clipboard">
-              <Input
-                id="username"
-                @name="username"
-                @type="text"
-                @class="input disabled"
-                @value={{@student.username}}
-                @disabled="disabled"
-              />
-              {{#if (is-clipboard-supported)}}
-                <div class="tooltip content-text content-text--small">
-                  <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextUsername}}</span>
-                  <CopyButton
-                    @aria-label="Copier l'identifiant"
-                    @clipboardText={{@student.username}}
-                    @success={{this.clipboardSuccessUsername}}
-                    {{ on 'mouseout' this.clipboardOutUsername}}
-                    @classNames="icon-button password-reset-window__clipboard-button"
-                  >
-                    <FaIcon @icon='copy' @prefix='far'></FaIcon>
-                  </CopyButton>
-                </div>
-              {{/if}}
-            </div>
+    <h6>
+      <FaIcon @icon="link" />
+      Méthodes de connexion
+    </h6>
+
+    <div>
+      {{#if @student.isAuthenticatedFromGar}}
+        <div class="password-reset-window__box">
+          <div class="password-reset-window__subTitle">
+            <span>Connecté avec Médiacentre</span>
+            <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
           </div>
+        </div>
       {{/if}}
 
-      {{#if @student.hasEmail}}
-          <div class="input-container">
+      <div class="password-reset-window__box">
+        {{#if @student.isAuthenticatedWithGarOnly}}
+          <div class="password-reset-window__subTitle">
+            <span>Ajouter une connexion avec un identifiant</span>
+            <FaIcon @icon="check-circle" @prefix="far" class="grey-icon" />
+          </div>
+          <button aria-label="Ajouter un identifiant" type="button" class="button"
+                  {{on 'click' this.generateUsernameWithTemporaryPassword}}>
+            Ajouter
+          </button>
+        {{else}}
+          {{#if @student.hasUsername}}
+            <div class="password-reset-window__subTitle">
+              <span>Connecté avec un identifiant</span>
+              <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
+            </div>
+            <div class="input-container">
+              <label for="username">Identifiant</label>
+              <div class="password-reset-window__clipboard">
+                <Input
+                  id="username"
+                  name="username"
+                  @type="text"
+                  class="input disabled"
+                  @value={{@student.username}}
+                  disabled={{true}}
+                />
+                {{#if (is-clipboard-supported)}}
+                  <div class="tooltip content-text content-text--small">
+                    <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextUsername}}</span>
+                    <CopyButton
+                      @aria-label="Copier l'identifiant"
+                      @clipboardText={{@student.username}}
+                      @success={{this.clipboardSuccessUsername}}
+                      {{ on 'mouseout' this.clipboardOutUsername}}
+                      @classNames="icon-button password-reset-window__clipboard-button"
+                    >
+                      <FaIcon @icon="copy" @prefix="far" />
+                    </CopyButton>
+                  </div>
+                {{/if}}
+              </div>
+            </div>
+          {{/if}}
+
+          {{#if (and @student.hasUsername @student.hasEmail)}}
+            <hr>
+          {{/if}}
+
+          {{#if @student.hasEmail}}
+            <div class="password-reset-window__subTitle">
+              <span>Connecté avec un e-mail</span>
+              <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
+            </div>
+            <div class="input-container">
               <label for="email">Adresse e-mail</label>
               <div class="password-reset-window__clipboard">
                 <Input
                   id="email"
-                  @name="email"
+                  name="email"
                   @type="text"
-                  @class="input disabled"
+                  class="input disabled"
                   @value={{@student.email}}
-                  @disabled="disabled"
+                  disabled={{true}}
                 />
                 {{#if (is-clipboard-supported)}}
                   <div class="tooltip content-text content-text--small">
@@ -53,61 +90,66 @@
                       {{ on 'mouseout' this.clipboardOutEmail}}
                       @classNames="icon-button password-reset-window__clipboard-button"
                     >
-                      <FaIcon @icon='copy' @prefix='far'></FaIcon>
+                      <FaIcon @icon="copy" @prefix="far" />
                     </CopyButton>
                   </div>
                 {{/if}}
               </div>
-          </div>
-      {{/if}}
-    </Modal::Body>
-    <Modal::Footer class="password-reset-window__footer">
-      {{#unless this.isUniquePasswordVisible}}
-        <div>
-          <button id="generate-password" type="button" class="button" {{on 'click' this.resetPassword}}>Réinitialiser le mot de passe</button>
+            </div>
+          {{/if}}
+        {{/if}}
+      </div>
+    </div>
 
-          <div class="password-reset-window__warning">
-            <FaIcon @icon='exclamation-triangle' @class="warning-icon" />
-            <span>Réinitialiser supprime le mot de passe actuel de l’élève</span>
+    {{#unless @student.isAuthenticatedWithGarOnly}}
+      <div class="password-reset-window__footer">
+        {{#if this.isUniquePasswordVisible}}
+          <div>
+            <div class="input-container">
+              <label for="generated-password">Mot de passe à usage unique</label>
+              <div class="password-reset-window__clipboard">
+                <Input
+                  id="generated-password"
+                  @type="text"
+                  name="generated-password"
+                  class="input"
+                  @value={{this.generatedPassword}}
+                  disabled={{true}}
+                />
+                {{#if (is-clipboard-supported)}}
+                  <div class="tooltip content-text content-text--small">
+                    <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextGeneratedPassword}}</span>
+                    <CopyButton
+                      @aria-label="Copier le mot de passe unique"
+                      @clipboardText={{this.generatedPassword}}
+                      @success={{this.clipboardSuccessGeneratedPassword}}
+                      {{on 'mouseout' this.clipboardOutGeneratedPassword}}
+                      @classNames="icon-button password-reset-window__clipboard-button"
+                    >
+                      <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
+                    </CopyButton>
+                  </div>
+                {{/if}}
+              </div>
+            </div>
+
+            <ol class="password-reset-window__informations">
+              <li>Communiquez ce mot de passe à votre élève</li>
+              <li>L'élève se connecte avec ce mot de passe à usage unique</li>
+              <li>Pix lui demande de choisir un nouveau mot de passe</li>
+            </ol>
           </div>
-        </div>
-      {{/unless}}
-      {{#if this.isUniquePasswordVisible}}
-        <div>
-          <div class="input-container">
-            <label for="generated-password">Mot de passe à usage unique</label>
-            <div class="password-reset-window__clipboard">
-              <Input
-                id="generated-password"
-                @name="generated-password"
-                @class="input"
-                @value={{this.generatedPassword}}
-                @disabled="true"
-              />
-              {{#if (is-clipboard-supported)}}
-                <div class="tooltip content-text content-text--small">
-                  <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextGeneratedPassword}}</span>
-                  <CopyButton
-                    @aria-label="Copier le mot de passe unique"
-                    @clipboardText={{this.generatedPassword}}
-                    @success={{this.clipboardSuccessGeneratedPassword}}
-                    {{ on 'mouseout' this.clipboardOutGeneratedPassword}}
-                    @classNames="icon-button password-reset-window__clipboard-button"
-                  >
-                    <FaIcon @icon='copy' class="fa-inverse" @prefix='far'></FaIcon>
-                  </CopyButton>
-                </div>
-              {{/if}}
+        {{else}}
+          <div>
+            <button id="generate-password" type="button" class="button" {{on 'click' this.resetPassword}}>Réinitialiser le mot de passe</button>
+
+            <div class="password-reset-window__warning">
+              <FaIcon @icon="exclamation-triangle" class="warning-icon" />
+              <span>Réinitialiser supprime le mot de passe actuel de l’élève</span>
             </div>
           </div>
-
-          <ol class="password-reset-window__informations">
-            <li>Communiquez ce mot de passe à votre élève</li>
-            <li>L'élève se connecte avec ce mot de passe à usage unique</li>
-            <li>Pix lui demande de choisir un nouveau mot de passe</li>
-          </ol>
-        </div>
-      {{/if}}
-    </Modal::Footer>
+        {{/if}}
+      </div>
+    {{/unless}}
   </form>
 </Modal::Dialog>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -60,23 +60,23 @@
                   @dropdownButtonClass="list-students-page__dropdown-button"
                   @dropdownContentClass="list-students-page__dropdown-content"
                 >
-                  {{#if (or student.hasUsername student.hasEmail)}}
+                  {{#if student.isAuthenticatedWithEmailOrUsernameOnly}}
                     <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
                       Gérer le compte
                     </Dropdown::Item>
+                  {{/if}}
+                  {{#if this.isGenerateUsernameFeatureIsEnabled}}
+                    {{#if student.isAuthenticatedFromGar}}
+                      <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                        Gérer le compte
+                      </Dropdown::Item>
+                    {{/if}}
                   {{/if}}
                   {{#if this.currentUser.isAdminInOrganization}}
                     <Dropdown::Item @onClick={{fn this.openDissociateModal student}}>
                       Dissocier le compte
                     </Dropdown::Item>
                   {{/if}}
-                {{#if this.isGenerateUsernameFeatureIsEnabled}}
-                  {{#if student.isAuthenticatedFromGarOnly}}
-                    <Dropdown::Item @onClick={{fn this.generateUsernameWithTemporaryPassword student}}>
-                      Générer identifiant
-                    </Dropdown::Item>
-                  {{/if}}
-                {{/if}}
                 </Dropdown::IconTrigger>
               {{/if}}
             </td>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -15,6 +14,7 @@ export default class ListItems extends Component {
   @tracked student = null;
   @tracked isShowingModal = false;
   @tracked isShowingDissociateModal = false;
+
   isGenerateUsernameFeatureIsEnabled = ENV.APP.IS_GENERATE_USERNAME_FEATURE_ENABLED;
 
   @action
@@ -37,24 +37,6 @@ export default class ListItems extends Component {
   @action
   closeDissociateModal() {
     this.isShowingDissociateModal = false;
-  }
-
-  @action
-  async generateUsernameWithTemporaryPassword(student) {
-    const schoolingRegistrationDependentUser = this.store.createRecord('schooling-registration-dependent-user', {
-      organizationId: this.currentUser.organization.id,
-      schoolingRegistrationId: student.id
-    });
-
-    try {
-      await schoolingRegistrationDependentUser.save({ adapterOptions: { generateUsernameAndTemporaryPassword: true } });
-      this.username = schoolingRegistrationDependentUser.username;
-      this.generatedPassword = schoolingRegistrationDependentUser.generatedPassword;
-      this.args.refreshModel();
-    } catch (response) {
-      const errorDetail = get(response, 'errors[0].detail', 'Une erreur est survenue, veuillez réessayer ultérieurement.');
-      this.notifications.sendError(errorDetail);
-    }
   }
 
 }

--- a/orga/app/models/schooling-registration-dependent-user.js
+++ b/orga/app/models/schooling-registration-dependent-user.js
@@ -5,5 +5,6 @@ export default class SchoolingRegistrationDependentUser extends Model {
   @attr('number') organizationId;
   @attr('number') schoolingRegistrationId;
   @attr('string') generatedPassword;
+  @attr('string') username;
 
 }

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -38,11 +38,17 @@ export default class Student extends Model {
 
   @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
   get isStudentAssociated() {
-    return Boolean(this.email || this.username || this.isAuthenticatedFromGar);
+    return Boolean(this.hasEmail || this.hasUsername || this.isAuthenticatedFromGar);
   }
 
   @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
-  get isAuthenticatedFromGarOnly() {
-    return Boolean(!this.email && !this.username && this.isAuthenticatedFromGar);
+  get isAuthenticatedWithGarOnly() {
+    return Boolean(!this.hasEmail && !this.hasUsername && this.isAuthenticatedFromGar);
   }
+
+  @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
+  get isAuthenticatedWithEmailOrUsernameOnly() {
+    return Boolean((this.hasEmail || this.hasUsername) && !this.isAuthenticatedFromGar);
+  }
+
 }

--- a/orga/app/styles/components/password-reset-modal.scss
+++ b/orga/app/styles/components/password-reset-modal.scss
@@ -1,7 +1,15 @@
 .password-reset-window {
   display: flex;
   flex-direction: column;
-  margin-top: 16px;
+  background-color: $grey-10;
+  padding: 24px;
+
+  h6 {
+    font-size: 1.125rem;
+    font-weight: normal;
+    color: $grey-90;
+    margin: 0px;
+  }
 
   label {
     color: $grey-60;
@@ -69,7 +77,8 @@
 
   &__footer {
     background-color: $grey-70;
-    border-radius: 8px 8px 4px 4px;
+    border-radius: 8px;
+    padding: 16px 24px;
 
     button {
       font-weight: 600;
@@ -78,6 +87,36 @@
 
     label {
       color: $white;
+    }
+  }
+
+  &__box {
+    background-color: $white;
+    border-radius: 8px;
+    margin-top: 16px;
+    padding: 16px 24px 1px 24px;
+
+    hr {
+      color: $grey-22;
+      margin-bottom: 16px;
+    }
+
+    .button {
+      margin-bottom: 16px;
+    }
+  }
+
+  &__subTitle {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 16px;
+
+    .green-icon {
+      color: $green;
+    }
+
+    .grey-icon {
+      color: $grey-45;
     }
   }
 }

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -13,6 +13,7 @@ module.exports = function() {
       'eye-slash',
       'exclamation-triangle',
       'hourglass-half',
+      'link',
       'power-off',
       'search',
       'share-square',
@@ -20,6 +21,7 @@ module.exports = function() {
       'times',
     ],
     'free-regular-svg-icons': [
+      'check-circle',
       'copy',
     ],
   };

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -257,9 +257,16 @@ export default function() {
   this.get('/campaign-participation-results/:id');
 
   this.post('/schooling-registration-dependent-users/password-update', (schema) => {
-    const schoolingRegistrationDependentUser = schema.schoolingRegistrationDependentUsers.create();
-    schoolingRegistrationDependentUser.generatedPassword = 'Passw0rd';
-    return schoolingRegistrationDependentUser;
+    return schema.schoolingRegistrationDependentUsers.create({
+      generatedPassword: 'Passw0rd'
+    });
+  });
+
+  this.post('/schooling-registration-dependent-users/generate-username-password', (schema) => {
+    return schema.schoolingRegistrationDependentUsers.create({
+      username: 'user.gar3112',
+      generatedPassword: 'Passw0rd'
+    });
   });
 
   this.post('/user-orga-settings', (schema, request) => {

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -2832,17 +2832,17 @@
       "dev": true
     },
     "@fortawesome/ember-fontawesome": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@fortawesome/ember-fontawesome/-/ember-fontawesome-0.1.14.tgz",
-      "integrity": "sha512-RQg9i7y8uxArgwRnWKA6orMKlftU2nnb0930ZqBD7+vmj9CbhQaYP51vEgIu5Qw9RUGAoqZDkpUwgsFXg39/fw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/ember-fontawesome/-/ember-fontawesome-0.2.1.tgz",
+      "integrity": "sha512-yGWv9pbsF5VJVbnEvydDZnU/BZ1eru+rZ0kAwmD1gaYPUvmqO3wi+Sshlp5yA1OjBVtcZ9qV/YAZr1oiBkjZFg==",
       "dev": true,
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.0",
-        "broccoli-file-creator": "^1.1.1",
-        "broccoli-merge-trees": "^2.0.0",
-        "broccoli-plugin": "^1.3.0",
-        "broccoli-rollup": "^2.0.0",
-        "broccoli-source": "^1.1.0",
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-plugin": "^3.0.0",
+        "broccoli-rollup": "^4.1.1",
+        "broccoli-source": "^3.0.0",
         "camel-case": "^3.0.0",
         "ember-ast-helpers": "0.3.5",
         "ember-cli-babel": "^7.7.3",
@@ -2850,9 +2850,118 @@
         "ember-get-config": "^0.2.4",
         "find-yarn-workspace-root": "^1.2.1",
         "glob": "^7.1.2",
-        "rollup-plugin-node-resolve": "^4.0.0"
+        "rollup-plugin-node-resolve": "^5.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+          "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+          "dev": true
+        },
+        "broccoli-file-creator": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
+          "integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^2.0.0"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            }
+          }
+        },
+        "broccoli-plugin": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
+          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^2.0.0",
+            "fs-merger": "^3.0.1",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^2.3.4",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "broccoli-rollup": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-4.1.1.tgz",
+          "integrity": "sha512-hkp0dB5chiemi32t6hLe5bJvxuTOm1TU+SryFlZIs95KT9+94uj0C8w6k6CsZ2HuIdIZg6D252t4gwOlcTXrpA==",
+          "dev": true,
+          "requires": {
+            "@types/broccoli-plugin": "^1.3.0",
+            "broccoli-plugin": "^2.0.0",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.6",
+            "node-modules-path": "^1.0.1",
+            "rollup": "^1.12.0",
+            "rollup-pluginutils": "^2.8.1",
+            "symlink-or-copy": "^1.2.0",
+            "walk-sync": "^1.1.3"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
+              "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^2.3.4",
+                "symlink-or-copy": "^1.1.8"
+              }
+            }
+          }
+        },
+        "broccoli-source": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.0.tgz",
+          "integrity": "sha512-G4Zc8HngZIdASyQOiz/9H/0Gjc2F02EFwhWF4wiueaI+/FBrM9Ixj6Prno/1aiLIYcN0JvRC3oytN9uOVonTww==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0"
+          }
+        },
         "ember-cli-htmlbars": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-3.1.0.tgz",
@@ -2864,22 +2973,75 @@
             "json-stable-stringify": "^1.0.1",
             "strip-bom": "^3.0.0"
           }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
+          "requires": {
+            "fs-updater": "^1.0.4",
+            "heimdalljs": "^0.2.5"
+          }
+        },
+        "rollup": {
+          "version": "1.32.1",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
+          "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "*",
+            "@types/node": "*",
+            "acorn": "^7.1.0"
+          }
+        },
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
         }
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.28.tgz",
-      "integrity": "sha512-gtis2/5yLdfI6n0ia0jH7NJs5i/Z/8M/ZbQL6jXQhCthEOe5Cr5NcQPhgTvFxNOtURE03/ZqUcEskdn2M+QaBg==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
+      "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==",
       "dev": true
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.28",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.28.tgz",
-      "integrity": "sha512-4LeaNHWvrneoU0i8b5RTOJHKx7E+y7jYejplR7uSVB34+mp3Veg7cbKk7NBCLiI4TyoWS1wh9ZdoyLJR8wSAdg==",
+      "version": "1.2.30",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz",
+      "integrity": "sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==",
       "dev": true,
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
+      },
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": {
+          "version": "0.2.30",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
+          "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg==",
+          "dev": true
+        }
       }
     },
     "@fortawesome/free-regular-svg-icons": {
@@ -2900,12 +3062,12 @@
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.0.tgz",
-      "integrity": "sha512-IHUgDJdomv6YtG4p3zl1B5wWf9ffinHIvebqQOmV3U+3SLw4fC+LUCCgwfETkbTtjy5/Qws2VoVf6z/ETQpFpg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz",
+      "integrity": "sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==",
       "dev": true,
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.28"
+        "@fortawesome/fontawesome-common-types": "^0.2.30"
       }
     },
     "@glimmer/compiler": {
@@ -20737,15 +20899,16 @@
       }
     },
     "rollup-plugin-node-resolve": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.4.tgz",
-      "integrity": "sha512-t/64I6l7fZ9BxqD3XlX4ZeO6+5RLKyfpwE2CiPNUKa+GocPlQhf/C208ou8y3AwtNsc6bjSk/8/6y/YAyxCIvw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==",
       "dev": true,
       "requires": {
         "@types/resolve": "0.0.8",
         "builtin-modules": "^3.1.0",
         "is-module": "^1.0.0",
-        "resolve": "^1.10.0"
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-pluginutils": {

--- a/orga/package.json
+++ b/orga/package.json
@@ -33,9 +33,9 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",
-    "@fortawesome/ember-fontawesome": "^0.1.13",
-    "@fortawesome/free-regular-svg-icons": "^5.8.2",
-    "@fortawesome/free-solid-svg-icons": "^5.8.2",
+    "@fortawesome/ember-fontawesome": "^0.2.1",
+    "@fortawesome/free-regular-svg-icons": "^5.14.0",
+    "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@glimmer/component": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/orga/tests/integration/components/password-reset-modal-test.js
+++ b/orga/tests/integration/components/password-reset-modal-test.js
@@ -1,11 +1,10 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
-import { run } from '@ember/runloop';
 import { resolve } from 'rsvp';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
-import Object from '@ember/object';
+import EmberObject from '@ember/object';
 import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';
 import faker from 'faker';
 
@@ -13,114 +12,179 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
   setupRenderingTest(hooks);
 
-  let username;
-  let email;
-  let student;
+  module('When Student is not connected with GAR method', function() {
 
-  hooks.beforeEach(function() {
-    const store = this.owner.lookup('service:store');
-    username = 'john.doe0112';
-    email = 'john.doe0112@example.net';
-    student =
-      run(() => store.createRecord('student', {
+    const username = 'john.doe0112';
+    const email = 'john.doe0112@example.net';
+
+    hooks.beforeEach(function() {
+      this.studentWithUsernameAndEmail = EmberObject.create({
         id: 1,
         username,
         email,
         firstName: 'John',
         lastName: 'Doe',
         birthdate: '2010-12-01',
-        organization: run(() => store.createRecord('organization', {}))
-      }));
-    this.set('student', student);
-    this.set('display', true);
-    this.set('close', () => { this.set('display', false); });
+        isAuthenticatedFromGar: false,
+        hasUsername: true,
+        hasEmail: true
+      });
 
-    return render(hbs`<PasswordResetModal @display={{display}} @close={{close}} @student={{student}} />`);
+      this.display = true;
+    });
+
+    module('When Student is connected with username method', function() {
+
+      test('should render component with username field', async function(assert) {
+        // when
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // then
+        assert.dom('#username').hasValue(username);
+      });
+
+      test('should render clipboard to copy username', async function(assert) {
+        // when
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // then
+        assert.dom('button[aria-label="Copier l\'identifiant"]').hasAttribute('data-clipboard-text', username);
+        assert.contains('Copier l\'identifiant');
+      });
+
+      test('should display tooltip when username copy button is clicked', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // when
+        await triggerCopySuccess('button[aria-label="Copier l\'identifiant"]');
+
+        // then
+        assert.dom('#username + .tooltip').hasText('Copié !');
+      });
+    });
+
+    module('When Student is connected with email method', function() {
+
+      test('should render component with email field', async function(assert) {
+        // when
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // then
+        assert.dom('#email').hasValue(email);
+      });
+
+      test('should render clipboard to copy email', async function(assert) {
+        // when
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // then
+        assert.dom('button[aria-label="Copier l\'adresse e-mail"]').hasAttribute('data-clipboard-text', email);
+        assert.contains('Copier l\'adresse e-mail');
+      });
+
+      test('should display tooltip when email copy button is clicked', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // when
+        await triggerCopySuccess('button[aria-label="Copier l\'adresse e-mail"]');
+
+        // then
+        assert.contains('Copié !');
+      });
+    });
+
+    module('When password is generated', function() {
+
+      let generatedPassword;
+
+      hooks.beforeEach(function() {
+        const storeStub = Service.extend({
+          createRecord: () => {
+            generatedPassword = faker.internet.password();
+            return EmberObject.create({
+              save() {
+                return resolve();
+              },
+              generatedPassword
+            });
+          }
+        });
+        this.owner.unregister('service:store');
+        this.owner.register('service:store', storeStub);
+      });
+
+      test('should display unique password input when reset password button is clicked', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // when
+        await click('#generate-password');
+
+        // then
+        assert.dom('#generated-password').exists();
+      });
+
+      test('should render clipboard to copy unique password', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // when
+        await click('#generate-password');
+
+        // then
+        assert.dom('button[aria-label="Copier le mot de passe unique"]').hasAttribute('data-clipboard-text', generatedPassword);
+        assert.contains('Copier le mot de passe unique');
+      });
+
+      test('should display tooltip when generated password copy button is clicked', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+
+        // when
+        await click('#generate-password');
+        await triggerCopySuccess('button[aria-label="Copier le mot de passe unique"]');
+
+        // then
+        assert.contains('Copié !');
+      });
+
+      test('should generate unique password each time the modal is used', async function(assert) {
+        // given
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await click('#generate-password');
+        const firstGeneratedPassword = this.element.querySelector('#generated-password').value;
+
+        // when
+        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await click('#generate-password');
+        const secondGeneratedPassword = this.element.querySelector('#generated-password').value;
+
+        // then
+        assert.notEqual(firstGeneratedPassword, secondGeneratedPassword);
+      });
+    });
   });
 
-  module('Student with username authentication method', function() {
-    test('should render component with username field', async function(assert) {
-      assert.dom('#username').hasValue(username);
-    });
-
-    test('should render clipboard to copy username', async function(assert) {
-      assert.dom('button[aria-label="Copier l\'identifiant"]').hasAttribute('data-clipboard-text', username);
-      assert.contains('Copier l\'identifiant');
-    });
-
-    test('should display tooltip when username copy button is clicked', async function(assert) {
-      await triggerCopySuccess('button[aria-label="Copier l\'identifiant"]');
-
-      assert.dom('#username + .tooltip').hasText('Copié !');
-    });
-  });
-
-  module('Student with email authentication method', function() {
-    test('should render component with email field', async function(assert) {
-      assert.dom('#email').hasValue(email);
-    });
-
-    test('should render clipboard to copy email', async function(assert) {
-      assert.dom('button[aria-label="Copier l\'adresse e-mail"]').hasAttribute('data-clipboard-text', email);
-      assert.contains('Copier l\'adresse e-mail');
-    });
-
-    test('should display tooltip when email copy button is clicked', async function(assert) {
-      await triggerCopySuccess('button[aria-label="Copier l\'adresse e-mail"]');
-
-      assert.contains('Copié !');
-    });
-  });
-
-  module('Unique password', function() {
-
-    let generatedPassword;
+  module('When Student is connected with GAR method', function() {
 
     hooks.beforeEach(function() {
-      const storeStub = Service.extend({
-        createRecord: () => {
-          generatedPassword = faker.internet.password();
-          return Object.create({
-            save() {
-              return resolve();
-            },
-            generatedPassword
-          });
-        }
+      this.studentGAR = EmberObject.create({
+        id: 2,
+        isAuthenticatedFromGar: true,
+        isAuthenticatedWithGarOnly: true
       });
-      this.owner.unregister('service:store');
-      this.owner.register('service:store', storeStub);
+      this.display = true;
     });
 
-    test('should display unique password input when reset password button is clicked', async function(assert) {
-      await click('.modal-footer div button');
+    test('should render component with GAR connection method', async function(assert) {
+      // when
+      await render(hbs`<PasswordResetModal @student={{this.studentGAR}} @display={{this.display}} />`);
 
-      assert.dom('#generated-password').exists();
-    });
-
-    test('should render clipboard to copy unique password', async function(assert) {
-      await click('.modal-footer div button');
-
-      assert.dom('button[aria-label="Copier le mot de passe unique"]').hasAttribute('data-clipboard-text', generatedPassword);
-      assert.contains('Copier le mot de passe unique');
-    });
-
-    test('should display tooltip when generated password copy button is clicked', async function(assert) {
-      await click('.modal-footer div button');
-      await triggerCopySuccess('button[aria-label="Copier le mot de passe unique"]');
-
-      assert.contains('Copié !');
-    });
-
-    test('should generate unique password each time the modal is used', async function(assert) {
-      await click('.modal-footer div button');
-      const firstGeneratedPassword = this.element.querySelector('#generated-password').value;
-      await click('[aria-label="Fermer la fenêtre"]');
-      this.set('display', true);
-      await click('.modal-footer div button');
-      const secondGeneratedPassword = this.element.querySelector('#generated-password').value;
-
-      assert.notEqual(firstGeneratedPassword, secondGeneratedPassword);
+      // then
+      assert.contains('Connecté avec Médiacentre');
+      assert.contains('Ajouter une connexion avec un identifiant');
     });
   });
 

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/sco-students | list-items', function(hooks) {
+
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -52,8 +53,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
   test('it should display the firstName, lastName and birthdate of student', async function(assert) {
     // given
-    const students = [{ lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') },];
-
+    const students = [{ lastName: 'La Terreur', firstName: 'Gigi', birthdate: new Date('2010-02-01') }];
     this.set('students', students);
 
     // when
@@ -66,14 +66,16 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
   });
 
   module('when user is filtering some users', function() {
+
     test('it should trigger filtering with lastname', async function(assert) {
+      // given
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);
       this.set('students', []);
 
-      // when
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
+      // when
       await fillIn('[placeholder="Rechercher par nom"]', 'bob');
 
       // then
@@ -84,13 +86,14 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
 
     test('it should trigger filtering with firstname', async function(assert) {
+      // given
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);
       this.set('students', []);
 
-      // when
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
+      // when
       await fillIn('[placeholder="Rechercher par prénom"]', 'bob');
 
       // then
@@ -101,14 +104,15 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
 
     test('it should trigger filtering with connexionType', async function(assert) {
+      // given
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);
       this.set('students', []);
       this.set('connexionTypesOptions', [{ value: 'email', label: 'email' }]);
 
-      // when
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}} @connexionTypesOptions={{connexionTypesOptions}} />`);
 
+      // when
       await fillIn('select', 'email');
 
       // then
@@ -120,6 +124,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
   });
 
   module('when user is not reconciled', function({ beforeEach }) {
+
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -144,6 +149,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
   });
 
   module('when user authentification method is username', function({ beforeEach }) {
+
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -168,6 +174,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
   });
 
   module('when user authentification method is email', function({ beforeEach }) {
+
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -192,6 +199,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
   });
 
   module('when user authentification method is samlId', function({ beforeEach }) {
+
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -204,26 +212,38 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           isAuthenticatedFromGar: true,
         })
       ]);
-      return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
     });
 
     test('it should display "Mediacentre" as authentication method', async function(assert) {
+      // when
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // then
       assert.dom('[aria-label="Élève"]').containsText('Mediacentre');
     });
 
     test('it should display the action menu', async function(assert) {
+      // when
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // then
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
     test('it should display the button generate username in the menu', async function(assert) {
+      // given
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // when
       await click('[aria-label="Afficher les actions"]');
 
       // then
-      assert.contains('Générer identifiant');
+      assert.contains('Gérer le compte');
     });
   });
 
   module('user rights', (hooks) => {
+
     hooks.beforeEach(function() {
       const store = this.owner.lookup('service:store');
       this.set('students', [
@@ -238,6 +258,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
 
     module('when user is admin in organization', (hooks) => {
+
       hooks.beforeEach(function() {
         this.set('importStudentsSpy', () => {});
         this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: true }));
@@ -249,6 +270,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       });
 
       test('it should display the dissociate action', async function(assert) {
+        // when
         await click('[aria-label="Afficher les actions"]');
 
         // then
@@ -257,6 +279,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
 
     module('when user is not admin in organization', (hooks) => {
+
       hooks.beforeEach(function() {
         this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: false }));
         return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
@@ -267,6 +290,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       });
 
       test('it should not display the dissociate action', async function(assert) {
+        // when
         await click('[aria-label="Afficher les actions"]');
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
Quand un élève change d'établissement, il ne peut plus se connecter avec son compte GAR.

## :robot: Solution
Ce ticket est la suite de #1664. 

Redonner l'accès à l'élève en lui générant un identifiant et un mot de passe temporaire pour se connecter.
Rajouter une entrée dans le menu qui va permettre au prof de générer un identifiant à l'élève.

## :rainbow: Remarques
1. Le _feature flipping_ sera utilisé.
Cette entrée ne sera pas visible à l'utilisateur, tant que le reste des fonctionnalités de l’Epix ne sera pas développé.
1. Le design de la modal a été modifié
![image](https://user-images.githubusercontent.com/88607/89629240-c2ed0600-d89d-11ea-98cb-a5abce9e0d60.png)

## :100: Pour tester
- Se connecter à Pix Orga avec le compte sco@example.net
- Aller sur la page Élèves
- Utiliser le compte élève qui dispose uniquement de la méthode de connexion GAR.
- Vérifier que l'entrée 'Gérer le compte' s'affiche pour cet élève.
- En cliquant sur ce bouton, vérifier le contenu de la modal
  - La méthode de connexion doit être 'Médiacentre'
  - Le bouton pour ajouter un identifiant doit être présent.
  - Si ce bouton est actionné, l'identifiant doit être créé (avec le mot de passe associé).