### PR TITLE
[TECH] Ajouter le dot reporter aux scripts de tests pour Pix Orga, Pix Certif et Pix Admin.

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -27,7 +27,8 @@
     "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
-    "test": "ember exam --reporter dot",
+    "test": "ember test --reporter dot",
+    "test:lint": "npm test && npm run lint",
     "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -29,7 +29,9 @@
     "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
-    "test": "ember test"
+    "test": "ember test --reporter dot",
+    "test:lint": "npm test && npm run lint",
+    "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -29,7 +29,9 @@
     "preinstall": "npx check-engine",
     "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
-    "test": "ember test"
+    "test": "ember test --reporter dot",
+    "test:lint": "npm test && npm run lint",
+    "test:watch": "ember exam --serve --reporter dot"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",


### PR DESCRIPTION
## :unicorn: Problème
Il commence à y avoir beaucoup de tests sur les applications Pix Orga, Pix Certif et Pix Admin. Lorsqu'un test échoue, cela devient illisible de trouver celui ou ceux qui échouent.

## :robot: Solution
Remplacer le reporter par défaut par le `dot reporter`.

## :rainbow: Remarques
Une solution encore mieux pourrait être d'avoir une solution hybride ? On ne serait pas obligés d'attendre la fin de l'exécution pour savoir quel test échoue.

## :100: Pour tester
Lancer le script de test sur chacune des applications.