### PR TITLE
[FEATURE] Afficher le palier atteint avec des étoiles (PIX-1051).

### DIFF
--- a/mon-pix/app/components/reached-stage.js
+++ b/mon-pix/app/components/reached-stage.js
@@ -4,12 +4,10 @@ import range from 'lodash/range';
 export default class ReachedStage extends Component {
 
   get acquiredStars() {
-    // returns an array of [1...N] where N is the number of acquired stars
     return range(1, this.args.starCount + 1);
   }
 
   get unacquiredStars() {
-    // returns an array of [N+1...M] where N is the number of acquired stars and M the total number of stages (stars)
     return range(this.args.starCount + 1, this.args.stageCount + 1);
   }
 }

--- a/mon-pix/app/components/reached-stage.js
+++ b/mon-pix/app/components/reached-stage.js
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+import range from 'lodash/range';
+
+export default class ReachedStage extends Component {
+
+  get acquiredStars() {
+    // returns an array of [1...N] where N is the number of acquired stars
+    return range(1, this.args.starCount + 1);
+  }
+
+  get unacquiredStars() {
+    // returns an array of [N+1...M] where N is the number of acquired stars and M the total number of stages (stars)
+    return range(this.args.starCount + 1, this.args.stageCount + 1);
+  }
+}
+

