### PR TITLE
[BUGFIX] Affichage de "started" au lieu d'"error" dans la liste de certifications sur Pix Admin

### DIFF
--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -1,6 +1,7 @@
 const status = {
   REJECTED: 'rejected',
-  VALIDATED: 'validated'
+  VALIDATED: 'validated',
+  ERROR: 'error',
 };
 
 class AssessmentResult {

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -1,14 +1,6 @@
 const { status: assessmentResultStatuses } = require('../models/AssessmentResult');
 
-const VALIDATED = assessmentResultStatuses.VALIDATED;
-const REJECTED = assessmentResultStatuses.REJECTED;
 const STARTED = 'started';
-
-const statuses = {
-  VALIDATED,
-  REJECTED,
-  STARTED,
-};
 
 class JuryCertificationSummary {
   constructor({
@@ -27,8 +19,8 @@ class JuryCertificationSummary {
     this.firstName = firstName;
     this.lastName = lastName;
     this.status = status;
-    if (![statuses.VALIDATED, statuses.REJECTED].includes(this.status)) {
-      this.status = statuses.STARTED;
+    if (!Object.values(assessmentResultStatuses).includes(this.status)) {
+      this.status = STARTED;
     }
     this.pixScore = pixScore;
     this.createdAt = createdAt;
@@ -40,4 +32,4 @@ class JuryCertificationSummary {
 }
 
 module.exports = JuryCertificationSummary;
-module.exports.statuses = statuses;
+module.exports.statuses = { ...assessmentResultStatuses, STARTED };

--- a/api/tests/unit/domain/models/AssessmentResult_test.js
+++ b/api/tests/unit/domain/models/AssessmentResult_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon } = require('../../../test-helper');
 const BookshelfAssessmentResults = require('../../../../lib/infrastructure/data/assessment-result');
 
-describe('Unit | Infrastructure | Models | BookshelfAssessmentResult', () => {
+describe('Unit | Domain | Models | BookshelfAssessmentResult', () => {
 
   describe('validation', () => {
 

--- a/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -1,0 +1,34 @@
+const { expect } = require('../../../test-helper');
+const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const forIn = require('lodash/forIn');
+
+describe('Unit | Domain | Models | JuryCertificationSummary', () => {
+
+  describe('validate', () => {
+
+    context('when a status is given',()   => {
+
+      forIn(AssessmentResult.status, (status, key) => {
+        it(`should returns "${status}" status`, () => {
+          // when
+          const juryCertificationSummary = new JuryCertificationSummary({ status });
+
+          // then
+          expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses[key]);
+        });
+      });
+    });
+
+    context('when no status is given',()   => {
+
+      it('should return "started"', () => {
+        // when
+        const juryCertificationSummary = new JuryCertificationSummary({ status: null });
+
+        // then
+        expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses.STARTED);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, sur la liste des certifications d'une session on affichait le status "started" au lieu de "error" pour certaines certif.

Normalement sur la page de la liste des certifs d'une session nous affichons le status de l'assessment-result de la certif.
Cependant, dans certains cas, l'assessment-result peut ne pas être créé et n'a donc pas de status affichable sur Pix Admin. Cela signifie aussi alors que l'assessment est resté en "started" (car l'assessment-result est créé quand l'assessment passe à l'état "completed").

Ainsi :
- dans le cas où la certif n'a pas d'assessment-result on afficher "started" comme status.
- dans le cas où la certif a un assessment-result on affiche le status de l'assessment-result (à savoir "rejected", "validated" ou "error").

https://1024pix.atlassian.net/secure/RapidBoard.jspa?rapidView=33&modal=detail&selectedIssue=PIX-1140

## :robot: Solution
Il manquait le status "error" dans la liste des status de l'assessment-results au niveau du modèle.

## :rainbow: Remarques
L'assessment c'est la fiche de test du candidat. L'assessment-result c'est la "fiche notée", le résultat du test.

Assessments.state = [aborted, completed, started]
AssessmentResults.status = [error, rejected, validated]

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
