### PR TITLE
[FEATURE] Déplacer le formulaire de vérification de score sur app (PIX-1109)

### DIFF
--- a/mon-pix/app/adapters/certification.js
+++ b/mon-pix/app/adapters/certification.js
@@ -1,0 +1,15 @@
+import classic from 'ember-classic-decorator';
+import ApplicationAdapter from './application';
+
+@classic
+export default class Certification extends ApplicationAdapter {
+
+  queryRecord(store, type, query) {
+    if (query.verificationCode) {
+      const url = `${this.host}/${this.namespace}/shared-certifications`;
+      return this.ajax(url, 'POST', { data: { verificationCode: query.verificationCode } });
+    }
+
+    return super.queryRecord(...arguments);
+  }
+}

--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -1,0 +1,63 @@
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+export default class FillInCertificateVerificationCode extends Controller {
+  @service store;
+  @service intl;
+
+  certificateVerificationCode = null;
+
+  codeRegex = /^P-[2346789BCDFGHJKMPQRTVWXY]{8}$/i;
+
+  @tracked
+  errorMessage = null;
+
+  @tracked
+  showNotFoundCertificationErrorMessage = false;
+
+  @action
+  async checkCertificate() {
+    this.clearErrors();
+
+    if (!this.certificateVerificationCode) {
+      this.errorMessage =  this.intl.t(
+        'pages.fill-in-certificate-verification-code.errors.missing-code'
+      );
+      return;
+    }
+
+    if (!this.isVerificationCodeValid()) {
+      this.errorMessage = this.intl.t(
+        'pages.fill-in-certificate-verification-code.errors.wrong-format'
+      );
+      return;
+    }
+
+    try {
+      await this.store.queryRecord('certification', { verificationCode: this.certificateVerificationCode.toUpperCase() });
+    } catch (error) {
+      this.onVerificateCertificationCodeError(error);
+    }
+  }
+
+  onVerificateCertificationCodeError(error) {
+    const { status } = error.errors[0];
+    if (status === '404') {
+      this.showNotFoundCertificationErrorMessage = true;
+    } else {
+      throw error;
+    }
+  }
+
+  isVerificationCodeValid() {
+    return this.codeRegex.test(this.certificateVerificationCode);
+  }
+
+  @action
+  clearErrors() {
+    this.errorMessage = null;
+    this.showNotFoundCertificationErrorMessage = false;
+  }
+}

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -50,6 +50,7 @@ Router.map(function() {
   this.route('user-certifications', { path: 'mes-certifications' }, function() {
     this.route('get', { path: '/:id' });
   });
+  this.route('fill-in-certificate-verification-code', { path: '/verification-code-certificat' });
 
   this.route('fill-in-campaign-code', { path: '/campagnes' });
   this.route('campaigns', { path: '/campagnes/:code' }, function() {

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -96,6 +96,7 @@
 @import 'pages/course-preview';
 @import 'pages/error';
 @import 'pages/fill-in-campaign-code';
+@import 'pages/fill-in-certificate-verification-code';
 @import 'pages/fill-in-id-pix';
 @import 'pages/join-restricted-campaign';
 @import 'pages/login-or-register-to-access-restricted-campaign';

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -1,0 +1,114 @@
+.fill-in-certificate-verification-code {
+
+  &__container {
+    padding-bottom: 30px;
+
+    @include device-is('tablet') {
+      padding: 40px;
+    }
+  }
+
+  &__title {
+    text-align: center;
+    margin-bottom: 32px;
+  }
+
+  &__instruction {
+    color: $grey-100;
+    font-family: $font-open-sans;
+    font-size: 1.219rem;
+    text-align: center;
+    font-weight: $font-light;
+    margin-bottom: 16px;
+  }
+
+  &__form-field {
+    display: inline-block;
+    text-align: left;
+
+    & input {
+      box-sizing: content-box;
+      border: solid 2px $grey-20;
+      border-radius: 3px;
+      outline: none;
+      height: 50px;
+      padding: 0 1px 1px .5ch;
+      text-transform: uppercase;
+      width: 15.3ch;
+      background: repeating-linear-gradient(90deg,
+        $grey-22 0,
+        $grey-22 1ch,
+        transparent 0,
+        transparent 1.5ch) 0 96%/98% 2px no-repeat;
+      background-origin: content-box;
+      color: $grey-70;
+      font-size: 1.875rem;
+      font-family: $font-roboto-mono;
+      letter-spacing: .5ch;
+
+      @media all and (-ms-high-contrast: none) {
+        //display differently for IE because 1 character (ch) is equal to 1.162
+        line-height: 0.7;
+        letter-spacing: .4ch;
+        background: repeating-linear-gradient(90deg,
+          $grey-22 0,
+          $grey-22 1.33ch,
+          transparent 0,
+          transparent 1.733ch) 0 96%/98% 2px no-repeat;
+        background-origin: content-box;
+      }
+
+      &::-ms-clear {
+        // not display cross that allow to clear field
+        display: none;
+      }
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 30px;
+  }
+
+  &__actions {
+    margin-top: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  &__error {
+    color: $pure-orange;
+    font-size: 0.875rem;
+    padding: 16px 10px;
+    text-align: center;
+  }
+
+  &__not-found {
+    margin: 32px auto 0;
+    background-color: #ffdbcc;
+    border-radius: 4px;
+    height: 46px;
+    line-height: 46px;
+    width: 436px;
+    text-align: center;
+
+    svg {
+      color: rgb(153, 0, 0);
+      margin-right: 6px;
+    }
+
+    span {
+      color: $error;
+      font-family: $font-roboto;
+      font-size: 14px;
+      font-weight: normal;
+      height: 22px;
+      letter-spacing: 0.15px;
+      width: 380px;
+    }
+  }
+}

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -22,17 +22,23 @@
             </div>
             {{/if}}
 
-            <div class="fill-in-certificate-verification-code__actions">
-              <button
-                type="submit"
-                class="button button--extra-big fill-in-certificate-verification-code__start-button"
-                {{action 'checkCertificate'}}>
-                Vérifer
-              </button>
-            </div>
-          </form>
+          <div class="fill-in-certificate-verification-code__actions">
+            <button
+              type="submit"
+              class="button button--extra-big fill-in-certificate-verification-code__start-button"
+              {{action 'checkCertificate'}}>
+              Vérifer
+            </button>
+          </div>
+        </form>
+        {{#if this.showNotFoundCertificationErrorMessage}}
+        <div class="fill-in-certificate-verification-code__not-found">
+          <FaIcon @icon="exclamation-triangle"/>
+          <span>Il n'y a pas de certificat Pix correspondant</span>
         </div>
-      </PixBlock>
+        {{/if}}
+      </div>
+    </PixBlock>
     </PixBackgroundHeader>
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -1,0 +1,38 @@
+<BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
+  <burger.outlet>
+    <NavbarHeader @burger={{burger}} />
+    <PixBackgroundHeader>
+      <PixBlock>
+        <div class="fill-in-certificate-verification-code__container">
+          <h3 class="fill-in-certificate-verification-code__title">Page de vérification du code de certificat</h3>
+          <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">Code de vérification (P-XXXXXXXX)</label>
+          <form class="fill-in-certificate-verification-code__form" autocomplete="off">
+
+            <div class="fill-in-certificate-verification-code__form-field">
+              <Input required
+                @type="text" @id="certificate-verification-code"
+                @value={{this.certificateVerificationCode}}
+                @maxlength="10"
+                @key-down={{this.clearErrorMessage}} />
+            </div>
+
+            {{#if this.errorMessage}}
+            <div class="fill-in-certificate-verification-code__error" aria-live="polite">
+              {{this.errorMessage}}
+            </div>
+            {{/if}}
+
+            <div class="fill-in-certificate-verification-code__actions">
+              <button
+                type="submit"
+                class="button button--extra-big fill-in-certificate-verification-code__start-button"
+                {{action 'checkCertificate'}}>
+                Vérifer
+              </button>
+            </div>
+          </form>
+        </div>
+      </PixBlock>
+    </PixBackgroundHeader>
+  </burger.outlet>
+</BurgerMenu>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -1,13 +1,17 @@
+{{page-title (t 'pages.fill-in-certificate-verification-code.title')}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
     <PixBackgroundHeader>
       <PixBlock>
         <div class="fill-in-certificate-verification-code__container">
-          <h3 class="fill-in-certificate-verification-code__title">Page de vérification du code de certificat</h3>
-          <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">Code de vérification (P-XXXXXXXX)</label>
           <form class="fill-in-certificate-verification-code__form" autocomplete="off">
-
+            <h3 class="fill-in-certificate-verification-code__title">
+              {{t "pages.fill-in-certificate-verification-code.first-title"}}
+            </h3>
+            <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">
+              {{t "pages.fill-in-certificate-verification-code.description"}}
+            </label>
             <div class="fill-in-certificate-verification-code__form-field">
               <Input required
                 @type="text" @id="certificate-verification-code"
@@ -27,14 +31,14 @@
               type="submit"
               class="button button--extra-big fill-in-certificate-verification-code__start-button"
               {{action 'checkCertificate'}}>
-              Vérifer
+              {{t "pages.fill-in-certificate-verification-code.verify"}}
             </button>
           </div>
         </form>
         {{#if this.showNotFoundCertificationErrorMessage}}
         <div class="fill-in-certificate-verification-code__not-found">
           <FaIcon @icon="exclamation-triangle"/>
-          <span>Il n'y a pas de certificat Pix correspondant</span>
+          <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
         </div>
         {{/if}}
       </div>

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code-test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code-test.js
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import sinon from 'sinon';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+describe('Unit | Controller | Fill in certificate verification Code', function() {
+
+  setupIntlRenderingTest();
+
+  let controller;
+  let storeStub;
+
+  beforeEach(function() {
+    controller = this.owner.lookup('controller:fill-in-certificate-verification-code');
+    storeStub = { queryRecord: sinon.stub() };
+    controller.transitionToRoute = sinon.stub();
+    controller.set('store', storeStub);
+    controller.set('errorMessage', null);
+    controller.set('certificateVerificationCode', null);
+    controller.set('showNotFoundCertificationErrorMessage', false);
+  });
+
+  describe('#checkCertificate', () => {
+
+    it('should set error when certificateVerificationCode code is empty', async () => {
+      // given
+      controller.set('certificateVerificationCode', '');
+
+      // when
+      await controller.actions.checkCertificate.call(controller);
+
+      // then
+      expect(controller.get('errorMessage')).to.equal('Veuillez saisir un code au format P-XXXXXXXX.');
+    });
+
+    it('should set error when certificateVerificationCode code is not matching the right format', async () => {
+      // given
+      controller.set('certificateVerificationCode', 'P-879888');
+
+      // when
+      await controller.actions.checkCertificate.call(controller);
+
+      // then
+      expect(controller.get('errorMessage')).to.equal('Veuillez vérifier votre code.');
+    });
+
+    it('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async () => {
+      // given
+      controller.set('certificateVerificationCode', 'P-222BBB78');
+      storeStub.queryRecord.rejects({ errors: [{ status: '404' }] });
+
+      // when
+      await controller.actions.checkCertificate.call(controller);
+
+      // then
+      expect(controller.get('showNotFoundCertificationErrorMessage')).to.equal(true);
+    });
+
+    it('should NOT set showNotFoundCertificationErrorMessage to true when a certificate is found', async () => {
+      // given
+      controller.set('certificateVerificationCode', 'P-222BBBDD');
+      storeStub.queryRecord.resolves({ result: { status: '200' } });
+
+      // when
+      await controller.actions.checkCertificate.call(controller);
+
+      // then
+      expect(controller.get('showNotFoundCertificationErrorMessage')).to.equal(false);
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -730,6 +730,18 @@
       "start": "Start"
     },
 
+    "fill-in-certificate-verification-code": {
+      "title": "Verifier une certification",
+      "first-title": "Vérifier un score de certification",
+      "description": "Code de vérification (P-XXXXXXXX)",
+      "errors": {
+        "wrong-format": "Veuillez vérifier votre code.",
+        "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",
+        "not-found": "Il n'y a pas de certificat Pix correspondant"
+      },
+      "verify": "Vérifier le score"
+    },
+
     "fill-in-id-pix": {
       "title": "Enter my username",
       "first-title": "Before starting",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -730,6 +730,18 @@
       "start": "Commencer"
     },
 
+    "fill-in-certificate-verification-code": {
+      "title": "Verifier une certification",
+      "first-title": "Vérifier un score de certification",
+      "description": "Code de vérification (P-XXXXXXXX)",
+      "errors": {
+        "wrong-format": "Veuillez vérifier votre code.",
+        "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",
+        "not-found": "Il n'y a pas de certificat Pix correspondant"
+      },
+      "verify": "Vérifier le score"
+    },
+
     "fill-in-id-pix": {
       "title": "Saisir mon identifiant",
       "first-title": "Avant de commencer",


### PR DESCRIPTION
## :unicorn: Problème
Le formulaire de vérification de score de certification a été implémenté sur pix.fr. Pour des raisons techniques (redirection avec passage de données), il est préférable que le formulaire de vérification et l'affichage du certificat simplifié soient sur la même app.
( Voir https://miro.com/app/board/o9J_ksgBAVM=/?moveToWidget=3074457349238649447&cot=6 )

## :robot: Solution
Mettre ce formulaire sur mon-pix (app)

## :rainbow: Remarques
Le design n'est pas définitif

## :100: Pour tester
- se rendre sur app /verification-code-certificat
- saisir le code P-222BBBCC et constater le status 200 de la requête dans l'inspecteur
- saisir le code P-222BBB22 et constater la notification "il n'y a pas de certificat Pix correspondant"