### PR TITLE
[BUGFIX] Mettre à jour le rôle d'un membre d'une équipe depuis Pix-Orga (pix-1278)

### DIFF
--- a/orga/app/components/routes/authenticated/team/items.js
+++ b/orga/app/components/routes/authenticated/team/items.js
@@ -35,12 +35,14 @@ export default class Items extends Component {
   }
 
   @action
-  updateRoleOfMember(membership) {
+  async updateRoleOfMember(membership) {
     this.isEditionMode = false;
 
     if (!this.selectedNewRole) return false;
 
     membership.organizationRole = this.selectedNewRole;
+
+    membership.organization = this.currentUser.organization;
 
     return membership.save();
   }


### PR DESCRIPTION
## :unicorn: Problème 

Une erreur 500 est déclenchée quand un administrateur essaye de mettre à jour le rôle d'un membre de l'organisation.
L'IHM n'affiche pas d'erreur et fait croire que la mise à jour s'est bien passée.
Or, si on rafraichit la page, on se rend compte que la mise à jour n'as pas aboutie et que l'ancienne valeur est affichée.

Analyse de la régression: 
Une relation bidirectionnelle entre le modèle "organisation" et "membership" a été enlevée. 
Par conséquent, le payload envoyé à l'API lors de la mise à jour ne contient plus de référence à l'organisation du membre.
Ce qui cause l'erreur 500 quand le pre-handler essaye de récupérer l'identifiant de l'organisation depuis le payload:
`const organizationId = (request.path && request.path.includes('memberships')) ?  request.payload.data.relationships.organization.data.id : parseInt(request.params.id) ;`

## :robot: Solution
Quick-Fix: Alimenter le modèle membership avec l'organisation de l'utilisateur connecté.
Le design de la route sera évolué pour ne pas prendre l'id d'organisation du payload mais plutot en path param. ( Dans un autre ticket)

## :100: Pour tester

1. Se connecter à Pix Orga avec l'utilisateur sco@example.net
2. Afficher La vue /equipe.
3. Modifier le rôle d'un membre.
4. Rafraichir la page et vérifier que la mise à jour s'est bien passée.
