### PR TITLE
[FEATURE] Associer le nouveau samlId de l'élève au compte GAR existant lors de la réconciliation (PIX-1038).

### DIFF
--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -65,6 +65,10 @@ async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSc
     const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
     const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION[authenticationMethod.authenticatedBy];
     const meta = { shortCode: error.shortCode, value: authenticationMethod.value };
+    if (authenticationMethod.authenticatedBy === 'samlId') {
+      meta.userId = userId;
+      meta.schoolingRegistrationId = matchingSchoolingRegistration.id;
+    }
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }
 }
@@ -78,6 +82,8 @@ async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(st
     const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
     const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION[authenticationMethod.authenticatedBy];
     const meta = { shortCode: error.shortCode, value: authenticationMethod.value };
+    if (authenticationMethod.authenticatedBy === 'samlId') { meta.userId = userId; }
+
     throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
   }
 }

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -1,5 +1,6 @@
 const { CampaignCodeError, ObjectValidationError } = require('../errors');
 const User = require('../models/User');
+const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
 
 module.exports = async function createUserAndReconcileToSchoolingRegistrationFromExternalUser({
   campaignCode,
@@ -10,6 +11,7 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
   tokenService,
   userRepository,
   schoolingRegistrationRepository,
+  studentRepository,
   obfuscationService,
 }) {
   const campaign = await campaignRepository.getByCode(campaignCode);
@@ -29,14 +31,6 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     birthdate,
   };
 
-  const schoolingRegistration = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({
-    organizationId: campaign.organizationId,
-    reconciliationInfo,
-    schoolingRegistrationRepository,
-    userRepository,
-    obfuscationService,
-  });
-
   const domainUser = new User({
     firstName: externalUser.firstName,
     lastName: externalUser.lastName,
@@ -45,10 +39,45 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     cgu: false,
   });
 
-  const userId = await userRepository.createAndReconcileUserToSchoolingRegistration({
-    domainUser,
-    schoolingRegistrationId: schoolingRegistration.id,
-  });
+  let matchedSchoolingRegistration;
+  let userId;
+  const reconciliationErrors = [
+    STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION.samlId.code,
+    STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION.samlId.code,
+  ];
+
+  try {
+
+    matchedSchoolingRegistration = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({
+      organizationId: campaign.organizationId,
+      reconciliationInfo,
+      schoolingRegistrationRepository,
+      userRepository,
+      obfuscationService,
+    });
+
+    const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
+    await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
+
+    userId = await userRepository.createAndReconcileUserToSchoolingRegistration({
+      domainUser,
+      schoolingRegistrationId: matchedSchoolingRegistration.id,
+    });
+
+  } catch (error) {
+
+    if (reconciliationErrors.includes(error.code)) {
+
+      await userRepository.updateUserAttributes(error.meta.userId, { samlId: externalUser.samlId });
+      const schoolingRegistrationId = error.meta.schoolingRegistrationId || matchedSchoolingRegistration.id;
+      const schoolingRegistration = await schoolingRegistrationRepository.reconcileUserToSchoolingRegistration({ userId: error.meta.userId , schoolingRegistrationId });
+      userId = schoolingRegistration.userId;
+
+    } else {
+      throw error;
+    }
+
+  }
 
   return userRepository.get(userId);
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -434,4 +434,19 @@ module.exports = {
       });
   },
 
+  async updateUserAttributes(id, userAttributes) {
+    try {
+      const bookshelfUser = await BookshelfUser
+        .where({ id })
+        .save(userAttributes, { patch: true, method: 'update' });
+      return bookshelfUser.toDomainEntity();
+
+    } catch (err) {
+      if (err instanceof BookshelfUser.NoRowsUpdatedError) {
+        throw new UserNotFoundError(`User not found for ID ${id}`);
+      }
+      throw err;
+    }
+  },
+
 };

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -763,6 +763,46 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
   });
 
