### PR TITLE
[FEATURE] Redisposer les boutons "c'est parti" et "modifier numéro étudiant"

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -47,11 +47,14 @@
   {{#if this.errorMessageForSupernumeraryForm}}
     <div class="join-restricted-campaign__error" aria-live="polite">{{{this.errorMessageForSupernumeraryForm}}}</div>
   {{/if}}
-  {{#if this.isLoading}}
-    <button type="button" disabled class="button button--big join-restricted-campaign__submit-button"><span class="loader-in-button">&nbsp;</span></button>
-  {{else}}
-    <button type="submit" class="button button--big join-restricted-campaign__submit-button" {{on 'click' this.submit}}>
-      C'est parti !
-    </button>
-  {{/if}}
+  <div class="join-restricted-campaign__container">
+    {{#if this.isLoading}}
+    <button type="button" disabled class="button button--big join-restricted-campaign"><span class="loader-in-button">&nbsp;</span></button>
+    {{else}}
+      <button type="submit" class="button button--big join-restricted-campaign" {{on 'click' this.submit}}>
+        C'est parti !
+      </button>
+    {{/if}}
+  </div>
+  
 </form>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -47,14 +47,12 @@
   {{#if this.errorMessageForSupernumeraryForm}}
     <div class="join-restricted-campaign__error" aria-live="polite">{{{this.errorMessageForSupernumeraryForm}}}</div>
   {{/if}}
-  <div class="join-restricted-campaign__container">
+  <button type="submit" disabled={{this.isLoading}} class="button button--big join-restricted-campaign__button" {{on 'click' this.submit}}>
     {{#if this.isLoading}}
-    <button type="button" disabled class="button button--big join-restricted-campaign"><span class="loader-in-button">&nbsp;</span></button>
+      <span class="loader-in-button">&nbsp;</span>
     {{else}}
-      <button type="submit" class="button button--big join-restricted-campaign" {{on 'click' this.submit}}>
-        C'est parti !
-      </button>
+      C'est parti !
     {{/if}}
-  </div>
+  </button>
   
 </form>

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -22,12 +22,14 @@
     }
   }
 
-  &__container {
-    padding-bottom: 30px;
+  &__back-button {
+    padding: 8px;
+    text-align: left;
+  }
 
-    @include device-is('tablet') {
-      padding: 40px;
-    }
+  &__container {
+    display: flex;
+    justify-content: center;
   }
 
   &__title {

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -22,14 +22,17 @@
     }
   }
 
-  &__back-button {
-    padding: 8px;
-    text-align: left;
+  &__container {
+    padding-bottom: 30px;
+
+    @include device-is('tablet') {
+      padding: 40px;
+    }
   }
 
-  &__container {
-    display: flex;
-    justify-content: center;
+  &__back-button {
+    padding: 4px 0;
+    text-align: right;
   }
 
   &__title {


### PR DESCRIPTION
## :unicorn: Problème
Suite à la démo, on a remarqué que le bouton "c'est parti" a été mis à gauche au lieu du milieu, et que le bouton "modifier le numéro étudiant" est au milieu au lieu d'être à gauche du champ numéro étudiant.

## :robot: Solution
Rétablir les positions des éléments

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur une campagne SUP
