### PR TITLE
[FEATURE] Mise à jour des messages d'erreurs R31, R32 et S63 dans Mon-Pix (PIX-1159).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -4,8 +4,10 @@ import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import { get, find } from 'lodash';
+import { get } from 'lodash';
 import ENV from 'mon-pix/config/environment';
+
+import { getJoinErrorsMessageByShortCode } from '../../../../utils/errors-messages';
 
 const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'Votre prénom n’est pas renseigné.',
@@ -213,16 +215,6 @@ export default class JoinSco extends Component {
 
   _showErrorMessageByShortCode(meta) {
     const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-
-    const errors = [
-      { code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'R11', message: `Vous possédez déjà un compte Pix avec l’adresse e-mail <br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R11)` },
-      { code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'R12', message:`Vous possédez déjà un compte Pix utilisé avec l’identifiant <br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R12)` },
-      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'R13', message: 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.' },
-      { code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION', shortCode:'R31', message:`Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l‘adresse mail <br>${meta.value}.<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br> (Code R31)` },
-      { code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'R32', message:`Vous possédez déjà un compte Pix utilisé dans votre établissement scolaire, avec l‘identifiant<br>${meta.value}.<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br> (Code R32)` },
-      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'R33', message:'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.' }
-    ];
-
-    return find(errors, ['shortCode', meta.shortCode]).message || defaultMessage;
+    return getJoinErrorsMessageByShortCode(meta) || defaultMessage;
   }
 }

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -12,7 +12,8 @@ import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-num
 import isEmailValid from '../../utils/email-validator';
 import isPasswordValid from '../../utils/password-validator';
 import ENV from 'mon-pix/config/environment';
-import { find } from 'lodash';
+
+import { getRegisterErrorsMessageByShortCode } from '../../utils/errors-messages';
 
 const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'Votre prénom n’est pas renseigné.',
@@ -188,17 +189,7 @@ export default class RegisterForm extends Component {
 
   _showErrorMessageByShortCode(meta) {
     const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-
-    const errors = [
-      { code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'S51', message: `Vous possédez déjà un compte Pix avec l’adresse e-mail<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S51)` },
-      { code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'S52', message:`Vous possédez déjà un compte Pix utilisé avec l’identifiant<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S52)` },
-      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION', shortCode:'S53', message: 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.' },
-      { code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION', shortCode:'S61', message:`Vous possédez déjà un compte Pix avec l‘adresse e-mail<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S61)` },
-      { code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'S62', message:`Vous possédez déjà un compte Pix avec l‘identifiant<br>${meta.value}<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br>(Code S62)` },
-      { code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION', shortCode:'S63', message:'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)' },
-    ];
-
-    return  find(errors, ['shortCode', meta.shortCode]).message || defaultMessage;
+    return getRegisterErrorsMessageByShortCode(meta) || defaultMessage;
   }
 
   @action

--- a/mon-pix/app/utils/errors-messages.js
+++ b/mon-pix/app/utils/errors-messages.js
@@ -1,0 +1,102 @@
+const JOIN_ERRORS = [
+  {
+    shortCode: 'R11',
+    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail <br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R11)',
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'R12',
+    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant <br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'R13',
+    message: 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l\'accès à ce compte à l\'aide de Pix Orga.',
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'R31',
+    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R31)',
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION'
+  },
+  {
+    shortCode: 'R32',
+    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R32)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
+  },
+  {
+    shortCode: 'R33',
+    message: 'Vous possédez déjà un compte Pix via l\'ENT. Utilisez-le pour rejoindre le parcours.',
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
+  }
+];
+
+const REGISTER_ERRORS = [
+  {
+    shortCode: 'S51',
+    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S51)',
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'S52',
+    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S52)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'S53',
+    message: 'Vous possédez déjà un compte Pix via l\'ENT. Utilisez-le pour rejoindre le parcours.',
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  },
+  {
+    shortCode: 'S61',
+    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S61)',
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION'
+  },
+  {
+    shortCode: 'S62',
+    message: 'Vous possédez déjà un compte Pix avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S62)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
+  },
+  {
+    shortCode: 'S63',
+    message: 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l\'accès à ce compte à l\'aide de Pix Orga.<br>(Code S63)',
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
+  },
+];
+
+function getJoinErrors() {
+  return JOIN_ERRORS;
+}
+
+function getJoinErrorsMessageByShortCode({ shortCode, value }) {
+  let message = undefined;
+
+  const error = JOIN_ERRORS.find((error) => error.shortCode === shortCode);
+  if (error) {
+    message = error.message.replace('#VALUE#', value);
+  }
+
+  return message;
+}
+
+function getRegisterErrors() {
+  return REGISTER_ERRORS;
+}
+
+function getRegisterErrorsMessageByShortCode({ shortCode, value }) {
+  let message = undefined;
+
+  const error = REGISTER_ERRORS.find((error) => error.shortCode === shortCode);
+  if (error) {
+    message = error.message.replace('#VALUE#', value);
+  }
+
+  return message;
+}
+
+export {
+  getJoinErrors,
+  getJoinErrorsMessageByShortCode,
+  getRegisterErrors,
+  getRegisterErrorsMessageByShortCode
+};

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -3,18 +3,16 @@
 
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { resolve, reject } from 'rsvp';
 import {
-  click,
-  fillIn,
-  find,
-  render,
-  triggerEvent
+  click, fillIn, find, render, triggerEvent
 } from '@ember/test-helpers';
