### PR TITLE
[BUGFIX] Empêcher de cliquer plusieurs fois sur retenter (PIX-1125).

### DIFF
--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,13 +1,16 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import config from 'mon-pix/config/environment';
+import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 
 export default class CompetenceCardDefault extends Component {
   @service currentUser;
   @service store;
   @service router;
   @service competenceEvaluation;
+  @tracked improveButtonStatus = buttonStatusTypes.unrecorded;
 
   get displayImproveButton() {
     return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
@@ -24,13 +27,22 @@ export default class CompetenceCardDefault extends Component {
     return this.args.scorecard.remainingDaysBeforeImproving > 0;
   }
 
+  get isImprovingButtonDisabled() {
+    return this.improveButtonStatus === buttonStatusTypes.pending;
+  }
+
   @action
   async improveCompetenceEvaluation() {
+    this.improveButtonStatus = buttonStatusTypes.pending;
+
     const userId = this.currentUser.user.id;
     const competenceId = this.args.scorecard.competenceId;
     const scorecardId = this.args.scorecard.id;
-
-    this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
+    try {
+      this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
+    } catch {
+      this.improveButtonStatus = buttonStatusTypes.unrecorded;
+    }
   }
 
 }

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -4,6 +4,7 @@ import EmberObject, { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A as EmberArray } from '@ember/array';
 import config from 'mon-pix/config/environment';
+import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 
 export default class ScorecardDetails extends Component {
   @service currentUser;
@@ -12,6 +13,7 @@ export default class ScorecardDetails extends Component {
   @service competenceEvaluation;
 
   @tracked showResetModal = false;
+  @tracked improveButtonStatus = buttonStatusTypes.unrecorded;
 
   get level() {
     return this.args.scorecard.isNotStarted ? null : this.args.scorecard.level;
@@ -39,6 +41,10 @@ export default class ScorecardDetails extends Component {
 
   get shouldWaitBeforeImproving() {
     return this.args.scorecard.remainingDaysBeforeImproving > 0;
+  }
+
+  get isImprovingButtonDisabled() {
+    return this.improveButtonStatus === buttonStatusTypes.pending;
   }
 
   get tutorialsGroupedByTubeName() {
@@ -83,11 +89,17 @@ export default class ScorecardDetails extends Component {
 
   @action
   async improveCompetenceEvaluation() {
+    this.improveButtonStatus = buttonStatusTypes.pending;
+
     const userId = this.currentUser.user.id;
     const competenceId = this.args.scorecard.competenceId;
     const scorecardId = this.args.scorecard.id;
+    try {
+      this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
+    } catch {
+      this.improveButtonStatus = buttonStatusTypes.unrecorded;
+    }
 
-    this.competenceEvaluation.improve({ userId, competenceId, scorecardId });
   }
 
 }

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -42,12 +42,16 @@
               <span class="competence-card-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown' daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
             </div>
           {{else}}
-            <button class="button button--extra-thin button--round button--link button--green competence-card__button" {{action "improveCompetenceEvaluation"}} type="button">
+            <button class="button button--extra-thin button--round button--link button--green competence-card__button" disabled={{this.isImprovingButtonDisabled}} {{action "improveCompetenceEvaluation"}} type="button">
+              {{#if this.isImprovingButtonDisabled}}
+                <span class="loader-in-button">&nbsp;</span>
+              {{else}}
               <span class="competence-card-button__label">{{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</span>
               </span>
-              <span class="competence-card-button__arrow">
+                <span class="competence-card-button__arrow">
               <FaIcon @icon='long-arrow-alt-right'></FaIcon>
               </span>
+              {{/if}}
             </button>
           {{/if}}
         {{/if}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -64,9 +64,13 @@
               </div>
             {{else}}
               <button class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button" {{action
-                      "improveCompetenceEvaluation"}} type="button">
-                {{t 'pages.competence-details.actions.improve.label'}}
-                <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}"</div>
+                      "improveCompetenceEvaluation"}} type="button" disabled={{this.isImprovingButtonDisabled}}>
+                {{#if this.isImprovingButtonDisabled}}
+                  <span class="loader-in-button">&nbsp;</span>
+                {{else}}
+                  {{t 'pages.competence-details.actions.improve.label'}}
+                  <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}"</div>
+                {{/if}}
               </button>
               <span class="scorecard-details__improving-text">{{t 'pages.competence-details.actions.improve.improvingText' }}</span>
             {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
- Actuellement, en cas de lenteur (se mettre en slow3G pour tester), il est possible de cliquer plusieurs fois sur "Retenter". Cela entraine plusieurs appels API, avec possiblement plusieurs créations d'assessment inutile.

## :robot: Solution
- Au premier clic, rendre le bouton disabled

## :rainbow: Remarques
- Réutilisation de ce qui a été fait pour les tuto (avec les `buttonStatusTypes`)
- Pour du long terme, il faudrait que ce mécanisme soit dans tous les boutons via PixUI

## :100: Pour tester
- Avoir sur la page profil ET sur une page compétence le bouton Retenter
- Se mettre en Slow 3G
- Cliquer plusieurs fois sur le bouton
- Voir dans le Network qu'il n'y a qu'un seul appel