### PR TITLE
[FEATURE] Amélioration de l'accessibilité de la bannière de reprise de campagne (PIX-1130).

### DIFF
--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -1,30 +1,16 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { classNames } from '@ember-decorators/component';
-import { computed } from '@ember/object';
-import { filterBy } from '@ember/object/computed';
 import _maxBy from 'lodash/maxBy';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 
-@classic
-@classNames('resume-campaign-banner')
 export default class ResumeCampaignBanner extends Component {
-  campaignParticipations = [];
 
-  @filterBy('campaignParticipations', 'isShared', false)
-  unsharedCampaignParticipations;
+  get unsharedCampaignParticipations() {
+    return this.args.campaignParticipations.filter((campaignParticipation) => campaignParticipation.isShared === false);
+  }
 
-  @computed('unsharedCampaignParticipations.@each.createdAt')
   get lastUnsharedCampaignParticipation() {
     return _maxBy(this.unsharedCampaignParticipations, 'createdAt');
   }
 
-  @computed(
-    'lastUnsharedCampaignParticipation.campaign.{title,code,isTypeAssessment},lastUnsharedCampaignParticipation.assessment.isCompleted'
-  )
   get campaignParticipationState() {
     if (this.lastUnsharedCampaignParticipation) {
       return {

--- a/mon-pix/app/styles/components/_resume-campaign-banner.scss
+++ b/mon-pix/app/styles/components/_resume-campaign-banner.scss
@@ -2,8 +2,6 @@
   width: 100%;
 
   @media (min-width: 768px) {
-    position: -webkit-sticky; /* Safari */
-    position: sticky;
     top: 0;
     z-index: 4;
   }
@@ -17,6 +15,7 @@
     padding: 5px;
 
     .resume-campaign-banner__title {
+      color: $grey-200;
       font-family: $font-open-sans;
       font-size: 0.75rem;
 

--- a/mon-pix/app/templates/components/navbar-header.hbs
+++ b/mon-pix/app/templates/components/navbar-header.hbs
@@ -1,4 +1,7 @@
 <nav class="navbar-header">
+  {{#if @campaignParticipations}}
+    <ResumeCampaignBanner  @campaignParticipations={{@campaignParticipations}}/>
+  {{/if}}
   {{#if (media 'isDesktop')}}
     <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}}/>
   {{else}}

--- a/mon-pix/app/templates/components/resume-campaign-banner-assessment.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner-assessment.hbs
@@ -1,15 +1,25 @@
 {{#if @isCompleted}}
   {{#if @title}}
-    <span class="resume-campaign-banner__title">{{t 'pages.profile.resume-campaign-banner.reminder-send-campaign-with-title' title=@title }}</span>
+    <span class="resume-campaign-banner__title">{{t
+            'pages.profile.resume-campaign-banner.reminder-send-campaign-with-title' title=@title }}</span>
   {{else}}
-    <span class="resume-campaign-banner__title">{{t 'pages.profile.resume-campaign-banner.reminder-send-campaign'}}</span>
+    <span class="resume-campaign-banner__title">{{t
+            'pages.profile.resume-campaign-banner.reminder-send-campaign'}}</span>
   {{/if}}
-  <LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">{{t 'pages.profile.resume-campaign-banner.actions.continue'}}</LinkTo>
+  <LinkTo @route="campaigns.start-or-resume" @model={{@code}}
+          class="resume-campaign-banner__button button button--big button--link"><span class="sr-only">{{t
+          'pages.profile.resume-campaign-banner.accessibility.share'}}</span>{{t
+          'pages.profile.resume-campaign-banner.actions.continue'}}</LinkTo>
 {{else}}
   {{#if @title}}
-    <span class="resume-campaign-banner__title">{{t 'pages.profile.resume-campaign-banner.reminder-continue-campaign-with-title' title=@title}}</span>
+    <span class="resume-campaign-banner__title">{{t
+            'pages.profile.resume-campaign-banner.reminder-continue-campaign-with-title' title=@title}}</span>
   {{else}}
-    <span class="resume-campaign-banner__title">{{t 'pages.profile.resume-campaign-banner.reminder-continue-campaign'}}</span>
+    <span class="resume-campaign-banner__title">{{t
+            'pages.profile.resume-campaign-banner.reminder-continue-campaign'}}</span>
   {{/if}}
-  <LinkTo @route="campaigns.start-or-resume" @model={{@code}} class="resume-campaign-banner__button button button--big button--link">{{t 'pages.profile.resume-campaign-banner.actions.resume'}}</LinkTo>
+  <LinkTo @route="campaigns.start-or-resume" @model={{@code}}
+          class="resume-campaign-banner__button button button--big button--link"><span class="sr-only">{{t
+          'pages.profile.resume-campaign-banner.accessibility.resume'}}</span>{{t
+          'pages.profile.resume-campaign-banner.actions.resume'}}</LinkTo>
 {{/if}}

--- a/mon-pix/app/templates/components/resume-campaign-banner.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner.hbs
@@ -1,3 +1,4 @@
+<div class="resume-campaign-banner">
 {{#if campaignParticipationState}}
   <div class="resume-campaign-banner__container">
     {{#if campaignParticipationState.isTypeAssessment}}
@@ -11,3 +12,4 @@
     {{/if}}
   </div>
 {{/if}}
+</div>

--- a/mon-pix/app/templates/profile.hbs
+++ b/mon-pix/app/templates/profile.hbs
@@ -1,10 +1,8 @@
 {{page-title (t 'pages.profile.title')}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
-    {{#if @model.campaignParticipations}}
-      <ResumeCampaignBanner @campaignParticipations={{@model.campaignParticipations}} />
-    {{/if}}
-    <NavbarHeader @burger={{burger}} />
+
+    <NavbarHeader @burger={{burger}} @campaignParticipations={{@model.campaignParticipations}}/>
 
     <ProfileContent @model={{@model}} />
 

--- a/mon-pix/tests/acceptance/profile-test.js
+++ b/mon-pix/tests/acceptance/profile-test.js
@@ -70,6 +70,21 @@ describe('Acceptance | Profile', function() {
     context('when user is doing a campaign of type assessment', function() {
       context('when user has not completed the campaign', () => {
 
+        it('should display accessibility information in the banner button', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, type: 'ASSESSMENT' });
+          server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+
+          // when
+          await visit('/');
+          const button = find('.resume-campaign-banner__button');
+          const a11yText = button.firstChild.textContent;
+
+          // then
+          expect(a11yText).to.equal('Continuer votre parcours');
+        });
+
         it('should display a resume campaign banner for a campaign with no title', async function() {
           // given
           const campaign = server.create('campaign', { isArchived: false, type: 'ASSESSMENT' });
@@ -80,8 +95,8 @@ describe('Acceptance | Profile', function() {
           await visit('/');
 
           // then
-          expect(find('.resume-campaign-banner__container').textContent).to.contain('Vous n\'avez pas terminé votre parcours');
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+          expect(find('.resume-campaign-banner__container')).to.exist;
+          expect(find('.resume-campaign-banner__button').lastChild).to.exist;
         });
 
         it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
@@ -94,8 +109,8 @@ describe('Acceptance | Profile', function() {
           await visit('/');
 
           // then
-          expect(find('.resume-campaign-banner__container').textContent).to.contain(`Vous n'avez pas terminé le parcours "${campaign.title}"`);
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+          expect(find('.resume-campaign-banner__container')).to.exist;
+          expect(find('.resume-campaign-banner__button').lastChild).to.exist;
         });
       });
 
@@ -112,8 +127,8 @@ describe('Acceptance | Profile', function() {
           await visit('/');
 
           // then
-          expect(find('.resume-campaign-banner__container').textContent).to.contain('N\'oubliez pas de finaliser votre envoi !');
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          expect(find('.resume-campaign-banner__container')).to.exist;
+          expect(find('.resume-campaign-banner__button').lastChild).to.exist;
         });
 
         it('should display a resume campaign banner for a campaign with a campaign with a title', async function() {
@@ -127,14 +142,30 @@ describe('Acceptance | Profile', function() {
           await visit('/');
 
           // then
-          expect(find('.resume-campaign-banner__container').textContent).to.contain(`Parcours "${campaign.title}" terminé. N'oubliez pas de finaliser votre envoi !`);
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          expect(find('.resume-campaign-banner__container')).to.exist;
+          expect(find('.resume-campaign-banner__button').lastChild).to.exist;
         });
       });
     });
 
     context('when user is doing a campaign of type collect profile', function() {
       context('when user has not shared the collect profile campaign', () => {
+        it('should display accessibility information in the banner', async function() {
+          // given
+          const campaign = server.create('campaign', { isArchived: false, type: 'ASSESSMENT' });
+          server.create('campaign-participation',
+            { campaign, user, isShared: false , createdAt: new Date('2020-04-20T04:05:06Z') });
+
+          // when
+          await visit('/');
+          const button = find('.resume-campaign-banner__button');
+          const a11yText = button.firstChild.textContent;
+
+          // then
+          expect(button).to.exist;
+          expect(a11yText).to.exist;
+        });
+
         it('should display a resume campaign banner for the campaign', async function() {
           // given
           const campaign = server.create('campaign', { isArchived: false, title: 'SomeTitle', type: 'PROFILES_COLLECTION' });
@@ -146,8 +177,8 @@ describe('Acceptance | Profile', function() {
           await visit('/');
 
           // then
-          expect(find('.resume-campaign-banner__container').textContent).to.contain('N\'oubliez pas de finaliser votre envoi !');
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          expect(find('.resume-campaign-banner__container')).to.exist;
+          expect(find('.resume-campaign-banner__button')).to.exist;
         });
       });
     });

--- a/mon-pix/tests/integration/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/integration/components/resume-campaign-banner-test.js
@@ -9,6 +9,10 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
   setupIntlRenderingTest();
 
+  beforeEach(function() {
+    this.intl.setLocale(['fr', 'fr']);
+  });
+
   describe('Banner display', function() {
     const campaignToResume = EmberObject.create({
       isShared: false,
@@ -60,9 +64,12 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+          const a11yText = find('.resume-campaign-banner__button').firstChild.textContent;
+          const buttonTextContent = find('.resume-campaign-banner__button').lastChild.textContent;
 
           // then
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Reprendre');
+          expect(a11yText).to.equal(this.intl.t('pages.profile.resume-campaign-banner.accessibility.resume'));
+          expect(buttonTextContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.actions.resume'));
         });
 
         it('should display a sentence to ask user to resume with the title of campaign', async function() {
@@ -73,7 +80,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
 
           // then
-          expect(find('.resume-campaign-banner__title').textContent).to.equal(`Vous n'avez pas terminé le parcours "${campaignToResume.campaign.title}"`);
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.reminder-continue-campaign-with-title', { title: campaignToResume.campaign.title }));
         });
 
         it('should display a simple sentence to ask user to resume when campaign has no title', async function() {
@@ -85,7 +92,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
 
           // then
-          expect(find('.resume-campaign-banner__title').textContent).to.equal('Vous n\'avez pas terminé votre parcours');
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.reminder-continue-campaign'));
         });
 
       });
@@ -120,9 +127,12 @@ describe('Integration | Component | resume-campaign-banner', function() {
 
           // when
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
+          const a11yText = find('.resume-campaign-banner__button').firstChild.textContent;
+          const buttonTextContent = find('.resume-campaign-banner__button').lastChild.textContent;
 
           // then
-          expect(find('.resume-campaign-banner__button').textContent).to.equal('Continuer');
+          expect(a11yText).to.equal(this.intl.t('pages.profile.resume-campaign-banner.accessibility.share'));
+          expect(buttonTextContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.actions.continue'));
         });
 
         it('should display a sentence to ask user to share his results with the title of campaign', async function() {
@@ -145,7 +155,7 @@ describe('Integration | Component | resume-campaign-banner', function() {
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
 
           // then
-          expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.reminder-send-campaign'));
         });
       });
 
@@ -195,9 +205,8 @@ describe('Integration | Component | resume-campaign-banner', function() {
           await render(hbs`<ResumeCampaignBanner @campaignParticipations={{campaignParticipations}} />`);
 
           // then
-          expect(find('.resume-campaign-banner__title').textContent).to.equal('N\'oubliez pas de finaliser votre envoi !');
+          expect(find('.resume-campaign-banner__title').textContent).to.equal(this.intl.t('pages.profile.resume-campaign-banner.reminder-send-campaign'));
         });
-
       });
     });
 

--- a/mon-pix/tests/unit/components/resume-campaign-banner-test.js
+++ b/mon-pix/tests/unit/components/resume-campaign-banner-test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import { A } from '@ember/array';
 
 describe('Unit | Component | resume-campaign-banner-component ', function() {
@@ -50,14 +51,14 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
   });
 
   beforeEach(function() {
-    component = this.owner.lookup('component:resume-campaign-banner');
+    component = createGlimmerComponent('component:resume-campaign-banner');
   });
 
   describe('#campaignParticipationState', function() {
     it('should return the most recent campaign among campaigns not finished and not shared', function() {
       // given
       const listCampaignParticipations = [oldCampaignNotFinished, campaignNotFinished];
-      component.set('campaignParticipations', listCampaignParticipations);
+      component.args.campaignParticipations = listCampaignParticipations;
 
       const expectedResult = {
         title: campaignNotFinished.campaign.title,
@@ -67,7 +68,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       };
 
       // when
-      const campaignParticipationState = component.get('campaignParticipationState');
+      const campaignParticipationState = component.campaignParticipationState;
 
       // then
       expect(campaignParticipationState).to.deep.equal(expectedResult);
@@ -76,10 +77,10 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     it('should return the most recent campaign among campaigns not finished and not shared dynamically', function() {
       // given
       const participations = A([]);
-      component.set('campaignParticipations', participations);
+      component.args.campaignParticipations = participations;
 
       // then
-      expect(component.get('campaignParticipationState')).to.equal(null);
+      expect(component.campaignParticipationState).to.equal(null);
 
       // when
       const updatableCampaignNotFinished = EmberObject.create({
@@ -94,17 +95,18 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       participations.addObject(updatableCampaignNotFinished);
 
       // then
-      expect(component.get('campaignParticipationState').code).to.equal('AZERTY0');
+      expect(component.campaignParticipationState.code).to.equal('AZERTY0');
 
-      updatableCampaignNotFinished.set('createdAt', '2000-05-13');
+      updatableCampaignNotFinished.createdAt = '2000-05-13';
 
-      expect(component.get('campaignParticipationState').code).to.equal(oldCampaignNotFinished.campaign.code);
+      expect(component.campaignParticipationState.code).to.equal(oldCampaignNotFinished.campaign.code);
     });
 
     it('should return the most recent campaign among campaigns not shared', function() {
       // given
       const listCampaignParticipations = [oldCampaignNotFinished, campaignFinishedButNotShared];
-      component.set('campaignParticipations', listCampaignParticipations);
+      component.args.campaignParticipations = listCampaignParticipations;
+
       const expectedResult = {
         title: campaignFinishedButNotShared.campaign.title,
         code: campaignFinishedButNotShared.campaign.code,
@@ -113,7 +115,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       };
 
       // when
-      const campaignParticipationState = component.get('campaignParticipationState');
+      const campaignParticipationState = component.campaignParticipationState;
 
       // then
       expect(campaignParticipationState).to.deep.equal(expectedResult);
@@ -122,7 +124,8 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     it('should return the only campaign not finished or not shared', function() {
       // given
       const listCampaignParticipations = [campaignFinished, campaignFinishedButNotShared];
-      component.set('campaignParticipations', listCampaignParticipations);
+      component.args.campaignParticipations = listCampaignParticipations;
+
       const expectedResult = {
         title: campaignFinishedButNotShared.campaign.title,
         code: campaignFinishedButNotShared.campaign.code,
@@ -131,7 +134,7 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
       };
 
       // when
-      const campaignParticipationState = component.get('campaignParticipationState');
+      const campaignParticipationState = component.campaignParticipationState;
 
       // then
       expect(campaignParticipationState).to.deep.equal(expectedResult);
@@ -140,10 +143,10 @@ describe('Unit | Component | resume-campaign-banner-component ', function() {
     it('should return null when all campaign are finished', function() {
       // given
       const listCampaignParticipations = [campaignFinished];
-      component.set('campaignParticipations', listCampaignParticipations);
+      component.args.campaignParticipations = listCampaignParticipations;
 
       // when
-      const campaignParticipationState = component.get('campaignParticipationState');
+      const campaignParticipationState = component.campaignParticipationState;
 
       // then
       expect(campaignParticipationState).to.equal(null);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -509,6 +509,10 @@
       },
       "first-title": "You have 16 skills to test. '<br>'Get your thinking hat on and off we go!",
       "resume-campaign-banner": {
+        "accessibility": {
+          "resume": "Resume your campaign",
+          "share": "Share your campaign results"
+        },
         "actions": {
           "continue": "Continue",
           "resume": "Resume"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -510,6 +510,10 @@
       },
       "first-title": "Vous avez 16 compétences à tester. '<br>'On se concentre et c'est partix&nbsp;!",
       "resume-campaign-banner": {
+        "accessibility": {
+          "resume": "Continuer votre parcours",
+          "share": "Partager les résultats de votre parcours"
+        },
         "actions": {
           "continue": "Continuer",
           "resume": "Reprendre"


### PR DESCRIPTION
## :unicorn: Problème
La bannière de reprise de campagne peut être améliorée d'un point de vue de l'accessibilité.

## :robot: Solution

- Mettre la bannière dans la `<nav>`
- Ajout d'informations en “sr-only” dans le bouton de reprise/partage
- Retirer la propriété CSS  `sticky` de la bannière pour qu'il ne se superpose pas au reste de la page.

## Remarques
- Ajout de la Glimmerization du composant `resume-campaign-banner`

## :100: Pour tester
Aller sur la page profil de pix-app et ouvrir la console pour: 
- trouver les textes visibles uniquement par les lecteurs d'écrans dans le bouton
- constater la disparition de la propriété `sticky` de la barre
- vérifier son déplacement dans la barre de navigation principale
