### PR TITLE
[FEATURE] Empêcher un élève de se réconcilier lors de l'inscription qu'il ait un compte utilisateur au sein du même établissement ou ailleurs (PIX-986).

### DIFF
--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -52,13 +52,13 @@ module.exports = {
     const payload = request.payload.data.attributes;
     const { 'campaign-code': campaignCode } = payload;
 
-    const user = {
+    const studentInformation = {
       firstName: payload['first-name'],
       lastName: payload['last-name'],
       birthdate: payload['birthdate'],
     };
 
-    const username = await usecases.generateUsername({ campaignCode, user });
+    const username = await usecases.generateUsername({ campaignCode, studentInformation });
 
     // we don't persist this ressource, we simulate response by adding the generated username
     const schoolingRegistrationWithUsernameResponse = {

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -35,4 +35,32 @@ module.exports = {
     FRENCH_FRANCE: 'fr-fr',
     FRENCH_SPOKEN: 'fr',
   },
+  STUDENT_RECONCILIATION_ERRORS: {
+    RECONCILIATION: {
+      IN_OTHER_ORGANIZATION: {
+        samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      }
+      ,
+      IN_SAME_ORGANIZATION: {
+        samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      }
+    },
+    LOGIN_OR_REGISTER: {
+      IN_OTHER_ORGANIZATION: {
+        samlId: { shortCode: 'S53', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      }
+      ,
+      IN_SAME_ORGANIZATION: {
+        samlId: { shortCode: 'S63', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        username: { shortCode: 'S62', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        email: { shortCode: 'S61', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      }
+    },
+  },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -490,6 +490,11 @@ class UserNotAuthorizedToUpdatePasswordError extends DomainError {
   }
 }
 
+class SchoolingRegistrationNotFound extends NotFoundError {
+  constructor(message = 'Aucune inscription d‘élève n‘a été trouvée.') {
+    super(message);
+  }
+}
 class UserNotFoundError extends NotFoundError {
   constructor(message = 'Ce compte est introuvable.') {
     super(message);
@@ -580,6 +585,7 @@ module.exports = {
   SameNationalStudentIdInOrganizationError,
   SchoolingRegistrationAlreadyLinkedToUserError,
   SchoolingRegistrationsCouldNotBeSavedError,
+  SchoolingRegistrationNotFound,
   SessionAlreadyFinalizedError,
   UserAlreadyLinkedToCandidateInSessionError,
   UserCouldNotBeReconciledError,

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { pipe } = require('lodash/fp');
 const randomString = require('randomstring');
+const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
 
 const {
   NotFoundError, SchoolingRegistrationAlreadyLinkedToUserError, AlreadyRegisteredUsernameError
@@ -9,20 +10,6 @@ const { areTwoStringsCloseEnough, isOneStringCloseEnoughFromMultipleStrings } = 
 const { normalizeAndRemoveAccents, removeSpecialCharacters } = require('./validation-treatments');
 
 const MAX_ACCEPTABLE_RATIO = 0.25;
-
-const STUDENT_RECONCILIATION_ERRORS = {
-  IN_OTHER_ORGANIZATION: {
-    samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-    username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-    email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-  }
-  ,
-  IN_SAME_ORGANIZATION: {
-    samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-    username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-    email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-  }
-};
 
 function findMatchingCandidateIdForGivenUser(matchingUserCandidates, user) {
   const standardizedUser = _standardizeUser(user);
@@ -76,7 +63,7 @@ async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSc
     const authentificationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
     const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
-    const error = STUDENT_RECONCILIATION_ERRORS.IN_SAME_ORGANIZATION[authentificationMethod.authenticatedBy];
+    const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION[authentificationMethod.authenticatedBy];
     const meta = { shortCode: error.shortCode, value: authentificationMethod.value };
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }
@@ -89,7 +76,7 @@ async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(st
     const authentificationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
     const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
-    const error = STUDENT_RECONCILIATION_ERRORS.IN_OTHER_ORGANIZATION[authentificationMethod.authenticatedBy];
+    const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION[authentificationMethod.authenticatedBy];
     const meta = { shortCode: error.shortCode, value: authentificationMethod.value };
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }

--- a/api/lib/domain/usecases/generate-username.js
+++ b/api/lib/domain/usecases/generate-username.js
@@ -1,21 +1,74 @@
-const { CampaignCodeError } = require('../errors');
+const { CampaignCodeError, SchoolingRegistrationNotFound, SchoolingRegistrationAlreadyLinkedToUserError } = require('../errors');
+const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
+const { find ,get } = require('lodash');
 
 module.exports = async function generateUsername({
-  user,
+  studentInformation,
   campaignCode,
   campaignRepository,
   schoolingRegistrationRepository,
   userReconciliationService,
-  userRepository,
   obfuscationService,
+  userRepository,
+  studentRepository,
 }) {
   const campaign = await campaignRepository.getByCode(campaignCode);
   if (!campaign || !campaign.organizationId) {
     throw new CampaignCodeError(`Le code campagne ${campaignCode} n'existe pas.`);
   }
 
-  await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId: campaign.organizationId, reconciliationInfo: user, schoolingRegistrationRepository, userRepository, obfuscationService });
+  const matchedSchoolingRegistration = await findMatchedSchoolingRegistrationForGivenOrganizationIdAndStudentInfo({ organizationId: campaign.organizationId, studentInformation, schoolingRegistrationRepository, userReconciliationService, obfuscationService });
+  await checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration, userRepository, obfuscationService);
 
-  return userReconciliationService.createUsernameByUser({ user , userRepository });
+  const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
+  await checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
+
+  return userReconciliationService.createUsernameByUser({ user: studentInformation , userRepository });
 
 };
+
+async function findMatchedSchoolingRegistrationForGivenOrganizationIdAndStudentInfo({ organizationId, studentInformation: { firstName, lastName, birthdate }, schoolingRegistrationRepository, userReconciliationService }) {
+  const schoolingRegistrations = await schoolingRegistrationRepository.findByOrganizationIdAndUserData({
+    organizationId,
+    reconciliationInfo: { birthdate },
+  });
+
+  if (schoolingRegistrations.length === 0) {
+    throw new SchoolingRegistrationNotFound('There were no schoolingRegistrations matching with organization and birthdate');
+  }
+
+  const schoolingRegistrationId = await userReconciliationService.findMatchingCandidateIdForGivenUser(schoolingRegistrations, { firstName, lastName });
+
+  if (!schoolingRegistrationId) {
+    throw new SchoolingRegistrationNotFound('There were no schoolingRegistrations matching with names');
+  }
+
+  return find(schoolingRegistrations, { 'id': schoolingRegistrationId });
+
+}
+
+async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSchoolingRegistration, userRepository, obfuscationService) {
+  if (get(matchingSchoolingRegistration, 'userId'))  {
+    const userId = matchingSchoolingRegistration.userId ;
+    const user = await userRepository.getUserAuthenticationMethods(userId);
+    const authenticationMethod = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
+
+    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
+    const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_SAME_ORGANIZATION[authenticationMethod.authenticatedBy];
+    const meta = { shortCode: error.shortCode, value: authenticationMethod.value };
+    throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
+  }
+}
+
+async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService) {
+  if (get(student, 'account')) {
+    const userId = student.account.userId;
+    const user = await userRepository.getUserAuthenticationMethods(userId);
+    const authenticationMethod = await obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
+
+    const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
+    const error = STUDENT_RECONCILIATION_ERRORS.LOGIN_OR_REGISTER.IN_OTHER_ORGANIZATION[authenticationMethod.authenticatedBy];
+    const meta = { shortCode: error.shortCode, value: authenticationMethod.value };
+    throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
+  }
+}

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -691,6 +691,118 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
       context('when schoolingRegistration is already associated in the same organization', () => {
 
+        it('should return a schooling registration already linked error (short code S61 when account with email)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = 'john.harry@example.net';
+          userWithEmailOnly.samlId = null;
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithEmailOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'S61', value: 'j***@example.net' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (short code S62 when connected with username)', async () => {
+          // given
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
+          userWithUsernameOnly.username = 'john.harry0702';
+          userWithUsernameOnly.email = null;
+          userWithUsernameOnly.samlId = null;
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithUsernameOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'S62', value: 'j***.h***2' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (short code S63 when account with samlId)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = null;
+          userWithEmailOnly.samlId = '12345689';
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
+          schoolingRegistration.userId = userWithEmailOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
+            meta: { shortCode: 'S63', value: null }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+      });
+
+      context('when schoolingRegistration is already associated in others organizations', () => {
+
         it('should respond with a 409 - Conflict', async () => {
           // given
           const schoolingRegistrationAlreadyMatched = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, firstName: user.firstName, lastName: user.lastName, userId: user.id });
@@ -706,6 +818,131 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.statusCode).to.equal(409);
           expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
         });
+
+        it('should return a schooling registration already linked error (short code S51 when account with email)', async () => {
+          // given
+          const userWithEmailOnly = databaseBuilder.factory.buildUser();
+          userWithEmailOnly.username = null;
+          userWithEmailOnly.email = 'john.harry@example.net';
+          userWithEmailOnly.samlId = null;
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithEmailOnly.id;
+
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'S51', value: 'j***@example.net' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (short code S52 when connected with username)', async () => {
+          // given
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
+          userWithUsernameOnly.email = null;
+          userWithUsernameOnly.username = 'john.harry0702';
+          userWithUsernameOnly.samlId = null;
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithUsernameOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'S52', value: 'j***.h***2' }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
+        it('should return a schooling registration already linked error (short code S53 when account with samlId)', async () => {
+          // given
+          const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
+          userWithSamlIdOnly.email = null;
+          userWithSamlIdOnly.username = null;
+          userWithSamlIdOnly.samlId = '12345678';
+
+          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
+          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
+          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
+          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
+          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
+          otherSchoolingRegistration.userId = userWithSamlIdOnly.id;
+          await databaseBuilder.commit();
+
+          const expectedResponse = {
+            status: '409',
+            code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
+            meta: { shortCode: 'S53', value: null }
+          };
+
+          options.headers.authorization = generateValidRequestAuthorizationHeader(userWithSamlIdOnly.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaignCode,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate
+            }
+          };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(409);
+          expect(response.result.errors[0]).to.deep.equal(expectedResponse);
+        });
+
       });
 
       context('when a field is not valid', () => {

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -58,10 +58,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R31 when account with email)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = 'john.harry@example.net';
-          userWithEmailOnly.samlId = null;
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: 'john.harry@example.net',
+            samlId: null
+          });
           const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
           schoolingRegistration.userId = userWithEmailOnly.id;
           await databaseBuilder.commit();
@@ -94,10 +95,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R32 when connected with username)', async () => {
           // given
-          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
-          userWithUsernameOnly.username = 'john.harry0702';
-          userWithUsernameOnly.email = null;
-          userWithUsernameOnly.samlId = null;
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser({
+            username: 'john.harry0702',
+            email: null,
+            samlId: null,
+          });
           const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
           schoolingRegistration.userId = userWithUsernameOnly.id;
           await databaseBuilder.commit();
@@ -130,10 +132,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R33 when account with samlId)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = null;
-          userWithEmailOnly.samlId = '12345689';
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: null,
+            samlId: '12345689',
+          });
           const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
           schoolingRegistration.userId = userWithEmailOnly.id;
           await databaseBuilder.commit();
