### PR TITLE
[FEATURE] Afficher une bannière invitant les membres d'une organisation SCO à importer des élèves si ce n'est pas fait après une certaine date (PIX-1085)

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -232,7 +232,8 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     lastName: userWithEmailAndUsername.lastName,
     birthdate: '2003-09-30',
     organizationId: SCO2OrganizationId,
-    nationalStudentId: INE
+    nationalStudentId: INE,
+    createdAt: new Date('2020-08-14')
   });
 
   databaseBuilder.factory.buildSchoolingRegistration({
@@ -241,7 +242,8 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     lastName: userWithEmailAndUsername.lastName,
     birthdate: '2003-09-30',
     organizationId: SCO2OrganizationId,
-    nationalStudentId: anotherINE
+    nationalStudentId: anotherINE,
+    createdAt: new Date('2020-08-14')
   });
 
 };

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const moment = require('moment');
 
 function parseJSONEnv(varName) {
   if (process.env[varName]) {
@@ -14,6 +15,18 @@ function isFeatureEnabled(environmentVariable) {
 function _getNumber(numberAsString, defaultIntNumber) {
   const number = parseInt(numberAsString, 10);
   return isNaN(number) ? defaultIntNumber : number;
+}
+
+function _getDate(dateAsString) {
+  if (!dateAsString) {
+    return null;
+  }
+  const dateAsMoment = moment(dateAsString);
+  if (!dateAsMoment.isValid()) {
+    return null;
+  }
+
+  return dateAsMoment.toDate();
 }
 
 module.exports = (function() {
@@ -117,6 +130,7 @@ module.exports = (function() {
       dayBeforeImproving: _getNumber(process.env.DAY_BEFORE_IMPROVING, 4),
       dayBeforeCompetenceResetV2: _getNumber(process.env.DAY_BEFORE_COMPETENCE_RESET_V2,7),
       garAccessV2: isFeatureEnabled(process.env.GAR_ACCESS_V2),
+      newYearSchoolingRegistrationsImportDate: _getDate(process.env.NEW_YEAR_SCHOOLING_REGISTRATIONS_IMPORT_DATE),
     },
 
     infra: {

--- a/api/lib/domain/read-models/Prescriber.js
+++ b/api/lib/domain/read-models/Prescriber.js
@@ -5,7 +5,7 @@ class Prescriber {
     firstName,
     lastName,
     pixOrgaTermsOfServiceAccepted,
-    areNewYearStudentsImported,
+    areNewYearSchoolingRegistrationsImported,
     // includes
     memberships = [],
     userOrgaSettings,
@@ -14,7 +14,7 @@ class Prescriber {
     this.firstName = firstName;
     this.lastName = lastName;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
-    this.areNewYearStudentsImported = areNewYearStudentsImported;
+    this.areNewYearSchoolingRegistrationsImported = areNewYearSchoolingRegistrationsImported;
     // includes
     this.memberships = memberships;
     this.userOrgaSettings = userOrgaSettings;

--- a/api/lib/domain/read-models/Prescriber.js
+++ b/api/lib/domain/read-models/Prescriber.js
@@ -5,6 +5,7 @@ class Prescriber {
     firstName,
     lastName,
     pixOrgaTermsOfServiceAccepted,
+    areNewYearStudentsImported,
     // includes
     memberships = [],
     userOrgaSettings,
@@ -13,6 +14,7 @@ class Prescriber {
     this.firstName = firstName;
     this.lastName = lastName;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
+    this.areNewYearStudentsImported = areNewYearStudentsImported;
     // includes
     this.memberships = memberships;
     this.userOrgaSettings = userOrgaSettings;

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -56,7 +56,7 @@ function _toUserOrgaSettingsDomain(userOrgaSettingsBookshelf) {
   });
 }
 
-async function _areNewYearStudentsImportedForPrescriber(prescriber) {
+async function _areNewYearSchoolingRegistrationsImportedForPrescriber(prescriber) {
   const currentOrganizationId = prescriber.userOrgaSettings.id ?
     prescriber.userOrgaSettings.currentOrganization.id :
     prescriber.memberships[0].organization.id;
@@ -67,7 +67,7 @@ async function _areNewYearStudentsImportedForPrescriber(prescriber) {
     .where('schooling-registrations.createdAt', '>=', DATE_FOR_IMPORT_BANNER)
     .first();
 
-  prescriber.areNewYearStudentsImported = Boolean(atLeastOneSchoolingRegistration);
+  prescriber.areNewYearSchoolingRegistrationsImported = Boolean(atLeastOneSchoolingRegistration);
 }
 
 module.exports = {
@@ -90,7 +90,7 @@ module.exports = {
         throw new ForbiddenAccess(`User of ID ${userId} is not a prescriber`);
       }
 
-      await _areNewYearStudentsImportedForPrescriber(prescriber);
+      await _areNewYearSchoolingRegistrationsImportedForPrescriber(prescriber);
 
       return prescriber;
     } catch (err) {

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -61,7 +61,7 @@ module.exports = {
         .fetch({ require: true,
           columns: ['id','firstName','lastName', 'pixOrgaTermsOfServiceAccepted'],
           withRelated: [
-            { 'memberships': (qb) => qb.where({ disabledAt: null }) },
+            { 'memberships': (qb) => qb.where({ disabledAt: null }).orderBy('id') },
             'memberships.organization',
             'userOrgaSettings',
             'userOrgaSettings.currentOrganization',

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -21,8 +21,8 @@ module.exports = {
       },
 
       attributes: [
-        'firstName', 'lastName', 'pixOrgaTermsOfServiceAccepted', 'areNewYearStudentsImported',
-        'memberships', 'userOrgaSettings', 
+        'firstName', 'lastName', 'pixOrgaTermsOfServiceAccepted', 'areNewYearSchoolingRegistrationsImported',
+        'memberships', 'userOrgaSettings',
       ],
       memberships: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -21,8 +21,8 @@ module.exports = {
       },
 
       attributes: [
-        'firstName', 'lastName', 'pixOrgaTermsOfServiceAccepted',
-        'memberships', 'userOrgaSettings'
+        'firstName', 'lastName', 'pixOrgaTermsOfServiceAccepted', 'areNewYearStudentsImported',
+        'memberships', 'userOrgaSettings', 
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -23,7 +23,8 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
         attributes: {
           'first-name': user.firstName,
           'last-name': user.lastName,
-          'pix-orga-terms-of-service-accepted': false
+          'pix-orga-terms-of-service-accepted': false,
+          'are-new-year-students-imported': false
         },
         relationships: {
           memberships: {

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
           'first-name': user.firstName,
           'last-name': user.lastName,
           'pix-orga-terms-of-service-accepted': false,
-          'are-new-year-students-imported': false
+          'are-new-year-schooling-registrations-imported': false
         },
         relationships: {
           memberships: {

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -156,7 +156,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
 
       context('when prescriber has a user-orga-settings', () => {
 
-        it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
+        it('should return areNewYearSchoolingRegistrationsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -169,10 +169,10 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
           const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
           // then
-          expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+          expect(foundPrescriber.areNewYearSchoolingRegistrationsImported).to.be.true;
         });
 
-        it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
+        it('should return areNewYearSchoolingRegistrationsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -185,14 +185,14 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
           const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
           // then
-          expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
+          expect(foundPrescriber.areNewYearSchoolingRegistrationsImported).to.be.false;
         });
 
       });
 
       context('when prescriber does not have a user-orga-settings', () => {
 
-        it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
+        it('should return areNewYearSchoolingRegistrationsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -204,10 +204,10 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
           const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
           // then
-          expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+          expect(foundPrescriber.areNewYearSchoolingRegistrationsImported).to.be.true;
         });
 
-        it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
+        it('should return areNewYearSchoolingRegistrationsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
           // given
           const userId = databaseBuilder.factory.buildUser().id;
           const organizationId = databaseBuilder.factory.buildOrganization().id;
@@ -219,7 +219,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
           const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
           // then
-          expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
+          expect(foundPrescriber.areNewYearSchoolingRegistrationsImported).to.be.false;
         });
 
       });

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -34,6 +34,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
       user = databaseBuilder.factory.buildUser(userToInsert);
       organization = databaseBuilder.factory.buildOrganization();
       membership = databaseBuilder.factory.buildMembership({
+        id: 3000001,
         userId: user.id,
         organizationId: organization.id,
       });
@@ -92,6 +93,20 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
       expect(associatedOrganization.code).to.equal(organization.code);
       expect(associatedOrganization.name).to.equal(organization.name);
       expect(associatedOrganization.type).to.equal(organization.type);
+    });
+
+    it('should return memberships ordered by id', async () => {
+      // given
+      const anotherMembership = databaseBuilder.factory.buildMembership({ id: 3000000, userId: user.id });
+      expectedPrescriber.memberships = [membership, anotherMembership];
+      await databaseBuilder.commit();
+
+      // when
+      const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+      // then
+      expect(foundPrescriber.memberships[0].id).to.equal(3000000);
+      expect(foundPrescriber.memberships[1].id).to.equal(3000001);
     });
 
     context('when the membership associated to the prescriber has been disabled', () => {

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -2,7 +2,7 @@ const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
 const faker = require('faker');
 const bcrypt = require('bcrypt');
 
-const { UserNotFoundError } = require('../../../../lib/domain/errors');
+const { ForbiddenAccess, UserNotFoundError } = require('../../../../lib/domain/errors');
 const prescriberRepository = require('../../../../lib/infrastructure/repositories/prescriber-repository');
 const Prescriber = require('../../../../lib/domain/read-models/Prescriber');
 const Membership = require('../../../../lib/domain/models/Membership');
@@ -30,182 +30,199 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
 
     let expectedPrescriber;
 
-    beforeEach(async () => {
-      user = databaseBuilder.factory.buildUser(userToInsert);
-      organization = databaseBuilder.factory.buildOrganization();
-      membership = databaseBuilder.factory.buildMembership({
-        id: 3000001,
-        userId: user.id,
-        organizationId: organization.id,
+    context('when user is not a prescriber', () => {
+
+      it('should throw a ForbiddenAccess error', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(prescriberRepository.getPrescriber)(userId);
+
+        // then
+        expect(error).to.be.an.instanceOf(ForbiddenAccess);
       });
-      userOrgaSettings = databaseBuilder.factory.buildUserOrgaSettings({
-        userId: user.id, currentOrganizationId: organization.id
+    });
+
+    context('when user is a prescriber', () => {
+
+      beforeEach(async () => {
+        user = databaseBuilder.factory.buildUser(userToInsert);
+        organization = databaseBuilder.factory.buildOrganization();
+        membership = databaseBuilder.factory.buildMembership({
+          id: 3000001,
+          userId: user.id,
+          organizationId: organization.id,
+        });
+        userOrgaSettings = databaseBuilder.factory.buildUserOrgaSettings({
+          userId: user.id, currentOrganizationId: organization.id
+        });
+
+        await databaseBuilder.commit();
+
+        expectedPrescriber = {
+          id: user.id,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+        };
       });
 
-      await databaseBuilder.commit();
+      it('should return the found prescriber', async () => {
+        // when
+        const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
 
-      expectedPrescriber = {
-        id: user.id,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-      };
-    });
+        // then
+        expect(foundPrescriber).to.be.an.instanceOf(Prescriber);
+        expect(foundPrescriber.id).to.equal(expectedPrescriber.id);
+        expect(foundPrescriber.firstName).to.equal(expectedPrescriber.firstName);
+        expect(foundPrescriber.lastName).to.equal(expectedPrescriber.lastName);
+        expect(foundPrescriber.pixOrgaTermsOfServiceAccepted).to.equal(expectedPrescriber.pixOrgaTermsOfServiceAccepted);
+      });
 
-    it('should return the found prescriber', async () => {
-      // when
-      const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+      it('should return a UserNotFoundError if no user is found', async () => {
+        // given
+        const nonExistentUserId = 678;
 
-      // then
-      expect(foundPrescriber).to.be.an.instanceOf(Prescriber);
-      expect(foundPrescriber.id).to.equal(expectedPrescriber.id);
-      expect(foundPrescriber.firstName).to.equal(expectedPrescriber.firstName);
-      expect(foundPrescriber.lastName).to.equal(expectedPrescriber.lastName);
-      expect(foundPrescriber.pixOrgaTermsOfServiceAccepted).to.equal(expectedPrescriber.pixOrgaTermsOfServiceAccepted);
-    });
+        // when
+        const result = await catchErr(prescriberRepository.getPrescriber)(nonExistentUserId);
 
-    it('should return a UserNotFoundError if no user is found', async () => {
-      // given
-      const nonExistentUserId = 678;
+        // then
+        expect(result).to.be.instanceOf(UserNotFoundError);
+      });
 
-      // when
-      const result = await catchErr(prescriberRepository.getPrescriber)(nonExistentUserId);
+      it('should return memberships associated to the prescriber', async () => {
+        // given
+        expectedPrescriber.memberships = [membership];
 
-      // then
-      expect(result).to.be.instanceOf(UserNotFoundError);
-    });
+        // when
+        const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
 
-    it('should return memberships associated to the prescriber', async () => {
-      // given
-      expectedPrescriber.memberships = [membership];
+        // then
+        const firstMembership = foundPrescriber.memberships[0];
+        expect(firstMembership).to.be.an.instanceof(Membership);
+        expect(firstMembership.id).to.equal(expectedPrescriber.memberships[0].id);
 
-      // when
-      const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+        const associatedOrganization = firstMembership.organization;
+        expect(associatedOrganization).to.be.an.instanceof(Organization);
+        expect(associatedOrganization.id).to.equal(organization.id);
+        expect(associatedOrganization.code).to.equal(organization.code);
+        expect(associatedOrganization.name).to.equal(organization.name);
+        expect(associatedOrganization.type).to.equal(organization.type);
+      });
 
-      // then
-      const firstMembership = foundPrescriber.memberships[0];
-      expect(firstMembership).to.be.an.instanceof(Membership);
-      expect(firstMembership.id).to.equal(expectedPrescriber.memberships[0].id);
+      it('should return memberships ordered by id', async () => {
+        // given
+        const anotherMembership = databaseBuilder.factory.buildMembership({ id: 3000000, userId: user.id });
+        expectedPrescriber.memberships = [membership, anotherMembership];
+        await databaseBuilder.commit();
 
-      const associatedOrganization = firstMembership.organization;
-      expect(associatedOrganization).to.be.an.instanceof(Organization);
-      expect(associatedOrganization.id).to.equal(organization.id);
-      expect(associatedOrganization.code).to.equal(organization.code);
-      expect(associatedOrganization.name).to.equal(organization.name);
-      expect(associatedOrganization.type).to.equal(organization.type);
-    });
+        // when
+        const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
 
-    it('should return memberships ordered by id', async () => {
-      // given
-      const anotherMembership = databaseBuilder.factory.buildMembership({ id: 3000000, userId: user.id });
-      expectedPrescriber.memberships = [membership, anotherMembership];
-      await databaseBuilder.commit();
+        // then
+        expect(foundPrescriber.memberships[0].id).to.equal(3000000);
+        expect(foundPrescriber.memberships[1].id).to.equal(3000001);
+      });
 
-      // when
-      const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+      it('should return user-orga-settings associated to the prescriber', async () => {
+        // given
+        expectedPrescriber.userOrgaSettings = userOrgaSettings;
 
-      // then
-      expect(foundPrescriber.memberships[0].id).to.equal(3000000);
-      expect(foundPrescriber.memberships[1].id).to.equal(3000001);
-    });
+        // when
+        const foundUser = await prescriberRepository.getPrescriber(user.id);
 
-    it('should return user-orga-settings associated to the prescriber', async () => {
-      // given
-      expectedPrescriber.userOrgaSettings = userOrgaSettings;
+        // then
+        expect(foundUser.userOrgaSettings).to.be.an.instanceOf(UserOrgaSettings);
+        expect(foundUser.userOrgaSettings.id).to.equal(expectedPrescriber.userOrgaSettings.id);
+        expect(foundUser.userOrgaSettings.currentOrganization.id).to.equal(expectedPrescriber.userOrgaSettings.currentOrganizationId);
+      });
 
-      // when
-      const foundUser = await prescriberRepository.getPrescriber(user.id);
-
-      // then
-      expect(foundUser.userOrgaSettings).to.be.an.instanceOf(UserOrgaSettings);
-      expect(foundUser.userOrgaSettings.id).to.equal(expectedPrescriber.userOrgaSettings.id);
-      expect(foundUser.userOrgaSettings.currentOrganization.id).to.equal(expectedPrescriber.userOrgaSettings.currentOrganizationId);
-    });
-
-    it('should return prescriber despite that user-orga-settings does not exists', async () => {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ userId, organizationId });
-
-      await databaseBuilder.commit();
-
-      // when
-      const foundPrescriber = await prescriberRepository.getPrescriber(userId);
-
-      // then
-      expect(foundPrescriber).to.be.an.instanceOf(Prescriber);
-    });
-
-    context('when prescriber has a user-orga-settings', () => {
-
-      it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
+      it('should return prescriber despite that user-orga-settings does not exists', async () => {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         databaseBuilder.factory.buildMembership({ userId, organizationId });
-        databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-08-17') });
+
         await databaseBuilder.commit();
 
         // when
         const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
         // then
-        expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+        expect(foundPrescriber).to.be.an.instanceOf(Prescriber);
       });
 
-      it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildMembership({ userId, organizationId });
-        databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-07-17') });
-        await databaseBuilder.commit();
+      context('when prescriber has a user-orga-settings', () => {
 
-        // when
-        const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+        it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({ userId, organizationId });
+          databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
+          databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-08-17') });
+          await databaseBuilder.commit();
 
-        // then
-        expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+
+          // then
+          expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+        });
+
+        it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the user-orga-settings', async () => {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({ userId, organizationId });
+          databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: organizationId });
+          databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-07-17') });
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+
+          // then
+          expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
+        });
+
       });
 
-    });
+      context('when prescriber does not have a user-orga-settings', () => {
 
-    context('when prescriber does not have a user-orga-settings', () => {
+        it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({ userId, organizationId });
+          databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-08-17') });
+          await databaseBuilder.commit();
 
-      it('should return areNewYearStudentsImported as true if there is at least one schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildMembership({ userId, organizationId });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-08-17') });
-        await databaseBuilder.commit();
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(userId);
 
-        // when
-        const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+          // then
+          expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+        });
 
-        // then
-        expect(foundPrescriber.areNewYearStudentsImported).to.be.true;
+        it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
+          // given
+          const userId = databaseBuilder.factory.buildUser().id;
+          const organizationId = databaseBuilder.factory.buildOrganization().id;
+          databaseBuilder.factory.buildMembership({ userId, organizationId });
+          databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-07-17') });
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(userId);
+
+          // then
+          expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
+        });
+
       });
-
-      it('should return areNewYearStudentsImported as false if there is no schooling-registrations created after 2020-08-15 for the organization of the first membership', async () => {
-        // given
-        const userId = databaseBuilder.factory.buildUser().id;
-        const organizationId = databaseBuilder.factory.buildOrganization().id;
-        databaseBuilder.factory.buildMembership({ userId, organizationId });
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, createdAt: new Date('2020-07-17') });
-        await databaseBuilder.commit();
-
-        // when
-        const foundPrescriber = await prescriberRepository.getPrescriber(userId);
-
-        // then
-        expect(foundPrescriber.areNewYearStudentsImported).to.be.false;
-      });
-
     });
   });
-
 });

--- a/api/tests/tooling/database-builder/factory/build-schooling-registration.js
+++ b/api/tests/tooling/database-builder/factory/build-schooling-registration.js
@@ -27,6 +27,7 @@ module.exports = function buildSchoolingRegistration({
   department = faker.name.jobArea(),
   group = faker.random.alphaNumeric(3),
   diploma = faker.name.jobType(),
+  createdAt = faker.date.recent(),
   organizationId,
   userId,
 } = {}) {
@@ -55,6 +56,7 @@ module.exports = function buildSchoolingRegistration({
     department,
     group,
     diploma,
+    createdAt,
     organizationId,
     userId,
   };

--- a/api/tests/tooling/domain-builder/factory/build-prescriber.js
+++ b/api/tests/tooling/domain-builder/factory/build-prescriber.js
@@ -53,6 +53,7 @@ module.exports = function buildPrescriber(
     firstName = faker.name.firstName(),
     lastName = faker.name.lastName(),
     pixOrgaTermsOfServiceAccepted = false,
+    areNewYearStudentsImported = false,
     memberships = _buildMemberships(),
     userOrgaSettings = _buildUserOrgaSettings()
   } = {}) {
@@ -60,6 +61,7 @@ module.exports = function buildPrescriber(
   return new Prescriber({
     id, firstName, lastName,
     pixOrgaTermsOfServiceAccepted,
+    areNewYearStudentsImported,
     memberships, userOrgaSettings
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-prescriber.js
+++ b/api/tests/tooling/domain-builder/factory/build-prescriber.js
@@ -53,7 +53,7 @@ module.exports = function buildPrescriber(
     firstName = faker.name.firstName(),
     lastName = faker.name.lastName(),
     pixOrgaTermsOfServiceAccepted = false,
-    areNewYearStudentsImported = false,
+    areNewYearSchoolingRegistrationsImported = false,
     memberships = _buildMemberships(),
     userOrgaSettings = _buildUserOrgaSettings()
   } = {}) {
@@ -61,7 +61,7 @@ module.exports = function buildPrescriber(
   return new Prescriber({
     id, firstName, lastName,
     pixOrgaTermsOfServiceAccepted,
-    areNewYearStudentsImported,
+    areNewYearSchoolingRegistrationsImported,
     memberships, userOrgaSettings
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -14,7 +14,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
           'first-name': prescriber.firstName,
           'last-name': prescriber.lastName,
           'pix-orga-terms-of-service-accepted': prescriber.pixOrgaTermsOfServiceAccepted,
-          'are-new-year-students-imported': prescriber.areNewYearStudentsImported
+          'are-new-year-schooling-registrations-imported': prescriber.areNewYearSchoolingRegistrationsImported
         },
         relationships: {
           memberships: {
@@ -126,7 +126,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       const prescriber = domainBuilder.buildPrescriber({
         firstName: user.firstName,
         lastName: user.lastName,
-        areNewYearStudentsImported: false,
+        areNewYearSchoolingRegistrationsImported: false,
         pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
         memberships: [membership],
         userOrgaSettings

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -14,6 +14,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
           'first-name': prescriber.firstName,
           'last-name': prescriber.lastName,
           'pix-orga-terms-of-service-accepted': prescriber.pixOrgaTermsOfServiceAccepted,
+          'are-new-year-students-imported': prescriber.areNewYearStudentsImported
         },
         relationships: {
           memberships: {
@@ -125,7 +126,8 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       const prescriber = domainBuilder.buildPrescriber({
         firstName: user.firstName,
         lastName: user.lastName,
-        pixOrgaTermsOfServiceAccepted:  user.pixOrgaTermsOfServiceAccepted,
+        areNewYearStudentsImported: false,
+        pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
         memberships: [membership],
         userOrgaSettings
       });

--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -1,0 +1,5 @@
+{{#if this.informationBannerMustBeDisplayed}}
+  <PixBanner @actionLabel='Importer la base Élèves' @actionUrl='authenticated.sco-students'>
+      Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga (<a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" target="_blank" rel="noopener noreferrer">plus d'info <FaIcon @icon="external-link-alt" /></a>)
+  </PixBanner>
+{{/if}}

--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -1,0 +1,11 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class InformationBanner extends Component {
+  @service currentUser;
+
+  get informationBannerMustBeDisplayed() {
+    return !this.currentUser.prescriber.areNewYearStudentsImported &&
+      this.currentUser.isSCOManagingStudents;
+  }
+}

--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -5,7 +5,7 @@ export default class InformationBanner extends Component {
   @service currentUser;
 
   get informationBannerMustBeDisplayed() {
-    return !this.currentUser.prescriber.areNewYearStudentsImported &&
+    return !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported &&
       this.currentUser.isSCOManagingStudents;
   }
 }

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -6,6 +6,7 @@ export default class Prescriber extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
+  @attr('boolean') areNewYearStudentsImported;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
 

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -6,7 +6,7 @@ export default class Prescriber extends Model {
   @attr('string') firstName;
   @attr('string') lastName;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
-  @attr('boolean') areNewYearStudentsImported;
+  @attr('boolean') areNewYearSchoolingRegistrationsImported;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
 

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -15,6 +15,8 @@
       <div class="topbar__user-logged-menu"><UserLoggedMenu /></div>
     </div>
 
+    <InformationBanner/>
+
     <div class="main-content__body page">
       {{outlet}}
     </div>

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -12,6 +12,7 @@ module.exports = function() {
       'eye',
       'eye-slash',
       'exclamation-triangle',
+      'external-link-alt',
       'hourglass-half',
       'link',
       'power-off',

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -2721,9 +2721,9 @@
       }
     },
     "@emotion/core": {
-      "version": "10.0.28",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.28.tgz",
-      "integrity": "sha512-pH8UueKYO5jgg0Iq+AmCLxBsvuGtvlmiDCOuv8fGNYn3cowFpLN98L8zO56U0H1PjDIyAlXymgL3Wu7u7v6hbA==",
+      "version": "10.0.35",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.35.tgz",
+      "integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
@@ -2777,6 +2777,14 @@
         "@emotion/unitless": "0.7.5",
         "@emotion/utils": "0.11.3",
         "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.13",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+          "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+          "dev": true
+        }
       }
     },
     "@emotion/sheet": {
@@ -3233,9 +3241,9 @@
       }
     },
     "@reach/router": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.3.tgz",
-      "integrity": "sha512-gOIAiFhWdiVGSVjukKeNKkCRBLmnORoTPyBihI/jLunICPgxdP30DroAvPQuf1eVfQbfGJQDJkwhJXsNPMnVWw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
+      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
       "dev": true,
       "requires": {
         "create-react-context": "0.3.0",
@@ -3291,26 +3299,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "@storybook/addon-centered": {
-      "version": "5.3.19",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.19.tgz",
-      "integrity": "sha512-uOgGF0WGM8a15ap266zplG20F79DyPvGpqzYhLXvbrOlUn+13yit3kCZpL3V5to4iQKQjpVL5wj1RJI8ar+JZw==",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "5.3.19",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.6.5",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-          "dev": true
-        }
-      }
     },
     "@storybook/addon-notes": {
       "version": "5.3.19",
@@ -3678,9 +3666,9 @@
       }
     },
     "@types/history": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.6.tgz",
-      "integrity": "sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
+      "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg==",
       "dev": true
     },
     "@types/is-function": {
@@ -3748,13 +3736,13 @@
       }
     },
     "@types/react": {
-      "version": "16.9.36",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.36.tgz",
-      "integrity": "sha512-mGgUb/Rk/vGx4NCvquRuSH0GHBQKb1OqpGS9cT9lFxlTLHZgkksgI60TuIxubmn7JuCb+sENHhQciqa0npm0AQ==",
+      "version": "16.9.46",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz",
+      "integrity": "sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "csstype": "^3.0.2"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -4540,35 +4528,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -8691,9 +8650,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-      "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
+      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
       "dev": true
     },
     "cyclist": {
@@ -8921,10 +8880,10 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
-    "detect-node": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
-      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+    "detect-node-es": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
+      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==",
       "dev": true
     },
     "diff": {
@@ -15567,9 +15526,9 @@
       }
     },
     "focus-lock": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.8.tgz",
-      "integrity": "sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
+      "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==",
       "dev": true
     },
     "follow-redirects": {
@@ -17160,6 +17119,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
+      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
       "dev": true
     },
     "json-schema": {
@@ -19197,14 +19162,14 @@
       }
     },
     "parse-json": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-      "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
     },
@@ -19378,18 +19343,15 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#24dba32eb25000e5ee276d8d6bf20b4f156d84db",
-      "from": "git://github.com/1024pix/pix-ui.git#v0.2.0",
+      "version": "git://github.com/1024pix/pix-ui.git#534aae10689dd8ffea5e6850df720badb298bc02",
+      "from": "git://github.com/1024pix/pix-ui.git#v0.8.0",
       "dev": true,
       "requires": {
-        "@storybook/addon-centered": "^5.3.19",
         "@storybook/addon-notes": "^5.3.19",
-        "axios": "^0.19.2",
         "ember-cli-babel": "^7.18.0",
         "ember-cli-htmlbars": "^4.2.3",
         "ember-cli-sass": "^10.0.1",
-        "moment": "^2.26.0",
-        "sass": "^1.26.5"
+        "ember-cli-string-utils": "^1.1.0"
       }
     },
     "pkg-dir": {
@@ -20008,9 +19970,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "dev": true,
       "requires": {
         "clipboard": "^2.0.0"
@@ -20390,13 +20352,13 @@
       "dev": true
     },
     "react-focus-lock": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.3.1.tgz",
-      "integrity": "sha512-j15cWLPzH0gOmRrUg01C09Peu8qbcdVqr6Bjyfxj80cNZmH+idk/bNBYEDSmkAtwkXI+xEYWSmHYqtaQhZ8iUQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.4.1.tgz",
+      "integrity": "sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.6.7",
+        "focus-lock": "^0.7.0",
         "prop-types": "^15.6.2",
         "react-clientside-effect": "^1.2.2",
         "use-callback-ref": "^1.2.1",
@@ -22004,9 +21966,9 @@
       "dev": true
     },
     "store2": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/store2/-/store2-2.11.2.tgz",
-      "integrity": "sha512-TQMKs+C6n9idtzLpxluikmDCYiDJrTbbIGn9LFxMg0BVTu+8JZKSlXTWYRpOFKlfKD5HlDWLVpJJyNGZ2e9l1A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
+      "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
     },
     "stream-browserify": {
@@ -23167,12 +23129,12 @@
       "dev": true
     },
     "use-sidecar": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.2.tgz",
-      "integrity": "sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.3.tgz",
+      "integrity": "sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==",
       "dev": true,
       "requires": {
-        "detect-node": "^2.0.4",
+        "detect-node-es": "^1.0.0",
         "tslib": "^1.9.3"
       }
     },

--- a/orga/package.json
+++ b/orga/package.json
@@ -79,7 +79,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v0.2.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v0.8.0",
     "query-string": "^6.13.1",
     "qunit-dom": "^0.9.2",
     "sass": "^1.22.12"

--- a/orga/tests/acceptance/information-banner-test.js
+++ b/orga/tests/acceptance/information-banner-test.js
@@ -24,7 +24,7 @@ module('Acceptance | Information Banner', function(hooks) {
       server.create('prescriber', {
         id: user.id,
         pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-        areNewYearStudentsImported: false,
+        areNewYearSchoolingRegistrationsImported: false,
         memberships: user.memberships,
         userOrgaSettings: user.userOrgaSettings,
       });

--- a/orga/tests/acceptance/information-banner-test.js
+++ b/orga/tests/acceptance/information-banner-test.js
@@ -1,0 +1,46 @@
+import { module, test } from 'qunit';
+import { visit, click, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Information Banner', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('ImportStudents banner', function() {
+
+    test('should redirect to /eleves when clicking on banner button', async function(assert) {
+      // given
+      const user = server.create('user', { pixOrgaTermsOfServiceAccepted: true });
+      const organization = server.create('organization', { type: 'SCO', isManagingStudents: true });
+      const membership = server.create('membership', {
+        organizationId: organization.id,
+        userId: user.id,
+      });
+      user.userOrgaSettings = server.create('user-orga-setting', { user, organization });
+      user.memberships = [membership];
+      server.create('prescriber', {
+        id: user.id,
+        pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+        areNewYearStudentsImported: false,
+        memberships: user.memberships,
+        userOrgaSettings: user.userOrgaSettings,
+      });
+      await authenticateSession({
+        user_id: user.id,
+        access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+        expires_in: 3600,
+        token_type: 'Bearer token type',
+      });
+
+      // when
+      await visit('/');
+      await click('.pix-banner a[href="/eleves"]');
+
+      // then
+      assert.equal(currentURL(), '/eleves');
+    });
+  });
+});

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | information-banner', function(hooks) {
 
       test('should render the banner', async function(assert) {
         // given
-        prescriber = { areNewYearStudentsImported: false };
+        prescriber = { areNewYearSchoolingRegistrationsImported: false };
         this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents }));
 
         // when
