### PR TITLE
[FEATURE] Permettre la modification de l'accès ou non à la fonctionnalité de collecte de profils depuis Pix Admin (PIX-1288).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -71,6 +71,18 @@
                  class={{if (v-get this.form 'email' 'isInvalid') "form-control is-invalid" "form-control"}}
                  @value={{this.form.email}} />
         </div>
+        <div class="form-field organization-edit-form__checkbox">
+          <label for="canCollectProfiles" class="form-field__label">Collecte de profils</label>
+          {{#if (v-get this.form 'canCollectProfiles' 'isInvalid')}}
+            <div class="form-field__error">
+              {{v-get this.form 'canCollectProfiles' 'message'}}
+            </div>
+          {{/if}}
+          <Input id="canCollectProfiles"
+                 @type="checkbox"
+                 class={{if (v-get this.form 'canCollectProfiles' 'isInvalid') "form-control is-invalid" "form-control"}}
+                 @checked={{this.form.canCollectProfiles}} />
+        </div>
         <div class="form-actions">
           <button class="btn btn-outline-default" aria-label="Annuler" type="button" {{on "click" this.cancel}}>Annuler</button>
           <button class="btn btn-success" aria-label="Enregistrer" type="submit">Enregistrer</button>
@@ -95,7 +107,7 @@
               Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
             {{/if}}
             Adresse e-mail: <span class ="organization'__email">{{@organization.email}}</span><br>
-            A accès aux campagnes de collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
+            Collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>
             Crédits : <span class="organization__credit">{{@organization.credit}}</span>
           </p>
           <button type="button" class="btn btn-outline-default" aria-label="Editer" {{on "click" this.toggleEditMode}}>Editer</button>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -51,6 +51,13 @@ const Validations = buildValidations({
       }),
     ],
   },
