### PR TITLE
[INFRA] Ajoute un stub manquant dans un test unitaire (PIX-1224)

### DIFF
--- a/api/tests/unit/domain/usecases/reconcile-user-to-schooling-registration-data_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-user-to-schooling-registration-data_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRegistration');
+const Student = require('../../../../lib/domain/models/Student');
 const userReconciliationService = require('../../../../lib/domain/services/user-reconciliation-service');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
@@ -93,11 +94,15 @@ describe('Unit | UseCase | reconcile-user-to-schooling-registration-data', () =>
         findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUserStub.resolves(schoolingRegistration);
         checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizationsStub.throws(new SchoolingRegistrationAlreadyLinkedToUserError(exceptedErrorMEssage));
         reconcileUserToSchoolingRegistrationStub.withArgs({ userId: user.id, schoolingRegistrationId }).resolves(schoolingRegistration);
+        const studentRepository = {
+          getReconciledStudentByNationalStudentId: () => new Student(),
+        };
 
         // when
         const result = await catchErr(usecases.reconcileUserToSchoolingRegistrationData)({
           reconciliationInfo: user,
           campaignCode,
+          studentRepository,
         });
 
         // then


### PR DESCRIPTION
## :unicorn: Problème

Dans le fichier `domain/usecases/reconcile-user-to-schooling-registration-data_test.js` le test unitaire `'should return a SchoolingRegistrationAlreadyLinkedToUser error'` échoue, car il essaie de se connecter à la base de données (et on n’a pas besoin de la base quand on lance les TU).

## :robot: Solution

Remplacer le `studentRepository` par un test double dans ce test.

## :100: Pour tester

Lancer `npm run test:api:unit`. Cette commande échoue avant la correction, et passe suite à la correction.