### PR TITLE
[TECH] Rajouter les sourcemap sur les front-end en production.

### DIFF
--- a/admin/ember-cli-build.js
+++ b/admin/ember-cli-build.js
@@ -4,8 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    sourcemaps: { enabled: true },
     babel: {
-      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+      sourceMaps: 'inline'
     },
     'ember-bootstrap': {
       'importBootstrapFont': false,

--- a/certif/ember-cli-build.js
+++ b/certif/ember-cli-build.js
@@ -6,8 +6,9 @@ const pluginsToBlacklist = environment === 'production' ? ['ember-freestyle'] : 
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    sourcemaps: { enabled: true },
     babel: {
-      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+      sourceMaps: 'inline'
     },
     'ember-cli-babel': {
       includePolyfill: true

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -4,8 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    sourcemaps: { enabled: true },
     babel: {
-      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+      sourceMaps: 'inline'
     },
     'ember-cli-babel': {
       includePolyfill: true

--- a/orga/ember-cli-build.js
+++ b/orga/ember-cli-build.js
@@ -4,10 +4,10 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   const app = new EmberApp(defaults, {
+    sourcemaps: { enabled: true },
     babel: {
-      sourceMaps: EmberApp.env() === 'development' ? 'inline' : false
+      sourceMaps: 'inline'
     },
-
     'ember-cli-template-lint': {
       testGenerator: 'qunit' // or 'mocha', etc.
     },


### PR DESCRIPTION
## :unicorn: Problème
Lors du build d'une application front, le code source Ember est transformé en JS.
Si une erreur est levée lors de l'exécution de ce code, le debugger du navigateur affiche le code JS, et non pas le code Ember, rendant ainsi le diagnostic difficile.

Les sourcemap permettent d'afficher le code source correspondant. Elles sont générées par Babel lors du build (fichier `ember-cli-build.js` section `sourceMaps`). Elle ne sont activées que si la variable NODE_ENV a pour valeur développement, et ce n'est jamais le cas sur Scalingo
```
scalingo --app pix-app-integration env | grep NODE_ENV
scalingo --app pix-front-review-pr1822 env | grep NODE_ENV
```
Les sourcemap sont [activées par défaut ](https://m.signalvnoise.com/paying-tribute-to-the-web-with-view-source/)en production sur Ruby pour faciliter l'apprentissage et le diagnostic

## :robot: Solution
Activer les sourcemap sur tous les environnements, dont la production

Activer les sourcemap Ember dans `ember-cli-build.js`
`sourcemaps: { enabled: true }`

On obtient pour router.js
```
 Router.map(function () {
    this.route('index', {
      path: '/'
    });
```

Mais on voit le code généré par Babel
`function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") (..)`

Si on active les sourcemap Babel dans `ember-cli-build.js`, il ne reste plus que le code original Ember
```
babel: {
   sourceMaps: 'inline'
},
```
## :rainbow: Remarques
Les sourcemap[ n'apparaissent pas ](https://indepth.dev/source-maps-from-top-to-bottom/)dans l'onglet Network

Les raisons pour utiliser l'option 'inline' plutôt que 'true' ne sont pas [claires](https://babeljs.io/docs/en/options#sourcemaps).
Ce choix est challengeable si vous avez de bons arguments.

Une recherche a été [effectuée](https://css-tricks.com/should-i-use-source-maps-in-production/) pour voir s'il peut y avoir des conséquences indésirables.

Axes
- sécurité: OK. Le code source est disponible sur Github, il n'y a aucun avantage à l'obfusquer côté client
- performance utilisateur: OK. Les sourcemap ne sont rapatriées que si les DevTools sont actifs
- performance build: OK. Le surcoût est de 2 secondes (`time npm run build` 31s avec / sans 33s )

## :100: Pour tester
Allez sur l'application (ex: [pix-app](https://app-pr1825.review.pix.fr)) et ouvrir les DevTools, onglet Debugger
Déroulez main Thread/<BASE_URL>/assets
Vérifier l'absence de
- `<APP>.js`
- `vendor.js`

Vérifiez qu'à la fin du fichier `<APP>.js `se trouve
`//# sourceMappingURL=<APP>.map`

Ajoutez un point d'arrêt sur le routeur pix-app (mon-pix/router.js)
Rechargez (F5) et vérifer que le code source suivant est affiché.
```
this.route('index', { path: '/' });
this.route('inscription');
```
