### PR TITLE
[BUGFIX] Améliorations de design des pages de connexion et de récupération d'espace de Pix Orga (PIX-1116).

### DIFF
--- a/orga/app/components/routes/join-request-form.hbs
+++ b/orga/app/components/routes/join-request-form.hbs
@@ -1,8 +1,7 @@
 <div class="join-request-form">
 
-  <p class="join-request-form__information">Tous les champs sont obligatoires.</p>
-
   <form {{on "submit" this.submit}}>
+    <p class="join-request-form__information">Tous les champs sont obligatoires.</p>
 
     <div class="input-container">
       <label for="uai" class="label">UAI/RNE de l'établissement</label>

--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -69,7 +69,7 @@
       {{#unless @isWithInvitation}}
         <div>
           <div class="login-form__recover-access-link help-text">
-            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga ?</LinkTo>
+            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga</LinkTo>
           </div>
           <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
         </div>

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -3,16 +3,13 @@
   &__information {
     font-family: $roboto;
     font-size: 0.875rem;
-    line-height: 1.375rem;
     margin: 0 0 24px;
   }
 
   &__legal-information {
+    color: $blue-zodiac;
     font-family: $roboto;
-    font-size: 0.875rem;
-    line-height: 1.375rem;
-    margin: 16px 0 24px;
-    text-align: center;
+    font-size: 0.6875rem;
     width: 500px;
   }
 

--- a/orga/app/styles/components/join-request-form.scss
+++ b/orga/app/styles/components/join-request-form.scss
@@ -10,7 +10,7 @@
     color: $blue-zodiac;
     font-family: $roboto;
     font-size: 0.6875rem;
-    width: 500px;
+    max-width: 500px;
   }
 
   &__back {

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -6,7 +6,6 @@
   background: $pix-orga-old-gradient;
   align-items: center;
   justify-content: center;
-  min-height: 800px;
 
   a {
     color: $communication-dark;
@@ -20,10 +19,10 @@
     border-radius: 10px;
     display: flex;
     flex-direction: column;
-    padding: 32px 10px 40px;
+    padding: 32px 10px 20px;
 
     @include device-is('tablet') {
-      padding: 32px 67px 40px;
+      padding: 32px 67px 20px;
     }
   }
 
@@ -43,8 +42,7 @@
     max-width: 497px;
     font-size: 0.875rem;
     font-weight: 400;
-    line-height: 1.375rem;
-    margin: 0 0 48px;
+    line-height: 1.25rem;
   }
 
   &__error-message {

--- a/orga/app/styles/pages/join-request.scss
+++ b/orga/app/styles/pages/join-request.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   background: $pix-orga-old-gradient;
   align-items: center;
   justify-content: center;
@@ -16,13 +16,15 @@
   }
 
   &__panel {
-    border-radius: 10px;
     display: flex;
     flex-direction: column;
+    border-radius: 0;
     padding: 32px 10px 20px;
 
     @include device-is('tablet') {
       padding: 32px 67px 20px;
+      margin: 10px 0;
+      border-radius: 10px;
     }
   }
 

--- a/orga/app/styles/pages/login.scss
+++ b/orga/app/styles/pages/login.scss
@@ -2,17 +2,22 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   background: $pix-orga-old-gradient;
   align-items: center;
   justify-content: center;
-  min-height: 800px;
 
   &__panel {
+    border-radius: 0;
     display: flex;
     flex-direction: column;
-    border-radius: 10px;
-    padding: 40px 60px;
+    padding: 40px 10px;
+
+    @include device-is('tablet') {
+      border-radius: 10px;
+      margin: 10px 0;
+      padding: 40px 60px;
+    }
   }
 
   .form-title {


### PR DESCRIPTION
## :unicorn: Problème
La page de récupération d'un espace Pix Orga "débordait" en hauteur sur des résolutions inférieures à 1920x1024. De plus, cette dernière ainsi que la page de connexion n'étaient pas adaptées à un usage sur mobile.

## :robot: Solution
Améliorer le design de ces pages.

## :100: Pour tester
- https://orga-pr1808.review.pix.fr/connexion
- https://orga-pr1808.review.pix.fr/demande-administration-sco