@@ -169,11 +172,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R11 when account with email)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = 'john.harry@example.net';
-          userWithEmailOnly.samlId = null;
-
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: 'john.harry@example.net',
+            samlId: null,
+          });
           const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
           otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
           otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
@@ -211,10 +214,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R12 when connected with username)', async () => {
           // given
-          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
-          userWithUsernameOnly.email = null;
-          userWithUsernameOnly.username = 'john.harry0702';
-          userWithUsernameOnly.samlId = null;
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser({
+            email: null,
+            username: 'john.harry0702',
+            samlId: null,
+          });
 
           const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
           otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
@@ -252,11 +256,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code R13 when account with samlId)', async () => {
           // given
-          const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
-          userWithSamlIdOnly.email = null;
-          userWithSamlIdOnly.username = null;
-          userWithSamlIdOnly.samlId = '12345678';
-
+          const userWithSamlIdOnly = databaseBuilder.factory.buildUser({
+            email: null,
+            username: null,
+            samlId: '12345678',
+          });
           const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
           otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
           otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
@@ -670,7 +674,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
           // then
           expect(response.statusCode).to.equal(404);
-          expect(response.result.errors[0].detail).to.equal('There are no schooling registrations found');
+          expect(response.result.errors[0].detail).to.equal('There were no schoolingRegistrations matching with organization and birthdate');
         });
       });
 