@@ -33,7 +33,7 @@ module('Integration | Component | information-banner', function(hooks) {
 
       test('should not render the banner', async function(assert) {
         // given
-        prescriber = { areNewYearStudentsImported: true };
+        prescriber = { areNewYearSchoolingRegistrationsImported: true };
         this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents }));
 
         // when
@@ -50,7 +50,7 @@ module('Integration | Component | information-banner', function(hooks) {
 
     test('should not render the banner regardless of whether students have been imported or not', async function(assert) {
       // given
-      prescriber = { areNewYearStudentsImported: false };
+      prescriber = { areNewYearSchoolingRegistrationsImported: false };
       this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents: false }));
 
       // when

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -1,0 +1,64 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+module('Integration | Component | information-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let prescriber;
+
+  module('when prescriber’s organization is of type SCO that manages students', function() {
+    const isSCOManagingStudents = true;
+
+    module('when prescriber has not imported student yet', function() {
+
+      test('should render the banner', async function(assert) {
+        // given
+        prescriber = { areNewYearStudentsImported: false };
+        this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents }));
+
+        // when
+        await render(hbs`<InformationBanner/>`);
+
+        // then
+        assert.contains('Importer la base Élèves');
+        assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
+        assert.dom('.pix-banner').includesText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga');
+      });
+    });
+
+    module('when prescriber has already imported students', function() {
+
+      test('should not render the banner', async function(assert) {
+        // given
+        prescriber = { areNewYearStudentsImported: true };
+        this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents }));
+
+        // when
+        await render(hbs`<InformationBanner/>`);
+
+        // then
+        assert.dom('.pix-banner').doesNotExist();
+      });
+    });
+
+  });
+
+  module('when prescriber’s organization is not of type SCO that manages students', function() {
+
+    test('should not render the banner regardless of whether students have been imported or not', async function(assert) {
+      // given
+      prescriber = { areNewYearStudentsImported: false };
+      this.owner.register('service:current-user', Service.extend({ prescriber, isSCOManagingStudents: false }));
+
+      // when
+      await render(hbs`<InformationBanner/>`);
+
+      // then
+      assert.dom('.pix-banner').doesNotExist();
+    });
+
+  });
+});

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -7,17 +7,9 @@ import Service from '@ember/service';
 module('Integration | Component | sidebar-menu', function(hooks) {
   setupRenderingTest(hooks);
 
-  let user;
-  hooks.beforeEach(function() {
-    user = Object.create({
-      firstName: 'givenFirstName',
-      lastName: 'givenLastName',
-    });
-  });
-
   test('it should display documentation a pro organization', async function(assert) {
     const organization = Object.create({ id: 1, isPro: true });
-    this.owner.register('service:current-user', Service.extend({ user, organization }));
+    this.owner.register('service:current-user', Service.extend({ organization }));
 
     // when
     await render(hbs`<SidebarMenu />`);
@@ -28,7 +20,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
 
   test('it should display documentation a sco organization', async function(assert) {
     const organization = Object.create({ id: 1, type: 'SCO' });
-    this.owner.register('service:current-user', Service.extend({ user, organization, isSCOManagingStudents: true }));
+    this.owner.register('service:current-user', Service.extend({ organization, isSCOManagingStudents: true }));
 
     // when
     await render(hbs`<SidebarMenu />`);
@@ -39,7 +31,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
 
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
     const organization = Object.create({ id: 1, type: 'SCO' });
-    this.owner.register('service:current-user', Service.extend({ user, organization, isSCOManagingStudents: false }));
+    this.owner.register('service:current-user', Service.extend({ organization, isSCOManagingStudents: false }));
 
     // when
     await render(hbs`<SidebarMenu />`);


### PR DESCRIPTION
## :unicorn: Problème
Dans le but d'accompagner un maximum les membres des organisations SCO pour la rentrée, il est prévu de mettre en place quelques éléments visuels pour guider les utilisateurs.
Le métier souhaite qu'on invite, à l'aide d'une bannière informative, les utilisateurs à importer des élèves si cela n'est pas encore fait. (Date de référence: 15 août 2020).

:warning:  Bannière à afficher uniquement pour les orgas de type SCO qui peuvent gérer des élèves et qui n'ont pas fait d'import après le 15 août 2020

## :robot: Solution
- Ajout d'un attribut `areNewYearStudentsImported` dans le modèle `Prescriber` côté API (vu ensemble, dette tactique, on va créer un read-model `Organization` spécifique pour l'usage prescripteur qui va embarquer cette donnée).
- Utilisation du composant `PixBanner` de `PixUI`.
- Date du 15 août 2020 mis en place en tant que variable d'environnement

## :rainbow: Remarques
- La stratégie d'arrêt d'affichage de bandeau n'a pas encore été arrêtée (le bandeau ne s'affiche plus si des élèves sont importés après le 15/08, mais si des élèves ne sont pas importés et que ça traîne jusqu'en décembre... :grimacing: )
- Bug dans PixUi, il faut utiliser le helper linkTo quand le lien est interne (c'est mieux pour ember)

## :100: Pour tester
Se connecter avec un compte non sco (pro@example.net par ex.) -> Bandeau pas affiché
Se connecter avec le compte sco sco@example.net -> Bandeau pas affiché car élèves importés après le 15
Se connecter avec le compte sco admin.sco2@example.net (Pix123, P MAJUSCULE !) -> Bandeau affiché !, disparait si on importe des élèves
