### PR TITLE
[FEATURE] Renvoyer un token contenant les informations permettant de créer l'utilisateur lors d'une requête provenant du GAR (PIX-1117).

### DIFF
--- a/api/lib/application/saml/saml-controller.js
+++ b/api/lib/application/saml/saml-controller.js
@@ -2,6 +2,7 @@ const saml = require('../../infrastructure/saml');
 const usecases = require('../../domain/usecases');
 const logger = require('../../infrastructure/logger');
 const tokenService = require('../../domain/services/token-service');
+const { features } = require('../../config');
 
 module.exports = {
 
@@ -23,6 +24,12 @@ module.exports = {
     }
 
     try {
+      if (features.garAccessV2) {
+        const externalUserToken = tokenService.createTokenForStudentReconciliation({ userAttributes });
+
+        return h.redirect(`/campagnes?externalUser=${externalUserToken}`);
+      }
+
       const user = await usecases.getOrCreateSamlUser({ userAttributes });
 
       const token = tokenService.createTokenFromUser(user, 'external');

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -80,6 +80,7 @@ module.exports = (function() {
       secret: process.env.AUTH_SECRET,
       tokenLifespan: (process.env.TOKEN_LIFE_SPAN || '7d'),
       tokenForCampaignResultLifespan: '1h',
+      tokenForStudentReconciliationLifespan: '1h',
     },
 
     saml: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -116,6 +116,7 @@ module.exports = (function() {
     features: {
       dayBeforeImproving: _getNumber(process.env.DAY_BEFORE_IMPROVING, 4),
       dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2,7),
+      garAccessV2: isFeatureEnabled(process.env.GAR_ACCESS_V2),
     },
 
     infra: {
@@ -146,6 +147,7 @@ module.exports = (function() {
 
     config.features.dayBeforeImproving = 4;
     config.features.dayBeforeCompetenceResetV2 = 7;
+    config.features.garAccessV2 = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -15,6 +15,15 @@ function createTokenForCampaignResults(userId) {
   }, settings.authentication.secret, { expiresIn: settings.authentication.tokenForCampaignResultLifespan });
 }
 
+function createTokenForStudentReconciliation({ userAttributes }) {
+  const { attributeMapping } = settings.saml;
+  return jsonwebtoken.sign({
+    first_name: userAttributes[attributeMapping.firstName],
+    last_name: userAttributes[attributeMapping.lastName],
+    saml_id: userAttributes[attributeMapping.samlId]
+  }, settings.authentication.secret, { expiresIn: settings.authentication.tokenForStudentReconciliationLifespan });
+}
+
 function extractTokenFromAuthChain(authChain) {
   if (!authChain) {
     return authChain;
@@ -55,6 +64,7 @@ function extractUserIdForCampaignResults(token) {
 module.exports = {
   createTokenFromUser,
   createTokenForCampaignResults,
+  createTokenForStudentReconciliation,
   extractUserIdForCampaignResults,
   extractUserId,
   extractTokenFromAuthChain,

--- a/api/tests/acceptance/application/saml-controller_test.js
+++ b/api/tests/acceptance/application/saml-controller_test.js
@@ -147,14 +147,6 @@ describe('Acceptance | Controller | saml-controller', () => {
 
   describe('POST /api/saml/assert', () => {
 
-    beforeEach(() => {
-      return knex('users').delete();
-    });
-
-    afterEach(() => {
-      return knex('users').delete();
-    });
-
     // Uses samlify to create a valid SAML response
     async function buildLoginResponse(attributes) {
       const identityProvider = samlify.IdentityProvider(idpConfig);
@@ -169,7 +161,7 @@ describe('Acceptance | Controller | saml-controller', () => {
         tempSandbox.stub(samlify.SamlLib.defaultLoginResponseTemplate, 'context').value(
           samlify.SamlLib.defaultLoginResponseTemplate.context.replace('{AttributeStatement}', `
           <saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
-            ${_.map(attributes, (value, key)=>`<saml2:Attribute Name="${key}">
+            ${_.map(attributes, (value, key) => `<saml2:Attribute Name="${key}">
                                                  <saml2:AttributeValue>${value}</saml2:AttributeValue>
                                                </saml2:Attribute>`).join('\n')}
           </saml2:AttributeStatement>`));
@@ -184,10 +176,15 @@ describe('Acceptance | Controller | saml-controller', () => {
       }
     }
 
-    context('when a not-seen-before user comes', async () => {
+    context('When garAccessV2 is disabled', () => {
+
       let goodSamlResponse, firstVisitResponse;
 
       beforeEach(async () => {
+        settings.features.garAccessV2 = false;
+
+        await knex('users').delete();
+
         goodSamlResponse = await buildLoginResponse({
           'IDO': 'IDO-for-adele',
           'NOM': 'Lopez',
@@ -202,6 +199,10 @@ describe('Acceptance | Controller | saml-controller', () => {
             SAMLResponse: goodSamlResponse.context
           }
         });
+      });
+
+      afterEach(() => {
+        return knex('users').delete();
       });
 
       it('should consume valid SAML assertion and create user', () => {
@@ -244,6 +245,36 @@ describe('Acceptance | Controller | saml-controller', () => {
         // then
         expect(otherUserResponse.statusCode).to.equal(302);
         expect(await knex('users').count('id as n')).to.deep.equal([{ n: 2 }]);
+      });
+    });
+
+    context('When garAccessV2 is enabled', () => {
+
+      let goodSamlResponse, firstVisitResponse;
+
+      beforeEach(async () => {
+        settings.features.garAccessV2 = true;
+
+        goodSamlResponse = await buildLoginResponse({
+          'IDO': 'IDO-for-adele',
+          'NOM': 'Lopez',
+          'PRE': 'Adèle',
+        });
+
+        // when
+        return firstVisitResponse = await server.inject({
+          method: 'POST',
+          url: '/api/saml/assert',
+          payload: {
+            SAMLResponse: goodSamlResponse.context
+          }
+        });
+      });
+
+      it('should consume valid SAML assertion create student reconciliation token', () => {
+        // then
+        expect(firstVisitResponse.statusCode).to.equal(302);
+        expect(firstVisitResponse.headers.location).to.match(/^\/campagnes\?externalUser=[-_a-zA-Z0-9.]+$/);
       });
     });
   });

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -2,8 +2,35 @@ const { expect } = require('../../../test-helper');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const User = require('../../../../lib/domain/models/User');
 const { InvalidTemporaryKeyError } = require('../../../../lib/domain/errors');
+const settings = require('../../../../lib/config');
+const jsonwebtoken = require('jsonwebtoken');
+const _ = require('lodash');
 
 describe('Unit | Domain | Service | Token Service', function() {
+
+  describe('#createTokenForStudentReconciliation', () => {
+
+    it('should create token with firstName, lastName, samlId', () => {
+      // given
+      const userAttributes = {
+        IDO: 'IDO-for-adele',
+        NOM: 'Lopez',
+        PRE: 'Adèle',
+      };
+      const expectedTokenAttributes = {
+        'first_name': 'Adèle',
+        'last_name': 'Lopez',
+        'saml_id': 'IDO-for-adele'
+      };
+
+      // when
+      const token = tokenService.createTokenForStudentReconciliation({ userAttributes });
+
+      // then
+      const decodedToken = jsonwebtoken.verify(token, settings.authentication.secret);
+      expect(_.omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
+    });
+  });
 
   describe('#extractUserId', () => {
 

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -4,13 +4,13 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class FillInCampaignCodeController extends Controller {
+
   @service store;
   @service intl;
 
   campaignCode = null;
 
-  @tracked
-  errorMessage = null;
+  @tracked errorMessage = null;
 
   @action
   async startCampaign() {

--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -1,9 +1,8 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import { isEmpty } from '@ember/utils';
 
-export default class JoinRoute extends Route.extend(SecuredRouteMixin) {
+export default class JoinRoute extends Route {
   @service currentUser;
   @service session;
 
@@ -12,16 +11,18 @@ export default class JoinRoute extends Route.extend(SecuredRouteMixin) {
   }
 
   async redirect(campaign) {
-    let schoolingRegistration = await this.store.queryRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code });
+    if (!this.session.get('data.externalUser')) {
+      let schoolingRegistration = await this.store.queryRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code });
 
-    if (isEmpty(schoolingRegistration) && campaign.organizationType === 'SCO') {
-      schoolingRegistration = await this.store.createRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code }).save({ adapterOptions: { tryReconciliation: true } });
-    }
+      if (isEmpty(schoolingRegistration) && campaign.organizationType === 'SCO') {
+        schoolingRegistration = await this.store.createRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code }).save({ adapterOptions: { tryReconciliation: true } });
+      }
 
-    if (!isEmpty(schoolingRegistration)) {
-      return this.replaceWith('campaigns.start-or-resume', campaign.code, {
-        queryParams: { associationDone: true }
-      });
+      if (!isEmpty(schoolingRegistration)) {
+        return this.replaceWith('campaigns.start-or-resume', campaign.code, {
+          queryParams: { associationDone: true }
+        });
+      }
     }
   }
 

--- a/mon-pix/app/routes/fill-in-campaign-code.js
+++ b/mon-pix/app/routes/fill-in-campaign-code.js
@@ -1,8 +1,18 @@
 import classic from 'ember-classic-decorator';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 @classic
 export default class FillInCampaignCodeRoute extends Route {
+
+  @service session;
+
+  beforeModel(transition) {
+    if (transition.to.queryParams.externalUser) {
+      this.session.set('data.externalUser', transition.to.queryParams.externalUser);
+    }
+  }
+
   deactivate() {
     this.controller.set('campaignCode', null);
   }

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -794,5 +794,29 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
         });
       });
     });
+
+    context('When user is redirected to fill-in-campaign-code after an external platform request', function() {
+
+      const campaignCode = 'CAMPAIGN_CODE';
+      const studentReconciliationToken = 'studentReconciliationToken';
+
+      context('When campaign is restricted and SCO', function() {
+        beforeEach(function() {
+          campaign = server.create('campaign', { isRestricted: true, organizationType: 'SCO', code: campaignCode });
+        });
+
+        it('should redirect to reconciliation form', async function() {
+          // given
+          await visit(`/campagnes?externalUser=${studentReconciliationToken}`);
+
+          // when
+          await fillIn('#campaign-code', campaignCode);
+          await click('.fill-in-campaign-code__start-button');
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaignCode}/privee/rejoindre`);
+        });
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
@@ -22,9 +22,10 @@ describe('Unit | Route | campaigns/restricted/join', function() {
         user: { id: 'id' },
       }));
       route.replaceWith = sinon.stub();
+      const transition = { to: { queryParams: {} } };
 
       // when
-      await route.redirect(campaign);
+      await route.redirect(campaign, transition);
 
       // then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });

--- a/mon-pix/tests/unit/routes/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/routes/fill-in-campaign-code-test.js
@@ -1,0 +1,30 @@
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | fill-in-campaign-code', function() {
+  setupTest();
+
+  context('#beforeModel', () => {
+
+    it('should store externalUser queryParam in session', function() {
+      // given
+      const route = this.owner.lookup('route:fill-in-campaign-code');
+
+      const setStub = sinon.stub();
+      const session = {
+        set: setStub
+      };
+      route.set('session', session);
+
+      const externalUser = 'external-user-token';
+      const transition = { to: { queryParams: { externalUser } } };
+
+      // when
+      route.beforeModel(transition);
+
+      // then
+      sinon.assert.calledWith(setStub, 'data.externalUser', externalUser);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, lorsque qu'une requête provenant du GAR est reçue, un utilisateur est créé grâce aux informations contenues dans la requête (prénom, nom et samlId). Afin d'empêcher de créer des comptes utilisateurs avant que l'élève ne se soit réconcilié avec son établissement scolaire lors du passage de son premier parcours, nous souhaitons, à terme, ne plus effectuer cette création à ce moment.

Afin de remplir cet objectif, nous avons besoin de fournir à l'application Pix App, les informations permettant de créer l'utilisateur. Afin de protéger les données de l'utilisateur et d'empêcher l'altération de celles-ci, nous voulons encapsuler ces données à l'intérieur d'un token qui sera stocké dans le `localStorage`.

## :robot: Solution
Créer le token lors de la requête du GAR et le stocker dans le `localStorage` (depuis la session ember-simple-auth)

## :rainbow: Remarques
Afin de pouvoir tester les requêtes envoyées par le GAR sur les RA et en local, une petite application a été adaptée afin de permettre de: 
- Générer les variables d'environnement nécessaire au bon fonctionnement du Saml sur Pix.
- Envoyer une requête contenant un utilisateur avec nom, prénom et samlId comme le ferait le GAR.
L'application est déployée à l'adresse https://pix-saml-idp.osc-fr1.scalingo.io/. 
Une documentation d'utilisation est disponible [ici](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1743323153/Tester+les+requ+tes+SAML+du+GAR)

## :100: Pour tester
- Se rendre sur https://pix-saml-idp.osc-fr1.scalingo.io/
- Changer les valeurs par défaut (nom, prénom, samlId) ou laisser tel quel
- Cliquer sur "Sign-In"
- Vérifier que l'utilisateur est bien redirigé vers la page permettant de rentrer un code parcours avec dans l'URL un `queryParam` `externalUser` contenant un token.
- Vérifier que le localStorage contient bien un attribut `externalUser`contenant le token dans la clé `ember_simple_auth-session`.
- Rentrer un code parcours et vérifier que l'on arrive bien sur le formulaire de réconciliation.
