### PR TITLE
[FEATURE] Ajout d'un script pour créer en masse les campagnes de rentrée du SCO (PIX-1083).

### DIFF
--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -49,7 +49,7 @@ function checkData(csvData) {
     if (_.isEmpty(customLandingPageText)) customLandingPageText = null;
 
     return { targetProfileId, name, externalId, title, customLandingPageText };
-  }).filter((data) => !!data);
+  });
 }
 
 async function prepareCampaigns(creatorId, campaignsData) {

--- a/api/scripts/prod/create-assessment-campaigns-for-sco.js
+++ b/api/scripts/prod/create-assessment-campaigns-for-sco.js
@@ -1,0 +1,144 @@
+// Usage: node create-assessment-campaigns.js --creatorId creatorId --filePath path/file.csv
+// To use on file with columns |targetProfileId, name, externalId, title, customLandingPageText|, those headers included
+const bluebird = require('bluebird');
+const yargs = require('yargs');
+const _ = require('lodash');
+const { knex } = require('../../db/knex-database-connection');
+const Campaign = require('../../lib/domain/models/Campaign');
+const campaignCodeGenerator = require('../../lib/domain/services/campaigns/campaign-code-generator');
+const campaignValidator = require('../../lib/domain/validators/campaign-validator');
+const campaignRepository = require('../../lib/infrastructure/repositories/campaign-repository');
+const { parseCsvWithHeader } = require('../helpers/csvHelpers');
+
+function _validateAndNormalizeCreatorId(creatorId) {
+  if (!creatorId || isNaN(creatorId)) {
+    throw new Error(`Le User n’est pas défini correctement : "${creatorId}".`);
+  }
+  return creatorId;
+}
+
+function _validateAndNormalizeFilePath(filePath) {
+  if (!filePath) {
+    throw new Error(`Le chemin du fichier n’est pas défini correctement : "${filePath}".`);
+  }
+  return filePath;
+}
+
+function _validateAndNormalizeArgs({ creatorId, filePath }) {
+  const finalCreatorId = _validateAndNormalizeCreatorId(creatorId);
+  const finalFilePath = _validateAndNormalizeFilePath(filePath);
+
+  return {
+    creatorId: finalCreatorId,
+    filePath: finalFilePath,
+  };
+}
+
+function checkData(csvData) {
+  return csvData.map(({ targetProfileId, name, externalId, title, customLandingPageText }) => {
+    if (!targetProfileId) {
+      throw new Error(`Un targetProfileId est manquant pour la campagne ${name}.`);
+    }
+    if (!name) {
+      throw new Error(`Un nom de campagne est manquant pour le profil cible ${targetProfileId}.`);
+    }
+    if (!externalId) {
+      throw new Error(`Un externalId est manquant pour le profil cible ${targetProfileId}.`);
+    }
+    if (_.isEmpty(title)) title = null;
+    if (_.isEmpty(customLandingPageText)) customLandingPageText = null;
+
+    return { targetProfileId, name, externalId, title, customLandingPageText };
+  }).filter((data) => !!data);
+}
+
+async function prepareCampaigns(creatorId, campaignsData) {
+  const campaigns = await bluebird.mapSeries(campaignsData, async (campaignData) => {
+
+    const organization = await getByExternalIdFetchingIdOnly(campaignData.externalId);
+
+    const campaign = {
+      creatorId,
+      organizationId: organization.id,
+      type: Campaign.types.ASSESSMENT,
+      targetProfileId: campaignData.targetProfileId,
+      name: campaignData.name,
+      title: campaignData.title,
+      customLandingPageText: campaignData.customLandingPageText,
+    };
+
+    campaignValidator.validate(campaign);
+    campaign.code = await campaignCodeGenerator.generate(campaignRepository);
+    return campaign;
+  });
+
+  return campaigns.flat();
+}
+
+async function getByExternalIdFetchingIdOnly(externalId) {
+  const organization = await knex('organizations').select('id', 'externalId')
+    .whereRaw('LOWER (??) = ?', ['externalId', externalId.toLowerCase()])
+    .first();
+
+  if (!organization) {
+    throw new Error(`L'organisation d'UAI ${externalId} n'existe pas.`);
+  }
+
+  return organization;
+}
+
+function createAssessmentCampaignsForSco(campaigns) {
+  return knex.batchInsert('campaigns', campaigns);
+}
+
+async function main() {
+  try {
+    const commandLineArgs = yargs
+      .option('creatorId', {
+        description: 'Id du créateur de la campagne',
+        type: 'number',
+      })
+      .option('filePath', {
+        description: 'Path du fichier CSV',
+        type: 'string',
+      })
+      .help()
+      .argv;
+    const { creatorId, filePath } = _validateAndNormalizeArgs(commandLineArgs);
+
+    console.log('Lecture et parsing du fichier csv... ');
+    const csvData = parseCsvWithHeader(filePath);
+
+    console.log('Vérification des données du fichier csv...');
+    const checkedData = checkData(csvData);
+
+    console.log('Création des modèles campagne...');
+    const campaigns = await prepareCampaigns(creatorId, checkedData);
+
+    console.log('Création des campagnes...');
+    await createAssessmentCampaignsForSco(campaigns);
+
+    console.log('FIN');
+  } catch (error) {
+    console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
+    yargs.showHelp();
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  createAssessmentCampaignsForSco,
+  prepareCampaigns,
+  checkData,
+  getByExternalIdFetchingIdOnly,
+};

--- a/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
+++ b/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
@@ -1,0 +1,209 @@
+const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+const {
+  prepareCampaigns,
+  checkData,
+  getByExternalIdFetchingIdOnly,
+} = require('../../../../scripts/prod/create-assessment-campaigns-for-sco');
+
+describe('Integration | Scripts | create-assessment-campaigns', () => {
+
+  describe('#prepareCampaigns', () => {
+
+    const externalId = '456A';
+    let organizationId;
+    beforeEach(() => {
+      organizationId = databaseBuilder.factory.buildOrganization({ externalId }).id;
+      return databaseBuilder.commit();
+    });
+
+    it('should create the campaign model', async () => {
+      // given
+      const creatorId = '789';
+      const targetProfileId = '123';
+      const campaignData = {
+        targetProfileId,
+        name: 'CampaignName',
+        externalId,
+        title: 'SomeTitle',
+        customLandingPageText: 'SomeLandingPage',
+      };
+
+      // when
+      const campaigns = await prepareCampaigns(creatorId, [campaignData]);
+
+      // then
+      expect(campaigns).to.have.length(1);
+      expect(campaigns[0].organizationId).to.equal(organizationId);
+      expect(campaigns[0].targetProfileId).to.equal(campaignData.targetProfileId);
+      expect(campaigns[0].name).to.equal(campaignData.name);
+      expect(campaigns[0].title).to.equal(campaignData.title);
+      expect(campaigns[0].customLandingPageText).to.equal(campaignData.customLandingPageText);
+    });
+
+    it('should generate a code for the campaign model', async () => {
+      // given
+      const creatorId = '789';
+      const targetProfileId = '123';
+      const campaignData = {
+        targetProfileId,
+        name: 'CampaignName',
+        externalId,
+      };
+
+      // when
+      const campaigns = await prepareCampaigns(creatorId, [campaignData]);
+
+      // then
+      expect(typeof campaigns[0].code === 'string').to.be.true;
+      expect(campaigns[0].code.length).to.equal(9);
+    });
+
+    it('should create campaigns for each target profile', async () => {
+      // given
+      const creatorId = '789';
+      const targetProfileId1 = '123';
+      const targetProfileId2 = '321';
+
+      const campaignData1 = {
+        targetProfileId: targetProfileId1,
+        name: 'Name1',
+        externalId,
+      };
+      const campaignData2 = {
+        targetProfileId: targetProfileId2,
+        name: 'Name2',
+        externalId,
+      };
+
+      // when
+      const campaigns = await prepareCampaigns(creatorId, [campaignData1, campaignData2]);
+
+      // then
+      expect(campaigns).to.have.length(2);
+      expect(campaigns[0].targetProfileId).to.equal(campaignData1.targetProfileId);
+      expect(campaigns[0].name).to.equal(campaignData1.name);
+      expect(campaigns[0].organizationId).to.equal(organizationId);
+      expect(campaigns[1].targetProfileId).to.equal(campaignData2.targetProfileId);
+      expect(campaigns[1].name).to.equal(campaignData2.name);
+      expect(campaigns[1].organizationId).to.equal(organizationId);
+    });
+
+    it('should throw a validate error when campaign is not valid', async () => {
+      // given
+      const campaignData = {
+        targetProfileId: 'foireux',
+        externalId,
+      };
+
+      // when
+      const error = await catchErr(prepareCampaigns)('123', [campaignData]);
+
+      // then
+      expect(error).to.be.instanceOf(EntityValidationError);
+    });
+  });
+
+  describe('#checkData', () => {
+
+    it('should create the campaign model', () => {
+      // given
+      const targetProfileId = '123';
+      const name = 'SomeName';
+      const externalId = '456';
+      const title = 'SomeTitle';
+      const customLandingPageText = 'SomeLandingPageText';
+      const csvData = [{ targetProfileId, name, externalId, title, customLandingPageText }];
+
+      // when
+      const checkedData = checkData(csvData);
+
+      // then
+      expect(checkedData[0]).to.deep.equal({
+        targetProfileId,
+        name,
+        externalId,
+        title,
+        customLandingPageText,
+      });
+    });
+
+    it('should throw an error if targetProfileId is missing', async () => {
+      // given
+      const targetProfileId = undefined;
+      const name = 'SomeName';
+      const externalId = '123';
+      const csvData = [{ targetProfileId, name, externalId }];
+
+      // when
+      const error = await catchErr(checkData)(csvData);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Un targetProfileId est manquant pour la campagne SomeName.');
+    });
+
+    it('should throw an error if campaign name is missing', async () => {
+      // given
+      const targetProfileId = '123';
+      const name = undefined;
+      const externalId = '123';
+      const csvData = [{ targetProfileId, name, externalId }];
+
+      // when
+      const error = await catchErr(checkData)(csvData);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Un nom de campagne est manquant pour le profil cible 123.');
+    });
+
+    it('should throw an error if externalId is missing', async () => {
+      // given
+      const targetProfileId = '123';
+      const name = 'SomeName';
+      const externalId = undefined;
+      const csvData = [{ targetProfileId, name, externalId }];
+
+      // when
+      const error = await catchErr(checkData)(csvData);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.equal('Un externalId est manquant pour le profil cible 123.');
+    });
+  });
+
+  describe('#getByExternalIdFetchingIdOnly', () => {
+    let organization;
+
+    beforeEach(async () => {
+      organization = databaseBuilder.factory.buildOrganization({ externalId: '1234568' });
+      databaseBuilder.factory.buildOrganization({ externalId: '9764321' });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return the organization based on the externalId', async () => {
+      // given
+      const externalId = '1234568';
+
+      // when
+      const foundOrganization = await getByExternalIdFetchingIdOnly(externalId);
+
+      // then
+      expect(foundOrganization.externalId).to.equal(organization.externalId);
+    });
+
+    it('should throw a not found error when externalId is not present in database', async () => {
+      // given
+      const externalId = '999';
+
+      // when
+      const error = await catchErr(getByExternalIdFetchingIdOnly)(externalId);
+
+      // then
+      expect(error).to.be.instanceOf(Error);
+    });
+  });
+});

--- a/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
+++ b/api/tests/integration/scripts/prod/create-assessment-campaigns-for-sco_test.js
@@ -17,30 +17,6 @@ describe('Integration | Scripts | create-assessment-campaigns', () => {
       return databaseBuilder.commit();
     });
 
-    it('should create the campaign model', async () => {
-      // given
-      const creatorId = '789';
-      const targetProfileId = '123';
-      const campaignData = {
-        targetProfileId,
-        name: 'CampaignName',
-        externalId,
-        title: 'SomeTitle',
-        customLandingPageText: 'SomeLandingPage',
-      };
-
-      // when
-      const campaigns = await prepareCampaigns(creatorId, [campaignData]);
-
-      // then
-      expect(campaigns).to.have.length(1);
-      expect(campaigns[0].organizationId).to.equal(organizationId);
-      expect(campaigns[0].targetProfileId).to.equal(campaignData.targetProfileId);
-      expect(campaigns[0].name).to.equal(campaignData.name);
-      expect(campaigns[0].title).to.equal(campaignData.title);
-      expect(campaigns[0].customLandingPageText).to.equal(campaignData.customLandingPageText);
-    });
-
     it('should generate a code for the campaign model', async () => {
       // given
       const creatorId = '789';
@@ -69,11 +45,15 @@ describe('Integration | Scripts | create-assessment-campaigns', () => {
         targetProfileId: targetProfileId1,
         name: 'Name1',
         externalId,
+        title: 'title1',
+        customLandingPageText: 'customLandingPageText1'
       };
       const campaignData2 = {
         targetProfileId: targetProfileId2,
         name: 'Name2',
         externalId,
+        title: 'title2',
+        customLandingPageText: 'customLandingPageText2'
       };
 
       // when
@@ -81,12 +61,18 @@ describe('Integration | Scripts | create-assessment-campaigns', () => {
 
       // then
       expect(campaigns).to.have.length(2);
+      expect(campaigns[0].organizationId).to.equal(organizationId);
       expect(campaigns[0].targetProfileId).to.equal(campaignData1.targetProfileId);
       expect(campaigns[0].name).to.equal(campaignData1.name);
-      expect(campaigns[0].organizationId).to.equal(organizationId);
+      expect(campaigns[0].title).to.equal(campaignData1.title);
+      expect(campaigns[0].customLandingPageText).to.equal(campaignData1.customLandingPageText);
+
+      expect(campaigns[1].organizationId).to.equal(organizationId);
       expect(campaigns[1].targetProfileId).to.equal(campaignData2.targetProfileId);
       expect(campaigns[1].name).to.equal(campaignData2.name);
-      expect(campaigns[1].organizationId).to.equal(organizationId);
+      expect(campaigns[1].title).to.equal(campaignData2.title);
+      expect(campaigns[1].customLandingPageText).to.equal(campaignData2.customLandingPageText);
+     
     });
 
     it('should throw a validate error when campaign is not valid', async () => {
@@ -106,7 +92,7 @@ describe('Integration | Scripts | create-assessment-campaigns', () => {
 
   describe('#checkData', () => {
 
-    it('should create the campaign model', () => {
+    it('should create proper campaign attributes', () => {
       // given
       const targetProfileId = '123';
       const name = 'SomeName';
@@ -125,6 +111,28 @@ describe('Integration | Scripts | create-assessment-campaigns', () => {
         externalId,
         title,
         customLandingPageText,
+      });
+    });
+
+    it('replace title and customLandingPageText when there has empty', () => {
+      // given
+      const targetProfileId = '123';
+      const name = 'SomeName';
+      const externalId = '456';
+      const title = '';
+      const customLandingPageText = '';
+      const csvData = [{ targetProfileId, name, externalId, title, customLandingPageText }];
+
+      // when
+      const checkedData = checkData(csvData);
+
+      // then
+      expect(checkedData[0]).to.deep.equal({
+        targetProfileId,
+        name,
+        externalId,
+        title: null,
+        customLandingPageText: null,
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Des milliers d'organisations SCO vont devoir créer exactement les mêmes campagnes avec les mêmes profils cible pour la rentrée de septembre 2020.

## :robot: Solution
On les aide, et on créé ces milliers de campagnes à l'aide d'un script.

## :rainbow: Remarques
NA

## :100: Pour tester
Lancer le script `node create-assessment-campaigns.js --creatorId creatorId --filePath path/file.csv` avec un fichier CSV sous la forme |targetProfileId, name, externalId, title, customLandingPageText| (headers inclus).
