### PR TITLE
[FEATURE] Remonter le champ affiché à l'utilisateur comme nom de catégorie (PIX-1161).

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -24,6 +24,7 @@ export default class FeedbackPanel extends Component {
   _category = null;
   _questions = questions;
   _sendButtonStatus = buttonStatusTypes.unrecorded;
+  _currentMajorCategory = null;
 
   constructor(owner, args) {
     super(owner, args);
@@ -57,6 +58,7 @@ export default class FeedbackPanel extends Component {
   @action
   async sendFeedback(event) {
     event && event.preventDefault();
+
     if (this.isSendButtonDisabled) {
       return;
     }
@@ -69,9 +71,12 @@ export default class FeedbackPanel extends Component {
       return;
     }
 
+    const category = this._category ?
+      this.intl.t(this._category) :
+      this.intl.t('pages.challenge.feedback-panel.form.fields.category-selection.options.' + this._currentMajorCategory);
     const feedback = this.store.createRecord('feedback', {
       content: this.content,
-      category: this._category,
+      category,
       assessment: this.args.assessment,
       challenge: this.args.challenge,
       answer: _.get(this.args, 'answer.value', null),
@@ -93,9 +98,10 @@ export default class FeedbackPanel extends Component {
     this.quickHelpInstructions = null;
     this.emptyTextBoxMessageError = null;
     this.displayQuestionDropdown = false;
+    this._category = null;
 
-    this.nextCategory = this._questions[event.target.value];
-    this._category = event.target.value;
+    this._currentMajorCategory = event.target.value;
+    this.nextCategory = this._questions[this._currentMajorCategory];
 
     if (this.nextCategory.length > 1) {
       this.displayQuestionDropdown = true;
@@ -111,7 +117,6 @@ export default class FeedbackPanel extends Component {
       this.quickHelpInstructions = null;
       this.emptyTextBoxMessageError = null;
     }
-
     this.emptyTextBoxMessageError = null;
     this._category = this.nextCategory[event.target.value].name;
     this._showFeedbackActionBasedOnCategoryType(this.nextCategory[event.target.value]);

--- a/mon-pix/app/static-data/feedback-panel-issue-labels.js
+++ b/mon-pix/app/static-data/feedback-panel-issue-labels.js
@@ -1,7 +1,7 @@
 const topLevelLabels = [
   {
     name: 'pages.challenge.feedback-panel.form.fields.category-selection.options.question',
-    value: 'instructions',
+    value: 'question',
   },
   {
     name: 'pages.challenge.feedback-panel.form.fields.category-selection.options.picture',
@@ -14,7 +14,7 @@ const topLevelLabels = [
   },
   {
     name: 'pages.challenge.feedback-panel.form.fields.category-selection.options.embed',
-    value: 'simulator',
+    value: 'embed',
   },
   {
     name: 'pages.challenge.feedback-panel.form.fields.category-selection.options.download',
@@ -41,7 +41,7 @@ const topLevelLabels = [
 ];
 
 const questions = {
-  'instructions': [
+  'question': [
     {
       name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.question-not-understood',
       type: 'textbox',
@@ -64,7 +64,7 @@ const questions = {
       type: 'textbox',
     }
   ],
-  'simulator': [
+  'embed': [
     {
       name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-not-displayed.label',
       type: 'tutorial',

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -20,7 +20,7 @@ const TEXTAREA = 'textarea.feedback-panel__field--content';
 const DROPDOWN = '.feedback-panel__dropdown';
 const TUTORIAL_AREA = '.feedback-panel__tutorial-content';
 
-const PICK_CATEGORY_WITH_NESTED_LEVEL = 'instructions';
+const PICK_CATEGORY_WITH_NESTED_LEVEL = 'question';
 const PICK_CATEGORY_WITH_TEXTAREA = 'link';
 const PICK_CATEGORY_WITH_TUTORIAL = 'picture';
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -249,7 +249,7 @@
             "category-selection": {
               "label": "J'ai un problème avec",
               "options": {
-                "accessibility": "L'accessibilité de l'épreuve",
+                "accessibility": "L’accessibilité de l’épreuve",
                 "answer": "La réponse",
                 "embed": "Le simulateur / l'application",
                 "download": "Le fichier à télécharger",


### PR DESCRIPTION
## :unicorn: Problème
- Avec l'arrivée de la traduction, le champ catégorie des signalements remontaient : 
-- Soit la clé de traduction pour les sous-catégories
-- Soit la valeur de la catégorie principale (link, instruction, etc.à

## :robot: Solution
- Aligner les valeurs des catégories principales avec la clé de traduction
- Garder en mémoire la catégorie principale
- Remonter la traduction de la sous-catégorie ou de la catégorie principale

- Au passage, on remet bien la catégorie (qui est la sous-catégorie) à null quand on change de catégorie principale, car par exemple si j'étais sur Embed > Mon embed ne fonctionne pas, on avait comme _category "Mon Embed ne fonctionne pas". Mais si je changeais pour la catégorie principale "Lien", on avait toujours le meme _category.

## :rainbow: Remarques
- Il faut ajouter une requete SQL à envoyer pour corriger les champs actuels et simplifier le travail du contenu :
```
update "feedbacks" set category = 'L’accessibilité de l’épreuve' where category = 'accessibility';
update "feedbacks" set category = 'Le lien indiqué dans la question' where "category" = 'link';
update "feedbacks" set category = 'Je ne suis pas d’accord avec la réponse' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.answer-not-agreed';
update "feedbacks" set category = 'J’ai un autre problème avec le fichier' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.download.other';
update "feedbacks" set category = 'Le simulateur / l’application a un autre problème' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.embed-other';
update "feedbacks" set category = 'J’ai un autre problème' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.other-difficulty';
update "feedbacks" set category = 'J’ai une suggestion d’amélioration de la plateforme' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.other-site-improvement';
update "feedbacks" set category = 'Je souhaite proposer une amélioration de la question' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.question-improvement';
update "feedbacks" set category = 'Je ne comprends pas la question' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.question-not-understood';
update "feedbacks" set category = 'Le tutoriel n’est pas adapté' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.tutorial-not-accepted';
update "feedbacks" set category = 'J’ai un tutoriel à vous proposer' where "category"='pages.challenge.feedback-panel.form.fields.detail-selection.options.tutorial-proposal';
```
## :100: Pour tester
- Envoyer des feedbacks des 2 niveaux (par exemple sur le Lien et sur les embed) et voir la catégorie en base de données
