### PR TITLE
[BUGFIX] Supprimer les données lors de la déconnexion de Pix Certif (PIX-993).

### DIFF
--- a/certif/app/routes/application.js
+++ b/certif/app/routes/application.js
@@ -3,7 +3,10 @@ import { inject as service } from '@ember/service';
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 
 export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
+
   @service currentUser;
+  @service url;
+
   routeAfterAuthentication = 'authenticated';
 
   beforeModel() {
@@ -16,10 +19,22 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   }
 
   sessionInvalidated() {
-    this.transitionTo('login');
+    const redirectionUrl = this._redirectionUrl();
+    this._clearStateAndRedirect(redirectionUrl);
+  }
+
+  _clearStateAndRedirect(url) {
+    return window.location.replace(url);
   }
 
   _loadCurrentUser() {
     return this.currentUser.load();
+  }
+
+  _redirectionUrl() {
+    const alternativeRootURL = this.session.alternativeRootURL;
+    this.session.alternativeRootURL = null;
+
+    return alternativeRootURL ? alternativeRootURL : this.url.homeUrl;
   }
 }

--- a/certif/app/services/current-domain.js
+++ b/certif/app/services/current-domain.js
@@ -1,0 +1,9 @@
+import Service  from '@ember/service';
+import last from 'lodash/last';
+
+export default class CurrentDomainService extends Service {
+
+  getExtension() {
+    return last(location.hostname.split('.'));
+  }
+}

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,0 +1,16 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import ENV from 'pix-certif/config/environment';
+
+export default class Url extends Service {
+
+  @service currentDomain;
+
+  definedHomeUrl = ENV.APP.HOME_URL;
+
+  get homeUrl() {
+    const homeUrl = `https://certif.pix.${this.currentDomain.getExtension()}`;
+    return this.definedHomeUrl || homeUrl;
+  }
+
+}

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -45,6 +45,7 @@ module.exports = function(environment) {
         FORBIDDEN: '403',
         NOT_FOUND: '404',
       },
+      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
     },
 
@@ -83,6 +84,7 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
+    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -93,17 +95,18 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
-    ENV.APP.API_HOST = 'http://localhost:3000';
-
     // Testem prefers this...
     ENV.locationType = 'none';
+
+    ENV.APP.API_HOST = 'http://localhost:3000';
+    ENV.APP.HOME_URL = '/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
-    ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+    ENV.APP.rootElement = '#ember-testing';
 
     ENV.notifications.autoClear = null;
     ENV.notifications.clearDuration = null;

--- a/certif/tests/acceptance/terms-of-service-test.js
+++ b/certif/tests/acceptance/terms-of-service-test.js
@@ -66,17 +66,6 @@ module('Acceptance | terms-of-service', function(hooks) {
       assert.equal(currentURL(), '/sessions/liste');
     });
 
-    test('it should logout when user clicks on cancel button', async function(assert) {
-      // given
-      await visit('/cgu');
-
-      // when
-      await click('#terms-of-service-cancel-button');
-
-      // then
-      assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still authenticated');
-    });
-
     test('it should not be possible to visit another page if cgu are not accepted', async function(assert) {
       // given
       await visit('/cgu');


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Certif, lorsqu'un utilisateur se déconnecte, le store Ember n'est pas vidé.

## :robot: Solution
- Utiliser la fonction native du browser `window.location.replace`.
- Modifier le code pour mettre en avant l'action implicite de suppression du state par `window.location.replace`, afin que l'introduction de nouvelles redirection n'entraîne pas de régression.

## :rainbow: Remarques
cf. #1607

## :100: Pour tester
- Se connecter à Pix Certif (ex. certifsco@example.net)
- Ouvrir l'Inspecteur Ember (_menu Data_)
- Consulter quelques pages, et vérifier que les données apparaissent dans le _menu Data_
- Se déconnecter de Pix Certif
- Vérifier que le _menu Data_ ne contient plus aucune donnée
- Dans la console, vérifier que Ember n'est plus monté en mémoire
  - `Ember.Application.NAMESPACES_BY_ID['pix-certif'].__container__.lookup('service:currentUser').user.firstName`