### PR TITLE
[BUGFIX] Mise à jour de la définition des erreurs S5x et S6x dans l'API et Mon-Pix (PIX-1248).

### DIFF
--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -38,28 +38,26 @@ module.exports = {
   STUDENT_RECONCILIATION_ERRORS: {
     RECONCILIATION: {
       IN_OTHER_ORGANIZATION: {
-        samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
         email: { shortCode: 'R11', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-      }
-      ,
+        username: { shortCode: 'R12', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        samlId: { shortCode: 'R13', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+      },
       IN_SAME_ORGANIZATION: {
-        samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
       }
     },
     LOGIN_OR_REGISTER: {
-      IN_OTHER_ORGANIZATION: {
-        samlId: { shortCode: 'S53', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-        email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
-      }
-      ,
       IN_SAME_ORGANIZATION: {
-        samlId: { shortCode: 'S63', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        username: { shortCode: 'S62', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
-        email: { shortCode: 'S61', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        email: { shortCode: 'S51', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        username: { shortCode: 'S52', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        samlId: { shortCode: 'S53', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+      },
+      IN_OTHER_ORGANIZATION: {
+        email: { shortCode: 'S61', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        username: { shortCode: 'S62', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
+        samlId: { shortCode: 'S63', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION' },
       }
     },
   },

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -742,7 +742,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
       context('when schoolingRegistration is already associated in the same organization', () => {
 
-        it('should return a schooling registration already linked error (short code S61 when account with email)', async () => {
+        it('should return a schooling registration already linked error (short code S51 when account with email)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser({
             username: null,
@@ -757,7 +757,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S61', value: 'j***@example.net' }
+            meta: { shortCode: 'S51', value: 'j***@example.net' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -778,7 +778,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (short code S62 when connected with username)', async () => {
+        it('should return a schooling registration already linked error (short code S52 when connected with username)', async () => {
           // given
           const userWithUsernameOnly = databaseBuilder.factory.buildUser({
             username: 'john.harry0702',
@@ -793,7 +793,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S62', value: 'j***.h***2' }
+            meta: { shortCode: 'S52', value: 'j***.h***2' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
@@ -814,7 +814,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (short code S63 when account with samlId)', async () => {
+        it('should return a schooling registration already linked error (short code S53 when account with samlId)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser({
             username: null,
@@ -830,7 +830,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'S63', value: null }
+            meta: { shortCode: 'S53', value: null }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -871,7 +871,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0].detail).to.equal('Un compte existe déjà pour l‘élève dans le même établissement.');
         });
 
-        it('should return a schooling registration already linked error (short code S51 when account with email)', async () => {
+        it('should return a schooling registration already linked error (short code S61 when account with email)', async () => {
           // given
           const userWithEmailOnly = databaseBuilder.factory.buildUser({
             username: null,
@@ -892,7 +892,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S51', value: 'j***@example.net' }
+            meta: { shortCode: 'S61', value: 'j***@example.net' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithEmailOnly.id);
@@ -913,7 +913,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (short code S52 when connected with username)', async () => {
+        it('should return a schooling registration already linked error (short code S62 when connected with username)', async () => {
           // given
           const userWithUsernameOnly = databaseBuilder.factory.buildUser({
             username: 'john.harry0702',
@@ -934,7 +934,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S52', value: 'j***.h***2' }
+            meta: { shortCode: 'S62', value: 'j***.h***2' }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithUsernameOnly.id);
@@ -955,7 +955,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
           expect(response.result.errors[0]).to.deep.equal(expectedResponse);
         });
 
-        it('should return a schooling registration already linked error (short code S53 when account with samlId)', async () => {
+        it('should return a schooling registration already linked error (short code S63 when account with samlId)', async () => {
           // given
           const userWithSamlIdOnly = databaseBuilder.factory.buildUser({
             email: null,
@@ -976,7 +976,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-            meta: { shortCode: 'S53', value: null }
+            meta: { shortCode: 'S63', value: null }
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithSamlIdOnly.id);

--- a/mon-pix/app/utils/errors-messages.js
+++ b/mon-pix/app/utils/errors-messages.js
@@ -35,33 +35,33 @@ const REGISTER_ERRORS = [
   {
     shortCode: 'S51',
     message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S51)',
-    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION'
   },
   {
     shortCode: 'S52',
-    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S52)',
-    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+    message: 'Vous possédez déjà un compte Pix avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S52)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
   },
   {
     shortCode: 'S53',
-    message: 'Vous possédez déjà un compte Pix via l\'ENT. Utilisez-le pour rejoindre le parcours.',
-    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+    message: 'Vous possédez déjà un compte Pix via l\'ENT.<br>Utilisez-le pour rejoindre le parcours.',
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
   },
   {
     shortCode: 'S61',
     message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S61)',
-    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION'
+    code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
   },
   {
     shortCode: 'S62',
-    message: 'Vous possédez déjà un compte Pix avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S62)',
-    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
+    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S62)',
+    code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
   },
   {
     shortCode: 'S63',
     message: 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l\'accès à ce compte à l\'aide de Pix Orga.<br>(Code S63)',
-    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION'
-  },
+    code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION'
+  }
 ];
 
 function getJoinErrors() {


### PR DESCRIPTION
## :unicorn: Problème
Ce fichier est erroné : https://github.com/1024pix/pix/blob/dev/api/lib/domain/constants.js 
La définition des `shortCode` S5x et S6x sont inversés.

## :robot: Solution
En se basant sur le wiki `Page de réconciliation hors-GAR` et les pages sous-jacentes, modifier les S5x et S6x en conséquence, dans l’API et dans Mon-Pix. 

## :100: Pour tester
cf. #1771
#### ex. : S63 - L'élève possède déjà un compte via l'ENT dans un autre établissement scolaire
* Sur Mon-Pix /campagnes/RESTRICD
* S'inscrire avec un élève déjà réconcilié (lié avec un compte possédant qu'un samlId)
```
Vous possédez déjà un compte Pix via l'ENT dans un autre établissement scolaire.
Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l'aide de Pix Orga.
(Code S63)
```