### PR TITLE
[BUGFIX] Permettre à tous les utilisateurs d'accéder au menu de déconnexion (PIX-1163). 

### DIFF
--- a/orga/app/controllers/authenticated/team/list.js
+++ b/orga/app/controllers/authenticated/team/list.js
@@ -7,5 +7,5 @@ export default class ListController extends Controller {
   queryParams = ['pageNumber', 'pageSize'];
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
-  @tracked pageSize = 10;
+  @tracked pageSize = 100;
 }


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs qui sont dans les pages suivantes de la liste des membres d'une organisation ne peuvent pas se déconnecter, ni changer d'organisation. 

## :robot: Solution
En solution temporaire, nous augmentons la taille du nombre de membre par page, ce qui permettra à presque tous les membres de pouvoir changer d'organisation. 

## :100: Pour tester
Voir dans l'onglet équipe que l'affichage par défaut est de 100.  