### PR TITLE
[TECH] Enlever le toggle sur le partage du code de vérification (PIX-1254)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -2,13 +2,11 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import config from 'mon-pix/config/environment';
 
 export default class UserCertificationsDetailHeader extends Component {
   @service intl;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
-  isSharedCertificateActive = config.APP.FT_IS_SHARED_CERTIFICATE_ACTIVE;
 
   get birthdate() {
     return this.intl.formatDate(this.args.certification.birthdate, { format: 'LL' });

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -24,41 +24,39 @@
 
     </div>
   </div>
-  {{#if this.isSharedCertificateActive}}
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
-        <div class="verification-code">
-          <h2 class="verification-code__title">
-            {{t "pages.certificate.verification-code.title"}}
-            <PixTooltip
-                @class="verification-code__tooltip"
-                @text={{t "pages.certificate.verification-code.tooltip"}}
-                @position='top'
-                @inline={{false}}
-                >
-              <div class="verification-code__title--info">{{t "pages.certificate.verification-code.info"}}</div>
-            </PixTooltip>
-          </h2>
-          <span class="verification-code__box">
-            <p class="verification-code__code">{{@certification.verificationCode}}</p>
+      <div class="verification-code">
+        <h2 class="verification-code__title">
+          {{t "pages.certificate.verification-code.title"}}
+          <PixTooltip
+              @class="verification-code__tooltip"
+              @text={{t "pages.certificate.verification-code.tooltip"}}
+              @position='top'
+              @inline={{false}}
+              >
+            <div class="verification-code__title--info">{{t "pages.certificate.verification-code.info"}}</div>
+          </PixTooltip>
+        </h2>
+        <span class="verification-code__box">
+          <p class="verification-code__code">{{@certification.verificationCode}}</p>
 
-            {{#if (is-clipboard-supported)}}
-              <PixTooltip
-                @text={{this.tooltipText}}
-                @position='bottom'
-                @inline={{true}}
-                >
-                  <CopyButton
-                    @clipboardText={{@certification.verificationCode}}
-                    @success={{this.clipboardSuccess}}
-                    @classNames="icon-button">
-                      <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
-                  </CopyButton>
-              </PixTooltip>
-            {{/if}}
-          </span>
-        </div>
+          {{#if (is-clipboard-supported)}}
+            <PixTooltip
+              @text={{this.tooltipText}}
+              @position='bottom'
+              @inline={{true}}
+              >
+                <CopyButton
+                  @clipboardText={{@certification.verificationCode}}
+                  @success={{this.clipboardSuccess}}
+                  @classNames="icon-button">
+                    <FaIcon class="verification-code__copy-button" @icon="copy" @prefix="far" alt="COPIER" />
+                </CopyButton>
+            </PixTooltip>
+          {{/if}}
+        </span>
+      </div>
     </div>
-  {{/if}}
   {{/if}}
 {{/if}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -46,7 +46,6 @@ module.exports = function(environment) {
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
-      FT_IS_SHARED_CERTIFICATE_ACTIVE: process.env.FT_IS_SHARED_CERTIFICATE_ACTIVE === 'true',
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {


### PR DESCRIPTION
This reverts commit 554644ab3ac6363fab53e462a611b62803948578.

## :unicorn: Problème
Un feature toggle avait été ajouté pour implémenter l'epix "Partage et contrôle du certificat".
Pour le moment pour voir la feature sur dev il est encore nécessaire de lancer avec :  `FT_IS_SHARED_CERTIFICATE_ACTIVE=true npm start`
Voir : https://github.com/1024pix/pix/pull/1791/commits/554644ab3ac6363fab53e462a611b62803948578

Cette epix étant terminée et le toggle étant désormais en mode "on" en production il n'est plus nécessaire de le garder.

## :robot: Solution
Enlever le feature toggle.

## :100: Pour tester
- `npm start`
- aller sur la page d'un certificat, constater qu'il y a bien l'encadré "code de vérification" visible
