### PR TITLE
[BUGFIX] Renommage de `stagesCount` en `stageCount` sur l'application front.

### DIFF
--- a/mon-pix/app/models/campaign-participation-result.js
+++ b/mon-pix/app/models/campaign-participation-result.js
@@ -11,7 +11,7 @@ export default class CampaignParticipationResult extends Model {
   @attr('number') totalSkillsCount;
   @attr('number') testedSkillsCount;
   @attr('number') validatedSkillsCount;
-  @attr('number') stagesCount;
+  @attr('number') stageCount;
 
   // includes
   @hasMany('campaignParticipationBadges') campaignParticipationBadges;

--- a/mon-pix/mirage/serializers/campaign-participation-result.js
+++ b/mon-pix/mirage/serializers/campaign-participation-result.js
@@ -7,7 +7,7 @@ export default ApplicationSerializer.extend({
     'validatedSkillsCount',
     'masteryPercentage',
     'isCompleted',
-    'stagesCount',
+    'stageCount',
   ],
   include: [
     'campaignParticipationBadges',

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -192,7 +192,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
           threshold: 50,
           starCount: 2,
         });
-        campaignParticipationResult.update({ reachedStage, stagesCount: 4 });
+        campaignParticipationResult.update({ reachedStage, stageCount: 4 });
 
         // when
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -631,7 +631,7 @@
       "information": "If you've ridden on Pix before, the questions you answered weren't asked again. However, the result displayed here takes into account all of your answers.",
       "not-finished": "You cannot send your results yet, we still have a few questions for you.",
       "send-results": "Send your results to the course organizer so that he can accompany you.",
-      "stages": "You reached stage # {reachedStage} out of {stagesCount} stages.",
+      "stages": "You reached stage # {reachedStage} out of {stageCount} stages.",
       "try-again": {
         "title": "Want to improve your results?",
         "description": "You can retry some questions"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -631,7 +631,7 @@
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
-      "stages": "Vous avez atteint le palier {reachedStage} sur un total de {stagesCount}.",
+      "stages": "Vous avez atteint le palier {reachedStage} sur un total de {stageCount}.",
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",
         "description": "Vous pouvez retenter certaines questions"


### PR DESCRIPTION
## :unicorn: Problème
Dans la PR https://github.com/1024pix/pix/pull/1759, le renommage de `stagesCount` en `stageCount` a été fait uniquement côté back, ainsi les campagnes avec palier sont en erreur et n'affichent pas leur page de résultat.

## :robot: Solution
Renommer `stagesCount` en `stageCount` sur l'application front et dans les tests.

## :rainbow: Remarques
Pas de dommage en prod, aucune campagne avec palier n'existe pour le moment.

## :100: Pour tester
Vérifier que la campagne AZERTY123 affiche correctement la page de résultat.
