### PR TITLE
[BUGFIX] Décoder correctement un jeton d'identification contenant des caractères accentués pour un élève provenant du GAR (PIX-1269).

### DIFF
--- a/mon-pix/app/helpers/jwt.js
+++ b/mon-pix/app/helpers/jwt.js
@@ -1,9 +1,9 @@
 import { helper } from '@ember/component/helper';
+import jwt_decode from 'jwt-decode';
 
 export function decodeToken(accessToken)
 {
-  const payloadOfToken = accessToken.split('.')[1];
-  return JSON.parse(atob(payloadOfToken));
+  return jwt_decode(accessToken);
 }
 
 export default helper(decodeToken);

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -38478,6 +38478,12 @@
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
+    "jwt-decode": {
+      "version": "3.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0-beta.2.tgz",
+      "integrity": "sha512-AnENY5syz7PzgpTzos9sxkqKTmHU0JeJOXZFHUc41bDyybC2yzZ+1r43ZLhk7+JCwF0yjISPuVK9ZWfA1nCUPA==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -103,6 +103,7 @@
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",
     "js-yaml": "^3.13.1",
+    "jwt-decode": "^3.0.0-beta.2",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",

--- a/mon-pix/tests/unit/helpers/jwt-test.js
+++ b/mon-pix/tests/unit/helpers/jwt-test.js
@@ -22,6 +22,19 @@ describe('Unit | Helpers | decodeToken', function() {
       expect(decodedToken).to.deep.equal(expectedResult);
     });
 
+    it('should decode valid token with accented characters in firstName, lastName', async function() {
+      const accessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiTm_DqW1pZSIsImxhc3RfbmFtZSI6IkHDrmnDr21hbsOoIiwic2FtbF9pZCI6InNhbWxJRDEyMzQ1NjciLCJpYXQiOjE1OTc5Mjk0NDgsImV4cCI6MTU5NzkzMzA0OH0.XZJCiDE73sTqHrSmVc99ynypQHzxw3wwZahLUvxgdZY';
+      const decodedToken = decodeToken(accessToken);
+      const expectedResult = {
+        first_name: 'Noémie',
+        last_name: 'Aîiïmanè',
+        saml_id: 'samlID1234567',
+        iat: 1597929448,
+        exp: 1597933048,
+      };
+      expect(decodedToken).to.deep.equal(expectedResult);
+    });
+
     it('should extract userId and source from token', function() {
       // given
       const user_id = 1;


### PR DESCRIPTION
## :unicorn: Problème
Le helper qui decode l'id token coté client renvoie une erreur quand les noms et prénoms contiennent des caractères accentués.
Cette erreur empêche l'utilisateur de rejoindre la campagne.
![image](https://user-images.githubusercontent.com/10045497/93242449-1ac53980-f787-11ea-85e5-35a36e881f5e.png)
La fonctions atob (décodage base64) ne gère pas correctement l'encodage UTF-8

## :robot: Solution
Remplacer le decode du jeton par la librairie jwt-decode, qui gère bien l'encodage.

## :100: Pour tester
Se connecter avec le [faux Gar ](https://pix-saml-idp.osc-fr1.scalingo.io/).
Renseigner un nom et un prénom accentué, ex: `Zoë Aàltra`
Entrer le code campagne `RESTRICTD`
Vérifier qu'on accède bien à l'écran de réconciliation, et que les noms et prénoms sont préservés
