### PR TITLE
[CLEANUP] Renommer le Label et la Github action pour l'auto-merge.

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: check
+name: automerge check
 on:
   pull_request:
     types:
@@ -14,8 +14,8 @@ jobs:
         uses: "pascalgn/automerge-action@v0.8.3"
         env:
           GITHUB_TOKEN: "${{ secrets.PIX_SERVICE_ACTIONS_TOKEN }}"
-          MERGE_LABELS: "Merge-auto test"
+          MERGE_LABELS: ":rocket: Ready to Merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
-          UPDATE_LABELS: "Merge-auto test"
+          UPDATE_LABELS: ":rocket: Ready to Merge"
           UPDATE_METHOD: "rebase"
           MERGE_FORKS: "false"


### PR DESCRIPTION
## :unicorn: Problème
La github action d'auto-merge est maintenant fonctionnelle, cependant, elle s'appelle `check` et porte sur le tag `Merge-auto test`.

## :robot: Solution
- Renommer l'action ;
- Faire porter l'auto-merge sur le tag ":rocket: Ready to merge"

## :rainbow: Remarques
Une présentation sera faite pour expliciter comment ça marche, et comment l'utiliser.

## :100: Pour tester
Lorque l'on va vouloir merger cette PR, mettre le label ":rocket: Ready to merge", cela devrait déclencher le check, rebase si besoin, merger, et supprimer la branche.
