### PR TITLE
[FEATURE] Ajouter la certif CléA sur pix admin (PIX-656)

### DIFF
--- a/admin/app/components/certification-list.js
+++ b/admin/app/components/certification-list.js
@@ -22,6 +22,10 @@ export default class CertificationList extends Component {
       title: 'Statut',
     },
     {
+      propertyName: 'cleaStatus',
+      title: 'Certification CléA numérique',
+    },
+    {
       propertyName: 'pixScore',
       title: 'Score',
     },

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -1,6 +1,16 @@
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 
+const ACQUIRED = 'acquired';
+const REJECTED = 'rejected';
+const NOT_PASSED = 'not_passed';
+
+const partnerCertificationStatusToDisplayName = {
+  [ACQUIRED]: 'Validée',
+  [REJECTED]: 'Rejetée',
+  [NOT_PASSED]: 'Non testée',
+};
+
 export default class JuryCertificationSummary extends Model {
 
   @attr() firstName;
@@ -12,6 +22,7 @@ export default class JuryCertificationSummary extends Model {
   @attr() isPublished;
   @attr() examinerComment;
   @attr() hasSeenEndTestScreen;
+  @attr() cleaCertificationStatus;
 
   @computed('createdAt')
   get creationDate() {
@@ -21,5 +32,10 @@ export default class JuryCertificationSummary extends Model {
   @computed('completedAt')
   get completionDate() {
     return (new Date(this.completedAt)).toLocaleString('fr-FR');
+  }
+
+  @computed('cleaCertificationStatus')
+  get cleaStatus() {
+    return partnerCertificationStatusToDisplayName[this.cleaCertificationStatus];
   }
 }

--- a/api/db/seeds/data/certification/certification-courses-builder.js
+++ b/api/db/seeds/data/certification/certification-courses-builder.js
@@ -26,6 +26,8 @@ const ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID = 105;
 const ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID = 106;
 const ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID = 107;
 const ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID = 108;
+const CERTIFICATION_COURSE_SUCCESS_ID = 200;
+const CERTIFICATION_COURSE_FAILURE_ID = 403;
 
 function certificationCoursesBuilder({ databaseBuilder }) {
   // Each certification tests present the same questions
@@ -37,17 +39,17 @@ function certificationCoursesBuilder({ databaseBuilder }) {
     { userId: CERTIF_SUCCESS_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, examinerComment: 'A regardé son téléphone pendant le test', hasSeenEndTestScreen: true, isPublished: false, verificationCode: null },
     { userId: CERTIF_FAILURE_USER_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, examinerComment: 'Son ordinateur a explosé', hasSeenEndTestScreen: false, isPublished: false, verificationCode: null },
     { userId: CERTIF_REGULAR_USER5_ID, sessionId: PROBLEMS_FINALIZED_SESSION_ID, assessmentId: ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID, candidateData: CANDIDATE_DATA_STARTED, examinerComment: 'Elle a pas finis sa certif', hasSeenEndTestScreen: false, isPublished: false, verificationCode: null  },
-    { userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null },
-    { userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null },
+    { id: CERTIFICATION_COURSE_SUCCESS_ID, userId: CERTIF_SUCCESS_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_SUCCESS, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null },
+    { id: CERTIFICATION_COURSE_FAILURE_ID, userId: CERTIF_FAILURE_USER_ID, sessionId: PUBLISHED_SESSION_ID, assessmentId: ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID, candidateData: CANDIDATE_DATA_FAILURE, hasSeenEndTestScreen: true, isPublished: true, verificationCode: null },
   ], (certificationCourseData) => {
     _buildCertificationCourse(databaseBuilder, certificationCourseData);
   });
 }
 
-function _buildCertificationCourse(databaseBuilder, { assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished, verificationCode }) {
+function _buildCertificationCourse(databaseBuilder, { id, assessmentId, userId, sessionId, candidateData, examinerComment, hasSeenEndTestScreen, isPublished, verificationCode }) {
   const createdAt = new Date('2020-01-31T00:00:00Z');
   const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-    ...candidateData, createdAt, isPublished, isV2Certification: true, examinerComment, hasSeenEndTestScreen, sessionId, userId, verificationCode,
+    ...candidateData, id,  createdAt, isPublished, isV2Certification: true, examinerComment, hasSeenEndTestScreen, sessionId, userId, verificationCode,
   }).id;
   databaseBuilder.factory.buildAssessment({
     id: assessmentId, certificationCourseId, type: 'CERTIFICATION', state: 'completed', userId, competenceId: null,
@@ -69,4 +71,6 @@ module.exports = {
   ASSESSMENT_STARTED_IN_PROBLEMS_FINALIZED_SESSION_ID,
   ASSESSMENT_SUCCESS_PUBLISHED_SESSION_ID,
   ASSESSMENT_FAILURE_PUBLISHED_SESSION_ID,
+  CERTIFICATION_COURSE_FAILURE_ID,
+  CERTIFICATION_COURSE_SUCCESS_ID,
 } ;

--- a/api/db/seeds/data/certification/partner-certification-builder.js
+++ b/api/db/seeds/data/certification/partner-certification-builder.js
@@ -1,0 +1,11 @@
+const Badge = require('../../../../lib/domain/models/Badge');
+const { CERTIFICATION_COURSE_SUCCESS_ID, CERTIFICATION_COURSE_FAILURE_ID } = require('./certification-courses-builder');
+
+function partnerCertificationBuilder({ databaseBuilder }) {
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_SUCCESS_ID, acquired: true, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
+  databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: CERTIFICATION_COURSE_FAILURE_ID, acquired: false, partnerKey: Badge.keys.PIX_EMPLOI_CLEA });
+}
+
+module.exports = {
+  partnerCertificationBuilder,
+};

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -10,6 +10,7 @@ const campaignParticipationsBuilder = require('./data/campaign-participations-bu
 const campaignsBuilder = require('./data/campaigns-builder');
 const { certificationCandidatesBuilder } = require('./data/certification/certification-candidates-builder');
 const { badgeAcquisitionBuilder } = require('./data/certification/badge-acquisition-builder');
+const { partnerCertificationBuilder } = require('./data/certification/partner-certification-builder');
 const { certificationCentersBuilder } = require('./data/certification/certification-centers-builder');
 const { certificationCoursesBuilder } = require('./data/certification/certification-courses-builder');
 const certificationScoresBuilder = require('./data/certification/certification-scores-builder');
@@ -59,6 +60,7 @@ exports.seed = (knex) => {
   certificationCoursesBuilder({ databaseBuilder });
   certificationScoresBuilder({ databaseBuilder });
   badgeAcquisitionBuilder({ databaseBuilder });
+  partnerCertificationBuilder({ databaseBuilder });
 
   // Éléments de parcours
   campaignsBuilder({ databaseBuilder });

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -2,6 +2,16 @@ const { status: assessmentResultStatuses } = require('../models/AssessmentResult
 
 const STARTED = 'started';
 
+const ACQUIRED = true;
+const REJECTED = false;
+const NOT_PASSED = null;
+
+const statuses = {
+  [ACQUIRED]: 'acquired',
+  [REJECTED]: 'rejected',
+  [NOT_PASSED]: 'not_passed',
+};
+
 class JuryCertificationSummary {
   constructor({
     id,
@@ -14,6 +24,7 @@ class JuryCertificationSummary {
     isPublished,
     examinerComment,
     hasSeenEndTestScreen,
+    cleaCertificationStatus,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -23,6 +34,7 @@ class JuryCertificationSummary {
       this.status = STARTED;
     }
     this.pixScore = pixScore;
+    this.cleaCertificationStatus = statuses[cleaCertificationStatus];
     this.createdAt = createdAt;
     this.completedAt = completedAt;
     this.isPublished = isPublished;

--- a/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
+++ b/api/lib/infrastructure/repositories/jury-certification-summary-repository.js
@@ -6,12 +6,13 @@ module.exports = {
 
   async findBySessionId(sessionId) {
     const results = await knex.with('certifications_every_assess_results', (qb) => {
-      qb.select('certification-courses.*', 'assessment-results.pixScore', 'assessment-results.status')
+      qb.select('certification-courses.*', 'assessment-results.pixScore', 'assessment-results.status', 'partner-certifications.acquired')
         .select(knex.raw('ROW_NUMBER() OVER (PARTITION BY ?? ORDER BY ?? DESC) AS asr_row_number',
           ['certification-courses.id', 'assessment-results.createdAt']))
         .from('certification-courses')
         .leftJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
         .leftJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+        .leftJoin('partner-certifications', 'partner-certifications.certificationCourseId', 'certification-courses.id')
         .where('certification-courses.sessionId', sessionId);
     })
       .select('*')
@@ -27,5 +28,6 @@ module.exports = {
 function _toDomain(juryCertificationSummaryFromDB) {
   return new JuryCertificationSummary({
     ...juryCertificationSummaryFromDB,
+    cleaCertificationStatus: juryCertificationSummaryFromDB.acquired,
   });
 }

--- a/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-certification-summary-serializer.js
@@ -14,6 +14,7 @@ module.exports = {
         'isPublished',
         'examinerComment',
         'hasSeenEndTestScreen',
+        'cleaCertificationStatus',
       ],
     }).serialize(juryCertificationSummary);
   },

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -57,8 +57,11 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         certif1 = dbf.buildCertificationCourse({ sessionId, lastName: 'AAA' });
         certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
 
+        const badge = dbf.buildBadge();
+
         const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
         dbf.buildAssessment({ certificationCourseId: certif2.id });
+        dbf.buildPartnerCertification({ certificationCourseId: certif1.id, partnerKey: badge.key });
 
         asr1 = dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
 
@@ -70,6 +73,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'is-published': certif1.isPublished,
           'created-at': certif1.createdAt,
           'completed-at': certif1.completedAt,
+          'clea-certification-status': 'acquired',
           'examiner-comment': certif1.examinerComment,
           'has-seen-end-test-screen': certif1.hasSeenEndTestScreen,
         };
@@ -80,6 +84,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
           'pix-score': null,
           'is-published': certif2.isPublished,
           'created-at': certif2.createdAt,
+          'clea-certification-status': 'not_passed',
           'completed-at': certif2.completedAt,
           'examiner-comment': certif2.examinerComment,
           'has-seen-end-test-screen': certif2.hasSeenEndTestScreen,

--- a/api/tests/tooling/database-builder/factory/build-partner-certification.js
+++ b/api/tests/tooling/database-builder/factory/build-partner-certification.js
@@ -3,7 +3,7 @@ const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildPartnerCertification({
   certificationCourseId,
-  partnerKey = faker.lorem.word,
+  partnerKey = faker.lorem.word(),
   acquired = true,
 }) {
   return databaseBuffer.objectsToInsert.push({


### PR DESCRIPTION
## :unicorn: Problème
Il n’est actuellement pas possible pour le pôle de certif de savoir dans Pix admin si un candidat a passé la certif CléA en plus de sa certif Pix. 

## :robot: Solution
Ajouter l’information si un candidat a passé la double certification dans le fichier avant jury

ajouter une colonne “Certification CléA numérique” (valeurs possibles validée / rejetée / non testée) après la colonne “Statut de la certification”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur pix admin, aller sur la session 8, et constater la présence de la colonne "Certification CléA numérique"

![image](https://user-images.githubusercontent.com/37305474/93606999-0e302380-f9c9-11ea-8030-bcabdcbd15db.png)
