### PR TITLE
[BUGFIX] Input du formulaire de vérification de certification cassé sous IE (Pix-1186)

### DIFF
--- a/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-certificate-verification-code.scss
@@ -46,6 +46,13 @@
       input {
         width: 15.3ch;
       }
+
+      @media all and (-ms-high-contrast: none) {
+
+        input {
+          width: 17.4ch;
+        }
+      }
     }
 
     .form__actions {


### PR DESCRIPTION
## :unicorn: Problème
Ouvrir la page de vérification du certificat sous IE : https://integration.pix.fr/verification-certificat

 Résultat obtenu : le code ne s’affiche pas en entier dans le champ prévu à cet effet

## :robot: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Ouvrir la RA sous IE, constater que le champs de saisie s'affiche en entier