### PR TITLE
[BUGFIX] Ajouter une validation JOI pour l'identifiant de l'invitation afin de ne pas générer une erreur 500. (PIX-1177)

### DIFF
--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -56,6 +56,9 @@ exports.register = async (server) => {
         auth: false,
         handler: organizationInvitationController.getOrganizationInvitation,
         validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required(),
+          }),
           query: Joi.object({
             code: Joi.string().required(),
           }),

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -61,6 +61,20 @@ describe('Unit | Router | organization-invitation-router', () => {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
+    it('should return Bad Request Error when invitation identifier is not a number', async () => {
+      // given
+      const options = {
+        method: 'GET',
+        url: '/api/organization-invitations/XXXXXXXXXXXXXXXX15812?code=DZWMP7L5UM'
+      };
+
+      // when
+      const response = await server.inject(options, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Bug en production: https://sentry.io/organizations/pix/issues/1862183363/?project=1398749&referrer=slack

Un appel à l'api avec un identifiant d'invitation qui n'est pas valide: /api/organization-invitations/XXXXXXXXXXXXXXXX15812
Une internal server error est renvoyée alors qu'on devrait s'attendre à une bad request.

## :robot: Solution
Ajouter une validation JOI pour ce paramètre.

![image](https://user-images.githubusercontent.com/10045497/91546372-9ec39880-e922-11ea-80fb-3e446ceb5437.png)


## :100: Pour tester
Cliquer sur le lien et voir le retour de l'api:
https://orga-pr1811.review.pix.fr/rejoindre?invitationId=XXXXXXXXXXXXXXXX15812&code=3M0G8N6DCF
