### PR TITLE
[CLEANUP] Mettre l'affichage du loading directement dans resume (PIX-1127).

### DIFF
--- a/mon-pix/app/templates/assessments/resume-loading.hbs
+++ b/mon-pix/app/templates/assessments/resume-loading.hbs
@@ -1,1 +1,0 @@
-<Loader @loaderText={{t "common.loading.test"}} />

--- a/mon-pix/app/templates/assessments/resume.hbs
+++ b/mon-pix/app/templates/assessments/resume.hbs
@@ -1,1 +1,1 @@
-{{outlet}}
+<Loader @loaderText={{t "common.loading.default"}} />


### PR DESCRIPTION
## :unicorn: Problème
Quand le cache est vide et que je lance une compétence, j'ai une page blanche pendant longtemps

## :robot: Solution
La page `hbs` de `assessments/resume` affiche maintenant l'image de chargement.

## :rainbow: Remarques
- Suppression du `resume-loading.hbs`

## :100: Pour tester
Lancer une compétence et ne pas voir de page blanche
En local, avoir le cache vide et lancer la page pour voir le loading.