### PR TITLE
[FEATURE] Affichage plus alertant et plus informatif des bannières SCO de Pix Orga.

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -1,9 +1,28 @@
 {{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
   <PixBanner @actionLabel='Importer la base Élèves' @actionUrl='authenticated.sco-students'>
-      Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga (<a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" target="_blank" rel="noopener noreferrer">plus d'info <FaIcon @icon="external-link-alt" /></a>)
+    <FaIcon @icon="exclamation-triangle" class="warning-icon" />
+    Rentrée 2020 : l’administrateur doit <strong>importer ou ré-importer la base</strong> élèves pour initialiser Pix Orga. Plus d’info
+    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link-dark" target="_blank" rel="noopener noreferrer">
+      collège
+      <FaIcon @icon="external-link-alt" />
+    </a>
+    et
+    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link-dark" target="_blank" rel="noopener noreferrer">
+      lycée (GT et Pro)
+      <FaIcon @icon="external-link-alt" />
+    </a>
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner>
-      Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint. (<a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" target="_blank" rel="noopener noreferrer">plus d’info <FaIcon @icon="external-link-alt" /></a>)
+    <strong>Parcours de rentrée 2020</strong> : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint. Plus d’info
+    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" class="link link-dark" target="_blank" rel="noopener noreferrer">
+      collège
+      <FaIcon @icon="external-link-alt" />
+    </a>
+    et
+    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" class="link link-dark" target="_blank" rel="noopener noreferrer">
+      lycée (GT et Pro)
+      <FaIcon @icon="external-link-alt" />
+    </a>
   </PixBanner>
 {{/if}}

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -9,6 +9,7 @@
 @import "globals/competences";
 @import "globals/errors";
 @import "globals/forms";
+@import "globals/icons";
 @import "globals/pages";
 @import "globals/panels";
 @import "globals/pix-loader";

--- a/orga/app/styles/globals/icons.scss
+++ b/orga/app/styles/globals/icons.scss
@@ -1,0 +1,3 @@
+.warning-icon {
+  color: $warning;
+}

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -86,4 +86,14 @@
     text-decoration: underline;
     color: $blue-hover;
   }
+
+  &-dark {
+    color: darken($blue, 20%);
+
+    &:hover,
+    &:focus,
+    &:active {
+      color:  darken($blue-hover, 10%);
+    }
+  }
 }

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -27,7 +27,8 @@ module('Integration | Component | information-banner', function(hooks) {
           // then
           assert.contains('Importer la base Élèves');
           assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
-          assert.dom('.pix-banner').includesText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga');
+          assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
+          assert.dom('.pix-banner').includesText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
         });
       });
 
@@ -52,7 +53,7 @@ module('Integration | Component | information-banner', function(hooks) {
           await render(hbs`<InformationBanner/>`);
 
           // then
-          assert.dom('.pix-banner').doesNotIncludeText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga');
+          assert.dom('.pix-banner').doesNotIncludeText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');
         });
       });
     });
@@ -125,7 +126,8 @@ module('Integration | Component | information-banner', function(hooks) {
 
           // then
           assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
-          assert.dom('.pix-banner').includesText('Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint.');
+          assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
+          assert.dom('.pix-banner').includesText('Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint. Plus d’info collège et lycée (GT et Pro)');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les bannières SCO ne sont pas assez alertantes et n'apportent pas assez d'information.

## :robot: Solution
- Rajouter une icone de warning sur le premier bandeau (pas sur le 2e, pour que l'on fasse la différence entre les 2 bandeaux)
- Rajouter des liens spécifiques collège et lycée (GT et Pro)
- Mettre des mots importants en gras

## :rainbow: Remarques
NA

## :100: Pour tester
- Aller sur Pix Orga en tant que sco@example.net, et voir le bandeau des campagnes ;
- Aller sur Pix Orga en tant que admin.sco2@example.net, et voir le bandeau d'import.
