### PR TITLE
[FEATURE] Amélioration de l'accessibilité de la page profil (PIX-1129).

### DIFF
--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -2,14 +2,15 @@
   <div class="background-banner"></div>
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner profile__panel">
-
+  <h1 class="sr-only">{{t 'pages.profile.accessibility.title'}}</h1>
     <div class="rounded-panel-header-with-components">
       <div class="rounded-panel-header__left-wrapper">
-        <h1 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
+        <div class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
         {{t 'pages.profile.first-title' htmlSafe=true}}
-        </h1>
+        </div>
       </div>
       <div class="rounded-panel-header__right-wrapper">
+        <h2 class="sr-only">{{t 'pages.profile.accessibility.user-score'}}</h2>
         <HexagonScore @pixScore={{@model.pixScore.value}} />
       </div>
     </div>

--- a/mon-pix/app/templates/components/profile-scorecards.hbs
+++ b/mon-pix/app/templates/components/profile-scorecards.hbs
@@ -1,4 +1,6 @@
 <div class="rounded-panel-body">
+  <h2 class="sr-only">{{t 'pages.profile.accessibility.user-skills'}}</h2>
+  <div>
   {{#each @areasCode as |areaCode|}}
     <div class="rounded-panel-body__areas">
       {{#each @scorecards as |scorecard|}}
@@ -10,4 +12,5 @@
       {{/each}}
     </div>
   {{/each}}
+  </div>
 </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -498,6 +498,11 @@
 
     "profile": {
       "title": "Your profile",
+      "accessibility": {
+        "title": "Your Pix profile",
+        "user-score": "Your Pix score",
+        "user-skills": "Your Pix skills"
+      },
       "competence-card": {
         "congrats": "Congrats!",
         "details": "details"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -498,6 +498,11 @@
 
     "profile": {
       "title": "Votre profil",
+      "accessibility": {
+        "title": "Votre profil Pix",
+        "user-score": "Votre nombre de Pix",
+        "user-skills": "Vos compétences Pix"
+      },
       "competence-card": {
         "congrats": "Bravo !",
         "details": "détails"


### PR DESCRIPTION
## :unicorn: Problème
Des soucis d'accessibilité au niveau des titres demeurent sur la page profil de Pix-app.

## :robot: Solution
Ajout de titres visibles uniquement pour les lecteurs d'écran.
Remplacement d'une balise `h1` non essentielle par une `div`

## :rainbow: Remarques
Ajout d'une `div` d'encapsulation des cards dans `profile-scorecards.hbs` afin d'opérer la séparation au niveau du DOM entre le H2 nouvellement ajouté et les cards, séparation nécessaire pour les tests.

## :100: Pour tester
Se connecter à la RA et lancer l'extension Chrome/Firefox "Wave"