### PR TITLE
[BUGFIX] Le script de Mimigration des snapshots KE essayait de générer des snapshots sur des participations ayant déjà un snapshot (PIX-1105)

### DIFF
--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns.js
@@ -45,7 +45,10 @@ function _validateAndNormalizeArgs({
 
 async function getEligibleCampaignParticipations(maxSnapshotCount) {
   return knex('campaign-participations').select('campaign-participations.userId', 'campaign-participations.sharedAt')
-    .leftJoin('knowledge-element-snapshots', 'knowledge-element-snapshots.userId', 'campaign-participations.userId')
+    .leftJoin('knowledge-element-snapshots', function() {
+      this.on('knowledge-element-snapshots.userId', 'campaign-participations.userId')
+        .andOn('knowledge-element-snapshots.snappedAt', 'campaign-participations.sharedAt');
+    })
     .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
     .whereNull('campaigns.archivedAt')
     .whereNotNull('campaign-participations.sharedAt')

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
@@ -9,6 +9,7 @@ const {
 describe('Integration | Scripts | generate-knowledge-element-snapshots-for-active-campaigns.js', () => {
 
   describe('#getEligibleCampaignParticipations', () => {
+    const maxParticipationCountToGet = 5;
 
     it('should avoid returning campaign participations that are not in active campaigns', async () => {
       // given
@@ -17,7 +18,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       await databaseBuilder.commit();
 
       // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
       expect(campaignParticipationData.length).to.equal(0);
@@ -30,7 +31,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       await databaseBuilder.commit();
 
       // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
       expect(campaignParticipationData.length).to.equal(0);
@@ -45,7 +46,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       await databaseBuilder.commit();
 
       // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
       expect(campaignParticipationData.length).to.equal(0);
@@ -59,7 +60,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       await databaseBuilder.commit();
 
       // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
       expect(campaignParticipationData.length).to.equal(1);
@@ -77,7 +78,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       await databaseBuilder.commit();
 
       // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(5);
+      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
 
       // then
       expect(campaignParticipationData.length).to.equal(1);

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns_test.js
@@ -66,12 +66,14 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
       expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation.userId, sharedAt: campaignParticipation.sharedAt });
     });
 
-    it('should return shared campaign participations from active campaigns even if there is a snapshot from an anterior date that already exists', async () => {
+    it('should return shared campaign participations from active campaigns even if there is a snapshot from a different date that already exists', async () => {
       // given
-      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: null }).id;
       const userId = databaseBuilder.factory.buildUser().id;
-      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId, sharedAt: new Date('2020-02-01'), userId });
-      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2019-01-01'), userId });
+      const campaignParticipationWithoutSnapshot = databaseBuilder.factory.buildCampaignParticipation({ sharedAt: new Date('2020-01-01'), userId });
+      databaseBuilder.factory.buildCampaignParticipation({ sharedAt: new Date('2020-02-01'), userId });
+      databaseBuilder.factory.buildCampaignParticipation({ sharedAt: new Date('2020-03-01'), userId });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2020-02-01'), userId });
+      databaseBuilder.factory.buildKnowledgeElementSnapshot({ snappedAt: new Date('2020-03-01'), userId });
       await databaseBuilder.commit();
 
       // when
@@ -79,7 +81,7 @@ describe('Integration | Scripts | generate-knowledge-element-snapshots-for-activ
 
       // then
       expect(campaignParticipationData.length).to.equal(1);
-      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipation.userId, sharedAt: campaignParticipation.sharedAt });
+      expect(campaignParticipationData[0]).to.deep.equal({ userId: campaignParticipationWithoutSnapshot.userId, sharedAt: campaignParticipationWithoutSnapshot.sharedAt });
     });
 
     it('should return maximum campaign participation as set in the parameter', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Tandis que nous essayions le script sur la base de réplication afin d'avoir une idée du temps d'exécution, nous avons eu la surprise ET la déception de constater qu'il ne fonctionnait pas !
Plus précisément, il semblait qu'il tentait de créer des snapshots sur des participations ayant déjà un snapshot correspondant.

Le bug se manifeste dans le cas où un utilisateur dispose de plus d'une participation.
On a rapidement soupçonné la requête permettant de récupérer la liste des participations ne disposant pas encore de snapshots.
Nous avons exécuté cette requête (SANS les conditions pour exclure les participations non éligibles) sur la réplication afin de mieux comprendre. En gros, on veut d'abord voir ce que nous retourne la jointure. 
Nous allons nous concentrer sur l'utilisateur 22. Cet utilisateur a deux participations, et il existe déjà un snapshot pour chacune d'entre elles. 
Du coup, la jointure dans la requête nous retourne ceci :
![without_cond](https://user-images.githubusercontent.com/48727874/89656232-95b74c80-d8cb-11ea-8b07-08c76b431bd5.png)
Ce qui est normal, elle retourne tous les matchs de la jointure, donc 2 * 2 combinaisons.

Ensuite, on a ajouté les conditions d'exclusion (qu'on pensait alors suffisantes), à savoir on exclut les lignes pour lesquelles `campaign-participations.sharedAt != knowledge-element-snapshots.snappedAt`, malheureusement, à cause de la combinatoire des matchs de jointure, il nous reste encore des lignes non désirées :
![with_cond](https://user-images.githubusercontent.com/48727874/89656768-55a49980-d8cc-11ea-958a-6ff38fb6e6bb.png)

## :robot: Solution
Ajouter une contrainte supplémentaire au niveau de la jointure

## :rainbow: Remarques
On a renforcé un test pour couvrir ce cas

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
