### PR TITLE
[FEATURE] Afficher le nom et prénom des inscriptions à la place des noms et prénoms des utilisateurs dans le CSV de campagne d'évaluation (PIX-1112).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -10,8 +10,8 @@ module.exports = {
           'campaign-participations.*',
           'assessments.state',
           _assessmentRankByCreationDate(),
-          'users.firstName',
-          'users.lastName',
+          knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
+          knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
           'schooling-registrations.studentNumber',
         ])
           .from('campaign-participations')

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-repository_test.js
@@ -292,6 +292,7 @@ describe('Integration | Repository | Campaign Assessment Participation', () => {
       beforeEach(async () => {
         const skill = airtableBuilder.factory.buildSkill({ id: 'skill' });
         airtableBuilder.mockLists({ skills: [skill] });
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
         campaignId = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId }, [skill]).id;
         const userId = databaseBuilder.factory.buildUser().id;
@@ -303,9 +304,9 @@ describe('Integration | Repository | Campaign Assessment Participation', () => {
           sharedAt: new Date('2020-12-12'),
         }).id;
 
-        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, createdAt: new Date('2020-10-10'), state: Assessment.states.COMPLETED }).id;
-        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId, firstName: 'John', lastName: 'Doe' }).id;
-        databaseBuilder.factory.buildSchoolingRegistration({ userId , firstName: 'Jane', lastName: 'Doe' }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, createdAt: new Date('2020-10-10'), state: Assessment.states.COMPLETED });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId, firstName: 'John', lastName: 'Doe' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: otherOrganizationId, userId, firstName: 'Jane', lastName: 'Doe' });
 
         await databaseBuilder.commit();
       });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -189,6 +189,32 @@ describe('Integration | Repository | Campaign Participation Info', () => {
       });
     });
 
+    context('when a participant has several schooling-registrations', () => {
+      let campaign;
+      beforeEach(async () => {
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        campaign = databaseBuilder.factory.buildCampaign({ organizationId });
+        const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId,
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId, firstName: 'John', lastName: 'Doe' });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId: otherOrganizationId, userId, firstName: 'Jane', lastName: 'Doe' });
+
+        await databaseBuilder.commit();
+      });
+
+      it('return the first name and the last name of the correct schooling-registration', async () => {
+        const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
+
+        expect(campaignParticipationInfos[0].participantFirstName).to.equal('John');
+        expect(campaignParticipationInfos[0].participantLastName).to.equal('Doe');
+      });
+    });
+
     context('when the participant has a schooling registration for the campaign\'s organization', () => {
       let schoolingRegistration;
       let campaign;

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -190,24 +190,21 @@ describe('Integration | Repository | Campaign Participation Info', () => {
     });
 
     context('when the participant has a schooling registration for the campaign\'s organization', () => {
-      let studentNumber;
+      let schoolingRegistration;
       let campaign;
       beforeEach(async () => {
-        const userId = databaseBuilder.factory.buildUser({
-          firstName: 'First',
-          lastName: 'Last',
-        }).id;
-        campaign = databaseBuilder.factory.buildCampaign({ sharedAt: null });
+        const userId = databaseBuilder.factory.buildUser().id;
+        campaign = databaseBuilder.factory.buildCampaign();
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
           campaignId: campaign.id,
           userId,
         }).id;
         databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'started' });
-        studentNumber = databaseBuilder.factory.buildSchoolingRegistration({
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({
           organizationId: campaign.organizationId,
           userId,
           studentNumber: 'Pipon et Jambon',
-        }).studentNumber;
+        });
         databaseBuilder.factory.buildSchoolingRegistration({
           userId,
           studentNumber: 'Yippee Ki Yay',
@@ -222,7 +219,17 @@ describe('Integration | Repository | Campaign Participation Info', () => {
         const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
 
         // then
-        expect(campaignParticipationInfos[0].studentNumber).to.equal(studentNumber);
+        expect(campaignParticipationInfos[0].studentNumber).to.equal(schoolingRegistration.studentNumber);
+      });
+
+      it('should return the first name and last of the schooling registration associated to the given organization', async () => {
+
+        // when
+        const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
+
+        // then
+        expect(campaignParticipationInfos[0].participantFirstName).to.equal(schoolingRegistration.firstName);
+        expect(campaignParticipationInfos[0].participantLastName).to.equal(schoolingRegistration.lastName);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Bien que liés à leur organisation, les élèves/étudiants étaient affichés avec leur nom et prénom de compte utilisateur dans le CSV. Cela pouvait être n'importe quoi, ex : Vladimir Poutine.

## :robot: Solution
Pour plus de cohérence pour l'équipe pédagogique, on affiche désormais le nom et prénom des inscriptions d'élèves/d'étudiants dans les écrans de Pix Orga pour les campagnes d'évaluation.

## :rainbow: Remarques
RAS 

## :100: Pour tester
Pour une organisation SCO :
- rejoindre la campagne RESTRICTD (campagne d'évaluation et restreinte), se réconcilier avec first last né le 10/10/2010 sur Pix App ;
- aller sur Pix Orga en tant que sco@example.net, sélectionner la bonne campagne, cliquer sur le bouton "télécharger les résultats" et vérifier l'affichage de First Last, et non du nom et prénom du compte utilisateur.

Pour une organisation PRO (non régression) :
- rejoindre la campagne AZERTY123 (campagne d'évaluation et non restreinte) sur Pix App ;
- aller sur Pix Orga en tant que pro@example.net, sélectionner la bonne campagne, cliquer sur le bouton "télécharger les résultats" et vérifier l'affichage du nom et prénom du compte utilisateur.