### PR TITLE
[FEATURE] Afficher titres et descriptifs du palier atteint (PIX-1050).

### DIFF
--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -74,6 +74,9 @@
       <div class="skill-review__reached-stage">
         {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.title}}
       </div>
+      <div class="skill-review__reached-stage-message">
+        {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.message}}
+      </div>
       <div class="skill-review__stage-count">
         {{t 'pages.skill-review.stages' reachedStage=this.model.campaignParticipation.campaignParticipationResult.reachedStage.starCount stageCount=this.model.campaignParticipation.campaignParticipationResult.stageCount}}
       </div>


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'ici on n'affichait pas le titre ni le descriptif du palier atteint, seulement son niveau.

## :robot: Solution
Récupérer le titre et le descriptif dans l'objet `reachedStage`.

## :rainbow: Remarques
Cette PR overlap pas mal avec la [https://github.com/1024pix/pix/pull/1762](https://github.com/1024pix/pix/pull/1762). Il ne reste plus qu'à ajouter la description.

## :100: Pour tester
Terminer la campagne `AZERTY123` et voir le titre, le descriptif et l'information **Vous avez atteint le palier X/Y**.
