### PR TITLE
[TECH] Suppression des imports par défault de lodash dans pix-app

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -39,6 +39,8 @@ module.exports = {
     /* Recommended rules */
     'ember/no-mixins': 'off',
     'ember/no-jquery': 'off',
+    /* Avoid lodash default import */
+    'no-restricted-imports': [2, { 'paths': ['lodash'] }],
   },
   overrides: [
     // node files

--- a/mon-pix/app/components/challenge-item-qrocm.js
+++ b/mon-pix/app/components/challenge-item-qrocm.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
-import _ from 'lodash';
 import { inject as service } from '@ember/service';
+import filter from 'lodash/filter';
+import isEmpty from 'lodash/isEmpty';
 
 import ChallengeItemGeneric from './challenge-item-generic';
 import jsyaml from 'js-yaml';
@@ -39,7 +40,7 @@ export default class ChallengeItemQrocm extends ChallengeItemGeneric {
   }
 
   _hasEmptyAnswerFields(answers) {
-    return _.filter(answers, _.isEmpty).length;
+    return filter(answers, isEmpty).length;
   }
 
   _getAnswerValue() {

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import config from 'mon-pix/config/environment';
 import Component from '@glimmer/component';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 export default class ChallengeStatement extends Component {
   @service mailGenerator;
@@ -50,7 +50,7 @@ export default class ChallengeStatement extends Component {
   }
 
   _initialiseDefaultAttachment() {
-    this.selectedAttachmentUrl = _.get(this.args.challenge, 'attachments.firstObject');
+    this.selectedAttachmentUrl = get(this.args.challenge, 'attachments.firstObject');
   }
 
   _formattedEmailForInstruction() {

--- a/mon-pix/app/components/communication-banner.js
+++ b/mon-pix/app/components/communication-banner.js
@@ -1,6 +1,6 @@
 import { htmlSafe } from '@ember/string';
 import Component from '@glimmer/component';
-const _ = require('lodash');
+import isEmpty from 'lodash/isEmpty';
 import ENV from 'mon-pix/config/environment';
 
 export default class CommunicationBanner extends Component {
@@ -14,7 +14,7 @@ export default class CommunicationBanner extends Component {
   };
 
   get isEnabled() {
-    return !_.isEmpty(this._rawBannerContent) && !_.isEmpty(this.bannerType);
+    return !isEmpty(this._rawBannerContent) && !isEmpty(this.bannerType);
   }
 
   get bannerContent() {

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { isEmpty } from '@ember/utils';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 import { topLevelLabels, questions } from 'mon-pix/static-data/feedback-panel-issue-labels';
@@ -80,7 +80,7 @@ export default class FeedbackPanel extends Component {
       category,
       assessment: this.args.assessment,
       challenge: this.args.challenge,
-      answer: _.get(this.args, 'answer.value', null),
+      answer: get(this.args, 'answer.value', null),
     });
 
     try {

--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -9,7 +9,7 @@ import classic from 'ember-classic-decorator';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 @classic
 @classNames('qcm-solution-panel')
@@ -21,14 +21,14 @@ export default class QcmSolutionPanel extends Component {
   @computed('solution')
   get solutionArray() {
     const solution = this.solution;
-    return !_.isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
+    return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
   }
 
   @computed('answer')
   get labeledCheckboxes() {
     const answer = this.answer.value;
     let checkboxes  = [];
-    if (!_.isEmpty(answer)) {
+    if (!isEmpty(answer)) {
       const proposals = this.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -9,7 +9,7 @@ import classic from 'ember-classic-decorator';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 @classic
 @classNames('qcu-solution-panel')
@@ -21,14 +21,14 @@ export default class QcuSolutionPanel extends Component {
   @computed('solution')
   get solutionArray() {
     const solution = this.solution;
-    return !_.isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
+    return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
   }
 
   @computed('answer')
   get labeledRadios() {
     const answer = this.answer.value;
     let radiosArray = [];
-    if (!_.isEmpty(answer)) {
+    if (!isEmpty(answer)) {
       const proposals = this.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -8,7 +8,7 @@ import classic from 'ember-classic-decorator';
 import { htmlSafe } from '@ember/template';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
-import _ from 'lodash';
+import keys from 'lodash/keys';
 import jsyaml from 'js-yaml';
 
 const classByResultValue = {
@@ -24,7 +24,7 @@ export default class QrocmDepSolutionPanel extends Component {
   get inputFields() {
     const escapedProposals = this.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.answer.value, _.keys(labels));
+    const answers = answersAsObject(this.answer.value, keys(labels));
 
     return Object.keys(labels).map((key) => {
       const answerIsEmpty = answers[key] === '';

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -6,7 +6,8 @@ import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import _ from 'lodash';
+import forEach from 'lodash/forEach';
+import keys from 'lodash/keys';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import solutionsAsObject from 'mon-pix/utils/solution-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
@@ -36,13 +37,13 @@ class QrocmIndSolutionPanel extends Component {
 
     const escapedProposals = this.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.answer.value, _.keys(labels));
+    const answers = answersAsObject(this.answer.value, keys(labels));
     const solutions = solutionsAsObject(this.solution);
     const resultDetails = resultDetailsAsObject(this.answer.resultDetails);
 
     const inputFields = [];
 
-    _.forEach(labels, (label, labelKey) => {
+    forEach(labels, (label, labelKey) => {
       const answerOutcome = _computeAnswerOutcome(answers[labelKey], resultDetails[labelKey]);
       const inputClass = _computeInputClass(answerOutcome);
 

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -4,7 +4,8 @@ import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 import { decodeToken } from 'mon-pix/helpers/jwt';
-import { get } from 'lodash';
+import get from 'lodash/get';
+
 import ENV from 'mon-pix/config/environment';
 
 import { getJoinErrorsMessageByShortCode } from '../../../../utils/errors-messages';

--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
@@ -27,8 +27,8 @@ export default class SigninForm extends Component {
     try {
       await this.args.authenticateUser(this.username, this.password);
     } catch (response) {
-      const error = _.get(response, 'errors[0]');
-      const isPasswordExpiredError = (_.get(error, 'title') === 'PasswordShouldChange');
+      const error = get(response, 'errors[0]');
+      const isPasswordExpiredError = (get(error, 'title') === 'PasswordShouldChange');
       if (isPasswordExpiredError) {
         await this.args.updateExpiredPassword(this.username, this.password);
       } else {
@@ -40,7 +40,7 @@ export default class SigninForm extends Component {
   }
 
   _manageErrorsApi(firstError) {
-    const statusCode = _.get(firstError, 'status');
+    const statusCode = get(firstError, 'status');
     this.errorMessage = this._showErrorMessages(statusCode);
   }
 

--- a/mon-pix/app/components/signup-form.js
+++ b/mon-pix/app/components/signup-form.js
@@ -5,10 +5,10 @@
 
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
+import get from 'lodash/get';
 import isEmailValid from 'mon-pix/utils/email-validator';
 import isPasswordValid from '../utils/password-validator';
 import ENV from 'mon-pix/config/environment';
-const _ = require('lodash');
 
 const ERROR_INPUT_MESSAGE_MAP = {
   firstName: 'pages.sign-up.fields.firstname.error',
@@ -143,7 +143,7 @@ export default Component.extend({
 
       this._trimNamesAndEmailOfUser();
 
-      const campaignCode = _.get(this.session, 'attemptedTransition.from.parent.params.code');
+      const campaignCode = get(this.session, 'attemptedTransition.from.parent.params.code');
 
       this.user.save({ adapterOptions: { campaignCode } }).then(() => {
         const credentials = { login: this.user.email, password: this.user.password };

--- a/mon-pix/app/components/timeout-jauge.js
+++ b/mon-pix/app/components/timeout-jauge.js
@@ -9,7 +9,7 @@ import { htmlSafe } from '@ember/string';
 import Component from '@ember/component';
 import { run } from '@ember/runloop';
 import { set, computed } from '@ember/object';
-import _ from 'lodash';
+import round from 'lodash/round';
 import ENV from 'mon-pix/config/environment';
 
 // see http://stackoverflow.com/a/37770048/2595513
@@ -39,7 +39,7 @@ export default Component.extend({
   _currentTime: Date.now(),
 
   remainingSeconds: computed('_elapsedTime', function() {
-    return _.round((this._totalTime - this._elapsedTime) / 1000);
+    return round((this._totalTime - this._elapsedTime) / 1000);
   }),
 
   remainingTime: computed('remainingSeconds', function() {

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -6,7 +6,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import isPasswordValid from '../utils/password-validator';
 import { tracked } from '@glimmer/tracking';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 
 const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';

--- a/mon-pix/app/components/warning-page.js
+++ b/mon-pix/app/components/warning-page.js
@@ -4,7 +4,7 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
-import _ from 'lodash';
+import isInteger from 'lodash/isInteger';
 
 function _pluralize(word, count) {
   if (!count) {
@@ -23,7 +23,7 @@ function _getSeconds(time) {
 
 function _formatTimeForText(time) {
 
-  if (!_.isInteger(time)) {
+  if (!isInteger(time)) {
     return '';
   }
 
@@ -39,7 +39,7 @@ function _formatTimeForText(time) {
 
 function _formatTimeForButton(time) {
 
-  if (!_.isInteger(time) || !time) {
+  if (!isInteger(time) || !time) {
     return 0;
   }
 

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -15,7 +15,7 @@ export default class ChallengeController extends Controller {
   }
 
   get pageTitle() {
-    const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, _.get(this.model, 'answer.id'));
+    const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
 
     return this.intl.t('pages.challenge.title', { stepNumber, totalChallengeNumber });

--- a/mon-pix/app/helpers/convert-to-html.js
+++ b/mon-pix/app/helpers/convert-to-html.js
@@ -1,9 +1,9 @@
 import { helper } from '@ember/component/helper';
 import showdown from 'showdown';
-import _ from 'lodash';
+import isArray from 'lodash/isArray';
 
 export function convertToHtml(params) {
-  if (_.isArray(params) && params.length > 0) {
+  if (isArray(params) && params.length > 0) {
     const converter = new showdown.Converter();
     return converter.makeHtml(params[0]);
   }

--- a/mon-pix/app/helpers/strip-instruction.js
+++ b/mon-pix/app/helpers/strip-instruction.js
@@ -1,6 +1,6 @@
 import { helper } from '@ember/component/helper';
 import $ from 'jquery';
-import _ from 'lodash';
+import truncate from 'lodash/truncate';
 
 export function stripInstruction(params) {
   let length = 70;
@@ -9,7 +9,7 @@ export function stripInstruction(params) {
   }
   const result = $(params[0]).text();
 
-  return _.truncate(result, {
+  return truncate(result, {
     length,
     separator: ' '
   });

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import isBoolean from 'lodash/isBoolean';
+import isString from 'lodash/isString';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
@@ -58,7 +60,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
         const campaignParticipation = await this.store.createRecord('campaign-participation', { campaign, participantExternalId: this.state.participantExternalId }).save();
         this._updateStateFrom({ ongoingCampaignParticipation: campaignParticipation });
       } catch (err) {
-        if (_.get(err, 'errors[0].status') === 403) {
+        if (get(err, 'errors[0].status') === 403) {
           this.session.invalidate();
           return this.transitionTo('campaigns.start-or-resume', campaign);
         }
@@ -120,15 +122,15 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     const hasUserCompletedRestrictedCampaignAssociation = this._handleQueryParamBoolean(queryParams.associationDone, this.state.hasUserCompletedRestrictedCampaignAssociation);
     const hasUserSeenLandingPage = this._handleQueryParamBoolean(queryParams.hasUserSeenLandingPage, this.state.hasUserSeenLandingPage);
     this.state = {
-      isCampaignRestricted: _.get(campaign, 'isRestricted', this.state.isCampaignRestricted),
-      isCampaignForSCOOrganization: _.get(campaign, 'organizationType') === 'SCO',
+      isCampaignRestricted: get(campaign, 'isRestricted', this.state.isCampaignRestricted),
+      isCampaignForSCOOrganization: get(campaign, 'organizationType') === 'SCO',
       hasUserCompletedRestrictedCampaignAssociation,
       hasUserSeenLandingPage,
       isUserLogged: this.session.isAuthenticated,
       doesUserHaveOngoingParticipation: Boolean(ongoingCampaignParticipation),
-      doesCampaignAskForExternalId: _.get(campaign, 'idPixLabel', this.state.doesCampaignAskForExternalId),
-      participantExternalId: _.get(queryParams, 'participantExternalId', this.state.participantExternalId),
-      externalUser: _.get(session, 'data.externalUser'),
+      doesCampaignAskForExternalId: get(campaign, 'idPixLabel', this.state.doesCampaignAskForExternalId),
+      participantExternalId: get(queryParams, 'participantExternalId', this.state.participantExternalId),
+      externalUser: get(session, 'data.externalUser'),
     };
   }
 
@@ -155,11 +157,11 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
   }
 
   _handleQueryParamBoolean(value, defaultValue) {
-    if (_.isBoolean(value)) {
+    if (isBoolean(value)) {
       return value;
     }
 
-    if (_.isString(value)) {
+    if (isString(value)) {
       return value.toLowerCase() === 'true';
     }
 

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,14 +1,14 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 @classic
 export default class ErrorRoute extends Route {
   @service session;
 
   hasUnauthorizedError(error) {
-    const statusCode = _.get(error, 'errors[0].code');
+    const statusCode = get(error, 'errors[0].code');
     return statusCode === 401;
   }
 

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -1,8 +1,7 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
-
-const _ = require('lodash');
+import get from 'lodash/get';
 
 @classic
 export default class ResetPasswordRoute extends Route {
@@ -16,7 +15,7 @@ export default class ResetPasswordRoute extends Route {
       const user = await this.store.queryRecord('user', { passwordResetTemporaryKey });
       return { user, temporaryKey: passwordResetTemporaryKey };
     } catch (error) {
-      const status = _.get(error, 'errors[0].status');
+      const status = get(error, 'errors[0].status');
       if (status && (status === 401 || status && 404)) {
         this.errors.push(this.intl.t('pages.reset-password.error'));
         this.replaceWith('password-reset-demand');

--- a/mon-pix/app/services/current-domain.js
+++ b/mon-pix/app/services/current-domain.js
@@ -1,5 +1,5 @@
 import Service  from '@ember/service';
-import { last } from 'lodash';
+import last from 'lodash/last';
 
 export default class CurrentDomainService extends Service {
   getExtension() {

--- a/mon-pix/app/services/current-user.js
+++ b/mon-pix/app/services/current-user.js
@@ -1,5 +1,5 @@
 import Service, { inject as service } from '@ember/service';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 export default class CurrentUserService extends Service {
   @service session;
@@ -17,7 +17,7 @@ export default class CurrentUserService extends Service {
         this._user = await this.store.queryRecord('user', { me: true });
       }
       catch (error) {
-        if (_.get(error, 'errors[0].code') === 401) {
+        if (get(error, 'errors[0].code') === 401) {
           return this.session.invalidate();
         }
       }

--- a/mon-pix/app/utils/labeled-checkboxes.js
+++ b/mon-pix/app/utils/labeled-checkboxes.js
@@ -1,4 +1,18 @@
-import _ from 'lodash';
+import isNil from 'lodash/isNil';
+import isEmpty from 'lodash/isEmpty';
+import size from 'lodash/size';
+import times from 'lodash/times';
+import constant from 'lodash/constant';
+import isArray from 'lodash/isArray';
+import every from 'lodash/every';
+import isBoolean from 'lodash/isBoolean';
+import isString from 'lodash/isString';
+
+import flow from 'lodash/fp/flow';
+import concat from 'lodash/fp/concat';
+import zip from 'lodash/fp/zip';
+
+const concatToEnd = concat.convert({ rearg: true });
 
 /*
  * Example :
@@ -19,29 +33,29 @@ import _ from 'lodash';
 export default function labeledCheckboxes(proposals, userAnswers) {
 
   // accept that user didn't give any answer yet
-  const definedUserAnswers = _.isNil(userAnswers) ? [] : userAnswers;
+  const definedUserAnswers = isNil(userAnswers) ? [] : userAnswers;
 
   // check pre-conditions
   if (isNotArrayOfString(proposals)) return [];
-  if (_.isEmpty(proposals)) return [];
+  if (isEmpty(proposals)) return [];
   if (_isNotArrayOfBoolean(definedUserAnswers)) return [];
-  if (_.size(definedUserAnswers) > _.size(proposals)) return [];
+  if (size(definedUserAnswers) > size(proposals)) return [];
 
-  const sizeDifference = _(proposals).size() - _(definedUserAnswers).size(); // 2
-  const arrayOfFalse = _.times(sizeDifference, _.constant(false));              // [false, false]
+  const sizeDifference = size(proposals) - size(definedUserAnswers); // 2
+  const arrayOfFalse = times(sizeDifference, constant(false));       // [false, false]
 
-  return _.chain(definedUserAnswers) // [false, true]
-    .concat(arrayOfFalse)     // [false, true, false, false]
-    .zip(proposals)           // [[false, 'prop 1'], [true, 'prop 2'], [false, 'prop 3'], [false, 'prop 4']]
-    .map(_.reverse)           // [['prop 1', false], ['prop 2', true], ['prop 3', false], ['prop 4', false]]
-    .value();
+  const propsBuilder = flow(    // [false, true]
+    concatToEnd(arrayOfFalse),  // [false, true, false, false]
+    zip(proposals),             // [['prop 1', false], ['prop 2', true], ['prop 3', false], ['prop 4', false]]
+  );
 
+  return propsBuilder(definedUserAnswers);
 }
 
 function _isNotArrayOfBoolean(collection) {
-  return !_.isArray(collection) || !_.every(collection, _.isBoolean);
+  return !isArray(collection) || !every(collection, isBoolean);
 }
 
 function isNotArrayOfString(collection) {
-  return !_.isArray(collection) || !_.every(collection, _.isString);
+  return !isArray(collection) || !every(collection, isString);
 }

--- a/mon-pix/app/utils/proposals-as-array.js
+++ b/mon-pix/app/utils/proposals-as-array.js
@@ -1,19 +1,23 @@
-import _ from 'lodash';
+import isString from 'lodash/isString';
+import isEmpty from 'lodash/isEmpty';
 
-function calculate(proposals) {
-  return _.chain(proposals)
-    .thru((e) => '\n' + e)
-    .split(/\n\s*-\s*/)
-    .drop(1)
-    .value();
-}
+import flow from 'lodash/fp/flow';
+import split from 'lodash/fp/split';
+import thru from 'lodash/fp/thru';
+import drop from 'lodash/fp/drop';
+
+const calculate = flow(
+  thru((e) => '\n' + e),
+  split(/\n\s*-\s*/),
+  drop(1)
+);
 
 export default function proposalsAsArray(proposals) {
   // check pre-conditions
   const DEFAULT_RETURN_VALUE = [];
 
-  if (!_.isString(proposals)) return DEFAULT_RETURN_VALUE;
-  if (_(proposals).isEmpty()) return DEFAULT_RETURN_VALUE;
+  if (!isString(proposals)) return DEFAULT_RETURN_VALUE;
+  if (isEmpty(proposals)) return DEFAULT_RETURN_VALUE;
 
   return calculate(proposals);
 }

--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -1,4 +1,4 @@
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 function parseInput(isInput, input) {
   let block;

--- a/mon-pix/app/utils/solution-as-object.js
+++ b/mon-pix/app/utils/solution-as-object.js
@@ -1,8 +1,9 @@
-import _ from 'lodash';
+import each from 'lodash/each';
+
 import jsyaml from 'js-yaml';
 
 function transformSolutionsToString(solutionsAsObject) {
-  _.each(solutionsAsObject, (potentialSolution) => {
+  each(solutionsAsObject, (potentialSolution) => {
     potentialSolution.forEach((value, index) => {
       potentialSolution[index] = potentialSolution[index].toString();
     });

--- a/mon-pix/app/utils/value-as-array-of-boolean.js
+++ b/mon-pix/app/utils/value-as-array-of-boolean.js
@@ -1,16 +1,28 @@
-import _ from 'lodash';
+import flow from 'lodash/fp/flow';
+import thru from 'lodash/fp/thru';
+import split from 'lodash/fp/split';
+import map from 'lodash/fp/map';
+import reject from 'lodash/fp/reject';
+import filter from 'lodash/fp/filter';
+import sortBy from 'lodash/fp/sortBy';
+import uniqBy from 'lodash/fp/uniqBy';
+import times from 'lodash/times';
+import max from 'lodash/max';
+import includes from 'lodash/includes';
+import isString from 'lodash/isString';
+import trim from 'lodash/trim';
+import identity from 'lodash/identity';
+import isEmpty from 'lodash/isEmpty';
 
-export default function valueAsArrayOfBoolean(value) {
-  return _.chain(value)                                                  // in the worst case : ',4, 2 , 2,1,  ,-1'
-    .thru((e) => _.isString(e) ? e : '')                           // check if string
-    .split(',')                                                          // now ['', '4', ' 2 ', ' 2', '1', '  ', '','-1']
-    .map(_.trim)                                                         // now ['', '4', '2', '2', '1', '', '','-1']
-    .reject(_.isEmpty)                                                   // now ['4', '2', '2', '1','-1']
-    .map(_.parseInt)                                                     // now [4, 2, 2, 1,-1]
-    .filter((e) => e >= 1)                                               // check if int >= 1
-    .sortBy()                                                            // now [1, 2, 2, 4]
-    .uniqBy()                                                            // now [1, 2, 4]
-    .map((e) => e - 1)                                                   // now [0, 1, 3]
-    .thru((e) => _.times(_.max(e) + 1, (o) => _(e).includes(o)))
-    .value();
-}
+export default flow(                                        // in the worst case : ',4, 2 , 2,1,  ,-1'
+  thru((e) => isString(e) ? e : ''),                        // check if string
+  split(','),                                               // now ['', '4', ' 2 ', ' 2', '1', '  ', '','-1']
+  map(trim),                                                // now ['', '4', '2', '2', '1', '', '','-1']
+  reject(isEmpty),                                          // now ['4', '2', '2', '1','-1']
+  map(parseInt),                                            // now [4, 2, 2, 1,-1]
+  filter((e) => e >= 1),                                    // check if int >= 1
+  sortBy(identity),                                         // now [1, 2, 2, 4]
+  uniqBy(identity),                                         // now [1, 2, 4]
+  map((e) => e - 1),                                        // now [0, 1, 3]
+  thru((e) => times(max(e) + 1, (o) => includes(e, o))),    // now [true, true, false, true]
+);

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -1,10 +1,10 @@
 import { Factory, trait } from 'ember-cli-mirage';
 import faker from 'faker';
-import _ from 'lodash';
+import sumBy from 'lodash/sumBy';
 
 function _addDefaultPixscore(user, server) {
   if (!user.pixScore) {
-    const pixScoreValue = _.sumBy(user.scorecards.models, 'earnedPix');
+    const pixScoreValue = sumBy(user.scorecards.models, 'earnedPix');
     user.update({
       pixScore: server.create('pix-score', { value: pixScoreValue }),
     });

--- a/mon-pix/mirage/routes/assessments/get-next-challenge.js
+++ b/mon-pix/mirage/routes/assessments/get-next-challenge.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import map from 'lodash/map';
+import first from 'lodash/first';
+import difference from 'lodash/difference';
 import Response from 'ember-cli-mirage/response';
 
 export default function(schema, request) {
@@ -20,12 +22,12 @@ export default function(schema, request) {
       break;
   }
   const answers = schema.answers.where({ assessmentId: assessment.id }).models;
-  const answeredChallengeIds = _.map(answers, 'challengeId');
+  const answeredChallengeIds = map(answers, 'challengeId');
   const allChallenges = schema.challenges.where((challenge) => {
     return challenge.id.startsWith(challengeIdStartsWith);
   });
-  const allChallengeIds  = _.map(allChallenges.models, 'id');
+  const allChallengeIds  = map(allChallenges.models, 'id');
 
-  const nextChallengeId = _(allChallengeIds).difference(answeredChallengeIds).first();
+  const nextChallengeId = first(difference(allChallengeIds, answeredChallengeIds));
   return nextChallengeId ? schema.challenges.find(nextChallengeId) : new Response(200, {}, { data: null });
 }

--- a/mon-pix/mirage/routes/post-session-participation.js
+++ b/mon-pix/mirage/routes/post-session-participation.js
@@ -1,5 +1,5 @@
 import Response from 'ember-cli-mirage/response';
-import _ from 'lodash';
+import every from 'lodash/every';
 
 export default function(schema, request) {
   const params = JSON.parse(request.requestBody);
@@ -7,7 +7,7 @@ export default function(schema, request) {
   const firstName = params.data.attributes['first-name'];
   const lastName = params.data.attributes['last-name'];
   const birthdate = params.data.attributes['birthdate'];
-  if (!_.every([firstName, lastName, birthdate, sessionId])) {
+  if (!every([firstName, lastName, birthdate, sessionId])) {
     return new Response(400);
   }
   if (lastName === 'PasInscrite') {

--- a/mon-pix/mirage/routes/users/reset-scorecard.js
+++ b/mon-pix/mirage/routes/users/reset-scorecard.js
@@ -1,11 +1,11 @@
-import _ from 'lodash';
+import find from 'lodash/find';
 
 export default function(schema, request) {
   const competenceId = request.params.competenceId;
   const userId = request.params.id;
 
   const userScorecards = schema.users.find(userId).scorecards.models;
-  const scorecard = _.find(userScorecards, { competenceId });
+  const scorecard = find(userScorecards, { competenceId });
 
   scorecard.update({
     status: 'NOT_STARTED',

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -4,7 +4,7 @@ import { describe, it, before } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 const assessment = {};
 let challenge = null;
@@ -117,7 +117,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
 
         // Then
         const size = findAll('.comparison-window .qcm-proposal-label__checkbox-picture').length;
-        _.times(size, function(index) {
+        times(size, function(index) {
           expect(find('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
         });
       });

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 const assessment = {};
 let challenge = null;
@@ -117,7 +117,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
 
         // Then
-        _.times(findAll('.comparison-window .qcu-panel__proposal-radio').length, function(index) {
+        times(findAll('.comparison-window .qcu-panel__proposal-radio').length, function(index) {
           expect(find('.comparison-window .qcu-panel__proposal-radio:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
         });
       });

--- a/mon-pix/tests/unit/components/signup-form-test.js
+++ b/mon-pix/tests/unit/components/signup-form-test.js
@@ -4,7 +4,7 @@
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import _ from 'lodash';
+import pick from 'lodash/pick';
 
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
@@ -53,7 +53,7 @@ describe('Unit | Component | signup-form', function() {
 
       // then
       const user = component.get('user');
-      expect(_.pick(user, ['firstName', 'lastName', 'email'])).to.deep.equal(expectedUser);
+      expect(pick(user, ['firstName', 'lastName', 'email'])).to.deep.equal(expectedUser);
     });
 
     it('should send campaignCode when is defined', () => {

--- a/mon-pix/tests/unit/models/assessment-test.js
+++ b/mon-pix/tests/unit/models/assessment-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { run } from '@ember/runloop';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
-import _ from 'lodash';
+import times from 'lodash/times';
 
 describe('Unit | Model | Assessment', function() {
   setupTest();
@@ -17,7 +17,7 @@ describe('Unit | Model | Assessment', function() {
 
     function newAnswers(store, nbAnswers) {
       return run(() => {
-        return _.times(nbAnswers, () => store.createRecord('answer'));
+        return times(nbAnswers, () => store.createRecord('answer'));
       });
     }
 


### PR DESCRIPTION
## :unicorn: Problème
Les imports par défaut de lodash font que tout `lodash` se retrouve dans le bundle final alors que l'on utilise pas tout.

## :robot: Solution
Import uniquement des modules utilisés:
```js
// avant
import _ from 'lodash'
// après
import get from 'lodash/get'
```

## :rainbow: Remarques

**Tâches effectuées:**
- Ajout de la règle `eslint` pour éviter d'utiliser les imports par défaut dans le futur
- Remplacement des import par défaut par les imports de modules utilisés
- Remplacement de certains import utilisant la syntaxe CommonJS (`require`) pour utiliser les ES Module (`import`)
- Remplacer les utilisations de `_.chain` par `flow()` de `lodash/fp`
  - Lire [Why using chain is a mistake ?](https://medium.com/bootstart/why-using-chain-is-a-mistake-9bc1f80d51ba)
  - _TLDR:_ `chain` importe tout `lodash`. Il est peu extensible et moins performant que `lodash/fp`

**Gains obtenus:**
- Disparition de la fameuse phrase au build: «_The code generator has deoptimised the styling of lodash.js as it exceeds the max of 500KB._»
- Avant: 1.83 MB (501.59 KB gzipped)
- Après: 1.8 MB (489.42 KB gzipped)
- **Gain -12 KB gzipped**