### PR TITLE
[FEATURE] Afficher les erreurs relatives aux comptes multiples dans une modal lors de la réconciliation (PIX-1023).

### DIFF
--- a/mon-pix/app/components/routes/login-or-register.js
+++ b/mon-pix/app/components/routes/login-or-register.js
@@ -1,16 +1,3 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-tagless-components: 0 */
+import Component from '@glimmer/component';
 
-import { action } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
-
-@classic
-export default class LoginOrRegister extends Component {
-  displayRegisterForm = true;
-
-  @action
-  toggleFormsVisibility() {
-    this.toggleProperty('displayRegisterForm');
-  }
-}
+export default class LoginOrRegister extends Component {}

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -12,9 +12,13 @@ export default class JoinRestrictedCampaignController extends Controller {
   @service session;
   @service store;
   @service intl;
+  @service url;
+  @service router;
 
   @tracked isLoading = false;
+  @tracked displayModal = false;
   @tracked errorMessage = null;
+  @tracked modalErrorMessage = null;
 
   @action
   attemptNext(schoolingRegistration) {
@@ -34,11 +38,29 @@ export default class JoinRestrictedCampaignController extends Controller {
     });
   }
 
+  @action
+  closeModal() {
+    this.displayModal = false;
+  }
+
+  @action
+  async goToHome() {
+    await this.session.invalidate();
+    return window.location.replace(this.url.homeUrl);
+  }
+
+  @action
+  async goToCampaignConnectionForm() {
+    await this.session.invalidate();
+    return this.router.replaceWith('campaigns.restricted.login-or-register-to-access', { queryParams: { displayRegisterForm: false } });
+  }
+
   _setErrorMessageForAttemptNextAction(errorResponse) {
     errorResponse.errors.forEach((error) => {
       if (error.status === '409') {
         const message = this._showErrorMessageByShortCode(error.meta);
-        return this.errorMessage = message;
+        this.displayModal = true;
+        return this.modalErrorMessage = message;
       }
       if (error.status === '404') {
         return this.errorMessage = 'Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/> <br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.';

--- a/mon-pix/app/controllers/campaigns/restricted/login-or-register-to-access.js
+++ b/mon-pix/app/controllers/campaigns/restricted/login-or-register-to-access.js
@@ -1,0 +1,16 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class LoginOrRegisterToAccessRoute extends Controller {
+
+  queryParams = ['displayRegisterForm'];
+
+  @tracked displayRegisterForm = true;
+
+  @action
+  toggleFormsVisibility() {
+    this.displayRegisterForm = !this.displayRegisterForm;
+  }
+
+}

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -95,3 +95,93 @@
     }
   }
 }
+
+.ember-modal-overlay.translucent {
+  background-color: rgba(red($grey-200), green($grey-200), blue($grey-200), 0.4);
+}
+
+.join-error-modal {
+  max-width: 500px;
+  position: absolute;
+  top: 230px;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    height: 78px;
+    background-color: $white;
+    padding: 20px;
+  }
+
+  &__body {
+    padding: 24px 30px 0;
+    background-color: $grey-10;
+    display: flex;
+    justify-content: center;
+  }
+
+  &__footer {
+    padding: 24px 30px;
+    background-color: $grey-10;
+    display: flex;
+    justify-content: center;
+
+    >.button {
+      margin: 0 8px;
+    }
+  }
+}
+
+.join-error-modal-header {
+  &__title {
+    display: flex;
+    align-items: center;
+  }
+
+  &__close {
+    &:hover {
+      cursor: pointer;
+    }
+  }
+}
+
+.join-error-modal-header-title {
+
+  &__icon {
+    font-size: 20px;
+    line-height: 30px;
+    color: $dark-error;
+  }
+
+  &__text {
+    margin-left: 8px;
+    font-family: $font-open-sans;
+    font-size: 1.25rem;
+    font-weight: $font-normal;
+    line-height: 1.875rem;
+    color: $grey-90;
+  }
+}
+
+.join-error-modal-header-close {
+  &__icon {
+    height: 32px;
+    width: 32px;
+    padding: 8px;
+    color: $grey-45;
+    background-color: $grey-15;
+    border-radius: 50px;
+  }
+}
+
+.join-error-modal-body {
+
+  &__message {
+    text-align: left;
+    font-family: $font-roboto;
+    font-size: 0.875rem;
+    font-weight: $font-normal;
+    color: $grey-200;
+  }
+}
+

--- a/mon-pix/app/templates/campaigns/restricted/join.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/join.hbs
@@ -15,3 +15,26 @@
     </div>
   </div>
 </div>
