### PR TITLE
[FEATURE] Ne pas afficher le lien de récupération sur la page d'acceptation d'une invitation (PIX-1149).

### DIFF
--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -66,12 +66,14 @@
       <div class="login-form__forgotten-password help-text">
         <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">Mot de passe oublié ?</a>
       </div>
-      <div>
-        <div class="login-form__recover-access-link help-text">
-          <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga ?</LinkTo>
+      {{#unless @isWithInvitation}}
+        <div>
+          <div class="login-form__recover-access-link help-text">
+            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga ?</LinkTo>
+          </div>
+          <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
         </div>
-        <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
-      </div>
+      {{/unless}}
     </div>
 
   </form>

--- a/orga/app/styles/components/login-form.scss
+++ b/orga/app/styles/components/login-form.scss
@@ -53,7 +53,7 @@
   }
 
   form {
-    width: 430px;
+    max-width: 430px;
     margin: auto;
 
     .input {


### PR DESCRIPTION
## :unicorn: Problème
Le lien de récupération fait sens sur la page de connexion simple (/connexion).
Il ne fait pas sens sur le composant de connexion dans la page d'acceptation d'invitation (/rejoindre)

## :robot: Solution
N'afficher le lien que sur la page de connexion (route /connexion)

## :rainbow: Remarques
Je ne suis pas convaincu par l'intérêt d'écrire un test, mais si vous trouvez cela pertinent, je le ferais.

Faire disparaître la scrollbar introduite par l'ajout du message suivant
> (réservé aux personnels de direction des établissements scolaires)

## :100: Pour tester
Se connecter et constater que le lien est présent
Créer une invitation (le mailing est activé), cliquer sur le lien dans le mail, et constater que le lien est absent
