### PR TITLE
[TECH] Ajout d'une méthode dans les airtableBuilder pour construire un objet Airtable à partir d'un objet du domain (PIX-1259)

### DIFF
--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -34,6 +34,7 @@ module.exports = class AirtableBuilder {
     skills,
     challenges,
     courses,
+    tutorials,
   }) {
     this.mockList({ tableName: 'Domaines' })
       .returns(areas)
@@ -52,6 +53,9 @@ module.exports = class AirtableBuilder {
       .activate();
     this.mockList({ tableName: 'Tests' })
       .returns(courses)
+      .activate();
+    this.mockList({ tableName: 'Tutoriels' })
+      .returns(tutorials)
       .activate();
   }
 

--- a/api/tests/tooling/airtable-builder/factory/build-area.js
+++ b/api/tests/tooling/airtable-builder/factory/build-area.js
@@ -33,4 +33,24 @@ const buildArea = function buildArea({
   };
 };
 
+buildArea.fromDomain = function buildAreaFromDomain({
+  domainArea,
+  locale = 'fr-fr',
+  createdAt = '2019-04-01T09:00:05.000Z',
+}) {
+  return {
+    id: domainArea.id,
+    'fields': {
+      'id persistant': domainArea.id,
+      'Competences (identifiants) (id persistant)': domainArea.competences,
+      'Couleur': domainArea.color,
+      'Code': domainArea.code,
+      'Titre fr-fr': locale === 'fr-fr' ? domainArea.title : 'un titre français',
+      'Titre en-us': locale === 'fr-fr' ? 'an english title' : domainArea.title,
+      'Nom': domainArea.name,
+    },
+    'createdTime': createdAt,
+  };
+};
+
 module.exports = buildArea;

--- a/api/tests/tooling/airtable-builder/factory/build-challenge.js
+++ b/api/tests/tooling/airtable-builder/factory/build-challenge.js
@@ -361,11 +361,62 @@ function rawBuildChallenge({
       'Record ID': recordID,
       'domaines': domaines,
       'Texte alternatif illustration': illustrationAlt,
-      'format': format,
+      'Format': format,
       'Langues': langues,
     },
     'createdTime': createdTime,
   };
 }
