### PR TITLE
[BUGFIX] Supprimer les données lors de la déconnexion de Pix Admin (PIX-994).

### DIFF
--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -6,6 +6,7 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
 
   @service currentUser;
   @service notifications;
+  @service url;
 
   routeAfterAuthentication = 'authenticated';
 
@@ -19,10 +20,22 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   }
 
   sessionInvalidated() {
-    this.transitionTo('login');
+    const redirectionUrl = this._redirectionUrl();
+    this._clearStateAndRedirect(redirectionUrl);
+  }
+
+  _clearStateAndRedirect(url) {
+    return window.location.replace(url);
   }
 
   _loadCurrentUser() {
     return this.currentUser.load();
+  }
+
+  _redirectionUrl() {
+    const alternativeRootURL = this.session.alternativeRootURL;
+    this.session.alternativeRootURL = null;
+
+    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
   }
 }

--- a/admin/app/services/current-domain.js
+++ b/admin/app/services/current-domain.js
@@ -1,0 +1,9 @@
+import Service  from '@ember/service';
+import last from 'lodash/last';
+
+export default class CurrentDomainService extends Service {
+
+  getExtension() {
+    return last(location.hostname.split('.'));
+  }
+}

--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -1,0 +1,16 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import ENV from 'pix-admin/config/environment';
+
+export default class Url extends Service {
+
+  @service currentDomain;
+
+  definedHomeUrl = ENV.APP.HOME_URL;
+
+  get homeUrl() {
+    const homeUrl = `https://admin.pix.${this.currentDomain.getExtension()}`;
+    return this.definedHomeUrl || homeUrl;
+  }
+
+}

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -44,6 +44,7 @@ module.exports = function(environment) {
         FORBIDDEN: '403',
         NOT_FOUND: '404',
       },
+      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL
@@ -85,6 +86,7 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
+    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -97,7 +99,10 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
+
     ENV.APP.API_HOST = 'http://localhost:3000';
+
+    ENV.APP.HOME_URL = '/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, lorsqu'un utilisateur se déconnecte, le store Ember n'est pas vidé.

## :robot: Solution
- Utiliser la fonction native du browser `window.location.replace`.
- Modifier le code pour mettre en avant l'action implicite de suppression du state par window.location.replace, afin que l'introduction de nouvelles redirection n'entraîne pas de régression.

## :rainbow: Remarques
cf. #1607 

## :100: Pour tester
- Se connecter à Pix Admin
- Ouvrir l'Inspecteur Ember (_menu Data_)
- Consulter quelques pages, et vérifier que les données apparaissent dans le _menu Data_
- Se déconnecter de Pix Admin
- Vérifier que le _menu Data_ ne contient plus aucune donnée
- Dans la console, vérifier que Ember n'est plus monté en mémoire
  - `Ember.Application.NAMESPACES_BY_ID['pix-admin'].__container__.lookup('service:currentUser').user.firstName`
