### PR TITLE
[FEATURE]Modifier les liens des documentations sco dans Pix Orga

### DIFF
--- a/orga/app/components/routes/authenticated/campaigns/new-item.hbs
+++ b/orga/app/components/routes/authenticated/campaigns/new-item.hbs
@@ -62,7 +62,7 @@
         <p class="form__comment" id="campaign-target-profile-comment-label">
           Si vous souhaitez avoir plus d'information, consultez
           <a class="link"
-             href="https://cloud.pix.fr/s/Rxm5kLR2dmFW7qq?path=%2FLes%20parcours%20dans%20Pix%20Orga"
+             href="https://cloud.pix.fr/s/zK7xHArNzGWaYP7"
              target="_blank"
              rel="noopener noreferrer"> la documentation correspondante</a>.
         </p>

--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -8,7 +8,7 @@ export default class SidebarMenu extends Component {
   @computed('currentUser.organization')
   get documentationUrl() {
     if (this.currentUser.isSCOManagingStudents) {
-      return 'https://cloud.pix.fr/s/rWcNFSgdnnNSdqF';
+      return 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f';
     }
 
     if (this.currentUser.organization.isPro) {

--- a/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaigns/new-item-test.js
@@ -128,6 +128,21 @@ module('Integration | Component | routes/authenticated/campaign | new-item', fun
     });
   });
 
+  module('when organization is a type SCO and user is creating an assessment campaign', function() {
+    test('it should display documentation of school paths', async function(assert) {
+      // given
+      const organization = EmberObject.create();
+      this.owner.register('service:current-user', Service.extend({ organization, isSCOManagingStudents: true }));
+      this.campaign = EmberObject.create({});
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaigns::NewItem @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
+
+      // then
+      assert.dom('a[href="https://cloud.pix.fr/s/zK7xHArNzGWaYP7"]').exists();
+    });
+  });
+
   test('it should send campaign creation action when submitted', async function(assert) {
     // given
     this.campaign = EmberObject.create({});

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -26,7 +26,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     await render(hbs`<SidebarMenu />`);
 
     // then
-    assert.dom('a[href="https://cloud.pix.fr/s/rWcNFSgdnnNSdqF"]').exists();
+    assert.dom('a[href="https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f"]').exists();
   });
 
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Suite à la migration de la documentation vers des supports genially, deux modifications d’URL sont à changer.

## :robot: Solution
Modification des liens dans la documentation de Pix orga ainsi que la création d'une campagne ayant pour objectif l'évaluation d'un participant.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre dans Pix Orga et cliquer sur **documentation** dans le panel gauche et créer une campagne ayant pour objectif l'évaluation d'un participant.
