### PR TITLE
[BUGFIX] Je dois pouvoir lancer mon parcours après m'être inscrit depuis la double mire SCO (PIX-1222)

### DIFF
--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -1,5 +1,4 @@
 const usecases = require('../../domain/usecases');
-const userSerializer = require('../../infrastructure/serializers/jsonapi/user-serializer');
 const schoolingRegistrationDependentUser = require('../../infrastructure/serializers/jsonapi/schooling-registration-dependent-user-serializer');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 const tokenService = require('../../domain/services/token-service');
@@ -19,9 +18,9 @@ module.exports = {
     };
     const locale = extractLocaleFromRequest(request);
 
-    const createdUser = await usecases.createAndReconcileUserToSchoolingRegistration({ userAttributes, campaignCode: payload['campaign-code'], locale });
+    await usecases.createAndReconcileUserToSchoolingRegistration({ userAttributes, campaignCode: payload['campaign-code'], locale });
 
-    return h.response(userSerializer.serialize(createdUser)).created();
+    return h.response().code(204);
   },
 
   async createUserAndReconcileToSchoolingRegistrationFromExternalUser(request, h) {

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -49,15 +49,12 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
         options.payload.data.attributes['with-username'] = false;
       });
 
-      it('should return an 201 status after having successfully created user and associated user to schoolingRegistration', async () => {
+      it('should return an 204 status after having successfully created user and associated user to schoolingRegistration', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(201);
-        expect(response.result.data.attributes.email).to.equal(email);
-        expect(response.result.data.attributes['first-name']).to.equal(schoolingRegistration.firstName);
-        expect(response.result.data.attributes['last-name']).to.equal(schoolingRegistration.lastName);
+        expect(response.statusCode).to.equal(204);
       });
 
       context('when no schoolingRegistration not linked yet found', () => {
@@ -108,15 +105,12 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
         options.payload.data.attributes['with-username'] = true;
       });
 
-      it('should return a 201 status after having successfully created user and associated user to schoolingRegistration', async () => {
+      it('should return a 204 status after having successfully created user and associated user to schoolingRegistration', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(201);
-        expect(response.result.data.attributes.username).to.equal(username);
-        expect(response.result.data.attributes['first-name']).to.equal(schoolingRegistration.firstName);
-        expect(response.result.data.attributes['last-name']).to.equal(schoolingRegistration.lastName);
+        expect(response.statusCode).to.equal(204);
       });
 
       context('when username is already taken', () => {

--- a/api/tests/acceptance/application/student-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/student-dependent-user-controller_test.js
@@ -50,15 +50,12 @@ describe('Acceptance | Controller | Student-dependent-user', () => {
         options.payload.data.attributes['with-username'] = false;
       });
 
-      it('should return an 201 status after having successfully created user and associated user to schoolingRegistration', async () => {
+      it('should return an 204 status after having successfully created user and associated user to schoolingRegistration', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(201);
-        expect(response.result.data.attributes.email).to.equal(email);
-        expect(response.result.data.attributes['first-name']).to.equal(schoolingRegistration.firstName);
-        expect(response.result.data.attributes['last-name']).to.equal(schoolingRegistration.lastName);
+        expect(response.statusCode).to.equal(204);
       });
 
       context('when no schoolingRegistration not linked yet found', () => {
@@ -109,15 +106,12 @@ describe('Acceptance | Controller | Student-dependent-user', () => {
         options.payload.data.attributes['with-username'] = true;
       });
 
-      it('should return an 201 status after having successfully created user and associated user to schoolingRegistration', async () => {
+      it('should return an 204 status after having successfully created user and associated user to schoolingRegistration', async () => {
         // when
         const response = await server.inject(options);
 
         // then
-        expect(response.statusCode).to.equal(201);
-        expect(response.result.data.attributes.username).to.equal(username);
-        expect(response.result.data.attributes['first-name']).to.equal(schoolingRegistration.firstName);
-        expect(response.result.data.attributes['last-name']).to.equal(schoolingRegistration.lastName);
+        expect(response.statusCode).to.equal(204);
       });
 
       context('when username is already taken', () => {

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -10,7 +10,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
 
   beforeEach(() => {
     sinon.stub(securityPreHandlers, 'checkUserBelongsToScoOrganizationAndManagesStudents').callsFake((request, h) => h.response(true));
-    sinon.stub(schoolingRegistrationDependentUserController, 'createAndReconcileUserToSchoolingRegistration').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(schoolingRegistrationDependentUserController, 'createAndReconcileUserToSchoolingRegistration').callsFake((request, h) => h.response().code(204));
     sinon.stub(schoolingRegistrationDependentUserController, 'createUserAndReconcileToSchoolingRegistrationFromExternalUser').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationDependentUserController, 'generateUsernameWithTemporaryPassword').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(schoolingRegistrationDependentUserController, 'updatePassword').callsFake((request, h) => h.response('ok').code(200));
@@ -48,7 +48,7 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
       response = await httpTestServer.request(method, url, payload);
 
       // then
-      expect(response.statusCode).to.equal(201);
+      expect(response.statusCode).to.equal(204);
     });
 
     it('should return 400 when firstName is empty', async () => {

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -46,7 +46,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
       context('When email is used', () => {
 
-        it('should return an HTTP response with status code 201', async () => {
+        it('should return an HTTP response with status code 204', async () => {
           // given
           payload.data.attributes.email = 'toto@example.net';
           payload.data.attributes['with-username'] = false;
@@ -56,14 +56,13 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
           const response = await httpTestServer.request('POST', '/api/schooling-registration-dependent-users', payload);
 
           // then
-          expect(response.statusCode).to.equal(201);
-          expect(response.result.data.id).to.equal(createdUser.id.toString());
+          expect(response.statusCode).to.equal(204);
         });
       });
 
       context('When username is used', () => {
 
-        it('should return an HTTP response with status code 201', async () => {
+        it('should return an HTTP response with status code 204', async () => {
           // given
           payload.data.attributes.username = 'robert.smith1212';
           payload.data.attributes['with-username'] = true;
@@ -73,8 +72,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
           const response = await httpTestServer.request('POST', '/api/schooling-registration-dependent-users', payload);
 
           // then
-          expect(response.statusCode).to.equal(201);
-          expect(response.result.data.id).to.equal(createdUser.id.toString());
+          expect(response.statusCode).to.equal(204);
         });
       });
 

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -7,26 +7,8 @@ export default class User extends ApplicationAdapter {
     return false;
   }
 
-  urlForCreateRecord(query, { adapterOptions }) {
-    const url = super.urlForCreateRecord(...arguments);
-    if (adapterOptions && adapterOptions.isSchoolingRegistrationDependentUser) {
-      return `${this.host}/${this.namespace}/schooling-registration-dependent-users`;
-    }
-
-    return url;
-  }
-
   createRecord(store, type, snapshot) {
     const { adapterOptions } = snapshot;
-
-    if (adapterOptions && adapterOptions.isSchoolingRegistrationDependentUser) {
-      const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
-      const serializedUser = this.serialize(snapshot);
-      serializedUser.data.attributes['campaign-code'] = adapterOptions.campaignCode;
-      serializedUser.data.attributes.birthdate = adapterOptions.birthdate;
-      serializedUser.data.attributes['with-username'] = adapterOptions.withUsername;
-      return this.ajax(url, 'POST', { data: serializedUser });
-    }
 
     if (adapterOptions && adapterOptions.updateExpiredPassword) {
       const url = this.buildURL('expired-password-update', null, snapshot, 'createRecord');

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -159,9 +159,12 @@ export default class RegisterForm extends Component {
         this.set('matchingStudentFound', true);
         this.set('isLoading', false);
         this.set('username', response.username);
-        return this.schoolingRegistrationDependentUser = this.store.createRecord('user', {
+        return this.schoolingRegistrationDependentUser = this.store.createRecord('schooling-registration-dependent-user', {
+          id: this.campaignCode + '_' + this.lastName,
+          campaignCode: this.campaignCode,
           firstName: this.firstName,
           lastName: this.lastName,
+          birthdate: this.birthdate,
           email: '',
           username: this.username,
           password: '',
@@ -203,6 +206,7 @@ export default class RegisterForm extends Component {
     this.set('isLoading', true);
     try {
       this.set('schoolingRegistrationDependentUser.password', this.password);
+      this.set('schoolingRegistrationDependentUser.withUsername', this.loginWithUsername);
       if (this.loginWithUsername) {
         this.set('schoolingRegistrationDependentUser.username', this.username);
         this.set('schoolingRegistrationDependentUser.email', undefined);
@@ -210,14 +214,7 @@ export default class RegisterForm extends Component {
         this.set('schoolingRegistrationDependentUser.email', this.email);
         this.set('schoolingRegistrationDependentUser.username', undefined);
       }
-      await this.schoolingRegistrationDependentUser.save({
-        adapterOptions: {
-          isSchoolingRegistrationDependentUser: true,
-          campaignCode: this.campaignCode,
-          birthdate: this.birthdate,
-          withUsername: this.loginWithUsername,
-        }
-      });
+      await this.schoolingRegistrationDependentUser.save();
     } catch (error) {
       this.set('isLoading', false);
       return this._updateInputsStatus();

--- a/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
+++ b/mon-pix/mirage/routes/schooling-registration-dependent-users/index.js
@@ -1,3 +1,4 @@
+import Response from 'ember-cli-mirage/response';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 
 export default function index(config) {
@@ -17,10 +18,10 @@ export default function index(config) {
       password: params.data.attributes['password'],
     };
     const student = schema.students.findBy({ firstName, lastName });
-    const user = schema.users.create(newUser);
-    student.update({ userId: user.id, organizationId });
+    const userId = schema.users.create(newUser).id;
+    student.update({ userId, organizationId });
     schema.schoolingRegistrationUserAssociations.create({ campaignCode });
-    return user;
+    return new Response(204);
   });
 
   config.post('/schooling-registration-dependent-users/external-user-token', (schema, request) => {

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -74,45 +74,6 @@ describe('Unit | Adapters | user', function() {
 
   describe('#createRecord', () => {
 
-    context('when isSchoolingRegistrationDependentUser is true', () => {
-
-      let expectedUrl, expectedMethod, expectedData, snapshot;
-
-      beforeEach(() => {
-        expectedUrl = 'http://localhost:3000/api/schooling-registration-dependent-users';
-        expectedMethod = 'POST';
-        expectedData = {
-          data: {
-            data: {
-              attributes: {
-                'campaign-code': 'AZERTY123',
-                birthdate: '2020-06-15',
-                'with-username': true
-              }
-            }
-          }
-        };
-        snapshot = {
-          record: { },
-          adapterOptions: {
-            isSchoolingRegistrationDependentUser: true,
-            campaignCode: 'AZERTY123',
-            birthdate: '2020-06-15',
-            withUsername: true
-          },
-          serialize: function() { return { data: { attributes: {} } }; },
-        };
-      });
-
-      it('should add attributes after serialization', async () => {
-        // when
-        await adapter.createRecord(null, { modelName: 'user' }, snapshot);
-
-        // then
-        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedData);
-      });
-    });
-
     context('when updateExpiredPassword is true', () => {
       it('should call expired-password-updates ', async () => {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Depuis un certain temps, il apparaît que suite à  l'inscription d'un élève depuis la double mire et à l'accès à la page de didacticiel, le clique sur les boutons "Ignorer"et "Suivant" ne fonctionne pas. Ce problème est dû à la disparition du `user` dans le store `ember-data`. En effet, lors de la destruction du composant d'inscription d'un élève, nous effectuons un `unloadRecord` des models `schooling-registration-user-association` et `schooling-registration-dependent-user` qui ne sont plus nécessaire. Néanmoins, suite à un changement de code afin, certainement, de se plier au fonctionnement d'`ember-data`, le model `schooling-registration-dependent-user` a été remplacé par le model `user` (Plus d'explication sur les raisons probables de ce changement plus bas). 

## :robot: Solution
Remplacer le model `user` par un `schooling-registration-dependent-user`. 

## :rainbow: Remarques
Ember Data nous force, lorsque nous effectuons un save sur un certain model, à renvoyer ce même model en réponse (si on souhaite retourner quelque chose). Or, la réponse d'un POST sur /api/schooling-registration-dependent-users renvoyait un user. Cette route a pour but de créer un `user` et de le réconcilier avec sa `schooling-registration`. Il a donc été décidé à l'époque de faire renvoyer par l'API le `user` créé avec un statut HTTP `201 Created`. Ce fonctionnement n'étant pas permis par Ember Data, la solution adoptée a été d'envoyer depuis Pix App un `user` à  la place d'un `schooling-registration-dependent-user`. Cette solution n'est, comme on a pu le voir plus haut, pas la bonne. Nous avons donc décidé ici de rollback le code qui a effectué ce changement et de faire renvoyer par l'API un statut HTTP `204 No Content`, le `user` précédemment retourné n'étant, de toute façon, pas exploité.
Par ailleurs, il apparaît que le remplacement du `schooling-registration-dependent-user` en `user` dans le `register-form.js` a été nécessaire suite à la montée de version d'Ember. Peut-être que le passage à Ember Octane à renforcer le bon usage du fonctionnement d'Ember Data et à empêcher ce qui été permis dans les versions antérieures.       

## :100: Pour tester
- Etre déconnecté
- Rejoindre le parcours [RESTRICTD](https://app-pr1835.review.pix.fr/campagnes/RESTRICTD)
- S'inscrire (Prénom= First, Nom=Last, DDN: 10/10/2010)
(si déjà réconcilié, exécuter 
```
UPDATE "schooling-registrations" SET "userId" =  NULL
WHERE "organizationId" = 3 AND "firstName" = 'First';
```

- Continuer jusqu'à la page didacticiel et vérifier que les boutons "Ignorer" et "Suivant" fonctionnent
