### PR TITLE
[BUGFIX] Nombre de caractères pour le code campagne KO [PIX-1220]

### DIFF
--- a/mon-pix/app/styles/globals/_inputs.scss
+++ b/mon-pix/app/styles/globals/_inputs.scss
@@ -5,7 +5,6 @@ input.input-code {
   min-height: 50px;
   padding: 0 1px 1px 0.5ch;
   text-transform: uppercase;
-  width: 15.3ch;
   background:
     repeating-linear-gradient(
         90deg,

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -28,6 +28,10 @@
   &__form-field {
     display: inline-block;
     text-align: left;
+
+    input {
+      width: 13.6ch;
+    }
   }
 
   &__form {

--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -42,6 +42,10 @@
         letter-spacing: 0.15px;
         line-height: 22px;
       }
+
+      input {
+        width: 15.3ch;
+      }
     }
 
     .form__actions {


### PR DESCRIPTION
## :unicorn: Problème
Les tirets pour le formulaire du code d'acces à la campagne ne correspondent plus au nombre de caracteres.
Il y en a 10 mais devrait y en avoir 9

## :robot: Solution
Changer la largeur de l'input en fonction des formulaires (au lieu d'un _width_ global)

## :100: Pour tester
/campagnes =>                  9 tirets 
/verification-certificat => 10 tirets