### PR TITLE
[FEATURE] Gérer l'invalidation du jeton d'identification d'un utilisateur externe (PIX-1252).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -196,6 +196,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.PasswordNotMatching) {
     return new HttpErrors.UnauthorizedError(error.message);
   }
+  if (error instanceof DomainErrors.InvalidExternalUserTokenError) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.InvalidTemporaryKeyError) {
     return new HttpErrors.UnauthorizedError(error.message);
   }

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -1,5 +1,5 @@
 const jsonwebtoken = require('jsonwebtoken');
-const { InvalidTemporaryKeyError } = require('../../domain/errors');
+const { InvalidTemporaryKeyError, InvalidExternalUserTokenError } = require('../../domain/errors');
 const settings = require('../../config');
 
 function createAccessTokenFromUser(user, source) {
@@ -66,7 +66,12 @@ function extractUserIdForCampaignResults(token) {
 }
 
 async function extractExternalUserFromIdToken(token) {
-  const externalUser = await decodeIfValid(token);
+  const externalUser = await getDecodedToken(token);
+
+  if (!externalUser) {
+    throw new InvalidExternalUserTokenError('Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.');
+  }
+
   return {
     firstName: externalUser['first_name'],
     lastName: externalUser['last_name'],

--- a/api/lib/domain/usecases/update-user-samlId.js
+++ b/api/lib/domain/usecases/update-user-samlId.js
@@ -8,7 +8,7 @@ module.exports = async function updateUserSamlId({
 }) {
   const samlId = tokenService.extractSamlId(externalUserToken);
   if (!samlId) {
-    throw new InvalidExternalUserTokenError();
+    throw new InvalidExternalUserTokenError('Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.');
   }
 
   const foundUserBySamlId = await userRepository.getBySamlId(samlId);

--- a/api/tests/acceptance/application/users/users-controller-update-user-samlid_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update-user-samlid_test.js
@@ -86,9 +86,9 @@ describe('Acceptance | Controller | users-controller-update-user-samlid', () => 
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should respond with a 400 if externalUserToken is invalid', async () => {
+    it('should respond with a 401 if externalUserToken is invalid', async () => {
       // given
-      const expectedErrorMessage = 'L’idToken de l’utilisateur externe est invalide.';
+      const expectedErrorMessage = 'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.';
       options.payload.data.attributes = {
         'external-user-token': 'ABCD',
       };
@@ -97,7 +97,7 @@ describe('Acceptance | Controller | users-controller-update-user-samlid', () => 
       const response = await server.inject(options);
 
       // then
-      expect(response.statusCode).to.equal(400);
+      expect(response.statusCode).to.equal(401);
       expect(response.result.errors[0].detail).to.equal(expectedErrorMessage);
     });
 

--- a/api/tests/integration/application/users/user-controller_test.js
+++ b/api/tests/integration/application/users/user-controller_test.js
@@ -162,16 +162,16 @@ describe('Integration | Application | Users | user-controller', () => {
         expect(response.result.errors[0].detail).to.equal('"data.attributes.external-user-token" is required');
       });
 
-      it('should return a 400 HTTP response when the IdToken is invalid', async () => {
+      it('should return a 401 HTTP response when the IdToken is invalid', async () => {
         // given
-        const expectedMessageError = 'L’idToken de l’utilisateur externe est invalide.';
-        usecases.updateUserSamlId.rejects(new InvalidExternalUserTokenError());
+        const expectedMessageError = 'Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.';
+        usecases.updateUserSamlId.rejects(new InvalidExternalUserTokenError(expectedMessageError));
 
         // when
         const response = await httpTestServer.request(method, url, payload);
 
         // then
-        expect(response.statusCode).to.equal(400);
+        expect(response.statusCode).to.equal(401);
         expect(response.result.errors[0].detail).to.equal(expectedMessageError);
       });
     });

--- a/api/tests/integration/domain/usecases/update-user-samlId_test.js
+++ b/api/tests/integration/domain/usecases/update-user-samlId_test.js
@@ -57,7 +57,7 @@ describe('Integration | UseCases | update-user-samlId', () => {
 
       // then
       expect(error).to.be.an.instanceof(InvalidExternalUserTokenError);
-      expect(error.message).to.equal('L’idToken de l’utilisateur externe est invalide.');
+      expect(error.message).to.equal('Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.');
     });
   });
 

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -4,7 +4,7 @@ const jsonwebtoken = require('jsonwebtoken');
 const { catchErr, expect } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/User');
-const { InvalidTemporaryKeyError } = require('../../../../lib/domain/errors');
+const { InvalidTemporaryKeyError, InvalidExternalUserTokenError } = require('../../../../lib/domain/errors');
 const settings = require('../../../../lib/config');
 
 const tokenService = require('../../../../lib/domain/services/token-service');
@@ -54,13 +54,15 @@ describe('Unit | Domain | Service | Token Service', () => {
       expect(result).to.deep.equal(externalUser);
     });
 
-    it('should throw an InvalidTemporaryKeyError if the accessToken is invalid', async () => {
+    it('should throw an InvalidExternalUserTokenError if the idToken is invalid', async () => {
       // given
-      const accessToken = 'WRONG_DATA';
+      const idToken = 'WRONG_DATA';
 
       // when
-      const error = await catchErr(tokenService.extractExternalUserFromIdToken)(accessToken);
-      expect(error).to.be.an.instanceof(InvalidTemporaryKeyError);
+      const error = await catchErr(tokenService.extractExternalUserFromIdToken)(idToken);
+      expect(error).to.be.an.instanceof(InvalidExternalUserTokenError);
+      expect(error.message).to.be.equal('Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.');
+
     });
 
   });

--- a/api/tests/unit/domain/usecases/update-user-samlId_test.js
+++ b/api/tests/unit/domain/usecases/update-user-samlId_test.js
@@ -71,7 +71,7 @@ describe('Unit | UseCase | update-user-samlId', () => {
 
       // then
       expect(error).to.be.an.instanceof(InvalidExternalUserTokenError);
-      expect(error.message).to.equal('L’idToken de l’utilisateur externe est invalide.');
+      expect(error.message).to.equal('Une erreur est survenue. Veuillez réessayer de vous connecter depuis le médiacentre.');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Quand le jeton d'identification d'un utilisateur externe est invalide (expiré, altéré),
et qu'il essaye de se réconcilier, on lui affiche le message de l'erreur suivant: 
_Demande de réinitialisation invalide_

<image src="https://user-images.githubusercontent.com/10045497/93366184-15c9be00-f84b-11ea-90f8-7a055648ab77.png" width="500" />

## :robot: Solution
* Ne pas utiliser la méthode decodeIfValid qui renvoie une erreur InvalidTemporaryKey.
* Lever une exception InvalidExternalUserTokenError si le jeton d'identification est invalide.
* En cas d'invalidité du jeton, afficher le message suivant : `Une erreur est survenue. Veuillez réessayer de vous connecter`.

## :rainbow: Remarques
Ceci est un début de refacto de cette partie de gestion de jeton.
Le refacto complet sera dans le ticket PIX-1283.

## :100: Pour tester
Se connecter via un jeton expiré ou invalide depuis le GAR depuis cette URL:
* [RA](https://app-pr1887.review.pix.fr/campagnes?externalUser=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiRmlyc3QiLCJsYXN0X25hbWUiOiJMYXN0Iiwic2FtbF9pZCI6IlNhbWxJZCIsImlhdCI6MTYwMDI3Mzc2MiwiZXhwIjoxNjAwMjczNzcyfQ.9dlD_pZdpxqUvjkI5riYf2rWGDlLnnYykrKag9xQXdI)
* [local](http://localhost:4200/campagnes?externalUser=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiRmlyc3QiLCJsYXN0X25hbWUiOiJMYXN0Iiwic2FtbF9pZCI6IlNhbWxJZCIsImlhdCI6MTYwMDI3Mzc2MiwiZXhwIjoxNjAwMjczNzcyfQ.9dlD_pZdpxqUvjkI5riYf2rWGDlLnnYykrKag9xQXdI)

Saisir le code campaign `RESTRICTD` puis continuer.
Saisir la date de naissance `10-10-2010`

Vérifier qu'on a le message suivant : `Une erreur est survenue. Veuillez réessayer de vous connecter.`
Vérifier que le code de retour de l'api est un 401
