### PR TITLE
[FEATURE] Afficher les paliers avec le design final (PIX-1052).

### DIFF
--- a/mon-pix/app/components/campaign-share-button.js
+++ b/mon-pix/app/components/campaign-share-button.js
@@ -1,0 +1,4 @@
+import Component from '@glimmer/component';
+
+export default class CampaignShareButton extends Component {
+}

--- a/mon-pix/app/components/campaign-skill-review-competence-result.js
+++ b/mon-pix/app/components/campaign-skill-review-competence-result.js
@@ -1,0 +1,4 @@
+import Component from '@glimmer/component';
+
+export default class CampaignSkillReviewCompetenceResult extends Component {
+}

--- a/mon-pix/app/components/reached-stage.js
+++ b/mon-pix/app/components/reached-stage.js
@@ -4,11 +4,11 @@ import range from 'lodash/range';
 export default class ReachedStage extends Component {
 
   get acquiredStars() {
-    return range(1, this.args.starCount + 1);
+    return range(1, this.args.starCount);
   }
 
   get unacquiredStars() {
-    return range(this.args.starCount + 1, this.args.stageCount + 1);
+    return range(this.args.starCount, this.args.stageCount);
   }
 }
 

--- a/mon-pix/app/components/skill-review-try-again.js
+++ b/mon-pix/app/components/skill-review-try-again.js
@@ -1,0 +1,4 @@
+import Component from '@glimmer/component';
+
+export default class SkillReviewTryAgain extends Component {
+}

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -12,6 +12,7 @@
     border: 1px solid rgb(231, 231, 231);
     border-radius: 16px;
     padding: 43px 26px;