@@ -693,12 +697,12 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S61 when account with email)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = 'john.harry@example.net';
-          userWithEmailOnly.samlId = null;
-          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
-          schoolingRegistration.userId = userWithEmailOnly.id;
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: 'john.harry@example.net',
+            samlId: null,
+          });
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: userWithEmailOnly.id });
           await databaseBuilder.commit();
 
           const expectedResponse = {
@@ -729,12 +733,12 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S62 when connected with username)', async () => {
           // given
-          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
-          userWithUsernameOnly.username = 'john.harry0702';
-          userWithUsernameOnly.email = null;
-          userWithUsernameOnly.samlId = null;
-          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
-          schoolingRegistration.userId = userWithUsernameOnly.id;
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser({
+            username: 'john.harry0702',
+            email: null,
+            samlId: null
+          });
+          const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: userWithUsernameOnly.id });
           await databaseBuilder.commit();
 
           const expectedResponse = {
@@ -765,10 +769,11 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S63 when account with samlId)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = null;
-          userWithEmailOnly.samlId = '12345689';
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: null,
+            samlId: '12345689'
+          });
           const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, userId: null });
           schoolingRegistration.userId = userWithEmailOnly.id;
           await databaseBuilder.commit();
@@ -821,18 +826,18 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S51 when account with email)', async () => {
           // given
