### PR TITLE
[FEATURE] Afficher le nom et prénom des inscriptions à la place des noms et prénoms des utilisateurs dans le CSV de collecte de profils (PIX-1089).

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -32,7 +32,6 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     lastName: sansaStark.lastName,
     birthdate: '2000-05-28',
     organizationId: 2,
-    nationalStudentId: 'TOTO',
     userId: sansaStark.id,
   });
 

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -362,7 +362,7 @@ describe('Integration | Repository | Campaign Participation', () => {
       await databaseBuilder.commit();
     });
 
-    it('should return the campaign-participation links to the given campaign', async () => {
+    it('should return the campaign-participation linked to the given campaign', async () => {
       // given
       const campaignId = campaign1.id;
 
@@ -371,7 +371,7 @@ describe('Integration | Repository | Campaign Participation', () => {
 
       // then
       const attributes = participationResultDatas.map((participationResultData) =>
-        _.pick(participationResultData, ['id', 'isShared', 'sharedAt', 'participantExternalId', 'userId', 'participantFirstName', 'participantLastName']));
+        _.pick(participationResultData, ['id', 'isShared', 'sharedAt', 'participantExternalId', 'userId']));
       expect(attributes).to.deep.equal([
         {
           id: campaignParticipation1.id,
@@ -379,10 +379,49 @@ describe('Integration | Repository | Campaign Participation', () => {
           sharedAt: campaignParticipation1.sharedAt,
           participantExternalId: campaignParticipation1.participantExternalId,
           userId: campaignParticipation1.userId,
-          participantFirstName: 'First',
-          participantLastName: 'Last',
         }
       ]);
+    });
+
+    context('when the participant is not linked to a schooling registration', () => {
+      it('should return the campaign participation with firstName and lastName from the user', async () => {
+        // given
+        const campaignId = campaign1.id;
+
+        // when
+        const participationResultDatas = await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+
+        // then
+        const attributes = participationResultDatas.map((participationResultData) =>
+          _.pick(participationResultData, ['participantFirstName', 'participantLastName']));
+        expect(attributes).to.deep.equal([{
+          participantFirstName: 'First',
+          participantLastName: 'Last',
+        }]);
+      });
+    });
+
+    context('when the participant is linked to a schooling registration', () => {
+      beforeEach(async () => {
+        databaseBuilder.factory.buildSchoolingRegistration({ firstName: 'Hubert', lastName: 'Parterre', userId, organizationId: campaign1.organizationId });
+        await databaseBuilder.commit();
+      });
+
+      it('should return the campaign participation with firstName and lastName from the schooling registration', async () => {
+        // given
+        const campaignId = campaign1.id;
+
+        // when
+        const participationResultDatas = await campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaignId);
+
+        // then
+        const attributes = participationResultDatas.map((participationResultData) =>
+          _.pick(participationResultData, ['participantFirstName', 'participantLastName']));
+        expect(attributes).to.deep.equal([{
+          participantFirstName: 'Hubert',
+          participantLastName: 'Parterre',
+        }]);
+      });
     });
 
     context('When sharedAt is null', () => {


### PR DESCRIPTION
## :unicorn: Problème
Bien que liés à leur organisation, les élèves/étudiants étaient affichés avec leur nom et prénom de compte utilisateur dans le CSV. Cela pouvait être n'importe quoi, ex : Vladimir Poutine.

## :robot: Solution
Pour plus de cohérence pour l'équipe pédagogique, on affiche désormais le nom et prénom des inscriptions d'élèves/d'étudiants dans les écrans de Pix Orga pour les campagnes de collecte de profils.

À venir : Faire de même pour :
- l'affichage des résultats de campagne d'évaluation dans les écrans de Pix Orga ;
- l'export CSV des campagnes d'évaluation.

l'affichage des résultats de campagne d'évaluation dans les écrans de Pix Orga est déjà en cours #1764 .

## :rainbow: Remarques
RAS 

## :100: Pour tester
Pour une organisation SCO :
- rejoindre la campagne SNAP456 (collecte de profils et restreinte), se réconcilier avec first last né le 10/10/2010 sur Pix App et envoyer le profil ;
- aller sur Pix Orga en tant que sco@example.net, sélectionner la bonne campagne, cliquer sur le bouton "télécharger les résultats" et vérifier l'affichage de First Last, et non du nom et prénom du compte utilisateur.

Pour une organisation PRO (non régression) :
- rejoindre la campagne SNAP123 (collecte de profils et non restreinte) sur Pix App et envoyer le profil ;
- aller sur Pix Orga en tant que pro@example.net, sélectionner la bonne campagne, cliquer sur le bouton "télécharger les résultats" et vérifier l'affichage du nom et prénom du compte utilisateur.