### PR TITLE
[FEATURE] Générer les codes de certification à la volée [PIX-1106]

### DIFF
--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -30,24 +30,24 @@ const ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID = 108;
 function certificationCoursesBuilder({ databaseBuilder }) {
   // Each certification tests present the same questions
   _.each([
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-222BBBDD' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-333CCCBB' },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'P-444DDDCC' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'P-55555522' },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true, isPublished: false, verificationCode: 'P-FFFFFFJJ' },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-666GGGKK' },
-    { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false, isPublished: false, verificationCode: 'P-777HHHMM'  },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-888JJJXX'  },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: 'P-999MMMPP'  },
+    { userId: CERTIF_SUCCESS_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_FAILURE_USER_ID, sessionId: TO_FINALIZE_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_SESSION_TO_FINALIZE_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: false, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_SUCCESS_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_FAILURE_USER_ID, sessionId: NO_PROBLEM_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: null, hasSeenEndTestScreen: true, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false, isPublished: false, verificationCode: null, },
+    { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false, isPublished: false, verificationCode: null,  },
+    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null, },
+    { userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null, },
   ], (certificationCourseData) => {
     _buildCertificationCourse(databaseBuilder, certificationCourseData);
   });
 }
 
-function _buildCertificationCourse(databaseBuilder, { assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished, verificationCode }) {
+function _buildCertificationCourse(databaseBuilder, { assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished, verificationCode, }) {
   const createdAt = new Date('2020-01-31T00:00:00Z');
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-    ...candidateData, createdAt, isPublished, isV2Certification: true, examinerComment, hasSeenEndTestScreen, sessionId, userId, verificationCode
+    ...candidateData, createdAt, isPublished, isV2Certification: true, examinerComment, hasSeenEndTestScreen, sessionId, userId, verificationCode,
   }).id;
   databaseBuilder.factory.buildAssessment({
     id: assessmentId, certificationCourseId, type: 'CERTIFICATION', state: 'completed', userId, competenceId: null,

--- a/api/lib/domain/usecases/certificate/get-private-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-private-certificate.js
@@ -8,7 +8,13 @@ module.exports = async function getPrivateCertificate({
   cleaCertificationStatusRepository,
   assessmentResultRepository,
   competenceTreeRepository,
+  verifyCertificateCodeService,
 }) {
+  const hasCode = await certificationRepository.hasVerificationCode(certificationId);
+  if (!hasCode) {
+    const code = await verifyCertificateCodeService.generateCertificateVerificationCode();
+    await certificationRepository.saveVerificationCode(certificationId, code);
+  }
   const certificate = await certificationRepository.getPrivateCertificateByCertificationCourseId({ id: certificationId });
   if (certificate.userId !== userId) {
     throw new NotFoundError();

--- a/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
+++ b/api/lib/domain/usecases/retrieve-last-or-create-certification-course.js
@@ -14,7 +14,6 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
   sessionRepository,
   certificationChallengesService,
   placementProfileService,
-  verifyCertificateCodeService,
 }) {
   const session = await sessionRepository.get(sessionId);
   if (session.accessCode !== accessCode) {
@@ -43,7 +42,6 @@ module.exports = async function retrieveLastOrCreateCertificationCourse({
     certificationCourseRepository,
     certificationChallengesService,
     placementProfileService,
-    verifyCertificateCodeService,
   });
 };
 
@@ -64,7 +62,6 @@ async function _startNewCertification({
   certificationCourseRepository,
   certificationChallengesService,
   placementProfileService,
-  verifyCertificateCodeService,
 }) {
   const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate: new Date() });
 
@@ -85,8 +82,7 @@ async function _startNewCertification({
   }
 
   const certificationCandidate = await certificationCandidateRepository.getBySessionIdAndUserId({ userId, sessionId });
-  const certificateVerificationCode = await verifyCertificateCodeService.generateCertificateVerificationCode();
-  const newCertificationCourse = CertificationCourse.from({ certificationCandidate, challenges: newCertificationChallenges, verificationCode: certificateVerificationCode });
+  const newCertificationCourse = CertificationCourse.from({ certificationCandidate, challenges: newCertificationChallenges });
 
   const savedCertificationCourse = await certificationCourseRepository.save({
     certificationCourse: newCertificationCourse,

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -114,6 +114,12 @@ module.exports = {
     return Boolean(certification.attributes.verificationCode);
   },
 
+  async saveVerificationCode(id, verificationCode) {
+    return CertificationCourseBookshelf
+      .where({ id })
+      .save({ verificationCode }, { method: 'update' });
+  },
+
   async getShareableCertificateByVerificationCode({ verificationCode }) {
     const certificationCourseDTO = await _getBaseCertificationQuery()
       .where({ verificationCode, 'isPublished': true })

--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -106,6 +106,14 @@ module.exports = {
       .save({ isPublished: toPublish }, { method: 'update' });
   },
 
+  async hasVerificationCode(id) {
+    const certification = await CertificationCourseBookshelf
+      .where({ id })
+      .fetch({ columns: 'verificationCode' });
+
+    return Boolean(certification.attributes.verificationCode);
+  },
+
   async getShareableCertificateByVerificationCode({ verificationCode }) {
     const certificationCourseDTO = await _getBaseCertificationQuery()
       .where({ verificationCode, 'isPublished': true })

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -87,6 +87,31 @@ describe('Integration | Repository | Certification ', () => {
     });
   });
 
+  describe('#hasVerificationCode', () => {
+
+    it('should return false if certificate does not have a verificationCode', async () => {
+      // given
+      const { certificationCourse } = _buildValidatedPublishedCertificationData({ verificationCode: null, certificationCenterId, certificationCenter, userId, type, pixScore });
+      await databaseBuilder.commit();
+      // when
+      const result = await certificationRepository.hasVerificationCode(certificationCourse.id);
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true if certificate has a verificationCode', async () => {
+      // given
+      const { certificationCourse } = _buildValidatedPublishedCertificationData({ verificationCode: 'P-888BBBDD', certificationCenterId, certificationCenter, userId, type, pixScore });
+      await databaseBuilder.commit();
+      // when
+      const result = await certificationRepository.hasVerificationCode(certificationCourse.id);
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
   describe('#findByUserId', () => {
     let expectedCertifications;
 
@@ -251,8 +276,7 @@ function _buildCertificationData({ isPublished, status, verificationCode, certif
     userId,
     sessionId: session.id,
     isPublished,
-
-    verificationCode
+    verificationCode,
   });
   const assessment = databaseBuilder.factory.buildAssessment({
     certificationCourseId: certificationCourse.id,

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -112,6 +112,23 @@ describe('Integration | Repository | Certification ', () => {
     });
   });
 
+  describe('#saveVerificationCode', () => {
+
+    it('should save verification code', async () => {
+      // given
+      const { certificationCourse } = _buildValidatedPublishedCertificationData({ verificationCode: null, certificationCenterId, certificationCenter, userId, type, pixScore });
+      await databaseBuilder.commit();
+      const verificationCode = 'P-XXXXXXXX';
+
+      // when
+      await certificationRepository.saveVerificationCode(certificationCourse.id, verificationCode);
+
+      // then
+      const savedCertificationCourse = await CertificationCourseBookshelf.where({ id: certificationCourse.id }).fetch({ columns: 'verificationCode' });
+      expect(savedCertificationCourse.attributes.verificationCode).to.equal(verificationCode);
+    });
+  });
+
   describe('#findByUserId', () => {
     let expectedCertifications;
 

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -27,18 +27,19 @@ describe('Integration | Repository | Certification ', () => {
   let sessionLatestAssessmentRejectedCertifCourseIds;
   let sessionWithStartedAndErrorCertifCourseIds;
 
+  let certificationCenterId;
+  let certificationCenter;
+
   beforeEach(async () => {
 
     userId = databaseBuilder.factory.buildUser().id;
     databaseBuilder.factory.buildBadge({ key: PARTNER_CLEA_KEY });
-    const {
+    ({
       id: certificationCenterId,
       name: certificationCenter,
-    } = databaseBuilder.factory.buildCertificationCenter({ name: 'Certif College' });
+    } = databaseBuilder.factory.buildCertificationCenter({ name: 'Certif College' }));
     ({ session: completeSession, certificationCourse: completeCertificationCourse, assessmentResult: completeAssementResult }
       = _buildValidatedPublishedCertificationData({ verificationCode, certificationCenterId, certificationCenter, userId, type, pixScore }));
-    _buildNotPublishedCertificationData({ verificationCode: notPublishedSessionVerificationCode, certificationCenterId, certificationCenter, userId, type, pixScore });
-    _buildRejectedCertificationData({ verificationCode: rejectedSessionVerificationCode, certificationCenterId, certificationCenter, userId, type, pixScore });
 
     expectedCertification = _buildPrivateCertificate(certificationCenter, completeCertificationCourse, completeAssementResult, completeSession.publishedAt);
     databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: expectedCertification.id, partnerKey: PARTNER_CLEA_KEY, acquired: false });
@@ -164,6 +165,10 @@ describe('Integration | Repository | Certification ', () => {
 
     context('when verificationCode match a not published certificate', () => {
       it('should throw an error', async () => {
+        // given
+        _buildNotPublishedCertificationData({ verificationCode: notPublishedSessionVerificationCode, certificationCenterId, certificationCenter, userId, type, pixScore });
+        await databaseBuilder.commit();
+
         // when
         const error = await catchErr(certificationRepository.getShareableCertificateByVerificationCode)({ verificationCode: notPublishedSessionVerificationCode });
 
@@ -171,8 +176,12 @@ describe('Integration | Repository | Certification ', () => {
         expect(error).to.be.instanceOf(NotFoundError);
       });
     });
+
     context('when verificationCode match an rejected certificate', () => {
       it('should throw an error', async () => {
+        // given
+        _buildRejectedCertificationData({ verificationCode: rejectedSessionVerificationCode, certificationCenterId, certificationCenter, userId, type, pixScore });
+        await databaseBuilder.commit();
         // when
         const error = await catchErr(certificationRepository.getShareableCertificateByVerificationCode)({ verificationCode: rejectedSessionVerificationCode });
 

--- a/api/tests/unit/domain/usecases/get-private-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-private-certificate_test.js
@@ -1,9 +1,9 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 const getPrivateCertificate = require('../../../../lib/domain/usecases/certificate/get-private-certificate');
 const ResultCompetenceTree = require('../../../../lib/domain/models/ResultCompetenceTree');
 
-describe('Unit | UseCase | getPrivateCertificate', () => {
+describe('Unit | UseCase | getPrivateCertificate', async () => {
 
   const userId = 2;
   const certificationId = '23';
@@ -22,6 +22,11 @@ describe('Unit | UseCase | getPrivateCertificate', () => {
     getCleaCertificationStatus: () => undefined,
   };
 
+  const dependencies = { certificationRepository,
+    cleaCertificationStatusRepository,
+    assessmentResultRepository,
+    competenceTreeRepository };
+
   beforeEach(() => {
     certificationRepository.getPrivateCertificateByCertificationCourseId = sinon.stub();
     assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks = sinon.stub();
@@ -29,11 +34,10 @@ describe('Unit | UseCase | getPrivateCertificate', () => {
     cleaCertificationStatusRepository.getCleaCertificationStatus = sinon.stub().resolves(cleaCertificationStatus);
   });
 
-  context('when the user is not owner of the certification', () => {
+  context('when the user is not owner of the certification', async () => {
 
     const randomOtherUserId = 666;
     let certificate;
-    let promise;
 
     beforeEach(() => {
       // given
@@ -42,37 +46,22 @@ describe('Unit | UseCase | getPrivateCertificate', () => {
         id: certificationId
       });
       certificationRepository.getPrivateCertificateByCertificationCourseId.resolves(certificate);
-
-      // when
-      promise = getPrivateCertificate({
-        certificationId,
-        certificationRepository,
-        cleaCertificationStatusRepository,
-        assessmentResultRepository,
-        competenceTreeRepository,
-        userId,
-      });
     });
 
-    it('should get the certification from the repository', () => {
-      // then
-      return promise.catch(() => {
-        expect(certificationRepository.getPrivateCertificateByCertificationCourseId).to.have.been.calledWith({ id: certificationId });
-      });
-    });
+    it('Should throw an error if user is not the owner of the certificate', async () => {
+      // given
+      const error = await catchErr(getPrivateCertificate)({ certificationId, userId, ...dependencies, });
 
-    it('should throw an notFound error', () => {
       // then
-      return expect(promise).to.be.rejectedWith(NotFoundError);
+      expect(error).to.be.instanceOf(NotFoundError);
     });
   });
 
-  context('when the user is owner of the certification', () => {
+  context('when the user is owner of the certification', async () => {
 
     let assessmentResult;
     let certificate;
     let competenceTree;
-    let promise;
 
     beforeEach(() => {
       // given
@@ -88,59 +77,40 @@ describe('Unit | UseCase | getPrivateCertificate', () => {
 
       competenceTree = domainBuilder.buildCompetenceTree();
       competenceTreeRepository.get.resolves(competenceTree);
-
-      // when
-      promise = getPrivateCertificate({
-        certificationId,
-        certificationRepository,
-        cleaCertificationStatusRepository,
-        assessmentResultRepository,
-        competenceTreeRepository,
-        userId,
-      });
     });
 
-    it('should get the certification from the repository', () => {
+    it('should get the certification from the repository', async () => {
       // then
-      return promise.then(() => {
-        expect(certificationRepository.getPrivateCertificateByCertificationCourseId).to.have.been.calledWith({ id: certificationId });
-      });
+      const result = await getPrivateCertificate({ certificationId, userId, ...dependencies, });
+      expect(result).to.equal(certificate);
     });
 
-    it('should return the certification returned from the repository', () => {
-      // then
-      return promise.then((certification) => {
-        expect(certification).to.equal(certification);
-      });
-    });
-
-    it('should return the certification with the resultCompetenceTree', () => {
+    it('should return the certification with the resultCompetenceTree', async () => {
       const expectedResultCompetenceTree = ResultCompetenceTree.generateTreeFromCompetenceMarks({
         competenceTree,
         competenceMarks: assessmentResult.competenceMarks,
       });
       expectedResultCompetenceTree.id = `${certificationId}-${assessmentResult.id}`;
+      const result = await getPrivateCertificate({ certificationId, userId, ...dependencies, });
 
       // then
-      return promise.then((certification) => {
-        expect(certification.resultCompetenceTree).to.be.an.instanceOf(ResultCompetenceTree);
-        expect(certification.resultCompetenceTree).to.deep.equal(expectedResultCompetenceTree);
-      });
+      expect(result.resultCompetenceTree).to.be.an.instanceOf(ResultCompetenceTree);
+      expect(result.resultCompetenceTree).to.deep.equal(expectedResultCompetenceTree);
+
     });
 
-    it('should set the included resultCompetenceTree id to certificationID-assessmentResultId', () => {
+    it('should set the included resultCompetenceTree id to certificationID-assessmentResultId', async () => {
       const expectedId = `${certificationId}-${assessmentResult.id}`;
+      const result = await getPrivateCertificate({ certificationId, userId, ...dependencies, });
 
       // then
-      return promise.then((certification) => {
-        expect(certification.resultCompetenceTree.id).to.equal(expectedId);
-      });
+      expect(result.resultCompetenceTree.id).to.equal(expectedId);
     });
 
-    it('should set cleaCertificationStatus', () => {
-      return promise.then((certification) => {
-        expect(certification.cleaCertificationStatus).to.equal(cleaCertificationStatus);
-      });
+    it('should set cleaCertificationStatus', async () => {
+      const result = await getPrivateCertificate({ certificationId, userId, ...dependencies, });
+
+      expect(result.cleaCertificationStatus).to.equal(cleaCertificationStatus);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
+++ b/api/tests/unit/domain/usecases/retrieve-last-or-create-certification-course_test.js
@@ -19,7 +19,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
   const competenceRepository = { listPixCompetencesOnly: sinon.stub() };
   const certificationCandidateRepository = { getBySessionIdAndUserId: sinon.stub() };
   const certificationChallengeRepository = { save: sinon.stub() };
-  const verifyCertificateCodeService = { generateCertificateVerificationCode: sinon.stub() };
   const certificationCourseRepository = {
     findOneCertificationCourseByUserIdAndSessionId: sinon.stub(),
     save: sinon.stub(),
@@ -39,7 +38,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
     sessionRepository,
     certificationChallengesService,
     placementProfileService,
-    verifyCertificateCodeService,
   };
 
   beforeEach(() => {
@@ -213,7 +211,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
         });
 
         context('when a certification still has not been created meanwhile', () => {
-          const verificationCode = Symbol('P-555555');
 
           const foundCertificationCandidate = {
             firstName: Symbol('firstName'),
@@ -233,7 +230,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
             birthplace: foundCertificationCandidate.birthCity,
             externalId: foundCertificationCandidate.externalId,
             isV2Certification: true,
-            verificationCode,
           };
 
           const savedCertificationChallenge1 = { id: 'savedCertificationChallenge1', };
@@ -284,9 +280,6 @@ describe('Unit | UseCase | retrieve-last-or-create-certification-course', () => 
           });
 
           it('should have save the certification course based on an appropriate argument', async function() {
-            // given
-            verifyCertificateCodeService.generateCertificateVerificationCode.resolves(verificationCode);
-
             // when
             await retrieveLastOrCreateCertificationCourse({
               sessionId,


### PR DESCRIPTION
## :unicorn: Problème
Les certifications créées avant cette feature n'ont pas de code de vérification.

## :robot: Solution
Plutôt que de générer un code de vérification à la création de la certification, on va les générer (si vide) au moment de la récuperation du certificat pour affichage. 
Si l'utilisateur ne va pas voir son certificat, il n'y aura pas de code généré.

## :rainbow: Remarques
Cette option permet de 
- ne pas faire de différence de code entre les certifications créées avant et apres la feature
- minimiser le nombre de codes générés (pas de visualisation de la certif: pas besoin de générer un code)

On pourrait minimiser encore plus en proposant un bouton pour générer ce code (on genère que si l'utilisateur en fait la demande explicite)

## :100: Pour tester
- Passer une certif puis la valider/publier et la visualiser depuis `/mes-certifications`
- Visualiser une certification existante en s'assurant au préalable qu'elle n'a pas de code de vérification
✅  un code de vérification s'affiche
