### PR TITLE
[FEATURE] Changement d'une phrase lors de l'envoi des résultats (PIX-1279)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -669,7 +669,7 @@
       },
       "information": "If you have already completed courses on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
-      "send-results": "Submit your results to the course organiser so they can provide you with support.",
+      "send-results": "Don't forget to submit your results.",
       "send-title": "Submit your results",
       "stage": {
         "masteryPercentage": "Success rate: {percentage} %",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -670,7 +670,7 @@
       },
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
-      "send-results": "Envoyez vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.",
+      "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
       "send-title": "Envoyez vos résultats",
       "stage": {
         "masteryPercentage": "{percentage} % de réussite",


### PR DESCRIPTION
## :unicorn: Problème
La phrase lors de l'envoi d'un résultat dans pix app n'est plus approprié.

## :robot: Solution
Modifier la phrase : Envoyer vos résultats à l'organisateur du parcours pour qu'il puisse vous accompagner.
par:
N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.

Plus modification coté trad 

## :rainbow: Remarques
RAS

## :100: Pour tester
Envoyer ses résultats après un test
