### PR TITLE
[TECH] Enable experimental decorators for vscode in sample config

### DIFF
--- a/.vscode/sample.settings.json
+++ b/.vscode/sample.settings.json
@@ -6,5 +6,6 @@
         "./mon-pix",
         "./api",
         "./orga"
-    ]
+    ],
+    "javascript.implicitProjectConfig.experimentalDecorators": true
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans vs code on a un warning sur les decorateurs ember

## :robot: Solution
Il faut activer une option dans la config (ou mettre a jour settings.json)
Ici on met à jour sample.settings.json

## :100: Pour tester
Ajouter la ligne du sample.settings.json dans settings.json (ou bien remplacer tout le fichier).

![image](https://user-images.githubusercontent.com/3769147/92247947-4400e280-eec8-11ea-8c56-a5cf6cba0964.png)

