### PR TITLE
[FEATURE] Cacher les liens de connexion et d'inscription pour les élèves venant du GAR (PIX-1249).

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -12,8 +12,7 @@ export default class NavbarDesktopHeader extends Component {
   @alias('session.isAuthenticated') isUserLogged;
 
   get menu() {
-    const menuItems = this._menuItems;
-    return this.isUserLogged ? menuItems.filterBy('permanent', true) : menuItems;
+    return (this.isUserLogged || this._isExternalUser) ? [] : this._menuItems;
   }
 
   get _menuItems() {
@@ -21,5 +20,9 @@ export default class NavbarDesktopHeader extends Component {
       { name: this.intl.t('navigation.not-logged.sign-in'), link: 'login', class: 'navbar-menu-signin-link' },
       { name: this.intl.t('navigation.not-logged.sign-up'), link: 'inscription', class: 'navbar-menu-signup-link' },
     ];
+  }
+
+  get _isExternalUser() {
+    return this.session.get('data.externalUser');
   }
 }

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -38,12 +38,12 @@ describe('Integration | Component | navbar-desktop-header', function() {
       expect(find('.navbar-desktop-header-container__menu')).to.not.exist;
     });
 
-    it('should display link to inscription page', function() {
+    it('should display link to signup page', function() {
       // then
       expect(find('.navbar-menu-signup-link')).to.exist;
     });
 
-    it('should display link to connection page', function() {
+    it('should display link to login page', function() {
       // then
       expect(find('.navbar-menu-signin-link')).to.exist;
     });
@@ -89,12 +89,12 @@ describe('Integration | Component | navbar-desktop-header', function() {
       expect(find('.logged-user-details')).to.exist;
     });
 
-    it('should not display link to inscription page', function() {
+    it('should not display link to signup page', function() {
       // then
       expect(find('.navbar-menu-signup-link')).to.not.exist;
     });
 
-    it('should not display link to connection page', function() {
+    it('should not display link to login page', function() {
       // then
       expect(find('.navbar-menu-signin-link')).to.not.exist;
     });
@@ -106,6 +106,49 @@ describe('Integration | Component | navbar-desktop-header', function() {
       expect(contains('Profil')).to.exist;
       expect(contains('Certification')).to.exist;
       expect(contains('Aide')).to.exist;
+    });
+  });
+
+  context('when user comes from external platform', function() {
+    beforeEach(async function() {
+      this.owner.register('service:session', Service.extend({
+        isAuthenticated: false,
+        data: {
+          externalUser: 'externalUserToken',
+        },
+      }));
+      setBreakpoint('desktop');
+      await render(hbs`<NavbarDesktopHeader/>`);
+    });
+
+    it('should be rendered', function() {
+      // then
+      expect(find('.navbar-desktop-header__container')).to.exist;
+    });
+
+    it('should display the Pix logo', function() {
+      // then
+      expect(find('.navbar-desktop-header-logo')).to.exist;
+      expect(find('.pix-logo')).to.exist;
+    });
+
+    it('should not display the navigation menu', function() {
+      // then
+      expect(find('.navbar-desktop-header-container__menu')).to.not.exist;
+    });
+
+    it('should not display link to signup page', function() {
+      // then
+      expect(find('.navbar-menu-signup-link')).to.not.exist;
+    });
+
+    it('should not display link to login page', function() {
+      // then
+      expect(find('.navbar-menu-signin-link')).to.not.exist;
+    });
+
+    it('should not display the join campaign link', function() {
+      expect(contains('J\'ai un code')).not.to.exist;
     });
   });
 

--- a/mon-pix/tests/unit/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header-test.js
@@ -27,10 +27,10 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
     context('#menu', function() {
       it('should only contains permanent menu items', function() {
         // given
-        const expectedLoggedUserMenu = [];
+        const expectedMenu = [];
 
         // then
-        expect(component.menu).to.deep.equal(expectedLoggedUserMenu);
+        expect(component.menu).to.deep.equal(expectedMenu);
       });
     });
   });
@@ -51,15 +51,37 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
     context('#menu', function() {
       it('should set with default values (including connexion link)', function() {
         // given
-        const expectedUnloggedUserMenu = [
+        const expectedMenu = [
           { link: 'login' },
           { link: 'inscription' },
         ];
 
         // then
-        expect(component.menu).to.have.lengthOf(expectedUnloggedUserMenu.length);
-        expect(component.menu[0].link).to.equal(expectedUnloggedUserMenu[0].link);
-        expect(component.menu[1].link).to.equal(expectedUnloggedUserMenu[1].link);
+        expect(component.menu).to.have.lengthOf(expectedMenu.length);
+        expect(component.menu[0].link).to.equal(expectedMenu[0].link);
+        expect(component.menu[1].link).to.equal(expectedMenu[1].link);
+      });
+    });
+  });
+
+  describe('When user comes from external platform', function() {
+    beforeEach(function() {
+      component = createGlimmerComponent('component:navbar-desktop-header');
+      component.session = Service.create({
+        isAuthenticated: false,
+        data: {
+          externalUser: 'externalUserToken',
+        },
+      });
+    });
+
+    context('#menu', function() {
+      it('should return permanent items only', function() {
+        // given
+        const expectedMenu = [];
+
+        // then
+        expect(component.menu).to.deep.equal(expectedMenu);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors de la première connexion à Pix pour un élève se connectant via le GAR, celui-ci est redirigé vers la page permettant de rentrer un code parcours. Il doit se réconcilier afin de créer un compte utilisateur. Néanmoins, lors de l'accès à la page permettant de rentrer un code parcours, les liens vers les formulaires d'inscription et de connexion sont présents ce qui est perturbant.

## :robot: Solution
Cacher les liens de connexion et d'inscription pour les élèves venant du GAR.

## :100: Pour tester
**GAR**
Connecter le faux SAML à la review app
Se connecter et vérifier que la page `campagnes` ne comporte pas de lien

**Hors GAR**
Dans storage, supprimer la clé `ember_simple_auth-session`
Recharger et vérifier que les liens "Se connecter" et 'S'incrire" apparaissent
