### PR TITLE
[FEATURE] Design de la page de vérification du certificat [PIX-1167]

### DIFF
--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -9,7 +9,7 @@ export default class FillInCertificateVerificationCode extends Controller {
 
   certificateVerificationCode = null;
 
-  codeRegex = /^P-[2346789BCDFGHJKMPQRTVWXY]{8}$/i;
+  codeRegex = /^P-[0-9A-Z]{8}$/i;
 
   @tracked
   errorMessage = null;

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -50,7 +50,7 @@ Router.map(function() {
   this.route('user-certifications', { path: 'mes-certifications' }, function() {
     this.route('get', { path: '/:id' });
   });
-  this.route('fill-in-certificate-verification-code', { path: '/verification-code-certificat' });
+  this.route('fill-in-certificate-verification-code', { path: '/verification-certificat' });
 
   this.route('fill-in-campaign-code', { path: '/campagnes' });
   this.route('campaigns', { path: '/campagnes/:code' }, function() {

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -13,6 +13,7 @@
 @import 'globals/breakpoints';
 @import 'globals/alert';
 @import 'globals/dimension';
+@import 'globals/inputs';
 @import 'globals/loading';
 @import 'globals/redesign-inputs';
 @import 'globals/pix-modal';

--- a/mon-pix/app/styles/globals/_inputs.scss
+++ b/mon-pix/app/styles/globals/_inputs.scss
@@ -3,29 +3,35 @@ input.input-code {
   border: solid 2px $grey-20;
   border-radius: 3px;
   min-height: 50px;
-  padding: 0 1px 1px .5ch;
+  padding: 0 1px 1px 0.5ch;
   text-transform: uppercase;
   width: 15.3ch;
-  background: repeating-linear-gradient(90deg,
-    $grey-22 0,
-    $grey-22 1ch,
-    transparent 0,
-    transparent 1.5ch) 0 96%/98% 2px no-repeat;
+  background:
+    repeating-linear-gradient(
+        90deg,
+        $grey-22 0,
+        $grey-22 1ch,
+        transparent 0,
+        transparent 1.5ch
+      ) 0 96%/98% 2px no-repeat;
   background-origin: content-box;
   color: $grey-70;
   font-size: 1.875rem;
   font-family: $font-roboto-mono;
-  letter-spacing: .5ch;
+  letter-spacing: 0.5ch;
 
   @media all and (-ms-high-contrast: none) {
     //display differently for IE because 1 character (ch) is equal to 1.162
     line-height: 0.7;
-    letter-spacing: .4ch;
-    background: repeating-linear-gradient(90deg,
-      $grey-22 0,
-      $grey-22 1.33ch,
-      transparent 0,
-      transparent 1.733ch) 0 96%/98% 2px no-repeat;
+    letter-spacing: 0.4ch;
+    background:
+      repeating-linear-gradient(
+          90deg,
+          $grey-22 0,
+          $grey-22 1.33ch,
+          transparent 0,
+          transparent 1.733ch
+        ) 0 96%/98% 2px no-repeat;
     background-origin: content-box;
   }
 
@@ -34,4 +40,3 @@ input.input-code {
     display: none;
   }
 }
-

--- a/mon-pix/app/styles/globals/_inputs.scss
+++ b/mon-pix/app/styles/globals/_inputs.scss
@@ -1,0 +1,37 @@
+input.input-code {
+  box-sizing: content-box;
+  border: solid 2px $grey-20;
+  border-radius: 3px;
+  min-height: 50px;
+  padding: 0 1px 1px .5ch;
+  text-transform: uppercase;
+  width: 15.3ch;
+  background: repeating-linear-gradient(90deg,
+    $grey-22 0,
+    $grey-22 1ch,
+    transparent 0,
+    transparent 1.5ch) 0 96%/98% 2px no-repeat;
+  background-origin: content-box;
+  color: $grey-70;
+  font-size: 1.875rem;
+  font-family: $font-roboto-mono;
+  letter-spacing: .5ch;
+
+  @media all and (-ms-high-contrast: none) {
+    //display differently for IE because 1 character (ch) is equal to 1.162
+    line-height: 0.7;
+    letter-spacing: .4ch;
+    background: repeating-linear-gradient(90deg,
+      $grey-22 0,
+      $grey-22 1.33ch,
+      transparent 0,
+      transparent 1.733ch) 0 96%/98% 2px no-repeat;
+    background-origin: content-box;
+  }
+
+  &::-ms-clear {
+    // not display cross that allow to clear field
+    display: none;
+  }
+}
+

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -28,45 +28,6 @@
   &__form-field {
     display: inline-block;
     text-align: left;
-
-    & input {
-      box-sizing: content-box;
-      border: solid 2px $grey-20;
-      border-radius: 3px;
-      outline: none;
-      height: 50px;
-      padding: 0 1px 1px 0.5ch;
-      text-transform: uppercase;
-      width: 13.6ch;
-      background: repeating-linear-gradient(90deg,
-        $grey-22 0,
-        $grey-22 1ch,
-        transparent 0,
-        transparent 1.5ch) 0 96%/98% 2px no-repeat;
-      background-origin: content-box;
-      color: $grey-70;
-      font-size: 1.875rem;
-      font-family: $font-roboto-mono;
-      letter-spacing: 0.5ch;
-
-      @media all and (-ms-high-contrast: none) {
-        //display differently for IE because 1 character (ch) is equal to 1.162
-        line-height: 0.7;
-        width: 15.6ch;
-        letter-spacing: 0.4ch;
-        background: repeating-linear-gradient(90deg,
-          $grey-22 0,
-          $grey-22 1.33ch,
-          transparent 0,
-          transparent 1.733ch) 0 96%/98% 2px no-repeat;
-        background-origin: content-box;
-      }
-
-      &::-ms-clear {
-        // not display cross that allow to clear field
-        display: none;
-      }
-    }
   }
 
   &__form {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -1,9 +1,12 @@
 .fill-in-certificate-verification-code {
-
   max-width: max-content;
-  padding: 48px 60px;
+  padding: 48px 24px;
   font-family: $font-roboto;
   text-align: center;
+
+  @include device-is('tablet') {
+    padding: 48px 60px;
+  }
 
   &__form {
     display: flex;
@@ -22,14 +25,15 @@
       max-width: 500px;
       color: $grey-60;
       font-weight: $font-light;
-      margin-bottom: 34px;
+      margin-bottom: 32px;
+      line-height: 22px;
     }
 
     .form__input-and-label {
       display: flex;
       flex-direction: column;
 
-      label  {
+      label {
         color: $grey-100;
         font-size: 0.875rem;
         font-weight: $font-normal;
@@ -40,17 +44,14 @@
       }
     }
 
-    input.input-code {
-      max-width: calc(280px - 4px - 0.5ch - 1px);
-    }
-
     .form__actions {
       margin-top: 24px;
       padding: 14px 20px;
+      width: calc(276px + 4px + 0.5ch + 1px);
     }
 
     .form__error--validation {
-      color: $pure-orange;
+      color: $red;
       font-size: 0.875rem;
       margin: 16px 10px 0 10px;
     }
@@ -58,6 +59,10 @@
     .form__error--not-found {
       margin: 0;
       margin-top: 16px;
+
+      svg {
+        margin-right: 4px;
+      }
     }
   }
 }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -11,18 +11,32 @@
     align-items: center;
 
     .form__title {
-      margin-bottom: 32px;
+      margin-bottom: 16px;
       font-size: 2rem;
       font-weight: $font-light;
       font-family: $font-open-sans;
       color: $grey-80;
     }
 
+    .form__description {
+      max-width: 500px;
+      color: $grey-60;
+      font-weight: $font-light;
+      margin-bottom: 34px;
+    }
+
     .form__label {
       color: $grey-100;
-      font-size: 1.219rem;
+      font-size: 0.875rem;
       font-weight: $font-light;
-      margin-bottom: 16px;
+      margin-bottom: 6px;
+      text-align: left;
+      letter-spacing: 0.15px;
+      line-height: 22px;
+    }
+
+    input.input-code {
+      max-width: calc(280px - 4px - 0.5ch - 1px);
     }
 
     .form__actions {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -6,6 +6,10 @@
   &__title {
     text-align: center;
     margin-bottom: 32px;
+    font-size: 2rem;
+    font-weight: $font-light;
+    font-family: $font-open-sans;
+    color: $grey-80;
   }
 
   &__instruction {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -2,6 +2,8 @@
 
   max-width: max-content;
   padding: 48px 60px;
+  font-family: $font-roboto;
+  text-align: center;
 
   &__form {
     display: flex;
@@ -9,7 +11,6 @@
     align-items: center;
 
     .form__title {
-      text-align: center;
       margin-bottom: 32px;
       font-size: 2rem;
       font-weight: $font-light;
@@ -19,9 +20,7 @@
 
     .form__label {
       color: $grey-100;
-      font-family: $font-open-sans;
       font-size: 1.219rem;
-      text-align: center;
       font-weight: $font-light;
       margin-bottom: 16px;
     }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -8,7 +8,7 @@
     flex-direction: column;
     align-items: center;
 
-    .fill-in-certificate-verification-code__title {
+    .form__title {
       text-align: center;
       margin-bottom: 32px;
       font-size: 2rem;
@@ -17,7 +17,7 @@
       color: $grey-80;
     }
 
-    .fill-in-certificate-verification-code__instruction {
+    .form__label {
       color: $grey-100;
       font-family: $font-open-sans;
       font-size: 1.219rem;
@@ -64,18 +64,18 @@
       }
     }
 
-    .fill-in-certificate-verification-code__actions {
+    .form__actions {
       margin-top: 24px;
     }
 
-    .fill-in-certificate-verification-code__error {
+    .form__error--validation {
       color: $pure-orange;
       font-size: 0.875rem;
       padding: 16px 10px;
       text-align: center;
     }
 
-    .fill-in-certificate-verification-code__not-found {
+    .form__error--not-found {
       margin: 32px auto 0;
       background-color: #ffdbcc;
       border-radius: 4px;

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -3,103 +3,101 @@
   max-width: max-content;
   padding: 48px 60px;
 
-  &__title {
-    text-align: center;
-    margin-bottom: 32px;
-    font-size: 2rem;
-    font-weight: $font-light;
-    font-family: $font-open-sans;
-    color: $grey-80;
-  }
-
-  &__instruction {
-    color: $grey-100;
-    font-family: $font-open-sans;
-    font-size: 1.219rem;
-    text-align: center;
-    font-weight: $font-light;
-    margin-bottom: 16px;
-  }
-
-  input {
-    box-sizing: content-box;
-    border: solid 2px $grey-20;
-    border-radius: 3px;
-    outline: none;
-    height: 50px;
-    padding: 0 1px 1px .5ch;
-    text-transform: uppercase;
-    width: 15.3ch;
-    background: repeating-linear-gradient(90deg,
-      $grey-22 0,
-      $grey-22 1ch,
-      transparent 0,
-      transparent 1.5ch) 0 96%/98% 2px no-repeat;
-    background-origin: content-box;
-    color: $grey-70;
-    font-size: 1.875rem;
-    font-family: $font-roboto-mono;
-    letter-spacing: .5ch;
-
-    @media all and (-ms-high-contrast: none) {
-      //display differently for IE because 1 character (ch) is equal to 1.162
-      line-height: 0.7;
-      letter-spacing: .4ch;
-      background: repeating-linear-gradient(90deg,
-        $grey-22 0,
-        $grey-22 1.33ch,
-        transparent 0,
-        transparent 1.733ch) 0 96%/98% 2px no-repeat;
-      background-origin: content-box;
-    }
-
-    &::-ms-clear {
-      // not display cross that allow to clear field
-      display: none;
-    }
-  }
-
   &__form {
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 30px;
-  }
 
-  &__actions {
-    margin-top: 24px;
-  }
-
-  &__error {
-    color: $pure-orange;
-    font-size: 0.875rem;
-    padding: 16px 10px;
-    text-align: center;
-  }
-
-  &__not-found {
-    margin: 32px auto 0;
-    background-color: #FFDBCC;
-    border-radius: 4px;
-    height: 46px;
-    line-height: 46px;
-    width: 436px;
-    text-align: center;
-
-    svg {
-      color: rgb(153, 0, 0);
-      margin-right: 6px;
+    .fill-in-certificate-verification-code__title {
+      text-align: center;
+      margin-bottom: 32px;
+      font-size: 2rem;
+      font-weight: $font-light;
+      font-family: $font-open-sans;
+      color: $grey-80;
     }
 
-    span {
-      color: $error;
-      font-family: $font-roboto;
-      font-size: 14px;
-      font-weight: normal;
-      height: 22px;
-      letter-spacing: 0.15px;
-      width: 380px;
+    .fill-in-certificate-verification-code__instruction {
+      color: $grey-100;
+      font-family: $font-open-sans;
+      font-size: 1.219rem;
+      text-align: center;
+      font-weight: $font-light;
+      margin-bottom: 16px;
+    }
+
+    input {
+      box-sizing: content-box;
+      border: solid 2px $grey-20;
+      border-radius: 3px;
+      outline: none;
+      height: 50px;
+      padding: 0 1px 1px .5ch;
+      text-transform: uppercase;
+      width: 15.3ch;
+      background: repeating-linear-gradient(90deg,
+        $grey-22 0,
+        $grey-22 1ch,
+        transparent 0,
+        transparent 1.5ch) 0 96%/98% 2px no-repeat;
+      background-origin: content-box;
+      color: $grey-70;
+      font-size: 1.875rem;
+      font-family: $font-roboto-mono;
+      letter-spacing: .5ch;
+  
+      @media all and (-ms-high-contrast: none) {
+        //display differently for IE because 1 character (ch) is equal to 1.162
+        line-height: 0.7;
+        letter-spacing: .4ch;
+        background: repeating-linear-gradient(90deg,
+          $grey-22 0,
+          $grey-22 1.33ch,
+          transparent 0,
+          transparent 1.733ch) 0 96%/98% 2px no-repeat;
+        background-origin: content-box;
+      }
+  
+      &::-ms-clear {
+        // not display cross that allow to clear field
+        display: none;
+      }
+    }
+
+    .fill-in-certificate-verification-code__actions {
+      margin-top: 24px;
+    }
+
+    .fill-in-certificate-verification-code__error {
+      color: $pure-orange;
+      font-size: 0.875rem;
+      padding: 16px 10px;
+      text-align: center;
+    }
+
+    .fill-in-certificate-verification-code__not-found {
+      margin: 32px auto 0;
+      background-color: #ffdbcc;
+      border-radius: 4px;
+      height: 46px;
+      line-height: 46px;
+      width: 436px;
+      text-align: center;
+  
+      svg {
+        color: rgb(153, 0, 0);
+        margin-right: 6px;
+      }
+  
+      span {
+        color: $error;
+        font-family: $font-roboto;
+        font-size: 14px;
+        font-weight: normal;
+        height: 22px;
+        letter-spacing: 0.15px;
+        width: 380px;
+      }
     }
   }
 }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -1,12 +1,7 @@
 .fill-in-certificate-verification-code {
 
-  &__container {
-    padding-bottom: 30px;
-
-    @include device-is('tablet') {
-      padding: 40px;
-    }
-  }
+  max-width: max-content;
+  padding: 48px 60px;
 
   &__title {
     text-align: center;
@@ -22,52 +17,41 @@
     margin-bottom: 16px;
   }
 
-  &__form-field {
-    display: inline-block;
-    text-align: left;
+  input {
+    box-sizing: content-box;
+    border: solid 2px $grey-20;
+    border-radius: 3px;
+    outline: none;
+    height: 50px;
+    padding: 0 1px 1px .5ch;
+    text-transform: uppercase;
+    width: 15.3ch;
+    background: repeating-linear-gradient(90deg,
+      $grey-22 0,
+      $grey-22 1ch,
+      transparent 0,
+      transparent 1.5ch) 0 96%/98% 2px no-repeat;
+    background-origin: content-box;
+    color: $grey-70;
+    font-size: 1.875rem;
+    font-family: $font-roboto-mono;
+    letter-spacing: .5ch;
 
-    & input {
-      box-sizing: content-box;
-      border: solid 2px $grey-20;
-      border-radius: 3px;
-      outline: none;
-      height: 50px;
-      padding: 0 1px 1px 0.5ch;
-      text-transform: uppercase;
-      width: 15.3ch;
-      background:
-        repeating-linear-gradient(
-            90deg,
-            $grey-22 0,
-            $grey-22 1ch,
-            transparent 0,
-            transparent 1.5ch
-          ) 0 96%/98% 2px no-repeat;
+    @media all and (-ms-high-contrast: none) {
+      //display differently for IE because 1 character (ch) is equal to 1.162
+      line-height: 0.7;
+      letter-spacing: .4ch;
+      background: repeating-linear-gradient(90deg,
+        $grey-22 0,
+        $grey-22 1.33ch,
+        transparent 0,
+        transparent 1.733ch) 0 96%/98% 2px no-repeat;
       background-origin: content-box;
-      color: $grey-70;
-      font-size: 1.875rem;
-      font-family: $font-roboto-mono;
-      letter-spacing: 0.5ch;
+    }
 
-      @media all and (-ms-high-contrast: none) {
-        //display differently for IE because 1 character (ch) is equal to 1.162
-        line-height: 0.7;
-        letter-spacing: 0.4ch;
-        background:
-          repeating-linear-gradient(
-              90deg,
-              $grey-22 0,
-              $grey-22 1.33ch,
-              transparent 0,
-              transparent 1.733ch
-            ) 0 96%/98% 2px no-repeat;
-        background-origin: content-box;
-      }
-
-      &::-ms-clear {
-        // not display cross that allow to clear field
-        display: none;
-      }
+    &::-ms-clear {
+      // not display cross that allow to clear field
+      display: none;
     }
   }
 
@@ -81,9 +65,6 @@
 
   &__actions {
     margin-top: 24px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 
   &__error {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -25,14 +25,19 @@
       margin-bottom: 34px;
     }
 
-    .form__label {
-      color: $grey-100;
-      font-size: 0.875rem;
-      font-weight: $font-light;
-      margin-bottom: 6px;
-      text-align: left;
-      letter-spacing: 0.15px;
-      line-height: 22px;
+    .form__input-and-label {
+      display: flex;
+      flex-direction: column;
+
+      label  {
+        color: $grey-100;
+        font-size: 0.875rem;
+        font-weight: $font-normal;
+        margin-bottom: 6px;
+        text-align: left;
+        letter-spacing: 0.15px;
+        line-height: 22px;
+      }
     }
 
     input.input-code {
@@ -41,6 +46,7 @@
 
     .form__actions {
       margin-top: 24px;
+      padding: 14px 20px;
     }
 
     .form__error--validation {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -26,44 +26,6 @@
       margin-bottom: 16px;
     }
 
-    input {
-      box-sizing: content-box;
-      border: solid 2px $grey-20;
-      border-radius: 3px;
-      outline: none;
-      height: 50px;
-      padding: 0 1px 1px .5ch;
-      text-transform: uppercase;
-      width: 15.3ch;
-      background: repeating-linear-gradient(90deg,
-        $grey-22 0,
-        $grey-22 1ch,
-        transparent 0,
-        transparent 1.5ch) 0 96%/98% 2px no-repeat;
-      background-origin: content-box;
-      color: $grey-70;
-      font-size: 1.875rem;
-      font-family: $font-roboto-mono;
-      letter-spacing: .5ch;
-  
-      @media all and (-ms-high-contrast: none) {
-        //display differently for IE because 1 character (ch) is equal to 1.162
-        line-height: 0.7;
-        letter-spacing: .4ch;
-        background: repeating-linear-gradient(90deg,
-          $grey-22 0,
-          $grey-22 1.33ch,
-          transparent 0,
-          transparent 1.733ch) 0 96%/98% 2px no-repeat;
-        background-origin: content-box;
-      }
-  
-      &::-ms-clear {
-        // not display cross that allow to clear field
-        display: none;
-      }
-    }
-
     .form__actions {
       margin-top: 24px;
     }

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -33,33 +33,12 @@
     .form__error--validation {
       color: $pure-orange;
       font-size: 0.875rem;
-      padding: 16px 10px;
-      text-align: center;
+      margin: 16px 10px 0 10px;
     }
 
     .form__error--not-found {
-      margin: 32px auto 0;
-      background-color: #ffdbcc;
-      border-radius: 4px;
-      height: 46px;
-      line-height: 46px;
-      width: 436px;
-      text-align: center;
-  
-      svg {
-        color: rgb(153, 0, 0);
-        margin-right: 6px;
-      }
-  
-      span {
-        color: $error;
-        font-family: $font-roboto;
-        font-size: 14px;
-        font-weight: normal;
-        height: 22px;
-        letter-spacing: 0.15px;
-        width: 380px;
-      }
+      margin: 0;
+      margin-top: 16px;
     }
   }
 }

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -17,8 +17,10 @@
         <form class="fill-in-campaign-code__form" autocomplete="off">
 
           <div class="fill-in-campaign-code__form-field">
-            <Input required 
-              @type="text" @id="campaign-code" 
+            <Input required
+              @id="campaign-code"
+              class="input-code"
+              @type="text"
               @value={{this.campaignCode}} 
               @maxlength="9"
               @key-down={{this.clearErrorMessage}} />

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -15,6 +15,7 @@
             {{t "pages.fill-in-certificate-verification-code.description"}}
           </label>
           <Input required
+            class="input-code"
             @type="text" @id="certificate-verification-code"
             @value={{this.certificateVerificationCode}}
             @maxlength="10"

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -7,9 +7,9 @@
       <PixBlock class="fill-in-certificate-verification-code">
         <form class="fill-in-certificate-verification-code__form" autocomplete="off">
 
-          <h3 class="fill-in-certificate-verification-code__title">
+          <h1 class="fill-in-certificate-verification-code__title">
             {{t "pages.fill-in-certificate-verification-code.first-title"}}
-          </h3>
+          </h1>
 
           <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">
             {{t "pages.fill-in-certificate-verification-code.description"}}

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -15,15 +15,17 @@
             {{t "pages.fill-in-certificate-verification-code.description"}}
           </p>
 
-          <label for="certificate-verification-code" class="form__label">
-            {{t "pages.fill-in-certificate-verification-code.label"}}
-          </label>
-          <Input required
-            class="input-code"
-            @type="text" @id="certificate-verification-code"
-            @value={{this.certificateVerificationCode}}
-            @maxlength="10"
-            @key-down={{this.clearErrorMessage}} />
+          <div class="form__input-and-label">
+            <label for="certificate-verification-code">
+              {{t "pages.fill-in-certificate-verification-code.label"}}
+            </label>
+            <Input required
+              class="input-code"
+              @type="text" @id="certificate-verification-code"
+              @value={{this.certificateVerificationCode}}
+              @maxlength="10"
+              @key-down={{this.clearErrorMessage}} />
+          </div>
 
           {{#if this.errorMessage}}
           <div class="form__error--validation" aria-live="polite">

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -34,9 +34,8 @@
           {{/if}}
 
           <button
-            class="form__actions"
             type="submit"
-            class="button button--extra-big form__start-button"
+            class="button button--extra-big form__start-button form__actions"
             {{action 'checkCertificate'}}>
             {{t "pages.fill-in-certificate-verification-code.verify"}}
           </button>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -7,11 +7,11 @@
       <PixBlock class="fill-in-certificate-verification-code">
         <form class="fill-in-certificate-verification-code__form" autocomplete="off">
 
-          <h1 class="fill-in-certificate-verification-code__title">
+          <h1 class="form__title">
             {{t "pages.fill-in-certificate-verification-code.first-title"}}
           </h1>
 
-          <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">
+          <label for="certificate-verification-code" class="form__label">
             {{t "pages.fill-in-certificate-verification-code.description"}}
           </label>
           <Input required
@@ -21,21 +21,21 @@
             @key-down={{this.clearErrorMessage}} />
 
           {{#if this.errorMessage}}
-          <div class="fill-in-certificate-verification-code__error" aria-live="polite">
+          <div class="form__error--validation" aria-live="polite">
             {{this.errorMessage}}
           </div>
           {{/if}}
 
           <button
-            class="fill-in-certificate-verification-code__actions"
+            class="form__actions"
             type="submit"
-            class="button button--extra-big fill-in-certificate-verification-code__start-button"
+            class="button button--extra-big form__start-button"
             {{action 'checkCertificate'}}>
             {{t "pages.fill-in-certificate-verification-code.verify"}}
           </button>
 
           {{#if this.showNotFoundCertificationErrorMessage}}
-          <div class="fill-in-certificate-verification-code__not-found">
+          <div class="form__error--not-found">
             <FaIcon @icon="exclamation-triangle"/>
             <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
           </div>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -11,8 +11,12 @@
             {{t "pages.fill-in-certificate-verification-code.first-title"}}
           </h1>
 
-          <label for="certificate-verification-code" class="form__label">
+          <p class="form__description">
             {{t "pages.fill-in-certificate-verification-code.description"}}
+          </p>
+
+          <label for="certificate-verification-code" class="form__label">
+            {{t "pages.fill-in-certificate-verification-code.label"}}
           </label>
           <Input required
             class="input-code"

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -1,47 +1,46 @@
 {{page-title (t 'pages.fill-in-certificate-verification-code.title')}}
+
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
     <PixBackgroundHeader>
-      <PixBlock>
-        <div class="fill-in-certificate-verification-code__container">
-          <form class="fill-in-certificate-verification-code__form" autocomplete="off">
-            <h3 class="fill-in-certificate-verification-code__title">
-              {{t "pages.fill-in-certificate-verification-code.first-title"}}
-            </h3>
-            <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">
-              {{t "pages.fill-in-certificate-verification-code.description"}}
-            </label>
-            <div class="fill-in-certificate-verification-code__form-field">
-              <Input required
-                @type="text" @id="certificate-verification-code"
-                @value={{this.certificateVerificationCode}}
-                @maxlength="10"
-                @key-down={{this.clearErrorMessage}} />
-            </div>
+      <PixBlock class="fill-in-certificate-verification-code">
+        <form class="fill-in-certificate-verification-code__form" autocomplete="off">
 
-            {{#if this.errorMessage}}
-            <div class="fill-in-certificate-verification-code__error" aria-live="polite">
-              {{this.errorMessage}}
-            </div>
-            {{/if}}
+          <h3 class="fill-in-certificate-verification-code__title">
+            {{t "pages.fill-in-certificate-verification-code.first-title"}}
+          </h3>
 
-          <div class="fill-in-certificate-verification-code__actions">
-            <button
-              type="submit"
-              class="button button--extra-big fill-in-certificate-verification-code__start-button"
-              {{action 'checkCertificate'}}>
-              {{t "pages.fill-in-certificate-verification-code.verify"}}
-            </button>
+          <label for="certificate-verification-code" class="fill-in-certificate-verification-code__instruction">
+            {{t "pages.fill-in-certificate-verification-code.description"}}
+          </label>
+          <Input required
+            @type="text" @id="certificate-verification-code"
+            @value={{this.certificateVerificationCode}}
+            @maxlength="10"
+            @key-down={{this.clearErrorMessage}} />
+
+          {{#if this.errorMessage}}
+          <div class="fill-in-certificate-verification-code__error" aria-live="polite">
+            {{this.errorMessage}}
           </div>
+          {{/if}}
+
+          <button
+            class="fill-in-certificate-verification-code__actions"
+            type="submit"
+            class="button button--extra-big fill-in-certificate-verification-code__start-button"
+            {{action 'checkCertificate'}}>
+            {{t "pages.fill-in-certificate-verification-code.verify"}}
+          </button>
+
+          {{#if this.showNotFoundCertificationErrorMessage}}
+          <div class="fill-in-certificate-verification-code__not-found">
+            <FaIcon @icon="exclamation-triangle"/>
+            <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
+          </div>
+          {{/if}}
         </form>
-        {{#if this.showNotFoundCertificationErrorMessage}}
-        <div class="fill-in-certificate-verification-code__not-found">
-          <FaIcon @icon="exclamation-triangle"/>
-          <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
-        </div>
-        {{/if}}
-      </div>
     </PixBlock>
     </PixBackgroundHeader>
   </burger.outlet>

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -36,10 +36,10 @@
           </button>
 
           {{#if this.showNotFoundCertificationErrorMessage}}
-          <div class="form__error--not-found">
+          <PixMessage @type='alert' class="form__error--not-found">
             <FaIcon @icon="exclamation-triangle"/>
             <span>{{t "pages.fill-in-certificate-verification-code.errors.not-found"}}</span>
-          </div>
+          </PixMessage>
           {{/if}}
         </form>
     </PixBlock>

--- a/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code-test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-certificate-verification-code-test.js
@@ -30,7 +30,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
       await controller.actions.checkCertificate.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Veuillez saisir un code au format P-XXXXXXXX.');
+      expect(controller.get('errorMessage')).to.equal('Merci de renseigner le code de vérification.');
     });
 
     it('should set error when certificateVerificationCode code is not matching the right format', async () => {
@@ -41,7 +41,7 @@ describe('Unit | Controller | Fill in certificate verification Code', function()
       await controller.actions.checkCertificate.call(controller);
 
       // then
-      expect(controller.get('errorMessage')).to.equal('Veuillez vérifier votre code.');
+      expect(controller.get('errorMessage')).to.equal('Veuillez vérifier le format de votre code (P-XXXXXXX).');
     });
 
     it('should set showNotFoundCertificationErrorMessage to true when no certificate is found', async () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -746,7 +746,8 @@
     "fill-in-certificate-verification-code": {
       "title": "Verifier une certification",
       "first-title": "Vérifier un score de certification",
-      "description": "Code de vérification (P-XXXXXXXX)",
+      "description": "La certification Pix atteste d’un niveau de maitrise des compétences numériques, reconnu par l’État et le monde professionnel.",
+      "label": "Code de vérification (P-XXXXXXXX)",
       "errors": {
         "wrong-format": "Veuillez vérifier votre code.",
         "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -749,8 +749,8 @@
       "description": "La certification Pix atteste d’un niveau de maitrise des compétences numériques, reconnu par l’État et le monde professionnel.",
       "label": "Code de vérification (P-XXXXXXXX)",
       "errors": {
-        "wrong-format": "Veuillez vérifier votre code.",
-        "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",
+        "wrong-format": "Veuillez vérifier le format de votre code (P-XXXXXXX).",
+        "missing-code": "Merci de renseigner le code de vérification.",
         "not-found": "Il n'y a pas de certificat Pix correspondant."
       },
       "verify": "Vérifier le certificat"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -744,15 +744,16 @@
     },
 
     "fill-in-certificate-verification-code": {
-      "title": "Verifier une certification",
-      "first-title": "Vérifier un score de certification",
-      "description": "Code de vérification (P-XXXXXXXX)",
+      "title": "Vérifier un certificat Pix",
+      "first-title": "Vérifier un certificat Pix",
+      "description": "La certification Pix atteste d’un niveau de maitrise des compétences numériques, reconnu par l’État et le monde professionnel.",
+      "label": "Code de vérification (P-XXXXXXXX)",
       "errors": {
         "wrong-format": "Veuillez vérifier votre code.",
         "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",
-        "not-found": "Il n'y a pas de certificat Pix correspondant"
+        "not-found": "Il n'y a pas de certificat Pix correspondant."
       },
-      "verify": "Vérifier le score"
+      "verify": "Vérifier le certificat"
     },
 
     "fill-in-id-pix": {


### PR DESCRIPTION
## :unicorn: Problème
Le design de la page de vérification de certificat n'avait pas encore été fixé.
https://1024pix.atlassian.net/browse/PIX-1167

## :robot: Solution
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/38167520/91580398-540b4600-e94d-11ea-9e1b-b2e91d710220.png">

## :rainbow: Remarques
- Les textes (traductions) ont été modifiés (vu avec Anne-So).
- La route a été renommée : `verification-certificat` (vu avec Anne-So).
- La regex pour valider le code a été changée: `/^P-[A-Z0-9]{8}$/i` car on ne souhaite pas indiquer à l'utilisateur que certains caractères ne sont pas valables (vu avec Anne-So). 

## :100: Pour tester
- aller sur `http://localhost:4200/verification-certificat`