+
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
+
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
 const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
@@ -24,7 +22,10 @@ const INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE = 'Votre année de naissance n’est p
 const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
+import { getRegisterErrorsMessageByShortCode } from 'mon-pix/utils/errors-messages';
+
 describe('Integration | Component | routes/register-form', function() {
+
   setupIntlRenderingTest();
 
   let sessionStub;
@@ -323,14 +324,16 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S61)', async function() {
           // given
+          const meta = { shortCode: 'S61', value: 'j***@example.net' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S61', value: 'j***@example.net' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l‘adresse e-mail<br>j***@example.net<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S61)';
 
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
@@ -370,14 +373,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
+          const meta = { shortCode: 'S62', value: 'j***.h***2' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S62', value: 'j***.h***2' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l‘identifiant<br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br>(Code S62)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -416,14 +422,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
+          const meta = { shortCode: 'S63', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S63', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -462,14 +471,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
+          const meta = { shortCode: 'S63', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S63', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -508,14 +520,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
+          const meta = { shortCode: 'S63', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S63', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -554,14 +569,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
+          const  meta = { shortCode: 'S63', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S63', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.<br>(Code S63)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -600,14 +618,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
+          const meta = { shortCode: 'S62', value: 'j***.h***2' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S62', value: 'j***.h***2' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l‘identifiant<br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l‘aide à un enseignant.<br>(Code S62)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -650,14 +671,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S51)', async function() {
           // given
+          const meta = { shortCode: 'S51', value: 'j***@example.net' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S51', value: 'j***@example.net' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l’adresse e-mail<br>j***@example.net<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S51)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -696,14 +720,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S52)', async function() {
           // given
+          const meta = { shortCode: 'S52', value: 'j***.h***2' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S52', value: 'j***.h***2' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant<br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S52)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -742,14 +769,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
+          const meta = { shortCode: 'S53', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S53', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -788,14 +818,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
+          const meta = { shortCode: 'S53', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S53', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -834,14 +867,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
+          const meta = { shortCode: 'S53', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S53', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -880,14 +916,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S53)', async function() {
           // given
+          const meta = { shortCode: 'S53', value: undefined };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S53', value: undefined }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT. Utilisez-le pour rejoindre le parcours.';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {
@@ -926,14 +965,17 @@ describe('Integration | Component | routes/register-form', function() {
 
         it('should display the error message related to the short code S52)', async function() {
           // given
+          const meta = { shortCode: 'S52', value: 'j***.h***2' };
+          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+
           const error = {
             status: '409',
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S52', value: 'j***.h***2' }
+            meta
           };
-          const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant<br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code S52)';
+
           this.owner.unregister('service:store');
           this.owner.register('service:store', storeStub);
           storeStub.prototype.createRecord = () => {

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -2,9 +2,13 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
+
 import createComponent from '../../../../../helpers/create-glimmer-component';
 
+import { getJoinErrorsMessageByShortCode } from 'mon-pix/utils/errors-messages';
+
 describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
+
   setupTest();
 
   let component;
@@ -467,14 +471,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R11)', async function() {
             // given
+            const meta = { shortCode: 'R11', value: 'j***@example.net' };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R11', value: 'j***@example.net' }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix avec l’adresse e-mail <br>j***@example.net<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R11)';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -493,14 +500,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R12)', async function() {
             // given
+            const meta = { shortCode: 'R12', value: 'j***.h***2' };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R12', value: 'j***.h***2' }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant <br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R12)';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -519,14 +529,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
+            const meta = { shortCode: 'R13', value: undefined };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R13', value: undefined }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -545,14 +558,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
+            const meta = { shortCode: 'R13', value: undefined };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R13', value: undefined }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -571,14 +587,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
+            const meta = { shortCode: 'R13', value: undefined };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R13', value: undefined }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -597,14 +616,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
+            const meta = { shortCode: 'R13', value: undefined };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R13', value: undefined }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix via l‘ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l‘aide de Pix Orga.';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when
@@ -623,14 +645,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
           it('should return a conflict error and display the error message related to the short code R12)', async function() {
             // given
+            const meta = { shortCode: 'R12', value: 'j***.h***2' };
+            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+
             const error = {
               status: '409',
               code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
               title: 'Conflict',
               detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta: { shortCode: 'R12', value: 'j***.h***2' }
+              meta
             };
-            const expectedErrorMessage = 'Vous possédez déjà un compte Pix utilisé avec l’identifiant <br>j***.h***2<br>Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.<br>(Code R12)';
+
             onSubmitToReconcileStub.rejects({ errors: [error] });
 
             // when

--- a/mon-pix/tests/unit/utils/errors-messages-test.js
+++ b/mon-pix/tests/unit/utils/errors-messages-test.js
@@ -1,0 +1,76 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import {
+  getJoinErrors,
+  getJoinErrorsMessageByShortCode,
+  getRegisterErrors,
+  getRegisterErrorsMessageByShortCode
+} from 'mon-pix/utils/errors-messages';
+
+describe('Unit | Utility | errors-messages', function() {
+
+  const JOIN_SHORT_CODES_ERRORS = [ 'R11', 'R12', 'R13', 'R31', 'R32', 'R33' ];
+  const REGISTER_SHORT_CODES_ERRORS = [ 'S51', 'S52', 'S53', 'S61', 'S62', 'S63' ];
+
+  describe('#getJoinErrors', () => {
+
+    it('should retrieve array of all join errors', () => {
+      // when
+      const errors = getJoinErrors();
+
+      // then
+      const shortCodes = errors.map((error) => error.shortCode);
+      expect(shortCodes).to.deep.equal(JOIN_SHORT_CODES_ERRORS);
+    });
+  });
+
+  describe('#getJoinErrorsMessageByShortCode', () => {
+
+    it('should retrieve all messages by shortCode with value', () => {
+      // given
+      const value = 'someData';
+
+      const expectedMessages = getJoinErrors()
+        .map(({ message }) => message.replace('#VALUE#', value));
+
+      // when
+      const messages = JOIN_SHORT_CODES_ERRORS
+        .map((shortCode) => getJoinErrorsMessageByShortCode({ shortCode, value }));
+
+      // then
+      expect(messages).to.deep.equal(expectedMessages);
+    });
+  });
+
+  describe('#getRegisterErrors', () => {
+
+    it('should retrieve array of all register errors', () => {
+      // when
+      const errors = getRegisterErrors();
+
+      // then
+      const shortCodes = errors.map((error) => error.shortCode);
+      expect(shortCodes).to.deep.equal(REGISTER_SHORT_CODES_ERRORS);
+    });
+  });
+
+  describe('#getRegisteErrorsMessageByShortCode', () => {
+
+    it('should retrieve all messages by shortCode with values', () => {
+      // given
+      const value = 'someData';
+
+      const expectedMessages = getRegisterErrors()
+        .map(({ message }) => message.replace('#VALUE#', value));
+
+      // when
+      const messages = REGISTER_SHORT_CODES_ERRORS
+        .map((shortCode) => getRegisterErrorsMessageByShortCode({ shortCode, value }));
+
+      // then
+      expect(messages).to.deep.equal(expectedMessages);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans Mon-Pix, les messages d'erreurs R31, R32 et S63, liés à la Réconciliation et à la Double-mire, comportent quelques imprécisions.

## :robot: Solution
Effectuer leur mise à jour.

## :rainbow: Remarques
Les listes d'erreurs spécifiques `Rxx` et `Sxx` ont été placées en dehors des components `components/routes/campaigns/restricted/join-sco.js` et `components/routes/register-form.js`.
On peut y avoir recours à travers un utilitaire dédié.

## :100: Pour tester
Scénarios possibles : 
Sur Mon-Pix /campagnes/RESTRICD

1. L'élève possède déjà une compte avec un e-mail
* Se connecter avec un compte non sco
* Rejoindre avec un élève déjà réconcilié (lié avec un compte possédant qu'un e-mail)
```
Vous possédez déjà un compte Pix avec l’adresse e-mail
e***@gmail.com
Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.
(Code R31)
```
2. L'élève possède déjà une compte avec un identifiant
* Se connecter avec un compte non sco
* Rejoindre avec un élève déjà réconcilié (lié avec un compte possédant qu'un identifiant)
```
Vous possédez déjà un compte Pix utilisé avec l’identifiant
e***.b***4
Pour continuer, connectez-vous à ce compte ou demandez de l'aide à un enseignant.
(Code R32)
```
3. L'élève possède déjà un compte via l'ENT dans un autre établissement scolaire
* S'inscrire avec un élève déjà réconcilié (lié avec un compte possédant qu'un samlId)
```
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l'aide de Pix Orga.
(Code S63)
```