### PR TITLE
[TECH] Suppression de divers index inutilisés et/ou redondants (PIX-1132)

### DIFF
--- a/api/db/migrations/20200814135754_drop-redundant-index-table-tutorial-evaluations-on-column-user-id.js
+++ b/api/db/migrations/20200814135754_drop-redundant-index-table-tutorial-evaluations-on-column-user-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'tutorial-evaluations';
+const USERID_COLUMN = 'userId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(USERID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(USERID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814140251_drop-not-need-index-table-tutorial-evaluations-on-column-tutorial-id.js
+++ b/api/db/migrations/20200814140251_drop-not-need-index-table-tutorial-evaluations-on-column-tutorial-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'tutorial-evaluations';
+const TUTORIALID_COLUMN = 'tutorialId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(TUTORIALID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(TUTORIALID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814141138_drop-unused-index-on-user-id-table-certification-candidates.js
+++ b/api/db/migrations/20200814141138_drop-unused-index-on-user-id-table-certification-candidates.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'certification-candidates';
+const USERID_COLUMN = 'userId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(USERID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(USERID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814142127_drop-unused-index-on-course-id-table-assessments.js
+++ b/api/db/migrations/20200814142127_drop-unused-index-on-course-id-table-assessments.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => {
+  return knex.raw('DROP INDEX IF EXISTS "assessment_courseid_index";');
+};
+
+exports.down = (knex) => {
+  return knex.raw('CREATE INDEX "assessment_courseid_index" ON assessments ("courseId");');
+};

--- a/api/db/migrations/20200814142831_drop-redundant-index-table-user-tutorials-on-column-user-id.js
+++ b/api/db/migrations/20200814142831_drop-redundant-index-table-user-tutorials-on-column-user-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'user_tutorials';
+const USERID_COLUMN = 'userId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(USERID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(USERID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814142948_drop-not-needed-index-table-user-tutorials-on-column-tutorial-id.js
+++ b/api/db/migrations/20200814142948_drop-not-needed-index-table-user-tutorials-on-column-tutorial-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'user_tutorials';
+const TUTORIALID_COLUMN = 'tutorialId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(TUTORIALID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(TUTORIALID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814144054_drop-not-needed-index-table-feedbacks-on-column-assessment-id.js
+++ b/api/db/migrations/20200814144054_drop-not-needed-index-table-feedbacks-on-column-assessment-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'feedbacks';
+const ASSESSMENTID_COLUMN = 'assessmentId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(ASSESSMENTID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(ASSESSMENTID_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814144606_drop-not-needed-index-table-assessments-on-column-type.js
+++ b/api/db/migrations/20200814144606_drop-not-needed-index-table-assessments-on-column-type.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessments';
+const TYPE_COLUMN = 'type';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(TYPE_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(TYPE_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814144712_drop-not-needed-index-table-assessments-on-column-state.js
+++ b/api/db/migrations/20200814144712_drop-not-needed-index-table-assessments-on-column-state.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessments';
+const TYPE_COLUMN = 'state';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(TYPE_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(TYPE_COLUMN);
+  });
+};

--- a/api/db/migrations/20200814144752_drop-not-needed-index-table-assessments-on-column-competence-id.js
+++ b/api/db/migrations/20200814144752_drop-not-needed-index-table-assessments-on-column-competence-id.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'assessments';
+const COMPETENCEID_COLUMN = 'competenceId';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropIndex(COMPETENCEID_COLUMN);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.index(COMPETENCEID_COLUMN);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Certains index ont été créés par le passé, et il se trouve qu'ils ne sont pas toujours utiles/utilisés.
On passe un petit coup de balai.
Je vous invite à consulter la page confluence et/ou cette PR-ci -> https://github.com/1024pix/pix/pull/1052
qui expliquent pourquoi c'est mal d'avoir des indexes mal placés !

## :robot: Solution
Liste des index retirés + raison du retrait :

### Table `tutorial-evaluations`
Cette table présente 3 index :
- sur `userId`
- sur `tutorialId`
- sur `userId, tutorialId` (l'existence de cet index est un effet de bord de la contrainte d'unicité !)

:arrow_right: Retrait de l'index sur `userId` car **_redondant_** avec celui sur `userId, tutorialId`
:arrow_right: Retrait de l'index sur `tutorialId` car, d'après ce que j'ai vu dans le `repository`, celui sur `userId, tutorialId` suffit amplement + la colonne `tutorialId` n'est jamais consultée dans une clause `WHERE` **_seule_** (sans `userId`)

### Table `user_evaluations`
Strictement la même explication que pour la table `tutorial-evaluations`

### Table `certification-candidates`
Cette table présente 2 index :
- sur `userId`
- sur `sessionId`

:arrow_right: Retrait de l'index sur `userId` car celui sur `sessionId` suffit amplement + la colonne `userId` n'est jamais consultée dans une clause `WHERE` **_seule_** (sans `sessionId`)

### Table `feedbacks`
La seule action effectuée en production sur cette table est un `INSERT INTO`. Si des indexes doivent être positionnés ce serait plutôt au niveau de la réplication.
:arrow_right: Retrait de l'index sur `assessmentId`

### Table `assessments`
Cette table présente plusieurs indexes :
- sur `competenceId`
- sur `courseId` (enfin, plus maintenant, je l'ai enlevé à la main sur production par erreur, my bad. J'ajoute quand même la migration appropriée avec une protection)
- sur `type`
- sur `state`
- sur `campaignParticipationId`
- sur `certificationCourseId`
- sur `userId`

:arrow_right: Retrait de l'index sur `courseId`. Jamais on ne recherche un assessment par l'id de démo. Cela n'a d'ailleurs pas de sens, car il en existe beaucoup pour le même `courseId`.
:arrow_right: Retrait de l'index sur `competenceId`. Jamais on ne recherche un assessment par l'id d'une compétence.
:arrow_right: Retrait de l'index sur `type`. Les fois où le type est mentionné dans une requête, il est accompagné d'autres colonnes dans la clause WHERE qui sont, pour le coup, beaucoup plus discriminantes (`campaignParticipationId` ou `certificationCourseId` par exemple)
:arrow_right: Retrait de l'index sur `state`. Jamais on ne recherche un assessment par son état uniquement (et de toute façon ça n'aurait pas de sens).

## :rainbow: Remarques
La migration ne devrait pas ralentir la prod, il s'agit de petites tables (sauf assessment). Mais de toute façon, DROP un index c'est pas ce qui coûte le plus cher pour la BDD. +
TODO: certains index étaient peut être utiles en réplication, pensez à les rajouter là-bas (via le script de réplication) si nécessaire.

## :100: Pour tester

