### PR TITLE
[A11Y] Afficher une instruction alternative (PIX-1151)

### DIFF
--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -52,6 +52,7 @@ class Challenge {
       embedUrl,
       format,
       illustrationAlt,
+      alternativeInstruction,
       illustrationUrl,
       instruction,
       proposals,
@@ -84,6 +85,7 @@ class Challenge {
     this.type = type;
     this.locales = locales;
     this.autoReply = autoReply;
+    this.alternativeInstruction = alternativeInstruction;
     // includes
     this.skills = skills;
     this.validator = validator;

--- a/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/challenge-datasource.js
@@ -35,6 +35,7 @@ module.exports = datasource.extend({
     'Format',
     'Langues',
     'Réponse automatique',
+    'Consigne alternative',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -82,7 +83,8 @@ module.exports = datasource.extend({
       illustrationAlt: airtableRecord.get('Texte alternatif illustration'),
       format: airtableRecord.get('Format') || 'mots',
       autoReply: Boolean(airtableRecord.get('Réponse automatique')) || false,
-      locales: _convertLanguagesToLocales(airtableRecord.get('Langues') || [])
+      locales: _convertLanguagesToLocales(airtableRecord.get('Langues') || []),
+      alternativeInstruction: airtableRecord.get('Consigne alternative') || ''
     };
   },
 

--- a/api/lib/infrastructure/repositories/challenge-repository.js
+++ b/api/lib/infrastructure/repositories/challenge-repository.js
@@ -88,6 +88,7 @@ function _toDomain({ challengeDataObject, skillDataObjects }) {
     type: challengeDataObject.type,
     status: challengeDataObject.status,
     instruction: challengeDataObject.instruction,
+    alternativeInstruction: challengeDataObject.alternativeInstruction,
     proposals: challengeDataObject.proposals,
     timer: challengeDataObject.timer,
     illustrationUrl: challengeDataObject.illustrationUrl,

--- a/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/challenge-serializer.js
@@ -20,6 +20,7 @@ module.exports = {
         'illustrationAlt',
         'format',
         'autoReply',
+        'alternativeInstruction',
       ],
       transform: (record) => {
         const challenge = _.pickBy(record, (value) => !_.isUndefined(value));

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -20,6 +20,7 @@ module.exports = function buildChallenge(
     type = Challenge.Type.QCM,
     locales = ['fr'],
     autReply = false,
+    alternativeInstruction,
     // includes
     answer,
     validator = new Validator(),
@@ -44,6 +45,7 @@ module.exports = function buildChallenge(
     type,
     locales,
     autReply,
+    alternativeInstruction,
     // includes
     answer,
     validator,

--- a/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/challengeAirtableDataObjectFixture.js
@@ -25,6 +25,7 @@ module.exports = function ChallengeAirtableDataObjectFixture({
   format = 'petit',
   locales = ['fr'],
   autoReply = false,
+  alternativeInstruction = '',
 } = {}) {
   return {
     id,
@@ -49,6 +50,7 @@ module.exports = function ChallengeAirtableDataObjectFixture({
     embedHeight,
     format,
     locales,
-    autoReply
+    autoReply,
+    alternativeInstruction
   };
 };

--- a/api/tests/unit/domain/models/Challenge_test.js
+++ b/api/tests/unit/domain/models/Challenge_test.js
@@ -31,6 +31,7 @@ describe('Unit | Domain | Models | Challenge', () => {
         format: 'phrase',
         locales: ['fr'],
         autoReply: true,
+        alternativeInstruction: 'Pour aider les personnes ne pouvant voir ou afficher les instructions',
       };
 
       // when

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -9,6 +9,7 @@ export default class ChallengeStatement extends Component {
   @service mailGenerator;
 
   @tracked selectedAttachmentUrl;
+  @tracked displayAlternativeInstruction = false;
 
   constructor() {
     super(...arguments);
@@ -36,6 +37,11 @@ export default class ChallengeStatement extends Component {
 
   get id() {
     return 'challenge_statement_' + this.args.challenge.id;
+  }
+
+  @action
+  toggleAlternativeInstruction() {
+    this.displayAlternativeInstruction = !this.displayAlternativeInstruction;
   }
 
   @action

--- a/mon-pix/app/models/challenge.js
+++ b/mon-pix/app/models/challenge.js
@@ -17,6 +17,7 @@ export default class Challenge extends Model {
   }) illustrationAlt;
   @attr('string') illustrationUrl;
   @attr('string') instruction;
+  @attr('string') alternativeInstruction;
   @attr('string') proposals;
   @attr('number') timer;
   @attr('string') type;

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -185,3 +185,26 @@
   font-weight: $font-heavy;
   text-transform: uppercase;
 }
+
+.challenge-statement__alternative-instruction {
+  margin-top: 20px;
+  margin-bottom: 20px;
+
+  button {
+    padding: 0;
+    font-size: 1rem;
+    color: $blue;
+    font-weight: 500;
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+
+    &:hover {
+      color: $dark-blue-pro
+    }
+  }
+
+  &-text {
+    margin-top: 10px;
+  }
+}

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -72,4 +72,19 @@
   {{#if @challenge.hasValidEmbedDocument}}
     <ChallengeEmbedSimulator @embedDocument={{this.challengeEmbedDocument}} />
   {{/if}}
+
+  {{#if @challenge.alternativeInstruction}}
+    <div class="challenge-statement__alternative-instruction">
+      {{#if this.displayAlternativeInstruction}}
+        <button type="button" {{on "click" this.toggleAlternativeInstruction}}>
+          {{t 'pages.challenge.statement.alternative-instruction.actions.hide'}}
+        </button>
+        <MarkdownToHtml class="challenge-statement__alternative-instruction-text" @markdown={{@challenge.alternativeInstruction}} />
+      {{else}}
+        <button type="button" {{on "click" this.toggleAlternativeInstruction}}>
+          {{t 'pages.challenge.statement.alternative-instruction.actions.display'}}
+        </button>
+      {{/if}}
+    </div>
+  {{/if}}
 </div>

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, findAll, render } from '@ember/test-helpers';
+import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -82,6 +82,82 @@ describe('Integration | Component | ChallengeStatement', function() {
       expect(find('.challenge-statement__instruction').textContent.trim())
         .to.equal('Veuillez envoyer un email à l\'adresse recigAYl5bl96WGXj-267845-0502@pix-infra.ovh pour valider cette épreuve');
     });
+  });
+
+  /*
+   * Alternative instruction
+   * ------------------------------------------------
+   */
+
+  describe('Alternative instruction section:', function() {
+
+    it('should hide alternative instruction zone if no alternative instruction', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        id: 'recigAYl5bl96WGXj',
+        instruction: 'La consigne de mon test',
+        alternativeInstruction: ''
+      });
+
+      // when
+      await renderChallengeStatement();
+
+      // then
+      expect(find('.challenge-statement__alternative-instruction')).to.not.exist;
+    });
+
+    it('should show alternative instruction zone if there is an alternative instruction', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        id: 'recigAYl5bl96WGXj',
+        instruction: 'La consigne de mon test',
+        alternativeInstruction: 'La consigne alternative de mon test'
+      });
+
+      // when
+      await renderChallengeStatement();
+
+      // then
+      expect(find('.challenge-statement__alternative-instruction')).to.exist;
+    });
+
+    it('should display alternative instruction text on button click', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        id: 'recigAYl5bl96WGXj',
+        instruction: 'La consigne de mon test',
+        alternativeInstruction: 'La consigne alternative de mon test'
+      });
+
+      // when
+      await renderChallengeStatement();
+      await click('.challenge-statement__alternative-instruction button');
+
+      // then
+      expect(find('.challenge-statement__alternative-instruction-text')).to.exist;
+    });
+
+    it('should hide alternative instruction text on second button click', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        id: 'recigAYl5bl96WGXj',
+        instruction: 'La consigne de mon test',
+        alternativeInstruction: 'La consigne alternative de mon test'
+      });
+
+      // when
+      await renderChallengeStatement();
+      await click('.challenge-statement__alternative-instruction button');
+      await click('.challenge-statement__alternative-instruction button');
+
+      // then
+      expect(find('.challenge-statement__alternative-instruction-text')).to.not.exist;
+    });
+
   });
 
   /*

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -317,6 +317,12 @@
         "label": "Challenge"
       },
       "statement": {
+        "alternative-instruction": {
+          "actions": {
+            "display": "Display alternative instruction",
+            "hide": "Hide alternative instruction"
+          }
+        },
         "file-download": {
           "actions": {
             "choose-type": "Select the type of file you want to use",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -317,6 +317,12 @@
         "label": "Question"
       },
       "statement": {
+        "alternative-instruction": {
+          "actions": {
+            "display": "Afficher l'alternative textuelle",
+            "hide": "Cacher l'alternative textuelle"
+          }
+        },
         "file-download": {
           "actions": {
             "choose-type": "Choisissez le type de fichier que vous voulez utiliser",


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs épreuves utilisent des images, des sites ou encore des embed qui ne sont pas accessible.

## :robot: Solution
Pour simplifier leur accessibilité, il est possible de proposer une alternative textuel.
Un nouveau champ `instruction alternative` est créée sur Airtable. Cette info est remontée au front pour être affichée.

## :100: Pour tester
Sur l'épreuve recwUSKozqBvghOXr: vérifier que l'on a une instruction alternative.