-          const userWithEmailOnly = databaseBuilder.factory.buildUser();
-          userWithEmailOnly.username = null;
-          userWithEmailOnly.email = 'john.harry@example.net';
-          userWithEmailOnly.samlId = null;
-
-          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
-          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
-          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
-          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
-          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
-          otherSchoolingRegistration.userId = userWithEmailOnly.id;
-
+          const userWithEmailOnly = databaseBuilder.factory.buildUser({
+            username: null,
+            email: 'john.harry@example.net',
+            samlId: null
+          });
+          databaseBuilder.factory.buildSchoolingRegistration({
+            nationalStudentId: schoolingRegistration.nationalStudentId,
+            birthdate: schoolingRegistration.birthdate,
+            firstName: schoolingRegistration.firstName,
+            lastName: schoolingRegistration.lastName,
+            userId: userWithEmailOnly.id,
+          });
           await databaseBuilder.commit();
 
           const expectedResponse = {
@@ -863,17 +868,18 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S52 when connected with username)', async () => {
           // given
-          const userWithUsernameOnly = databaseBuilder.factory.buildUser();
-          userWithUsernameOnly.email = null;
-          userWithUsernameOnly.username = 'john.harry0702';
-          userWithUsernameOnly.samlId = null;
-
-          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
-          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
-          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
-          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
-          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
-          otherSchoolingRegistration.userId = userWithUsernameOnly.id;
+          const userWithUsernameOnly = databaseBuilder.factory.buildUser({
+            username: 'john.harry0702',
+            email: null,
+            samlId: null
+          });
+          databaseBuilder.factory.buildSchoolingRegistration({
+            nationalStudentId: schoolingRegistration.nationalStudentId,
+            birthdate: schoolingRegistration.birthdate,
+            firstName: schoolingRegistration.firstName,
+            lastName: schoolingRegistration.lastName,
+            userId: userWithUsernameOnly.id,
+          });
           await databaseBuilder.commit();
 
           const expectedResponse = {
@@ -904,17 +910,18 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         it('should return a schooling registration already linked error (short code S53 when account with samlId)', async () => {
           // given
-          const userWithSamlIdOnly = databaseBuilder.factory.buildUser();
-          userWithSamlIdOnly.email = null;
-          userWithSamlIdOnly.username = null;
-          userWithSamlIdOnly.samlId = '12345678';
-
-          const otherSchoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration();
-          otherSchoolingRegistration.nationalStudentId = schoolingRegistration.nationalStudentId;
-          otherSchoolingRegistration.birthdate = schoolingRegistration.birthdate;
-          otherSchoolingRegistration.firstName = schoolingRegistration.firstName;
-          otherSchoolingRegistration.lastName = schoolingRegistration.lastName;
-          otherSchoolingRegistration.userId = userWithSamlIdOnly.id;
+          const userWithSamlIdOnly = databaseBuilder.factory.buildUser({
+            email: null,
+            username: null,
+            samlId: '12345678',
+          });
+          databaseBuilder.factory.buildSchoolingRegistration({
+            nationalStudentId: schoolingRegistration.nationalStudentId,
+            birthdate: schoolingRegistration.birthdate,
+            firstName: schoolingRegistration.firstName,
+            lastName: schoolingRegistration.lastName,
+            userId: userWithSamlIdOnly.id,
+          });
           await databaseBuilder.commit();
 
           const expectedResponse = {

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../../../test-helper');
-const { emailObfuscation, usernameObfuscation, getUserAuthenticationMethodWithObfuscation } = require('../../../../lib/domain/services/obfuscation-service');
+const obfuscationService = require('../../../../lib/domain/services/obfuscation-service');
 const User = require('../../../../lib/domain/models/User');
 describe('Unit | Service | user-authentication-method-obfuscation-service', () => {
 
@@ -9,7 +9,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       // Given
       const email = 'johnHarry@example.net';
       // When
-      const value = emailObfuscation(email);
+      const value = obfuscationService.emailObfuscation(email);
       //Then
       expect(value).to.be.equal('j***@example.net');
     });
@@ -22,7 +22,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       // Given
       const username = 'john.harry0702';
       // When
-      const value = usernameObfuscation(username);
+      const value = obfuscationService.usernameObfuscation(username);
       //Then
       expect(value).to.be.equal('j***.h***2');
     });
@@ -31,14 +31,14 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
 
   describe('#getUserAuthenticationMethodWithObfuscation', () => {
 
-    it('should return authenticated with samlId when user is authenticated with samlId only',() => {
+    it('should return authenticated with samlId when user is authenticated with samlId only',  () => {
       // Given
       const samlId = '1234567';
       const user = new User({ samlId });
       user.samlId = '1234567';
 
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'samlId',
@@ -47,13 +47,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       expect(value).to.be.deep.equal(expectedResult);
     });
 
-    it('should return authenticated with samlId when user is authenticated with samlId and username',() => {
+    it('should return authenticated with samlId when user is authenticated with samlId and username',  () => {
       // Given
       const samlId = '1234567';
       const username = 'john.harry.0702';
       const user = new User({ samlId, username });
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'samlId',
@@ -62,7 +62,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       expect(value).to.be.deep.equal(expectedResult);
     });
 
-    it('should return authenticated with samlId when user is authenticated with samlId, username and email',() => {
+    it('should return authenticated with samlId when user is authenticated with samlId, username and email',  () => {
       // Given
       const samlId = '1234567';
       const username = 'john.harry.0702';
@@ -70,7 +70,7 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
 
       const user = new User({ samlId, username, email });
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'samlId',
@@ -79,13 +79,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       expect(value).to.be.deep.equal(expectedResult);
     });
 
-    it('should return authenticated with username when user is authenticated with username only',() => {
+    it('should return authenticated with username when user is authenticated with username only',  () => {
       // Given
       const username = 'john.harry0702';
       const user = new User({ username });
 
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'username',
@@ -94,14 +94,14 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       expect(value).to.be.deep.equal(expectedResult);
     });
 
-    it('should return authenticated with username when user is authenticated with username and email',() => {
+    it('should return authenticated with username when user is authenticated with username and email',  () => {
       // Given
       const username = 'john.harry0702';
       const email = 'john.harry@example.net';
       const user = new User({ username, email });
 
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'username',
@@ -110,13 +110,13 @@ describe('Unit | Service | user-authentication-method-obfuscation-service', () =
       expect(value).to.be.deep.equal(expectedResult);
     });
 
-    it('should return authenticated with username when user is authenticated with email only',() => {
+    it('should return authenticated with username when user is authenticated with email only',  () => {
       // Given
       const email = 'john.harry@example.net';
       const user = new User({ email });
 
       // When
-      const value = getUserAuthenticationMethodWithObfuscation(user);
+      const value = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
       //Then
       const expectedResult = {
         authenticatedBy : 'email',

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -192,7 +192,7 @@ export default class RegisterForm extends Component {
       { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'S53', message: 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.' },
       { code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION', shortCode:'S61', message:`Vous possédez déjà un compte Pix avec l‘adresse e-mail<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S61)` },
       { code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'S62', message:`Vous possédez déjà un compte Pix avec l‘identifiant<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br>(Code S62)` },
-      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'S63', message:'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.' }
+      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'S63', message:'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)' },
     ];
 
     return  find(errors, ['shortCode', meta.shortCode]).message || defaultMessage;

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -38,7 +38,7 @@ describe('Integration | Component | routes/register-form', function() {
 
   it('renders', async function() {
     // when
-    await render(hbs`{{routes/register-form}}`);
+    await render(hbs`<Routes::RegisterForm/>`);
 
     //then
     expect(find('.register-form')).to.exist;
@@ -78,7 +78,7 @@ describe('Integration | Component | routes/register-form', function() {
       const sessionServiceObserver = this.owner.lookup('service:session');
       this.set('loginWithUsername', false);
 
-      await render(hbs`{{routes/register-form loginWithUsername=loginWithUsername}}`);
+      await render(hbs`<Routes::RegisterForm @loginWithUsername={{this.loginWithUsername}} />`);
 
       await fillIn('#firstName', 'pix');
       await fillIn('#lastName', 'pix');
@@ -108,7 +108,7 @@ describe('Integration | Component | routes/register-form', function() {
       const sessionServiceObserver = this.owner.lookup('service:session');
       this.set('loginWithUsername', true);
 
-      await render(hbs`{{routes/register-form loginWithUsername=loginWithUsername}}`);
+      await render(hbs`<Routes::RegisterForm @loginWithUsername={{this.loginWithUsername}} />`);
 
       await fillIn('#firstName', 'pix');
       await fillIn('#lastName', 'pix');
@@ -141,7 +141,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       it(`should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await render(hbs`<Routes::RegisterForm />`);
 
         // when
         await fillIn('#firstName', stringFilledIn);
@@ -159,7 +159,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       it(`should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await render(hbs`<Routes::RegisterForm />`);
 
         // when
         await fillIn('#lastName', stringFilledIn);
@@ -178,7 +178,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       it(`should display an error message on dayOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await render(hbs`<Routes::RegisterForm />`);
 
         // when
         await fillIn('#dayOfBirth', stringFilledIn);
@@ -197,7 +197,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       it(`should display an error message on monthOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await render(hbs`<Routes::RegisterForm />`);
 
         // when
         await fillIn('#monthOfBirth', stringFilledIn);
@@ -216,7 +216,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       it(`should display an error message on yearOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
-        await render(hbs`{{routes/register-form}}`);
+        await render(hbs`<Routes::RegisterForm />`);
 
         // when
         await fillIn('#yearOfBirth', stringFilledIn);
@@ -237,7 +237,7 @@ describe('Integration | Component | routes/register-form', function() {
         // given
         this.set('matchingStudentFound', true);
         this.set('schoolingRegistrationDependentUser', EmberObject.create({ email : stringFilledIn , unloadRecord() {return resolve();}  }));
-        await render(hbs`{{routes/register-form matchingStudentFound=true schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+        await render(hbs`<Routes::RegisterForm @matchingStudentFound=true @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} /> `);
 
         // when
         await click('.pix-toggle__off');
@@ -260,7 +260,7 @@ describe('Integration | Component | routes/register-form', function() {
         // given
         this.set('matchingStudentFound', true);
         this.set('schoolingRegistrationDependentUser', EmberObject.create({ password : stringFilledIn , unloadRecord() {return resolve();}  }));
-        await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+        await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
 
         // when
         await fillIn('#password', stringFilledIn);
@@ -301,7 +301,7 @@ describe('Integration | Component | routes/register-form', function() {
           return resolve();
         };
 
-        await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+        await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
 
         await fillIn('#firstName', 'pix');
         await fillIn('#lastName', 'pix');
@@ -309,8 +309,10 @@ describe('Integration | Component | routes/register-form', function() {
         await fillIn('#monthOfBirth', '10');
         await fillIn('#yearOfBirth', '2010');
 
+        // when
         await click('#submit-search');
 
+        // then
         expect(find('.register-form__error').innerHTML).to.equal(errorMessage);
       });
     });
@@ -319,7 +321,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by email only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S61)', async function() {
+        it('should display the error message related to the short code S61)', async function() {
           // given
           const error = {
             status: '409',
@@ -352,16 +354,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -369,7 +368,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by username only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S62)', async function() {
+        it('should display the error message related to the short code S62)', async function() {
           // given
           const error = {
             status: '409',
@@ -401,16 +400,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -418,7 +414,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S63)', async function() {
+        it('should display the error message related to the short code S63)', async function() {
           // given
           const error = {
             status: '409',
@@ -427,7 +423,7 @@ describe('Integration | Component | routes/register-form', function() {
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
             meta: { shortCode: 'S63', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -450,16 +446,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -467,7 +460,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId and username', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S63)', async function() {
+        it('should display the error message related to the short code S63)', async function() {
           // given
           const error = {
             status: '409',
@@ -476,7 +469,7 @@ describe('Integration | Component | routes/register-form', function() {
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
             meta: { shortCode: 'S63', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -499,16 +492,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -516,7 +506,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId and email', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S63)', async function() {
+        it('should display the error message related to the short code S63)', async function() {
           // given
           const error = {
             status: '409',
@@ -525,7 +515,7 @@ describe('Integration | Component | routes/register-form', function() {
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
             meta: { shortCode: 'S63', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -548,16 +538,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -565,7 +552,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId, email and username', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S63)', async function() {
+        it('should display the error message related to the short code S63)', async function() {
           // given
           const error = {
             status: '409',
@@ -574,7 +561,7 @@ describe('Integration | Component | routes/register-form', function() {
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
             meta: { shortCode: 'S63', value: undefined }
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.';
+          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -597,16 +584,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -614,7 +598,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by email and username', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S62)', async function() {
+        it('should display the error message related to the short code S62)', async function() {
           // given
           const error = {
             status: '409',
@@ -646,16 +630,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -667,7 +648,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by email only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S51)', async function() {
+        it('should display the error message related to the short code S51)', async function() {
           // given
           const error = {
             status: '409',
@@ -699,16 +680,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -716,7 +694,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by username only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S52)', async function() {
+        it('should display the error message related to the short code S52)', async function() {
           // given
           const error = {
             status: '409',
@@ -748,16 +726,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -765,7 +740,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId only', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S53)', async function() {
+        it('should display the error message related to the short code S53)', async function() {
           // given
           const error = {
             status: '409',
@@ -797,16 +772,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -814,7 +786,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId and username', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S53)', async function() {
+        it('should display the error message related to the short code S53)', async function() {
           // given
           const error = {
             status: '409',
@@ -846,16 +818,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -863,7 +832,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId and email', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S53)', async function() {
+        it('should display the error message related to the short code S53)', async function() {
           // given
           const error = {
             status: '409',
@@ -895,16 +864,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          await fillInputReconciliationForm();
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -912,7 +878,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by SamlId, username and email', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S53)', async function() {
+        it('should display the error message related to the short code S53)', async function() {
           // given
           const error = {
             status: '409',
@@ -944,16 +910,13 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
 
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -961,7 +924,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       describe('When student account is authenticated by username and email', async function() {
 
-        it('should return a conflict error and display the error message related to the short code S52)', async function() {
+        it('should display the error message related to the short code S52)', async function() {
           // given
           const error = {
             status: '409',
@@ -993,16 +956,12 @@ describe('Integration | Component | routes/register-form', function() {
             return resolve();
           };
 
-          await render(hbs`{{routes/register-form matchingStudentFound=matchingStudentFound schoolingRegistrationDependentUser=schoolingRegistrationDependentUser}}`);
+          await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+          await fillInputReconciliationForm();
 
-          await fillIn('#firstName', 'pix');
-          await fillIn('#lastName', 'pix');
-          await fillIn('#dayOfBirth', '10');
-          await fillIn('#monthOfBirth', '10');
-          await fillIn('#yearOfBirth', '2010');
-
+          // when
           await click('#submit-search');
-
+          // then
           expect(find('.register-form__error').innerHTML).to.equal(expectedErrorMessage);
         });
 
@@ -1011,3 +970,11 @@ describe('Integration | Component | routes/register-form', function() {
     });
   });
 });
+
+async function fillInputReconciliationForm() {
+  await fillIn('#firstName', 'pix');
+  await fillIn('#lastName', 'pix');
+  await fillIn('#dayOfBirth', '10');
+  await fillIn('#monthOfBirth', '10');
+  await fillIn('#yearOfBirth', '2010');
+}


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lorsqu'un élève tente de rejoindre un parcours restreint, il est invité à s'inscrire ou à se créer un compte. Si celui ci décide de s'inscrire, un formulaire de réconciliation +  création de compte est affiché
Cependant, a aucun moment, nous cherchons à vérifier s'il n'existe pas :

- Un compte utilisateur qui existe déjà pour cet élève dans un autre établissement
- Un compte utilisateur qui existe déjà pour cette élève dans l'établissement actuel 

Le but de ce ticket étant de ne pas favoriser le multi-compte en forçant l'élève à réutiliser un compte existant.

## :robot: Solution
Afficher un message d'erreur (différent suivant la méthode de connexion e-mail, identifiant ou GAR) si:

- L'élève possède déjà un compte réconcilié dans un autre établissement (erreur #6) code: S61, S62 et S63
- L'élève possède déjà un compte réconcilié dans l'établissement actuel (erreur #5), code: S51, S52 et S53

## :rainbow: Remarques
Afin d'avoir des contextes isolés par usecase métier et d'afficher des messages d'erreurs spécifiques au contexte métier. On a choisi de déplacer un bout de traitement du service vers le usecase en faisant du refactoring. Par la suite, on pourra faire des abstractions une fois la fonctionnalité terminée.

## :100: Pour tester
Les messages d'erreurs et les scénarios sont décrites dans ce document: 
https://docs.google.com/document/d/17FnXibce-pMfVfM5QoytSMuDC18zzeiOLwpMHSimuR0/edit
