### PR TITLE
[TECH] test && commit || revert

### DIFF
--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -1,20 +1,31 @@
 #!/usr/bin/env bash
-
 alteredFilePaths=$(git ls-files -m '*.js');
+files=$@
+
+function lint () {
+  npx eslint $alteredFilePaths --fix
+}
+
+function test () {
+  npm run test:api:path $files -- --bail
+}
+
+function commit () {
+  echo "TCR => COMMIT"
+  git commit -am "TCR:WIP"
+}
+
+function revert () {
+  echo "TCR => REVERT"
+  git checkout HEAD lib/
+}
 
 if [ ! -z "$alteredFilePaths" ] ; then
-  if npx eslint $alteredFilePaths --fix ; then
-    if npm run test:api:path $@ -- --bail; then
-      echo "TCR => COMMIT"
-      git commit -am "TCR:WIP"
-    else
-      echo "TCR => REVERT"
-      git checkout HEAD lib/
-    fi
+  if lint ; then
+    test && commit || revert
   else
     echo "TCR => ABORT"
   fi
 else
   echo "TCR => NOTHING HAS CHANGED"
 fi
-

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -1,0 +1,18 @@
+alteredFilePaths=$(git ls-files -m '*.js');
+
+if [ ! -z "$alteredFilePaths" ] ; then
+  if eslint $alteredFilePaths --fix ; then
+    if npm run test:api:path $@ -- --bail; then
+      echo "TCR => COMMIT"
+      git commit -am "TCR:WIP"
+    else
+      echo "TCR => REVERT"
+      git checkout HEAD lib/
+    fi
+  else
+    echo "TCR => ABORT"
+  fi
+else
+  echo "TCR => NOTHING HAS CHANGED"
+fi
+

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 alteredFilePaths=$(git ls-files -m '*.js');
 
 if [ ! -z "$alteredFilePaths" ] ; then

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -3,7 +3,7 @@
 alteredFilePaths=$(git ls-files -m '*.js');
 
 if [ ! -z "$alteredFilePaths" ] ; then
-  if eslint $alteredFilePaths --fix ; then
+  if npx eslint $alteredFilePaths --fix ; then
     if npm run test:api:path $@ -- --bail; then
       echo "TCR => COMMIT"
       git commit -am "TCR:WIP"

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -22,7 +22,7 @@ function revert () {
 
 if [ ! -z "$alteredFilePaths" ] ; then
   if lint ; then
-    test && commit || revert
+    if test ; then commit ; else revert ; fi
   else
     echo "TCR => ABORT"
   fi

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -20,7 +20,7 @@ function revert () {
   git checkout HEAD lib/
 }
 
-if [ ! -z "$alteredFilePaths" ] ; then
+if [ -n "$alteredFilePaths" ] ; then
   if lint ; then
     if test ; then commit ; else revert ; fi
   else

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -4,10 +4,12 @@ alteredFilePaths=$(git ls-files -m '*.js');
 files=( "$@" )
 
 function _lint () {
+  echo "TCR => LINT"
   npx eslint $alteredFilePaths --fix
 }
 
 function _test () {
+  echo "TCR => TEST"
   npm run test:api:path "${files[0]}" -- --bail
 }
 

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
+
 alteredFilePaths=$(git ls-files -m '*.js');
-files=$@
+files=( "$@" )
 
 function lint () {
   npx eslint $alteredFilePaths --fix
 }
 
 function test () {
-  npm run test:api:path $files -- --bail
+  npm run test:api:path "${files[0]}" -- --bail
 }
 
 function commit () {

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -3,27 +3,27 @@
 alteredFilePaths=$(git ls-files -m '*.js');
 files=( "$@" )
 
-function lint () {
+function _lint () {
   npx eslint $alteredFilePaths --fix
 }
 
-function test () {
+function _test () {
   npm run test:api:path "${files[0]}" -- --bail
 }
 
-function commit () {
+function _commit () {
   echo "TCR => COMMIT"
   git commit -am "TCR:WIP"
 }
 
-function revert () {
+function _revert () {
   echo "TCR => REVERT"
   git checkout HEAD lib/
 }
 
 if [ -n "$alteredFilePaths" ] ; then
-  if lint ; then
-    if test ; then commit ; else revert ; fi
+  if _lint ; then
+    if _test ; then _commit ; else _revert ; fi
   else
     echo "TCR => ABORT"
   fi

--- a/api/scripts/tcr/tcr.sh
+++ b/api/scripts/tcr/tcr.sh
@@ -23,12 +23,13 @@ function _revert () {
   git checkout HEAD lib/
 }
 
-if [ -n "$alteredFilePaths" ] ; then
-  if _lint ; then
-    if _test ; then _commit ; else _revert ; fi
-  else
-    echo "TCR => ABORT"
-  fi
-else
+if [ -z "$alteredFilePaths" ] ; then
   echo "TCR => NOTHING HAS CHANGED"
+  exit 1
 fi
+
+if ! _lint ; then
+  exit 1
+fi
+
+if _test ; then _commit ; else _revert ; fi


### PR DESCRIPTION
## :unicorn: Problème
On souhaite s'essayer au `test && commit || revert` (dit TCR).

[TCR c'est quoi ?](https://blog.zenika.com/2018/12/03/tdd-est-mort-longue-vie-tcr/)

## :robot: Solution
Il existe plusieurs variante de TCR décrites [dans cet article](https://medium.com/@tdeniffel/tcr-variants-test-commit-revert-bf6bd84b17d3).

La variante choisie à ce stade est la variante "_Gentle_":
- Pas de revert sur le code de prod en raison d'une erreur de syntaxe
- Si les tests ne passent pas, seul le code de prod est revert, le code de test est conservé.

## :rainbow: Remarques
Workflow : 

1. J'écris un test 
2. Je le lance pour vérifier qu'il est rouge (même chose que pour TDD) pour m'assurer : 
  - il vient créer un besoin de comportement nouveau
  - que le message d'erreur quand le tests échoue est suffisamment explicite
3. J'écris le code de prod pour faire passer le test
4. je lance ./script/tcr/tcr.sh api/tests/chemin/vers/mon/fichier/de/test/1 api/tests/chemin/vers/mon/fichier/de/test/2 ...
Si les tests passent, un commit a été créé. S'ils échouent, je retente ma chance en :
- tentant une autre implem pour faire passer le test
- écrivant un tests plus petit

## :100: Pour tester
Voir ci-dessus.
