### PR TITLE
[BUGFIX] Interdire les caractères spéciaux pour le numéro étudiant lors de l'import CSV des étudiants (PIX-1226).

### DIFF
--- a/api/lib/domain/validators/higher-education-registration-validator.js
+++ b/api/lib/domain/validators/higher-education-registration-validator.js
@@ -5,7 +5,7 @@ const validationConfiguration = { allowUnknown: true };
 const MAX_LENGTH = 255;
 
 const validationSchema = Joi.object({
-  studentNumber: Joi.string().max(MAX_LENGTH)
+  studentNumber: Joi.string().regex(/^[a-zA-Z0-9_\\-]*$/).max(MAX_LENGTH)
     .when('$isSupernumerary', {
       switch: [{
         is: true,
@@ -64,6 +64,9 @@ module.exports = {
       }
       if (type === 'boolean.base') {
         err.why = 'not_a_boolean';
+      }
+      if (err.key === 'studentNumber' && type === 'string.pattern.base') {
+        err.why = 'student_number_format';
       }
       throw err;
     }

--- a/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
@@ -48,7 +48,7 @@ class HigherEducationRegistrationParser {
     }
 
     this._checkColumns(fields);
-       
+
     registrationLines.forEach((line, index) => {
       const registrationAttributes = this._lineToRegistrationAttributes(line);
       try {
@@ -65,7 +65,7 @@ class HigherEducationRegistrationParser {
    * Identify which encoding has the given file.
    * To check it, we decode and parse the first line of the file with supported encodings.
    * If there is one with at least "First name" or "Student number" correctly parsed and decoded.
-   */ 
+   */
   _getFileEncoding() {
     const supported_encodings = ['utf-8', 'win1252', 'macintosh'];
     const { firstName, studentNumber } = COLUMN_NAME_BY_ATTRIBUTE;
@@ -82,7 +82,7 @@ class HigherEducationRegistrationParser {
     const decodedInput = iconv.decode(this._input, encoding);
     const { data: registrationLines, meta: { fields }, errors } = papa.parse(decodedInput, PARSING_OPTIONS);
 
-    if (errors.length) {  
+    if (errors.length) {
       errors.forEach((error) => {
         if (error.type === 'Delimiter') {
           throw new CsvImportError('Le fichier doit être au format csv avec séparateur virgule ou point-virgule.');
@@ -103,6 +103,9 @@ class HigherEducationRegistrationParser {
     }
     if (err.why === 'not_a_date' || err.why === 'date_format') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “Date de naissance” doit être au format jj/mm/aaaa.`);
+    }
+    if (err.why === 'student_number_format') {
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “numéro étudiant” ne doit pas avoir de caractères spéciaux.`);
     }
     if (err.why === 'required') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column}” est obligatoire.`);

--- a/api/tests/unit/domain/models/HigherEducationRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherEducationRegistration_test.js
@@ -26,7 +26,7 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
       });
     });
 
-    ['firstName', 'lastName', 'studentNumber'].forEach((field) => {
+    ['firstName', 'lastName', 'birthdate', 'studentNumber'].forEach((field) => {
       it(`throw an error when ${field} is required`, async () => {
         const error = await catchErr(buildRegistration)({ ...validAttributes, [field]: undefined, isSupernumerary: false });
 

--- a/api/tests/unit/domain/models/HigherEducationRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherEducationRegistration_test.js
@@ -161,5 +161,41 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
         expect(error.why).to.equal('email_format');
       });
     });
+
+    context('student number', () => {
+      context('when student number is not correctly formed', () => {
+        [
+          '#123457',
+          '1 23457',
+          '1.23457',
+          '1,23457E+11',
+          'gégé',
+        ].forEach((value) => {
+          it(`throw an error when student number is ${value}`, async () => {
+            const error = await catchErr(buildRegistration)({ ...validAttributes, studentNumber: value });
+
+            expect(error.why).to.equal('student_number_format');
+            expect(error.key).to.equal('studentNumber');
+          });
+        });
+      });
+
+      context('when student number is correctly formed', () => {
+        [
+          '123456',
+          '1234aA',
+          '1-a-B',
+          '1_a_B',
+        ].forEach((value) => {
+          it(`throw an error when student number is ${value}`, async () => {
+            try {
+              await buildRegistration({ ...validAttributes, studentNumber: value });
+            } catch (e) {
+              expect.fail('higherEducationRegistration is valid when student number is correctly formed');
+            }
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Si nous avons un numéro étudiant comportant 12 chiffres comme : "123456789999", celui-ci est formaté par excel en : 1,23457E+11 

## :robot: Solution
Empêcher la saisie sous cette forme en affichant une erreur : "Ligne XX : Le numéro étudiant ne doit pas comporter de caractères spéciaux"

## :rainbow: Remarques
- on autorise n'importe quel caractère alphanumérique minuscule-majuscule avec tiret et underscore.

NB : on ne peut convertir, puisque on a une perte de chiffres.

## :100: Pour tester
- importer un fichier avec un étudiant ayant pour numéro étudiant 1,23457E+11
