### PR TITLE
[BUGFIX] Ne pas afficher la page /profil suite à l'authentification d'un élève provenant du GAR (PIX-1217).

### DIFF
--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -25,6 +25,11 @@ export default class JoinRestrictedCampaignController extends Controller {
     const response = await externalUser.save();
 
     this.session.set('data.externalUser', null);
+
+    // Needed to avoid ember-simple-auth from redirecting to routeAfterAuthentication (ie /profil) after authentication
+    // https://github.com/simplabs/ember-simple-auth/blob/e88f1c163e5e9c7a8524bdfca115843d30128a86/addon/mixins/application-route-mixin.js#L104-L112
+    this.session.set('attemptedTransition', { retry: () => {} });
+
     await this.session.authenticate('authenticator:oauth2', { token: response.accessToken });
     await this.currentUser.load();
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la création du compte d'un élève provenant du GAR et de sa réconciliation, un access-token est renvoyé par l'API. Grâce à ce token, le front est capable d'authentifier l'utilisateur afin de lui permettre de poursuivre son parcours. Néanmoins, le comportement par défaut d'ember-simple-auth est de rediriger l'utilisateur vers une certaine page suite à son authentification (/profil dans Pix App). Ce comportement provoque pendant un court instant l'affichage du profil de l'utilisateur avant de le rediriger vers la suite de son parcours.

## :robot: Solution
Surcharger l'`attemptedTransition` de la session `ember-simple-auth` afin d'empêcher la redirection vers la `routeAfterAuthentication`.

## :rainbow: Remarques
https://github.com/simplabs/ember-simple-auth/blob/e88f1c163e5e9c7a8524bdfca115843d30128a86/addon/mixins/application-route-mixin.js#L104-L112

## :100: Pour tester
- Simuler la connexion d'un élève provenant du GAR.
- Le réconcilier et vérifier que l'on accède bien à la suite du parcours sans afficher le profil de l'utilisateur. 
