### PR TITLE
[FEATURE] Ameliorer l'affichage du certificat sur mobile et tablette [PIX-1184]

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -58,12 +58,13 @@
 .attestation-and-verification-code {
   background-color: $grey-10;
   border-radius: 8px;
-  margin-left: auto;
   padding: 24px 20px;
 
   .verification-code {
     font-family: $font-open-sans;
     color: $grey-90;
+    width: 230px;
+    margin: auto;
 
     &__title {
       display: flex;
@@ -83,7 +84,6 @@
     }
 
     &__box {
-      width: 230px;
       padding: 10px 20px;
       border: 1.5px $grey-22 dashed;
       border-radius: 4px;
@@ -111,6 +111,20 @@
 
         &:hover { color: darken($blue, 20%); }
       }
+    }
+  }
+
+  @include device-is('tablet') {
+    margin-left: 0;
+    flex-grow: 1;
+  }
+
+  @include device-is('desktop') {
+    margin-left: auto;
+    flex-grow: 0;
+
+    .verification-code {
+      margin: 0;
     }
   }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -83,7 +83,7 @@
     }
 
     &__box {
-      width: 240px;
+      width: 230px;
       padding: 10px 20px;
       border: 1.5px $grey-22 dashed;
       border-radius: 4px;

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -23,12 +23,21 @@
     text-align: center;
   }
 