+  describe('#updateUserAttributes', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser(userToInsert);
+      await databaseBuilder.commit();
+    });
+
+    it('should update samlId of the user', async () => {
+      // given
+      const patchUserSamlId = {
+        id : userInDb.id,
+        samlId : '123456789',
+      };
+
+      // when
+      const updatedUser = await userRepository.updateUserAttributes(userInDb.id, patchUserSamlId);
+
+      // then
+      expect(updatedUser).to.be.an.instanceOf(User);
+      expect(updatedUser.samlId).to.equal(patchUserSamlId.samlId);
+    });
+
+    it('should throw UserNotFoundError when user id not found', async () => {
+      // given
+      const wrongUserId = 0;
+      const patchUserSamlId = {
+        samlId : '123456789',
+      };
+
+      // when
+      const error = await catchErr(userRepository.updateUserAttributes)(wrongUserId, patchUserSamlId);
+
+      // then
+      expect(error).to.be.instanceOf(UserNotFoundError);
+    });
+
+  });
+
   describe('#updateUserDetailsForAdministration', () => {
 
     let userInDb;

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -45,6 +45,10 @@ function generateValidRequestAuthorizationHeader(userId = 1234) {
   return `Bearer ${accessToken}`;
 }
 
+function generateIdTokenForExternalUser(externalUser) {
+  return tokenService.createIdTokenForUserReconciliation(externalUser);
+}
+
 async function getCountOfAllRowsInDatabase()
 {
   const results = [];
@@ -173,6 +177,7 @@ module.exports = {
   domainBuilder: require('./tooling/domain-builder/factory'),
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
+  generateIdTokenForExternalUser,
   getCountOfAllRowsInDatabase,
   hFake,
   HttpTestServer: require('./tooling/server/http-test-server'),

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -332,6 +332,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
             schoolingRegistrations[0].userId = '123';
             userRepositoryStub = {
               getUserAuthenticationMethods: sinon.stub().resolves(),
+              updateUserAttributes: sinon.stub().resolves(),
             };
             obfuscationServiceStub = {
               getUserAuthenticationMethodWithObfuscation: sinon.stub().returns({ authenticatedBy: 'email' }),
@@ -341,7 +342,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
           it('should throw OrganizationStudentAlreadyLinkedToUserError', async () => {
             // given
             schoolingRegistrationRepositoryStub.findByOrganizationIdAndUserData.resolves(schoolingRegistrations);
-
+            userRepositoryStub.getUserAuthenticationMethods.resolves({ email: 'email@example.net' });
             // when
             const result = await catchErr(userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser)({ organizationId, reconciliationInfo: user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub, userRepository: userRepositoryStub, obfuscationService: obfuscationServiceStub });
 
@@ -398,6 +399,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
         schoolingRegistrations[0].userId = '123';
         userRepositoryStub = {
           getUserAuthenticationMethods: sinon.stub().resolves(),
+          updateUserAttributes: sinon.stub().resolves(),
         };
         obfuscationServiceStub = {
           getUserAuthenticationMethodWithObfuscation: sinon.stub().returns({ authenticatedBy: 'email' }),
@@ -406,6 +408,7 @@ describe('Unit | Service | user-reconciliation-service', () => {
         user = {
           studentNumber: '123A',
         };
+        userRepositoryStub.getUserAuthenticationMethods.resolves({ email: 'email@example.net' });
 
         // when
         const result = await catchErr(userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser)({ organizationId, reconciliationInfo: user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub, userRepository: userRepositoryStub, obfuscationService: obfuscationServiceStub });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un élève provenant du GAR tente de se réconcilier alors qu’il possède déjà un compte GAR réconcilié dans son établissement actuel ou dans un autre établissement, une erreur est renvoyée par l’API. 
Cette erreur est ensuite affichée dans une modal qui l’invite à continuer en se connectant à son compte existant. 
Néanmoins, comme le compte réconcilié existant est connecté via le GAR, il n’existe aucun moyen pour l'élève de pouvoir s’y connecter.

## :robot: Solution

Associer le nouveau samlId de l'élève au compte GAR existant.
Remplacer le samlId actuel de l'élève par le nouveau samlId contenu dans le token.
Ne plus renvoyer le message d’erreur et poursuivre l’accès au parcours.

## :rainbow: Remarques
 Un refactoring est en cours

## :100: Pour tester
Compte réconcilié dans le même établissement:
- Aller sur https://pix-saml-idp.osc-fr1.scalingo.io/ (modifier l'url de destination pour https://app-pr1832.review.pix.fr si différente)
- Renseigner les champs pour le compte "user gar"
- Rejoindre la campagne RESTRICTD
- Remplir le formulaire de réconciliation avec la date de naissance 30/09/2010
- Accéder au début du parcours.
- Vérifier que le `samlId` de l'utilisateur a bien été modifié
`select s."firstName", s."lastName", s.birthdate, s."nationalStudentId", u.id, u."samlId" from "schooling-registrations" as s join users as u on u.id = s."userId" where s.id = 100066;`

Compte réconcilié dans un autre établissement:
- Aller sur https://pix-saml-idp.osc-fr1.scalingo.io/ (modifier l'url de destination pour https://app-pr1832.review.pix.fr si différente)
- Renseigner les champs pour le compte "Lyanna Mormont"
- Rejoindre la campagne RESTRICTD
- Remplir le formulaire de réconciliation avec la date de naissance 30/09/2003
- Accéder au début du parcours.
- Vérifier que le `samlId` de l'utilisateur a bien été modifié et que le "userId" de la `schooling-registrations` est bien renseigné 
`select s."firstName", s."lastName", s.birthdate, s."nationalStudentId", u.id, u."samlId" from "schooling-registrations" as s join users as u on u.id = s."userId" where s.id = 100062;`

Penser à supprimer le "userId" pour le cas précédent afin de faciliter le test des autres `update "schooling-registrations" set "userId" = null where id = 100062;`  