### PR TITLE
[FEATURE] Modifier le numéro d'un étudiant dans Pix Orga (PIX-1058).

### DIFF
--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -1,3 +1,4 @@
+const JSONAPIError = require('jsonapi-serializer').Error;
 class BaseHttpError extends Error {
   constructor(message) {
     super(message);
@@ -89,6 +90,15 @@ class BadRequestError extends BaseHttpError {
   }
 }
 
+function sendJsonApiError(httpError, h) {
+  const jsonApiError = new JSONAPIError({
+    status: httpError.status.toString(),
+    title: httpError.title,
+    detail: httpError.message,
+  });
+  return h.response(jsonApiError).code(httpError.status).takeover();
+}
+
 module.exports = {
   BadRequestError,
   BaseHttpError,
@@ -99,6 +109,7 @@ module.exports = {
   NotFoundError,
   PasswordShouldChangeError,
   PreconditionFailedError,
+  sendJsonApiError,
   UnauthorizedError,
   UnprocessableEntityError,
 };

--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -90,4 +90,18 @@ module.exports = {
     await usecases.dissociateUserFromSchoolingRegistration({ userId, schoolingRegistrationId: payload['schooling-registration-id'] });
     return h.response().code(204);
   },
+
+  async updateStudentNumber(request, h) {
+    const payload = request.payload.data.attributes;
+    const { userId } = request.auth.credentials;
+    const organizationId =  request.params.id;
+
+    const student = {
+      id: request.params.studentId,
+      studentNumber: payload['student-number'],
+    };
+
+    await usecases.updateStudentNumber({ userId, student, organizationId });
+    return h.response().code(204);
+  },
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -202,6 +202,7 @@ module.exports = injectDependencies({
   updatePublicationSession: require('./update-publication-session'),
   updateSchoolingRegistrationDependentUserPassword: require('./update-schooling-registration-dependent-user-password'),
   updateSession: require('./update-session'),
+  updateStudentNumber: require('./update-student-number'),
   updateUserDetailsForAdministration: require('./update-user-details-for-administration'),
   updateUserPassword: require('./update-user-password'),
   updateUserSamlId: require('./update-user-samlId'),

--- a/api/lib/domain/usecases/update-student-number.js
+++ b/api/lib/domain/usecases/update-student-number.js
@@ -1,0 +1,20 @@
+const _ = require('lodash');
+const { AlreadyExistingEntity } = require('../../domain/errors');
+
+module.exports = async function updateStudentNumber({
+  schoolingRegistrationRepository,
+  student,
+  organizationId,
+}) {
+  const { id, studentNumber } = student;
+
+  const [schoolingRegistration] = await schoolingRegistrationRepository.findOneByOrganizationIdAndStudentNumber(organizationId, studentNumber);
+
+  if (_.isEmpty(schoolingRegistration)) {
+    await schoolingRegistrationRepository.updateStudentNumber(id, studentNumber);
+  } else {
+    const errorMessage = `Le numéro étudiant saisi est déjà utilisé par l’étudiant ${schoolingRegistration.firstName} ${schoolingRegistration.lastName}.`;
+    throw new AlreadyExistingEntity(errorMessage);
+  }
+};
+

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -119,6 +119,17 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations);
   },
 
+  async findOneByOrganizationIdAndStudentNumber(organizationId, studentNumber) {
+    const schoolingRegistration = await BookshelfSchoolingRegistration
+      .query((qb) => {
+        qb.where('organizationId', organizationId);
+        qb.whereRaw('LOWER(?)=LOWER(??)', [studentNumber, 'studentNumber']);
+      })
+      .fetchAll();
+
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistration);
+  },
+
   async findSupernumeraryByOrganizationIdAndBirthdate({ organizationId, birthdate }) {
     const schoolingRegistrations = await BookshelfSchoolingRegistration
       .query((qb) => {
@@ -165,6 +176,14 @@ module.exports = {
       .where({ userId, organizationId })
       .fetch()
       .then((schoolingRegistration) => bookshelfToDomainConverter.buildDomainObject(BookshelfSchoolingRegistration, schoolingRegistration));
+  },
+
+  async updateStudentNumber(studentId, studentNumber) {
+    await BookshelfSchoolingRegistration
+      .where('id', studentId)
+      .save({ studentNumber }, {
+        patch: true,
+      });
   },
 
   get(schoolingRegistrationId) {

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -1249,4 +1249,47 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
       expect(response.statusCode).to.equal(403);
     });
   });
+
+  describe('#updateStudentNumber', () => {
+    let organizationId;
+    const studentNumber = '54321';
+    let schoolingRegistrationId;
+    let authorizationToken;
+
+    beforeEach(async () => {
+      organizationId = databaseBuilder.factory.buildOrganization({ isManagingStudents: true, type: 'SUP' }).id;
+
+      const user = databaseBuilder.factory.buildUser();
+      authorizationToken = generateValidRequestAuthorizationHeader(user.id);
+      schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ organizationId }).id;
+      databaseBuilder.factory.buildMembership({ organizationId, userId: user.id, organizationRole: Membership.roles.ADMIN });
+      await databaseBuilder.commit();
+    });
+    
+    context('Success cases', () => {
+
+      it('should return an HTTP response with status code 204', async () => {
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${schoolingRegistrationId}`,
+          headers: {
+            authorization: authorizationToken,
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': studentNumber,
+              },
+            },
+          },
+        };
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+
+    });
+  });
 });

--- a/api/tests/integration/application/schooling-registration-user-associations/schooling-registration-user-association-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-user-associations/schooling-registration-user-association-controller_test.js
@@ -67,5 +67,4 @@ describe('Integration | Application | Schooling-registration-user-association | 
       });
     });
   });
-
 });

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -1216,4 +1216,17 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
 
   });
 
+  describe('#updateStudentNumber', () => {
+    it('should update the student number', async () => {
+      // given
+      const id = databaseBuilder.factory.buildSchoolingRegistration({ studentNumber: 12345 }).id;
+      await databaseBuilder.commit();
+
+      // when
+      await schoolingRegistrationRepository.updateStudentNumber(id, 54321);
+      const [schoolingRegistration] = await knex.select('studentNumber').from('schooling-registrations').where({ id });
+      expect(schoolingRegistration.studentNumber).to.equal('54321');
+    });
+  });
+
 });

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -1,0 +1,180 @@
+const { expect, sinon, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const Hapi = require('@hapi/hapi');
+const schoolingRegistrationUserAssociationController = require('../../../../lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller');
+const preHandler = require('../../../../lib/application/security-pre-handlers');
+
+const route = require('../../../../lib/application/schooling-registration-user-associations');
+
+describe('Unit | Application | Router | campaign-router ', function() {
+
+  let server;
+  const userId = 2;
+  const organizationId = 2;
+  const studentId = '1234';
+
+  beforeEach(() => {
+    sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
+    sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+
+    server = Hapi.server();
+
+    return server.register(route);
+  });
+
+  describe('PATCH /api/organizations/id/schooling-registration-user-associations/studentId', () => {
+    
+    context('when the user is authenticated', () => {
+      beforeEach(() => {
+        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response(true));
+      });
+
+      afterEach(() => {
+        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
+      });
+
+      it('should exist', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': '1234',
+              },
+            },
+          },
+        };
+      
+        // when
+        const response = await server.inject(options);
+      
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+      
+      it('should return a 422 status error when student-number parameter is not a string', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': 1234,
+              },
+            },
+          },
+        };
+        
+        // when
+        const response = await server.inject(options);
+
+        const payload = JSON.parse(response.payload);
+        
+        // then
+        expect(response.statusCode).to.equal(422);
+        expect(payload.errors[0].title).to.equal('Unprocessable entity');
+        expect(payload.errors[0].detail).to.equal('Un des champs saisis n’est pas valide.');
+      });
+
+      it('should return a 404 status error when organizationId parameter is not a number', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/FAKE_ORGANIZATION_ID/schooling-registration-user-associations/${studentId}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': '1234',
+              },
+            },
+          },
+        };
+        
+        // when
+        const response = await server.inject(options);
+
+        const payload = JSON.parse(response.payload);
+        
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(payload.errors[0].title).to.equal('Not Found');
+        expect(payload.errors[0].detail).to.equal('Ressource non trouvée');
+      });
+
+      it('should return a 404 status error when studentId parameter is not a number', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/FAKE_STUDENT_ID`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': '1234',
+              },
+            },
+          },
+        };
+        
+        // when
+        const response = await server.inject(options);
+
+        const payload = JSON.parse(response.payload);
+        
+        // then
+        expect(response.statusCode).to.equal(404);
+        expect(payload.errors[0].title).to.equal('Not Found');
+        expect(payload.errors[0].detail).to.equal('Ressource non trouvée');
+      });
+
+    });
+
+    context('when the user is not authenticated', () => {
+      beforeEach(() => {
+        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response().code(403).takeover());
+      });
+    
+      afterEach(() => {
+        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
+      });
+
+      it('should return an error when the user is not authenticated', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(userId),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'student-number': '1234',
+              },
+            },
+          },
+        };
+      
+        // when
+        const response = await server.inject(options);
+      
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+  });
+});