--- a/mon-pix/app/controllers/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/assessment/skill-review.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import times from 'lodash/times';
 
 export default class SkillReviewController extends Controller {
   @tracked displayLoadingButton = false;
@@ -26,16 +25,8 @@ export default class SkillReviewController extends Controller {
     return this.model.campaignParticipation.campaignParticipationResult.get('reachedStage');
   }
 
-  get _stageCount() {
+  get stageCount() {
     return this.model.campaignParticipation.campaignParticipationResult.get('stageCount');
-  }
-
-  get plainStars() {
-    return times(this.reachedStage.get('starCount'), String);
-  }
-
-  get clearStars() {
-    return times(this._stageCount - this.plainStars.length, String);
   }
 
   @action

--- a/mon-pix/app/controllers/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/assessment/skill-review.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import times from 'lodash/times';
 
 export default class SkillReviewController extends Controller {
   @tracked displayLoadingButton = false;
@@ -19,6 +20,22 @@ export default class SkillReviewController extends Controller {
   get acquiredBadges() {
     const badges = this.model.campaignParticipation.campaignParticipationResult.get('campaignParticipationBadges');
     return badges.filter((badge) => badge.isAcquired);
+  }
+
+  get reachedStage() {
+    return this.model.campaignParticipation.campaignParticipationResult.get('reachedStage');
+  }
+
+  get _stageCount() {
+    return this.model.campaignParticipation.campaignParticipationResult.get('stageCount');
+  }
+
+  get plainStars() {
+    return times(this.reachedStage.get('starCount'), String);
+  }
+
+  get clearStars() {
+    return times(this._stageCount - this.plainStars.length, String);
   }
 
   @action

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -65,6 +65,7 @@
 @import 'components/qroc-solution-panel';
 @import 'components/qroc-solution-panel';
 @import 'components/qrocm-solution-panel';
+@import 'components/reached-stage';
 @import 'components/register-form';
 @import 'components/reset-password-form';
 @import 'components/resume-campaign-banner';

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -1,0 +1,49 @@
+.reached-stage {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 48px;
+
+  @include device-is('tablet') {
+    flex-direction: row;
+  }
+
+  &__left-container {
+    background: $white;
+    border: 1px solid rgb(231, 231, 231);
+    border-radius: 16px;
+    padding: 43px 26px;
+  }
+
+  &__percentage-text {
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    font-weight: $font-medium;
+    color: $grey-40;
+    text-align: center;
+  }
+
+  &__stars img {
+    margin: 4px;
+    padding-bottom: 16px;
+  }
+
+  &__right-container {
+    padding-left: 40px;
+  }
+
+  &__title {
+    font-family: $font-open-sans;
+    font-size: 1.875rem;
+    font-weight: $font-bold;
+    color: $grey-100;
+    padding-bottom: 10px;
+  }
+
+  &__message {
+    font-family: $font-open-sans;
+    font-size: 1.125rem;
+    font-weight: $font-normal;
+    color: $grey-45;
+  }
+}
+

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -49,57 +49,6 @@
   }
 }
 
-.reached-stage {
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 48px;
-
-  @include device-is('tablet') {
-    flex-direction: row;
-  }
-
-  &__left-container {
-    background: rgb(255, 255, 255);
-    border: 1px solid rgb(231, 231, 231);
-    box-shadow: 0px 2px 4px 0px rgba(52, 69, 99, 0.11),
-      0px 2px 12px 4px rgba(122, 134, 154, 0.08);
-    border-radius: 16px;
-    padding: 43px 26px;
-  }
-
-  &__percentage-text {
-    font-family: $font-roboto;
-    font-size: 0.875em;
-    font-weight: $font-medium;
-    color: $grey-40;
-    text-align: center;
-  }
-
-  &__stars img {
-    margin: 4px;
-    padding-bottom: 16px;
-  }
-
-  &__right-container {
-    padding-left: 40px;
-  }
-
-  &__title {
-    font-family: $font-open-sans;
-    font-size: 1.875em;
-    font-weight: $font-bold;
-    color: $grey-100;
-    padding-bottom: 10px;
-  }
-
-  &__message {
-    font-family: $font-open-sans;
-    font-size: 1.125em;
-    font-weight: $font-normal;
-    color: $grey-45;
-  }
-}
-
 .skill-review-information {
   &__info-icon {
     float: left;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -9,7 +9,7 @@
     margin-top: -160px;
 
     @include device-is('tablet') {
-      padding: 60px;
+      padding: 32px 48px;
     }
   }
 
@@ -46,6 +46,57 @@
 
   &__improvement-button {
     height: 50px;
+  }
+}
+
+.reached-stage {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 48px;
+
+  @include device-is('tablet') {
+    flex-direction: row;
+  }
+
+  &__left-container {
+    background: rgb(255, 255, 255);
+    border: 1px solid rgb(231, 231, 231);
+    box-shadow: 0px 2px 4px 0px rgba(52, 69, 99, 0.11),
+      0px 2px 12px 4px rgba(122, 134, 154, 0.08);
+    border-radius: 16px;
+    padding: 43px 26px;
+  }
+
+  &__percentage-text {
+    font-family: $font-roboto;
+    font-size: 0.875em;
+    font-weight: $font-medium;
+    color: $grey-40;
+    text-align: center;
+  }
+
+  &__stars img {
+    margin: 4px;
+    padding-bottom: 16px;
+  }
+
+  &__right-container {
+    padding-left: 40px;
+  }
+
+  &__title {
+    font-family: $font-open-sans;
+    font-size: 1.875em;
+    font-weight: $font-bold;
+    color: $grey-100;
+    padding-bottom: 10px;
+  }
+
+  &__message {
+    font-family: $font-open-sans;
+    font-size: 1.125em;
+    font-weight: $font-normal;
+    color: $grey-45;
   }
 }
 

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -1,10 +1,10 @@
 {{page-title (t 'pages.skill-review.title')}}
 
-<div class="background-banner-wrapper">
+<PixBackgroundHeader>
   <div class="skill-review__banner">
     <AssessmentBanner @title={{this.model.assessment.title}} @displayHomeLink={{false}} />
   </div>
-  <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner skill-review__result-container">
+  <PixBlock @shadow="heavy" class="skill-review__result-container">
     {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
       <h3 class="rounded-panel-title skill-review-result__abstract">
         {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
@@ -39,6 +39,45 @@
           {{/if}}
         {{/if}}
       </div>
+
+      {{#if this.reachedStage}}
+      <div>
+        <PixBlock @shadow="heavy">
+          <div>
+            {{#each this.plainStars as |star|}}
+              <img src="{{this.rootURL}}/images/stage-plain-star.svg"/>
+            {{/each}}
+            {{#each this.clearStars as |star|}}
+              <img src="{{this.rootURL}}/images/stage-clear-star.svg"/>
+            {{/each}}
+          </div>
+          <div>
+            {{t 'pages.skill-review.stage.masteryPercentage' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+          </div>
+        </PixBlock>
+         <div class="skill-review__reached-stage">
+           {{this.reachedStage.title}}
+         </div>
+         <div class="skill-review__reached-stage-message">
+           {{this.reachedStage.message}}
+         </div>
+       </div>
+      {{/if}}
+
+      {{#if this.showBadges}}
+        <div class="badge-acquired-container">
+          {{#each this.acquiredBadges as |badge|}}
+            <BadgeAcquiredCard
+              @title="{{badge.title}}"
+              @message="{{badge.message}}"
+              @imageUrl="{{badge.imageUrl}}"
+              @altMessage="{{badge.altMessage}}"
+            />
+          {{/each}}
+        </div>
+        <div class="skill-review-result__dash-line"></div>
+      {{/if}}
+
       {{#if this.displayImprovementButton}}
         {{#unless model.campaignParticipation.isShared}}
           <div class="skill-review-result__dash-line"></div>
@@ -70,33 +109,7 @@
     {{/if}}
     <div class="skill-review-result__dash-line"></div>
 
-    {{#if this.model.campaignParticipation.campaignParticipationResult.reachedStage}}
-      <div class="skill-review__reached-stage">
-        {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.title}}
-      </div>
-      <div class="skill-review__reached-stage-message">
-        {{this.model.campaignParticipation.campaignParticipationResult.reachedStage.message}}
-      </div>
-      <div class="skill-review__stage-count">
-        {{t 'pages.skill-review.stages' reachedStage=this.model.campaignParticipation.campaignParticipationResult.reachedStage.starCount stageCount=this.model.campaignParticipation.campaignParticipationResult.stageCount}}
-      </div>
-    {{/if}}
-
-    {{#if this.showBadges}}
-      <div class="badge-acquired-container">
-        {{#each this.acquiredBadges as |badge|}}
-          <BadgeAcquiredCard
-            @title="{{badge.title}}"
-            @message="{{badge.message}}"
-            @imageUrl="{{badge.imageUrl}}"
-            @altMessage="{{badge.altMessage}}"
-          />
-        {{/each}}
-      </div>
-      <div class="skill-review-result__dash-line"></div>
-    {{/if}}
-
-    <div class="skill-review-result__table-header">
+   <div class="skill-review-result__table-header">
       <h2 class="skill-review-result__subtitle">
         {{t 'pages.skill-review.details.title'}}
       </h2>
@@ -158,5 +171,5 @@
       </div>
     </div>
 
-  </div>
-</div>
+  </PixBlock>
+</PixBackgroundHeader>

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -41,25 +41,27 @@
       </div>
 
       {{#if this.reachedStage}}
-      <div>
-        <PixBlock @shadow="heavy">
-          <div>
-            {{#each this.plainStars as |star|}}
-              <img src="{{this.rootURL}}/images/stage-plain-star.svg"/>
-            {{/each}}
-            {{#each this.clearStars as |star|}}
-              <img src="{{this.rootURL}}/images/stage-clear-star.svg"/>
-            {{/each}}
-          </div>
-          <div>
-            {{t 'pages.skill-review.stage.masteryPercentage' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
-          </div>
-        </PixBlock>
-         <div class="skill-review__reached-stage">
-           {{this.reachedStage.title}}
+        <div class="reached-stage">
+          <div class="reached-stage__left-container">
+            <div class="reached-stage__stars">
+              {{#each this.plainStars as |star|}}
+                <img src="{{this.rootURL}}/images/stage-plain-star.svg"/>
+              {{/each}}
+              {{#each this.clearStars as |star|}}
+                <img src="{{this.rootURL}}/images/stage-clear-star.svg"/>
+              {{/each}}
+            </div>
+            <div class="reached-stage__percentage-text">
+              {{t 'pages.skill-review.stage.masteryPercentage' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+            </div>
          </div>
-         <div class="skill-review__reached-stage-message">
-           {{this.reachedStage.message}}
+         <div class="reached-stage__right-container">
+           <div class="reached-stage__title">
+             {{this.reachedStage.title}}
+           </div>
+           <div class="reached-stage__message">
+             {{this.reachedStage.message}}
+           </div>
          </div>
        </div>
       {{/if}}

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -41,39 +41,23 @@
       </div>
 
       {{#if this.reachedStage}}
-        <div class="reached-stage">
-          <div class="reached-stage__left-container">
-            <div class="reached-stage__stars">
-              {{#each this.plainStars as |star|}}
-                <img src="{{this.rootURL}}/images/stage-plain-star.svg"/>
-              {{/each}}
-              {{#each this.clearStars as |star|}}
-                <img src="{{this.rootURL}}/images/stage-clear-star.svg"/>
-              {{/each}}
-            </div>
-            <div class="reached-stage__percentage-text">
-              {{t 'pages.skill-review.stage.masteryPercentage' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
-            </div>
-         </div>
-         <div class="reached-stage__right-container">
-           <div class="reached-stage__title">
-             {{this.reachedStage.title}}
-           </div>
-           <div class="reached-stage__message">
-             {{this.reachedStage.message}}
-           </div>
-         </div>
-       </div>
+        <ReachedStage
+          @stageCount={{this.stageCount}}
+          @title={{this.reachedStage.title}}
+          @message={{this.reachedStage.message}}
+          @starCount={{this.reachedStage.starCount}}
+          @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+        />
       {{/if}}
 
       {{#if this.showBadges}}
         <div class="badge-acquired-container">
           {{#each this.acquiredBadges as |badge|}}
             <BadgeAcquiredCard
-              @title="{{badge.title}}"
-              @message="{{badge.message}}"
-              @imageUrl="{{badge.imageUrl}}"
-              @altMessage="{{badge.altMessage}}"
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
             />
           {{/each}}
         </div>

--- a/mon-pix/app/templates/components/reached-stage.hbs
+++ b/mon-pix/app/templates/components/reached-stage.hbs
@@ -1,0 +1,29 @@
+<div class="reached-stage">
+  <div class="reached-stage__left-container">
+    <div class="reached-stage__stars">
+      {{#each this.acquiredStars as |star|}}
+        <img
+          id="acquired-star-{{star}}"
+          src="{{this.rootURL}}/images/stage-plain-star.svg"
+          alt={{t 'pages.skill-review.stage.alt.acquiredStar' index=star}}/>
+      {{/each}}
+      {{#each this.unacquiredStars as |star|}}
+        <img
+          id="unacquired-star-{{star}}"
+          src="{{this.rootURL}}/images/stage-clear-star.svg"
+          alt={{t 'pages.skill-review.stage.alt.unacquiredStar' index=star}}/>
+      {{/each}}
+    </div>
+    <div class="reached-stage__percentage-text">
+      {{t 'pages.skill-review.stage.masteryPercentage' percentage=@percentage}}
+    </div>
+ </div>
+ <div class="reached-stage__right-container">
+   <div class="reached-stage__title">
+     {{@title}}
+   </div>
+   <div class="reached-stage__message">
+     {{@message}}
+   </div>
+ </div>
+</div>

--- a/mon-pix/public/images/stage-clear-star.svg
+++ b/mon-pix/public/images/stage-clear-star.svg
@@ -1,0 +1,23 @@
+<svg width="36" height="36" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <filter x="-15.3%" y="-15.3%" width="130.6%" height="130.6%" filterUnits="objectBoundingBox" id="b">
+            <feGaussianBlur stdDeviation="4" in="SourceAlpha" result="shadowBlurInner1"/>
+            <feOffset dy="3" in="shadowBlurInner1" result="shadowOffsetInner1"/>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.4 0" in="shadowInnerInner1" result="shadowMatrixInner1"/>
+            <feGaussianBlur stdDeviation="1.5" in="SourceAlpha" result="shadowBlurInner2"/>
+            <feOffset dy="1" in="shadowBlurInner2" result="shadowOffsetInner2"/>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.1 0" in="shadowInnerInner2" result="shadowMatrixInner2"/>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"/>
+                <feMergeNode in="shadowMatrixInner2"/>
+            </feMerge>
+        </filter>
+        <path d="M8.423 35.82c-.761.507-1.765-.125-1.635-1.03l1.619-11.335L.311 15.36a1.059 1.059 0 01.6-1.796l11.268-1.61L17.027.642c.367-.856 1.58-.856 1.946 0l4.848 11.31 11.269 1.61a1.059 1.059 0 01.599 1.797l-8.096 8.096 1.62 11.334c.129.906-.875 1.538-1.636 1.03L18 29.436 8.423 35.82z" id="a"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <use fill="#E9EAFC" xlink:href="#a"/>
+        <use fill="#000" filter="url(#b)" xlink:href="#a"/>
+    </g>
+</svg>

--- a/mon-pix/public/images/stage-plain-star.svg
+++ b/mon-pix/public/images/stage-plain-star.svg
@@ -1,0 +1,27 @@
+<svg width="36" height="36" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <linearGradient x1="68.643%" y1="0%" x2="68.643%" y2="100%" id="c">
+            <stop stop-color="#FEDC41" offset="0%"/>
+            <stop stop-color="#FF9F00" offset="100%"/>
+        </linearGradient>
+        <filter x="-15.3%" y="-15.3%" width="130.6%" height="130.6%" filterUnits="objectBoundingBox" id="a">
+            <feGaussianBlur stdDeviation="4" in="SourceAlpha" result="shadowBlurInner1"/>
+            <feOffset dy="3" in="shadowBlurInner1" result="shadowOffsetInner1"/>
+            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
+            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.4 0" in="shadowInnerInner1" result="shadowMatrixInner1"/>
+            <feGaussianBlur stdDeviation="1.5" in="SourceAlpha" result="shadowBlurInner2"/>
+            <feOffset dy="1" in="shadowBlurInner2" result="shadowOffsetInner2"/>
+            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
+            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.1 0" in="shadowInnerInner2" result="shadowMatrixInner2"/>
+            <feMerge>
+                <feMergeNode in="shadowMatrixInner1"/>
+                <feMergeNode in="shadowMatrixInner2"/>
+            </feMerge>
+        </filter>
+        <path d="M8.423 35.82c-.761.507-1.765-.125-1.635-1.03l1.619-11.335L.311 15.36a1.059 1.059 0 01.6-1.796l11.268-1.61L17.027.642c.367-.856 1.58-.856 1.946 0l4.848 11.31 11.269 1.61a1.059 1.059 0 01.599 1.797l-8.096 8.096 1.62 11.334c.129.906-.875 1.538-1.636 1.03L18 29.436 8.423 35.82z" id="b"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd">
+        <use fill="#000" filter="url(#a)" xlink:href="#b"/>
+        <use fill="url(#c)" xlink:href="#b"/>
+    </g>
+</svg>

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -181,7 +181,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('.skill-review__reached-stage')).to.exist;
+        expect(find('.reached-stage')).to.exist;
       });
 
       it('should not display reached stage when campaign has no stages', async function() {
@@ -189,7 +189,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('.skill-review__reached-stage')).to.not.exist;
+        expect(find('.reached-stage')).to.not.exist;
       });
 
       it('should share the results', async function() {

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -184,37 +184,12 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         expect(find('.skill-review__reached-stage')).to.exist;
       });
 
-      it('should display stages count when campaign has stages', async function() {
-        // given
-        const reachedStage = server.create('reached-stage', {
-          title: 'You reached Stage 1',
-          message: 'You are almost a rock star',
-          threshold: 50,
-          starCount: 2,
-        });
-        campaignParticipationResult.update({ reachedStage, stageCount: 4 });
-
-        // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
-
-        // then
-        expect(find('.skill-review__stage-count')).to.exist;
-      });
-
       it('should not display reached stage when campaign has no stages', async function() {
         // when
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
         expect(find('.skill-review__reached-stage')).to.not.exist;
-      });
-
-      it('should not display stages count when campaign has no stages', async function() {
-        // when
-        await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
-
-        // then
-        expect(find('.skill-review__stage-count')).to.not.exist;
       });
 
       it('should share the results', async function() {

--- a/mon-pix/tests/integration/components/reached-stage-test.js
+++ b/mon-pix/tests/integration/components/reached-stage-test.js
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { find, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+describe('Integration | Component | reached-stage', function() {
+  setupIntlRenderingTest();
+
+  beforeEach(function() {
+    // given
+    this.set('reachedStageTitle', 'title');
+    this.set('reachedStageMessage', 'message');
+    this.set('reachedStageStarCount', 3);
+    this.set('percentage', 50);
+    this.set('stageCount', 5);
+  });
+
+  it('should render the reached stage', async function() {
+    // when
+    await render(hbs`<ReachedStage @title={{this.reachedStageTitle}} @message={{this.reachedStageMessage}} @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+
+    // then
+    expect(find('.reached-stage')).to.exist;
+    expect(find('.reached-stage__title').textContent.trim()).to.equal('title');
+    expect(find('.reached-stage__message').textContent.trim()).to.equal('message');
+    expect(find('.reached-stage__percentage-text').textContent.trim()).to.equal('50 % de réussite');
+    _expectStars(this.reachedStageStarCount, this.stageCount);
+  });
+
+  describe('stars rendering', function() {
+    [
+      { starCount: 0, stageCount: 1 },
+      { starCount: 5, stageCount: 5 },
+      { starCount: 5, stageCount: 6 },
+      { starCount: 2, stageCount: 10 },
+      { starCount: 2, stageCount: 3 },
+      { starCount: 4, stageCount: 5 },
+    ].map(({ starCount, stageCount }) => {
+      it(`displays ${starCount} plain stars out of ${stageCount} stars`, async function() {
+        // given
+        this.set('reachedStageStarCount', starCount);
+        this.set('stageCount', stageCount);
+
+        // when
+        await render(hbs`<ReachedStage @title={{this.reachedStageTitle}} @message={{this.reachedStageMessage}} @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+
+        // then
+        _expectStars(starCount, stageCount);
+      });
+    });
+  });
+});
+
+function _expectStars(starCount, stageCount) {
+  for (let index = 1 ; index <= starCount ; index ++) {
+    expect(find(`#acquired-star-${index}`)).to.exist;
+    expect(find(`#unacquired-star-${index}`)).to.not.exist;
+  }
+  for (let index = starCount + 1 ; index <= stageCount ; index ++) {
+    expect(find(`#acquired-star-${index}`)).to.not.exist;
+    expect(find(`#unacquired-star-${index}`)).to.exist;
+  }
+}

--- a/mon-pix/tests/unit/components/reached-stage-test.js
+++ b/mon-pix/tests/unit/components/reached-stage-test.js
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | reached-stage', function() {
+
+  setupTest();
+
+  [
+    { starCount: 0, stageCount: 1, acquiredStars: [], unacquiredStars: [1] },
+    { starCount: 5, stageCount: 5, acquiredStars: [1, 2, 3, 4, 5], unacquiredStars: [] },
+    { starCount: 5, stageCount: 6, acquiredStars: [1, 2, 3, 4, 5], unacquiredStars: [6] },
+    { starCount: 2, stageCount: 10, acquiredStars: [1, 2], unacquiredStars: [3, 4, 5, 6, 7, 8, 9, 10] },
+    { starCount: 2, stageCount: 3, acquiredStars: [1, 2], unacquiredStars: [3] },
+    { starCount: 4, stageCount: 5, acquiredStars: [1, 2, 3, 4], unacquiredStars: [5] },
+  ].map(({ starCount, stageCount, acquiredStars, unacquiredStars }) => {
+    context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+      describe('#get acquiredStars', function() {
+        it(`should return ${JSON.stringify(acquiredStars)}`, function() {
+          // given
+          const component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+
+          // then
+          expect(component.acquiredStars).to.deep.equal(acquiredStars);
+        });
+      });
+
+      describe('#get unacquiredStars', function() {
+        it(`should return ${JSON.stringify(unacquiredStars)}`, function() {
+          // given
+          const component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+
+          // then
+          expect(component.unacquiredStars).to.deep.equal(unacquiredStars);
+        });
+      });
+    });
+  });
+});
+

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -632,7 +632,11 @@
       "not-finished": "You cannot send your results yet, we still have a few questions for you.",
       "send-results": "Send your results to the course organizer so that he can accompany you.",
       "stage": {
-        "masteryPercentage": "{percentage} % success"
+        "masteryPercentage": "{percentage} % success",
+        "alt": {
+          "acquiredStar": "Stage #{index} reached",
+          "unacquiredStar": "Stage #{index} not reached"
+        }
       },
       "try-again": {
         "title": "Want to improve your results?",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -631,7 +631,9 @@
       "information": "If you've ridden on Pix before, the questions you answered weren't asked again. However, the result displayed here takes into account all of your answers.",
       "not-finished": "You cannot send your results yet, we still have a few questions for you.",
       "send-results": "Send your results to the course organizer so that he can accompany you.",
-      "stages": "You reached stage # {reachedStage} out of {stageCount} stages.",
+      "stage": {
+        "masteryPercentage": "{percentage} % success"
+      },
       "try-again": {
         "title": "Want to improve your results?",
         "description": "You can retry some questions"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -632,7 +632,11 @@
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
       "stage": {
-        "masteryPercentage": "{percentage} % de réussite"
+        "masteryPercentage": "{percentage} % de réussite",
+        "alt": {
+          "acquiredStar": "Palier n°{index} atteint",
+          "unacquiredStar": "Palier n°{index} non atteint"
+        }
       },
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -631,7 +631,9 @@
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
-      "stages": "Vous avez atteint le palier {reachedStage} sur un total de {stageCount}.",
+      "stage": {
+        "masteryPercentage": "{percentage} % de réussite"
+      },
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",
         "description": "Vous pouvez retenter certaines questions"


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le palier atteint est affiché avec une simple phrase.

## :robot: Solution
Afficher le palier atteint conformément au design, avec des étoiles pleines jusqu'au palier atteint inclus, et les paliers non-atteints avec des étoiles vides.

## :rainbow: Remarques
Ce ticket ne traite que l'affichage des étoiles. Le reste du design sera traité dans des tickets ultérieurs.

## :100: Pour tester
Compléter la campagne AZERTY123 et vérifier le design du palier atteint sur la page de résultat.
