### PR TITLE
[BUGFIX] Pouvoir valider une épreuve QCU sous IE (PIX-1120).

### DIFF
--- a/mon-pix/app/components/challenge-item-qcu.js
+++ b/mon-pix/app/components/challenge-item-qcu.js
@@ -12,7 +12,7 @@ export default class ChallengeItemQcu extends ChallengeItemGeneric {
   _getAnswerValue() {
     const checkedInputValues = [];
     const radioInputElements = document.querySelectorAll('input[type="radio"]:checked');
-    radioInputElements.forEach(function(element) {
+    Array.prototype.forEach.call(radioInputElements, function(element) {
       checkedInputValues.push(element.getAttribute('data-value'));
     });
     return checkedInputValues.join('');


### PR DESCRIPTION
## :unicorn: Problème
Les QCU ne marche pas sous IE

> Bien que NodeList ne soit pas un tableau (Array), il est possible d'itérer dessus en utilisant forEach(). Il peut également être converti en tableau (Array) en utilisant Array.from().

> Néanmoins certains vieux navigateurs n'ont pas encore implémenté NodeList.forEach() ni Array.from(). Mais ces limitations peuvent être contournées en utilisant Array.prototype.forEach() (plus dans ce document).


## :robot: Solution
- Utiliser Array.prototype.forEach

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sous IE : 
https://app-pr1770.review.pix.fr/challenges/recjB3FJD1EByyMVV/preview