### PR TITLE
[TECH] Réparation de tests autos flaky liés à la violation de contrainte d'unicité de la key d'un badge (PIX-1243)

### DIFF
--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -20,7 +20,7 @@ describe('Acceptance | API | Certifications', () => {
 
     userId = databaseBuilder.factory.buildUser().id;
     session = databaseBuilder.factory.buildSession();
-    badge = databaseBuilder.factory.buildBadge();
+    badge = databaseBuilder.factory.buildBadge({ key: 'charlotte_aux_fraises' });
     certificationCourse = databaseBuilder.factory.buildCertificationCourse({
       sessionId: session.id,
       userId,

--- a/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-acquisition-repository_test.js
@@ -10,7 +10,7 @@ describe('Integration | Repository | Badge Acquisition', () => {
   describe('#create', () => {
 
     beforeEach(async () => {
-      const badgeId = databaseBuilder.factory.buildBadge().id;
+      const badgeId = databaseBuilder.factory.buildBadge({ key: 'éclair_au_chocolat' }).id;
       const userId = databaseBuilder.factory.buildUser().id;
 
       badgeAcquisitionToCreate = databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });
@@ -43,7 +43,7 @@ describe('Integration | Repository | Badge Acquisition', () => {
     let badgeId;
 
     beforeEach(async () => {
-      badgeId = databaseBuilder.factory.buildBadge().id;
+      badgeId = databaseBuilder.factory.buildBadge({ key: 'beignet_a_la_creme' }).id;
       userId = databaseBuilder.factory.buildUser().id;
 
       badgeAcquisitionToCreate = databaseBuilder.factory.buildBadgeAcquisition({ badgeId, userId });

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -167,7 +167,7 @@ describe('Integration | Repository | Badge', () => {
 
     beforeEach(() => {
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-      databaseBuilder.factory.buildBadge({ targetProfileId });
+      databaseBuilder.factory.buildBadge({ targetProfileId, key: 'mille_feuilles' });
       const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
       databaseBuilder.factory.buildCampaignParticipation({ campaignId });
       return databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -161,13 +161,13 @@ describe('Integration | Repository | Certification Course', function() {
       _.each([
         {
           certificationCourseId: expectedCertificationCourse.id,
-          partnerKey: databaseBuilder.factory.buildBadge({}).key
+          partnerKey: databaseBuilder.factory.buildBadge({ key: 'forêt_noire' }).key
         },
         {
           certificationCourseId: expectedCertificationCourse.id,
-          partnerKey: databaseBuilder.factory.buildBadge({}).key
+          partnerKey: databaseBuilder.factory.buildBadge({ key: 'baba_au_rhum' }).key
         },
-        { certificationCourseId: anotherCourseId, partnerKey: databaseBuilder.factory.buildBadge({}).key },
+        { certificationCourseId: anotherCourseId, partnerKey: databaseBuilder.factory.buildBadge({ key: 'tropézienne' }).key },
       ], (acquiredPartnerCertification) =>
         databaseBuilder.factory.buildPartnerCertification(acquiredPartnerCertification));
       return databaseBuilder.commit();


### PR DESCRIPTION
## :unicorn: Problème
Certains tests auto échouent apparemment sans raison.

## :robot: Solution
En l'occurrence, il s'agissait d'une malchance "faker". 
Le badge présente un champ "key" qui doit être unique en base. Or, son instanciation par défaut dans le builder est réalisée par faker. Faker ne garantit absolument pas le tirage d'un mot unique.
Il faut donc  construire une clé dont on est sûr qu'elle est unique dans le contexte du test.

## :rainbow: Remarques
Au passage, on a remarqué pendant l'enquête sur ce flaky test que le databaseBuilder ne se rétablit pas correctement si ça throw et que c'est pas catch. (dans les beforeEach() par exemple). Un petit refacto autour du databaseBuilder est prévu dans une PR à venir.

## :100: Pour tester

