### PR TITLE
[BUGFIX] Correction de l'affichage du texte de réinitialisation des embed (PIX-1094)

### DIFF
--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -83,9 +83,7 @@
 
 .embed-reboot__content {
   display:flex;
-  justify-content: space-between;
   align-items: center;
-  width: 100px;
 
   &:active, &:hover {
     cursor: pointer;
@@ -95,4 +93,8 @@
 .embed-reboot-content__text {
   font-family: $font-roboto;
   font-size: 0.938rem;
+}
+
+.embed-reboot-content__icon {
+  margin-right: 10px;
 }

--- a/mon-pix/app/templates/components/challenge-embed-simulator.hbs
+++ b/mon-pix/app/templates/components/challenge-embed-simulator.hbs
@@ -24,7 +24,7 @@
 
   <div class="embed__reboot">
     <div class="link link--grey embed-reboot__content" role="button" {{on 'click' this.rebootSimulator}}>
-      <FaIcon @icon="redo-alt"></FaIcon>
+      <FaIcon @icon="redo-alt" class="embed-reboot-content__icon"></FaIcon>
       <div class="embed-reboot-content__text">{{t "pages.challenge.embed-simulator.actions.reset"}} </div>
     </div>
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Dans les épreuves avec des embed, le texte de réinitialisation était éloigné de l'icone correspondante.
![image](https://user-images.githubusercontent.com/36371437/89655813-ee3a1a00-d8ca-11ea-8de0-1a79060043f8.png)

## :robot: Solution
Suppression du space-between séparant le texte de l'icone
Ajout d'une classe CSS à la favicon et d'une margin-right

![image](https://user-images.githubusercontent.com/36371437/89656137-71f40680-d8cb-11ea-9a78-64d2a2c0323b.png) 

## :100: Pour tester
Réaliser le challenge : recnS18nXFT6qxWL0 en versions FR et EN (param: ?lang=en)
