### PR TITLE
[BUGFIX] Saisie de l'UAI insensible à la casse sur le formulaire d'activation des espaces PixOrga (PIX-1239)

### DIFF
--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -43,6 +43,28 @@ exports.register = async (server) => {
       config: {
         auth: false,
         handler: organizationInvitationController.sendScoInvitation,
+        validate: {
+          payload:
+            Joi.object({
+              data: {
+                attributes: {
+                  'uai': Joi.string().required(),
+                  'first-name': Joi.string().required(),
+                  'last-name': Joi.string().required(),
+                },
+                type: 'sco-organization-invitations'
+              }
+            }),
+          failAction: (request, h, err) => {
+            const errorHttpStatusCode = 400;
+            const jsonApiError = new JSONAPIError({
+              status: errorHttpStatusCode.toString(),
+              title: 'Bad request',
+              detail: err.details[0].message,
+            });
+            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+          }
+        },
         notes: [
           '- Cette route permet d\'envoyer une invitation pour rejoindre une organisation de type SCO en tant que ADMIN, en renseignant un **UAI**, un **NOM** et un **PRENOM**'
         ],

--- a/api/lib/domain/usecases/send-sco-invitation.js
+++ b/api/lib/domain/usecases/send-sco-invitation.js
@@ -6,7 +6,7 @@ let organizationsFound = null;
 
 module.exports = async function sendScoInvitation({ uai, firstName, lastName, locale, organizationRepository, organizationInvitationRepository }) {
 
-  organizationsFound = await organizationRepository.findScoOrganizationByUai(uai);
+  organizationsFound = await organizationRepository.findScoOrganizationByUai(uai.trim());
 
   const nbOrganizations = _.get(organizationsFound, 'length', 0);
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -103,7 +103,8 @@ module.exports = {
 
   findScoOrganizationByUai(uai) {
     return BookshelfOrganization
-      .where({ externalId: uai, type: Organization.types.SCO })
+      .query((qb) => qb.where({ type: Organization.types.SCO })
+        .whereRaw('LOWER("externalId") = ? ', `${uai.toLowerCase()}`))
       .fetchAll({ columns: ['id', 'type', 'externalId', 'email'] })
       .then((organizations) => organizations.models.map(_toDomain));
   },

--- a/api/tests/integration/application/organization-invitations/index_test.js
+++ b/api/tests/integration/application/organization-invitations/index_test.js
@@ -57,13 +57,54 @@ describe('Integration | Application | Organization-invitations | Routes', () => 
       await server.register(route);
     });
 
-    it('should exists', async () => {
+    it('should send invitation when payload is valid', async () => {
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/organization-invitations/sco',
+        payload: {
+          data: {
+            type: 'sco-organization-invitations',
+            attributes: {
+              uai: '1234567A',
+              'first-name': 'john',
+              'last-name': 'harry',
+            },
+          }
+        }
+      };
+
       // when
-      const response = await server.inject({ method: 'POST', url: '/api/organization-invitations/sco' });
+      const response = await server.inject(options);
 
       // then
       expect(response.statusCode).to.equal(201);
     });
+
+    it('should return bad request when payload is not valid', async () => {
+
+      // given
+      const options = {
+        method: 'POST',
+        url: '/api/organization-invitations/sco',
+        payload: {
+          data: {
+            type: 'sco-organization-invitations',
+            attributes: {
+              uai: '1234567A',
+              lastName: 'harry',
+            },
+          }
+        }
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
   });
 
   describe('GET /api/organization-invitations/:id', () => {

--- a/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
+++ b/api/tests/integration/application/organization-invitations/organization-invitation-controller_test.js
@@ -95,7 +95,7 @@ describe('Integration | Application | Organization-invitations | organization-in
     const uai = '1234567A';
     const payload = {
       data: {
-        type: 'organization-invitations',
+        type: 'sco-organization-invitations',
         attributes: {
           uai,
           'first-name': 'john',

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -281,6 +281,9 @@ describe('Integration | Repository | Organization', function() {
         { type: 'PRO', name: 'organization 1', externalId: '1234567', email: null },
         { type: 'SCO', name: 'organization 2', externalId: '1234568', email: 'sco.generic.account@example.net' },
         { type: 'SUP', name: 'organization 3', externalId: '1234569', email: null },
+        { type: 'SCO', name: 'organization 4', externalId: '0595401A', email: 'sco2.generic.account@example.net' },
+        { type: 'SCO', name: 'organization 5', externalId: '0587996a', email: 'sco3.generic.account@example.net' },
+        { type: 'SCO', name: 'organization 6', externalId: '058799Aa', email: 'sco4.generic.account@example.net' },
       ], (organization) => {
         return databaseBuilder.factory.buildOrganization(organization);
       });
@@ -292,6 +295,70 @@ describe('Integration | Repository | Organization', function() {
       // given
       const uai = '1234568';
       const organizationSCO = organizations[1];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+
+      // then
+      expect(foundOrganization).to.have.lengthOf(1);
+      expect(foundOrganization[0]).to.be.an.instanceof(Organization);
+      expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
+      expect(foundOrganization[0].type).to.equal(organizationSCO.type);
+      expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+
+    it('should return external identifier for SCO organizations matching given UAI with lower case', async () => {
+      // given
+      const uai = '0595401a';
+      const organizationSCO = organizations[3];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+
+      // then
+      expect(foundOrganization).to.have.lengthOf(1);
+      expect(foundOrganization[0]).to.be.an.instanceof(Organization);
+      expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
+      expect(foundOrganization[0].type).to.equal(organizationSCO.type);
+      expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+
+    it('should return external identifier for SCO organizations matching given UAI with Upper case', async () => {
+      // given
+      const uai = '0587996A';
+      const organizationSCO = organizations[4];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+
+      // then
+      expect(foundOrganization).to.have.lengthOf(1);
+      expect(foundOrganization[0]).to.be.an.instanceof(Organization);
+      expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
+      expect(foundOrganization[0].type).to.equal(organizationSCO.type);
+      expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+
+    it('should return external identifier for SCO organizations matching given UAI with Upper and lower case', async () => {
+      // given
+      const uai = '058799Aa';
+      const organizationSCO = organizations[5];
+
+      // when
+      const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);
+
+      // then
+      expect(foundOrganization).to.have.lengthOf(1);
+      expect(foundOrganization[0]).to.be.an.instanceof(Organization);
+      expect(foundOrganization[0].externalId).to.equal(organizationSCO.externalId);
+      expect(foundOrganization[0].type).to.equal(organizationSCO.type);
+      expect(foundOrganization[0].email).to.equal(organizationSCO.email);
+    });
+
+    it('should return external identifier for SCO organizations matching given UAI with lower and upper case', async () => {
+      // given
+      const uai = '058799aA';
+      const organizationSCO = organizations[5];
 
       // when
       const foundOrganization = await organizationRepository.findScoOrganizationByUai(uai);

--- a/orga/app/components/routes/join-request-form.js
+++ b/orga/app/components/routes/join-request-form.js
@@ -31,7 +31,7 @@ export default class JoinRequestForm extends Component {
   async submit(event) {
     event.preventDefault();
     this.isLoading = true;
-    const scoOrganizationInvitation = { uai: this.uai, firstName: this.firstName, lastName: this.lastName };
+    const scoOrganizationInvitation = { uai: this.uai.trim(), firstName: this.firstName.trim(), lastName: this.lastName.trim() };
     await this.args.createScoOrganizationInvitation(scoOrganizationInvitation);
     this.isLoading = false;
   }

--- a/orga/tests/integration/components/routes/join-request-form-test.js
+++ b/orga/tests/integration/components/routes/join-request-form-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render, triggerEvent } from '@ember/test-helpers';
+import {  fillIn, render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/join-request-form', function(hooks) {
@@ -42,5 +42,6 @@ module('Integration | Component | routes/join-request-form', function(hooks) {
         assert.contains(EMPTY_LASTNAME_ERROR_MESSAGE);
       });
     });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
En saisissant l’UAI: ‘0595401a’ dans le formulaire d'activation des espaces PixOrga, le user reçoit le message d’erreur suivant “L'UAI/RNE de l'établissement n’est pas reconnu. Merci de contacter le support.“.
Cela est dû au "a" de l'UAI, ajouté en minuscule au lieu d'une majuscule.

## :robot: Solution

- Faire en sorte que L’UAI ne soit pas sensible à la casse : ‘0595401A’ = ‘0595401a’

`      .query((qb) => qb.where({ type: Organization.types.SCO })
        .whereRaw('LOWER("externalId") = ? ', ${uai.toLowerCase()}))`

- Ajout trim() pour les 3 champs : firstName, lastName, uai.

## :rainbow: Remarques
Ajout d'un BSR Joi pour les inputs du formulaire 

## :100: Pour tester
- Aller dans la page https://orga-pr1852.review.pix.fr/demande-administration-sco

- Saisir '1237457A' dans l'input UAI, puis '1237457a'

- Vérifier que le message d'erreur n'apparaîsse plus.
