### PR TITLE
[FEATURE] Affichage certificat partageable [PIX-787]

### DIFF
--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -37,8 +37,8 @@ function certificationCoursesBuilder({ databaseBuilder }) {
     { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'P-FFFFFFJJ' },
     { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-666GGGKK' },
     { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-777HHHMM'  },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-888JJJLL'  },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-999LLLPP'  },
+    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-888JJJXX'  },
+    { userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-999MMMPP'  },
   ], (certificationCourseData) => {
     _buildCertificationCourse(databaseBuilder, certificationCourseData);
   });

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -24,7 +24,7 @@ describe('Acceptance | API | Certifications', () => {
     certificationCourse = databaseBuilder.factory.buildCertificationCourse({
       sessionId: session.id,
       userId,
-      isPublished: false
+      isPublished: true
     });
     assessment = databaseBuilder.factory.buildAssessment({
       userId,
@@ -37,7 +37,7 @@ describe('Acceptance | API | Certifications', () => {
       level: 1,
       pixScore: 23,
       emitter: 'PIX-ALGO',
-      status: 'rejected',
+      status: 'validated',
     });
     databaseBuilder.factory.buildPartnerCertification({
       certificationCourseId: certificationCourse.id,
@@ -480,10 +480,10 @@ describe('Acceptance | API | Certifications', () => {
           url: '/api/shared-certifications',
           payload: {},
         };
-  
+
         // when
         const response = await server.inject(options);
-  
+
         // then
         expect(response.statusCode).to.equal(500);
       });
@@ -496,10 +496,10 @@ describe('Acceptance | API | Certifications', () => {
           url: '/api/shared-certifications',
           payload: { verificationCode },
         };
-  
+
         // when
         const response = await server.inject(options);
-  
+
         // then
         expect(response.statusCode).to.equal(404);
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -19,6 +19,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
             'last-name': 'The all mighty',
             'birthplace': 'Namek',
             'birthdate': '1989-10-24',
+            'delivered-at': '2020-10-24',
             'external-id': 'xenoverse2',
             'examiner-comment': 'Un signalement surveillant',
           },
@@ -31,6 +32,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
         lastName: 'The all mighty',
         birthplace: 'Namek',
         birthdate: '1989-10-24',
+        deliveredAt: '2020-10-24',
         externalId: 'xenoverse2',
         examinerComment: 'Un signalement surveillant',
       };

--- a/mon-pix/app/controllers/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/controllers/fill-in-certificate-verification-code.js
@@ -36,16 +36,21 @@ export default class FillInCertificateVerificationCode extends Controller {
     }
 
     try {
-      await this.store.queryRecord('certification', { verificationCode: this.certificateVerificationCode.toUpperCase() });
+      const certification = await this.store.queryRecord('certification', { verificationCode: this.certificateVerificationCode.toUpperCase() });
+      return this.transitionToRoute('shared-certification', certification);
     } catch (error) {
       this.onVerificateCertificationCodeError(error);
     }
   }
 
   onVerificateCertificationCodeError(error) {
-    const { status } = error.errors[0];
-    if (status === '404') {
-      this.showNotFoundCertificationErrorMessage = true;
+    if (error.errors) {
+      const { status } = error.errors[0];
+      if (status === '404') {
+        this.showNotFoundCertificationErrorMessage = true;
+      } else {
+        throw error;
+      }
     } else {
       throw error;
     }

--- a/mon-pix/app/router.js
+++ b/mon-pix/app/router.js
@@ -47,6 +47,7 @@ Router.map(function() {
     this.route('resume', { path: '/:certification_course_id' });
     this.route('results', { path: '/:certification_number/results' });
   });
+  this.route('shared-certification', { path: '/partage-certificat/:id' });
   this.route('user-certifications', { path: 'mes-certifications' }, function() {
     this.route('get', { path: '/:id' });
   });

--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -1,0 +1,15 @@
+import Route from '@ember/routing/route';
+
+export default class SharedCertificationRoute extends Route {
+
+  async redirect(model, transition) {
+    if (!model.data) {
+      if (transition && transition.from) {
+        transition.abort();
+      } else {
+        this.replaceWith('/verification-certificat');
+      }
+    }
+  }
+
+}

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -1,0 +1,1 @@
+{{this.model.id}}

--- a/mon-pix/app/templates/shared-certification.hbs
+++ b/mon-pix/app/templates/shared-certification.hbs
@@ -1,1 +1,19 @@
-{{this.model.id}}
+{{page-title (t 'pages.shared-certification.title')}}
+
+<PixBackgroundHeader class="user-certifications-page-get">
+
+  <PixBlock class="user-certifications-page-get__header">
+    <PixReturnTo @route="fill-in-certificate-verification-code" @shade="white" class="user-certifications-page-get__return-to">
+      {{t "pages.shared-certification.back-link"}}
+    </PixReturnTo>
+    <UserCertificationsDetailHeader @certification={{this.model}} />
+  </PixBlock>
+
+  <div class="user-certifications-page-get__details-body">
+    <UserCertificationsDetailCompetencesList @resultCompetenceTree={{this.model.resultCompetenceTree}} />
+    {{#if this.model.hasCleaCertif}}
+      <UserCertificationsDetailResult @certification={{this.model}} />
+    {{/if}}
+  </div>
+
+</PixBackgroundHeader>

--- a/mon-pix/tests/unit/routes/shared-certification-test.js
+++ b/mon-pix/tests/unit/routes/shared-certification-test.js
@@ -1,0 +1,24 @@
+// import { expect } from 'chai';
+import sinon from 'sinon';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | shared-certification', function() {
+  setupTest();
+
+  it('should redirect if there a no data (direct access)', function() {
+    const route = this.owner.lookup('route:shared-certification');
+    sinon.stub(route, 'replaceWith');
+
+    route.redirect({}, {});
+    sinon.assert.calledWithExactly(route.replaceWith,'/verification-certificat');
+  });
+
+  it('should not redirect with certification', function() {
+    const route = this.owner.lookup('route:shared-certification');
+    sinon.stub(route, 'replaceWith');
+
+    route.redirect({ data: {} }, {});
+    sinon.assert.notCalled(route.replaceWith);
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -756,6 +756,11 @@
       "verify": "Vérifier le score"
     },
 
+    "shared-certification": {
+      "title": "Partage de certificat",
+      "back-link": "Retour à la saisie du code de vérification"
+    },
+
     "fill-in-id-pix": {
       "title": "Enter my username",
       "first-title": "Before starting",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -756,6 +756,11 @@
       "verify": "Vérifier le certificat"
     },
 
+    "shared-certification": {
+      "title": "Partage de certificat",
+      "back-link": "Retour à la saisie du code de vérification"
+    },
+
     "fill-in-id-pix": {
       "title": "Saisir mon identifiant",
       "first-title": "Avant de commencer",


### PR DESCRIPTION
## :unicorn: Problème
On doit pouvoir afficher le certificat "simplifié" apres avoir indiqué son code de validation dans le formulaire

## :robot: Solution
Ajouter la route et la relier au formulaire de verification `/verification-certificat`

## :rainbow: Remarques
RAS

## :100: Pour tester
- Aller sur `/verification-certificat`
- Renseigner un code valide pour une certification publiée et validé => affichage du certificat
- Renseigner un code valide pour une certification publiée et NON validé => pas d'affichage du certificat
- Renseigner un code valide pour une certification non publiée => pas d'affichage du certificat
