### PR TITLE
[BUGFIX] L'import d'étudiants via CSV annule la réconciliation si elle existe (PIX-1087)

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -113,8 +113,8 @@ module.exports = {
   async importHigherEducationRegistrations(request, h) {
     const organizationId = parseInt(request.params.id);
     const buffer = request.payload;
-    const higherEducationRegistrationParser = new HigherEducationRegistrationParser(buffer);
-    await usecases.importHigherEducationRegistrations({ organizationId, higherEducationRegistrationParser });
+    const higherEducationRegistrationParser = new HigherEducationRegistrationParser(buffer, organizationId);
+    await usecases.importHigherEducationRegistrations({ higherEducationRegistrationParser });
     return h.response(null).code(204);
   },
 

--- a/api/lib/domain/models/HigherEducationRegistration.js
+++ b/api/lib/domain/models/HigherEducationRegistration.js
@@ -16,7 +16,6 @@ class HigherEducationRegistration {
     group,
     studyScheme,
     organizationId,
-    userId,
     isSupernumerary = false,
   } = {}) {
     this.firstName = firstName;
@@ -33,7 +32,6 @@ class HigherEducationRegistration {
     this.group = group;
     this.studyScheme = studyScheme;
     this.organizationId = organizationId;
-    this.userId = userId;
     this.isSupernumerary = isSupernumerary;
     this._validate();
   }

--- a/api/lib/domain/models/HigherEducationRegistration.js
+++ b/api/lib/domain/models/HigherEducationRegistration.js
@@ -43,6 +43,7 @@ class HigherEducationRegistration {
       birthdate: this.birthdate,
       studentNumber: this.studentNumber,
       email: this.email,
+      organizationId: this.organizationId,
       isSupernumerary: this.isSupernumerary,
     });
   }

--- a/api/lib/domain/usecases/import-higher-education-registrations.js
+++ b/api/lib/domain/usecases/import-higher-education-registrations.js
@@ -1,4 +1,4 @@
-module.exports = async function importHigherEducationRegistration({ organizationId, higherEducationRegistrationRepository, higherEducationRegistrationParser }) {
+module.exports = async function importHigherEducationRegistration({ higherEducationRegistrationRepository, higherEducationRegistrationParser }) {
   const higherEducationRegistrationSet = higherEducationRegistrationParser.parse();
-  await higherEducationRegistrationRepository.saveSet(higherEducationRegistrationSet, organizationId);
+  await higherEducationRegistrationRepository.saveSet(higherEducationRegistrationSet);
 };

--- a/api/lib/domain/usecases/register-supernumerary-higher-education-registration.js
+++ b/api/lib/domain/usecases/register-supernumerary-higher-education-registration.js
@@ -30,7 +30,6 @@ module.exports = async function registerSupernumeraryHigherEducationRegistration
   }
 
   const higherEducationRegistration = new HigherEducationRegistration({
-    userId,
     studentNumber,
     firstName,
     lastName,
@@ -39,5 +38,5 @@ module.exports = async function registerSupernumeraryHigherEducationRegistration
     isSupernumerary: true,
   });
 
-  await higherEducationRegistrationRepository.save(higherEducationRegistration);
+  await higherEducationRegistrationRepository.saveAndReconcile(higherEducationRegistration, userId);
 };

--- a/api/lib/domain/validators/higher-education-registration-validator.js
+++ b/api/lib/domain/validators/higher-education-registration-validator.js
@@ -18,6 +18,7 @@ const validationSchema = Joi.object({
   lastName: Joi.string().required(),
   birthdate: Joi.date().required().format('YYYY-MM-DD'),
   email: Joi.string().email().optional(),
+  organizationId: Joi.number().integer().required(),
   isSupernumerary: Joi.boolean().required()
 });
 

--- a/api/lib/infrastructure/repositories/higher-education-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-education-registration-repository.js
@@ -35,11 +35,10 @@ module.exports = {
     }
   },
 
