### PR TITLE
[BUGFIX] Restreindre le choix des épreuves de certifications aux épreuves franco-françaises (fr-fr) (Pix-1123)

### DIFF
--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -22,7 +22,7 @@ module.exports = {
 
     const challengeIdsCorrectlyAnswered = await answerRepository.findChallengeIdsFromAnswerIds(answerIds);
 
-    const allChallenges = await challengeRepository.findOperative();
+    const allChallenges = await challengeRepository.findFrenchFranceOperative();
     const challengesAlreadyAnswered = challengeIdsCorrectlyAnswered.map((challengeId) => Challenge.findById(allChallenges, challengeId));
 
     challengesAlreadyAnswered.forEach((challenge) => {

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -108,6 +108,11 @@ module.exports = datasource.extend({
       _.includes(OPERATIVE_CHALLENGES, challengeData.status));
   },
 
+  async findOperativeWithLocale(locale) {
+    const operativeChallenges = await this.findOperative();
+    return operativeChallenges.filter((challenge) => _.includes(challenge.locales, locale));
+  },
+
   async findValidated() {
     const challenges = await this.list();
     return challenges.filter((challengeData) =>

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -108,9 +108,13 @@ module.exports = datasource.extend({
       _.includes(OPERATIVE_CHALLENGES, challengeData.status));
   },
 
-  async findOperativeWithLocale(locale) {
+  async _findOperativeHavingLocale(locale) {
     const operativeChallenges = await this.findOperative();
     return operativeChallenges.filter((challenge) => _.includes(challenge.locales, locale));
+  },
+
+  async findFrenchFranceOperative() {
+    return this._findOperativeHavingLocale(FRENCH_FRANCE);
   },
 
   async findValidated() {

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -38,6 +38,12 @@ module.exports = {
     return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
   },
 
+  async findFrenchFranceOperative() {
+    const challengeDataObjects = await challengeDatasource.findFrenchFranceOperative();
+    const operativeSkills = await skillDatasource.findOperative();
+    return _toDomainCollection({ challengeDataObjects, skills: operativeSkills });
+  },
+
   async findValidatedByCompetenceId(competenceId) {
     const challengeDataObjects = await challengeDatasource.findValidatedByCompetenceId(competenceId);
     const activeSkills = await skillDatasource.findActive();

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -87,7 +87,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
   ];
 
   beforeEach(() => {
-    sinon.stub(challengeRepository, 'findOperative').resolves([
+    sinon.stub(challengeRepository, 'findFrenchFranceOperative').resolves([
       challengeForSkillCitation4,
       anotherChallengeForSkillCitation4,
       challengeForSkillCitation4AndMoteur3,
@@ -147,7 +147,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       await certificationChallengesService.pickCertificationChallenges(placementProfile);
 
       // then
-      sinon.assert.calledOnce(challengeRepository.findOperative);
+      sinon.assert.calledOnce(challengeRepository.findFrenchFranceOperative);
     });
 
     it('should assign skill to related competence', async () => {
@@ -316,7 +316,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
         challengeForSkillRequin5,
         challengeForSkillRequin8,
       ];
-      challengeRepository.findOperative.resolves(onlyOneChallengeForCitation4AndMoteur3);
+      challengeRepository.findFrenchFranceOperative.resolves(onlyOneChallengeForCitation4AndMoteur3);
       placementProfile.userCompetences = [userCompetence1];
       answerRepository.findChallengeIdsFromAnswerIds.withArgs([123, 456, 789]).resolves(['challengeRecordIdTwo']);
       // when

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -150,7 +150,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     });
   });
 
-  describe('#findOperativeWithLocale', () => {
+  describe('#findFrenchFranceOperative', () => {
 
     it('should retrieve the operative Challenges of given locale only', async () => {
       // given
@@ -162,7 +162,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       ]);
 
       // when
-      const result = await challengeDatasource.findOperativeWithLocale(FRENCH_FRANCE);
+      const result = await challengeDatasource.findFrenchFranceOperative();
 
       // then
       expect(_.map(result, 'id')).to.deep.equal([

--- a/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/challenge-datasource_test.js
@@ -39,15 +39,24 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     }),
     challenge_web1 = challengeRawAirTableFixture({
       id: 'challenge-web1',
-      fields: { 'Acquix (id persistant)': [web1.id] }
+      fields: {
+        'Acquix (id persistant)': [web1.id],
+        'Langues' : ['Francophone', 'Franco Français']
+      }
     }),
     challenge_web1_notValidated = challengeRawAirTableFixture({
       id: 'challenge-web1',
-      fields: { 'Acquix (id persistant)': [web1.id], Statut: 'proposé' }
+      fields: {
+        'Acquix (id persistant)': [web1.id], Statut: 'proposé',
+        'Langues' : ['Francophone', 'Franco Français']
+      }
     }),
     challenge_web2 = challengeRawAirTableFixture({
       id: 'challenge-web2',
-      fields: { 'Acquix (id persistant)': [web2.id] }
+      fields: {
+        'Acquix (id persistant)': [web2.id],
+        'Langues' : ['Anglais']
+      }
     }),
     challenge_web3 = challengeRawAirTableFixture({
       id: 'challenge-web3',
@@ -55,7 +64,10 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
     }),
     challenge_web3_archived = challengeRawAirTableFixture({
       id: 'challenge-web3-archived',
-      fields: { 'Acquix (id persistant)': [web3.id], Statut: 'archivé' }
+      fields: {
+        'Acquix (id persistant)': [web3.id], Statut: 'archivé',
+        'Langues' : ['Franco Français']
+      }
     });
 
   beforeEach(() => {
@@ -133,6 +145,28 @@ describe('Unit | Infrastructure | Datasource | Airtable | ChallengeDatasource', 
       expect(_.map(result, 'id')).to.deep.equal([
         'challenge-web1',
         'challenge-web2',
+        'challenge-web3-archived',
+      ]);
+    });
+  });
+
+  describe('#findOperativeWithLocale', () => {
+
+    it('should retrieve the operative Challenges of given locale only', async () => {
+      // given
+      sinon.stub(airtable, 'findRecords').resolves([
+        challenge_web1,
+        challenge_web1_notValidated,
+        challenge_web2,
+        challenge_web3_archived,
+      ]);
+
+      // when
+      const result = await challengeDatasource.findOperativeWithLocale(FRENCH_FRANCE);
+
+      // then
+      expect(_.map(result, 'id')).to.deep.equal([
+        'challenge-web1',
         'challenge-web3-archived',
       ]);
     });

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -454,6 +454,130 @@ describe('Unit | Repository | challenge-repository', () => {
       });
     });
 
+    describe('#findFrenchFranceOperative', () => {
+
+      beforeEach(() => {
+        sinon.stub(challengeDatasource, 'findFrenchFranceOperative');
+        sinon.stub(solutionAdapter, 'fromChallengeAirtableDataObject');
+      });
+
+      context('when query happens with no error', () => {
+        it('returns challenges', async () => {
+          // given
+          const airtableChallenge1 = domainBuilder.buildChallengeAirtableDataObject({
+            id: 'rec_challenge_1',
+            skillIds: [skillWeb1.id],
+          });
+          const airtableChallenge2 = domainBuilder.buildChallengeAirtableDataObject({
+            id: 'rec_challenge_2',
+            skillIds: [skillURL2.id, skillURL3.id, 'not_existing_skill_id'],
+          });
+          challengeDatasource.findFrenchFranceOperative.resolves([
+            airtableChallenge1,
+            airtableChallenge2,
+          ]);
+
+          const solution1 = domainBuilder.buildSolution();
+          solutionAdapter.fromChallengeAirtableDataObject.withArgs(airtableChallenge1).returns(solution1);
+
+          const solution2 = domainBuilder.buildSolution();
+          solutionAdapter.fromChallengeAirtableDataObject.withArgs(airtableChallenge2).returns(solution2);
+
+          // when
+          const challenges = await challengeRepository.findFrenchFranceOperative();
+
+          // then
+          expect(challenges).to.deep.equal(
+            [
+              new Challenge({
+                answer: undefined,
+                attachments: airtableChallenge1.attachments,
+                autoReply: undefined,
+                competenceId: airtableChallenge1.competenceId,
+                embedHeight: airtableChallenge1.embedHeight,
+                embedTitle: airtableChallenge1.embedTitle,
+                embedUrl: airtableChallenge1.embedUrl,
+                format: airtableChallenge1.format,
+                id: airtableChallenge1.id,
+                illustrationAlt: airtableChallenge1.illustrationAlt,
+                illustrationUrl: airtableChallenge1.illustrationUrl,
+                instruction: airtableChallenge1.instruction,
+                locales: airtableChallenge1.locales,
+                proposals: airtableChallenge1.proposals,
+                skills: [
+                  new Skill({
+                    competenceId: skillWeb1.competenceId,
+                    id: skillWeb1.id,
+                    name: skillWeb1.name,
+                    pixValue: skillWeb1.pixValue,
+                    tubeId: skillWeb1.tubeId,
+                    tutorialIds: skillWeb1.tutorialIds
+                  })
+                ],
+                status: airtableChallenge1.status,
+                timer: airtableChallenge1.timer,
+                type: airtableChallenge1.type,
+                validator: new ValidatorQCM({ solution: solution1 })
+              }),
+              new Challenge({
+                answer: undefined,
+                attachments: airtableChallenge2.attachments,
+                autoReply: undefined,
+                competenceId: airtableChallenge2.competenceId,
+                embedHeight: airtableChallenge2.embedHeight,
+                embedTitle: airtableChallenge2.embedTitle,
+                embedUrl: airtableChallenge2.embedUrl,
+                format: airtableChallenge2.format,
+                id: airtableChallenge2.id,
+                illustrationAlt: airtableChallenge2.illustrationAlt,
+                illustrationUrl: airtableChallenge2.illustrationUrl,
+                instruction: airtableChallenge2.instruction,
+                locales: airtableChallenge2.locales,
+                proposals: airtableChallenge2.proposals,
+                skills: [
+                  new Skill({
+                    competenceId: skillURL2.competenceId,
+                    id: skillURL2.id,
+                    name: skillURL2.name,
+                    pixValue: skillURL2.pixValue,
+                    tubeId: skillURL2.tubeId,
+                    tutorialIds: skillURL2.tutorialIds
+                  }),
+                  new Skill({
+                    competenceId: skillURL3.competenceId,
+                    id: skillURL3.id,
+                    name: skillURL3.name,
+                    pixValue: skillURL3.pixValue,
+                    tubeId: skillURL3.tubeId,
+                    tutorialIds: skillURL3.tutorialIds
+                  })
+                ],
+                status: airtableChallenge2.status,
+                timer: airtableChallenge2.timer,
+                type: airtableChallenge2.type,
+                validator: new ValidatorQCM({ solution: solution2 })
+              })
+            ]
+          );
+        });
+      });
+
+      context('when the datasource is on error', () => {
+
+        it('should transfer the error', () => {
+          // given
+          const error = new Error();
+          challengeDatasource.findFrenchFranceOperative.rejects(error);
+
+          // when
+          const promise = challengeRepository.findFrenchFranceOperative();
+
+          // then
+          return expect(promise).to.have.been.rejectedWith(error);
+        });
+      });
+    });
+
     describe('#findValidatedByCompetenceId', () => {
 
       let competence;

--- a/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
+++ b/api/tests/unit/infrastructure/repositories/challenge-repository_test.js
@@ -4,7 +4,7 @@ const AirtableResourceNotFound = require(
   '../../../../lib/infrastructure/datasources/airtable/AirtableResourceNotFound');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
-const { DEFAULT_ID, DEFAULT_TUTORIAL_ID }  = require('../../../tooling/fixtures/infrastructure/skillRawAirTableFixture');
+const { DEFAULT_ID, DEFAULT_TUTORIAL_ID } = require('../../../tooling/fixtures/infrastructure/skillRawAirTableFixture');
 const Challenge = require('../../../../lib/domain/models/Challenge');
 const Skill = require('../../../../lib/domain/models/Skill');
 const Solution = require('../../../../lib/domain/models/Solution');
@@ -338,88 +338,103 @@ describe('Unit | Repository | challenge-repository', () => {
       });
 
       context('when query happens with no error', () => {
-
-        let promise;
-
-        beforeEach(() => {
+        it('returns challenges', async () => {
           // given
+          const airtableChallenge1 = domainBuilder.buildChallengeAirtableDataObject({
+            id: 'rec_challenge_1',
+            skillIds: [skillWeb1.id],
+          });
+          const airtableChallenge2 = domainBuilder.buildChallengeAirtableDataObject({
+            id: 'rec_challenge_2',
+            skillIds: [skillURL2.id, skillURL3.id, 'not_existing_skill_id'],
+          });
           challengeDatasource.findOperative.resolves([
-            domainBuilder.buildChallengeAirtableDataObject({
-              id: 'rec_challenge_1',
-              skillIds: [skillWeb1.id],
-            }),
-            domainBuilder.buildChallengeAirtableDataObject({
-              id: 'rec_challenge_2',
-              skillIds: [skillURL2.id, skillURL3.id, 'not_existing_skill_id'],
-            }),
+            airtableChallenge1,
+            airtableChallenge2,
           ]);
 
-          solutionAdapter.fromChallengeAirtableDataObject.returns(domainBuilder.buildSolution());
+          const solution1 = domainBuilder.buildSolution();
+          solutionAdapter.fromChallengeAirtableDataObject.withArgs(airtableChallenge1).returns(solution1);
+
+          const solution2 = domainBuilder.buildSolution();
+          solutionAdapter.fromChallengeAirtableDataObject.withArgs(airtableChallenge2).returns(solution2);
 
           // when
-          promise = challengeRepository.findOperative();
-        });
+          const challenges = await challengeRepository.findOperative();
 
-        it('should succeed', () => {
           // then
-          return expect(promise).to.be.fulfilled;
-        });
-
-        it('should call challengeDataObjects with competence', () => {
-          // then
-          return promise.then(() => {
-            expect(challengeDatasource.findOperative).to.have.been.calledWithExactly();
-          });
-        });
-
-        it('should resolve an array of 2 Challenge domain objects', () => {
-          // then
-          return promise.then((challenges) => {
-            expect(challenges).to.be.an('array');
-            expect(challenges).to.have.lengthOf(2);
-            challenges.map((challenge) => expect(challenge).to.be.an.instanceOf(Challenge));
-          });
-        });
-
-        it('should load skills in the challenges', () => {
-          // then
-          return promise.then((challenges) => {
-            expect(challenges[0].skills).to.deep.equal([
-              {
-                'id': 'recSkillWeb1',
-                'name': '@web1',
-                'pixValue': 2,
-                'competenceId': 'rec1',
-                'tutorialIds': [DEFAULT_TUTORIAL_ID],
-                'tubeId': 'recTube1',
-              }
-            ]);
-            expect(challenges[1].skills).to.deep.equal([
-              {
-                'id': 'recSkillURL2',
-                'name': '@url2',
-                'pixValue': 3,
-                'competenceId': 'rec1',
-                'tutorialIds': [DEFAULT_TUTORIAL_ID],
-                'tubeId': 'recTube2',
-              },
-              {
-                'id': 'recSkillURL3',
-                'name': '@url3',
-                'pixValue': 3,
-                'competenceId': 'rec1',
-                'tutorialIds': [DEFAULT_TUTORIAL_ID],
-                'tubeId': 'recTube3',
-              },
-            ]);
-          });
-        });
-
-        it('should not retrieve skills individually', () => {
-          // then
-          return promise.then(() => {
-            expect(skillDatasource.get).not.to.have.been.called;
-          });
+          expect(challenges).to.deep.equal(
+            [
+              new Challenge({
+                answer: undefined,
+                attachments: airtableChallenge1.attachments,
+                autoReply: undefined,
+                competenceId: airtableChallenge1.competenceId,
+                embedHeight: airtableChallenge1.embedHeight,
+                embedTitle: airtableChallenge1.embedTitle,
+                embedUrl: airtableChallenge1.embedUrl,
+                format: airtableChallenge1.format,
+                id: airtableChallenge1.id,
+                illustrationAlt: airtableChallenge1.illustrationAlt,
+                illustrationUrl: airtableChallenge1.illustrationUrl,
+                instruction: airtableChallenge1.instruction,
+                locales: airtableChallenge1.locales,
+                proposals: airtableChallenge1.proposals,
+                skills: [
+                  new Skill({
+                    competenceId: skillWeb1.competenceId,
+                    id: skillWeb1.id,
+                    name: skillWeb1.name,
+                    pixValue: skillWeb1.pixValue,
+                    tubeId: skillWeb1.tubeId,
+                    tutorialIds: skillWeb1.tutorialIds
+                  })
+                ],
+                status: airtableChallenge1.status,
+                timer: airtableChallenge1.timer,
+                type: airtableChallenge1.type,
+                validator: new ValidatorQCM({ solution: solution1 })
+              }),
+              new Challenge({
+                answer: undefined,
+                attachments: airtableChallenge2.attachments,
+                autoReply: undefined,
+                competenceId: airtableChallenge2.competenceId,
+                embedHeight: airtableChallenge2.embedHeight,
+                embedTitle: airtableChallenge2.embedTitle,
+                embedUrl: airtableChallenge2.embedUrl,
+                format: airtableChallenge2.format,
+                id: airtableChallenge2.id,
+                illustrationAlt: airtableChallenge2.illustrationAlt,
+                illustrationUrl: airtableChallenge2.illustrationUrl,
+                instruction: airtableChallenge2.instruction,
+                locales: airtableChallenge2.locales,
+                proposals: airtableChallenge2.proposals,
+                skills: [
+                  new Skill({
+                    competenceId: skillURL2.competenceId,
+                    id: skillURL2.id,
+                    name: skillURL2.name,
+                    pixValue: skillURL2.pixValue,
+                    tubeId: skillURL2.tubeId,
+                    tutorialIds: skillURL2.tutorialIds
+                  }),
+                  new Skill({
+                    competenceId: skillURL3.competenceId,
+                    id: skillURL3.id,
+                    name: skillURL3.name,
+                    pixValue: skillURL3.pixValue,
+                    tubeId: skillURL3.tubeId,
+                    tutorialIds: skillURL3.tutorialIds
+                  })
+                ],
+                status: airtableChallenge2.status,
+                timer: airtableChallenge2.timer,
+                type: airtableChallenge2.type,
+                validator: new ValidatorQCM({ solution: solution2 })
+              })
+            ]
+          );
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la sélection des questions des épreuves de certification, les épreuves candidates sont choisies parmi toutes les épreuves dîtes "operatives" (i.e. :  'validé', 'validé sans test', 'pré-validé' ou 'archivé' voir ici : #1587 ) sans considération de leur langue. Ainsi des questions en anglais pouvaient être sélectionnées pour une certification en français.

## :robot: Solution
Restreindre le pool d'épreuves candidates aux épreuves "operatives" **franco-françaises** (c'est à faire ayant la locale `fr-fr`)

## :rainbow: Remarques
Idéalement il faudrait utiliser la méthode `challengeRepository.findFrenchFranceOperative()` aussi dans le scoring de certification (`api/lib/domain/services/certification-result-service.js`). Pour ce faire, il faudra s'assurer qu'aucun candidat n'a répondu à au moins une question qui ne soit pas fr-fr lors de sont test de certification. 

## :100: Pour tester
TBD