+  canCollectProfiles: {
+    validators: [
+      validator('inclusion', {
+        in: [true, false],
+      }),
+    ],
+  },
 });
 
 class Form extends Object.extend(Validations) {
@@ -58,6 +65,7 @@ class Form extends Object.extend(Validations) {
   @tracked externalId;
   @tracked provinceCode;
   @tracked email;
+  @tracked canCollectProfiles;
 }
 
 export default class OrganizationInformationSection extends Component {
@@ -114,6 +122,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('externalId', !this.form.externalId ? null : this.form.externalId.trim());
     this.args.organization.set('provinceCode', !this.form.provinceCode ? null : this.form.provinceCode.trim());
     this.args.organization.set('email', !this.form.email ? null : this.form.email.trim());
+    this.args.organization.set('canCollectProfiles', this.form.canCollectProfiles);
 
     this.isEditMode = false;
     return this.args.onSubmit();
@@ -124,6 +133,6 @@ export default class OrganizationInformationSection extends Component {
     this.form.externalId = this.args.organization.externalId;
     this.form.provinceCode = this.args.organization.provinceCode;
     this.form.email = this.args.organization.email;
-
+    this.form.canCollectProfiles = this.args.organization.canCollectProfiles;
   }
 }

--- a/admin/app/styles/authenticated/organizations/get.scss
+++ b/admin/app/styles/authenticated/organizations/get.scss
@@ -48,6 +48,17 @@
 
     .organization__edit-form {
       width: 500px;
+
+      .organization-edit-form__checkbox {
+        display: flex;
+        align-items: center;
+
+        & > input[type=checkbox] {
+          margin: 0 8px;
+          width: 16px;
+          height: 16px;
+        }
+      }
     }
   }
 

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -16,7 +16,7 @@ module('Acceptance | organization information management', function(hooks) {
 
     test('should edit organization\'s name, externalId, provinceCode and email', async function(assert) {
       // given
-      const organization = this.server.create('organization', { name: 'oldOrganizationName', externalId: 'oldOrganizationExternalId', provinceCode: 'oldProvinceCode' });
+      const organization = this.server.create('organization', { name: 'oldOrganizationName', externalId: 'oldOrganizationExternalId', provinceCode: 'oldProvinceCode', canCollectProfiles: true });
       await visit(`/organizations/${organization.id}`);
       await click('button[aria-label="Editer"]');
 

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -48,7 +48,7 @@ module('Integration | Component | organization-information-section', function(ho
     let organization;
 
     hooks.beforeEach(function() {
-      organization = EmberObject.create({ id: 1, name: 'Organization SCO', externalId: 'VELIT', provinceCode: 'h50', email: 'sco.generic.account@example.net' });
+      organization = EmberObject.create({ id: 1, name: 'Organization SCO', externalId: 'VELIT', provinceCode: 'h50', email: 'sco.generic.account@example.net', canCollectProfiles: false });
       this.set('organization', organization);
     });
 
@@ -83,6 +83,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('input#externalId').hasValue(organization.externalId);
       assert.dom('input#provinceCode').hasValue(organization.provinceCode);
       assert.dom('input#email').hasValue(organization.email);
+      assert.dom('input#canCollectProfiles').isNotChecked();
     });
 
     test('it should show error message if organization\'s name is empty', async function(assert) {
@@ -176,6 +177,7 @@ module('Integration | Component | organization-information-section', function(ho
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', 'new provinceCode');
+      await click('input#canCollectProfiles');
 
       // when
       await click('button[aria-label=\'Annuler\'');
@@ -184,6 +186,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('.organization__name').hasText(organization.name);
       assert.dom('.organization__externalId').hasText(organization.externalId);
       assert.dom('.organization__provinceCode').hasText(organization.provinceCode);
+      assert.dom('.organization__canCollectProfiles').hasText('Non');
     });
 
     test('it should submit the form if there is no error', async function(assert) {
@@ -194,6 +197,7 @@ module('Integration | Component | organization-information-section', function(ho
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', '  ');
+      await click('input#canCollectProfiles');
 
       // when
       await click('button[aria-label=\'Enregistrer\'');
@@ -202,6 +206,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('.organization__name').hasText('new name');
       assert.dom('.organization__externalId').hasText('new externalId');
       assert.dom('.organization__provinceCode').doesNotExist();
+      assert.dom('.organization__canCollectProfiles').hasText('Oui');
     });
   });
 

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -45,9 +45,10 @@ module.exports = {
       'external-id': externalId,
       'province-code': provinceCode,
       'is-managing-students': isManagingStudents,
+      'can-collect-profiles': canCollectProfiles,
     } = request.payload.data.attributes;
 
-    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, email })
+    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, canCollectProfiles, email })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -18,7 +18,7 @@ module.exports = async function updateOrganizationInformation({
   organization.email = email;
   organization.externalId = externalId;
   organization.provinceCode = provinceCode;
-  if (isManagingStudents) organization.isManagingStudents = isManagingStudents;
+  organization.isManagingStudents = isManagingStudents;
   organization.canCollectProfiles = canCollectProfiles;
 
   await organizationRepository.update(organization);

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -6,6 +6,7 @@ module.exports = async function updateOrganizationInformation({
   externalId,
   provinceCode,
   isManagingStudents,
+  canCollectProfiles,
   email,
   organizationRepository,
 }) {
@@ -18,6 +19,7 @@ module.exports = async function updateOrganizationInformation({
   organization.externalId = externalId;
   organization.provinceCode = provinceCode;
   if (isManagingStudents) organization.isManagingStudents = isManagingStudents;
+  organization.canCollectProfiles = canCollectProfiles;
 
   await organizationRepository.update(organization);
 

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -66,7 +66,7 @@ module.exports = {
 
   update(organization) {
 
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'email']);
+    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'canCollectProfiles', 'email']);
 
     return new BookshelfOrganization({ id: organization.id })
       .save(organizationRawData, { patch: true })

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -170,7 +170,7 @@ describe('Acceptance | Application | organization-controller', () => {
     let organization;
 
     beforeEach(async () => {
-      organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization({ canCollectProfiles: false });
       await databaseBuilder.commit();
       payload = {
         data: {
@@ -180,6 +180,7 @@ describe('Acceptance | Application | organization-controller', () => {
             'external-id': '0446758F',
             'province-code': '044',
             'email': 'sco.generic.newaccount@example.net',
+            'can-collect-profiles': 'true',
           },
         },
       };
@@ -199,13 +200,14 @@ describe('Acceptance | Application | organization-controller', () => {
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should create and return the new organization', async () => {
+    it('should return the updated organization', async () => {
       // when
       const response = await server.inject(options);
 
       // then
       expect(response.result.data.attributes['external-id']).to.equal('0446758F');
       expect(response.result.data.attributes['province-code']).to.equal('044');
+      expect(response.result.data.attributes['can-collect-profiles']).to.equal('true');
       expect(parseInt(response.result.data.id)).to.equal(organization.id);
     });
 

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -89,6 +89,7 @@ describe('Integration | Repository | Organization', function() {
       organization.externalId = '999Z527F';
       organization.provinceCode = '999';
       organization.isManagingStudents = true;
+      organization.canCollectProfiles = true;
 
       // when
       const organizationSaved = await organizationRepository.update(organization);
@@ -101,6 +102,7 @@ describe('Integration | Repository | Organization', function() {
       expect(organizationSaved.externalId).to.equal(organization.externalId);
       expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
       expect(organizationSaved.isManagingStudents).to.equal(organization.isManagingStudents);
+      expect(organizationSaved.canCollectProfiles).to.equal(organization.canCollectProfiles);
     });
   });
 

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -15,6 +15,7 @@ describe('Unit | UseCase | update-organization-information', () => {
       externalId: 'extId',
       provinceCode: '666',
       isManagingStudents: false,
+      canCollectProfiles: true,
       email: null,
     });
     organizationRepository = {
@@ -175,6 +176,18 @@ describe('Unit | UseCase | update-organization-information', () => {
       expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
       expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
       expect(resultOrganization.isManagingStudents).to.equal(isManagingStudents);
+    });
+
+    it('should allow to update the organization canCollectProfiles (only) if modified', async () => {
+      // when
+      await updateOrganizationInformation({
+        id: originalOrganization.id,
+        canCollectProfiles: false,
+        organizationRepository,
+      });
+
+      // then
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, canCollectProfiles: false });
     });
 
     it('should allow to update the organization email', async () => {

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -14,73 +14,61 @@ describe('Unit | UseCase | update-organization-information', () => {
       logoUrl: 'http://old.logo.url',
       externalId: 'extId',
       provinceCode: '666',
-      isManagingStudents: false,
+      isManagingStudents: true,
       canCollectProfiles: true,
       email: null,
     });
     organizationRepository = {
       get: sinon.stub().resolves(originalOrganization),
-      update: sinon.stub().callsFake((modifiedOrganization) => modifiedOrganization),
+      update: sinon.stub(),
     };
   });
 
   context('when organization exists', () => {
 
-    it('should allow to update the organization name (only) if modified', () => {
+    it('should allow to update the organization name (only) if modified', async () => {
       // given
       const newName = 'New name';
 
       // when
-      const promise = updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         name: newName,
         organizationRepository,
       });
 
       // then
-      return promise.then((resultOrganization) => {
-        expect(resultOrganization.name).to.equal(newName);
-        expect(resultOrganization.type).to.equal(originalOrganization.type);
-        expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      });
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, name: newName });
     });
 
-    it('should allow to update the organization type (only) if modified', () => {
+    it('should allow to update the organization type (only) if modified', async () => {
       // given
       const newType = 'PRO';
 
       // when
-      const promise = updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         type: newType,
         organizationRepository,
       });
 
       // then
-      return promise.then((resultOrganization) => {
-        expect(resultOrganization.name).to.equal(originalOrganization.name);
-        expect(resultOrganization.type).to.equal(newType);
-        expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      });
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, type: newType });
     });
 
-    it('should allow to update the organization logo URL (only) if modified', () => {
+    it('should allow to update the organization logo URL (only) if modified', async () => {
       // given
       const newLogoUrl = 'http://new.logo.url';
 
       // when
-      const promise = updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         logoUrl: newLogoUrl,
         organizationRepository,
       });
 
       // then
-      return promise.then((resultOrganization) => {
-        expect(resultOrganization.name).to.equal(originalOrganization.name);
-        expect(resultOrganization.type).to.equal(originalOrganization.type);
-        expect(resultOrganization.logoUrl).to.equal(newLogoUrl);
-      });
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, logoUrl: newLogoUrl });
     });
 
     it('should allow to update the organization external id (only) if modified', async () => {
@@ -88,18 +76,14 @@ describe('Unit | UseCase | update-organization-information', () => {
       const externalId = '9752145V';
 
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         externalId,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.equal(externalId);
-      expect(resultOrganization.provinceCode).to.equal(originalOrganization.provinceCode);
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, externalId });
     });
 
     it('should allow to update the organization external id with null value', async () => {
@@ -107,18 +91,14 @@ describe('Unit | UseCase | update-organization-information', () => {
       const externalId = null;
 
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         externalId,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.be.null;
-      expect(resultOrganization.provinceCode).to.equal(originalOrganization.provinceCode);
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, externalId });
     });
 
     it('should allow to update the organization province code (only) if modified', async () => {
@@ -126,18 +106,14 @@ describe('Unit | UseCase | update-organization-information', () => {
       const provinceCode = '975';
 
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         provinceCode,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
-      expect(resultOrganization.provinceCode).to.equal(provinceCode);
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, provinceCode });
     });
 
     it('should allow to update the organization province code with null value', async () => {
@@ -145,37 +121,26 @@ describe('Unit | UseCase | update-organization-information', () => {
       const provinceCode = null;
 
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         provinceCode,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
-      expect(resultOrganization.provinceCode).to.be.null;
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, provinceCode });
     });
 
     it('should allow to update the organization isManagingStudents (only) if modified', async () => {
-      // given
-      const isManagingStudents = true;
-
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
-        isManagingStudents,
+        isManagingStudents: false,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
-      expect(resultOrganization.isManagingStudents).to.equal(isManagingStudents);
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, isManagingStudents: false });
     });
 
     it('should allow to update the organization canCollectProfiles (only) if modified', async () => {
@@ -195,21 +160,15 @@ describe('Unit | UseCase | update-organization-information', () => {
       const newEmail = 'sco.generic.newaccount@example.net';
 
       // when
-      const resultOrganization = await updateOrganizationInformation({
+      await updateOrganizationInformation({
         id: originalOrganization.id,
         email: newEmail,
         organizationRepository,
       });
 
       // then
-      expect(resultOrganization.name).to.equal(originalOrganization.name);
-      expect(resultOrganization.type).to.equal(originalOrganization.type);
-      expect(resultOrganization.logoUrl).to.equal(originalOrganization.logoUrl);
-      expect(resultOrganization.externalId).to.equal(originalOrganization.externalId);
-      expect(resultOrganization.isManagingStudents).to.equal(originalOrganization.isManagingStudents);
-      expect(resultOrganization.email).to.equal(newEmail);
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, email: newEmail });
     });
-
   });
 
   context('when an error occurred', () => {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement pour permettre à une organisation de faire des campagnes de collecte de profils, les prescripteurs doivent faire une demande auprès du métier, qui eux derrière font une demande auprès de l'équipe prescription.

## :robot: Solution
Permettre la modification de l'accès ou non à la fonctionnalité de collecte de profils depuis Pix Admin.

## :rainbow: Remarques
Petit quick win déchargeant quelque peu la team prescription.

## :100: Pour tester
Aller sur Pix Admin, choisir une organisation, cliquer sur "modifier" puis changer "Collecte de profils" et valider. Vérifier que cela a bien été pris en compte.