### PR TITLE
[BUGFIX] Ajout d'une validation JOI sur la longueur des inputs firstName, lastName, email et password d'un utilisateur sur le formulaire d'inscription Pix-app (PIX-1253).

### DIFF
--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -10,18 +10,23 @@ const userValidationJoiSchema = Joi.object({
 
   firstName: Joi.string()
     .required()
+    .max(255)
     .messages({
       'string.empty': 'Votre prénom n’est pas renseigné.',
+      'string.max': 'Votre prénom ne doit pas dépasser les 255 caractères.',
     }),
 
   lastName: Joi.string()
     .required()
+    .max(255)
     .messages({
       'string.empty': 'Votre nom n’est pas renseigné.',
+      'string.max': 'Votre nom ne doit pas dépasser les 255 caractères.',
     }),
 
   email: Joi.string()
     .email()
+    .max(255)
     .messages({
       'string.empty': 'Votre adresse e-mail n’est pas renseignée.',
       'string.email': 'Le format de l\'adresse e-mail est incorrect.',
@@ -35,9 +40,11 @@ const userValidationJoiSchema = Joi.object({
   password: Joi.string()
     .pattern(pattern)
     .required()
+    .max(255)
     .messages({
       'string.empty': 'Votre mot de passe n’est pas renseigné.',
       'string.pattern.base': 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.',
+      'string.max': 'Votre mot de passe ne doit pas dépasser les 255 caractères.',
     }),
 
   cgu: Joi.boolean()

--- a/api/tests/unit/domain/validators/user-validator_test.js
+++ b/api/tests/unit/domain/validators/user-validator_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable mocha/no-identical-title */
 const { expect, catchErr } = require('../../../test-helper');
 const userValidator = require('../../../../lib/domain/validators/user-validator');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
@@ -214,6 +215,40 @@ describe('Unit | Domain | Validators | user-validator', function() {
             // then
             expect(errors.invalidAttributes).to.have.lengthOf(5);
           }
+        });
+
+        it('should reject with errors on firstName, lastName and password when firstName, lastName and password have a maximum length of 255', async () => {
+          // given
+          const expectedFirstNameError = {
+            attribute: 'firstName',
+            message: 'Votre prénom ne doit pas dépasser les 255 caractères.',
+          };
+          const expectedLastNameError = {
+            attribute: 'lastName',
+            message: 'Votre nom ne doit pas dépasser les 255 caractères.',
+          };
+          const expectedPasswordError = {
+            attribute: 'password',
+            message: 'Votre mot de passe ne doit pas dépasser les 255 caractères.',
+          };
+
+          user = {
+            firstName: 'John'.repeat(70),
+            lastName: 'Doe'.repeat(90),
+            email: 'john.doe@example.net',
+            password: 'Password1234'.repeat(22),
+            cgu: true,
+          };
+
+          // when
+          const errors = await catchErr(userValidator.validate)({ user });
+
+          // then
+          expect(errors.invalidAttributes).to.have.lengthOf(3);
+          expect(errors).to.be.instanceOf(EntityValidationError);
+          expect(errors.invalidAttributes[0]).to.deep.equal(expectedFirstNameError);
+          expect(errors.invalidAttributes[1]).to.deep.equal(expectedLastNameError);
+          expect(errors.invalidAttributes[2]).to.deep.equal(expectedPasswordError);
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Il apparaît que des utilisateurs essayent de s'inscrire à Pix en spécifiant un nom, prénom, e-mail ou mot de passe supérieur à 255 caractères ce qui produit une erreur en base de données.

## :robot: Solution
Limiter le nombre de caractères acceptés sur les différents inputs par la validation JOI du user-validator.js, avec un .max(255), et un message unique à chaque input : 
```
.messages({
      'string.max': 'Votre mot de passe ne doit pas dépasser les 255 caractères.'
    })
```
Pas d'ajout de message d'erreur sur l'email, car la validation JOI .email() renvoie déjà un message d'erreur lorsque l'on tente d'entrer un e-mail de 255 caractères  : 
```
{attribute: 'email',
    message: "Le format de l'adresse e-mail est incorrect."} 
```
https://github.com/sideway/joi/issues/2113

## :rainbow: Remarques
BSR de la gestion d'erreurs sur le formulaire d'inscription prévu sur une prochaine PR

## :100: Pour tester

- Aller sur le formulaire d'inscription
- Remplir les inputs firstName, lastName et password en dépassant les 255 caractères.
- Lorsque vous tentez de vous inscrire, des messages d'erreurs sur les champs indiqueront le dépassement des 255 caractères.