-  &__comment-jury {
-    margin: 8px;
-    font-family: $font-open-sans;
-    font-size: 0.875rem;
-    font-weight: $font-medium;
-    line-height: 1.375rem;
+  &__jury {
+
+    &__info {
+      font-size: 0.75rem;
+    }
+
+    &__comment {
+      font-size: 0.875rem;
+    }
+
+    p {
+      font-family: $font-open-sans;
+      font-weight: $font-medium;
+      line-height: 1.375rem;
+    }
   }
 
   @include device-is('mobile') {

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -7,8 +7,10 @@
   height: 100%;
   color: $grey-80;
   font-size: 1.125rem;
-  line-height: 1.625rem;
-  margin-bottom: 40px;
+
+  div {
+    line-height: 1.625rem;
+  }
 
   h2 {
     color: $grey-60;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -20,6 +20,7 @@
 
   &__details-body {
     display: flex;
+    flex-direction: row-reverse;
     width: 100%;
     max-width: 980px;
     margin: 0 10px;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -41,6 +41,10 @@
       position: relative;
     }
 
+    &__header {
+      flex-direction: column;
+    }
+
     &__details-body {
       flex-wrap: wrap;
     }
@@ -50,6 +54,10 @@
 @include device-is('tablet') {
 
   .user-certifications-page-get {
+
+    &__header {
+      flex-direction: column;
+    }
 
     &__details-body {
       flex-wrap: wrap;
@@ -63,6 +71,10 @@
 
     &__details-body {
       flex-wrap: nowrap;
+    }
+
+    &__header {
+      flex-direction: row;
     }
   }
 }

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -25,40 +25,40 @@
     </div>
   </div>
   {{#if this.isSharedCertificateActive}}
-  <div class="attestation-and-verification-code">
-    {{#if @certification.verificationCode}}
-      <div class="verification-code">
-        <h2 class="verification-code__title">
-          {{t "pages.certificate.verification-code.title"}}
-          <PixTooltip
-              @class="verification-code__tooltip"
-              @text={{t "pages.certificate.verification-code.tooltip"}}
-              @position='top'
-              @inline={{false}}
-              >
-            <div class="verification-code__title--info">{{t "pages.certificate.verification-code.info"}}</div>
-          </PixTooltip>
-        </h2>
-        <span class="verification-code__box">
-          <p class="verification-code__code">{{@certification.verificationCode}}</p>
-
-          {{#if (is-clipboard-supported)}}
+  {{#if @certification.verificationCode}}
+    <div class="attestation-and-verification-code">
+        <div class="verification-code">
+          <h2 class="verification-code__title">
+            {{t "pages.certificate.verification-code.title"}}
             <PixTooltip
-              @text={{this.tooltipText}}
-              @position='bottom'
-              @inline={{true}}
-              >
-                <CopyButton
-                  @clipboardText={{@certification.verificationCode}}
-                  @success={{this.clipboardSuccess}}
-                  @classNames="icon-button">
-                    <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
-                </CopyButton>
+                @class="verification-code__tooltip"
+                @text={{t "pages.certificate.verification-code.tooltip"}}
+                @position='top'
+                @inline={{false}}
+                >
+              <div class="verification-code__title--info">{{t "pages.certificate.verification-code.info"}}</div>
             </PixTooltip>
-          {{/if}}
-        </span>
-      </div>
-    {{/if}}
-  </div>
+          </h2>
+          <span class="verification-code__box">
+            <p class="verification-code__code">{{@certification.verificationCode}}</p>
+
+            {{#if (is-clipboard-supported)}}
+              <PixTooltip
+                @text={{this.tooltipText}}
+                @position='bottom'
+                @inline={{true}}
+                >
+                  <CopyButton
+                    @clipboardText={{@certification.verificationCode}}
+                    @success={{this.clipboardSuccess}}
+                    @classNames="icon-button">
+                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
+                  </CopyButton>
+              </PixTooltip>
+            {{/if}}
+          </span>
+        </div>
+    </div>
+  {{/if}}
   {{/if}}
 {{/if}}

--- a/mon-pix/app/templates/components/user-certifications-detail-result.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-result.hbs
@@ -1,8 +1,11 @@
 {{#if certification.commentForCandidate}}
   <h2>{{t "pages.certificate.jury-title"}}</h2>
-  <PixBlock>
-    <p class="user-certifications-detail-result__comment-jury">
+  <PixBlock class="user-certifications-detail-result__jury">
+    <p class="user-certifications-detail-result__jury__comment">
       {{certification.commentForCandidate}}
+    </p>
+    <p class="user-certifications-detail-result__jury__info">
+      {{fa-icon 'info-circle'}} {{t "pages.certificate.jury-info"}}
     </p>
   </PixBlock>
 {{/if}}

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -8,10 +8,10 @@
   </PixBlock>
 
   <div class="user-certifications-page-get__details-body">
-    <UserCertificationsDetailCompetencesList @resultCompetenceTree={{@model.resultCompetenceTree}} />
     {{#if (or @model.commentForCandidate @model.hasCleaCertif)}}
       <UserCertificationsDetailResult @certification={{@model}} />
     {{/if}}
+    <UserCertificationsDetailCompetencesList @resultCompetenceTree={{@model.resultCompetenceTree}} />
   </div>
 
 </PixBackgroundHeader>

--- a/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
+++ b/mon-pix/tests/integration/components/user-certifications-detail-result-test.js
@@ -38,8 +38,8 @@ describe('Integration | Component | user certifications detail result', function
     });
 
     it('should show the comment for candidate', function() {
-      expect(find('.user-certifications-detail-result__comment-jury')).to.exist;
-      expect(find('.user-certifications-detail-result__comment-jury').textContent).to.include('Comment for candidate');
+      expect(find('.user-certifications-detail-result__jury__comment')).to.exist;
+      expect(find('.user-certifications-detail-result__jury__comment').textContent).to.include('Comment for candidate');
     });
   });
 
@@ -66,7 +66,7 @@ describe('Integration | Component | user certifications detail result', function
     });
 
     it('should not show the comment for candidate', function() {
-      expect(find('.user-certifications-detail-result__comment-jury')).to.not.exist;
+      expect(find('.user-certifications-detail-result__jury__comment')).to.not.exist;
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -114,6 +114,7 @@
       },
       "issued-on": "Issued on",
       "jury-title": "Jury observations",
+      "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
 
       "validity": "Certificate valid for 3 years"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -114,6 +114,7 @@
       },
       "issued-on": "Délivré le",
       "jury-title": "Observations du jury",
+      "jury-info": "Les observations du jury ne sont pas partagées sur la page de vérification de votre certificat.",
 
       "validity": "Certificat valable 3 ans"
     },


### PR DESCRIPTION
## :unicorn: Problème
Le code de verification ne s'affiche pas correctement sur mobile et tablette
## :robot: Solution
Passer le code de verification en dessous sur tablette et mobile

## :rainbow: Remarques
En bonus, pour coller à la charte
- Les observations du jury + certif cléA repassent au dessus 
- Fix differents decalages 
- Ajouts des infos observations jury

## :100: Pour tester
[maquettes abstract](https://share.goabstract.com/be2a499a-1d5c-4211-903d-9aecdabfde09)
