### PR TITLE
[TECH] Ajout d'une règle de linter pour éviter d'importer Lodash complétement.

### DIFF
--- a/orga/.eslintrc.js
+++ b/orga/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    'no-restricted-imports': [2, { 'paths': ['lodash'] }]
   },
   overrides: [
     // node files

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -52,7 +52,7 @@ export default class ListItems extends Component {
       this.generatedPassword = schoolingRegistrationDependentUser.generatedPassword;
       this.args.refreshModel();
     } catch (response) {
-      const errorDetail = _.get(response, 'errors[0].detail', 'Une erreur est survenue, veuillez réessayer ultérieurement.');
+      const errorDetail = get(response, 'errors[0].detail', 'Une erreur est survenue, veuillez réessayer ultérieurement.');
       this.notifications.sendError(errorDetail);
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Lors de la PR #1669, nous avons vu qu'en évitant d'importer Lodash de cette façon : `import _ from 'lodash'` cela permet de gagner 500kb sur le bundle.
Afin de continuer dans cette optique, je propose de rajouter une règle de linter afin de prévenir l'import global. 

## :robot: Solution
Ajouter une règle de linter 
Fixer le seul import qui ne respectait pas la règle. 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
