### PR TITLE
[FEATURE] Ajout d'une erreur lors de tentative d'accès à un certificat partageable via url (PIX-1192)

### DIFF
--- a/mon-pix/app/routes/fill-in-certificate-verification-code.js
+++ b/mon-pix/app/routes/fill-in-certificate-verification-code.js
@@ -1,0 +1,21 @@
+import classic from 'ember-classic-decorator';
+import { inject as service } from '@ember/service';
+import Route from '@ember/routing/route';
+
+@classic
+export default class FillInCertificateVerificationCodeRoute extends Route {
+
+  @service intl;
+
+  message = null;
+
+  beforeModel(transition) {
+    if (transition.to.queryParams.unallowedAccess) {
+      this.message = this.intl.t('pages.fill-in-certificate-verification-code.errors.unallowed-access');
+    }
+  }
+
+  setupController() {
+    this.controller.set('errorMessage', this.message);
+  }
+}

--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -7,7 +7,7 @@ export default class SharedCertificationRoute extends Route {
       if (transition && transition.from) {
         transition.abort();
       } else {
-        this.replaceWith('/verification-certificat');
+        this.replaceWith('/verification-certificat?unallowedAccess=true');
       }
     }
   }

--- a/mon-pix/tests/unit/routes/shared-certification-test.js
+++ b/mon-pix/tests/unit/routes/shared-certification-test.js
@@ -11,7 +11,7 @@ describe('Unit | Route | shared-certification', function() {
     sinon.stub(route, 'replaceWith');
 
     route.redirect({}, {});
-    sinon.assert.calledWithExactly(route.replaceWith,'/verification-certificat');
+    sinon.assert.calledWithExactly(route.replaceWith,'/verification-certificat?unallowedAccess=true');
   });
 
   it('should not redirect with certification', function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -769,7 +769,8 @@
       "errors": {
         "wrong-format": "Veuillez vérifier votre code.",
         "missing-code": "Veuillez saisir un code au format P-XXXXXXXX.",
-        "not-found": "Il n'y a pas de certificat Pix correspondant"
+        "not-found": "Il n'y a pas de certificat Pix correspondant",
+        "unallowed-access": "Merci de renseigner le code de vérification au format P-XXXXXXXX dans le champ ci-dessus."
       },
       "verify": "Vérifier le score"
     },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -769,7 +769,8 @@
       "errors": {
         "wrong-format": "Veuillez vérifier le format de votre code (P-XXXXXXX).",
         "missing-code": "Merci de renseigner le code de vérification.",
-        "not-found": "Il n'y a pas de certificat Pix correspondant."
+        "not-found": "Il n'y a pas de certificat Pix correspondant.",
+        "unallowed-access": "Merci de renseigner le code de vérification au format P-XXXXXXXX dans le champ ci-dessus."
       },
       "verify": "Vérifier le certificat"
     },


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu’un utilisateur entre une URL avec le code de vérification directement indiqué, il ne pourra pas accéder au certificat partageable mais sera redirigé sur la page de vérification. Néanmoins pour le moment, il n’y a pas de message d’erreur lui permettant de comprendre pourquoi il a été automatiquement redirigé sur cette page, il y a donc un risque de messages au support si des utilisateurs s’obstinent à utiliser l’URL plutôt que d’entrer le code dans le champ correspondant.


## :robot: Solution
Afficher un message d’erreur lorsqu’un utilisateur est redirigé sur la page de vérification du certificat Pix après avoir entré une URL contenant un code de vérification : "Merci de renseigner le code de vérification au format P-XXXXXXXX dans le champ ci-dessus."

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Se rendre sur la RA app/verification-certificat
- Entrer le code P-MY62DJJT
- Copier l'url du certificat partageable
- Le coller dans une nouvelle tab
- Constater le message d'erreur  "Merci de renseigner le code de vérification au format P-XXXXXXXX dans le champ ci-dessus." en dessous de l'input

![image](https://user-images.githubusercontent.com/37305474/92228478-3b001900-eea8-11ea-8af6-daefd66a2380.png)
