### PR TITLE
[FEATURE] Eviter d'induire en erreur nos utilisateurs en affichant des boutons qui ne permettront pas de poursuivre leur parcours (PIX-1164).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -55,9 +55,9 @@
     <div class="join-restricted-campaign__error" aria-live="polite">{{{this.errorMessage}}}</div>
   {{/if}}
   {{#if this.isLoading}}
-    <button type="button" disabled class="button button--big"><span class="loader-in-button">&nbsp;</span></button>
+    <button type="button" disabled class="button button--big join-restricted-campaign__button"><span class="loader-in-button">&nbsp;</span></button>
   {{else}}
-    <button type="submit" class="button button--big" {{on 'click' this.submit}}>
+    <button type="submit" class="button button--big join-restricted-campaign__button" {{on 'click' this.submit}}>
       C'est parti !
     </button>
   {{/if}}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -79,8 +79,10 @@
     </div>
 
     <div class="join-error-modal__footer">
-      <button class="button button--grey" type="button" aria-label="Quitter" {{on 'click' this.goToHome}}>Quitter</button>
-      <button class="button" type="button" aria-label="Continuer avec mon compte Pix" {{on 'click' this.goToCampaignConnectionForm}}>Continuer avec mon compte Pix</button>
+      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" aria-label="Quitter" {{on 'click' this.goToHome}}>Quitter</button>
+      {{#if this.displayContinueButton}}
+        <button class="button" type="button" aria-label="Continuer avec mon compte Pix" {{on 'click' this.goToCampaignConnectionForm}}>Continuer avec mon compte Pix</button>
+      {{/if}}
     </div>
   </PixModal>
 {{/if}}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -14,6 +14,7 @@ const ERROR_INPUT_MESSAGE_MAP = {
   monthOfBirth: 'Votre mois de naissance n’est pas valide.',
   yearOfBirth: 'Votre année de naissance n’est pas valide.',
 };
+const ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS = ['R13', 'R33'];
 
 const isDayValid = (value) => value > 0 && value <= 31;
 const isMonthValid = (value) => value > 0 && value <= 12;
@@ -42,6 +43,7 @@ export default class JoinSco extends Component {
   @tracked errorMessage;
   @tracked displayModal = false;
   @tracked modalErrorMessage = null;
+  @tracked displayContinueButton = false;
 
   @tracked firstName = '';
   @tracked lastName = '';
@@ -199,6 +201,7 @@ export default class JoinSco extends Component {
       if (error.status === '409') {
         const message = this._showErrorMessageByShortCode(error.meta);
         this.displayModal = true;
+        this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
         return this.modalErrorMessage = message;
       }
       if (error.status === '404') {
@@ -220,6 +223,6 @@ export default class JoinSco extends Component {
       { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'R33', message:'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.' }
     ];
 
-    return  find(errors, ['shortCode', meta.shortCode]).message || defaultMessage;
+    return find(errors, ['shortCode', meta.shortCode]).message || defaultMessage;
   }
 }

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -92,14 +92,9 @@
     }
   }
 
-  &__submit-button {
-    margin: 10px 0 0 0;
-    width: 100%;
-  }
-
-  &__back-button {
-    margin: 0;
-    text-align: right;
+  &__button {
+    display: block;
+    margin: 0 auto;
   }
 
   &__no-student-number {

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -483,7 +483,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.true;
           });
 
         });
@@ -508,7 +509,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.true;
           });
 
         });
@@ -533,7 +535,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.false;
           });
 
         });
@@ -558,7 +561,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.false;
           });
 
         });
@@ -583,7 +587,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.false;
           });
 
         });
@@ -608,7 +613,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.false;
           });
 
         });
@@ -633,7 +639,8 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             // then
             sinon.assert.calledOnce(record.unloadRecord);
             expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.equal(false);
+            expect(component.isLoading).to.be.false;
+            expect(component.displayContinueButton).to.be.true;
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la réconciliation d'un élève provenant du GAR, et que celui-ci obtient une erreur R13 ou R33, c'est-à-dire quand il est réconcilié avec compte GAR dans l'établissement actuel ou un autre. 
Celui-ci est alors invité à continuer avec son compte Pix, alors qu'il ne peut pas. 

## :robot: Solution
Ne plus afficher le bouton "continuer sur mon compte Pix". 

## :100: Pour tester
- Se réconcilier avec l'utilisateur "user gar" (30/09/2010).
- Vérifier que l'erreur "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours." est bien affichée (R33) et que le bouton "Continuer sur mon compte Pix" n'apparaît pas.

- Se réconcilier avec l'utilisateur "first last" (10/10/2010).
- Vérifier que l'erreur "Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.
Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga." est bien affichée (R13) et que le bouton "Continuer sur mon parcours Pix" n'apparaît pas.