### PR TITLE
[TECH] Muscler les tests sur la sélection des épreuves de certification

### DIFF
--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -1,4 +1,5 @@
 const { expect, knex, nock, databaseBuilder, airtableBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const createServer = require('../../../../server');
 const BookshelfAnswer = require('../../../../lib/infrastructure/data/answer');
 
@@ -31,6 +32,7 @@ describe('Acceptance | Controller | answer-controller-save', () => {
     afterEach(() => {
       nock.cleanAll();
       airtableBuilder.cleanAll();
+      cache.flushAll();
 
       return knex('answers').delete();
     });

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -11,26 +11,172 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
   let options;
   let server;
   let user, assessment;
-  let competencesAssociatedSkillsAndChallenges;
+  const learningContent = [
+    {
+      id: 'recArea0',
+      competences: [
+        {
+          id: 'recCompetence0',
+          tubes: [
+            {
+              id: 'recTube0_0',
+              skills: [
+                {
+                  id: 'recSkill0_0',
+                  nom: '@recSkill0_0',
+                  challenges: [
+                    { id: 'recChallenge0_0_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill0_1',
+                  nom: '@recSkill0_1',
+                  challenges: [
+                    { id: 'recChallenge0_1_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill0_2',
+                  nom: '@recSkill0_2',
+                  challenges: [
+                    { id: 'recChallenge0_2_0' }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'recCompetence1',
+          tubes: [
+            {
+              id: 'recTube1_0',
+              skills: [
+                {
+                  id: 'recSkill1_0',
+                  nom: '@recSkill1_0',
+                  challenges: [
+                    { id: 'recChallenge1_0_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill1_1',
+                  nom: '@recSkill1_1',
+                  challenges: [
+                    { id: 'recChallenge1_1_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill1_2',
+                  nom: '@recSkill1_2',
+                  challenges: [
+                    { id: 'recChallenge1_2_0' }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'recCompetence2',
+          tubes: [
+            {
+              id: 'recTube2_0',
+              skills: [
+                {
+                  id: 'recSkill2_0',
+                  nom: '@recSkill2_0',
+                  challenges: [
+                    { id: 'recChallenge2_0_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill2_1',
+                  nom: '@recSkill2_1',
+                  challenges: [
+                    { id: 'recChallenge2_1_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill2_2',
+                  nom: '@recSkill2_2',
+                  challenges: [
+                    { id: 'recChallenge2_2_0' }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'recCompetence3',
+          tubes: [
+            {
+              id: 'recTube3_0',
+              skills: [
+                {
+                  id: 'recSkill3_0',
+                  nom: '@recSkill3_0',
+                  challenges: [
+                    { id: 'recChallenge3_0_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill3_1',
+                  nom: '@recSkill3_1',
+                  challenges: [
+                    { id: 'recChallenge3_1_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill3_2',
+                  nom: '@recSkill3_2',
+                  challenges: [
+                    { id: 'recChallenge3_2_0' }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          id: 'recCompetence4',
+          tubes: [
+            {
+              id: 'recTube4_0',
+              skills: [
+                {
+                  id: 'recSkill4_0',
+                  nom: '@recSkill4_0',
+                  challenges: [
+                    { id: 'recChallenge4_0_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill4_1',
+                  nom: '@recSkill4_1',
+                  challenges: [
+                    { id: 'recChallenge4_1_0' }
+                  ]
+                },
+                {
+                  id: 'recSkill4_2',
+                  nom: '@recSkill4_2',
+                  challenges: [
+                    { id: 'recChallenge4_2_0' }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ];
 
   before(() => {
-    const learningContentForCertification = airtableBuilder.factory.buildLearningContentForCertification();
-    airtableBuilder.mockList({ tableName: 'Domaines' })
-      .returns([learningContentForCertification.area])
-      .activate();
-    airtableBuilder.mockList({ tableName: 'Competences' })
-      .returns(learningContentForCertification.competences)
-      .activate();
-    airtableBuilder.mockList({ tableName: 'Tubes' })
-      .returns(learningContentForCertification.tubes)
-      .activate();
-    airtableBuilder.mockList({ tableName: 'Acquis' })
-      .returns(learningContentForCertification.skills)
-      .activate();
-    airtableBuilder.mockList({ tableName: 'Epreuves' })
-      .returns(learningContentForCertification.challenges)
-      .activate();
-    competencesAssociatedSkillsAndChallenges = learningContentForCertification.competencesAssociatedSkillsAndChallenges;
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
   });
 
   after(() => {
@@ -98,7 +244,10 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         campaignUser = databaseBuilder.factory.buildUser({});
         const targetProfile = databaseBuilder.factory.buildTargetProfile();
         const campaign = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfile.id });
-        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaign.id, userId: campaignUser.id });
+        const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: campaignUser.id
+        });
         const campaignAssessment = databaseBuilder.factory.buildAssessment({
           id: 5,
           type: 'CAMPAIGN',
@@ -109,12 +258,15 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
         const targetProfileId = campaign.targetProfileId;
         const anyDateBeforeCampaignParticipation = new Date(campaignParticipation.sharedAt.getTime() - 60 * 1000);
         badge = databaseBuilder.factory.buildBadge({ targetProfileId });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: competencesAssociatedSkillsAndChallenges[0].skillId });
+        databaseBuilder.factory.buildTargetProfileSkill({
+          targetProfileId,
+          skillId: 'recSkill0_0'
+        });
         databaseBuilder.factory.buildKnowledgeElement({
-          skillId: competencesAssociatedSkillsAndChallenges[0].skillId,
+          skillId: 'recSkill0_0',
           assessmentId: campaignAssessment.id,
           userId: campaignUser.id,
-          competenceId: competencesAssociatedSkillsAndChallenges[0].competenceId,
+          competenceId: 'recCompetence0',
           createdAt: anyDateBeforeCampaignParticipation
         });
         databaseBuilder.factory.buildBadgeCriterion({
@@ -161,14 +313,25 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
 
       beforeEach(() => {
         const limitDate = new Date('2020-01-01T00:00:00Z');
-        certifiableUserId = databaseBuilder.factory.buildCertifiableUser({ competencesAssociatedSkillsAndChallenges, limitDate }).id;
+        certifiableUserId = databaseBuilder.factory.buildUser().id;
+
+        const competenceIdSkillIdPairs = databaseBuilder.factory.buildCorrectAnswersAndKnowledgeElementsForLearningContent({
+          learningContent,
+          userId: certifiableUserId,
+          placementDate: limitDate,
+          earnedPix: 8,
+        });
+
         certificationAssessmentId = databaseBuilder.factory.buildAnsweredNotCompletedCertificationAssessment({
           certifiableUserId,
-          competencesAssociatedSkillsAndChallenges,
+          competenceIdSkillIdPairs,
           limitDate: moment(limitDate).add(1, 'day').toDate(),
         }).id;
         const badgeId = databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_EMPLOI_CLEA }).id;
-        databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId, skillIds: [ competencesAssociatedSkillsAndChallenges[0].skillId ] });
+        databaseBuilder.factory.buildBadgePartnerCompetence({
+          badgeId,
+          skillIds: ['recSkill0_0']
+        });
 
         return databaseBuilder.commit();
       });

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -412,7 +412,7 @@ describe('Acceptance | API | Certification Course', () => {
     let userId;
     let sessionId;
 
-    beforeEach(async() => {
+    beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
       sessionId = databaseBuilder.factory.buildSession({ accessCode: '123' }).id;
       const payload = {
@@ -452,34 +452,180 @@ describe('Acceptance | API | Certification Course', () => {
 
     context('when the certification course does not exist', () => {
       let certificationCandidate;
+      const learningContent = [
+        {
+          id: 'recArea0',
+          competences: [
+            {
+              id: 'recCompetence0',
+              tubes: [
+                {
+                  id: 'recTube0_0',
+                  skills: [
+                    {
+                      id: 'recSkill0_0',
+                      nom: '@recSkill0_0',
+                      challenges: [
+                        { id: 'recChallenge0_0_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill0_1',
+                      nom: '@recSkill0_1',
+                      challenges: [
+                        { id: 'recChallenge0_1_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill0_2',
+                      nom: '@recSkill0_2',
+                      challenges: [
+                        { id: 'recChallenge0_2_0' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              id: 'recCompetence1',
+              tubes: [
+                {
+                  id: 'recTube1_0',
+                  skills: [
+                    {
+                      id: 'recSkill1_0',
+                      nom: '@recSkill1_0',
+                      challenges: [
+                        { id: 'recChallenge1_0_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill1_1',
+                      nom: '@recSkill1_1',
+                      challenges: [
+                        { id: 'recChallenge1_1_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill1_2',
+                      nom: '@recSkill1_2',
+                      challenges: [
+                        { id: 'recChallenge1_2_0' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              id: 'recCompetence2',
+              tubes: [
+                {
+                  id: 'recTube2_0',
+                  skills: [
+                    {
+                      id: 'recSkill2_0',
+                      nom: '@recSkill2_0',
+                      challenges: [
+                        { id: 'recChallenge2_0_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill2_1',
+                      nom: '@recSkill2_1',
+                      challenges: [
+                        { id: 'recChallenge2_1_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill2_2',
+                      nom: '@recSkill2_2',
+                      challenges: [
+                        { id: 'recChallenge2_2_0' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              id: 'recCompetence3',
+              tubes: [
+                {
+                  id: 'recTube3_0',
+                  skills: [
+                    {
+                      id: 'recSkill3_0',
+                      nom: '@recSkill3_0',
+                      challenges: [
+                        { id: 'recChallenge3_0_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill3_1',
+                      nom: '@recSkill3_1',
+                      challenges: [
+                        { id: 'recChallenge3_1_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill3_2',
+                      nom: '@recSkill3_2',
+                      challenges: [
+                        { id: 'recChallenge3_2_0' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              id: 'recCompetence4',
+              tubes: [
+                {
+                  id: 'recTube4_0',
+                  skills: [
+                    {
+                      id: 'recSkill4_0',
+                      nom: '@recSkill4_0',
+                      challenges: [
+                        { id: 'recChallenge4_0_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill4_1',
+                      nom: '@recSkill4_1',
+                      challenges: [
+                        { id: 'recChallenge4_1_0' }
+                      ]
+                    },
+                    {
+                      id: 'recSkill4_2',
+                      nom: '@recSkill4_2',
+                      challenges: [
+                        { id: 'recChallenge4_2_0' }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ];
 
       beforeEach(async () => {
         // given
-        const { area, competences, tubes, skills, challenges, competencesAssociatedSkillsAndChallenges } = airtableBuilder.factory.buildLearningContentForCertification();
-        airtableBuilder.mockList({ tableName: 'Domaines' })
-          .returns([area])
-          .activate();
-        airtableBuilder.mockList({ tableName: 'Competences' })
-          .returns(competences)
-          .activate();
-        airtableBuilder.mockList({ tableName: 'Tubes' })
-          .returns(tubes)
-          .activate();
-        airtableBuilder.mockList({ tableName: 'Acquis' })
-          .returns(skills)
-          .activate();
-        airtableBuilder.mockList({ tableName: 'Epreuves' })
-          .returns(challenges)
-          .activate();
-
+        const airTableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+        airtableBuilder.mockLists(airTableObjects);
         certificationCandidate = databaseBuilder.factory.buildCertificationCandidate({ sessionId, userId });
-        const assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
-        const commonUserIdAssessmentIdAndEarnedPixForAllKEs = { userId, assessmentId, earnedPix: 4 };
-        competencesAssociatedSkillsAndChallenges.forEach((element) => {
-          const { challengeId, competenceId } = element;
-          const answerId = databaseBuilder.factory.buildAnswer({ assessmentId, challengeId }).id;
-          databaseBuilder.factory.buildKnowledgeElement({ ...commonUserIdAssessmentIdAndEarnedPixForAllKEs, competenceId, answerId });
+        databaseBuilder.factory.buildCorrectAnswersAndKnowledgeElementsForLearningContent({
+          learningContent,
+          userId,
+          earnedPix: 4
         });
+
         await databaseBuilder.commit();
 
         // when
@@ -547,5 +693,5 @@ describe('Acceptance | API | Certification Course', () => {
     });
 
   });
-
 });
+

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -4,6 +4,7 @@ const {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
 } = require('../../../test-helper');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { map } = require('lodash');
@@ -138,6 +139,11 @@ describe('Acceptance | API | Certifications', () => {
       airtableBuilder.mockList({ tableName: 'Competences' })
         .returns(competences)
         .activate();
+    });
+
+    after(() => {
+      airtableBuilder.cleanAll();
+      return cache.flushAll();
     });
 
     beforeEach(() => {

--- a/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
+++ b/api/tests/acceptance/application/users/users-controller-reset-scorecard_test.js
@@ -1,4 +1,5 @@
 const { knex, airtableBuilder, databaseBuilder, expect, generateValidRequestAuthorizationHeader, sinon } = require('../../../test-helper');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const _ = require('lodash');
 
 const createServer = require('../../../../server');
@@ -182,6 +183,10 @@ describe('Acceptance | Controller | users-controller-reset-scorecard', () => {
         await knex('assessments').delete();
         await knex('campaign-participations').delete();
         return airtableBuilder.cleanAll();
+      });
+
+      after(() => {
+        return cache.flushAll();
       });
 
       it('should return 200 and the updated scorecard', async () => {

--- a/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
+++ b/api/tests/acceptance/application/users/users-get-shared-profile-for-campaign_test.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const { expect, generateValidRequestAuthorizationHeader, databaseBuilder, airtableBuilder } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
@@ -46,6 +47,11 @@ describe('Acceptance | Route | GET /users/{userId}/campaigns/{campaignId}/profil
       };
 
       return databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      airtableBuilder.cleanAll();
+      return cache.flushAll();
     });
 
     describe('Success case', () => {

--- a/api/tests/integration/domain/services/pick-certification-challenge_test.js
+++ b/api/tests/integration/domain/services/pick-certification-challenge_test.js
@@ -1,0 +1,708 @@
+const { expect, databaseBuilder, airtableBuilder } = require('../../../test-helper');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
+const certificationChallengesService = require('../../../../lib/domain/services/certification-challenges-service');
+const moment = require('moment');
+const { PIX_COUNT_BY_LEVEL } = require('../../../../lib/domain/constants');
+
+describe('Integration | CertificationChallengeService | pickCertificationChallenge', function() {
+  const placementDate = new Date('2020-01-01T00:00:00Z');
+  const certificationDate = _addOneDayToDate(placementDate);
+  const sufficientPixValueToBeCertifiableOnCompetence = PIX_COUNT_BY_LEVEL;
+  const unsufficientPixValueToBeCertifiableOnCompetence = 1;
+  let certifiableUserId;
+
+  beforeEach(() => {
+    certifiableUserId = databaseBuilder.factory.buildUser().id;
+  });
+
+  afterEach(() => {
+    airtableBuilder.cleanAll();
+    return cache.flushAll();
+  });
+
+  it('picks only operative challenges', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: '', // unoperative
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+                        statut: 'validé', // operative
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate,
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill2',
+      challengeId: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate,
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+
+    //then
+    expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence1_Tube1_Skill2_Challenge1']);
+  });
+
+  it('picks only fr-fr challenges', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Anglais', 'Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    nom: '@recArea1_Competence1_Tube1_Skill2',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill2',
+      challengeId: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await databaseBuilder.commit();
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+
+    //then
+    expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence1_Tube1_Skill2_Challenge1']);
+  });
+
+  it('picks challenges on certifiable competences only', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            id: 'recArea1_Competence2',
+            tubes: [
+              {
+                id: 'recArea1_Competence2_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence2_Tube1_Skill1',
+                    nom: '@recArea1_Competence2_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence2_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: unsufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence2',
+      skillId: 'recArea1_Competence2_Tube1_Skill1',
+      challengeId: 'recArea1_Competence2_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+
+    //then
+    expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence2_Tube1_Skill1_Challenge1']);
+  });
+
+  it('picks challenges on Pix competences only', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            origin: 'Pix+', // Non-pix
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            id: 'recArea1_Competence2',
+            origin: 'Pix',
+            tubes: [
+              {
+                id: 'recArea1_Competence2_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence2_Tube1_Skill1',
+                    nom: '@recArea1_Competence2_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence2_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence2',
+      skillId: 'recArea1_Competence2_Tube1_Skill1',
+      challengeId: 'recArea1_Competence2_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+
+    //then
+    expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(['recArea1_Competence2_Tube1_Skill1_Challenge1']);
+  });
+
+  it('picks one skill-related challenge, starting by unanswered challenges first', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      },
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge2',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      },
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge3',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    expect(challenges.length).to.equal(1);
+    expect(challenges[0].challengeId).to.be.oneOf(['recArea1_Competence1_Tube1_Skill1_Challenge2', 'recArea1_Competence1_Tube1_Skill1_Challenge3']);
+  });
+
+  it('picks one skill-related challenge, falling back on already answered challenges if no unanswered one is available', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      },
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge2',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      },
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge3',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill2',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge2',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill3',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge3',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    expect(challenges.length).to.equal(1);
+    expect(['recArea1_Competence1_Tube1_Skill1_Challenge1', 'recArea1_Competence1_Tube1_Skill1_Challenge2', 'recArea1_Competence1_Tube1_Skill1_Challenge3']).to.include(challenges[0].challengeId);
+  });
+
+  it('picks one challenge by skill to a maximum of 3 challenges by competence starting by most difficult skills', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@area1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    nom: '@area1_Competence1_Tube1_Skill2',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill3',
+                    nom: '@area1_Competence1_Tube1_Skill3',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill3_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill4',
+                    nom: '@area1_Competence1_Tube1_Skill4',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill4_Challenge1',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill2',
+      challengeId: 'recArea1_Competence1_Tube1_Skill2_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill3',
+      challengeId: 'recArea1_Competence1_Tube1_Skill3_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill4',
+      challengeId: 'recArea1_Competence1_Tube1_Skill4_Challenge1',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await databaseBuilder.commit();
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    expect(challenges.length).to.equal(3);
+    expect(challenges.map((challenge) => challenge.challengeId)).to.deep.equal(
+      [
+        'recArea1_Competence1_Tube1_Skill4_Challenge1',
+        'recArea1_Competence1_Tube1_Skill3_Challenge1',
+        'recArea1_Competence1_Tube1_Skill2_Challenge1',
+      ]
+    );
+  });
+
+  it('picks the same challenge only once even if it is related to two different skills (QROCmDep)', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge',
+                        statut: 'validé',
+                        langues: ['Franco Français']
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge' // same id
+                      }
+                    ]
+                  },
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill1',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    await _buildCorrectAnswerAndKnowledgeElement({
+      userId: certifiableUserId,
+      competenceId: 'recArea1_Competence1',
+      skillId: 'recArea1_Competence1_Tube1_Skill2',
+      challengeId: 'recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge',
+      pixValue: sufficientPixValueToBeCertifiableOnCompetence,
+      acquisitionDate: placementDate
+    });
+    const placementProfile = await placementProfileService.getPlacementProfile({
+      userId: certifiableUserId,
+      limitDate: certificationDate
+    });
+
+    // when
+    const challenges = await certificationChallengesService.pickCertificationChallenges(placementProfile);
+    expect(challenges.length).to.equal(1);
+    expect(challenges[0].challengeId).to.equal('recArea1_Competence1_Tube1_Skill1_And_Skill2_Challenge');
+  });
+});
+
+async function _buildCorrectAnswerAndKnowledgeElement({
+  userId,
+  competenceId,
+  challengeId,
+  pixValue,
+  acquisitionDate,
+  skillId
+}) {
+  const assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+  const answerId = databaseBuilder.factory.buildAnswer({
+    assessmentId,
+    challengeId
+  }).id;
+  databaseBuilder.factory.buildKnowledgeElement({
+    userId,
+    assessmentId,
+    earnedPix: pixValue,
+    competenceId,
+    answerId,
+    createdAt: acquisitionDate,
+    skillId
+  });
+  await databaseBuilder.commit();
+}
+
+function _addOneDayToDate(date) {
+  return moment(date).add(1, 'day').toDate();
+}
+

--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -27,4 +27,28 @@ module.exports = class AirtableBuilder {
     this.nock.cleanAll();
   }
 
+  mockLists({
+    areas,
+    competences,
+    tubes,
+    skills,
+    challenges
+  }) {
+    this.mockList({ tableName: 'Domaines' })
+      .returns(areas)
+      .activate();
+    this.mockList({ tableName: 'Competences' })
+      .returns(competences)
+      .activate();
+    this.mockList({ tableName: 'Tubes' })
+      .returns(tubes)
+      .activate();
+    this.mockList({ tableName: 'Acquis' })
+      .returns(skills)
+      .activate();
+    this.mockList({ tableName: 'Epreuves' })
+      .returns(challenges)
+      .activate();
+  }
+
 };

--- a/api/tests/tooling/airtable-builder/factory/index.js
+++ b/api/tests/tooling/airtable-builder/factory/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   buildArea: require('./build-area'),
-  buildLearningContentForCertification: require('./build-learning-content-for-certification'),
+  buildLearningContent: require('./learning-content/build-learning-content'),
   buildChallenge: require('./build-challenge'),
   buildCompetence: require('./build-competence'),
   buildCourse: require('./build-course'),

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content-test.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content-test.js
@@ -1,0 +1,284 @@
+const { expect, airtableBuilder } = require('../../../../test-helper');
+const cache = require('../../../../../lib/infrastructure/caches/learning-content-cache');
+const areaDatasource = require('../../../../../lib/infrastructure/datasources/airtable/area-datasource');
+const competenceDatasource = require('../../../../../lib/infrastructure/datasources/airtable/competence-datasource');
+const tubeDatasource = require('../../../../../lib/infrastructure/datasources/airtable/tube-datasource');
+const skillDatasource = require('../../../../../lib/infrastructure/datasources/airtable/skill-datasource');
+const challengeDatasource = require('../../../../../lib/infrastructure/datasources/airtable/challenge-datasource');
+
+describe('Integration | buildLearningContent', () => {
+
+  afterEach(() => {
+    airtableBuilder.cleanAll();
+    return cache.flushAll();
+  });
+
+  it('builds areas', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: []
+      },
+      {
+        id: 'recArea2',
+        competences: []
+      },
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const areas = await areaDatasource.list();
+    expect(areas[0].id).to.equal('recArea1');
+    expect(areas[1].id).to.equal('recArea2');
+  });
+
+  it('builds competences', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: []
+          },
+          {
+            id: 'recArea1_Competence2',
+            tubes: []
+          }
+        ]
+      },
+      {
+        id: 'recArea2',
+        competences: [
+          {
+            id: 'recArea2_Competence1',
+            tubes: [],
+            origin: 'Pix+'
+          },
+          {
+            id: 'recArea2_Competence2',
+            tubes: [],
+            origin: 'Pix+'
+          }
+        ]
+      },
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const areas = await areaDatasource.list();
+    const competences = await competenceDatasource.list();
+    expect(areas[0].competenceIds).to.deep.equal(['recArea1_Competence1', 'recArea1_Competence2']);
+    expect(areas[1].competenceIds).to.deep.equal(['recArea2_Competence1', 'recArea2_Competence2']);
+    expect(competences[0].id).to.deep.equal('recArea1_Competence1');
+    expect(competences[0].areaId).to.deep.equal('recArea1');
+    expect(competences[0].origin).to.deep.equal('Pix');
+    expect(competences[1].id).to.deep.equal('recArea1_Competence2');
+    expect(competences[1].areaId).to.deep.equal('recArea1');
+    expect(competences[1].origin).to.deep.equal('Pix');
+    expect(competences[2].id).to.deep.equal('recArea2_Competence1');
+    expect(competences[2].areaId).to.deep.equal('recArea2');
+    expect(competences[2].origin).to.deep.equal('Pix+');
+    expect(competences[3].id).to.deep.equal('recArea2_Competence2');
+    expect(competences[3].areaId).to.deep.equal('recArea2');
+    expect(competences[3].origin).to.deep.equal('Pix+');
+  });
+
+  it('builds tubes', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: []
+              },
+              {
+                id: 'recArea1_Competence1_Tube2',
+                skills: []
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const competences = await competenceDatasource.list();
+    const tubes = await tubeDatasource.list();
+    expect(competences[0].id).to.deep.equal('recArea1_Competence1');
+    expect(tubes[0].id).to.deep.equal('recArea1_Competence1_Tube1');
+    expect(tubes[0].competenceId).to.deep.equal('recArea1_Competence1');
+    expect(tubes[1].id).to.deep.equal('recArea1_Competence1_Tube2');
+    expect(tubes[1].competenceId).to.deep.equal('recArea1_Competence1');
+  });
+
+  it('builds skills', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    nom: '@accesDonnées1',
+                    status: 'actif',
+                    challenges: []
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    nom: '@accesDonnées2',
+                    status: 'archivé',
+                    challenges: []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const competences = await competenceDatasource.list();
+    const skills = await skillDatasource.list();
+    expect(competences[0].skillIds).to.deep.equal(['recArea1_Competence1_Tube1_Skill1', 'recArea1_Competence1_Tube1_Skill2']);
+    expect(skills[0].id).to.deep.equal('recArea1_Competence1_Tube1_Skill1');
+    expect(skills[0].competenceId).to.deep.equal('recArea1_Competence1');
+    expect(skills[0].tubeId).to.deep.equal('recArea1_Competence1_Tube1');
+    expect(skills[0].status).to.deep.equal('actif');
+    expect(skills[0].name).to.deep.equal('@accesDonnées1');
+
+    expect(skills[1].id).to.deep.equal('recArea1_Competence1_Tube1_Skill2');
+    expect(skills[1].competenceId).to.deep.equal('recArea1_Competence1');
+    expect(skills[1].tubeId).to.deep.equal('recArea1_Competence1_Tube1');
+    expect(skills[1].status).to.deep.equal('archivé');
+    expect(skills[1].name).to.deep.equal('@accesDonnées2');
+  });
+
+  it('builds challenges', async () => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé'
+                      },
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge2',
+                        statut: 'archivé',
+                        langues: ['Francophone', 'Franco Français']
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const challenges = await challengeDatasource.list();
+    expect(challenges[0].id).to.equal('recArea1_Competence1_Tube1_Skill1_Challenge1');
+    expect(challenges[0].skillIds).to.deep.equal(['recArea1_Competence1_Tube1_Skill1']);
+    expect(challenges[0].status).to.deep.equal('validé');
+    expect(challenges[1].id).to.equal('recArea1_Competence1_Tube1_Skill1_Challenge2');
+    expect(challenges[1].skillIds).to.deep.equal(['recArea1_Competence1_Tube1_Skill1']);
+    expect(challenges[1].status).to.deep.equal('archivé');
+    expect(challenges[1].locales).to.deep.equal(['fr', 'fr-fr']);
+  });
+
+  it('builds challenges | a single challenge is linked several skills', async() => {
+    // given
+    const learningContent = [
+      {
+        id: 'recArea1',
+        competences: [
+          {
+            id: 'recArea1_Competence1',
+            tubes: [
+              {
+                id: 'recArea1_Competence1_Tube1',
+                skills: [
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill1',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1',
+                        statut: 'validé'
+                      }
+                    ]
+                  },
+                  {
+                    id: 'recArea1_Competence1_Tube1_Skill2',
+                    status: 'actif',
+                    challenges: [
+                      {
+                        id: 'recArea1_Competence1_Tube1_Skill1_Challenge1', // same id
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ];
+
+    // when
+    const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+    airtableBuilder.mockLists(airtableObjects);
+
+    // then
+    const challenges = await challengeDatasource.list();
+    expect(challenges[0].id).to.equal('recArea1_Competence1_Tube1_Skill1_Challenge1');
+    expect(challenges[0].skillIds).to.deep.equal(['recArea1_Competence1_Tube1_Skill1', 'recArea1_Competence1_Tube1_Skill2']);
+    expect(challenges[0].status).to.deep.equal('validé');
+  });
+});

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
@@ -1,0 +1,80 @@
+const _ = require('lodash');
+const buildSkill = require('../build-skill');
+const buildChallenge = require('../build-challenge');
+const buildTube = require('../build-tube');
+const buildCompetence = require('../build-competence');
+const buildArea = require('../build-area');
+
+const buildLearningContent = function(learningContent) {
+  const allCompetences = [];
+  const allTubes = [];
+  const allSkills = [];
+  const allChallenges = [];
+  const areas = learningContent.map((area) => {
+    const competences = area.competences.map((competence) => {
+      const tubes = competence.tubes.map((tube) => {
+        const skills = tube.skills.map((skill) => {
+          const challenges = skill.challenges.map((challenge) => {
+            const sameChallengeForAnotherSkill = allChallenges.flat().find((otherSkillChallenge) => otherSkillChallenge.id === challenge.id);
+            if (!sameChallengeForAnotherSkill) {
+              return buildChallenge({
+                id: challenge.id,
+                competences: [competence.id],
+                acquix: [skill.id],
+                statut: challenge.statut,
+                langues: challenge.langues
+              });
+            } else {
+              sameChallengeForAnotherSkill.fields['Acquix (id persistant)'].push(skill.id);
+              return;
+            }
+          });
+          allChallenges.push(challenges);
+          return buildSkill(
+            {
+              id: skill.id,
+              epreuves: [skill.challenges.map((challenge) => challenge.id)],
+              tube: [tube.id],
+              status: skill.status,
+              compétenceViaTube: [competence.id],
+              nom: skill.nom
+            }
+          );
+        });
+        allSkills.push(skills);
+        return buildTube(
+          {
+            id: tube.id,
+            competences: [competence.id]
+          }
+        );
+      });
+      allTubes.push(tubes);
+      return buildCompetence(
+        {
+          id: competence.id,
+          epreuves: competence.tubes.flatMap((tube) => tube.skills).flatMap((skill) => skill.challenges).map((challenge) => challenge.id),
+          tubes: competence.tubes.map((tube) => tube.id),
+          acquisViaTubes: competence.tubes.flatMap((tube) => tube.skills).map((skill) => skill.id),
+          domaineIds: [area.id],
+          origin: competence.origin
+        }
+      );
+    });
+    allCompetences.push(competences);
+    return buildArea({
+      id: area.id,
+      competenceIds: competences.map((competence) => competence.id),
+      nomCompetences: competences.map((competence) => competence.name)
+    });
+  });
+  return {
+    areas,
+    competences: allCompetences.flat(),
+    tubes: allTubes.flat(),
+    skills: allSkills.flat(),
+    challenges: _.compact(allChallenges.flat())
+  };
+};
+
+module.exports = buildLearningContent;

--- a/api/tests/tooling/database-builder/factory/build-answered-not-completed-certification-assessment.js
+++ b/api/tests/tooling/database-builder/factory/build-answered-not-completed-certification-assessment.js
@@ -6,12 +6,12 @@ const buildAnswer = require('./build-answer');
 
 module.exports = function buildAnsweredNotCompletedCertificationAssessment({
   certifiableUserId,
-  competencesAssociatedSkillsAndChallenges,
+  competenceIdSkillIdPairs,
   limitDate,
 }) {
   const certificationCourseId = buildCertificationCourse({ userId: certifiableUserId, createdAt: limitDate, isV2Certification: true }).id;
   const certificationAssessment = buildAssessment({ certificationCourseId, userId: certifiableUserId, state: Assessment.states.STARTED, type: Assessment.types.CERTIFICATION, createdAt: limitDate });
-  competencesAssociatedSkillsAndChallenges.forEach((element) => {
+  competenceIdSkillIdPairs.forEach((element) => {
     const { challengeId, competenceId } = element;
     buildCertificationChallenge({ courseId: certificationCourseId, challengeId, competenceId });
     buildAnswer({ assessmentId: certificationAssessment.id, challengeId, result: 'ok' });

--- a/api/tests/tooling/database-builder/factory/build-correct-answer-and-knowledge-element.js
+++ b/api/tests/tooling/database-builder/factory/build-correct-answer-and-knowledge-element.js
@@ -1,0 +1,30 @@
+const buildAssessment = require('./build-assessment');
+const buildAnswer = require('./build-answer');
+const buildKnowledgeElement = require('./build-knowledge-element');
+
+const buildCorrectAnswerAndKnowledgeElement = async function({
+  userId,
+  competenceId,
+  challengeId,
+  pixValue,
+  acquisitionDate,
+  skillId
+}) {
+  const assessmentId = buildAssessment({ userId }).id;
+  const answerId = buildAnswer({
+    assessmentId,
+    challengeId
+  }).id;
+  buildKnowledgeElement({
+    userId,
+    assessmentId,
+    earnedPix: pixValue,
+    competenceId,
+    answerId,
+    createdAt: acquisitionDate,
+    skillId
+  });
+};
+
+module.exports = buildCorrectAnswerAndKnowledgeElement;
+

--- a/api/tests/tooling/database-builder/factory/build-correct-answers-and-knowledge-elements-for-learning-content.js
+++ b/api/tests/tooling/database-builder/factory/build-correct-answers-and-knowledge-elements-for-learning-content.js
@@ -1,0 +1,36 @@
+const buildCorrectAnswerAndKnowledgeElement = require('./build-correct-answer-and-knowledge-element');
+
+const buildCorrectAnswersAndKnowledgeElementsForLearningContent = function(
+  {
+    learningContent,
+    userId,
+    placementDate,
+    earnedPix,
+  }) {
+  const competenceIdSkillIdPairs = [];
+  learningContent.forEach((area) => {
+    area.competences.forEach((competence) => {
+      competence.tubes.forEach((tube) => {
+        tube.skills.forEach((skill) => {
+          competenceIdSkillIdPairs.push({ competenceId: competence.id, skillId: skill.id });
+          skill.challenges.forEach((challenge) => {
+            buildCorrectAnswerAndKnowledgeElement(
+              {
+                userId,
+                competenceId: competence.id,
+                skillId: skill.id,
+                challengeId: challenge.id,
+                pixValue: earnedPix,
+                acquisitionDate: placementDate
+              }
+            );
+          });
+        });
+      });
+    });
+  });
+  return competenceIdSkillIdPairs;
+};
+
+module.exports = buildCorrectAnswersAndKnowledgeElementsForLearningContent;
+

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -24,6 +24,8 @@ module.exports = {
   buildCertificationReport: require('./build-certification-report'),
   buildCompetenceEvaluation: require('./build-competence-evaluation'),
   buildCompetenceMark: require('./build-competence-mark'),
+  buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
+  buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildOrganization: require('./build-organization'),


### PR DESCRIPTION
## :unicorn: Problème
1. Lors d'un précédent refacto (voir ici : #1694 ) on s'est aperçu qu'il était possible de casser l'algorithme de sélection des épreuves de certification sans faire passer aucun test au rouge, il nous a fallu passer par un `git bisect` avec un script de generation de 100+ tests de certification pre- et post-refacto pour identifier l'endroit de la regression. 

2. Les tests actuellement en place sur cet algorithme font intervenir de nombreux stubs et mock (récupération des `KnowledgeElements`, récupération d'un `placementProfile`, récupération du contenu depuis _Airtable_) ce qui ne permet pas de faire un refacto en profondeur sereinement.   

3. Le set-up de ces tests est extrêmement verbeux car il faut mettre en place :
- le referentiel _Airtable_
- les `KnowledgeElements`
- les `Answers`
Ce qui rend les tests incompréhensibles et fatiguants à lire dès le `beforeEach` sans même avoir encore regarder les `assert`

## :robot: Solution
1. Couvrir tout les cas limites:
- Epreuve supprimée dans _Airtable_
- Compétences non-pix
- Questions non-franco-françaises
- Compétence ayant moins de 3 épreuves dans le référentiel
- Epreuve validant différents acquis (`QROCmDep`)

2. Passer par des tests d'intégration qui permettent de couvrir tout la chaine : récupération des données, arrangement des données, algorithme de selection sur les données arrangées et ainsi de refactorer tout la structure interne sans dépendre de signatures de méthodes/stub/mocks.

3. Mettre en place des helpers de tests qui permettent de mettre en place simplement un référentiel _Airtable_ ainsi que des `KnowledgeElements`. Objectif : garder un contexte clair et concis dans le `// given` des tests tout en cachant un maximum de bruit pour ne pas épuiser la charge cognitive lors de leur lecture. 

## :rainbow: Remarques
RAS

## :100: Pour tester
Iso-fonctionnel : seul les tests et les helpers de tests ont été modifiés, aucun code de production.