### PR TITLE
[FEATURE] Amélioration de l'accessibilité des pages login/signup (PIX-1180).

### DIFF
--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -33,8 +33,7 @@
         {{/if}}
       {{/if}}
     </div>
-
 </div>
-{{#if displayMessage}}
-    <div id="validationMessage" class="form-textfield__message {{validationMessageClass}} form-textfield__message-{{textfieldType}}" role="alert">{{validationMessage}}</div>
-{{/if}}
+
+<div id="validationMessage-{{textfieldName}}" class="form-textfield__message {{validationMessageClass}} form-textfield__message-{{textfieldType}}" role="alert">{{#if displayMessage}}{{validationMessage}}{{/if}}</div>
+

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -1,4 +1,4 @@
-<div class="sign-form__container">
+<main class="sign-form__container">
 
   <a href={{this.homeUrl}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
@@ -62,4 +62,4 @@
     </form>
   {{/if}}
 
-</div>
+</main>

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -1,4 +1,4 @@
-<div class="sign-form__container">
+<main class="sign-form__container">
 
   <a href={{this.homeUrl}} class="pix-logo__link" title="{{t 'navigation.homepage'}}">
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'common.pix'}}">
@@ -47,4 +47,4 @@
       </button>
     </div>
   </form>
-</div>
+</main>

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -1,4 +1,4 @@
-<div class="sign-form__container">
+<main class="sign-form__container">
 
   <a href={{homeUrl}} class="pix-logo__link" title="{{t 'navigation.homepage'}}">
     <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'common.pix'}}">
@@ -107,4 +107,4 @@
     </div>
 
   </form>
-</div>
+</main>

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -148,7 +148,7 @@ describe('Integration | Component | routes/register-form', function() {
         await triggerEvent('#firstName', 'blur');
 
         // then
-        expect(find('#register-firstName-container #validationMessage').textContent).to.equal(EMPTY_FIRSTNAME_ERROR_MESSAGE);
+        expect(find('#register-firstName-container #validationMessage-firstName').textContent).to.equal(EMPTY_FIRSTNAME_ERROR_MESSAGE);
         expect(find('#register-firstName-container .form-textfield__input-container--error')).to.exist;
       });
     });
@@ -166,7 +166,7 @@ describe('Integration | Component | routes/register-form', function() {
         await triggerEvent('#lastName', 'blur');
 
         // then
-        expect(find('#register-lastName-container #validationMessage').textContent).to.equal(EMPTY_LASTNAME_ERROR_MESSAGE);
+        expect(find('#register-lastName-container #validationMessage-lastName').textContent).to.equal(EMPTY_LASTNAME_ERROR_MESSAGE);
         expect(find('#register-lastName-container .form-textfield__input-container--error')).to.exist;
       });
     });
@@ -245,7 +245,7 @@ describe('Integration | Component | routes/register-form', function() {
         await triggerEvent('#email', 'blur');
 
         // then
-        expect(find('#register-email-container #validationMessage').textContent).to.equal(EMPTY_EMAIL_ERROR_MESSAGE);
+        expect(find('#register-email-container #validationMessage-email').textContent).to.equal(EMPTY_EMAIL_ERROR_MESSAGE);
         expect(find('#register-email-container .form-textfield__input-container--error')).to.exist;
       });
     });
@@ -267,7 +267,7 @@ describe('Integration | Component | routes/register-form', function() {
         await triggerEvent('#password', 'blur');
 
         // then
-        expect(find('#register-password-container #validationMessage').textContent).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
+        expect(find('#register-password-container #validationMessage-password').textContent).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
         expect(find('#register-password-container .form-textfield__input-container--error')).to.exist;
       });
     });

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -202,9 +202,9 @@ describe('Integration | Component | signup form', function() {
 
         // then
         return settled().then(() => {
-          expect(find('.form-textfield__message-text').getAttribute('class')).
-            to.
-            contain('form-textfield__message--error');
+          expect(find('#validationMessage-firstName').getAttribute('class'))
+            .to
+            .contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(emptyFirstnameErrorMessage);
           expect(find('#firstName').getAttribute('class')).to.contain('form-textfield__input--error');
           expect(find('.form-textfield-icon__state--error')).to.exist;
@@ -222,8 +222,8 @@ describe('Integration | Component | signup form', function() {
         await triggerEvent('#lastName', 'blur');
 
         // then
-        return settled().then(() => {
-          expect(find('.form-textfield__message-text').getAttribute('class')).
+        return settled().then(async function() {
+          expect(find('#validationMessage-lastName').getAttribute('class')).
             to.
             contain('form-textfield__message--error');
           expect(find('.form-textfield__message--error').textContent.trim()).to.equal(emptyLastnameErrorMessage);
@@ -386,7 +386,7 @@ describe('Integration | Component | signup form', function() {
 
           // then
           return settled().then(() => {
-            expect(find('.form-textfield__message-text').getAttribute('class')).
+            expect(find('#validationMessage-firstName').getAttribute('class')).
               to.
               contain('form-textfield__message--success');
             expect(find('.form-textfield__message--error')).not.to.exist;
@@ -407,7 +407,7 @@ describe('Integration | Component | signup form', function() {
 
           // then
           return settled().then(() => {
-            expect(find('.form-textfield__message-text').getAttribute('class')).
+            expect(find('#validationMessage-lastName').getAttribute('class')).
               to.
               contain('form-textfield__message--success');
             expect(find('.form-textfield__message--error')).not.to.exist;


### PR DESCRIPTION
## :unicorn: Problème
Plusieurs soucis d'accessibilité sont encore présents sur les pages login et signup de pix-app.

## :robot: Solution
- Ajout de balises `<main>` dans les composants visés
- Modification de l'affichage du texte d'erreur du formulaire et des tests associés afin de corriger un souci de broken ARIA reference.

## :rainbow: Remarques
Ajout d'un tag "data-test" dans la `<div>` de message d'erreur du formTextField afin de plus facilement faire référence à l'élément visé dans les tests.
--> Le test helper find renvoie uniquement le premier élément correspondant du HTML (dans ce cas l'input firstName, causant l'échec des tests pour l'input lastName)

## :100: Pour tester
Accéder à la age d'inscription/connexion et de la RA et utiliser l'extension Chrome/Firefox "Wave"
