### PR TITLE
[FEATURE] Activer l'ajout d'un moyen de connexion dans tous les cas (PIX-1141).

### DIFF
--- a/orga/app/components/manage-authentication-method-modal.hbs
+++ b/orga/app/components/manage-authentication-method-modal.hbs
@@ -1,5 +1,5 @@
-<Modal::Dialog @title="Gestion du compte Pix de l'élève" @display={{@display}} @close={{this.closePasswordReset}}>
-  <form class="password-reset-window">
+<Modal::Dialog @title="Gestion du compte Pix de l'élève" @display={{@display}} @close={{this.closeWindow}}>
+  <form class="manage-authentication-window">
     <h6>
       <FaIcon @icon="link" />
       Méthodes de connexion
@@ -7,17 +7,17 @@
 
     <div>
       {{#if @student.isAuthenticatedFromGar}}
-        <div class="password-reset-window__box">
-          <div class="password-reset-window__subTitle">
+        <div class="manage-authentication-window__box">
+          <div class="manage-authentication-window__subTitle">
             <span>Connecté avec Médiacentre</span>
             <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
           </div>
         </div>
       {{/if}}
 
-      <div class="password-reset-window__box">
+      <div class="manage-authentication-window__box">
         {{#if @student.isAuthenticatedWithGarOnly}}
-          <div class="password-reset-window__subTitle">
+          <div class="manage-authentication-window__subTitle">
             <span>Ajouter une connexion avec un identifiant</span>
             <FaIcon @icon="check-circle" @prefix="far" class="grey-icon" />
           </div>
@@ -27,13 +27,13 @@
           </button>
         {{else}}
           {{#if @student.hasUsername}}
-            <div class="password-reset-window__subTitle">
+            <div class="manage-authentication-window__subTitle">
               <span>Connecté avec un identifiant</span>
               <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
             </div>
             <div class="input-container">
               <label for="username">Identifiant</label>
-              <div class="password-reset-window__clipboard">
+              <div class="manage-authentication-window__clipboard">
                 <Input
                   id="username"
                   name="username"
@@ -44,13 +44,13 @@
                 />
                 {{#if (is-clipboard-supported)}}
                   <div class="tooltip content-text content-text--small">
-                    <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextUsername}}</span>
+                    <span class="tooltip-text manage-authentication-window__tooltip-text">{{this.tooltipTextUsername}}</span>
                     <CopyButton
                       @aria-label="Copier l'identifiant"
                       @clipboardText={{@student.username}}
                       @success={{this.clipboardSuccessUsername}}
                       {{ on 'mouseout' this.clipboardOutUsername}}
-                      @classNames="icon-button password-reset-window__clipboard-button"
+                      @classNames="icon-button manage-authentication-window__clipboard-button"
                     >
                       <FaIcon @icon="copy" @prefix="far" />
                     </CopyButton>
@@ -65,13 +65,13 @@
           {{/if}}
 
           {{#if @student.hasEmail}}
-            <div class="password-reset-window__subTitle">
+            <div class="manage-authentication-window__subTitle">
               <span>Connecté avec un e-mail</span>
               <FaIcon @icon="check-circle" @prefix="far" class="green-icon" />
             </div>
             <div class="input-container">
               <label for="email">Adresse e-mail</label>
-              <div class="password-reset-window__clipboard">
+              <div class="manage-authentication-window__clipboard">
                 <Input
                   id="email"
                   name="email"
@@ -82,13 +82,13 @@
                 />
                 {{#if (is-clipboard-supported)}}
                   <div class="tooltip content-text content-text--small">
-                    <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextEmail}}</span>
+                    <span class="tooltip-text manage-authentication-window__tooltip-text">{{this.tooltipTextEmail}}</span>
                     <CopyButton
                       @aria-label="Copier l'adresse e-mail"
                       @clipboardText={{@student.email}}
                       @success={{this.clipboardSuccessEmail}}
                       {{ on 'mouseout' this.clipboardOutEmail}}
-                      @classNames="icon-button password-reset-window__clipboard-button"
+                      @classNames="icon-button manage-authentication-window__clipboard-button"
                     >
                       <FaIcon @icon="copy" @prefix="far" />
                     </CopyButton>
@@ -102,12 +102,12 @@
     </div>
 
     {{#unless @student.isAuthenticatedWithGarOnly}}
-      <div class="password-reset-window__footer">
+      <div class="manage-authentication-window__footer">
         {{#if this.isUniquePasswordVisible}}
           <div>
             <div class="input-container">
               <label for="generated-password">Mot de passe à usage unique</label>
-              <div class="password-reset-window__clipboard">
+              <div class="manage-authentication-window__clipboard">
                 <Input
                   id="generated-password"
                   @type="text"
@@ -118,13 +118,13 @@
                 />
                 {{#if (is-clipboard-supported)}}
                   <div class="tooltip content-text content-text--small">
-                    <span class="tooltip-text password-reset-window__tooltip-text">{{this.tooltipTextGeneratedPassword}}</span>
+                    <span class="tooltip-text manage-authentication-window__tooltip-text">{{this.tooltipTextGeneratedPassword}}</span>
                     <CopyButton
                       @aria-label="Copier le mot de passe unique"
                       @clipboardText={{this.generatedPassword}}
                       @success={{this.clipboardSuccessGeneratedPassword}}
                       {{on 'mouseout' this.clipboardOutGeneratedPassword}}
-                      @classNames="icon-button password-reset-window__clipboard-button"
+                      @classNames="icon-button manage-authentication-window__clipboard-button"
                     >
                       <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
                     </CopyButton>
@@ -133,7 +133,7 @@
               </div>
             </div>
 
-            <ol class="password-reset-window__informations">
+            <ol class="manage-authentication-window__informations">
               <li>Communiquez ce mot de passe à votre élève</li>
               <li>L'élève se connecte avec ce mot de passe à usage unique</li>
               <li>Pix lui demande de choisir un nouveau mot de passe</li>
@@ -143,7 +143,7 @@
           <div>
             <button id="generate-password" type="button" class="button" {{on 'click' this.resetPassword}}>Réinitialiser le mot de passe</button>
 
-            <div class="password-reset-window__warning">
+            <div class="manage-authentication-window__warning">
               <FaIcon @icon="exclamation-triangle" class="warning-icon" />
               <span>Réinitialiser supprime le mot de passe actuel de l’élève</span>
             </div>

--- a/orga/app/components/manage-authentication-method-modal.hbs
+++ b/orga/app/components/manage-authentication-method-modal.hbs
@@ -1,4 +1,4 @@
-<Modal::Dialog @title="Gestion du compte Pix de l'élève" @display={{@display}} @close={{this.closeWindow}}>
+<Modal::Dialog @title="Gestion du compte Pix de l'élève" @display={{@display}} @close={{this.closeModal}}>
   <form class="manage-authentication-window">
     <h6>
       <FaIcon @icon="link" />

--- a/orga/app/components/manage-authentication-method-modal.js
+++ b/orga/app/components/manage-authentication-method-modal.js
@@ -82,7 +82,7 @@ export default class ManageAuthenticationMethodModal extends Component {
   }
 
   @action
-  closeWindow() {
+  closeModal() {
     this.isUniquePasswordVisible = false;
     this.args.close();
   }

--- a/orga/app/components/manage-authentication-method-modal.js
+++ b/orga/app/components/manage-authentication-method-modal.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import get from 'lodash/get';
 
-export default class PasswordResetModal extends Component {
+export default class ManageAuthenticationMethodModal extends Component {
 
   @service store;
   @service notifications;
@@ -82,7 +82,7 @@ export default class PasswordResetModal extends Component {
   }
 
   @action
-  closePasswordReset() {
+  closeWindow() {
     this.isUniquePasswordVisible = false;
     this.args.close();
   }

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -65,12 +65,10 @@
                       Gérer le compte
                     </Dropdown::Item>
                   {{/if}}
-                  {{#if this.isGenerateUsernameFeatureIsEnabled}}
-                    {{#if student.isAuthenticatedFromGar}}
-                      <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
-                        Gérer le compte
-                      </Dropdown::Item>
-                    {{/if}}
+                  {{#if student.isAuthenticatedFromGar}}
+                    <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                      Gérer le compte
+                    </Dropdown::Item>
                   {{/if}}
                   {{#if this.currentUser.isAdminInOrganization}}
                     <Dropdown::Item @onClick={{fn this.openDissociateModal student}}>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -60,16 +60,9 @@
                   @dropdownButtonClass="list-students-page__dropdown-button"
                   @dropdownContentClass="list-students-page__dropdown-content"
                 >
-                  {{#if student.isAuthenticatedWithEmailOrUsernameOnly}}
-                    <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
-                      Gérer le compte
-                    </Dropdown::Item>
-                  {{/if}}
-                  {{#if student.isAuthenticatedFromGar}}
-                    <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
-                      Gérer le compte
-                    </Dropdown::Item>
-                  {{/if}}
+                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                    Gérer le compte
+                  </Dropdown::Item>
                   {{#if this.currentUser.isAdminInOrganization}}
                     <Dropdown::Item @onClick={{fn this.openDissociateModal student}}>
                       Dissocier le compte

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -60,7 +60,7 @@
                   @dropdownButtonClass="list-students-page__dropdown-button"
                   @dropdownContentClass="list-students-page__dropdown-content"
                 >
-                  <Dropdown::Item @onClick={{fn this.openPasswordReset student}}>
+                  <Dropdown::Item @onClick={{fn this.openAuthenticationMethodModal student}}>
                     Gérer le compte
                   </Dropdown::Item>
                   {{#if this.currentUser.isAdminInOrganization}}
@@ -83,11 +83,11 @@
     {{/unless}}
   </div>
 
-  <PasswordResetModal
+  <ManageAuthenticationMethodModal
     @organizationId={{this.currentUser.organization.id}}
     @student={{this.student}}
-    @display={{this.isShowingModal}}
-    @close={{this.closePasswordReset}}
+    @display={{this.isShowingAuthenticationMethodModal}}
+    @close={{this.closeAuthenticationMethodModal}}
   />
   <DissociateUserModal
     @student={{this.student}}

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import ENV from 'pix-orga/config/environment';
 import { tracked } from '@glimmer/tracking';
 
 export default class ListItems extends Component {
@@ -14,8 +13,6 @@ export default class ListItems extends Component {
   @tracked student = null;
   @tracked isShowingModal = false;
   @tracked isShowingDissociateModal = false;
-
-  isGenerateUsernameFeatureIsEnabled = ENV.APP.IS_GENERATE_USERNAME_FEATURE_ENABLED;
 
   @action
   openPasswordReset(student) {

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -11,18 +11,18 @@ export default class ListItems extends Component {
   @service notifications;
 
   @tracked student = null;
-  @tracked isShowingModal = false;
+  @tracked isShowingAuthenticationMethodModal = false;
   @tracked isShowingDissociateModal = false;
 
   @action
-  openPasswordReset(student) {
+  openAuthenticationMethodModal(student) {
     this.student = student;
-    this.isShowingModal = true;
+    this.isShowingAuthenticationMethodModal = true;
   }
 
   @action
-  closePasswordReset() {
-    this.isShowingModal = false;
+  closeAuthenticationMethodModal() {
+    this.isShowingAuthenticationMethodModal = false;
   }
 
   @action

--- a/orga/app/models/student.js
+++ b/orga/app/models/student.js
@@ -46,9 +46,4 @@ export default class Student extends Model {
     return Boolean(!this.hasEmail && !this.hasUsername && this.isAuthenticatedFromGar);
   }
 
-  @computed('hasUsername', 'hasEmail', 'isAuthenticatedFromGar')
-  get isAuthenticatedWithEmailOrUsernameOnly() {
-    return Boolean((this.hasEmail || this.hasUsername) && !this.isAuthenticatedFromGar);
-  }
-
 }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -34,7 +34,7 @@
 @import "components/sidebar-menu";
 @import "components/login-or-register";
 @import "components/user-logged-menu";
-@import "components/password-reset-modal";
+@import "components/manage-authentication-method-modal";
 @import "components/modal";
 @import "pages/login";
 @import "pages/join";

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -1,4 +1,4 @@
-.password-reset-window {
+.manage-authentication-window {
   display: flex;
   flex-direction: column;
   background-color: $grey-10;

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -31,8 +31,7 @@ module.exports = function(environment) {
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
       HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
-      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
-      IS_GENERATE_USERNAME_FEATURE_ENABLED: process.env.IS_GENERATE_USERNAME_FEATURE_ENABLED === 'true',
+      PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.'
     },
 
     googleFonts: [
@@ -89,7 +88,6 @@ module.exports = function(environment) {
   if (environment === 'test') {
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
-    ENV.APP.IS_GENERATE_USERNAME_FEATURE_ENABLED = true;
 
     // Testem prefers this...
     ENV.locationType = 'none';

--- a/orga/tests/integration/components/manage-authentication-method-modal-test.js
+++ b/orga/tests/integration/components/manage-authentication-method-modal-test.js
@@ -8,11 +8,11 @@ import EmberObject from '@ember/object';
 import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';
 import faker from 'faker';
 
-module('Integration | Component | password-reset-modal', function(hooks) {
+module('Integration | Component | manage-authentication-method-modal', function(hooks) {
 
   setupRenderingTest(hooks);
 
-  module('When Student is not connected with GAR method', function() {
+  module('When Student is not connected with GAR method', function(hooks) {
 
     const username = 'john.doe0112';
     const email = 'john.doe0112@example.net';
@@ -37,7 +37,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should render component with username field', async function(assert) {
         // when
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // then
         assert.dom('#username').hasValue(username);
@@ -45,7 +45,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should render clipboard to copy username', async function(assert) {
         // when
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // then
         assert.dom('button[aria-label="Copier l\'identifiant"]').hasAttribute('data-clipboard-text', username);
@@ -54,7 +54,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should display tooltip when username copy button is clicked', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
         await triggerCopySuccess('button[aria-label="Copier l\'identifiant"]');
@@ -68,7 +68,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should render component with email field', async function(assert) {
         // when
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // then
         assert.dom('#email').hasValue(email);
@@ -76,7 +76,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should render clipboard to copy email', async function(assert) {
         // when
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // then
         assert.dom('button[aria-label="Copier l\'adresse e-mail"]').hasAttribute('data-clipboard-text', email);
@@ -85,7 +85,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should display tooltip when email copy button is clicked', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
         await triggerCopySuccess('button[aria-label="Copier l\'adresse e-mail"]');
@@ -117,7 +117,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should display unique password input when reset password button is clicked', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
         await click('#generate-password');
@@ -128,7 +128,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should render clipboard to copy unique password', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
         await click('#generate-password');
@@ -140,7 +140,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should display tooltip when generated password copy button is clicked', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
         await click('#generate-password');
@@ -152,12 +152,12 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
       test('should generate unique password each time the modal is used', async function(assert) {
         // given
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
         await click('#generate-password');
         const firstGeneratedPassword = this.element.querySelector('#generated-password').value;
 
         // when
-        await render(hbs`<PasswordResetModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
+        await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
         await click('#generate-password');
         const secondGeneratedPassword = this.element.querySelector('#generated-password').value;
 
@@ -180,7 +180,7 @@ module('Integration | Component | password-reset-modal', function(hooks) {
 
     test('should render component with GAR connection method', async function(assert) {
       // when
-      await render(hbs`<PasswordResetModal @student={{this.studentGAR}} @display={{this.display}} />`);
+      await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentGAR}} @display={{this.display}} />`);
 
       // then
       assert.contains('Connecté avec Médiacentre');

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -208,6 +208,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
+    // eslint-disable-next-line mocha/no-identical-title
     test('it should display the manage account entry menu', async function(assert) {
       // given
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
@@ -252,6 +253,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
+    // eslint-disable-next-line mocha/no-identical-title
     test('it should display the manage account entry menu', async function(assert) {
       // given
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -13,7 +13,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     this.set('noop', sinon.stub());
   });
 
-  test('it should show title of team page', async function(assert) {
+  test('it should show title of students page', async function(assert) {
     // when
     await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @triggerFiltering={{noop}}/>`);
 
@@ -171,6 +171,17 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     test('it should display actions menu', async function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
+
+    test('it should display the manage account entry menu', async function(assert) {
+      // given
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // when
+      await click('[aria-label="Afficher les actions"]');
+
+      // then
+      assert.contains('Gérer le compte');
+    });
   });
 
   module('when user authentification method is email', function({ beforeEach }) {
@@ -195,6 +206,17 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
     test('it should display actions menu for email', async function(assert) {
       assert.dom('[aria-label="Afficher les actions"]').exists();
+    });
+
+    test('it should display the manage account entry menu', async function(assert) {
+      // given
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // when
+      await click('[aria-label="Afficher les actions"]');
+
+      // then
+      assert.contains('Gérer le compte');
     });
   });
 
@@ -230,7 +252,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
-    test('it should display the button generate username in the menu', async function(assert) {
+    test('it should display the manage account entry menu', async function(assert) {
       // given
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -148,6 +148,33 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
+  module('when user is reconciled', function({ beforeEach }) {
+
+    beforeEach(function() {
+      const store = this.owner.lookup('service:store');
+      this.set('students', [
+        store.createRecord('student', {
+          lastName: 'La Terreur',
+          firstName: 'Gigi',
+          birthdate: '2010-01-01',
+          username: 'blueivy.carter0701',
+          isAuthenticatedFromGar: false,
+        })
+      ]);
+      return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+    });
+    test('it should display the manage account entry menu', async function(assert) {
+      // given
+      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+
+      // when
+      await click('[aria-label="Afficher les actions"]');
+
+      // then
+      assert.contains('Gérer le compte');
+    });
+  });
+
   module('when user authentification method is username', function({ beforeEach }) {
 
     beforeEach(function() {
@@ -172,16 +199,6 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
-    test('it should display the manage account entry menu', async function(assert) {
-      // given
-      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
-
-      // when
-      await click('[aria-label="Afficher les actions"]');
-
-      // then
-      assert.contains('Gérer le compte');
-    });
   });
 
   module('when user authentification method is email', function({ beforeEach }) {
@@ -208,17 +225,6 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
-    // eslint-disable-next-line mocha/no-identical-title
-    test('it should display the manage account entry menu', async function(assert) {
-      // given
-      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
-
-      // when
-      await click('[aria-label="Afficher les actions"]');
-
-      // then
-      assert.contains('Gérer le compte');
-    });
   });
 
   module('when user authentification method is samlId', function({ beforeEach }) {
@@ -253,17 +259,6 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       assert.dom('[aria-label="Afficher les actions"]').exists();
     });
 
-    // eslint-disable-next-line mocha/no-identical-title
-    test('it should display the manage account entry menu', async function(assert) {
-      // given
-      await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
-
-      // when
-      await click('[aria-label="Afficher les actions"]');
-
-      // then
-      assert.contains('Gérer le compte');
-    });
   });
 
   module('user rights', (hooks) => {


### PR DESCRIPTION
## :unicorn: Problème
La [PR 1751](https://github.com/1024pix/pix/pull/1751/) permettait aux professeurs d'ajouter un moyen de connexion GAR aux utilisateurs connecté par le GAR. Cette fonctionnalité faisait l'objet d'un feature-flipping qui n'est plus d'actualité.

## :robot: Solution
Activer l'ajout du moyen de connexion dans tous les contextes (supprimer le FF).

## :rainbow: Remarques
Suite aux modification récentes, le code n'était plus cohérent.
En conséquence, des affichages conditionnels redondants ont été supprimés et un composant a été renommé

## :100: Pour tester
La variable d'environnement IS_GENERATE_USERNAME_FEATURE_ENABLED qui active le FF est absente de tous les environnements, donc aucune modification d'environnement n'est nécessaire.

Etapes:
- se connecter sur l'organisation The Night Watch avec l'utilisateur sco@example.net
- localiser l'élève gar/user qui n'a qu'une méthode de connexion _Médiacentre_
- cliquer sur _Gérer le compte_
- cliquer sur _Ajouter une connexion avec un identifiant_
- se connecter avec le compte fourni