--- a/api/tests/unit/domain/usecases/update-student-number_test.js
+++ b/api/tests/unit/domain/usecases/update-student-number_test.js
@@ -1,0 +1,52 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const updateStudentNumber = require('../../../../lib/domain/usecases/update-student-number');
+const { AlreadyExistingEntity } = require('../../../../lib/domain/errors');
+describe('Unit | UseCase | update-student-number', () => {
+  const organizationId = 2;
+  const student = {
+    id: 1234,
+    studentNumber: 4321,
+  };
+
+  let schoolingRegistration;
+
+  const schoolingRegistrationRepository = {
+    findOneByOrganizationIdAndStudentNumber: sinon.stub(),
+    updateStudentNumber: sinon.stub(),
+  };
+
+  context('When there are a schooling registration with a same student number', () => {
+    beforeEach(() => {
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+
+      schoolingRegistrationRepository.findOneByOrganizationIdAndStudentNumber
+        .withArgs(organizationId, student.studentNumber)
+        .resolves([schoolingRegistration]);
+    });
+    it('should return an error', async () => {
+      // when 
+      const error = await catchErr(updateStudentNumber)({ schoolingRegistrationRepository, student, organizationId });
+      const errorMessage = `Le numéro étudiant saisi est déjà utilisé par l’étudiant ${schoolingRegistration.firstName} ${schoolingRegistration.lastName}.`;
+        
+      // then
+      expect(error).to.be.instanceOf(AlreadyExistingEntity);
+      expect(error.message).to.equal(errorMessage);
+    
+    });
+  });
+  
+  context('When there are not schooling registration with the same student number', () => {
+    beforeEach(() => {
+      schoolingRegistrationRepository.findOneByOrganizationIdAndStudentNumber.withArgs(organizationId,student.studentNumber).resolves([]);
+    });
+    it('should update a student number', async () => {
+      // when
+      await updateStudentNumber({ schoolingRegistrationRepository, student, organizationId });
+        
+      // then
+      expect(schoolingRegistrationRepository.updateStudentNumber).to.have.been.calledWith(student.id, student.studentNumber);
+      
+    });
+  });
+  
+});

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -94,6 +94,7 @@ $pix-modal-border-radius: 5px;
       }
 
       .pix-modal-body {
+        border-top: $grey-20;
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/orga/app/adapters/student.js
+++ b/orga/app/adapters/student.js
@@ -20,4 +20,23 @@ export default class StudentAdapter extends ApplicationAdapter {
     const url = `${this.host}/${this.namespace}/schooling-registration-user-associations`;
     return this.ajax(url, 'DELETE', { data });
   }
+
+  updateRecord(store, type, snapshot) {
+    const { id, adapterOptions } = snapshot;
+  
+    if (adapterOptions.updateStudentNumber) {
+      const { organizationId, studentNumber } = adapterOptions;
+      const url = `${this.host}/${this.namespace}/organizations/${organizationId}/schooling-registration-user-associations/${id}`;
+      const data = {
+        data: {
+          attributes: {
+            'student-number': studentNumber,
+          },
+        },
+      };
+      return this.ajax(url, 'PATCH', { data });
+    }
+  
+    return super.updateRecord(store, type, snapshot);
+  }
 }

