### PR TITLE
[BUGFIX] Ordre d'affichage des blocs sur le certificat (PIX-1250)

### DIFF
--- a/mon-pix/app/styles/components/_user-certifications-detail-competences-list.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competences-list.scss
@@ -2,7 +2,6 @@
   flex-grow: 1;
 
   h2 {
-    color: $grey-60;
     font-family: $font-open-sans;
     font-size: 1.125rem;
     margin-bottom: 8px;

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -59,7 +59,7 @@
 .attestation-and-verification-code {
   background-color: $grey-10;
   border-radius: 8px;
-  padding: 24px 20px;
+  padding: 16px 20px;
 
   .verification-code {
     font-family: $font-open-sans;
@@ -70,19 +70,10 @@
 
     &__title {
       display: flex;
-      font-size: 0.875rem;
-      padding: 10px 0;
-      color: $grey-60;
+      font-size: 1rem;
+      padding: 0;
+      padding-bottom: 8px;
       font-weight: initial;
-
-      .verification-code__tooltip span {
-        width: 245px;
-      }
-
-      &--info {
-        margin-left: 6px;
-        color: $blue;
-      }
     }
 
     &__box {
@@ -113,6 +104,13 @@
 
         &:hover { color: darken($blue, 20%); }
       }
+    }
+
+    &__informations {
+      font-size: 0.8125rem;
+      margin: 0;
+      margin-top: 8px;
+      line-height: 20px;
     }
   }
 

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -29,6 +29,7 @@
     &--grey {
       color: $grey-45;
       font-size: 0.875rem;
+      line-height: 23px;
 
       &:nth-child(2) {
         margin-top: 10px;
@@ -65,6 +66,7 @@
     color: $grey-90;
     width: 230px;
     margin: auto;
+    letter-spacing: 0;
 
     &__title {
       display: flex;

--- a/mon-pix/app/styles/components/_user-certifications-detail-result.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-result.scss
@@ -13,7 +13,6 @@
   }
 
   h2 {
-    color: $grey-60;
     font-family: $font-open-sans;
     font-size: 1.125rem;
     margin-bottom: 8px;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -10,13 +10,12 @@
 
   &__details-body {
     display: flex;
-    flex-direction: row-reverse;
     width: 100%;
     max-width: 980px;
   }
 }
 
-@include device-is('mobile') {
+@mixin contentInColumn() {
 
   .user-certifications-page-get {
 
@@ -26,34 +25,38 @@
 
     &__details-body {
       flex-wrap: wrap;
+      flex-direction: column-reverse;
     }
   }
 }
 
-@include device-is('tablet') {
+@mixin contentInRow() {
 
   .user-certifications-page-get {
-
-    &__header {
-      flex-direction: column;
-    }
-
-    &__details-body {
-      flex-wrap: wrap;
-    }
-  }
-}
-
-@include device-is('desktop') {
-
-  .user-certifications-page-get {
-
-    &__details-body {
-      flex-wrap: nowrap;
-    }
 
     &__header {
       flex-direction: row;
     }
+
+    &__details-body {
+      flex-wrap: nowrap;
+      flex-direction: row;
+    }
   }
+}
+
+@include device-is('mobile') {
+  @include contentInColumn();
+
+  .user-certifications-page-get__return-to {
+    margin-left: -22px;
+  }
+}
+
+@include device-is('tablet') {
+  @include contentInColumn();
+}
+
+@include device-is('desktop') {
+  @include contentInRow();
 }

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -8,38 +8,17 @@
     align-self: start;
   }
 
-  &--over-background-banner {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    max-width: 980px;
-    z-index: 1;
-    margin: 68px 0 40px 0;
-    position: relative;
-  }
-
   &__details-body {
     display: flex;
     flex-direction: row-reverse;
     width: 100%;
     max-width: 980px;
-    margin: 0 10px;
   }
 }
 
 @include device-is('mobile') {
 
   .user-certifications-page-get {
-
-    &__return-to {
-      margin-left: -22px;
-    }
-
-    &--over-background-banner {
-      z-index: 1;
-      margin-top: 68px;
-      position: relative;
-    }
 
     &__header {
       flex-direction: column;

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -13,6 +13,10 @@
     width: 100%;
     max-width: 980px;
   }
+
+  h2 {
+    color: $grey-90;
+  }
 }
 
 @mixin contentInColumn() {

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -26,37 +26,32 @@
   </div>
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
-      <div class="verification-code">
-        <h2 class="verification-code__title">
-          {{t "pages.certificate.verification-code.title"}}
-          <PixTooltip
-              @class="verification-code__tooltip"
-              @text={{t "pages.certificate.verification-code.tooltip"}}
-              @position='top'
-              @inline={{false}}
-              >
-            <div class="verification-code__title--info">{{t "pages.certificate.verification-code.info"}}</div>
-          </PixTooltip>
-        </h2>
-        <span class="verification-code__box">
-          <p class="verification-code__code">{{@certification.verificationCode}}</p>
+        <div class="verification-code">
+          <h2 class="verification-code__title">
+            {{t "pages.certificate.verification-code.title"}}
+          </h2>
+          <span class="verification-code__box">
+            <p class="verification-code__code">{{@certification.verificationCode}}</p>
 
-          {{#if (is-clipboard-supported)}}
-            <PixTooltip
-              @text={{this.tooltipText}}
-              @position='bottom'
-              @inline={{true}}
-              >
-                <CopyButton
-                  @clipboardText={{@certification.verificationCode}}
-                  @success={{this.clipboardSuccess}}
-                  @classNames="icon-button">
-                    <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
-                </CopyButton>
-            </PixTooltip>
-          {{/if}}
-        </span>
-      </div>
+            {{#if (is-clipboard-supported)}}
+              <PixTooltip
+                @text={{this.tooltipText}}
+                @position='bottom'
+                @inline={{true}}
+                >
+                  <CopyButton
+                    @clipboardText={{@certification.verificationCode}}
+                    @success={{this.clipboardSuccess}}
+                    @classNames="icon-button">
+                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
+                  </CopyButton>
+              </PixTooltip>
+            {{/if}}
+          </span>
+          <p class="verification-code__informations">
+            {{t "pages.certificate.verification-code.tooltip"}}
+          </p>
+        </div>
     </div>
   {{/if}}
 {{/if}}

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -8,10 +8,10 @@
   </PixBlock>
 
   <div class="user-certifications-page-get__details-body">
+    <UserCertificationsDetailCompetencesList @resultCompetenceTree={{@model.resultCompetenceTree}} />
     {{#if (or @model.commentForCandidate @model.hasCleaCertif)}}
       <UserCertificationsDetailResult @certification={{@model}} />
     {{/if}}
-    <UserCertificationsDetailCompetencesList @resultCompetenceTree={{@model.resultCompetenceTree}} />
   </div>
 
 </PixBackgroundHeader>


### PR DESCRIPTION
## :unicorn: Problème
En format desktop le macaron Cléa s'affiche avant le détail des compétences. Cela devrait être l'inverse.
![image](https://user-images.githubusercontent.com/38167520/92696274-eb0ecf80-f349-11ea-9dd5-3507f78a418d.png)


## :robot: Solution
Changer l'ordre d'affichage des éléments (le plus important en premier). 
Adapter l'ordre pour l'affichage tablet et mobile (on souhaite dans ces deux cas afficher le macaron Cléa avant le détail des compétences, cependant l'affichage est en colonne, non pas en ligne).

## :100: Pour tester
Pour lancer mon-pix: `FT_IS_SHARED_CERTIFICATE_ACTIVE=true npm start`
Pour avoir un certificat avec badge Cléa : modifier la valeur `hasCleaCertif` dans les data de l'addon ember
<img width="1403" alt="image" src="https://user-images.githubusercontent.com/38167520/92699562-08459d00-f34e-11ea-90f8-33747ce9a800.png">


**Premier cas de figure à tester :**
- Aller sur la page d'un certificat (ex: http://localhost:4200/mes-certifications/104105).

**Deuxième cas de figure :**
- Aller sur la page de vérification d'un certificat (ex: http://localhost:4200/verification-certificat)
- Rentrer le code noté sur le précédent certificat

**Pour les 2 cas :**
- Vérifier pour le format desktop: le détail des compétences s'affiche avant le macaron Cléa et ils sont alignés.
- Vérifier pour les formats tablette et mobile: le macaron Cléa s'affiche avant le détail des compétences et ils sont en colonne.