+    min-width: 300px;
   }
 
   &__percentage-text {

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -1,12 +1,4 @@
 .reached-stage {
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 48px;
-
-  @include device-is('tablet') {
-    flex-direction: row;
-  }
-
   &__left-container {
     background: $white;
     border: 1px solid rgb(231, 231, 231);
@@ -22,13 +14,16 @@
     color: $grey-40;
     text-align: center;
   }
-
+  &__stars {
+    text-align: center;
+  }
   &__stars img {
-    margin: 4px;
+    margin: 3px;
     padding-bottom: 16px;
   }
 
   &__right-container {
+    padding-top: 20px;
     padding-left: 40px;
   }
 
@@ -45,6 +40,7 @@
     font-size: 1.125rem;
     font-weight: $font-normal;
     color: $grey-45;
+    line-height: 1.8rem;
   }
 }
 

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -23,8 +23,12 @@
   }
 
   &__right-container {
-    padding-top: 20px;
-    padding-left: 40px;
+    padding: 20px 40px 0 40px;
+    text-align: center;
+
+    @include device-is('tablet') {
+      text-align: left;
+    }
   }
 
   &__title {

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -11,6 +11,7 @@
   border: none;
   outline: none;
   transition: background-color 0.2s ease;
+  padding: 5px 5px;
 
   &:hover, &:active, &:focus {
     background-color: $blue-hover;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -156,10 +156,13 @@
   }
 
   &__share-container {
-    padding: 16px 0px 32px 40px;
+    padding: 16px 40px 32px 40px;
     text-align: center;
     &--left {
-      text-align: left;
+      text-align: center;
+      @include device-is('tablet') {
+        text-align: left;
+      }
     }
   }
 
@@ -204,9 +207,10 @@
 
   &__thanks {
     font-family: $font-open-sans;
-    font-weight: $font-light;
-    font-size: 1.5rem;
-    padding-top: 20px;
+    font-weight: $font-semi-bold;
+    font-size: 1rem;
+    line-height: 2rem;
+    padding: 16px 0;
   }
 
   &__error {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -4,6 +4,16 @@
     margin-bottom: 30px;
   }
 
+  &__result-and-action {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 48px;
+    margin:auto;
+
+    @include device-is('tablet') {
+      flex-direction: row;
+    }
+  }
   &__result-container {
     padding: 40px 10px;
     margin-top: -160px;
@@ -135,8 +145,11 @@
   }
 
   &__share-container {
-    padding: 16px 60px 32px 60px;
+    padding: 16px 0px 32px 40px;
     text-align: center;
+    &--left {
+      text-align: left;
+    }
   }
 
   &__table-header {
@@ -163,18 +176,19 @@
 }
 
 .skill-review-share {
+  flex: auto;
+  align-items: center;
+
   &__button {
-    text-transform: uppercase;
     letter-spacing: 0.031rem;
   }
 
   &__legal {
-    text-align: center;
-    font-size: 1.25rem;
-    color: $grey-60;
+    font-family: $font-roboto;
+    font-size: 0.85rem;
+    color: $grey-45;
     line-height: 2rem;
-    font-weight: $font-light;
-    margin: 0 20px 16px 20px;
+    font-weight: $font-normal;
   }
 
   &__thanks {

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -115,6 +115,17 @@
     text-align: center;
     text-transform: none;
     margin: 16px 0;
+    font-size: 1.625rem;
+    color: $grey-90;
+    font-family: $font-open-sans;
+    font-weight: $font-light;
+    letter-spacing: 0.009rem;
+    line-height: 2.75rem;
+
+    @include device-is('tablet') {
+      font-size: 2rem;
+      line-height: 3.375rem;
+    }
 
     > strong {
       color: $blue;

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -1,66 +1,13 @@
 {{page-title (t 'pages.skill-review.title')}}
 
 <div class="background-banner-wrapper">
+
   <div class="skill-review__banner">
     <AssessmentBanner @title={{this.model.assessment.title}} @displayHomeLink={{false}} />
   </div>
+
   <PixBlock @shadow="heavy" class="skill-review__result-container">
-    {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
-
-    <div class="skill-review__result-and-action">
-      {{#if this.reachedStage}}
-        <ReachedStage
-          @stageCount={{this.stageCount}}
-          @starCount={{this.reachedStage.starCount}}
-          @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
-        />
-      {{/if}}
-        <div class="skill-review-share">
-          {{#if this.reachedStage}}
-            <div class="reached-stage__right-container">
-              <div class="reached-stage__title">
-                {{this.reachedStage.title}}
-              </div>
-              <div class="reached-stage__message">
-                {{this.reachedStage.message}}
-              </div>
-            </div>
-          {{else}}
-            <h3 class="rounded-panel-title skill-review-result__abstract">
-              {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
-            </h3>
-          {{/if}}
-          <div class="skill-review-result__share-container {{if this.reachedStage "skill-review-result__share-container--left"}}">
-            <CampaignShareButton
-              @isShared={{this.model.campaignParticipation.isShared}}
-              @displayErrorMessage={{this.displayErrorMessage}}
-              @displayLoadingButton={{this.displayLoadingButton}}
-              @shareCampaignParticipation={{this.shareCampaignParticipation}}
-            />
-          </div>
-      </div>
-    </div>
-
-      {{#if this.showBadges}}
-        <div class="badge-acquired-container">
-          {{#each this.acquiredBadges as |badge|}}
-            <BadgeAcquiredCard
-              @title={{badge.title}}
-              @message={{badge.message}}
-              @imageUrl={{badge.imageUrl}}
-              @altMessage={{badge.altMessage}}
-            />
-          {{/each}}
-        </div>
-        <div class="skill-review-result__dash-line"></div>
-      {{/if}}
-
-      {{#if this.displayImprovementButton}}
-        <SkillReviewTryAgain
-                @campaignParticipation={{this.model.campaignParticipation}}
-                @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
-      {{/if}}
-    {{else}}
+    {{#if this.model.campaignParticipation.campaign.isArchived}}
 
       <div class="skill-review__campaign-archived">
         <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg">
@@ -72,24 +19,85 @@
         </LinkTo>
       </div>
 
+    {{else}}
+      <div class="skill-review__result-and-action">
+        <h2 class="sr-only">{{t 'pages.skill-review.abstract-title'}}</h2>
+        {{#if this.reachedStage}}
+          <ReachedStage
+            @stageCount={{this.stageCount}}
+            @starCount={{this.reachedStage.starCount}}
+            @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+          />
+        {{/if}}
+
+          <div class="skill-review-share">
+
+            {{#if this.reachedStage}}
+              <div class="reached-stage__right-container">
+                <div class="reached-stage__title">
+                  {{this.reachedStage.title}}
+                </div>
+                <div class="reached-stage__message">
+                  {{this.reachedStage.message}}
+                </div>
+              </div>
+            {{else}}
+              <p class="rounded-panel-title skill-review-result__abstract">
+                {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
+              </p>
+            {{/if}}
+            <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
+
+            <div class="skill-review-result__share-container {{if this.reachedStage "skill-review-result__share-container--left"}}">
+              <CampaignShareButton
+                @isShared={{this.model.campaignParticipation.isShared}}
+                @displayErrorMessage={{this.displayErrorMessage}}
+                @displayLoadingButton={{this.displayLoadingButton}}
+                @shareCampaignParticipation={{this.shareCampaignParticipation}}
+              />
+            </div>
+        </div>
+      </div>
+
+      {{#if this.showBadges}}
+        <h2 class="sr-only">{{t 'pages.skill-review.badges-title'}}</h2>
+        <div class="badge-acquired-container">
+          {{#each this.acquiredBadges as |badge|}}
+            <BadgeAcquiredCard
+                    @title={{badge.title}}
+                    @message={{badge.message}}
+                    @imageUrl={{badge.imageUrl}}
+                    @altMessage={{badge.altMessage}}
+            />
+          {{/each}}
+        </div>
+        <div class="skill-review-result__dash-line"></div>
+      {{/if}}
+
+      {{#if this.displayImprovementButton}}
+        <SkillReviewTryAgain
+                @campaignParticipation={{this.model.campaignParticipation}}
+                @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
+      {{/if}}
     {{/if}}
+
     <div class="skill-review-result__dash-line"></div>
 
-   <div class="skill-review-result__table-header">
-      <h2 class="skill-review-result__subtitle">
-        {{t 'pages.skill-review.details.title'}}
-      </h2>
-      <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
-        <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
-          {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
-        </span>
-      </CircleChart>
-    </div>
+     <div class="skill-review-result__table-header">
+        <h2 class="skill-review-result__subtitle">
+          {{t 'pages.skill-review.details.title'}}
+        </h2>
+        <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
+          <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
+            {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
+          </span>
+        </CircleChart>
+      </div>
 
-    <CampaignSkillReviewCompetenceResult
-            @showCleaCompetences={{this.showCleaCompetences}}
-            @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
-            @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}} />
+     <CampaignSkillReviewCompetenceResult
+              @showCleaCompetences={{this.showCleaCompetences}}
+              @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
+              @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}} />
 
     <div class="skill-review-result__information">
       {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -1,6 +1,6 @@
 {{page-title (t 'pages.skill-review.title')}}
 
-<PixBackgroundHeader>
+<div class="background-banner-wrapper">
   <div class="skill-review__banner">
     <AssessmentBanner @title={{this.model.assessment.title}} @displayHomeLink={{false}} />
   </div>
@@ -31,35 +31,12 @@
             </h3>
           {{/if}}
           <div class="skill-review-result__share-container {{if this.reachedStage "skill-review-result__share-container--left"}}">
-            {{#if this.model.campaignParticipation.isShared}}
-              <p class="skill-review-share__thanks">
-                {{t 'pages.skill-review.already-shared'}}
-              </p>
-              <LinkTo @route="index" class="skill-review-share__back-to-home link">
-                {{t 'pages.skill-review.actions.continue'}}
-              </LinkTo>
-            {{else}}
-
-              {{#if this.displayErrorMessage}}
-                <div class="skill-review-share__error" aria-live="polite">
-                  {{t 'pages.skill-review.not-finished'}}
-                </div>
-              {{/if}}
-
-              {{#if this.displayLoadingButton}}
-                <button type="button" disabled class="button button--extra-big button--green button--round skill-review-share__button">
-                  <span class="loader-in-button">&nbsp;</span>
-                </button>
-              {{else}}
-                <button class="button button--extra-big button--green button--round skill-review-share__button" {{on "click" this.shareCampaignParticipation}} type="button">
-                  {{t 'pages.skill-review.actions.send'}}
-                </button>
-              {{/if}}
-              <p class="skill-review-share__legal">
-                {{t 'pages.skill-review.send-results'}}
-              </p>
-
-            {{/if}}
+            <CampaignShareButton
+              @isShared={{this.model.campaignParticipation.isShared}}
+              @displayErrorMessage={{this.displayErrorMessage}}
+              @displayLoadingButton={{this.displayLoadingButton}}
+              @shareCampaignParticipation={{this.shareCampaignParticipation}}
+            />
           </div>
       </div>
     </div>
@@ -122,4 +99,4 @@
     </div>
 
   </PixBlock>
-</PixBackgroundHeader>
+</div>

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -65,24 +65,12 @@
       {{/if}}
 
       {{#if this.displayImprovementButton}}
-        {{#unless model.campaignParticipation.isShared}}
-          <div class="skill-review-result__dash-line"></div>
-          <div class="skill-review__begin-improvement">
-            <div>
-              <h2 class="skill-review__subtitle">
-                {{t 'pages.skill-review.try-again.title'}}
-              </h2>
-              <p class="skill-review__explain-text">
-                {{t 'pages.skill-review.try-again.description'}}
-              </p>
-            </div>
-            <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" this.improvementCampaignParticipation}} type="button">
-              {{t 'pages.skill-review.actions.try-again'}}
-            </button>
-          </div>
-        {{/unless}}
+        <SkillReviewTryAgain
+                @campaignParticipation={{this.model.campaignParticipation}}
+                @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
       {{/if}}
     {{else}}
+
       <div class="skill-review__campaign-archived">
         <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg">
         <p class="skill-review__campaign-archived-text">
@@ -92,6 +80,7 @@
           {{t 'pages.skill-review.actions.continue'}}
         </LinkTo>
       </div>
+
     {{/if}}
     <div class="skill-review-result__dash-line"></div>
 

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -6,49 +6,62 @@
   </div>
   <PixBlock @shadow="heavy" class="skill-review__result-container">
     {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
-      <h3 class="rounded-panel-title skill-review-result__abstract">
-        {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
-      </h3>
-      <div class="skill-review-result__share-container">
-        {{#if this.model.campaignParticipation.isShared}}
-          <p class="skill-review-share__thanks">
-            {{t 'pages.skill-review.already-shared'}}
-          </p>
-          <LinkTo @route="index" class="skill-review-share__back-to-home link">
-            {{t 'pages.skill-review.actions.continue'}}
-          </LinkTo>
-        {{else}}
-          <p class="skill-review-share__legal">
-            {{t 'pages.skill-review.send-results'}}
-          </p>
 
-          {{#if this.displayErrorMessage}}
-            <div class="skill-review-share__error" aria-live="polite">
-              {{t 'pages.skill-review.not-finished'}}
-            </div>
-          {{/if}}
-
-          {{#if this.displayLoadingButton}}
-            <button type="button" disabled class="button button--extra-big skill-review-share__button">
-              <span class="loader-in-button">&nbsp;</span>
-            </button>
-          {{else}}
-            <button class="button button--extra-big skill-review-share__button" {{on "click" this.shareCampaignParticipation}} type="button">
-              {{t 'pages.skill-review.actions.send'}}
-            </button>
-          {{/if}}
-        {{/if}}
-      </div>
-
+    <div class="reached-stage">
       {{#if this.reachedStage}}
         <ReachedStage
           @stageCount={{this.stageCount}}
-          @title={{this.reachedStage.title}}
-          @message={{this.reachedStage.message}}
           @starCount={{this.reachedStage.starCount}}
           @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
         />
       {{/if}}
+        <div class="skill-review__result-and-action">
+          {{#if this.reachedStage}}
+            <div class="reached-stage__right-container">
+              <div class="reached-stage__title">
+                {{this.reachedStage.title}}
+              </div>
+              <div class="reached-stage__message">
+                {{this.reachedStage.message}}
+              </div>
+            </div>
+          {{else}}
+            <h3 class="rounded-panel-title skill-review-result__abstract">
+              {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
+            </h3>
+          {{/if}}
+          <div class="skill-review-result__share-container">
+            {{#if this.model.campaignParticipation.isShared}}
+              <p class="skill-review-share__thanks">
+                {{t 'pages.skill-review.already-shared'}}
+              </p>
+              <LinkTo @route="index" class="skill-review-share__back-to-home link">
+                {{t 'pages.skill-review.actions.continue'}}
+              </LinkTo>
+            {{else}}
+              <p class="skill-review-share__legal">
+                {{t 'pages.skill-review.send-results'}}
+              </p>
+
+              {{#if this.displayErrorMessage}}
+                <div class="skill-review-share__error" aria-live="polite">
+                  {{t 'pages.skill-review.not-finished'}}
+                </div>
+              {{/if}}
+
+              {{#if this.displayLoadingButton}}
+                <button type="button" disabled class="button button--extra-big skill-review-share__button">
+                  <span class="loader-in-button">&nbsp;</span>
+                </button>
+              {{else}}
+                <button class="button button--extra-big skill-review-share__button" {{on "click" this.shareCampaignParticipation}} type="button">
+                  {{t 'pages.skill-review.actions.send'}}
+                </button>
+              {{/if}}
+            {{/if}}
+          </div>
+      </div>
+    </div>
 
       {{#if this.showBadges}}
         <div class="badge-acquired-container">

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -106,49 +106,10 @@
       </CircleChart>
     </div>
 
-    <table class="default-table">
-      <thead>
-      <tr>
-        <th>{{t 'pages.skill-review.details.header-skill'}}</th>
-        <th>{{t 'pages.skill-review.details.header-result'}}</th>
-      </tr>
-      </thead>
-
-      <tbody>
-      {{#if this.showCleaCompetences}}
-        {{#each this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults as |partnerCompetence|}}
-          <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
-            <td>
-              <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}">&#8226;</span>
-              <span>{{partnerCompetence.name}}</span>
-            </td>
-            <td>
-              <ProgressionGauge @total={{partnerCompetence.totalSkillsCountPercentage}}
-                                @value={{partnerCompetence.masteryPercentage}}>
-                {{t 'pages.skill-review.details.skill-progress' percentage=partnerCompetence.masteryPercentage skill=partnerCompetence.name htmlSafe=true}}
-              </ProgressionGauge>
-            </td>
-          </tr>
-        {{/each}}
-      {{else}}
-        {{#each this.model.campaignParticipation.campaignParticipationResult.competenceResults as |competence|}}
-          <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
-            <td>
-              <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}">&#8226;</span>
-              <span>{{competence.name}}</span>
-            </td>
-            <td>
-              <ProgressionGauge @total={{competence.totalSkillsCountPercentage}}
-                                @value={{competence.masteryPercentage}}>
-                {{t 'pages.skill-review.details.skill-progress' percentage=competence.masteryPercentage skill=competence.name htmlSafe=true}}
-              </ProgressionGauge>
-            </td>
-          </tr>
-        {{/each}}
-      {{/if}}
-
-      </tbody>
-    </table>
+    <CampaignSkillReviewCompetenceResult
+            @showCleaCompetences={{this.showCleaCompetences}}
+            @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
+            @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}} />
 
     <div class="skill-review-result__information">
       {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -64,10 +64,10 @@
         <div class="badge-acquired-container">
           {{#each this.acquiredBadges as |badge|}}
             <BadgeAcquiredCard
-                    @title={{badge.title}}
-                    @message={{badge.message}}
-                    @imageUrl={{badge.imageUrl}}
-                    @altMessage={{badge.altMessage}}
+              @title={{badge.title}}
+              @message={{badge.message}}
+              @imageUrl={{badge.imageUrl}}
+              @altMessage={{badge.altMessage}}
             />
           {{/each}}
         </div>
@@ -76,8 +76,8 @@
 
       {{#if this.displayImprovementButton}}
         <SkillReviewTryAgain
-                @campaignParticipation={{this.model.campaignParticipation}}
-                @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
+          @campaignParticipation={{this.model.campaignParticipation}}
+          @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
       {{/if}}
     {{/if}}
 
@@ -95,9 +95,10 @@
       </div>
 
      <CampaignSkillReviewCompetenceResult
-              @showCleaCompetences={{this.showCleaCompetences}}
-              @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
-              @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}} />
+       @showCleaCompetences={{this.showCleaCompetences}}
+       @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
+       @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}}
+     />
 
     <div class="skill-review-result__information">
       {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -7,7 +7,7 @@
   <PixBlock @shadow="heavy" class="skill-review__result-container">
     {{#if (not this.model.campaignParticipation.campaign.isArchived )}}
 
-    <div class="reached-stage">
+    <div class="skill-review__result-and-action">
       {{#if this.reachedStage}}
         <ReachedStage
           @stageCount={{this.stageCount}}
@@ -15,7 +15,7 @@
           @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
         />
       {{/if}}
-        <div class="skill-review__result-and-action">
+        <div class="skill-review-share">
           {{#if this.reachedStage}}
             <div class="reached-stage__right-container">
               <div class="reached-stage__title">
@@ -30,7 +30,7 @@
               {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
             </h3>
           {{/if}}
-          <div class="skill-review-result__share-container">
+          <div class="skill-review-result__share-container {{if this.reachedStage "skill-review-result__share-container--left"}}">
             {{#if this.model.campaignParticipation.isShared}}
               <p class="skill-review-share__thanks">
                 {{t 'pages.skill-review.already-shared'}}
@@ -39,9 +39,6 @@
                 {{t 'pages.skill-review.actions.continue'}}
               </LinkTo>
             {{else}}
-              <p class="skill-review-share__legal">
-                {{t 'pages.skill-review.send-results'}}
-              </p>
 
               {{#if this.displayErrorMessage}}
                 <div class="skill-review-share__error" aria-live="polite">
@@ -50,14 +47,18 @@
               {{/if}}
 
               {{#if this.displayLoadingButton}}
-                <button type="button" disabled class="button button--extra-big skill-review-share__button">
+                <button type="button" disabled class="button button--extra-big button--green button--round skill-review-share__button">
                   <span class="loader-in-button">&nbsp;</span>
                 </button>
               {{else}}
-                <button class="button button--extra-big skill-review-share__button" {{on "click" this.shareCampaignParticipation}} type="button">
+                <button class="button button--extra-big button--green button--round skill-review-share__button" {{on "click" this.shareCampaignParticipation}} type="button">
                   {{t 'pages.skill-review.actions.send'}}
                 </button>
               {{/if}}
+              <p class="skill-review-share__legal">
+                {{t 'pages.skill-review.send-results'}}
+              </p>
+
             {{/if}}
           </div>
       </div>

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -1,8 +1,9 @@
 {{#if @isShared}}
-  <p class="skill-review-share__thanks">
+  <div class="skill-review-share__thanks">
     {{t 'pages.skill-review.already-shared'}}
-  </p>
+  </div>
   <LinkTo @route="index" class="skill-review-share__back-to-home link">
+    <FaIcon @icon='arrow-right'></FaIcon>
     {{t 'pages.skill-review.actions.continue'}}
   </LinkTo>
 {{else}}
@@ -14,16 +15,15 @@
   {{/if}}
 
   {{#if @displayLoadingButton}}
-    <button type="button" disabled class="button button--extra-big button--green button--round skill-review-share__button">
+    <button type="button" disabled class="button button--green button--round skill-review-share__button">
       <span class="loader-in-button">&nbsp;</span>
     </button>
   {{else}}
-    <button class="button button--extra-big button--green button--round skill-review-share__button" {{on "click" @shareCampaignParticipation}} type="button">
+    <button class="button button--green button--round skill-review-share__button" {{on "click" @shareCampaignParticipation}} type="button">
       {{t 'pages.skill-review.actions.send'}}
     </button>
   {{/if}}
   <p class="skill-review-share__legal">
     {{t 'pages.skill-review.send-results'}}
   </p>
-
 {{/if}}

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -1,0 +1,29 @@
+{{#if @isShared}}
+  <p class="skill-review-share__thanks">
+    {{t 'pages.skill-review.already-shared'}}
+  </p>
+  <LinkTo @route="index" class="skill-review-share__back-to-home link">
+    {{t 'pages.skill-review.actions.continue'}}
+  </LinkTo>
+{{else}}
+
+  {{#if @displayErrorMessage}}
+    <div class="skill-review-share__error" aria-live="polite">
+      {{t 'pages.skill-review.not-finished'}}
+    </div>
+  {{/if}}
+
+  {{#if @displayLoadingButton}}
+    <button type="button" disabled class="button button--extra-big button--green button--round skill-review-share__button">
+      <span class="loader-in-button">&nbsp;</span>
+    </button>
+  {{else}}
+    <button class="button button--extra-big button--green button--round skill-review-share__button" {{on "click" @shareCampaignParticipation}} type="button">
+      {{t 'pages.skill-review.actions.send'}}
+    </button>
+  {{/if}}
+  <p class="skill-review-share__legal">
+    {{t 'pages.skill-review.send-results'}}
+  </p>
+
+{{/if}}

--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -1,0 +1,43 @@
+<table class="default-table">
+  <thead>
+  <tr>
+    <th>{{t 'pages.skill-review.details.header-skill'}}</th>
+    <th>{{t 'pages.skill-review.details.header-result'}}</th>
+  </tr>
+  </thead>
+
+  <tbody>
+  {{#if @showCleaCompetences}}
+    {{#each @partnerCompetenceResults as |partnerCompetence|}}
+      <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
+        <td>
+          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}">&#8226;</span>
+          <span>{{partnerCompetence.name}}</span>
+        </td>
+        <td>
+          <ProgressionGauge @total={{partnerCompetence.totalSkillsCountPercentage}}
+                            @value={{partnerCompetence.masteryPercentage}}>
+            {{t 'pages.skill-review.details.skill-progress' percentage=partnerCompetence.masteryPercentage skill=partnerCompetence.name htmlSafe=true}}
+          </ProgressionGauge>
+        </td>
+      </tr>
+    {{/each}}
+    {{else}}
+    {{#each @competenceResults as |competence|}}
+      <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
+        <td>
+          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}">&#8226;</span>
+          <span>{{competence.name}}</span>
+        </td>
+        <td>
+          <ProgressionGauge @total={{competence.totalSkillsCountPercentage}}
+                            @value={{competence.masteryPercentage}}>
+            {{t 'pages.skill-review.details.skill-progress' percentage=competence.masteryPercentage skill=competence.name htmlSafe=true}}
+          </ProgressionGauge>
+        </td>
+      </tr>
+    {{/each}}
+  {{/if}}
+
+  </tbody>
+</table>

--- a/mon-pix/app/templates/components/reached-stage.hbs
+++ b/mon-pix/app/templates/components/reached-stage.hbs
@@ -1,4 +1,3 @@
-<div class="reached-stage">
   <div class="reached-stage__left-container">
     <div class="reached-stage__stars">
       {{#each this.acquiredStars as |star|}}
@@ -18,12 +17,3 @@
       {{t 'pages.skill-review.stage.masteryPercentage' percentage=@percentage}}
     </div>
  </div>
- <div class="reached-stage__right-container">
-   <div class="reached-stage__title">
-     {{@title}}
-   </div>
-   <div class="reached-stage__message">
-     {{@message}}
-   </div>
- </div>
-</div>

--- a/mon-pix/app/templates/components/skill-review-try-again.hbs
+++ b/mon-pix/app/templates/components/skill-review-try-again.hbs
@@ -1,0 +1,16 @@
+{{#unless @campaignParticipation.isShared}}
+  <div class="skill-review-result__dash-line"></div>
+  <div class="skill-review__begin-improvement">
+    <div>
+      <h2 class="skill-review__subtitle">
+        {{t 'pages.skill-review.try-again.title'}}
+      </h2>
+      <p class="skill-review__explain-text">
+        {{t 'pages.skill-review.try-again.description'}}
+      </p>
+    </div>
+    <button class="button button--dark-grey button--big skill-review__improvement-button" {{on "click" @improvementCampaignParticipation}} type="button">
+      {{t 'pages.skill-review.actions.try-again'}}
+    </button>
+  </div>
+{{/unless}}

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -2,6 +2,7 @@ module.exports = function() {
   return {
     'free-solid-svg-icons': [
       'arrow-left',
+      'arrow-right',
       'bars',
       'bookmark',
       'check-circle',

--- a/mon-pix/public/images/stage-plain-star.svg
+++ b/mon-pix/public/images/stage-plain-star.svg
@@ -1,27 +1,25 @@
 <svg width="36" height="36" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <defs>
-        <linearGradient x1="68.643%" y1="0%" x2="68.643%" y2="100%" id="c">
-            <stop stop-color="#FEDC41" offset="0%"/>
-            <stop stop-color="#FF9F00" offset="100%"/>
-        </linearGradient>
-        <filter x="-15.3%" y="-15.3%" width="130.6%" height="130.6%" filterUnits="objectBoundingBox" id="a">
-            <feGaussianBlur stdDeviation="4" in="SourceAlpha" result="shadowBlurInner1"/>
-            <feOffset dy="3" in="shadowBlurInner1" result="shadowOffsetInner1"/>
-            <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
-            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.4 0" in="shadowInnerInner1" result="shadowMatrixInner1"/>
-            <feGaussianBlur stdDeviation="1.5" in="SourceAlpha" result="shadowBlurInner2"/>
-            <feOffset dy="1" in="shadowBlurInner2" result="shadowOffsetInner2"/>
-            <feComposite in="shadowOffsetInner2" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner2"/>
-            <feColorMatrix values="0 0 0 0 0.756862745 0 0 0 0 0.780392157 0 0 0 0 0.815686275 0 0 0 0.1 0" in="shadowInnerInner2" result="shadowMatrixInner2"/>
-            <feMerge>
-                <feMergeNode in="shadowMatrixInner1"/>
-                <feMergeNode in="shadowMatrixInner2"/>
-            </feMerge>
-        </filter>
-        <path d="M8.423 35.82c-.761.507-1.765-.125-1.635-1.03l1.619-11.335L.311 15.36a1.059 1.059 0 01.6-1.796l11.268-1.61L17.027.642c.367-.856 1.58-.856 1.946 0l4.848 11.31 11.269 1.61a1.059 1.059 0 01.599 1.797l-8.096 8.096 1.62 11.334c.129.906-.875 1.538-1.636 1.03L18 29.436 8.423 35.82z" id="b"/>
-    </defs>
-    <g fill="none" fill-rule="evenodd">
-        <use fill="#000" filter="url(#a)" xlink:href="#b"/>
-        <use fill="url(#c)" xlink:href="#b"/>
-    </g>
+  <defs>
+    <linearGradient x1="68.643%" y1="0%" x2="68.643%" y2="100%" id="c">
+      <stop stop-color="#FEDC41" offset="0%"/>
+      <stop stop-color="#FF9F00" offset="100%"/>
+    </linearGradient>
+    <filter x="-52.8%" y="-30.6%" width="205.6%" height="205.6%" filterUnits="objectBoundingBox" id="a">
+      <feOffset dy="2" in="SourceAlpha" result="shadowOffsetOuter1"/>
+      <feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/>
+      <feColorMatrix values="0 0 0 0 1 0 0 0 0 0.836855084 0 0 0 0 0.330297256 0 0 0 0.29763986 0" in="shadowBlurOuter1" result="shadowMatrixOuter1"/>
+      <feOffset dy="8" in="SourceAlpha" result="shadowOffsetOuter2"/>
+      <feGaussianBlur stdDeviation="5" in="shadowOffsetOuter2" result="shadowBlurOuter2"/>
+      <feColorMatrix values="0 0 0 0 0.236882084 0 0 0 0 0.501349488 0 0 0 0 0.817920918 0 0 0 0.0851449275 0" in="shadowBlurOuter2" result="shadowMatrixOuter2"/>
+      <feMerge>
+        <feMergeNode in="shadowMatrixOuter1"/>
+        <feMergeNode in="shadowMatrixOuter2"/>
+      </feMerge>
+    </filter>
+    <path d="M8.423 35.82c-.761.507-1.765-.125-1.635-1.03l1.619-11.335L.311 15.36a1.059 1.059 0 01.6-1.796l11.268-1.61L17.027.642c.367-.856 1.58-.856 1.946 0l4.848 11.31 11.269 1.61a1.059 1.059 0 01.599 1.797l-8.096 8.096 1.62 11.334c.129.906-.875 1.538-1.636 1.03L18 29.436 8.423 35.82z" id="b"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <use fill="#000" filter="url(#a)" xlink:href="#b"/>
+    <use fill="url(#c)" xlink:href="#b"/>
+  </g>
 </svg>

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -181,7 +181,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('.reached-stage')).to.exist;
+        expect(find('.reached-stage__left-container')).to.exist;
       });
 
       it('should not display reached stage when campaign has no stages', async function() {

--- a/mon-pix/tests/integration/components/reached-stage-test.js
+++ b/mon-pix/tests/integration/components/reached-stage-test.js
@@ -49,11 +49,11 @@ describe('Integration | Component | reached-stage', function() {
 });
 
 function _expectStars(starCount, stageCount) {
-  for (let index = 1 ; index <= starCount ; index ++) {
+  for (let index = 1 ; index < starCount ; index ++) {
     expect(find(`#acquired-star-${index}`)).to.exist;
     expect(find(`#unacquired-star-${index}`)).to.not.exist;
   }
-  for (let index = starCount + 1 ; index <= stageCount ; index ++) {
+  for (let index = starCount ; index < stageCount ; index ++) {
     expect(find(`#acquired-star-${index}`)).to.not.exist;
     expect(find(`#unacquired-star-${index}`)).to.exist;
   }

--- a/mon-pix/tests/integration/components/reached-stage-test.js
+++ b/mon-pix/tests/integration/components/reached-stage-test.js
@@ -9,8 +9,6 @@ describe('Integration | Component | reached-stage', function() {
 
   beforeEach(function() {
     // given
-    this.set('reachedStageTitle', 'title');
-    this.set('reachedStageMessage', 'message');
     this.set('reachedStageStarCount', 3);
     this.set('percentage', 50);
     this.set('stageCount', 5);
@@ -18,12 +16,10 @@ describe('Integration | Component | reached-stage', function() {
 
   it('should render the reached stage', async function() {
     // when
-    await render(hbs`<ReachedStage @title={{this.reachedStageTitle}} @message={{this.reachedStageMessage}} @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+    await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
 
     // then
-    expect(find('.reached-stage')).to.exist;
-    expect(find('.reached-stage__title').textContent.trim()).to.equal('title');
-    expect(find('.reached-stage__message').textContent.trim()).to.equal('message');
+    expect(find('.reached-stage__stars')).to.exist;
     expect(find('.reached-stage__percentage-text').textContent.trim()).to.equal('50 % de réussite');
     _expectStars(this.reachedStageStarCount, this.stageCount);
   });
@@ -43,7 +39,7 @@ describe('Integration | Component | reached-stage', function() {
         this.set('stageCount', stageCount);
 
         // when
-        await render(hbs`<ReachedStage @title={{this.reachedStageTitle}} @message={{this.reachedStageMessage}} @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
+        await render(hbs`<ReachedStage @starCount={{this.reachedStageStarCount}} @percentage={{this.percentage}} @stageCount={{this.stageCount}} />`);
 
         // then
         _expectStars(starCount, stageCount);

--- a/mon-pix/tests/unit/components/reached-stage-test.js
+++ b/mon-pix/tests/unit/components/reached-stage-test.js
@@ -8,12 +8,12 @@ describe('Unit | Component | reached-stage', function() {
   setupTest();
 
   [
-    { starCount: 0, stageCount: 1, acquiredStars: [], unacquiredStars: [1] },
-    { starCount: 5, stageCount: 5, acquiredStars: [1, 2, 3, 4, 5], unacquiredStars: [] },
-    { starCount: 5, stageCount: 6, acquiredStars: [1, 2, 3, 4, 5], unacquiredStars: [6] },
-    { starCount: 2, stageCount: 10, acquiredStars: [1, 2], unacquiredStars: [3, 4, 5, 6, 7, 8, 9, 10] },
-    { starCount: 2, stageCount: 3, acquiredStars: [1, 2], unacquiredStars: [3] },
-    { starCount: 4, stageCount: 5, acquiredStars: [1, 2, 3, 4], unacquiredStars: [5] },
+    { starCount: 1, stageCount: 1, acquiredStars: [], unacquiredStars: [] },
+    { starCount: 5, stageCount: 5, acquiredStars: [1, 2, 3, 4], unacquiredStars: [] },
+    { starCount: 5, stageCount: 6, acquiredStars: [1, 2, 3, 4], unacquiredStars: [5] },
+    { starCount: 2, stageCount: 10, acquiredStars: [1], unacquiredStars: [2, 3, 4, 5, 6, 7, 8, 9] },
+    { starCount: 2, stageCount: 3, acquiredStars: [1], unacquiredStars: [2] },
+    { starCount: 4, stageCount: 5, acquiredStars: [1, 2, 3], unacquiredStars: [4] },
   ].map(({ starCount, stageCount, acquiredStars, unacquiredStars }) => {
     context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
       describe('#get acquiredStars', function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -613,6 +613,7 @@
     "skill-review": {
       "title": "Result",
       "abstract": "You control '<strong>'{percentage}%'</strong>'<br/> of tested skills.",
+      "abstract-title": "Your results",
       "actions": {
         "continue": "Continue your Pix experience",
         "send": "I send my results",
@@ -620,6 +621,7 @@
       },
       "already-shared": "Thank you, your results have been sent!",
       "archived": "This route has been archived by the organizer. <br/> Sending results is no longer possible but they are taken into account in your route.",
+      "badges-title": "Your success",
       "details": {
         "title": "Your detailed results",
         "header-skill": "Skills tested",
@@ -631,6 +633,7 @@
       "information": "If you've ridden on Pix before, the questions you answered weren't asked again. However, the result displayed here takes into account all of your answers.",
       "not-finished": "You cannot send your results yet, we still have a few questions for you.",
       "send-results": "Send your results to the course organizer so that he can accompany you.",
+      "send-title": "Send your results",
       "stage": {
         "masteryPercentage": "{percentage} % success",
         "alt": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -613,6 +613,7 @@
     "skill-review": {
       "title": "Résultat",
       "abstract": "Vous maîtrisez '<strong>'{percentage}%'</strong>'<br/> des compétences testées.",
+      "abstract-title": "Votre résultat pour ce parcours",
       "actions": {
         "continue": "Continuez votre expérience Pix",
         "send": "J'envoie mes résultats",
@@ -620,6 +621,7 @@
       },
       "already-shared": "Merci, vos résultats ont bien été envoyés !",
       "archived": "Ce parcours a été archivé par l'organisateur.<br/> L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.",
+      "badges-title": "Vos réussites",
       "details": {
         "title": "Vos résultats détaillés",
         "header-skill": "Compétences testées",
@@ -631,6 +633,7 @@
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
+      "send-title": "Envoyez vos résultats",
       "stage": {
         "masteryPercentage": "{percentage} % de réussite",
         "alt": {


### PR DESCRIPTION
## :unicorn: Problème
- Le gain des paliers ne s'affichaient pas correctement

## :robot: Solution
- Sortir la partie Texte du ReachedStage qui contient maintenant le bouton dans `skill-review`
- Ne laisser dans le component que la partie avec les étoiles et le résultats
- N'utiliser qu'un seul bouton entre les deux types de fin de campagne (avec ou sans palier)
- Cela change le style pour les fins de campagnes habituelles (vu avec Quentin)

## :rainbow: Remarques
- Des parties de la page skill-review a été déplacé dans des composants pour alléger la page

## :100: Pour tester
- Passer la campagne AZERTY123 pour voir les paliers, et partager son profil
- Passer la campagne AZERTY456 pour voir une campagne sans palier et voir que tout est encore OK