### PR TITLE
[BUGFIX] Scroll automatique sur le formulaire de signalement (PIX-1174)

### DIFF
--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -1,4 +1,5 @@
 import { action } from '@ember/object';
+import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
@@ -152,10 +153,12 @@ export default class FeedbackPanel extends Component {
   }
 
   _scrollIntoFeedbackPanel() {
-    const feedbackPanelElements = document.getElementsByClassName('feedback-panel__view');
-    if (feedbackPanelElements && feedbackPanelElements[0]) {
-      feedbackPanelElements[0].scrollIntoView();
-    }
+    later(function() {
+      const feedbackPanelElements = document.getElementsByClassName('feedback-panel__view');
+      if (feedbackPanelElements && feedbackPanelElements[0]) {
+        feedbackPanelElements[0].scrollIntoView();
+      }
+    });
   }
 
   get _isComparisonWindowContext() {


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on clique sur le bouton "signaler un problème" sur la page d'une épreuve, le formulaire s'affiche sous le bouton.
Lorsque la consigne de l'épreuve est longue, le formulaire peut-être caché sous l'écran.

## :robot: Solution
L'affichage du formulaire dépend de la variable `this.isFormOpened`: lorsqu'elle est à `true`, le formulaire s'affiche.
Or lorsque l'on set la variable à true et que juste après, on cherche le formulaire dans le DOM, Ember n'a pas encore rafraichi la vue et donc le formulaire n'est pas encore présent.
L'utilisation de `Ember.run.later` permet d'indiquer à Ember d'éxécuter une fonction quand la vue sera prête.
https://guides.emberjs.com/release/applications/run-loop/

## :rainbow: Remarques
Cela peut aussi se régler avec `setTimeout` au lieu de `Ember.run.later` mais on sort alors du process Ember.

## :100: Pour tester
Se rendre sur une épreuve, puis vérifier qu'après avoir cliquer sur `Signaler un problème`, le formulaire soit visible à l'écran sans avoir besoin de scroller vers le bas de l'écran.
