### PR TITLE
[FEATURE] Mise à jour des messages contenus dans la modale Dissocier un élève, dans Pix Orga (PIX-1155).

### DIFF
--- a/orga/app/components/dissociate-user-modal.hbs
+++ b/orga/app/components/dissociate-user-modal.hbs
@@ -1,14 +1,8 @@
 <Modal::Dialog class="dissociate-user-modal" @title="Dissocier le compte Pix de l'élève" @display={{@display}} @close={{@close}}>
   <Modal::Body class="dissociate-user-modal__content">
     <p class="content-text">
-    {{#if @student.hasEmail}}
-        Souhaitez-vous dissocier le compte <span class="content-text--bold">{{@student.email}}</span> de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
-    {{else if @student.hasUsername}}
-        Souhaitez-vous dissocier le compte <span class="content-text--bold">{{@student.username}}</span> de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
-    {{else}}
-        Souhaitez-vous dissocier le compte du médiacenter de l'ENT de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
-    {{/if}}
-      </p>
+      Souhaitez-vous dissocier le compte Pix de l'élève <span class="content-text--bold">{{@student.firstName}} {{@student.lastName}} ?</span>
+    </p>
     <p class="content-text content-text--info">
       L’élève pourra s’associer à nouveau avec une autre méthode d’authentification lors d’une prochaine campagne.
       <br/>

--- a/orga/tests/integration/components/dissociate-user-modal-test.js
+++ b/orga/tests/integration/components/dissociate-user-modal-test.js
@@ -5,6 +5,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | dissociate-user-modal', function(hooks) {
+
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -15,12 +16,12 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     return render(hbs`<DissociateUserModal @refreshModel={{refreshModel}} @display={{display}} @close={{close}} @student={{student}}/>`);
   });
 
-  module('when the user is authenticated  with an email', function() {
+  module('when the user is authenticated with an email', function() {
 
     test('it displays a message for user authentified by email', async function(assert) {
       this.set('student', { hasEmail: true, email: 'rocky.balboa@example.net', firstName: 'Rocky',  lastName: 'Balboa' });
 
-      assert.contains('Souhaitez-vous dissocier le compte rocky.balboa@example.net de l\'élève Rocky Balboa ?');
+      assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Rocky Balboa ?');
     });
   });
 
@@ -29,7 +30,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     test('it displays a message for user authentified by username', async function(assert) {
       this.set('student', { hasUsername: true, username: 'appolo.creed', firstName: 'Appolo',  lastName: 'Creed' });
 
-      assert.contains('Souhaitez-vous dissocier le compte appolo.creed de l\'élève Appolo Creed ?');
+      assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Appolo Creed ?');
     });
   });
 
@@ -38,7 +39,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     test('it displays a message for user authentified with GAR', async function(assert) {
       this.set('student', { hasEmail: false, hasUsername: false, firstName: 'Ivan', lastName: 'Drago' });
 
-      assert.contains('Souhaitez-vous dissocier le compte du médiacenter de l\'ENT de l\'élève Ivan Drago ?');
+      assert.contains('Souhaitez-vous dissocier le compte Pix de l\'élève Ivan Drago ?');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Les messages contenus dans la modale Dissocier un élève rendent difficile la compréhension.

## :robot: Solution
Les mettre à jour en simplifiant le wording de la 1ere phrase.
On garde les 2 autres phrases en dessous.

## :100: Pour tester
Dans Pix Orga, se rendre sur la page des Elèves, et dissocier un élève.
La modale doit être correctement mise à jour.
