### PR TITLE
[FEATURE] Ajout d'une couleur pour le status de la certification Cléa (PIX-657)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -7,7 +7,6 @@ import { schedule } from '@ember/runloop';
 import { cloneDeep } from 'lodash';
 import { tracked } from '@glimmer/tracking';
 import _ from 'lodash';
-import { ACQUIRED, REJECTED } from '../../../../models/certification';
 
 export default class CertificationInformationsController extends Controller {
 
@@ -33,14 +32,13 @@ export default class CertificationInformationsController extends Controller {
     return this.certification.status !== 'missing-assessment';
   }
 
-  @computed('certification.cleaCertificationStatus')
+  @computed('certification.{isCleaCertificationIsAcquired,isCleaCertificationIsRejected}')
   get cleaStatusClass() {
-    const cleaStatus = this.certification.cleaCertificationStatus;
     const cleaClass = 'certification-informations__clea--';
-    if (cleaStatus === ACQUIRED) {
+    if (this.certification.isCleaCertificationIsAcquired) {
       return `${cleaClass}acquired`;
     }
-    if (cleaStatus === REJECTED) {
+    if (this.certification.isCleaCertificationIsRejected) {
       return `${cleaClass}rejected`;
     }
     return '';

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -7,6 +7,7 @@ import { schedule } from '@ember/runloop';
 import { cloneDeep } from 'lodash';
 import { tracked } from '@glimmer/tracking';
 import _ from 'lodash';
+import { ACQUIRED, REJECTED } from '../../../../models/certification';
 
 export default class CertificationInformationsController extends Controller {
 
@@ -30,6 +31,19 @@ export default class CertificationInformationsController extends Controller {
   @computed('certification.status')
   get isValid() {
     return this.certification.status !== 'missing-assessment';
+  }
+
+  @computed('certification.cleaCertificationStatus')
+  get cleaStatusClass() {
+    const cleaStatus = this.certification.cleaCertificationStatus;
+    const cleaClass = 'certification-informations__clea--';
+    if (cleaStatus === ACQUIRED) {
+      return `${cleaClass}acquired`;
+    }
+    if (cleaStatus === REJECTED) {
+      return `${cleaClass}rejected`;
+    }
+    return '';
   }
 
   @action

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -78,4 +78,14 @@ export default class Certification extends Model {
   get displayCleaCertificationStatus() {
     return partnerCertificationStatusToDisplayName[this.cleaCertificationStatus];
   }
+
+  @computed('cleaCertificationStatus')
+  get isCleaCertificationIsAcquired() {
+    return this.cleaCertificationStatus === ACQUIRED;
+  }
+
+  @computed('cleaCertificationStatus')
+  get isCleaCertificationIsRejected() {
+    return this.cleaCertificationStatus === REJECTED;
+  }
 }

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -12,4 +12,13 @@
   &__published-float {
     float: right;
   }
+
+  &__clea--acquired .certification-info-value {
+    color: $success;
+    font-weight: bold;
+  }
+  &__clea--rejected .certification-info-value {
+    color: $error;
+    font-weight: bold;
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -14,7 +14,7 @@
             <CertificationInfoField @value={{this.certification.completionDate}} @edition={{false}} @label="Terminée le :" />
             <CertificationInfoField @value={{this.certification.publishedText}} @edition={{false}} @label="Publiée :" />
             <CertificationInfoField @value={{this.certification.isV2CertificationText}} @edition={{false}} @label="Certification v2 :" />
-            <CertificationInfoField @value={{this.certification.displayCleaCertificationStatus}} @edition={{false}} @label="Certification CléA numérique :" />
+            <CertificationInfoField @value={{this.certification.displayCleaCertificationStatus}} @edition={{false}} @label="Certification CléA numérique :" @class={{this.cleaStatusClass}} />
           </div>
         </div>
       </div>

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -53,6 +53,24 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
+  module('#cleaStatusClass', () => {
+
+    test('it should return acquired class', async function(assert) {
+      controller.certification = EmberObject.create({ cleaCertificationStatus: 'acquired' });
+      assert.equal(controller.cleaStatusClass, 'certification-informations__clea--acquired');
+    });
+
+    test('it should return rejected class', async function(assert) {
+      controller.certification = EmberObject.create({ cleaCertificationStatus: 'rejected' });
+      assert.equal(controller.cleaStatusClass, 'certification-informations__clea--rejected');
+    });
+
+    test('it should return empty class', async function(assert) {
+      controller.certification = EmberObject.create({ cleaCertificationStatus: undefined });
+      assert.equal(controller.cleaStatusClass, '');
+    });
+  });
+
   module('#onUpdateScore', () => {
 
     module('when there is a given score', function() {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -56,17 +56,20 @@ module('Unit | Controller | authenticated/certifications/certification/informati
   module('#cleaStatusClass', () => {
 
     test('it should return acquired class', async function(assert) {
-      controller.certification = EmberObject.create({ cleaCertificationStatus: 'acquired' });
+      controller.certification = EmberObject.create({ isCleaCertificationIsAcquired: true });
       assert.equal(controller.cleaStatusClass, 'certification-informations__clea--acquired');
     });
 
     test('it should return rejected class', async function(assert) {
-      controller.certification = EmberObject.create({ cleaCertificationStatus: 'rejected' });
+      controller.certification = EmberObject.create({ isCleaCertificationIsRejected: true });
       assert.equal(controller.cleaStatusClass, 'certification-informations__clea--rejected');
     });
 
     test('it should return empty class', async function(assert) {
-      controller.certification = EmberObject.create({ cleaCertificationStatus: undefined });
+      controller.certification = EmberObject.create({
+        isCleaCertificationIsAcquired: false,
+        isCleaCertificationIsRejected: false,
+      });
       assert.equal(controller.cleaStatusClass, '');
     });
   });

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -1,14 +1,72 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import { ACQUIRED, REJECTED, NOT_PASSED } from 'pix-admin/models/certification';
 
 module('Unit | Model | certification', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
+  let store;
+
+  hooks.beforeEach(async function() {
+    store = this.owner.lookup('service:store');
+  });
+
   test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
     const model = run(() => store.createRecord('certification', {}));
     assert.ok(model);
   });
+
+  module('#isCleaCertificationIsAcquired', function() {
+
+    const cleaStatusesAndExpectedResult = new Map([
+      [ACQUIRED, true],
+      [REJECTED, false],
+      [NOT_PASSED, false],
+    ]);
+    cleaStatusesAndExpectedResult.forEach((expectedResult, cleaStatus) => {
+      module(`when cleaCertificationStatus is ${cleaStatus}`, function() {
+
+        test(`isCleaCertificationIsAcquired should be ${expectedResult}`, function(assert) {
+          // given
+          const certification = run(() => store.createRecord('certification', {
+            cleaCertificationStatus: cleaStatus,
+          }));
+
+          // when
+          const result = certification.isCleaCertificationIsAcquired;
+
+          // then
+          assert.equal(result, expectedResult);
+        });
+      });
+    });
+  });
+
+  module('#isCleaCertificationIsRejected', function() {
+
+    const cleaStatusesAndExpectedResult = new Map([
+      [ACQUIRED, false],
+      [REJECTED, true],
+      [NOT_PASSED, false],
+    ]);
+    cleaStatusesAndExpectedResult.forEach((expectedResult, cleaStatus) => {
+      module(`when cleaCertificationStatus is ${cleaStatus}`, function() {
+
+        test(`isCleaCertificationIsRejected should be ${expectedResult}`, function(assert) {
+          // given
+          const certification = run(() => store.createRecord('certification', {
+            cleaCertificationStatus: cleaStatus,
+          }));
+  
+          // when
+          const result = certification.isCleaCertificationIsRejected;
+  
+          // then
+          assert.equal(result, expectedResult);
+        });
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
L’info de savoir si un candidat a passé et obtenu ou échoué sa certif CléA numérique est maintenant visible sur la page de détails d’une certif. Dans un souci de facilité de lecture de cette information, nous souhaitons changer le style en fonction de la valeur affichée.

## :robot: Solution
Appliquer le style suivant en fonction de la valeur affichée :
- validée : en vert et bold
- rejetée : en rouge et bold
- non testée : sans style

## :rainbow: Remarques
Des nouvelles seeds vont être crée pour avoir 2 certif qui ont passées le Cléa (une acquise et l'autre rejetée) dans une autre PR.

## :100: Pour tester
Rajouter une certif Cléa réussie à échouée à 2 certif.
Soit rajouter dans la table 'partner-certifications' les lignes suivantes : 
<img width="539" alt="image" src="https://user-images.githubusercontent.com/38167520/93596195-3ca60280-f9b9-11ea-8636-574b47705910.png">
- Aller sur PixAdmin, dans l'onglet 'Certifications' chercher les id ci-dessus (104117, 104166) + une autre certif au hasard. Constater que le status de la première s'affiche en vert, la seconde en rouge, la troisième sans couleur. 
<img width="539" alt="image" src="https://user-images.githubusercontent.com/38167520/93596447-a0c8c680-f9b9-11ea-9948-476f2a47de19.png">


