### PR TITLE
Homogénéiser le lien de récupération d'espace.

### DIFF
--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -69,7 +69,7 @@
       {{#unless @isWithInvitation}}
         <div>
           <div class="login-form__recover-access-link help-text">
-            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga ?</LinkTo>
+            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga</LinkTo>
           </div>
           <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Le texte du lien est à la forme interrogative (sans contexte Souhaitez-vous...), ce qui exclut que le verne soit conjugué à l'indicatif, or c'est le cas.
> Activez ou récupérez votre espace PixOrga ?

## :robot: Solution
Supprimer le point d'interrogation (en suivant ce lien, vous ..)
> Activez ou récupérez votre espace PixOrga

## :100: Pour tester
Se rendre sur la page d'accueil
