### PR TITLE
[FEATURE] Donner accès à la récupération d'une organisation (PIX-884).

### DIFF
--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -1,4 +1,5 @@
 <div class="login-form">
+
   {{#unless @isWithInvitation }}
     <div class="login-form__information">
       L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.
@@ -61,10 +62,18 @@
       {{/if}}
     </div>
 
-    <div class="login-form__forgotten-password help-text">
-      <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">Mot de passe oublié ?</a>
+    <div>
+      <div class="login-form__forgotten-password help-text">
+        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">Mot de passe oublié ?</a>
+      </div>
+      <div>
+        <div class="login-form__recover-access-link help-text">
+          <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga ?</LinkTo>
+        </div>
+        <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
+      </div>
     </div>
-  </form>
 
+  </form>
 
 </div>

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -20,6 +20,18 @@
   &__forgotten-password {
     font-size: 0.875rem;
     text-align: left;
+    margin-bottom: 8px;
+  }
+
+  &__recover-access-link {
+    font-size: 0.875rem;
+    text-align: left;
+    line-height: 1.375rem;
+  }
+
+  &__recover-access-message {
+    font-size: 0.875rem;
+    text-align: left;
   }
 
   &__button {
@@ -41,7 +53,7 @@
   }
 
   form {
-    width: 352px;
+    width: 430px;
     margin: auto;
 
     .input {


### PR DESCRIPTION
## :unicorn: Problème
La fonctionnalité de récupération d'un accès à une organisation n'est pas référencée depuis la page de connexion à Pix Orga

## :robot: Solution
Ajouter le lien [vers cette page](https://app.pix.fr/demande-administration-sco)

## :100: Pour tester
Visiter la page d'[accueil](https://orga-pr1785.review.pix.fr/connexion)
