### PR TITLE
[FEATURE] Autoriser le format de date DD/MM/YY dans le fichier d'import des étudiants du SUP (Pix-1134).

### DIFF
--- a/api/lib/infrastructure/files/attendance-sheet/attendance-sheet-transformation-structures.js
+++ b/api/lib/infrastructure/files/attendance-sheet/attendance-sheet-transformation-structures.js
@@ -37,7 +37,7 @@ const _TRANSFORMATION_STRUCT_COMMON_V1_1 = [
     header: 'Date de naissance (format : jj/mm/aaaa)',
     property: 'birthdate',
     transformFn: (cellVal) => {
-      return convertDateValue(cellVal, 'DD/MM/YYYY', 'YYYY-MM-DD');
+      return convertDateValue({ dateString: cellVal, inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' });
     },
   },
 ];
@@ -87,7 +87,7 @@ const _TRANSFORMATION_STRUCT_COMMON_V1_2 = [
     header: 'Date de naissance (format : jj/mm/aaaa)',
     property: 'birthdate',
     transformFn: (cellVal) => {
-      return convertDateValue(cellVal, 'DD/MM/YYYY', 'YYYY-MM-DD');
+      return convertDateValue({ dateString: cellVal, inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' });
     },
   },
 ];

--- a/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
@@ -45,7 +45,7 @@ class HigherEducationRegistrationParser {
       registrationAttributes[attribute] = line[column];
     });
 
-    registrationAttributes['birthdate'] = convertDateValue(line[columnNameByAttribute.birthdate], 'DD/MM/YYYY', 'YYYY-MM-DD');
+    registrationAttributes['birthdate'] = convertDateValue({ dateString: line[columnNameByAttribute.birthdate], inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
 
     return registrationAttributes;
   }

--- a/api/lib/infrastructure/utils/date-utils.js
+++ b/api/lib/infrastructure/utils/date-utils.js
@@ -4,8 +4,13 @@ function isValidDate(dateValue, format) {
   return moment.utc(dateValue, format, true).isValid();
 }
 
-function convertDateValue(dateString, inputFormat, outputFormat) {
-  return isValidDate(dateString, inputFormat) ? moment(dateString, inputFormat, true).format(outputFormat) : null;
+function convertDateValue({ dateString, inputFormat, alternativeInputFormat = null, outputFormat }) {
+  if (isValidDate(dateString, inputFormat)) {
+    return moment(dateString, inputFormat, true).format(outputFormat);
+  } else if (alternativeInputFormat && isValidDate(dateString, alternativeInputFormat)) {
+    return moment(dateString, alternativeInputFormat, true).format(outputFormat);
+  }
+  return null;
 }
 
 module.exports = {

--- a/api/tests/unit/infrastructure/utils/date-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/date-utils_test.js
@@ -61,19 +61,44 @@ describe('Unit | Utils | date-utils', () => {
 
   describe('#convertDateValue', () => {
 
-    context('when dateValue does not match inputFormat', () => {
+    context('when alternativeInputFormat does not exist', () => {
 
-      it('should return null', () => {
-        expect(convertDateValue('1980-05-05', 'DD/MM/YYYY', 'YYYY-MM-DD')).to.be.null;
+      context('when dateValue does not match inputFormat', () => {
+        it('should return null', () => {
+          expect(convertDateValue({ dateString: '1980-05-05', inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' })).to.be.null;
+        });
+      });
+
+      context('when dateValue matches inputFormat', () => {
+        it('should return converted date', () => {
+          expect(convertDateValue({ dateString: '05/05/1980', inputFormat: 'DD/MM/YYYY', outputFormat: 'YYYY-MM-DD' })).to.equal('1980-05-05');
+        });
       });
     });
 
-    context('when dateValue matches inputFormat', () => {
+    context('when alternativeInputFormat exists', () => {
 
-      it('should return null', () => {
-        expect(convertDateValue('05/05/1980', 'DD/MM/YYYY', 'YYYY-MM-DD')).to.equal('1980-05-05');
+      context('when dateValue does not match nor inputFormat, nor alternativeInputFormat', () => {
+        it('should return null', () => {
+          expect(convertDateValue({ dateString: '1980-05-05', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.be.null;
+        });
+      });
+
+      context('when dateValue matches inputFormat', () => {
+        it('should return converted date', () => {
+          expect(convertDateValue({ dateString: '05/05/1980', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal('1980-05-05');
+        });
+      });
+
+      context('when dateValue matches alternativeInputFormat', () => {
+        it('should return converted date with date < 2000', () => {
+          expect(convertDateValue({ dateString: '05/05/80', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal('1980-05-05');
+        });
+
+        it('should return converted date with date > 2000', () => {
+          expect(convertDateValue({ dateString: '05/05/02', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal('2002-05-05');
+        });
       });
     });
   });
-
 });


### PR DESCRIPTION
## :unicorn: Problème
Bien qu'ayant saisis une date au format DD/MM/YYYY, Excel transforme cette dernière en une date DD/MM/YY au moment de l'enregistrement.

## :robot: Solution
Autoriser également ce format de date.

## :rainbow: Remarques
NA

## :100: Pour tester
- Télécharger le modèle, le remplir avec une date au format DD/MM/YYYY, vérifier que le fichier s'importe bien, et que c'est la bonne date qui est importée.