-  saveSet(higherEducationRegistrationSet, organizationId) {
+  saveSet(higherEducationRegistrationSet) {
     const registrationDataToSave = higherEducationRegistrationSet.registrations.map((registration) => {
       const registrationToSave = _.pick(registration, ATTRIBUTES_TO_SAVE);
       registrationToSave.status = registration.studyScheme;
-      registrationToSave.organizationId = organizationId;
       return registrationToSave;
     });
 

--- a/api/lib/infrastructure/repositories/higher-education-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-education-registration-repository.js
@@ -19,15 +19,15 @@ const ATTRIBUTES_TO_SAVE = [
   'birthdate',
   'organizationId',
   'isSupernumerary',
-  'userId'
 ];
 
 module.exports = {
 
-  async save(higherEducationRegistration) {
+  async saveAndReconcile(higherEducationRegistration, userId) {
     try {
       const registrationToSave = _.pick(higherEducationRegistration, ATTRIBUTES_TO_SAVE);
       registrationToSave.status = higherEducationRegistration.studyScheme;
+      registrationToSave.userId = userId;
 
       await knex('schooling-registrations').insert({ ...registrationToSave });
     } catch (error) {

--- a/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
@@ -20,8 +20,9 @@ const columnNameByAttribute = {
 
 class HigherEducationRegistrationParser {
 
-  constructor(input) {
+  constructor(input, organizationId) {
     this._input = input;
+    this._organizationId = organizationId;
   }
 
   parse() {
@@ -46,6 +47,7 @@ class HigherEducationRegistrationParser {
     });
 
     registrationAttributes['birthdate'] = convertDateValue({ dateString: line[columnNameByAttribute.birthdate], inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
+    registrationAttributes['organizationId'] = this._organizationId;
 
     return registrationAttributes;
   }

--- a/api/tests/integration/domain/usecases/import-higher-education-registrations_test.js
+++ b/api/tests/integration/domain/usecases/import-higher-education-registrations_test.js
@@ -18,7 +18,7 @@ describe('Integration | UseCase | ImportHigherEducationRegistration', () => {
 
     const organization = databaseBuilder.factory.buildOrganization();
     await databaseBuilder.commit();
-    await importHigherEducationRegistration({ organizationId: organization.id, higherEducationRegistrationRepository, higherEducationRegistrationParser: new HigherEducationRegistrationParser(buffer) });
+    await importHigherEducationRegistration({ higherEducationRegistrationRepository, higherEducationRegistrationParser: new HigherEducationRegistrationParser(buffer, organization.id) });
 
     const registrations = await knex('schooling-registrations').where({ organizationId: organization.id });
     expect(registrations).to.have.lengthOf(2);

--- a/api/tests/integration/infrastructure/repositories/higher-education-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-education-registration-repository_test.js
@@ -19,6 +19,7 @@ describe('Integration | Infrastructure | Repository | higher-education-registrat
 
         const higherEducationRegistrationSet = new HigherEducationRegistrationSet();
         const registration1 = {
+          organizationId: organization.id,
           firstName: 'Elle',
           middleName: 'One',
           thirdName: 'Eyed',
@@ -50,6 +51,7 @@ describe('Integration | Infrastructure | Repository | higher-education-registrat
           status: 'I have no idea what it\'s like.'
         };
         const registration2 = {
+          organizationId: organization.id,
           firstName: 'O-Ren',
           middleName: 'Unknown',
           thirdName: 'Unknown',
@@ -112,6 +114,7 @@ describe('Integration | Infrastructure | Repository | higher-education-registrat
           firstName: 'Elle',
           lastName: 'Driver',
           birthdate: '2020-01-01',
+          organizationId: organization.id
         };
 
         higherEducationRegistrationSet.addRegistration(registration);
@@ -144,6 +147,7 @@ describe('Integration | Infrastructure | Repository | higher-education-registrat
           birthdate: '2020-01-01',
           preferredLastName: 'Sidewinder',
           studentNumber: '12',
+          organizationId: organization.id,
         };
 
         higherEducationRegistrationSet.addRegistration(registration);

--- a/api/tests/unit/domain/models/HigherEducationRegistrationSet_test.js
+++ b/api/tests/unit/domain/models/HigherEducationRegistrationSet_test.js
@@ -23,7 +23,6 @@ describe('Unit | Domain | Models | HigherEducationRegistrationSet', () => {
           educationalTeam: 'Pai Mei',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'I have no idea what it\'s like.',
-          userId: 12345,
           organizationId: 1,
           isSupernumerary: false
         };
@@ -72,7 +71,6 @@ describe('Unit | Domain | Models | HigherEducationRegistrationSet', () => {
           educationalTeam: 'Pai Mei',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'I have always no idea what it\'s like.',
-          userId: 123456,
           organizationId: 2,
           isSupernumerary: false
         };

--- a/api/tests/unit/domain/models/HigherEducationRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherEducationRegistration_test.js
@@ -12,7 +12,8 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
       studentNumber: 'A12345',
       firstName: 'Oren',
       lastName: 'Ishii',
-      birthdate: '2020-01-01'
+      birthdate: '2020-01-01',
+      organizationId: 123,
     };
 
     context('when firstName is not present', () => {
@@ -121,6 +122,19 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
 
         const errorList = error.invalidAttributes.map(({ attribute }) => attribute);
         expect(errorList).to.exactlyContain(['lastName', 'firstName']);
+      });
+    });
+
+    context('when organizationId is not valid', () => {
+      it('throws an error when organizationId is not defined', async () => {
+        const error = await catchErr(buildRegistration)({ ...validAttributes, organizationId: null });
+
+        expect(error).to.be.instanceOf(EntityValidationError);
+      });
+      it('throws an error when organizationId is not a number', async () => {
+        const error = await catchErr(buildRegistration)({ ...validAttributes, organizationId: 'salut' });
+
+        expect(error).to.be.instanceOf(EntityValidationError);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
@@ -2,12 +2,12 @@ const { expect } = require('../../../../test-helper');
 const HigherEducationRegistrationParser = require('../../../../../lib/infrastructure/serializers/csv/higher-education-registration-parser');
 const _ = require('lodash');
 
-describe('HigherEducationRegistrationParser', () => {
+describe('Unit | Infrastructure | HigherEducationRegistrationParser', () => {
   context('when the header is correctly formed', () => {
     context('when there is no line', () => {
       it('returns an empty HigherEducationRegistrationSet', () => {
         const input = 'Premier prénom;Deuxième prénom;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime';
-        const parser = new HigherEducationRegistrationParser(input);
+        const parser = new HigherEducationRegistrationParser(input, 123);
 
         const higherEducationRegistrationSet = parser.parse();
 
@@ -20,7 +20,7 @@ describe('HigherEducationRegistrationParser', () => {
         Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
         O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
         `;
-        const parser = new HigherEducationRegistrationParser(input);
+        const parser = new HigherEducationRegistrationParser(input, 456);
 
         const higherEducationRegistrationSet = parser.parse();
         const registrations = higherEducationRegistrationSet.registrations;
@@ -32,7 +32,8 @@ describe('HigherEducationRegistrationParser', () => {
         Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123456;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
         O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
         `;
-        const parser = new HigherEducationRegistrationParser(input);
+        const organizationId = 789;
+        const parser = new HigherEducationRegistrationParser(input, organizationId);
 
         const higherEducationRegistrationSet = parser.parse();
         const registrations = _.sortBy(higherEducationRegistrationSet.registrations, 'preferredLastName');
@@ -50,7 +51,7 @@ describe('HigherEducationRegistrationParser', () => {
           educationalTeam: 'Hattori Hanzo',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'hello darkness my old friend',
-          organizationId: undefined,
+          organizationId,
           isSupernumerary: false
         });
         expect(registrations[1]).to.deep.equal({
@@ -67,7 +68,7 @@ describe('HigherEducationRegistrationParser', () => {
           educationalTeam: 'Bill',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: undefined,
-          organizationId: undefined,
+          organizationId,
           isSupernumerary: false
         });
       });

--- a/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
@@ -50,7 +50,6 @@ describe('HigherEducationRegistrationParser', () => {
           educationalTeam: 'Hattori Hanzo',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: 'hello darkness my old friend',
-          userId: undefined,
           organizationId: undefined,
           isSupernumerary: false
         });
@@ -68,7 +67,6 @@ describe('HigherEducationRegistrationParser', () => {
           educationalTeam: 'Bill',
           group: 'Deadly Viper Assassination Squad',
           studyScheme: undefined,
-          userId: undefined,
           organizationId: undefined,
           isSupernumerary: false
         });


### PR DESCRIPTION
## :unicorn: Problème
La team prescription était heureuse ce matin. Pourquoi, me demandez-vous ? 
Car, tandis qu'elle faisait le point sur la backlog durant le stand-up, elle remarqua que le ticket PIX-1087, nommé **ETQ Prescripteur SUP ADMIN, JV pouvoir mettre à jour mes étudiants surnuméraires grâce à un nouvel import si le numéro étudiant est identique** avait déjà été réalisé, en effet de bord à un ticket précédent. 
"Mais ça marche déjà ça !" s'exclama Lise
"Normalement oui, je ne vois pas pourquoi cela ne marcherait pas" renchérit Arthur.
Tandis qu'Yvonnick affichait un air satisfait, Laura, comme à son habitude, cria :
"Validons-le rapidement, et passons le d'un bout à l'autre du board en quelques minutes !". 

Nous clappâmes (du verbe clapper), puis nous nous empressâmes de tester la fonctionnalité. Arthur, ayant une bonne connaissance des données présentes en intégration, pris l'initiative et réalisa les manipulations nécessaires. 
Quelle ne fut pas notre immense tristesse lorsque nous constatâmes, avec dépit, que lors d'un réimport de données comprenant les informations d'un étudiant déjà présent dans la liste en surnuméraire, et donc réconcilié avec son compte, cette même réconciliation se voit anéantie...

## :robot: Solution
Les attributs upsertés lors de l'import sont les mêmes que ceux utilisés lors de la réconciliation côté APP. Du coup, dans le cadre de l'import, le champ `userId` est à undefined, ce qui se transforme en NULL lors de l'upsert (et donc écrase une éventuelle valeur présente).

Plus largement, on remarque que le modèle HigherEducationRegistration contient des attributs qui ne sont pas toujours instanciés de façon constante. Du coup, les modifs du ticket :
- On supprime l'attribut `userId` du modèle, et on altère la méthode de répo de réconciliation qui va save AND reconcile
- On rend l'attribut `organizationId` pour unformiser l'interface repository (c'était pas clair, dans une méthode on passe l'orga en paramètre, dans l'autre l'orga est déjà set dans le modèle HigherEducationRegistration).

## :rainbow: Remarques
Je suis pas satisfaite du nom de la méthode de répo `saveAndReconcile`

## :100: Pour tester
Créer une campagne depuis le compte PixOrga sup@example.net
Participer à une campagne depuis PixApp en s'ajoutant en candidat surnuméraire.
Revenir sur PixOrga, faire un réimport en ajoutant le candidat surnuméraire dans le fichier (ajouter le même numéro étudiant)
Constater la non-régression de la mise à jour dans l'import + la non suppression de la réconciliation
