### PR TITLE
[FEATURE] Afficher la description des commentaires jury dans certificat Pix  (Pix-1188)

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -24,11 +24,22 @@
   }
 
   &__comment-jury {
+    display: flex;
+    flex-direction: column;
     margin: 8px;
     font-family: $font-open-sans;
     font-size: 0.875rem;
     font-weight: $font-medium;
     line-height: 1.375rem;
+
+    span {
+      margin-top: 32px;
+      font-size: 12px;
+
+      svg {
+        margin-right: 2px;
+      }
+    }
   }
 
   @include device-is('mobile') {

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,9 +1,13 @@
 {{#if certification.commentForCandidate}}
   <h2>{{t "pages.certificate.jury-title"}}</h2>
   <PixBlock>
-    <p class="user-certifications-detail-result__comment-jury">
+    <div class="user-certifications-detail-result__comment-jury">
       {{certification.commentForCandidate}}
-    </p>
+    <span>
+      <FaIcon @icon='info-circle' />
+        {{t "pages.certificate.jury-comment-description"}}
+    </span>
+    </div>
   </PixBlock>
 {{/if}}
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -114,6 +114,7 @@
       },
       "issued-on": "Issued on",
       "jury-title": "Jury observations",
+      "jury-comment-description": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
 
       "validity": "Certificate valid for 3 years"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -114,6 +114,7 @@
       },
       "issued-on": "Délivré le",
       "jury-title": "Observations du jury",
+      "jury-comment-description": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
 
       "validity": "Certificat valable 3 ans"
     },


### PR DESCRIPTION
## :unicorn: Problème
Lors de l’implémentation du nouveau design du certificat Pix, nous n’avions pas affiché la phrase expliquant au candidat qu’en cas de partage de son certificat, le commentaire jury ne sera pas visible par un tiers. En effet, il n'était à ce moment encore pas possible de partager son certificat pour un candidat donc ça n'était pas pertinent de l’afficher.

Le partage et contrôle du certificat étant maintenant possible, nous pouvons afficher cette information au candidat.

## :robot: Solution
Pour un certificat avec un commentaire jury, ajouter l’information suivante : “Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

![image](https://user-images.githubusercontent.com/37305474/92091893-aa570980-edd1-11ea-8f00-a2ffabf38981.png)


## :100: Pour tester
- Se connecter avec anne success
- Se rendre dans "Mes certifications" et afficher le certificat publié
- A l'aide du plugin Ember Data, ajouter du lorem ipsum dans Data > certification > commentForCandidate
- Constater le texte: "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat."

![image](https://user-images.githubusercontent.com/37305474/92092419-5ac50d80-edd2-11ea-92e4-cf47745ae330.png)
