### PR TITLE
[CLEANUP] Ajout du linter pour vérifier les alt sur les images.

### DIFF
--- a/mon-pix/.template-lintrc.js
+++ b/mon-pix/.template-lintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     'no-quoteless-attributes': false,
     'no-triple-curlies': false,
     'no-unused-block-params': false,
-    'require-valid-alt-text': false,
     'style-concatenation': false,
   },
 };

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -10,7 +10,7 @@
     {{#if this.model.campaignParticipation.campaign.isArchived}}
 
       <div class="skill-review__campaign-archived">
-        <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg">
+        <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg" alt="" role="none">
         <p class="skill-review__campaign-archived-text">
           {{t 'pages.skill-review.archived' htmlSafe=true}}
         </p>

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -10,7 +10,7 @@
     {{#if this.model.campaignParticipation.campaign.isArchived}}
 
       <div class="skill-review__campaign-archived">
-        <img class="skill-reviw__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg" alt="" role="none">
+        <img class="skill-review__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg" alt="" role="none">
         <p class="skill-review__campaign-archived-text">
           {{t 'pages.skill-review.archived' htmlSafe=true}}
         </p>

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -8,7 +8,7 @@
     </div>
 
     <div class="campaign-tutorial__explanation-icon">
-      <img alt="" src="{{rootURL}}/images/tutorial-campaign/{{@model.icon}}">
+      <img alt="" role="none" src="{{rootURL}}/images/tutorial-campaign/{{@model.icon}}">
     </div>
 
 

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -36,7 +36,7 @@
 
           <div class="campaign-landing-page__details__measure__container">
             <img class="campaign-landing-page__details__article-image measure"
-                 src="{{this.rootURL}}/images/landing-page/icon-mesurer.svg" alt="">
+                 src="{{this.rootURL}}/images/landing-page/icon-mesurer.svg" role="none" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
                 {{t "pages.campaign-landing.assessment.evaluate.title"}}
@@ -56,7 +56,7 @@
           <hr class="campaign-landing-page__dash-line">
 
           <div class="campaign-landing-page__details__measure__container">
-            <img src="{{this.rootURL}}/images/landing-page/icon-conseil.svg" alt="">
+            <img src="{{this.rootURL}}/images/landing-page/icon-conseil.svg" role="none" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
                 {{t "pages.campaign-landing.assessment.develop.title"}}
@@ -70,7 +70,7 @@
           <hr class="campaign-landing-page__dash-line">
 
           <div class="campaign-landing-page__details__measure__container">
-            <img src="{{this.rootURL}}/images/landing-page/icon-certif.svg" alt="">
+            <img src="{{this.rootURL}}/images/landing-page/icon-certif.svg" role="none" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
                 {{t "pages.campaign-landing.assessment.certify.title"}}

--- a/mon-pix/app/templates/components/certification-banner.hbs
+++ b/mon-pix/app/templates/components/certification-banner.hbs
@@ -1,7 +1,7 @@
 <div class="assessment-banner--certification certification-banner">
   <div class="assessment-banner-container">
     <div class="assessment-banner__pix-logo">
-      <img src="/images/pix-logo-blanc.svg" alt="">
+      <img src="/images/pix-logo-blanc.svg" role="none" alt="">
     </div>
     <div class="assessment-banner__splitter"></div>
     <h1 class="assessment-banner__title">{{this.currentUser.user.fullName}}</h1>

--- a/mon-pix/app/templates/components/certifications-list-item.hbs
+++ b/mon-pix/app/templates/components/certifications-list-item.hbs
@@ -7,7 +7,7 @@
       </div>
 
       <div class="certifications-list-item__cell-double-width">
-        <img src="/images/icons/icon-croix.svg" alt="" class="certifications-list-item__cross-img">
+        <img src="/images/icons/icon-croix.svg" alt="" role="none" class="certifications-list-item__cross-img">
         {{t "pages.certifications-list.statuses.fail.title"}}
       </div>
       <div class="certifications-list-item__cell-pix-score"></div>
@@ -41,7 +41,7 @@
     </div>
 
     <div class="certifications-list-item__cell-double-width">
-      <img src="/images/icons/icon-check-vert.svg" alt="" class="certifications-list-item__green-check-img">
+      <img src="/images/icons/icon-check-vert.svg" alt="" role="none" class="certifications-list-item__green-check-img">
       {{t "pages.certifications-list.statuses.success.title"}}
     </div>
     <div class="certifications-list-item__cell-pix-score">
@@ -67,7 +67,7 @@
     </div>
 
     <div class="certifications-list-item__cell-double-width">
-      <img src="/images/sablier.svg" alt="" class="certifications-list-item__hourglass-img">
+      <img src="/images/sablier.svg" alt="" role="none" class="certifications-list-item__hourglass-img">
       {{t "pages.certifications-list.statuses.not-published.title"}}
     </div>
     <div class="certifications-list-item__cell-pix-score"></div>

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -67,6 +67,7 @@
               <div class="comparison-windows__default-message-picto-container">
                 <img src="{{this.rootURL}}/images/comparison-window/icon-tuto.svg"
                     alt=""
+                    role="none"
                     class="comparison-windows__default-message-picto">
               </div>
               <div class="comparison-windows__default-message-title">{{t "pages.comparison-window.upcoming-tutorials"}}</div>

--- a/mon-pix/app/templates/components/form-textfield-date.hbs
+++ b/mon-pix/app/templates/components/form-textfield-date.hbs
@@ -20,10 +20,14 @@
     <div class="form-textfield__icon">
       {{#if dayHasIcon}}
         {{#if (eq dayValidationStatus 'error') }}
-          <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
+          <img
+            src="/images/icons/icon-error.svg"
+            class="form-textfield-icon__state form-textfield-icon__state--error"
+            alt={{t "common.form.error"}}
+          >
         {{else}}
           <img src="/images/icons/icon-success.svg"
-               class="form-textfield-icon__state form-textfield-icon__state--success">
+               class="form-textfield-icon__state form-textfield-icon__state--success"  alt={{t "common.form.success"}}>
         {{/if}}
       {{/if}}
     </div>
@@ -44,10 +48,13 @@
     <div class="form-textfield__icon">
       {{#if monthHasIcon}}
         {{#if (eq monthValidationStatus 'error') }}
-          <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
+          <img
+            src="/images/icons/icon-error.svg"
+            class="form-textfield-icon__state form-textfield-icon__state--error"
+            alt={{t "common.form.error"}}>
         {{else}}
           <img src="/images/icons/icon-success.svg"
-               class="form-textfield-icon__state form-textfield-icon__state--success">
+               class="form-textfield-icon__state form-textfield-icon__state--success"  alt={{t "common.form.success"}}>
         {{/if}}
       {{/if}}
     </div>
@@ -68,10 +75,13 @@
     <div class="form-textfield__icon">
       {{#if yearHasIcon}}
         {{#if (eq yearValidationStatus 'error') }}
-          <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
+          <img
+            src="/images/icons/icon-error.svg"
+            class="form-textfield-icon__state form-textfield-icon__state--error"
+            alt={{t "common.form.error"}}>
         {{else}}
           <img src="/images/icons/icon-success.svg"
-               class="form-textfield-icon__state form-textfield-icon__state--success">
+               class="form-textfield-icon__state form-textfield-icon__state--success"  alt={{t "common.form.success"}}>
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -27,9 +27,9 @@
       {{/if}}
       {{#if hasIcon}}
         {{#if (eq validationStatus 'error') }}
-            <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error">
+            <img src="/images/icons/icon-error.svg" class="form-textfield-icon__state form-textfield-icon__state--error" alt={{t "common.form.error"}}>
         {{else}}
-            <img src="/images/icons/icon-success.svg" class="form-textfield-icon__state form-textfield-icon__state--success">
+            <img src="/images/icons/icon-success.svg" class="form-textfield-icon__state form-textfield-icon__state--success" alt={{t "common.form.success"}}>
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/app/templates/components/levelup-notif.hbs
+++ b/mon-pix/app/templates/components/levelup-notif.hbs
@@ -1,7 +1,7 @@
 <div {{did-update this.resetLevelUp}}>
   {{#unless this.closeLevelup}}
     <div class="levelup">
-      <img src="{{rootURL}}/images/levelup.svg">
+      <img src="{{rootURL}}/images/levelup.svg" alt="" role="none">
       <div class="levelup__icon-card-level">{{@level}}</div>
       <div class="levelup__competence">
         <div class="levelup-competence__level">{{t "pages.levelup-notif.obtained-level" level=@level}}</div>

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -25,7 +25,7 @@
 
     {{#unless isResultOk}}
       <div class="correction-qroc-box__solution">
-        <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+        <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
         <div class="correction-qroc-box__solution-text">{{solutionToDisplay}}</div>
       </div>
     {{/unless}}

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -27,7 +27,7 @@
     {{/each}}
     {{#unless answerIsCorrect}}
       <div class="correction-qrocm__solution">
-        <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+        <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
         <div class="correction-qrocm__solution-text">{{expectedAnswers}}</div>
       </div>
     {{/unless}}

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -12,7 +12,7 @@
         </textarea>
         {{#if field.emptyOrWrongAnswer}}
             <div class="correction-qrocm__solution">
-                <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+                <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
                 <div class="correction-qrocm__solution-text">{{field.solution}}</div>
             </div>
         {{/if}}
@@ -24,7 +24,7 @@
                disabled>
         {{#if field.emptyOrWrongAnswer}}
           <div class="correction-qrocm__solution">
-            <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+            <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
             <div class="correction-qrocm__solution-text">{{field.solution}}</div>
           </div>
         {{/if}}
@@ -37,7 +37,7 @@
                  disabled>
           {{#if field.emptyOrWrongAnswer}}
             <div class="correction-qrocm__solution">
-              <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="">
+              <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
               <div class="correction-qrocm__solution-text">{{field.solution}}</div>
             </div>
           {{/if}}

--- a/mon-pix/app/templates/components/reached-stage.hbs
+++ b/mon-pix/app/templates/components/reached-stage.hbs
@@ -19,6 +19,6 @@
       </div>
     </div>
     {{#if @imageUrl}}
-      <img class="reached-stage__image" src={{ @imageUrl }}  alt=""/>
+      <img class="reached-stage__image" src={{ @imageUrl }}  alt="" role="none"/>
     {{/if}}
  </div>

--- a/mon-pix/app/templates/components/tutorial-panel.hbs
+++ b/mon-pix/app/templates/components/tutorial-panel.hbs
@@ -11,6 +11,7 @@
           <div class="tutorial-panel__hint-picto-container">
             <img src="{{this.rootURL}}/images/comparison-window/icon-lampe.svg"
                  alt=""
+                 role="none"
                  class="tutorial-panel__hint-picto">
           </div>
           <MarkdownToHtml @class="tutorial-panel__hint-content" @markdown={{@hint}} />

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -4,7 +4,7 @@
     <NavbarHeader @burger={{burger}} />
     <header role="banner" class="background-banner">
       <div class="user-tutorials-banner">
-        <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" alt=""/>
+        <img src="{{rootURL}}/images/user-tutorials/banner-icon.svg" class="user-tutorials-banner__icon" role="none" alt=""/>
         <h3 class="user-tutorials-banner__title">{{t 'pages.user-tutorials.title'}}</h3>
         <p class="user-tutorials-banner__description">
           {{t 'pages.user-tutorials.description'}}
@@ -24,6 +24,7 @@
       <article aria-label="tutoriels" class="rounded-panel user-tutorials-no-tutorial">
         <div class="user-tutorials-no-tutorial__illustration">
           <img src="{{rootURL}}/{{t 'pages.user-tutorials.empty-list-info.image-link'}}"
+               role="none"
                alt=""/>
         </div>
         <div class="user-tutorials-no-tutorial__instructions">

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -16,8 +16,10 @@
       "quit": "Exit"
     },
     "form": {
+      "error": "error",
       "mandatory": "required",
-      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required"
+      "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required",
+      "success": "success"
     },
     "french-republic": "French Republic",
     "level": "level",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -16,8 +16,10 @@
       "quit": "Quitter"
     },
     "form": {
+      "error": "erreur",
       "mandatory": "obligatoire",
-      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires"
+      "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
+      "success": "correct"
     },
     "french-republic": "République française",
     "level": "niveau",


### PR DESCRIPTION
## :unicorn: Problème
- Certaines images n'ont pas d'attribut `alt` ou de `role`.

## :robot: Solution
- Utiliser la règle de linter `require-valid-alt-text`
- Corriger les balises `img` existantes

## :rainbow: Remarques
-

## :100: Pour tester
-
