### PR TITLE
[FEATURE] Ajout d'un bouton pour télécharger l'attestation du certificat Pix (PIX-809)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import config from 'mon-pix/config/environment';
 
 export default class UserCertificationsDetailHeader extends Component {
   @service intl;
@@ -9,6 +10,7 @@ export default class UserCertificationsDetailHeader extends Component {
   @service session;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
+  isCertificateAttestationActive = config.APP.FT_IS_CERTIFICATE_ATTESTATION_ACTIVE;
 
   get birthdate() {
     return this.intl.formatDate(this.args.certification.birthdate, { format: 'LL' });

--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -5,6 +5,8 @@ import { tracked } from '@glimmer/tracking';
 
 export default class UserCertificationsDetailHeader extends Component {
   @service intl;
+  @service fileSaver;
+  @service session;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
 
@@ -15,5 +17,14 @@ export default class UserCertificationsDetailHeader extends Component {
   @action
   clipboardSuccess() {
     this.tooltipText = this.intl.t('pages.certificate.verification-code.copied');
+  }
+
+  @action
+  downloadAttestation() {
+    const certifId = this.args.certification.id;
+    const url = `/api/attestation/${certifId}`;
+    const fileName = 'attestation_pix.pdf';
+    const token = this.session.data.authenticated.access_token;
+    this.fileSaver.save({ url, fileName, token });
   }
 }

--- a/mon-pix/app/services/file-saver.js
+++ b/mon-pix/app/services/file-saver.js
@@ -1,0 +1,46 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+
+export default class FileSaver extends Service {
+  _downloadFileForIEBrowser({ fileContent, fileName }) {
+    window.navigator.msSaveOrOpenBlob(fileContent, fileName);
+  }
+
+  _downloadFileForModernBrowsers({ fileContent, fileName }) {
+    const link = document.createElement('a');
+    link.style.display = 'none';
+    link.href = URL.createObjectURL(fileContent);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  _fetchData({ url, token }) {
+    return fetch(url, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+  }
+
+  async save({
+    url,
+    fileName,
+    token,
+    fetcher = this._fetchData,
+    downloadFileForIEBrowser = this._downloadFileForIEBrowser,
+    downloadFileForModernBrowsers = this._downloadFileForModernBrowsers,
+  }) {
+    const response = await fetcher({ url, token });
+
+    if (response.headers && response.headers.get('Content-Disposition')) {
+      const contentDispositionHeader = response.headers.get('Content-Disposition');
+      [, fileName] = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDispositionHeader);
+    }
+    const fileContent = await response.blob();
+
+    const browserIsInternetExplorer = window.document.documentMode;
+    browserIsInternetExplorer
+      ? downloadFileForIEBrowser({ fileContent, fileName })
+      : downloadFileForModernBrowsers({ fileContent, fileName });
+  }
+}

--- a/mon-pix/app/styles/components/_user-certifications-detail-header.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-header.scss
@@ -61,10 +61,26 @@
   border-radius: 8px;
   padding: 16px 20px;
 
+  .attestation {
+    font-size: 0.875rem;
+    margin: auto;
+    text-align: center;
+
+    button {
+      max-width: 250px;
+      padding: 14px 20px;
+    }
+  }
+
+  hr {
+    margin: 24px 0;
+    border: 1px solid $grey-15;
+  }
+
   .verification-code {
     font-family: $font-open-sans;
     color: $grey-90;
-    width: 230px;
+    max-width: 250px;
     margin: auto;
     letter-spacing: 0;
 
@@ -123,7 +139,8 @@
     margin-left: auto;
     flex-grow: 0;
 
-    .verification-code {
+    .verification-code,
+    .attestation {
       margin: 0;
     }
   }

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -26,10 +26,12 @@
   </div>
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
+        {{#if this.isCertificateAttestationActive}}
         <div class="attestation">
           <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>{{t "pages.certificate.attestation"}}</button>
         </div>
         <hr>
+        {{/if}}
         <div class="verification-code">
           <h2 class="verification-code__title">
             {{t "pages.certificate.verification-code.title"}}

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -27,7 +27,7 @@
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
         <div class="attestation">
-          <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>Télécharger mon attestation</button>
+          <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>{{t "pages.certificate.attestation"}}</button>
         </div>
         <hr>
         <div class="verification-code">
@@ -47,7 +47,7 @@
                     @clipboardText={{@certification.verificationCode}}
                     @success={{this.clipboardSuccess}}
                     @classNames="icon-button">
-                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
+                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt={{t "pages.certificate.verification-code.alt"}} />
                   </CopyButton>
               </PixTooltip>
             {{/if}}

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -26,6 +26,10 @@
   </div>
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
+        <div class="attestation">
+          <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>Télécharger mon attestation</button>
+        </div>
+        <hr>
         <div class="verification-code">
           <h2 class="verification-code__title">
             {{t "pages.certificate.verification-code.title"}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -46,6 +46,7 @@ module.exports = function(environment) {
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
+      FT_IS_CERTIFICATE_ATTESTATION_ACTIVE: process.env.FT_IS_CERTIFICATE_ATTESTATION_ACTIVE === 'true',
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -26888,9 +26888,9 @@
       }
     },
     "ember-fetch": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-7.0.0.tgz",
-      "integrity": "sha512-kmTdRTbLRv8gtHEBxsi3kxgMNa2VEqQFv1QM+3ZH3xJHdGG/SbIgCItY6JBu9wPR8EOARgoxFMprI1anFDHKrw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-7.1.0.tgz",
+      "integrity": "sha512-FF2uEE7MXahNpXsQt9J3iJdPJDu27WL/ZD4NLuIWKgSAnFEvOxrjqhrU0fNMbkmJmlMBwGykbNiZVXDMpHbuLg==",
       "dev": true,
       "requires": {
         "abortcontroller-polyfill": "^1.4.0",
@@ -26902,32 +26902,203 @@
         "broccoli-templater": "^2.0.1",
         "calculate-cache-key-for-tree": "^2.0.0",
         "caniuse-api": "^3.0.0",
-        "ember-cli-babel": "^7.13.0",
-        "ember-cli-typescript": "^2.0.2",
+        "ember-cli-babel": "^7.13.2",
+        "ember-cli-typescript": "^3.1.3",
         "node-fetch": "^2.6.0",
         "whatwg-fetch": "^3.0.0"
       },
       "dependencies": {
-        "@babel/plugin-transform-typescript": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.4.5.tgz",
-          "integrity": "sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==",
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "dev": true,
           "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "@babel/plugin-syntax-typescript": "^7.2.0"
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.11.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+          "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.10.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
+          "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-member-expression-to-functions": "^7.10.5",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/helper-plugin-utils": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+          "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
+          "dev": true
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.10.4",
+            "@babel/helper-optimise-call-expression": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.11.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+          "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.11.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+          "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==",
+          "dev": true
+        },
+        "@babel/plugin-syntax-typescript": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
+          "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.10.4"
+          }
+        },
+        "@babel/plugin-transform-typescript": {
+          "version": "7.8.7",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.7.tgz",
+          "integrity": "sha512-7O0UsPQVNKqpHeHLpfvOG4uXmlw+MOxYvUv6Otc9uH5SYMIxvF6eBdjkWvC3f9G+VXe0RsNExyAQBeTRug/wqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-syntax-typescript": "^7.8.3"
+          }
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+          "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.11.5",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.11.0",
+            "@babel/parser": "^7.11.5",
+            "@babel/types": "^7.11.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.11.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "@types/node": {
-          "version": "9.6.55",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.55.tgz",
-          "integrity": "sha512-e/5tg8Ok0gSrN6pvHphnwTK0/CD9VPZrtZqpvvpEFAtfs+ZntusgGaWkf2lSEq1OFe2EDPeUMiMVpy4nZpJ4AQ==",
+          "version": "9.6.58",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.58.tgz",
+          "integrity": "sha512-I5B2ZIvr5G5qW6VUZgMk284p/41/U5x3Lqyz3Hz9va3bmxgV7p5CBnDPGv/lGFgGDP4415pqZXLsa4cKA3BHAg==",
           "dev": true
         },
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "broccoli-rollup": {
@@ -26949,6 +27120,17 @@
             "walk-sync": "^0.3.1"
           }
         },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -26959,48 +27141,79 @@
           }
         },
         "ember-cli-typescript": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-2.0.2.tgz",
-          "integrity": "sha512-7I5azCTxOgRDN8aSSnJZIKSqr+MGnT+jLTUbBYqF8wu6ojs2DUnTePxUcQMcvNh3Q3B1ySv7Q/uZFSjdU9gSjA==",
+          "version": "3.1.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz",
+          "integrity": "sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==",
           "dev": true,
           "requires": {
-            "@babel/plugin-proposal-class-properties": "^7.1.0",
-            "@babel/plugin-transform-typescript": "~7.4.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+            "@babel/plugin-proposal-optional-chaining": "^7.6.0",
+            "@babel/plugin-transform-typescript": "~7.8.0",
             "ansi-to-html": "^0.6.6",
+            "broccoli-stew": "^3.0.0",
             "debug": "^4.0.0",
             "ember-cli-babel-plugin-helpers": "^1.0.0",
-            "execa": "^1.0.0",
-            "fs-extra": "^7.0.0",
+            "execa": "^3.0.0",
+            "fs-extra": "^8.0.0",
             "resolve": "^1.5.0",
             "rsvp": "^4.8.1",
-            "semver": "^6.0.0",
+            "semver": "^6.3.0",
             "stagehand": "^1.0.0",
-            "walk-sync": "^1.0.0"
+            "walk-sync": "^2.0.0"
           },
           "dependencies": {
             "walk-sync": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-              "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+              "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
               "dev": true,
               "requires": {
                 "@types/minimatch": "^3.0.3",
                 "ensure-posix-path": "^1.1.0",
-                "matcher-collection": "^1.1.1"
+                "matcher-collection": "^2.0.0",
+                "minimatch": "^3.0.4"
               }
             }
           }
         },
