### PR TITLE
[TECH] Eviter de lever des faux erreurs 500 quand les erreurs du domaines ne sont pas associées à des erreurs HTTP.

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -190,6 +190,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.PasswordResetDemandNotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }
+  if (error instanceof DomainErrors.PasswordNotMatching) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.InvalidTemporaryKeyError) {
     return new HttpErrors.UnauthorizedError(error.message);
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -1,8 +1,8 @@
 class BaseHttpError extends Error {
   constructor(message) {
     super(message);
-    this.title = 'Internal Server Error';
-    this.status = 500;
+    this.title = 'Default Bad Request';
+    this.status = 400;
   }
 }
 

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -287,7 +287,7 @@ describe('Acceptance | Controller | password-controller', () => {
 
     context('When password is invalid', () => {
 
-      it('should respond 500 HTTP status code', async () => {
+      it('should respond 401 HTTP status code', async () => {
         // given
         options.payload.data.attributes = { username, expiredPassword: 'wrongPassword01', newPassword };
 
@@ -295,7 +295,7 @@ describe('Acceptance | Controller | password-controller', () => {
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(500);
+        expect(response.statusCode).to.equal(401);
       });
     });
 

--- a/api/tests/integration/application/passwords/password-controller_test.js
+++ b/api/tests/integration/application/passwords/password-controller_test.js
@@ -56,7 +56,7 @@ describe('Integration | Application | Passwords | password-controller', () => {
         expect(response.statusCode).to.equal(404);
       });
 
-      it('should respond an HTTP response with status code 500 when PasswordNotMatching', async () => {
+      it('should respond an HTTP response with status code 401 when PasswordNotMatching', async () => {
         // given
         usecases.updateExpiredPassword.rejects(new PasswordNotMatching());
 
@@ -64,7 +64,7 @@ describe('Integration | Application | Passwords | password-controller', () => {
         const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(response.statusCode).to.equal(500);
+        expect(response.statusCode).to.equal(401);
       });
 
       it('should respond an HTTP response with status code 403 when ForbiddenAccess', async () => {

--- a/api/tests/integration/application/pre-response-utils_test.js
+++ b/api/tests/integration/application/pre-response-utils_test.js
@@ -29,7 +29,7 @@ describe('Integration | Application | PreResponse-utils', () => {
       { should: 'should return HTTP code 412 when PreconditionFailedError', response: new PreconditionFailedError('Error message'), expectedStatusCode: 412 },
       { should: 'should return HTTP code 422 when EntityValidationError', response: new EntityValidationError({ invalidAttributes }), expectedStatusCode: 422 },
       { should: 'should return HTTP code 422 when UnprocessableEntityError', response: new UnprocessableEntityError('Error message'), expectedStatusCode: 422 },
-      { should: 'should return HTTP code 500 when BaseHttpError', response: new BaseHttpError('Error message'), expectedStatusCode: 500 },
+      { should: 'should return HTTP code 400 when BaseHttpError', response: new BaseHttpError('Error message'), expectedStatusCode: 400 },
     ];
 
     successfulCases.forEach((testCase) => {

--- a/api/tests/unit/application/errors_test.js
+++ b/api/tests/unit/application/errors_test.js
@@ -6,9 +6,9 @@ describe('Unit | Application | HTTP Errors', () => {
   describe('#BaseHttpError', () => {
     it('should have a title, message, and errorCode property', () => {
       // given
-      const expectedTitle = 'Internal Server Error';
+      const expectedTitle = 'Default Bad Request';
       const expectedMessage = 'Boom...';
-      const expectedErrorCode = 500;
+      const expectedErrorCode = 400;
 
       // when
       const httpError = new BaseHttpError('Boom...');

--- a/mon-pix/tests/acceptance/update-expired-password-test.js
+++ b/mon-pix/tests/acceptance/update-expired-password-test.js
@@ -32,12 +32,12 @@ describe('Acceptance | Update Expired Password', function() {
     // given
     const badPasswordErrorResponse = {
       errors: [{
-        status: 500,
-        title: 'Internal Server Error',
+        status: 401,
+        title: 'Unauthorized',
         detail: 'Mauvais mot de passe.'
       }]
     };
-    this.server.post('/expired-password-updates', () => (badPasswordErrorResponse), 500);
+    this.server.post('/expired-password-updates', () => (badPasswordErrorResponse), 401);
 
     await fillIn('#password', 'newPass12345!');
 

--- a/mon-pix/tests/unit/components/update-expired-password_test.js
+++ b/mon-pix/tests/unit/components/update-expired-password_test.js
@@ -143,7 +143,7 @@ describe('Unit | Component | Update Expired Password', () => {
       it('should set authenticationHasFailed to true', async () => {
         // given
         const response = {
-          errors: [ { status: '500' } ]
+          errors: [ { status: '400' } ]
         };
         component.session.authenticate.rejects(response);
 


### PR DESCRIPTION
## :unicorn: Problème
Quand une erreur de la couche du domaine n'est pas associée à une erreur de la couche  HTTP, l'API envoie une erreur 500.
L'[erreur manager](https://github.com/1024pix/pix/blob/dev/api/lib/application/error-manager.js) mappe toutes les 'DomainError' connu vers des sous-classes de 'HttpError' qui correspondent à des 4xx, et celles qui ne connaît pas vers 'BaseHttpError' qui génère une Internal Server Error.
Non seulement, l'API n'est pas censée envoyer des erreurs 500 volontaires, mais le détail de l'erreur n'est pas interceptée par Sentry.
On se retrouve donc avec des faux 500 qui nécessitent des investigations inutiles.

Example avec l'erreur PasswordNotMatching qui est transformée en 500 au lieu d'un 401:
![image](https://user-images.githubusercontent.com/10045497/91281211-17422200-e788-11ea-9740-e0d7addc2df1.png)


## :robot: Solution
Un quick fix est de changer le status code et le title de la classe http base error.
Mapper l'erreur PasswordNotMatching avec une UnauthorizedError et renvoyer une 401.
Améliorer la gestion d'erreur coté IHM pour différencier entre les erreurs 4XX et 5XX.

## :rainbow: Remarques
Une réflexion autour de cette gestion est à construire dans un second temps.


## :100: Pour tester

1. Se connecter à [Pix](https://app-pr1804.review.pix.fr) avec le compte sco2@example.net qui doit changer son mot de passe expiré.
2. Vérifier qu'on est bien redirigé pour mettre à jour son mot de passe.
3. Saisir le nouveau mot de passe et vérifier qu'on accède bien à la page de profile.