### PR TITLE
[FEATURE] Afficher le nombre de paliers atteints et le nombre de paliers maximum (PIX-1049).

### DIFF
--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -16,7 +16,8 @@ class CampaignParticipationResult {
     // relationships
     campaignParticipationBadges,
     competenceResults = [],
-    reachedStage
+    reachedStage,
+    stageCount,
   } = {}) {
     this.id = id;
     // attributes
@@ -29,6 +30,7 @@ class CampaignParticipationResult {
     this.campaignParticipationBadges = campaignParticipationBadges;
     this.competenceResults = competenceResults;
     this.reachedStage = reachedStage;
+    this.stageCount = stageCount;
   }
 
   static buildFrom({ campaignParticipationId, assessment, competences, targetProfile, knowledgeElements, campaignBadges = [], acquiredBadgeIds = [] }) {

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -48,7 +48,7 @@ class CampaignParticipationResult {
     const totalSkillsCount = _.sumBy(targetedCompetenceResults, 'totalSkillsCount');
     const testedSkillsCount = _.sumBy(targetedCompetenceResults, 'testedSkillsCount');
 
-    const stages = targetProfile.stages;
+    const stages = targetProfile.stages || null;
 
     return new CampaignParticipationResult({
       id: campaignParticipationId,
@@ -60,6 +60,7 @@ class CampaignParticipationResult {
       competenceResults: targetedCompetenceResults,
       campaignParticipationBadges,
       reachedStage: _computeReachedStage({ stages, totalSkillsCount, validatedSkillsCount }),
+      stageCount: stages && stages.length,
     });
   }
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-result-serializer.js
@@ -13,6 +13,7 @@ module.exports = {
         'competenceResults',
         'progress',
         'reachedStage',
+        'stageCount',
       ],
       campaignParticipationBadges: {
         ref: 'id',

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -85,6 +85,14 @@ describe('Acceptance | API | Campaign Participation Result', () => {
       targetProfileId: targetProfile.id
     });
 
+    databaseBuilder.factory.buildStage({
+      id: 2,
+      message: 'Tu as le palier 2',
+      title: 'palier 2',
+      threshold: 50,
+      targetProfileId: targetProfile.id
+    });
+
     targetProfileSkills.slice(2).forEach((targetProfileSkill, index) => {
       databaseBuilder.factory.buildKnowledgeElement({
         userId: user.id,
@@ -185,6 +193,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
             'tested-skills-count': 5,
             'validated-skills-count': 3,
             'is-completed': true,
+            'stage-count': 2,
           },
           relationships: {
             'campaign-participation-badges': {

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-result.js
@@ -12,6 +12,7 @@ module.exports = function buildCampaignParticipationResult(
     competenceResults = [],
     campaignParticipationBadges,
     reachedStage = {},
+    stageCount = 5,
   } = {}) {
 
   return new CampaignParticipationResult({
@@ -23,5 +24,6 @@ module.exports = function buildCampaignParticipationResult(
     competenceResults,
     campaignParticipationBadges,
     reachedStage,
+    stageCount,
   });
 };

--- a/api/tests/unit/domain/models/CampaignParticipationResult_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipationResult_test.js
@@ -76,6 +76,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           knowledgeElementsCount: 2,
           campaignParticipationBadges: [],
           reachedStage: null,
+          stageCount: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -136,6 +137,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             threshold: 20,
             starCount: 2
           },
+          stageCount: 5,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -185,6 +187,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           knowledgeElementsCount: 2,
           campaignParticipationBadges: [],
           reachedStage: null,
+          stageCount: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -291,6 +294,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             }],
           }],
           reachedStage: null,
+          stageCount: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -431,6 +435,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
             targetProfileId: 1,
           }],
           reachedStage: null,
+          stageCount: null,
           competenceResults: [{
             id: 1,
             name: 'Economie symbiotique',
@@ -528,6 +533,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           validatedSkillsCount: 1,
           knowledgeElementsCount: 2,
           reachedStage: null,
+          stageCount: null,
           campaignParticipationBadges: [{
             id: 1,
             isAcquired: true,
@@ -672,7 +678,7 @@ describe('Unit | Domain | Models | CampaignParticipationResult', () => {
           validatedSkillsCount: 1,
           knowledgeElementsCount: 2,
           reachedStage: null,
-
+          stageCount: null,
           campaignParticipationBadges: [{
             id: 1,
             isAcquired: true,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-result-serializer_test.js
@@ -45,6 +45,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
         threshold: 50,
         starCount: 2
       };
+      const stageCount = 3;
       const campaignParticipationResult = domainBuilder.buildCampaignParticipationResult({
         isCompleted: true,
         testedSkillsCount,
@@ -52,7 +53,8 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
         validatedSkillsCount,
         competenceResults,
         campaignParticipationBadges: [campaignParticipationBadge],
-        reachedStage
+        reachedStage,
+        stageCount,
       });
 
       const expectedSerializedCampaignParticipationResult = {
@@ -64,6 +66,7 @@ describe('Unit | Serializer | JSON API | campaign-participation-result-serialize
             'total-skills-count': totalSkillsCount,
             'validated-skills-count': validatedSkillsCount,
             'progress': 1,
+            'stage-count': stageCount,
           },
           id: '1',
           relationships: {

--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -11,6 +11,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
+  @attr('number') stagesCount;
 
   // includes
   @hasMany('campaignParticipationBadges') campaignParticipationBadges;

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -74,6 +74,9 @@
       <div class="skill-review__reached-stage">
         {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.title}}
       </div>
+      <div class="skill-review__stage-count">
+        {{t 'pages.skill-review.stages' reachedStage=this.model.campaignParticipation.campaignParticipationResult.reachedStage.starCount stageCount=this.model.campaignParticipation.campaignParticipationResult.stageCount}}
+      </div>
     {{/if}}
 
     {{#if this.showBadges}}

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -7,6 +7,7 @@ export default ApplicationSerializer.extend({
     'validatedSkillsCount',
     'masteryPercentage',
     'isCompleted',
+    'stagesCount',
   ],
   include: [
     'campaignParticipationBadges',

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -184,12 +184,37 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         expect(find('.skill-review__reached-stage')).to.exist;
       });
 
+      it('should display stages count when campaign has stages', async function() {
+        // given
+        const reachedStage = server.create('reached-stage', {
+          title: 'You reached Stage 1',
+          message: 'You are almost a rock star',
+          threshold: 50,
+          starCount: 2,
+        });
+        campaignParticipationResult.update({ reachedStage, stagesCount: 4 });
+
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
+
+        // then
+        expect(find('.skill-review__stage-count')).to.exist;
+      });
+
       it('should not display reached stage when campaign has no stages', async function() {
         // when
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
         expect(find('.skill-review__reached-stage')).to.not.exist;
+      });
+
+      it('should not display stages count when campaign has no stages', async function() {
+        // when
+        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
+
+        // then
+        expect(find('.skill-review__stage-count')).to.not.exist;
       });
 
       it('should share the results', async function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -631,6 +631,7 @@
       "information": "If you've ridden on Pix before, the questions you answered weren't asked again. However, the result displayed here takes into account all of your answers.",
       "not-finished": "You cannot send your results yet, we still have a few questions for you.",
       "send-results": "Send your results to the course organizer so that he can accompany you.",
+      "stages": "You reached stage # {reachedStage} out of {stagesCount} stages.",
       "try-again": {
         "title": "Want to improve your results?",
         "description": "You can retry some questions"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -631,6 +631,7 @@
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
+      "stages": "Vous avez atteint le palier {reachedStage} sur un total de {stagesCount}.",
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",
         "description": "Vous pouvez retenter certaines questions"


### PR DESCRIPTION
## :unicorn: Problème
Dans les campagnes dont le profil cible possède des paliers, l'utilisateur ne sait pas le nombre de paliers atteints ni le nombre de paliers existants.

## :robot: Solution
Ajout de la propriété `stageCount` dans le résultat de la campagne et affichage du nombre de paliers atteints et du nombre de paliers maximum sur la page de résultat de la campagne (`skill-review`).

## :rainbow: Remarques
Ce ticket ne traite pas le design définitif.

## :100: Pour tester
Participer à la campagne `AZERTY123`.
Vérifier que la page de résultats affiche le nombre de paliers atteints et le nombre de palier maximum.
Participer à une autre campagne et vérifier qu'aucun notion de palier n'est affichée.