+
+buildChallenge.fromDomain = function buildChallengeFromDomain({
+  domainChallenge,
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+
+  const languages = [];
+  for (const locale of domainChallenge.locales) {
+    if (locale === 'fr') {
+      languages.push('Francophone');
+    }
+    if (locale === 'fr-fr') {
+      languages.push('Franco Français');
+    }
+    if (locale === 'en') {
+      languages.push('Anglais');
+    }
+  }
+
+  return {
+    id: domainChallenge.id,
+    'fields': {
+      'id persistant': domainChallenge.id,
+      'Consigne': domainChallenge.instruction,
+      'Consigne alternative': domainChallenge.alternativeInstruction,
+      'Propositions': domainChallenge.proposals,
+      'Type d\'épreuve': domainChallenge.type,
+      'Illustration de la consigne': [{ url: domainChallenge.illustrationUrl }],
+      'Pièce jointe': domainChallenge.attachments ? domainChallenge.attachments.map((attachmentUrl) => {
+        return { url: attachmentUrl };
+      }) : null,
+      'Bonnes réponses': 'Une solution',
+      'Timer': domainChallenge.timer,
+      'Compétences (via tube) (id persistant)': [domainChallenge.competenceId],
+      'Statut': domainChallenge.status,
+      'Embed URL': domainChallenge.embedUrl,
+      'Embed title': domainChallenge.embedTitle,
+      'Embed height': domainChallenge.embedHeight,
+      'Acquix (id persistant)': domainChallenge.skills.map(({ id }) => id),
+      'Texte alternatif illustration': domainChallenge.illustrationAlt,
+      'Format': domainChallenge.format,
+      'Réponse automatique': domainChallenge.autoReply ? 'Oui' : null,
+      'Langues': languages,
+      'T1 - Espaces, casse & accents': 'Activé',
+      'T2 - Ponctuation': 'Désactivé',
+      'T3 - Distance d\'édition': 'Activé',
+      'Scoring': 'Le scoring',
+    },
+    'createdTime': createdAt,
+  };
+};
 
 module.exports = buildChallenge;

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -1,4 +1,4 @@
-module.exports = function buildCompetence({
+const buildCompetence = function buildCompetence({
   id = 'recsvLz0W2ShyfD63',
   domaineIds = [
     'recvoGdo7z2z7pXWa',
@@ -86,3 +86,27 @@ module.exports = function buildCompetence({
     'createdTime': createdTime,
   };
 };
+
+buildCompetence.fromDomain = function buildCompetenceFromDomain({
+  domainCompetence,
+  locale = 'fr-fr',
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+  return {
+    id: domainCompetence.id,
+    'fields': {
+      'id persistant': domainCompetence.id,
+      'Domaine (id persistant)': domainCompetence.area ? [domainCompetence.area.id] : [],
+      'Sous-domaine': domainCompetence.index,
+      'Titre fr-fr': locale === 'fr-fr' ? domainCompetence.name : 'un titre français',
+      'Titre en-us': locale === 'fr-fr' ? 'an english title' : domainCompetence.name,
+      'Description fr-fr': locale === 'fr-fr' ? domainCompetence.description : 'une description française',
+      'Description en-us': locale === 'fr-fr' ? 'an english description' : domainCompetence.description,
+      'Acquis (via Tubes) (id persistant)': domainCompetence.skillIds,
+      'Origine': domainCompetence.origin,
+    },
+    'createdTime': createdAt,
+  };
+};
+
+module.exports = buildCompetence;

--- a/api/tests/tooling/airtable-builder/factory/build-course.js
+++ b/api/tests/tooling/airtable-builder/factory/build-course.js
@@ -1,4 +1,4 @@
-module.exports = function buildCourse({
+const buildCourse = function buildCourse({
   id = 'recPBOj7JzBcgXEtO',
   nom = '3.4 niveau 1 et 2',
   description = 'Programmer niveau 1 et 2',
@@ -65,3 +65,24 @@ module.exports = function buildCourse({
     'createdTime': createdTime,
   };
 };
+
+buildCourse.fromDomain = function buildCourseFromDomain({
+  domainCourse,
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+  return {
+    id: domainCourse.id,
+    'fields': {
+      'id persistant': domainCourse.id,
+      'Nom': domainCourse.name,
+      'Description': domainCourse.description,
+      'Image': [{ url: domainCourse.imageUrl }],
+      'Épreuves (id persistant)': domainCourse.challenges,
+      'Nb d\'épreuves': domainCourse.challenges.length,
+      'Competence (id persistant)': domainCourse.competences,
+    },
+    'createdTime': createdAt,
+  };
+};
+
+module.exports = buildCourse;

--- a/api/tests/tooling/airtable-builder/factory/build-skill.js
+++ b/api/tests/tooling/airtable-builder/factory/build-skill.js
@@ -1,4 +1,4 @@
-module.exports = function buildSkill({
+const buildSkill = function buildSkill({
   id = 'recTIddrkopID28Ep',
   indiceFr = 'Peut-on géo-localiser un téléphone lorsqu’il est éteint ? Dans quelle condition une application peut-elle utiliser les données de géolocalisation du t...',
   indiceEn = 'Can we gelocate ?',
@@ -58,3 +58,32 @@ module.exports = function buildSkill({
     'createdTime': createdTime,
   };
 };
+
+buildSkill.fromDomain = function buildSkillFromDomain({
+  domainSkill,
+  challengeIds = [],
+  status = 'actif',
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+  return {
+    id: domainSkill.id,
+    fields: {
+      'id persistant': domainSkill.id,
+      'Indice fr-fr': 'un indice français',
+      'Indice en-us': 'an english hint',
+      'Statut de l\'indice': 'no status',
+      'Epreuves': challengeIds,
+      'Comprendre (id persistant)': domainSkill.tutorialIds,
+      'En savoir plus (id persistant)': [],
+      'Tags': [],
+      'Tube (id persistant)': [domainSkill.tubeId],
+      'Status': status,
+      'Nom': domainSkill.name,
+      'Compétence (via Tube) (id persistant)': [domainSkill.competenceId],
+      'PixValue': domainSkill.pixValue,
+    },
+    'createdTime': createdAt,
+  };
+};
+
+module.exports = buildSkill;

--- a/api/tests/tooling/airtable-builder/factory/build-tube.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tube.js
@@ -1,4 +1,4 @@
-module.exports = function buildTube({
+const buildTube = function buildTube({
   id = 'recTIeergjhID28Ep',
   nom = '@web',
   titre = '',
@@ -29,3 +29,27 @@ module.exports = function buildTube({
     'createdTime': createdTime,
   };
 };
+
+buildTube.fromDomain = function buildTubeFromDomain({
+  domainTube,
+  locale = 'fr-fr',
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+  return {
+    id: domainTube.id,
+    fields: {
+      'id persistant': domainTube.id,
+      'Nom': domainTube.name,
+      'Titre': domainTube.title,
+      'Description': domainTube.description,
+      'Titre pratique fr-fr': locale === 'fr-fr' ? domainTube.practicalTitle : 'un titre français',
+      'Titre pratique en-us': locale === 'fr-fr' ? 'an english title' : domainTube.practicalTitle,
+      'Description pratique fr-fr': locale === 'fr-fr' ? domainTube.practicalDescription : 'une description française',
+      'Description pratique en-us': locale === 'fr-fr' ? 'an english description' : domainTube.practicalDescription,
+      'Competences (id persistant)': [domainTube.competenceId],
+    },
+    'createdTime': createdAt,
+  };
+};
+
+module.exports = buildTube;

--- a/api/tests/tooling/airtable-builder/factory/build-tutorial.js
+++ b/api/tests/tooling/airtable-builder/factory/build-tutorial.js
@@ -1,4 +1,4 @@
-module.exports = function buildTutorial({
+const buildTutorial = function buildTutorial({
   id = 'recTIddrgjhID28Ep',
   titre = 'Communiquer',
   format = 'vidéo',
@@ -23,3 +23,25 @@ module.exports = function buildTutorial({
     'createdTime': createdTime,
   };
 };
+
+buildTutorial.fromDomain = function buildTutorialFromDomain({
+  domainTutorial,
+  language = 'fr-fr',
+  createdAt = '2018-03-15T14:38:03.000Z',
+}) {
+  return {
+    id: domainTutorial.id,
+    fields: {
+      'id persistant': domainTutorial.id,
+      'Titre': domainTutorial.title,
+      'Format': domainTutorial.format,
+      'Durée': domainTutorial.duration,
+      'Source': domainTutorial.source,
+      'Lien': domainTutorial.link,
+      'Langue': language,
+    },
+    'createdTime': createdAt,
+  };
+};
+
+module.exports = buildTutorial;

--- a/api/tests/tooling/domain-builder/factory/build-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-challenge.js
@@ -7,27 +7,27 @@ module.exports = function buildChallenge(
   {
     id = faker.random.uuid(),
     // attributes
-    attachments,
+    attachments = ['URL pièce jointe'],
     embedHeight,
     embedTitle,
     embedUrl,
-    format,
-    illustrationUrl,
-    instruction,
-    proposals,
+    format = 'petit',
+    illustrationUrl = 'Une URL vers l\'illustration',
+    illustrationAlt = 'Le texte de l\'illustration',
+    instruction = 'Des instructions',
+    alternativeInstruction = 'Des instructions alternatives',
+    proposals = 'Une proposition',
     status = 'validé',
     timer,
     type = Challenge.Type.QCM,
     locales = ['fr'],
-    autReply = false,
-    alternativeInstruction,
+    autoReply = false,
     // includes
     answer,
     validator = new Validator(),
     skills = buildSkillCollection(),
     // references
     competenceId = faker.random.uuid(),
-    illustrationAlt,
   } = {}) {
   return new Challenge({
     id,
@@ -44,7 +44,7 @@ module.exports = function buildChallenge(
     timer,
     type,
     locales,
-    autReply,
+    autoReply,
     alternativeInstruction,
     // includes
     answer,

--- a/api/tests/tooling/domain-builder/factory/build-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-course.js
@@ -2,7 +2,7 @@ const faker = require('faker');
 const Course = require('../../../../lib/domain/models/Course');
 
 module.exports = function buildCourse({
-  id = faker.random.number(),
+  id = `rec${faker.random.uuid()}`,
 
   // attributes
   description = faker.lorem.sentence(),


### PR DESCRIPTION
## :unicorn: Problème
Dans le travail entamé sur la conversion de tests de repositories unitaires en tests d'intégration, j'ai eu besoin de pouvoir facilement créer des données du référentiel, puis de vérifier que ces données, récupérées via les repositories, étaient bien retournées (sous la forme d'un domain modèle).
J'avais ajouté de l'outillage dans ce sens dans la PR https://github.com/1024pix/pix/pull/1849, mais elle est devenu assez grosse. Du coup, je décharge l'aspect "tooling" d'abord dans cette PR.

## :robot: Solution
Pour chaque airtableBuilder, on ajoute une méthode buildFromDomain qui permet de créer un objet airtable à partir d'un objet du domaine. Ca permet de décharger la responsabilité de connaître le mapping d'attributs entre les deux au builder (et aussi la gestion de la locale par ex.).
Pour voir le gain du point de vue de l'expressivité et de la place, je vous invite à aller voir la PR https://github.com/1024pix/pix/pull/1849, au niveau des tests d'intégration. J'ai pas encore retiré le tooling là-bas pour justement illustrer le gain.

## :rainbow: Remarques

## :100: Pour tester
Aucune régression
