### PR TITLE
[BUGFIX] Affichage des étoiles lorsque le texte du palier est trop long (PIX-1165).

### DIFF
--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -19,7 +19,10 @@
 
 .reached-stage-score {
   &__stars {
-    text-align: center;
+    min-width: 200px;
+    max-width: 250px;
+    display: flex;
+    justify-content: center;
   }
   &__stars img {
     margin: 3px;


### PR DESCRIPTION
## :unicorn: Problème
Quand le texte du palier est très long, les étoiles et l'image sont écrasés sur le coté

![image](https://user-images.githubusercontent.com/36371437/91436271-11237280-e868-11ea-9e04-5122bad89394.png)

## :robot: Solution
Ajout d'une largeur mini et maxi à la div contenant les étoiles et d'une propriété flex afin de se charger du retour à la ligne en cas de nombreuses étoiles.

<img width="928" alt="Capture d’écran 2020-08-27 à 13 07 33" src="https://user-images.githubusercontent.com/36371437/91436305-23051580-e868-11ea-83fd-0089a57f5cd6.png">

## :100: Pour tester
Réaliser la campagne avec le code AZERTY123 sur la RA : https://app-pr1807.review.pix.fr