-        "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
           }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "magic-string": {
           "version": "0.24.1",
@@ -27011,10 +27224,41 @@
             "sourcemap-codec": "^1.4.1"
           }
         },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
         "rollup": {
@@ -27047,6 +27291,30 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -79,7 +79,7 @@
     "ember-decorators": "^6.1.1",
     "ember-exam": "^4.0.9",
     "ember-export-application-global": "^2.0.1",
-    "ember-fetch": "^7.0.0",
+    "ember-fetch": "^7.1.0",
     "ember-intl": "^5.3.1",
     "ember-keyboard": "^5.0.0",
     "ember-load-initializers": "^2.1.1",

--- a/mon-pix/tests/unit/services/file-saver-test.js
+++ b/mon-pix/tests/unit/services/file-saver-test.js
@@ -1,0 +1,78 @@
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Service | file-saver', function() {
+  setupTest();
+  let fileSaver;
+  
+  beforeEach(function() {
+    fileSaver = this.owner.lookup('service:file-saver');
+  });
+  
+  describe('#save', function() {
+    const id = 123456;
+    const url = `/attestation/${id}`;
+    const token = 'mytoken';
+    const defaultFileName = 'mon-super-fichier.plouf';
+    const responseFileName = 'fichier.plouf';
+    const responseContent = new Blob();
+
+    let fetchStub;
+    let blobStub;
+    let downloadFileForIEBrowserStub;
+    let downloadFileForModernBrowsersStub;
+
+    beforeEach(function() {
+      fileSaver = this.owner.lookup('service:file-saver');
+      blobStub = sinon.stub().resolves(responseContent);
+      downloadFileForIEBrowserStub = sinon.stub().returns();
+      downloadFileForModernBrowsersStub = sinon.stub().returns();
+    });
+
+    describe('when response does have a fileName info in headers', function() {
+      it('should give fileName from response', async function() {
+        // given
+        const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
+        const response = { headers, blob: blobStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        await fileSaver.save({
+          url,
+          fileName: defaultFileName,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+  
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: responseFileName };
+        sinon.assert.calledWith(downloadFileForModernBrowsersStub, expectedArgs);
+      });
+    });
+
+    describe('when response does not have a fileName info in headers', function() {
+      it('should give default fileName', async function() {
+        // given
+        const response = { blob: blobStub };
+        fetchStub = sinon.stub().resolves(response);
+  
+        // when
+        await fileSaver.save({
+          url,
+          fileName: defaultFileName,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: defaultFileName };
+        sinon.assert.calledWith(downloadFileForModernBrowsersStub, expectedArgs);
+      });
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -94,12 +94,14 @@
       "back-link": "Return to my certificates",
       "candidate-birth-complete": "Born on {birthdate} in {birthplace}",
       "certification-center": "Certification centre:",
+      "attestation": "Télécharger mon attestation",
       "verification-code": {
         "title": "Verification code",
         "info": "(?)",
-        "tooltip": "Communicate this code to allow a third party to verify the authenticity of your certificate.",
-        "copy": "Copy the code",
-        "copied": "Copied!"
+        "tooltip": "Communiquez ce code pour permettre à un tiers de vérifier l'authenticité de votre certificat",
+        "copy": "Copier le code",
+        "copied": "Code copié !",
+        "alt": "Copy"
       },
       "clea": {
         "title": "CléA certified",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -94,12 +94,14 @@
       "back-link": "Retour à mes certifications",
       "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
       "certification-center": "Centre de certification :",
+      "attestation": "Télécharger mon attestation",
       "verification-code": {
         "title": "Code de vérification",
         "info": "(?)",
         "tooltip": "Communiquez ce code pour permettre à un tiers de vérifier l'authenticité de votre certificat",
         "copy": "Copier le code",
-        "copied": "Code copié !"
+        "copied": "Code copié !",
+        "alt": "Copier"
       },
       "clea": {
         "title": "Certifié Cléa",


### PR DESCRIPTION
## :unicorn: Problème
Un candidat ayant obtenu son certificat Pix n’a aujourd’hui aucun moyen simple de le partager (il peut faire une capture d'écran de son certificat mais c’est compliqué de l’avoir au format A4). L’objectif de l'épix Attestation certif est de permettre aux candidats de télécharger une attestation PDF de leur certificat. L’attestation a été implémentée, il s’agit maintenant de la rendre accessible au candidat.

## :robot: Solution
Ajout d'un bouton “Télécharger mon attestation” sur le certificat du candidat.
<img width="1122" alt="image" src="https://user-images.githubusercontent.com/38167520/92707763-da645680-f355-11ea-9616-de5a4c3dce4d.png">


## :rainbow: Remarques
Cette feature est soumise à un Feature Toggle : `FT_IS_CERTIFICATE_ATTESTATION_ACTIVE`.
Ajout d'un service `fileSaver` qui utilise [fetch](https://github.com/ember-cli/ember-fetch) pour aller récupérer les données du fichier (compatible avec IE11).

## :100: Pour tester
- `FT_IS_CERTIFICATE_ATTESTATION_ACTIVE=true npm start`
- aller sur la page d'un certificat 
- constater l'apparition d'un nouveau bouton "Télécharger mon attestation"
- cliquer dessus, vérifier que cela lance le téléchargement d'un fichier
