### PR TITLE
[BUGFIX] Ne pas tenter de créer un utilisateur dont le samlId existe déjà en base (PIX-1251).

### DIFF
--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -59,6 +59,11 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
     await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
 
+    const user = await userRepository.getBySamlId(externalUser.samlId);
+    if (user) {
+      return user;
+    }
+
     userId = await userRepository.createAndReconcileUserToSchoolingRegistration({
       domainUser,
       schoolingRegistrationId: matchedSchoolingRegistration.id,

--- a/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
+++ b/api/tests/integration/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user_test.js
@@ -271,5 +271,24 @@ describe('Integration | UseCases | create-user-and-reconcile-to-schooling-regist
         });
       });
     });
+    context('When the external user is already created', () => {
+
+      it('should return the already created user', async () => {
+        // given
+        const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ firstName, lastName, organizationId });
+        schoolingRegistration.userId = undefined;
+        const alreadyCreatedUser = databaseBuilder.factory.buildUser({ firstName, lastName, samlId });
+        await databaseBuilder.commit();
+
+        // when
+        const user = await createUserAndReconcileToSchoolingRegistrationByExternalUser({
+          campaignCode, token, birthdate: schoolingRegistration.birthdate, campaignRepository, tokenService,
+          schoolingRegistrationRepository, studentRepository, userRepository, userReconciliationService, obfuscationService,
+        });
+
+        // then
+        expect(user.id).to.equal(alreadyCreatedUser.id);
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
En production, 10 fois par jour, une erreur est remontée sur le endpoint `schooling-registration-dependent-users/external-user-token`, dû à une une violation de la contrainte d'unicité `users_samlid_unique`.  Celle-ci se produit lorsque l'on tente d'insérer en base un utilisateur avec un `samlId` déjà existant. 

Après analyse, la cause probable de cette erreur est une race condition: un même utilisateur déclenche en parallèle plusieurs demandes de réconciliation, l'une de celle-ci abouti, et la création d'utilisateur de l'autre tombe en erreur.

Dasn tous les cas, le compte de l'utilisateur a déjà été créé et réconcilié, et la deuxième demande n'appelle aucune action, sauf de signaler que tout s'est bien passé.

## :robot: Solution
Vérifier, avant la création d'un utilisateur, si ce dernier exist en base (grâce à son `samlId`).
Si c'est le cas, simuler une fin correcte en le renvoyant prématurément (ne pas tenter de le réconcilier/créer).

## :rainbow: Remarques
[Log Datadog](
https://app.datadoghq.eu/logs?cols=core_host%2Ccore_service&from_ts=1597069939559&index=main&live=true&messageDisplay=inline&query=%40http.url_details.path%3A%22%2Fapi%2Fschooling-registration-dependent-users%2Fexternal-user-token%22+-status%3A%28warn+OR+info+OR+ok%29+host%3Arouter+service%3Apix-app-production+%40network.client.ip%3A%2880.11.235.157+OR+195.98.232.200%29&stream_sort=desc&to_ts=1599661939559)

```
method=POST path="/api/schooling-registration-dependent-users/external-user-token" 
status-code: 500
```

[Log Sentry](https://sentry.io/organizations/pix/issues/1884012992/?project=1398749&query=is%3Aunresolved#)
```
insert into "users" ("cgu", "email (..)
duplicate key value violates unique constraint "users_samlid_unique"
```