--- a/orga/app/components/edit-student-number-modal.hbs
+++ b/orga/app/components/edit-student-number-modal.hbs
@@ -1,7 +1,9 @@
 <Modal::Dialog class="edit-student-number-modal" @title="Édition du numéro étudiant" @display={{@display}} @close={{this.close}}>
   <form {{on 'submit' (fn this.updateStudentNumber)}}>
     <Modal::Body class="edit-student-number-modal__content">
-      <p class="content-text">Numéro étudiant actuel de {{@student.firstName}} {{@student.lastName}} est : <span class=" content-text--info">{{@student.studentNumber}}</span></p>
+      {{#if @student.studentNumber}}
+        <p class="content-text">Numéro étudiant actuel de {{@student.firstName}} {{@student.lastName}} est : <span class=" content-text--info">{{@student.studentNumber}}</span></p>
+      {{/if}}
       <label for="studentNumber" class="content-text">Nouveau numéro étudiant</label>
       <div class="input-container">
         <Input
@@ -18,7 +20,7 @@
     </Modal::Body>
     <Modal::Footer class="edit-student-number-modal__actions">
       <button type="button" class="button button--light-grey" {{on 'click' this.close}}>Annuler</button>
-      <button type="submit" disabled={{this.isDisabled}} class="button">Mettre à jour</button>    
+      <button type="submit" disabled={{this.isDisabled}} class="button">Mettre à jour</button>
     </Modal::Footer>
   </form>
 </Modal::Dialog>

--- a/orga/app/components/edit-student-number-modal.hbs
+++ b/orga/app/components/edit-student-number-modal.hbs
@@ -1,0 +1,24 @@
+<Modal::Dialog class="edit-student-number-modal" @title="Édition du numéro étudiant" @display={{@display}} @close={{this.close}}>
+  <form {{on 'submit' (fn this.updateStudentNumber)}}>
+    <Modal::Body class="edit-student-number-modal__content">
+      <p class="content-text">Numéro étudiant actuel de {{@student.firstName}} {{@student.lastName}} est : <span class=" content-text--info">{{@student.studentNumber}}</span></p>
+      <label for="studentNumber" class="content-text">Nouveau numéro étudiant</label>
+      <div class="input-container">
+        <Input
+          id="studentNumber"
+          type="text"
+          @value={{this.newStudentNumber}}
+          class="input"
+        />
+
+        <div class='form__error error-message'>
+          {{this.error}}
+        </div>
+      </div>
+    </Modal::Body>
+    <Modal::Footer class="edit-student-number-modal__actions">
+      <button type="button" class="button button--light-grey" {{on 'click' this.close}}>Annuler</button>
+      <button type="submit" disabled={{this.isDisabled}} class="button">Mettre à jour</button>    
+    </Modal::Footer>
+  </form>
+</Modal::Dialog>

--- a/orga/app/components/edit-student-number-modal.js
+++ b/orga/app/components/edit-student-number-modal.js
@@ -17,8 +17,11 @@ export default class EditStudentNumberModal extends Component {
   @action
   async updateStudentNumber(event) {
     event.preventDefault();
+    if (!this.newStudentNumber.trim()) {
+      return this.error = 'Le numéro étudiant ne doit pas être vide.';
+    }
     try {
-      await this.args.onSaveStudentNumber(this.newStudentNumber);
+      await this.args.onSaveStudentNumber(this.newStudentNumber.trim());
       this.notifications.sendSuccess(`La modification du numéro étudiant ${this.args.student.firstName} ${this.args.student.lastName} a bien été effectué.`);
       this.close();
     } catch (errorResponse) {
@@ -31,12 +34,13 @@ export default class EditStudentNumberModal extends Component {
     this._resetInput();
     this.args.closeModal();
   }
-    
+
   _handleError(errorResponse) {
     errorResponse.errors.forEach((error) => {
       if (error.status === '412') {
-        this.error = error.detail;
+        return this.error = error.detail;
       }
+      throw error;
     });
   }
 

--- a/orga/app/components/edit-student-number-modal.js
+++ b/orga/app/components/edit-student-number-modal.js
@@ -1,0 +1,47 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class EditStudentNumberModal extends Component {
+  @service notifications;
+
+  @tracked error = null;
+  @tracked newStudentNumber = null;
+
+  get isDisabled() {
+    const emptyValues = ['', null];
+    return emptyValues.includes(this.newStudentNumber);
+  }
+
+  @action
+  async updateStudentNumber(event) {
+    event.preventDefault();
+    try {
+      await this.args.onSaveStudentNumber(this.newStudentNumber);
+      this.notifications.sendSuccess(`La modification du numéro étudiant ${this.args.student.firstName} ${this.args.student.lastName} a bien été effectué.`);
+      this.close();
+    } catch (errorResponse) {
+      this._handleError(errorResponse);
+    }
+  }
+
+  @action
+  close() {
+    this._resetInput();
+    this.args.closeModal();
+  }
+    
+  _handleError(errorResponse) {
+    errorResponse.errors.forEach((error) => {
+      if (error.status === '412') {
+        this.error = error.detail;
+      }
+    });
+  }
+
+  _resetInput() {
+    this.newStudentNumber = null;
+    this.error = null;
+  }
+}

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -22,6 +22,7 @@
           <Table::Header>Nom</Table::Header>
           <Table::Header>Prénom</Table::Header>
           <Table::Header>Date de naissance</Table::Header>
+          <Table::Header />
         </tr>
         <tr>
           <Table::Header/>
@@ -38,7 +39,8 @@
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>
-          </tr>
+          <Table::Header />
+        </tr>
       </thead>
 
       {{#if @students}}
@@ -48,7 +50,20 @@
             <td>{{student.studentNumber}}</td>
             <td>{{student.lastName}}</td>
             <td>{{student.firstName}}</td>
-            <td>{{moment-format student.birthdate 'DD/MM/YYYY' allow-empty=true}}</td>
+            <td>{{moment-format student.birthdate 'DD/MM/YYYY'}}</td>
+            <td class="list-students-page__actions">
+              {{#if this.currentUser.isAdminInOrganization}}
+                <Dropdown::IconTrigger
+                  @icon="ellipsis-v"
+                  @dropdownButtonClass="list-students-page__dropdown-button"
+                  @dropdownContentClass="list-students-page__dropdown-content"
+                >
+                  <Dropdown::Item @onClick={{fn this.openEditStudentNumberModal student}}>
+                    Éditer le numéro étudiant
+                  </Dropdown::Item>
+                </Dropdown::IconTrigger>
+              {{/if}}
+            </td>
           </tr>
         {{/each}}
 
@@ -60,6 +75,19 @@
       <div class="table__empty content-text">Aucun étudiant.</div>
     {{/unless}}
   </div>
+
+  <EditStudentNumberModal
+    @student={{this.selectedStudent}}
+    @onSaveStudentNumber={{this.onSaveStudentNumber}}
+    @display={{this.isShowingEditStudentNumberModal}}
+    @closeModal={{this.closeEditStudentNumberModal}}
+  />
 </div>
+
+{{#if @isLoading}}
+  <ModalDialog @translucentOverlay={{true}} @containerClass="modal__translucent">
+    <PixLoader />
+  </ModalDialog>
+{{/if}}
 
 <PaginationControl @pagination={{@students.meta}}/>

--- a/orga/app/components/routes/authenticated/sup-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.js
@@ -1,14 +1,41 @@
 import { inject as service } from '@ember/service';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-orga/config/environment';
 
 export default class ListItems extends Component {
   @service currentUser;
   @service session;
 
-  @computed('currentUser.organization.id')
+  @tracked selectedStudent = null;
+  @tracked isShowingEditStudentNumberModal = false;
+
   get urlToDownloadCsvTemplate() {
     return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
+  }
+
+  @action
+  async onSaveStudentNumber(newStudentNumber) {
+    await this.selectedStudent.save({ 
+      adapterOptions: { 
+        updateStudentNumber: true,
+        organizationId: this.currentUser.organization.id,
+        studentNumber: newStudentNumber,
+      },
+    });
+    this.selectedStudent.studentNumber = newStudentNumber;
+  }
+
+  @action
+  openEditStudentNumberModal(student) {
+    this.selectedStudent = student;
+    this.isShowingEditStudentNumberModal = true;
+  }
+
+  @action
+  closeEditStudentNumberModal() {
+    this.selectedStudent = null;
+    this.isShowingEditStudentNumberModal = false;
   }
 }

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -68,6 +68,7 @@ export default class ListController extends Controller {
     }
   }
 
+  @action
   refresh() {
     this.send('refreshModel');
   }

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -21,6 +21,7 @@
 @import "components/circle-chart";
 @import "components/current-organization";
 @import "components/dissociate-user-modal";
+@import "components/edit-student-number-modal";
 @import "components/dropdown";
 @import "components/join-request-form";
 @import "components/pagination-control";

--- a/orga/app/styles/components/edit-student-number-modal.scss
+++ b/orga/app/styles/components/edit-student-number-modal.scss
@@ -1,0 +1,38 @@
+.edit-student-number-modal {
+  .content-text {
+    color: $grey-90;
+
+    &--info {
+      font-size: 0.875rem;
+      color: $grey-60;
+    }
+  }
+
+  &__content, &__actions {
+    background: $grey-10;
+  }
+
+  &__content{
+    padding-top: 37px;
+    padding-bottom: 10px;
+
+    .content-text:first-child {
+      margin-top: 0;
+      margin-bottom: 33px;
+    }
+    .content-text:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+
+    button:first-child {
+      margin-right: 25px;
+    }
+  }
+}
+
+

--- a/orga/app/styles/components/modal.scss
+++ b/orga/app/styles/components/modal.scss
@@ -23,6 +23,7 @@
       .modal-header {
         position: relative;
         padding: 32px 48px;
+        border-bottom: 1px solid $grey-20;
 
         &__title {
           font-family: $open-sans;
@@ -37,8 +38,8 @@
 
         &__icon {
           position: absolute;
-          right: 8px;
-          top: 8px;
+          right: 32px;
+          top: 32px;
           color: $grey-45;
           font-size: 1.5rem;
           padding: 3px 9px;

--- a/orga/app/styles/globals/buttons.scss
+++ b/orga/app/styles/globals/buttons.scss
@@ -21,6 +21,15 @@
     transition: background-color 0.2s ease;
   }
 
+  &:disabled {
+    background-color: $grey-30;
+    
+    &:hover, &:active, &:focus {
+      cursor: default;
+      background-color: $grey-30;
+    }
+  }
+
   &--white {
     background-color: $white;
     color: $grey-100;

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -205,6 +205,17 @@ export default function() {
     }
   });
 
+  this.patch('/organizations/:id/schooling-registration-user-associations/:studentId', (schema, request) => {
+    const { studentId } = request.params;
+    const { data: { attributes : { ['student-number']: studentNumber } } } = JSON.parse(request.requestBody);
+
+    if (schema.students.all().models.find((student) => student.studentNumber === studentNumber)) {
+      return new Response(412);
+    }
+    const student = schema.students.find(studentId);
+    return student.update({ studentNumber });
+  });
+
   this.get('/campaigns/:id');
 
   this.patch('/campaigns/:id');

--- a/orga/tests/acceptance/sup-student-list-test.js
+++ b/orga/tests/acceptance/sup-student-list-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { find, triggerEvent, visit } from '@ember/test-helpers';
+import { find, triggerEvent, visit, click, typeIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -21,7 +21,7 @@ module('Acceptance | Sup Student List', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('When admin uploads a file', function(hooks) {
+  module('When admin', function(hooks) {
     hooks.beforeEach(async function() {
       user = createUserManagingStudents('ADMIN', 'SUP');
       createPrescriberByUser(user);
@@ -34,35 +34,83 @@ module('Acceptance | Sup Student List', function(hooks) {
       });
     });
 
-    test('it should display success message and reload students', async function(assert) {
-      // given
-      await visit('/etudiants');
+    module('And uploads a file', function() {
+      test('it should display success message and reload students', async function(assert) {
+        // given
+        await visit('/etudiants');
 
-      const file = new Blob(['foo'], { type: 'valid-file' });
+        const file = new Blob(['foo'], { type: 'valid-file' });
 
-      // when
-      const input = find('#students-file-upload');
-      await triggerEvent(input, 'change', { files: [file] });
+        // when
+        const input = find('#students-file-upload');
+        await triggerEvent(input, 'change', { files: [file] });
 
-      // then
-      assert.dom('[data-test-notification-message="success"]').hasText('La liste a été importée avec succès.');
-      assert.dom('[aria-label="Étudiant"]').exists({ count: 1 });
-      assert.contains('Cover');
-      assert.contains('Harry');
+        // then
+        assert.dom('[data-test-notification-message="success"]').hasText('La liste a été importée avec succès.');
+        assert.dom('[aria-label="Étudiant"]').exists({ count: 1 });
+        assert.contains('Cover');
+        assert.contains('Harry');
+      });
+
+      test('it should display an error message when import failed', async function(assert) {
+        // given
+        await visit('/etudiants');
+
+        const file = new Blob(['foo'], { type: 'invalid-file' });
+
+        // when
+        const input = find('#students-file-upload');
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.dom('[data-test-notification-message="error"]').exists();
+      });
     });
 
-    test('it should display an error message when import failed', async function(assert) {
-      // given
-      await visit('/etudiants');
+    module('And edit the student number', function(hooks) {
+      hooks.beforeEach(() => {
+        const { organizationId } = user.memberships.models.firstObject;
+        server.create('student', {
+          studentNumber: '123',
+          firstName: 'toto',
+          lastName: 'banana',
+          organizationId,
+        });
+        server.create('student', {
+          studentNumber: '321',
+          firstName: 'toto',
+          lastName: 'banana',
+          organizationId,
+        });
+      });
+      
+      test('it should update the student number', async function(assert) {
+        // given
+        await visit('/etudiants');
+        
+        // when
+        await click('[aria-label="Afficher les actions"]');
+        await click('[aria-label="Actions"]>*:first-child');
+        await typeIn('#studentNumber', '1234');
+        await click('button[type=submit]');
+      
+        // then
+        assert.contains('1234');
+      });
 
-      const file = new Blob(['foo'], { type: 'invalid-file' });
-
-      // when
-      const input = find('#students-file-upload');
-      await triggerEvent(input, 'change', { files: [file] });
-
-      // then
-      assert.dom('[data-test-notification-message="error"]').exists();
+      test('it should not update the student number if exists', async function(assert) {
+        // given
+        await visit('/etudiants');
+        
+        // when
+        await click('[aria-label="Afficher les actions"]');
+        await click('[aria-label="Actions"]>*:first-child');
+        await typeIn('#studentNumber', '321');
+        await click('button[type=submit]');
+      
+        // then
+        assert.contains('123');
+      });
     });
   });
 });

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
     notificationsStub = this.owner.lookup('service:notifications');
 
     closeStub = sinon.stub();
-    
+
     sinon.stub(notificationsStub, 'sendSuccess');
 
     this.set('display', true);
@@ -36,8 +36,19 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
   module('when the edit student number modal is open', function() {
 
-    test('should render component with student number text', async function(assert) {
-      assert.contains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
+    module('when there is student number', function() {
+      test('should render component with student number text', async function(assert) {
+        assert.contains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
+      });
+    });
+
+    module('when there is no student number yet', function() {
+      test('should not render component with student number text', async function(assert) {
+        this.student.set('studentNumber', null);
+        render(hbs`<EditStudentNumberModal @display={{display}} @closeModal={{close}} @student={{this.student}} @onSaveStudentNumber={{onSaveStudentNumber}}/>`);
+
+        assert.notContains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
+      });
     });
 
     test('should render component with student number input', async function(assert) {
@@ -53,7 +64,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       test('should have the update button enable', async function(assert) {
         // when
         await fillIn('#studentNumber', this.student.studentNumber);
-  
+
         // then
         assert.dom('button[type=submit]').doesNotHaveAttribute('disabled');
 

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -1,0 +1,187 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | edit-student-number-modal', function(hooks) {
+  setupRenderingTest(hooks);
+  let closeStub;
+  let notificationsStub;
+  let onSaveStudentNumberStub;
+
+  hooks.beforeEach(function() {
+    this.student = EmberObject.create({
+      id: '123',
+      firstName: 'Lyanna',
+      lastName: 'Mormont',
+      studentNumber: '1234',
+    });
+
+    onSaveStudentNumberStub = sinon.stub();
+
+    notificationsStub = this.owner.lookup('service:notifications');
+
+    closeStub = sinon.stub();
+    
+    sinon.stub(notificationsStub, 'sendSuccess');
+
+    this.set('display', true);
+    this.set('close', closeStub);
+    this.set('onSaveStudentNumber', onSaveStudentNumberStub);
+
+    return render(hbs`<EditStudentNumberModal @display={{display}} @closeModal={{close}} @student={{this.student}} @onSaveStudentNumber={{onSaveStudentNumber}}/>`);
+  });
+
+  module('when the edit student number modal is open', function() {
+
+    test('should render component with student number text', async function(assert) {
+      assert.contains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
+    });
+
+    test('should render component with student number input', async function(assert) {
+      assert.dom('#studentNumber').exists();
+    });
+
+    test('should render component with update button', async function(assert) {
+      assert.contains('Mettre à jour');
+    });
+
+    module('When a student number is entered', function() {
+
+      test('should have the update button enable', async function(assert) {
+        // when
+        await fillIn('#studentNumber', this.student.studentNumber);
+  
+        // then
+        assert.dom('button[type=submit]').doesNotHaveAttribute('disabled');
+
+      });
+    });
+  
+    module('when a student number is not entered yet', function() {
+  
+      test('should have the update button disable', async function(assert) {
+        // when
+        await fillIn('#studentNumber', '');
+        await click('button[type=submit]');
+  
+        // then
+        assert.dom('button[type=submit]').exists();
+        assert.dom('button[type=submit]').hasAttribute('disabled');
+      });
+    });
+
+    module('when the update button is clicked and the student number is entered', function() {
+      test('it display success notification', async function(assert) {
+        // given
+        onSaveStudentNumberStub.withArgs(123456).resolves(); 
+       
+        // when
+        await fillIn('#studentNumber', 123456);
+        await click('button[type=submit]');
+  
+        // then
+        assert.dom('.error-message').hasText('');
+        sinon.assert.calledOnce(closeStub);
+        assert.ok(notificationsStub.sendSuccess.calledWith(`La modification du numéro étudiant ${this.student.firstName} ${this.student.lastName} a bien été effectué.`));
+      });
+    });
+
+    module('when the update button is clicked with the student number and this student number already exist', function() {
+      test('it display an error under student number input', async function(assert) {
+        // given
+        const error = {
+          errors: [{
+            status: '412',
+            detail: 'Error occured',
+          }],
+        };
+        onSaveStudentNumberStub.rejects(error);
+
+        // when
+        await fillIn('#studentNumber', 77107);
+        await click('button[type=submit]');
+
+        // then
+        assert.contains('Error occured');
+      });
+    });
+
+    module('when the update button is clicked with the student number and this student number already exist', function() {
+      test('it remove errors when submitting is a success', async function(assert) {
+        // given
+        const error = {
+          errors: [{
+            status: '412',
+            detail: 'Error occured',
+          }],
+        };
+        onSaveStudentNumberStub.onFirstCall().rejects(error).onSecondCall().resolves();
+
+        // when
+        await fillIn('#studentNumber', 77107);
+        await click('button[type=submit]');
+        await fillIn('#studentNumber', 65432);
+        await click('button[type=submit]');
+
+        // then
+        assert.notContains('Error occured');
+      });
+    });
+
+    module('when the close button is clicked', function() {
+      test('it remove errors and student number value', async function(assert) {
+        // given
+        const error = {
+          errors: [{
+            status: '412',
+            detail: 'Error occured',
+          }],
+        };
+
+        // when
+        onSaveStudentNumberStub.rejects(error);
+        await click('[aria-label="Fermer la fenêtre"]');
+
+        // then
+        assert.dom('button[type=submit]').hasValue('');
+        assert.dom('.error-message').hasText('');
+        sinon.assert.calledOnce(closeStub);
+      });
+    });
+
+    module('when the cancel button is clicked', function() {
+      test('it remove errors and student number value too', async function(assert) {
+        // given
+        const error = {
+          errors: [{
+            status: '412',
+            detail: 'Error occured',
+          }],
+        };
+
+        // when
+        onSaveStudentNumberStub.rejects(error);
+        await click('.button--light-grey');
+
+        // then
+        assert.dom('button[type=submit]').hasValue('');
+        assert.dom('.error-message').hasText('');
+        sinon.assert.calledOnce(closeStub);
+      });
+    });
+  });
+
+  module('when the edit student number modal is not open', function() {
+    test('should not render component', async function(assert) {
+      // given
+      this.set('display', false);
+      render(hbs`<EditStudentNumberModal @display={{display}} @closeModal={{close}} @student={{this.student}}/>`);
+
+      // then
+      assert.dom('[aria-modal="true"]').doesNotExist();
+    });
+  });
+});

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -70,33 +70,44 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
       });
     });
-  
+
     module('when a student number is not entered yet', function() {
-  
+
       test('should have the update button disable', async function(assert) {
         // when
         await fillIn('#studentNumber', '');
         await click('button[type=submit]');
-  
+
         // then
         assert.dom('button[type=submit]').exists();
         assert.dom('button[type=submit]').hasAttribute('disabled');
       });
     });
 
-    module('when the update button is clicked and the student number is entered', function() {
+    module('when the update button is clicked and a good student number is entered', function() {
       test('it display success notification', async function(assert) {
         // given
-        onSaveStudentNumberStub.withArgs(123456).resolves(); 
-       
+        onSaveStudentNumberStub.withArgs(123456).resolves();
+
         // when
         await fillIn('#studentNumber', 123456);
         await click('button[type=submit]');
-  
+
         // then
         assert.dom('.error-message').hasText('');
         sinon.assert.calledOnce(closeStub);
         assert.ok(notificationsStub.sendSuccess.calledWith(`La modification du numéro étudiant ${this.student.firstName} ${this.student.lastName} a bien été effectué.`));
+      });
+    });
+
+    module('when the update button is clicked and a wrong student number is entered', function() {
+      test('it display error message', async function(assert) {
+        // when
+        await fillIn('#studentNumber', ' ');
+        await click('button[type=submit]');
+
+        // then
+        assert.dom('.error-message').hasText('Le numéro étudiant ne doit pas être vide.');
       });
     });
 

--- a/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
@@ -9,7 +9,7 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
 
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/sup-students/list');
-    controller.refresh = () => {};
+    controller.send = sinon.stub();
   });
 
   module('#importStudents', function() {
@@ -24,7 +24,7 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
 
       controller.session = session;
       await controller.importStudents(file);
-
+      
       assert.ok(file.uploadBinary.calledWith(importStudentsURL, { headers }));
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Les administrateurs de Pix Orga n'ont aucun moyen de modifier le numéro étudiant d'un personne.

## :robot: Solution
Ajouter un select option dans la liste des élèves si le prescripteur à les droits dans l'organisation, modifier le numéro étudiant via une pop-up

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à une organisation SUP, cliquer sur le dropdown d'actions > modifier le numéro de l'étudiant, puis saisir le nouveau numéro étudiant.
