### PR TITLE
[TECH] Utiliser les snapshots KE dans l'affichage de la liste des participants des campagnes de collecte de profiles (PIX-1068).

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, airtableBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, airtableBuilder, knex } = require('../../../test-helper');
 const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const CampaignProfilesCollectionParticipationSummary = require('../../../../lib/domain/read-models/CampaignProfilesCollectionParticipationSummary');
 const campaignProfilesCollectionParticipationSummaryRepository = require('../../../../lib/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository');
@@ -22,7 +22,8 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
       await databaseBuilder.commit();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+      await knex('knowledge-element-snapshots').delete();
       airtableBuilder.cleanAll();
       return cache.flushAll();
     });

--- a/orga/app/components/pagination-control.hbs
+++ b/orga/app/components/pagination-control.hbs
@@ -6,6 +6,7 @@
         <option value="10" selected="{{if (eq this.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq this.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>
+        <option value="100" selected="{{if (eq this.pageSize 100) true}}">100</option>
       </select>
       <FaIcon class='page-size__choice--icon' @icon='sort'></FaIcon>
     </div>


### PR DESCRIPTION
## :unicorn: Problème
On poursuit l'amélioration des perfs autour de l'ensemble de la navigation dans PixOrga.
Aujourd'hui, c'est affichage de la liste des participants d'une campagne de collecte de profils, qui fait suite à https://github.com/1024pix/pix/pull/1749 qui traitait la liste des participants d'une campagne d'évaluation.
A ce titre, nous n'avons pas effectué à nouveau un relevé de métriques, car les deux opérations sont assez similaires.

## :robot: Solution
On utilise les snapshotsKE dans la récupération de la liste + on les récupère par paquet.

## :rainbow: Remarques
On a monté la pagination à 100 sur pix-orga.

## :100: Pour tester
Tester la non régression de l'affichage de la liste et des résultats.
On peut aussi expérimenter la différence de vitesse en essayant en local le avant / après.
Pour cela, créer une campagne de test :
`node pix/api/scripts/generate-campaign-with-participants.js --organizationId 1 --participantCount 150 --campaignType profiles_collection`
Puis consulter la page des participants plusieurs fois sans l'amélioration, puis plusieurs fois avec. Ca va beaucoup plus vite avec ;)
