### PR TITLE
[BUGFIX] Parsing de date avec une année sur 2 digits pour l'import CSV SUP

### DIFF
--- a/api/lib/infrastructure/utils/date-utils.js
+++ b/api/lib/infrastructure/utils/date-utils.js
@@ -1,5 +1,11 @@
 const moment = require('moment-timezone');
 
+moment.parseTwoDigitYear = function(yearString) {
+  const year = parseInt(yearString);
+  const currentYear = new Date().getFullYear();
+  return 2000 + year < currentYear ? 2000 + year : 1900 + year;
+};
+
 function isValidDate(dateValue, format) {
   return moment.utc(dateValue, format, true).isValid();
 }

--- a/api/tests/unit/infrastructure/utils/date-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/date-utils_test.js
@@ -90,13 +90,21 @@ describe('Unit | Utils | date-utils', () => {
         });
       });
 
-      context('when dateValue matches alternativeInputFormat', () => {
-        it('should return converted date with date < 2000', () => {
-          expect(convertDateValue({ dateString: '05/05/80', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal('1980-05-05');
+      context('when dateValue matches alternativeInputFormat with 2 digits year', () => {
+        it('should return converted date with year 2000 if input year < the current year', () => {
+          const currentYear = new Date().getFullYear();
+          const currentTwoDigitYear = currentYear - 2000;
+          const inputDate = '05/05/' + (currentTwoDigitYear - 1);
+          const expectedDate = (currentYear - 1) + '-05-05';
+          expect(convertDateValue({ dateString: inputDate, inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal(expectedDate);
         });
 
-        it('should return converted date with date > 2000', () => {
-          expect(convertDateValue({ dateString: '05/05/02', inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal('2002-05-05');
+        it('should return converted date with year 1900 if input year >= the current year', () => {
+          const currentYear = new Date().getFullYear();
+          const currentTwoDigitYear = currentYear - 2000;
+          const inputDate = '05/05/' + currentTwoDigitYear;
+          const expectedDate = (1900 + currentTwoDigitYear) + '-05-05';
+          expect(convertDateValue({ dateString: inputDate, inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' })).to.equal(expectedDate);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Dans l'import CSV des étudiants SUP la date de naissance est obligatoire et peut être importé au format `DD-MM-YYYY` et `DD-MM-YY` (car par défaut Excel exporte la date avec une année en 2 digits si la colonne est de type date).

Or quand on réalise un import CSV avec une date ayant une année sur 2 digits on obtient des résultats incohérent, par exemple: 

- Date dans le fichier : `01/01/57`
- Date en base de données : `01/01/2057`

`01/01/2057` est incohérent pour une date de naissance (date dans le futur),  le résultat attendu est `01/01/1957`.

## :robot: Solution

`moment` possède une fonction spécifique pour parser les années sur 2 digits. Voici l'implémentation actuelle de `moment`:

```js
hooks.parseTwoDigitYear = function (input) {
    return toInt(input) + (toInt(input) > 68 ? 1900 : 2000);
};
```
> Si l'année sur 2 digits est supérieure à 68, il s'agit de l'année 1900, sinon 2000

Cette fonction peut être surchargée, donc pour rendre plus cohérent et intelligent le parsing des 2 digit sur les dates de naissance, nous allons la modifier pour mettre en place les règles suivantes:
- C'est de l'année 2000 si l'année sur 2 digit est inférieure ou égale à l'année en cours,
- C'est de l'année 1900 si l'année sur 2 digit est supérieure à l'année en cours,

> Si on est en 2020 et que l'année en 2 digit est 22, on aura 1922.
> Si on est en 2020 et que l'année en 2 digit est 19, on aura 2019.

## :rainbow: Remarques

> ⚠️ La configuration du parsing sur 2 digits de moment est global. Il s'applique sur toutes les instances de moment et donc touche tous les parsings de l'API.

## :100: Pour tester

1. Se connecter sur pix-orga avec le compte sup
2. importer des étudiants via le fichier CSV.
    - Avec un étudiant ayant une date de naissance au format `DD-MM-YY` avec l'année comprise entre 01 et 20
    - Avec un étudiant ayant une date de naissance au format `DD-MM-YY` avec l'année supérieure à 20

> Le premier doit avoir une date importée en 20XX
> Le second doit avoir une date importée en 19XX