+{{#if this.displayModal}}
+  <PixModal @containerClass="join-error-modal" @onClose={{action this.closeModal}}>
+    <div class="join-error-modal__header">
+      <div class="join-error-modal-header__title">
+        <FaIcon @icon="times-circle" class="join-error-modal-header-title__icon"></FaIcon>
+        <h1 class="join-error-modal-header-title__text">Information de connexion</h1>
+      </div>
+      <div class="join-error-modal-header__close" aria-label={{t "common.actions.close"}} {{action this.closeModal}}>
+        <img src="/images/icons/icon-croix.svg" alt="Close" class="join-error-modal-header-close__icon">
+      </div>
+    </div>
+
+    <div class="join-error-modal__body">
+      <div class="join-error-modal-body__message" aria-live="polite">{{{modalErrorMessage}}}</div>
+    </div>
+
+    <div class="join-error-modal__footer">
+      <button class="button button--grey" type="button" aria-label="Quitter" {{on 'click' this.goToHome}}>Quitter</button>
+      <button class="button" type="button" aria-label="Continuer avec mon compte Pix" {{on 'click' this.goToCampaignConnectionForm}}>Continuer avec mon compte Pix</button>
+    </div>
+  </PixModal>
+{{/if}}
+

--- a/mon-pix/app/templates/campaigns/restricted/login-or-register-to-access.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/login-or-register-to-access.hbs
@@ -1,3 +1,3 @@
 <div class="login-or-register-to-access-restricted-campaign">
-  <Routes::LoginOrRegister @organizationName={{@model.organizationName}} @campaignCode={{@model.code}} />
+  <Routes::LoginOrRegister @organizationName={{@model.organizationName}} @campaignCode={{@model.code}} @displayRegisterForm={{this.displayRegisterForm}} @toggleFormsVisibility={{this.toggleFormsVisibility}} />
 </div>

--- a/mon-pix/app/templates/components/routes/login-or-register.hbs
+++ b/mon-pix/app/templates/components/routes/login-or-register.hbs
@@ -7,11 +7,11 @@
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
         <h1 class="form-title">Je m’inscris sur Pix</h1>
-        {{#unless this.displayRegisterForm}}
-          <button id="register-button" {{action "toggleFormsVisibility"}} class="button button--white button--bordered button--uppercase" type="button">S'inscrire</button>
+        {{#unless @displayRegisterForm}}
+          <button id="register-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">S'inscrire</button>
         {{/unless}}
-        <div class={{concat "login-or-register-panel-form__expandable" (if this.displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
-          {{#if this.displayRegisterForm}}
+        <div class={{concat "login-or-register-panel-form__expandable" (if @displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
+          {{#if @displayRegisterForm}}
             <Routes::RegisterForm @campaignCode={{@campaignCode}} />
           {{/if}}
         </div>
@@ -19,11 +19,11 @@
       <div class="login-or-register-panel__divider"></div>
       <div class="login-or-register-panel__form">
         <h1 class="form-title">J’ai déjà un compte Pix</h1>
-        {{#if this.displayRegisterForm}}
-          <button id="login-button" {{action "toggleFormsVisibility"}} class="button button--white button--bordered button--uppercase" type="button">Se connecter</button>
+        {{#if @displayRegisterForm}}
+          <button id="login-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">Se connecter</button>
         {{/if}}
-        <div class={{concat "login-or-register-panel-form__expandable" (if (not this.displayRegisterForm) " login-or-register-panel-form__expandable--expanded")}}>
-          {{#unless this.displayRegisterForm}}
+        <div class={{concat "login-or-register-panel-form__expandable" (if (not @displayRegisterForm) " login-or-register-panel-form__expandable--expanded")}}>
+          {{#unless @displayRegisterForm}}
             <Routes::LoginForm />
           {{/unless}}
         </div>

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -72,7 +72,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -98,7 +98,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -124,7 +124,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -150,7 +150,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -176,7 +176,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -202,7 +202,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -228,7 +228,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -258,7 +258,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -284,7 +284,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -310,7 +310,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -336,7 +336,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -362,7 +362,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -388,7 +388,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });
@@ -414,7 +414,7 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
 
           // then
           sinon.assert.calledOnce(schoolingRegistration.unloadRecord);
-          expect(controller.get('errorMessage')).to.equal(expectedErrorMessage);
+          expect(controller.get('modalErrorMessage')).to.equal(expectedErrorMessage);
           sinon.assert.notCalled(controller.transitionToRoute);
           expect(controller.get('isLoading')).to.equal(false);
         });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la réconciliation d'un élève, une erreur est affichée dans le cas où cet élève possède déjà un compte réconcilié dans son établissement actuel ou dans un autre établissement. Cet erreur est actuellement affichée en dessous du formulaire de réconciliation et force l'élève à se connecter à son compte déjà réconcilié plutôt que de poursuivre avec son compte actuel. Cependant, aucun bouton ou information n'existe afin de l'aider dans cette démarche.

## :robot: Solution
Ajouter une modal dans laquelle sera affichée l'erreur et qui contiendra deux boutons:
- "Quitter" qui déconnectera l'utilisateur et le redirigera vers pix.fr.
- "Poursuivre avec mon compte Pix" qui déconnectera l'utilisateur et le redirigera vers la double mire avec la partie connexion ouverte.

## :rainbow: Remarques
Afin de ne pas avoir la redirection vers "pix.fr" en dur dans le code (et donc pour tous les environnements), nous avons utilisé la variable `homeUrl` du service `url`.

## :100: Pour tester
- Se connecter à Pix.
- Rejoindre le parcours `RESTRICTD`
- Rentrer les informations suivantes:
    - Prénom: First
    - Nom: Last
    - Date de naissance: 10/10/2010
- Vérifier qu'une erreur s'affiche bien dans une modale et tester les boutons. 
