### PR TITLE
[CLEANUP] Interdire les textes non traduits dans les templates de pix app

### DIFF
--- a/mon-pix/.template-lintrc.js
+++ b/mon-pix/.template-lintrc.js
@@ -15,5 +15,6 @@ module.exports = {
     'no-triple-curlies': false,
     'no-unused-block-params': false,
     'style-concatenation': false,
-  },
+    'no-bare-strings': ['Pix', '&nbsp;', '&#8226;','.', '*', '1024', '/', '•', '-', '%'],
+  }
 };

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -1,11 +1,11 @@
 <form>
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">Prénom</label>
+    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
     <Input
             @id="firstName"
             @type="text"
             @value={{this.firstName}}
-            placeholder="Prénom"
+            placeholder={{t 'pages.join.fields.firstname.label'}}
             @readonly={{this.isDisabled}}
             @disabled={{this.isDisabled}}
             class={{if this.validation.firstName "input--error"}}
@@ -17,12 +17,12 @@
   </div>
 
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">Nom</label>
+    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.lastname.label'}}</label>
     <Input
             @id="lastName"
             @type="text"
             @value={{this.lastName}}
-            placeholder="Nom"
+            placeholder={{t 'pages.join.fields.lastname.label'}}
             @readonly={{this.isDisabled}}
             @disabled={{this.isDisabled}}
             class={{if this.validation.lastName "input--error"}}
@@ -34,11 +34,11 @@
   </div>
 
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">Date de naissance</label>
+    <label class="join-restricted-campaign__label">{{t 'pages.join.fields.birthdate.label'}}</label>
     <div class="join-restricted-campaign__birthdate">
-      <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder="JJ" class={{if this.validation.dayOfBirth "input--error"}} @focusOut={{ fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth }} />
-      <Input @id="monthOfBirth" @type="text" @value={{this.monthOfBirth}} placeholder="MM" class={{if this.validation.monthOfBirth "input--error"}} @focusOut={{ fn this.triggerInputMonthValidation "monthOfBirth" this.monthOfBirth }} />
-      <Input @id="yearOfBirth" @type="text" @value={{this.yearOfBirth}} placeholder="AAAA" class={{if this.validation.yearOfBirth "input--error"}} @focusOut={{ fn this.triggerInputYearValidation "yearOfBirth" this.yearOfBirth }} />
+      <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder={{t 'pages.join.fields.birthdate.day-format'}} class={{if this.validation.dayOfBirth "input--error"}} @focusOut={{ fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth }} />
+      <Input @id="monthOfBirth" @type="text" @value={{this.monthOfBirth}} placeholder={{t 'pages.join.fields.birthdate.month-format'}} class={{if this.validation.monthOfBirth "input--error"}} @focusOut={{ fn this.triggerInputMonthValidation "monthOfBirth" this.monthOfBirth }} />
+      <Input @id="yearOfBirth" @type="text" @value={{this.yearOfBirth}} placeholder={{t 'pages.join.fields.birthdate.year-format'}} class={{if this.validation.yearOfBirth "input--error"}} @focusOut={{ fn this.triggerInputYearValidation "yearOfBirth" this.yearOfBirth }} />
     </div>
     <div class={{if this.validation.dayOfBirth "join-restricted-campaign__field-error"}} role="alert">
       {{this.validation.dayOfBirth}}
@@ -58,7 +58,7 @@
     <button type="button" disabled class="button button--big join-restricted-campaign__button"><span class="loader-in-button">&nbsp;</span></button>
   {{else}}
     <button type="submit" class="button button--big join-restricted-campaign__button" {{on 'click' this.submit}}>
-      C'est parti !
+      {{t 'pages.join.button'}}
     </button>
   {{/if}}
 </form>
@@ -66,10 +66,10 @@
   <PixModal @containerClass="join-error-modal" @onClose={{action this.closeModal}}>
     <div class="join-error-modal__header">
       <div class="join-error-modal-header__title">
-        <h1 class="join-error-modal-header-title__text">Information de connexion</h1>
+        <h1 class="join-error-modal-header-title__text">{{t 'pages.join.sco.login-information-title'}}</h1>
       </div>
       <div class="join-error-modal-header__close" aria-label={{t "common.actions.close"}} {{on 'click' this.closeModal}}>
-        <img src="/images/icons/icon-croix.svg" alt="Close" class="join-error-modal-header-close__icon">
+        <img src="/images/icons/icon-croix.svg" alt={{t 'common.actions.close'}} class="join-error-modal-header-close__icon">
       </div>
     </div>
 
@@ -78,9 +78,10 @@
     </div>
 
     <div class="join-error-modal__footer">
-      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" aria-label="Quitter" {{on 'click' this.goToHome}}>Quitter</button>
+      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
+          {{t 'common.actions.quit'}}</button>
       {{#if this.displayContinueButton}}
-        <button class="button" type="button" aria-label="Continuer avec mon compte Pix" {{on 'click' this.goToCampaignConnectionForm}}>Continuer avec mon compte Pix</button>
+        <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>{{t 'pages.join.sco.continue-with-pix'}}</button>
       {{/if}}
     </div>
   </PixModal>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -11,11 +11,11 @@ import ENV from 'mon-pix/config/environment';
 import { getJoinErrorsMessageByShortCode } from '../../../../utils/errors-messages';
 
 const ERROR_INPUT_MESSAGE_MAP = {
-  firstName: 'Votre prénom n’est pas renseigné.',
-  lastName: 'Votre nom n’est pas renseigné.',
-  dayOfBirth: 'Votre jour de naissance n’est pas valide.',
-  monthOfBirth: 'Votre mois de naissance n’est pas valide.',
-  yearOfBirth: 'Votre année de naissance n’est pas valide.',
+  firstName: 'pages.join.fields.firstname.error',
+  lastName: 'pages.join.fields.lastname.error',
+  dayOfBirth: 'pages.join.fields.birthdate.day-error',
+  monthOfBirth: 'pages.join.fields.birthdate.month-error',
+  yearOfBirth: 'pages.join.fields.birthdate.year-error',
 };
 const ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS = ['R13', 'R33'];
 
@@ -175,7 +175,7 @@ export default class JoinSco extends Component {
 
   _executeFieldValidation(key, value, isValid) {
     const isInvalidInput = !isValid(value);
-    const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
+    const message = isInvalidInput ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
     this.validation[key] = message;
   }
 
@@ -210,7 +210,7 @@ export default class JoinSco extends Component {
         return this.modalErrorMessage = message;
       }
       if (error.status === '404') {
-        return this.errorMessage = 'Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/> <br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.';
+        return this.errorMessage = this.intl.t('pages.join.sco.error-not-found', { htmlSafe: true });
       }
       return this.errorMessage = error.detail;
     });

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -218,6 +218,6 @@ export default class JoinSco extends Component {
 
   _showErrorMessageByShortCode(meta) {
     const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-    return getJoinErrorsMessageByShortCode(meta) || defaultMessage;
+    return this.intl.t(getJoinErrorsMessageByShortCode(meta), { value: meta.value, htlmSafe:true })  || defaultMessage;
   }
 }

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -1,12 +1,12 @@
 <form>
   <div class="join-restricted-campaign__row">
-    <label class="join-restricted-campaign__label">Numéro étudiant</label>
+    <label class="join-restricted-campaign__label">{{t 'pages.join.sup.fields.student-number.label'}}</label>
     <Input
             @id="studentNumber"
             @type="text"
             @name="studentNumber"
             @value={{this.studentNumber}}
-            placeholder="Numéro étudiant"
+            placeholder={{t 'pages.join.sup.fields.student-number.label'}}
             @disabled={{this.showFurtherInformationForm}}
             @readonly={{this.showFurtherInformationForm}}
             class={{if this.validation.studentNumber "input--error"}}
@@ -17,13 +17,13 @@
     </div>
     {{#if this.showFurtherInformationForm}}
       <button type="button" class="link join-restricted-campaign__back-button" {{on 'click' this.hideFurtherInformationForm}}>
-        Modifier le numéro étudiant
+        {{t 'pages.join.sup.fields.student-number.modify'}}
       </button>
     {{/if}}
 
     <label for="no-student-number">
       <Input @type="checkbox" @id="no-student-number" class="join-restricted-campaign__no-student-number" @checked={{this.noStudentNumber}} {{on 'click' this.toggleNoStudentNumber}}/>
-      Je n’ai pas de numéro étudiant
+      {{t 'pages.join.sup.fields.student-number.not-existing'}}
     </label>
   </div>
 
@@ -48,7 +48,7 @@
     {{#if this.isLoading}}
       <span class="loader-in-button">&nbsp;</span>
     {{else}}
-      C'est parti !
+      {{t 'pages.join.button'}}
     {{/if}}
   </button>
 

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.js
@@ -5,12 +5,12 @@ import Component from '@glimmer/component';
 import { standardizeNumberInTwoDigitFormat } from 'mon-pix/utils/standardize-number';
 
 const ERROR_INPUT_MESSAGE_MAP = {
-  studentNumber: 'Votre numéro étudiant n’est pas renseigné.',
-  firstName: 'Votre prénom n’est pas renseigné.',
-  lastName: 'Votre nom n’est pas renseigné.',
-  dayOfBirth: 'Votre jour de naissance n’est pas valide.',
-  monthOfBirth: 'Votre mois de naissance n’est pas valide.',
-  yearOfBirth: 'Votre année de naissance n’est pas valide.',
+  studentNumber: 'pages.join.sup.fields.student-number.error',
+  firstName: 'pages.join.fields.firstname.error',
+  lastName: 'pages.join.fields.lastname.error',
+  dayOfBirth: 'pages.join.fields.birthdate.day-error',
+  monthOfBirth: 'pages.join.fields.birthdate.month-error',
+  yearOfBirth: 'pages.join.fields.birthdate.year-error',
 };
 
 const isDayValid = (value) => value > 0 && value <= 31;
@@ -29,6 +29,7 @@ class Validation {
 
 export default class JoinSup extends Component {
   @service store;
+  @service intl;
   @tracked errorMessage;
   @tracked isLoading = false;
   @tracked showFurtherInformationForm = false;
@@ -144,7 +145,7 @@ export default class JoinSup extends Component {
 
   _setErrorMessageForAttemptNextAction(errorResponse) {
     const ERRORS_HANDLED = ['409', '404'];
-    const ERRORS_HANDLED_MESSAGE = 'Veuillez vérifier les informations saisies, ou si vous avez déjà un compte Pix, connectez-vous avec celui-ci.';
+    const ERRORS_HANDLED_MESSAGE = this.intl.t('pages.join.sup.error');
     errorResponse.errors.forEach((error) => {
       if (ERRORS_HANDLED.includes(error.status)) {
         return this.errorMessage = ERRORS_HANDLED_MESSAGE;
@@ -161,7 +162,7 @@ export default class JoinSup extends Component {
 
   _executeFieldValidation(key, value, isValid) {
     const isInvalidInput = !isValid(value);
-    const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
+    const message = isInvalidInput ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
     this.validation[key] = message;
   }
 

--- a/mon-pix/app/components/routes/campaigns/restricted/user-information-form.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/user-information-form.hbs
@@ -1,10 +1,10 @@
 <div class="join-restricted-campaign__row">
-  <label class="join-restricted-campaign__label">Prénom</label>
+  <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
   <Input
     @id="firstName"
     @type="text"
     @value={{@firstName}}
-    placeholder="Prénom"
+    placeholder={{t 'pages.join.fields.firstname.label'}}
     @readonly={{this.isDisabled}}
     @disabled={{this.isDisabled}}
     class={{if @validation.firstName "input--error"}}
@@ -16,12 +16,12 @@
 </div>
 
 <div class="join-restricted-campaign__row">
-  <label class="join-restricted-campaign__label">Nom</label>
+  <label class="join-restricted-campaign__label">{{t 'pages.join.fields.lastname.label'}}</label>
   <Input
     @id="lastName"
     @type="text"
     @value={{@lastName}}
-    placeholder="Nom"
+    placeholder={{t 'pages.join.fields.lastname.label'}}
     @readonly={{this.isDisabled}}
     @disabled={{this.isDisabled}}
     class={{if @validation.lastName "input--error"}}
@@ -33,11 +33,11 @@
 </div>
 
 <div class="join-restricted-campaign__row">
-  <label class="join-restricted-campaign__label">Date de naissance</label>
+  <label class="join-restricted-campaign__label">{{t 'pages.join.fields.birthdate.label'}}</label>
   <div class="join-restricted-campaign__birthdate">
-    <Input @id="dayOfBirth" @type="text" @value={{@dayOfBirth}} placeholder="JJ" class={{if @validation.dayOfBirth "input--error"}} @focusOut={{fn @triggerInputDayValidation "dayOfBirth" @dayOfBirth}} />
-    <Input @id="monthOfBirth" @type="text" @value={{@monthOfBirth}} placeholder="MM" class={{if @validation.monthOfBirth "input--error"}} @focusOut={{fn @triggerInputMonthValidation "monthOfBirth" @monthOfBirth}} />
-    <Input @id="yearOfBirth" @type="text" @value={{@yearOfBirth}} placeholder="AAAA" class={{if @validation.yearOfBirth "input--error"}} @focusOut={{fn @triggerInputYearValidation "yearOfBirth" @yearOfBirth}} />
+    <Input @id="dayOfBirth" @type="text" @value={{@dayOfBirth}} placeholder={{t 'pages.join.fields.birthdate.day-format'}} class={{if @validation.dayOfBirth "input--error"}} @focusOut={{fn @triggerInputDayValidation "dayOfBirth" @dayOfBirth}} />
+    <Input @id="monthOfBirth" @type="text" @value={{@monthOfBirth}} placeholder={{t 'pages.join.fields.birthdate.month-format'}} class={{if @validation.monthOfBirth "input--error"}} @focusOut={{fn @triggerInputMonthValidation "monthOfBirth" @monthOfBirth}} />
+    <Input @id="yearOfBirth" @type="text" @value={{@yearOfBirth}} placeholder={{t 'pages.join.fields.birthdate.year-format'}} class={{if @validation.yearOfBirth "input--error"}} @focusOut={{fn @triggerInputYearValidation "yearOfBirth" @yearOfBirth}} />
   </div>
   <div class={{if @validation.dayOfBirth "join-restricted-campaign__field-error"}} role="alert">
     {{@validation.dayOfBirth}}

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -15,6 +15,7 @@ export default class LoginForm extends Component {
   @inject store;
   @inject router;
   @inject currentUser;
+  @inject intl;
 
   login = null;
   password = null;
@@ -92,9 +93,9 @@ export default class LoginForm extends Component {
   }
 
   _manageErrorsApi(errorsApi) {
-    const defaultErrorMessage = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
-    const errorMessageStatusCode4xx = 'Les données que vous avez soumises ne sont pas au bon format.';
-    const unexpectedUserAccountErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme ';
+    const defaultErrorMessage = this.intl.t('api-error-messages.internal-server-error');
+    const errorMessageStatusCode4xx = this.intl.t('api-error-messages.bad-request-error');
+    const unexpectedUserAccountErrorMessage = this.intl.t('pages.login-or-register.login-form.unexpected-user-account-error');
 
     let errorMessage = defaultErrorMessage;
 

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -189,7 +189,8 @@ export default class RegisterForm extends Component {
 
   _showErrorMessageByShortCode(meta) {
     const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-    return getRegisterErrorsMessageByShortCode(meta) || defaultMessage;
+    return this.intl.t(getRegisterErrorsMessageByShortCode(meta), { value: meta.value, htlmSafe:true })  || defaultMessage;
+
   }
 
   @action

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -16,13 +16,13 @@ import ENV from 'mon-pix/config/environment';
 import { getRegisterErrorsMessageByShortCode } from '../../utils/errors-messages';
 
 const ERROR_INPUT_MESSAGE_MAP = {
-  firstName: 'Votre prénom n’est pas renseigné.',
-  lastName: 'Votre nom n’est pas renseigné.',
-  dayOfBirth: 'Votre jour de naissance n’est pas valide.',
-  monthOfBirth: 'Votre mois de naissance n’est pas valide.',
-  yearOfBirth: 'Votre année de naissance n’est pas valide.',
-  email: 'Votre email n’est pas valide.',
-  password: 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.',
+  firstName: 'pages.login-or-register.register-form.fields.firstname.error',
+  lastName: 'pages.login-or-register.register-form.fields.lastname.error',
+  dayOfBirth: 'pages.login-or-register.register-form.fields.birthdate.day-error',
+  monthOfBirth: 'pages.login-or-register.register-form.fields.birthdate.month-error',
+  yearOfBirth: 'pages.login-or-register.register-form.fields.birthdate.year-error',
+  email: 'pages.login-or-register.register-form.fields.email.error',
+  password: 'pages.login-or-register.register-form.fields.password.error',
 };
 
 const isDayValid = (value) => value > 0 && value <= 31;
@@ -269,7 +269,7 @@ export default class RegisterForm extends Component {
 
   _executeFieldValidation(key, value, isValid) {
     const isInvalidInput = !isValid(value);
-    const message = isInvalidInput ? ERROR_INPUT_MESSAGE_MAP[key] : null;
+    const message = isInvalidInput ? this.intl.t(ERROR_INPUT_MESSAGE_MAP[key]) : null;
     const status =  isInvalidInput ? 'error' : 'success';
     const statusObject = 'validation.' + key + '.status';
     const messageObject = 'validation.' + key + '.message';

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -9,7 +9,7 @@ import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 
-const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
 
 const VALIDATION_MAP = {
   default: {
@@ -43,6 +43,13 @@ export default class UpdateExpiredPasswordForm extends Component {
 
   get homeUrl() {
     return this.url.homeUrl;
+  }
+
+  get validationMessage() {
+    if (this.validation.message) {
+      return this.intl.t(this.validation.message);
+    }
+    return null;
   }
 
   @action

--- a/mon-pix/app/templates/campaigns/restricted/join.hbs
+++ b/mon-pix/app/templates/campaigns/restricted/join.hbs
@@ -1,12 +1,12 @@
-{{page-title "Rejoindre"}}
+{{page-title (t 'pages.join.title')}}
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
   <div
     class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner join-restricted-campaign__container">
     <div class="join-restricted-campaign">
-      <div class="join-restricted-campaign__title">Rejoignez l'organisation {{@model.organizationName}}</div>
-      <div class="join-restricted-campaign__subtitle">Remplissez les informations manquantes</div>
+      <div class="join-restricted-campaign__title">{{t 'pages.join.first-title' organizationName=@model.organizationName}}</div>
+      <div class="join-restricted-campaign__subtitle">{{t 'pages.join.subtitle'}}</div>
       {{#if (eq @model.organizationType "SCO")}}
         <Routes::Campaigns::Restricted::JoinSco @campaignCode={{@model.code}} @onSubmitToCreateAndReconcile={{this.createAndReconcile}} @onSubmitToReconcile={{this.reconcile}} />
       {{else}}

--- a/mon-pix/app/templates/competences/results.hbs
+++ b/mon-pix/app/templates/competences/results.hbs
@@ -25,7 +25,7 @@
               <div class="competence-results-banner__text">
                 <div class="competence-results-banner-text__results">
                   <div class="competence-results-banner-text-results__label">{{t 'pages.competence-result.header.you-have-earned'}}</div>
-                  <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}} pix</div>
+                  <div class="competence-results-banner-text-results__value">{{@model.scorecard.earnedPix}} {{t 'common.pix'}}</div>
                 </div>
               </div>
             </div>

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -27,7 +27,7 @@
                     @id="certificationJoinerDayOfBirth"
                     @input={{action "handleDayInputChange"}}
                     @focus-in={{action "handleInputFocus"}}
-                    aria-label="jour de naissance (JJ)" />
+                    aria-label={{t 'pages.certification-joiner.form.fields.birth-day'}} />
               <div class="certification-joiner__divider"></div>
             <Input @min="1"
                     @max="12"
@@ -36,14 +36,14 @@
                     @id="certificationJoinerMonthOfBirth"
                     @input={{action "handleMonthInputChange"}}
                     @focus-in={{action "handleInputFocus"}}
-                    aria-label="mois de naissance (MM)"/>
+                    aria-label={{t 'pages.certification-joiner.form.fields.birth-month'}}/>
               <div class="certification-joiner__divider"></div>
             <Input @min="1900"
                     @type="number"
                     @value={{this.yearOfBirth}} placeholder="AAAA"
                     @id="certificationJoinerYearOfBirth"
                     @focus-in={{action "handleInputFocus"}}
-                    aria-label="année de naissance (AAAA)"/>
+                    aria-label={{t 'pages.certification-joiner.form.fields.birth-year'}}/>
           </div>
         </div>
       {{#if this.errorMessage}}

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -1,5 +1,5 @@
 <div class="congratulations-banner" >
-  <button aria-label="Fermer" class="icon-button congratulations-banner__icon" {{on 'click' @closeBanner}} type="button">
+  <button aria-label={{t 'common.actions.close'}} class="icon-button congratulations-banner__icon" {{on 'click' @closeBanner}} type="button">
     {{fa-icon 'times'}}
   </button>
   <p class="congratulations-banner__message">{{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}</p>

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -17,7 +17,7 @@
          @disabled={{disabled}} />
     <div class="form-textfield__icon">
       {{#if isPassword}}
-          <button type="button" aria-label="rendre le mot de passe lisible" class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>
+          <button type="button" aria-label={{t 'common.form.visible-password'}} class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>
             {{#if isPasswordVisible}}
                 <div tabindex="-1" onmousedown={{action 'togglePasswordVisibility'}}>{{fa-icon 'eye' class="fa-fw form-textfield-icon-button__eye"}}</div>
             {{else}}

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -1,6 +1,6 @@
 <main class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
+  <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.homepage'}}>
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 
@@ -34,7 +34,7 @@
     </div>
 
     <div class="password-reset-demand-form__home-link">
-      <a href={{this.homeUrl}} class="link" title="Lien vers la page d'accueil de Pix">{{t 'pages.password-reset-demand.actions.back-home'}}</a>
+      <a href={{this.homeUrl}} class="link">{{t 'pages.password-reset-demand.actions.back-home'}}</a>
     </div>
   {{else}}
     <form {{on 'submit' this.savePasswordResetDemand}} class="sign-form__body">

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -1,6 +1,6 @@
 <div class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
+  <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.back-to-homepage'}}>
     <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
   </a>
 

--- a/mon-pix/app/templates/components/routes/login-form.hbs
+++ b/mon-pix/app/templates/components/routes/login-form.hbs
@@ -1,6 +1,6 @@
 <div class="login-form">
   {{#if isErrorMessagePresent}}
-    <div id="login-form-error-message" class="login-form__error-message error-message">L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects</div>
+    <div id="login-form-error-message" class="login-form__error-message error-message">{{t 'pages.login-or-register.login-form.error'}}</div>
   {{/if}}
 
   {{#if hasUpdateUserError}}
@@ -10,7 +10,7 @@
   <form {{action 'authenticate' on='submit'}}>
 
     <div id="login-email-container">
-      <FormTextfield @label="Adresse e-mail ou identifiant"
+      <FormTextfield @label={{t 'pages.login-or-register.login-form.fields.login.label'}}
                      @textfieldName="login"
                      @validationStatus="default"
                      @inputBindingValue={{login}}
@@ -18,7 +18,7 @@
     </div>
 
     <div id="login-password-container">
-      <FormTextfield @label="Mot de passe"
+      <FormTextfield @label={{t 'pages.login-or-register.login-form.fields.password.label'}}
                      @textfieldName="password"
                      @validationStatus="default"
                      @inputBindingValue={{password}}
@@ -29,20 +29,20 @@
       {{#if isLoading}}
         <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button id="submit-connexion" type="submit" class="button button--uppercase">Je me connecte</button>
+        <button id="submit-connexion" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.login-form.button'}}</button>
       {{/if}}
     </div>
 
   </form>
 
   <div class="login-form__forgotten-password help-text">
-    <span>Mot de passe oublié ? Vous avez un compte Pix avec :</span>
+    <span>{{t 'pages.login-or-register.login-form.forgotten-password.instruction'}}</span>
     <ul>
-      <li>Une Adresse e-mail :
-        <LinkTo @id="link_password-reset-demand" @route="password-reset-demand" target="_blank" rel="noopener noreferrer" class="link">Cliquez ici pour le réinitialiser</LinkTo>
+      <li>{{t 'pages.login-or-register.login-form.forgotten-password.email'}}
+        <LinkTo @id="link_password-reset-demand" @route="password-reset-demand" target="_blank" rel="noopener noreferrer" class="link">{{t 'pages.login-or-register.login-form.forgotten-password.reset-link'}}</LinkTo>
       </li>
       <li>
-        Un identifiant : Contactez votre enseignant pour le réinitialiser
+        {{t 'pages.login-or-register.login-form.forgotten-password.other-identity'}}
       </li>
     </ul>
   </div>

--- a/mon-pix/app/templates/components/routes/login-or-register.hbs
+++ b/mon-pix/app/templates/components/routes/login-or-register.hbs
@@ -3,12 +3,14 @@
     <div>
       <img src="/images/pix-logo.svg" alt="Pix" class="login-or-register-panel__logo">
     </div>
-    <span class="login-or-register-panel__invitation">{{@organizationName}} vous invite à rejoindre Pix</span>
+    <span class="login-or-register-panel__invitation">{{t 'pages.login-or-register.invitation' organizationName=@organizationName}}</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">Je m’inscris sur Pix</h1>
+        <h1 class="form-title">{{t 'pages.login-or-register.register-form.title'}}</h1>
         {{#unless @displayRegisterForm}}
-          <button id="register-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">S'inscrire</button>
+          <button id="register-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">
+            {{t 'pages.login-or-register.register-form.button'}}
+          </button>
         {{/unless}}
         <div class={{concat "login-or-register-panel-form__expandable" (if @displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
           {{#if @displayRegisterForm}}
@@ -18,9 +20,9 @@
       </div>
       <div class="login-or-register-panel__divider"></div>
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">J’ai déjà un compte Pix</h1>
+        <h1 class="form-title">{{t 'pages.login-or-register.login-form.title'}}</h1>
         {{#if @displayRegisterForm}}
-          <button id="login-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">Se connecter</button>
+          <button id="login-button" {{action @toggleFormsVisibility}} class="button button--white button--bordered button--uppercase" type="button">{{t 'pages.login-or-register.login-form.button'}}</button>
         {{/if}}
         <div class={{concat "login-or-register-panel-form__expandable" (if (not @displayRegisterForm) " login-or-register-panel-form__expandable--expanded")}}>
           {{#unless @displayRegisterForm}}

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -3,7 +3,7 @@
     <span class="register-form__required-inputs">{{t 'common.form.mandatory-fields' htmlSafe=true}}</span>
 
     <div id="register-firstName-container">
-      <FormTextfield @label="Prénom"
+      <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.firstname.label'}}
                      @textfieldName="firstName"
                      @inputBindingValue={{this.firstName}}
                      @onValidate={{action "triggerInputStringValidation" "firstName" this.firstName}}
@@ -15,7 +15,7 @@
     </div>
 
     <div id="register-lastName-container">
-      <FormTextfield @label="Nom"
+      <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.lastname.label'}}
                      @textfieldName="lastName"
                      @inputBindingValue={{this.lastName}}
                      @onValidate={{action "triggerInputStringValidation" "lastName" this.lastName}}
@@ -27,7 +27,7 @@
     </div>
 
     <div id="register-birthdate-container">
-      <FormTextfieldDate @label="Date de naissance (JJ/MM/AAAA)"
+      <FormTextfieldDate @label={{t 'pages.login-or-register.register-form.fields.birthdate.label'}}
                          @dayTextfieldName="dayOfBirth"
                          @monthTextfieldName="monthOfBirth"
                          @yearTextfieldName="yearOfBirth"
@@ -56,7 +56,7 @@
         {{#if this.isLoading}}
           <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
         {{else}}
-          <button id="submit-search" type="submit" class="button button--uppercase">Je m'inscris</button>
+          <button id="submit-search" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.register-form.button-form'}}</button>
         {{/if}}
       </div>
     {{/unless}}
@@ -67,17 +67,17 @@
 
   <hr>
 
-  <label class="register-form__login-options">Je m'inscris avec :</label>
+  <label class="register-form__login-options">{{t 'pages.login-or-register.register-form.options.text'}}</label>
   <div id="login-mode-container">
-            <PixToggle @valueFirstLabel="Mon identifiant"
-                       @valueSecondLabel="Mon adresse e-mail"
+            <PixToggle @valueFirstLabel={{t 'pages.login-or-register.register-form.options.username'}}
+                       @valueSecondLabel={{t 'pages.login-or-register.register-form.options.email'}}
                        @onToggle={{action "onToggle"}} />
   </div>
 
   <form {{action 'register' on='submit'}} autocomplete="off">
     {{#if this.loginWithUsername}}
         <div id="register-username-container">
-          <FormTextfield @label="Mon identifiant"
+          <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.username.label'}}
                          @textfieldName="username"
                          @inputBindingValue={{this.username}}
                          @onValidate={{action "triggerInputStringValidation" "username" this.username}}
@@ -88,8 +88,8 @@
         </div>
     {{else}}
         <div id="register-email-container">
-          <FormTextfield @label="Adresse e-mail"
-                         @help="(ex: nom@exemple.fr)"
+          <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.email.label'}}
+                         @help={{t 'pages.login-or-register.register-form.fields.email.help'}}
                          @textfieldName="email"
                          @inputBindingValue={{this.email}}
                          @onValidate={{action "triggerInputEmailValidation" "email" this.email}}
@@ -99,8 +99,8 @@
         </div>
     {{/if}}
     <div id="register-password-container">
-      <FormTextfield @label="Mot de passe"
-                     @help="(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)"
+      <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.password.label'}}
+                     @help={{t 'pages.login-or-register.register-form.fields.password.help'}}
                      @textfieldName="password"
                      @inputBindingValue={{this.password}}
                      @onValidate={{action "triggerInputPasswordValidation" "password" this.password}}
@@ -113,7 +113,7 @@
       {{#if this.isLoading}}
         <button type="button" disabled class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button id="submit-registration" type="submit" class="button button--uppercase">Je m'inscris</button>
+        <button id="submit-registration" type="submit" class="button button--uppercase">{{t 'pages.login-or-register.register-form.button-form'}}</button>
       {{/if}}
     </div>
 
@@ -121,7 +121,7 @@
       <span class="icon-button register-form-return-button__icon">
         <FaIcon @icon='arrow-left'></FaIcon>
       </span>
-      Ce n'est pas moi
+      {{t 'pages.login-or-register.register-form.not-me'}}
     </LinkTo>
 
   </form>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -69,7 +69,7 @@
                   <span class="loader-in-button">&nbsp;</span>
                 {{else}}
                   {{t 'pages.competence-details.actions.improve.label'}}
-                  <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}"</div>
+                  <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}</div>
                 {{/if}}
               </button>
               <span class="scorecard-details__improving-text">{{t 'pages.competence-details.actions.improve.improvingText' }}</span>

--- a/mon-pix/app/templates/components/update-expired-password-form.hbs
+++ b/mon-pix/app/templates/components/update-expired-password-form.hbs
@@ -1,15 +1,15 @@
 <div class="update-expired-password-form__container">
 
-    <a href={{this.homeUrl}} class="pix-logo__link" title="Lien vers la page d'accueil de Pix">
+    <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.back-to-homepage'}}>
       <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
     </a>
 
     <div class="update-expired-password-form__header">
-      <h1 class="update-expired-password-form-title">Réinitialiser le mot de passe</h1>
+      <h1 class="update-expired-password-form-title">{{t 'pages.update-expired-password.first-title'}}</h1>
 
       {{#unless this.authenticationHasFailed}}
         <div class="update-expired-password-form-header__instruction update-expired-password-form-subtitle">
-          Choisissez un nouveau mot de passe pour continuer
+          {{t 'pages.update-expired-password.subtitle'}}
         </div>
       {{/unless}}
     </div>
@@ -18,13 +18,13 @@
       <form {{on "submit" this.handleUpdatePasswordAndAuthenticate}} class="update-expired-password-form__body">
 
         <div class="update-expired-password-form-body__input">
-          <FormTextfield @label="Mot de passe"
-                         @help="(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)"
+          <FormTextfield @label={{t 'pages.update-expired-password.fields.label'}}
+                         @help={{t 'pages.update-expired-password.fields.help'}}
                          @textfieldName="password"
                          @inputBindingValue={{this.newPassword}}
                          @onValidate={{this.validatePassword}}
                          @validationStatus={{this.validation.status}}
-                         @validationMessage={{this.validation.message}}
+                         @validationMessage={{this.validationMessage}}
                          @required="true" />
         </div>
 
@@ -35,7 +35,7 @@
             </button>
           {{else}}
             <button type="submit" class="button button--thin button--round update-expired-password-form-body__bottom-button--round">
-              Réinitialiser
+              {{t 'pages.update-expired-password.button'}}
             </button>
           {{/if}}
         </div>
@@ -45,11 +45,11 @@
     {{#if this.authenticationHasFailed}}
       <div class="update-expired-password-form__body">
         <div class="password-reset-demand-form__body password-reset-demand-form__body--centered update-expired-password-form-text" aria-live="polite">
-          Votre mot de passe a été mis à jour.
+          {{t 'pages.update-expired-password.validation'}}
         </div>
         <div class="update-expired-password-form-body__bottom-button update-expired-password-form-body__bottom-button--big">
           <LinkTo @route="login" class="button button--link button--uppercase button--thin button--round">
-            Je me connecte
+            {{t 'pages.update-expired-password.go-to-login'}}
           </LinkTo>
         </div>
       </div>

--- a/mon-pix/app/templates/components/warning-page.hbs
+++ b/mon-pix/app/templates/components/warning-page.hbs
@@ -8,7 +8,7 @@
   </div>
   <div class="challenge-item-warning__allocated-time">
     <div class="challenge__allocated-time__jauge">
-      <img class="challenge__allocated-time__warning-icon" src="/images/icon-timed-challenge.svg" alt="Message d'avertissement">
+      <img class="challenge__allocated-time__warning-icon" src="/images/icon-timed-challenge.svg" alt="" role="presentation">
       <span class="challenge__allocated-time__value">{{allocatedTime}}</span>
     </div>
   </div>

--- a/mon-pix/app/templates/not-connected.hbs
+++ b/mon-pix/app/templates/not-connected.hbs
@@ -1,11 +1,10 @@
-{{page-title 'Déconnecté'}}
+{{page-title (t 'pages.not-connected.title')}}
 <div class="not-connected">
   <div class="rounded-panel not-connected__container">
     <img class="pix-logo__image not-connected__logo" src="/images/pix-logo.svg" alt="Pix">
 
     <p class="not-connected__text-block">
-    Vous êtes bien déconnecté(e).
-      <br>Merci, à bientôt.
+    {{t 'pages.not-connected.message' htmlSafe=true}}
     </p>
   </div>
 </div>

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -1,35 +1,35 @@
-{{page-title 'Conditions d\'utilisation'}}
+{{page-title (t 'pages.terms-of-service.title')}}
 <div class="terms-of-service-page">
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{homeUrl}} title="Page d'accueil">
+      <a href={{homeUrl}} title={{t 'navigation.homepage'}}>
         <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
       </a>
     </div>
 
-    <h2 class="terms-of-service-form__title">Conditions d'utilisation</h2>
+    <h2 class="terms-of-service-form__title">{{t 'pages.terms-of-service.title'}}</h2>
 
     <div class="terms-of-service-form__description">
-      Nous avons mis à jour nos conditions d'utilisation. Veuillez les accepter afin de pouvoir continuer votre expérience sur Pix.
+      {{t 'pages.terms-of-service.message'}}
     </div>
 
     <div class="terms-of-service-form__conditions">
       <label for="pix-cgu">
         <Input @type="checkbox" @id="pix-cgu" class="terms-of-service-form-conditions__check" @checked={{this.isTermsOfServiceValidated}}/>
-        J'accepte les <a href="https://pix.fr/conditions-generales-d-utilisation" class="link" target="_blank">conditions
-        d'utilisation de Pix</a>
+        {{t 'pages.terms-of-service.cgu' htmlSafe=true}}
+
       </label>
       {{#if this.showErrorTermsOfServiceNotSelected }}
         <div class="terms-of-service-form-conditions__validation-error">
-          {{'Vous devez accepter les conditions d’utilisation de Pix.'}}
+          {{t 'pages.terms-of-service.form.error-message'}}
         </div>
       {{/if}}
     </div>
 
     <div class="terms-of-service-form__actions">
-      <LinkTo @route="logout" class="button terms-of-service-form-actions__cancel">Retour</LinkTo>
-      <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>Je continue</button>
+      <LinkTo @route="logout" class="button terms-of-service-form-actions__cancel">{{t 'common.actions.back'}}</LinkTo>
+      <button type="submit" class="button terms-of-service-form-actions__submit" {{on 'click' this.submit}}>{{t 'pages.terms-of-service.form.button'}}</button>
     </div>
 
   </div>

--- a/mon-pix/app/templates/update-expired-password.hbs
+++ b/mon-pix/app/templates/update-expired-password.hbs
@@ -1,4 +1,4 @@
-{{page-title 'Changer mon mot de passe'}}
+{{page-title (t 'pages.update-expired-password.title')}}
 <div class="update-expired-password-form-page">
   <UpdateExpiredPasswordForm @user={{@model}} />
 </div>

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -12,7 +12,7 @@
       </div>
     </header>
     {{#if this.model}}
-      <article aria-label="tutoriels" class="user-tutorials-content">
+      <article aria-label={{t 'pages.user-tutorials.label'}} class="user-tutorials-content">
         <h3 class="user-tutorials-content__title">{{t 'pages.user-tutorials.list.title'}}</h3>
         <div>
           {{#each this.model as |userTutorial|}}
@@ -21,7 +21,7 @@
         </div>
       </article>
     {{else}}
-      <article aria-label="tutoriels" class="rounded-panel user-tutorials-no-tutorial">
+      <article aria-label={{t 'pages.user-tutorials.label'}} class="rounded-panel user-tutorials-no-tutorial">
         <div class="user-tutorials-no-tutorial__illustration">
           <img src="{{rootURL}}/{{t 'pages.user-tutorials.empty-list-info.image-link'}}"
                role="none"

--- a/mon-pix/app/utils/errors-messages.js
+++ b/mon-pix/app/utils/errors-messages.js
@@ -1,32 +1,32 @@
 const JOIN_ERRORS = [
   {
     shortCode: 'R11',
-    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail <br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R11)',
+    message: 'api-error-messages.join-error.r11',
     code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
   {
     shortCode: 'R12',
-    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant <br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R12)',
+    message: 'api-error-messages.join-error.r12',
     code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
   {
     shortCode: 'R13',
-    message: 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l\'accès à ce compte à l\'aide de Pix Orga.',
+    message: 'api-error-messages.join-error.r13',
     code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
   {
     shortCode: 'R31',
-    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R31)',
+    message: 'api-error-messages.join-error.r31',
     code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION',
   },
   {
     shortCode: 'R32',
-    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code R32)',
+    message: 'api-error-messages.join-error.r32',
     code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
   },
   {
     shortCode: 'R33',
-    message: 'Vous possédez déjà un compte Pix via l\'ENT. Utilisez-le pour rejoindre le parcours.',
+    message: 'api-error-messages.join-error.r33',
     code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
   },
 ];
@@ -34,69 +34,47 @@ const JOIN_ERRORS = [
 const REGISTER_ERRORS = [
   {
     shortCode: 'S51',
-    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S51)',
+    message: 'api-error-messages.register-error.s51',
     code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_SAME_ORGANIZATION',
   },
   {
     shortCode: 'S52',
-    message: 'Vous possédez déjà un compte Pix avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S52)',
+    message: 'api-error-messages.register-error.s52',
     code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
   },
   {
     shortCode: 'S53',
-    message: 'Vous possédez déjà un compte Pix via l\'ENT.<br>Utilisez-le pour rejoindre le parcours.',
+    message: 'api-error-messages.register-error.s53',
     code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
   },
   {
     shortCode: 'S61',
-    message: 'Vous possédez déjà un compte Pix avec l\'adresse e-mail<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S61)',
+    message: 'api-error-messages.register-error.s61',
     code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
   {
     shortCode: 'S62',
-    message: 'Vous possédez déjà un compte Pix utilisé avec l\'identifiant<br>#VALUE#<br>Pour continuer, connectez-vous à ce compte ou demandez de l\'aide à un enseignant.<br>(Code S62)',
+    message: 'api-error-messages.register-error.s62',
     code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
   {
     shortCode: 'S63',
-    message: 'Vous possédez déjà un compte Pix via l\'ENT dans un autre établissement scolaire.<br>Pour continuer, contactez un enseignant qui pourra vous donner l\'accès à ce compte à l\'aide de Pix Orga.<br>(Code S63)',
+    message: 'api-error-messages.register-error.s63',
     code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
   },
 ];
 
-function getJoinErrors() {
-  return JOIN_ERRORS;
-}
-
-function getJoinErrorsMessageByShortCode({ shortCode, value }) {
-  let message = undefined;
-
+function getJoinErrorsMessageByShortCode({ shortCode }) {
   const error = JOIN_ERRORS.find((error) => error.shortCode === shortCode);
-  if (error) {
-    message = error.message.replace('#VALUE#', value);
-  }
-
-  return message;
+  return error.message;
 }
 
-function getRegisterErrors() {
-  return REGISTER_ERRORS;
-}
-
-function getRegisterErrorsMessageByShortCode({ shortCode, value }) {
-  let message = undefined;
-
+function getRegisterErrorsMessageByShortCode({ shortCode }) {
   const error = REGISTER_ERRORS.find((error) => error.shortCode === shortCode);
-  if (error) {
-    message = error.message.replace('#VALUE#', value);
-  }
-
-  return message;
+  return error.message;
 }
 
 export {
-  getJoinErrors,
   getJoinErrorsMessageByShortCode,
-  getRegisterErrors,
   getRegisterErrorsMessageByShortCode,
 };

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -886,7 +886,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           it('should display an specific error message if GAR authentication method adding has failed due to wrong connected account', async () => {
             // given
-            const expectedErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme ';
+            const expectedErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme : ';
             const expectedObfuscatedConnectionMethod = 't***@example.net';
             const errorsApi = new Response(409, {}, {
               errors: [{

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -278,7 +278,7 @@ describe('Integration | Component | routes/login-form', function() {
 
     it('should display the specific error message if update fails with http error 409 and code UNEXPECTED_USER_ACCOUNT', async function() {
       // given
-      const expectedErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme t***@exmaple.net';
+      const expectedErrorMessage = 'L\'adresse e-mail ou l\'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme : t***@exmaple.net';
       const apiReturn = {
         errors: [{
           status: 409,

--- a/mon-pix/tests/integration/components/routes/login-or-register-test.js
+++ b/mon-pix/tests/integration/components/routes/login-or-register-test.js
@@ -1,16 +1,19 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { beforeEach, describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-describe('Integration | Routes | routes/login-or-register', () => {
+describe('Integration | Routes | routes/login-or-register', function() {
 
   setupIntlRenderingTest();
+  beforeEach(function() {
+    this.set('toggleFormsVisibility', '');
+  });
 
-  it('should render', async () => {
+  it('should render', async function() {
     // when
-    await render(hbs`{{routes/login-or-register}}`);
+    await render(hbs`{{routes/login-or-register toggleFormsVisibility=toggleFormsVisibility}}`);
 
     // then
     expect(find('.login-or-register')).to.exist;
@@ -18,7 +21,7 @@ describe('Integration | Routes | routes/login-or-register', () => {
 
   it('should display the organization name the user is invited to', async () => {
     // when
-    await render(hbs`{{routes/login-or-register organizationName='Organization Aztec'}}`);
+    await render(hbs`{{routes/login-or-register organizationName='Organization Aztec' toggleFormsVisibility=toggleFormsVisibility}}`);
 
     // then
     expect(find('.login-or-register-panel__invitation').textContent)

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -22,8 +22,6 @@ const INVALID_YEAR_OF_BIRTH_ERROR_MESSAGE = 'Votre année de naissance n’est p
 const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
-import { getRegisterErrorsMessageByShortCode } from 'mon-pix/utils/errors-messages';
-
 describe('Integration | Component | routes/register-form', function() {
 
   setupIntlRenderingTest();
@@ -325,7 +323,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S61)', async function() {
           // given
           const meta = { shortCode: 'S61', value: 'j***@example.net' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s61', { value: meta.value });
 
           const error = {
             status: '409',
@@ -374,7 +372,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S62)', async function() {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s62', { value: meta.value });
 
           const error = {
             status: '409',
@@ -423,7 +421,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S63)', async function() {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
 
           const error = {
             status: '409',
@@ -472,7 +470,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S63)', async function() {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
 
           const error = {
             status: '409',
@@ -521,7 +519,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S63)', async function() {
           // given
           const meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
 
           const error = {
             status: '409',
@@ -570,7 +568,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S63)', async function() {
           // given
           const  meta = { shortCode: 'S63', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s63', { value: meta.value });
 
           const error = {
             status: '409',
@@ -619,7 +617,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S62)', async function() {
           // given
           const meta = { shortCode: 'S62', value: 'j***.h***2' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s62', { value: meta.value });
 
           const error = {
             status: '409',
@@ -672,7 +670,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S51)', async function() {
           // given
           const meta = { shortCode: 'S51', value: 'j***@example.net' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s51', { value: meta.value });
 
           const error = {
             status: '409',
@@ -721,7 +719,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S52)', async function() {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s52', { value: meta.value });
 
           const error = {
             status: '409',
@@ -770,7 +768,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S53)', async function() {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
 
           const error = {
             status: '409',
@@ -819,7 +817,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S53)', async function() {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
 
           const error = {
             status: '409',
@@ -868,7 +866,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S53)', async function() {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
 
           const error = {
             status: '409',
@@ -917,7 +915,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S53)', async function() {
           // given
           const meta = { shortCode: 'S53', value: undefined };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s53', { value: meta.value });
 
           const error = {
             status: '409',
@@ -966,7 +964,7 @@ describe('Integration | Component | routes/register-form', function() {
         it('should display the error message related to the short code S52)', async function() {
           // given
           const meta = { shortCode: 'S52', value: 'j***.h***2' };
-          const expectedErrorMessage = getRegisterErrorsMessageByShortCode(meta);
+          const expectedErrorMessage =  this.intl.t('api-error-messages.register-error.s52', { value: meta.value });
 
           const error = {
             status: '409',

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -6,10 +6,12 @@ import sinon from 'sinon';
 import createComponent from '../../../../../helpers/create-glimmer-component';
 
 import { getJoinErrorsMessageByShortCode } from 'mon-pix/utils/errors-messages';
+import setupIntl from '../../../../../helpers/setup-intl';
 
 describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
   setupTest();
+  setupIntl();
 
   let component;
   let storeStub;
@@ -473,7 +475,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        expect(component.errorMessage).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/> <br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
+        expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/><br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
       });
 
       describe('When student is already reconciled in others organization', async function() {

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -4,8 +4,6 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 import createComponent from '../../../../../helpers/create-glimmer-component';
-
-import { getJoinErrorsMessageByShortCode } from 'mon-pix/utils/errors-messages';
 import setupIntl from '../../../../../helpers/setup-intl';
 
 describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
@@ -485,7 +483,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R11)', async function() {
             // given
             const meta = { shortCode: 'R11', value: 'j***@example.net', userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', { value: meta.value });
 
             const error = {
               status: '409',
@@ -515,7 +513,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R12)', async function() {
             // given
             const meta = { shortCode: 'R12', value: 'j***.h***2', userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r12', { value: meta.value });
 
             const error = {
               status: '409',
@@ -545,7 +543,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
             const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
 
             const error = {
               status: '409',
@@ -575,7 +573,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
             const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
 
             const error = {
               status: '409',
@@ -605,7 +603,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
             const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
 
             const error = {
               status: '409',
@@ -635,7 +633,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R13)', async function() {
             // given
             const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
 
             const error = {
               status: '409',
@@ -665,7 +663,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
           it('should return a conflict error and display the error message related to the short code R12)', async function() {
             // given
             const meta = { shortCode: 'R12', value: 'j***.h***2', userId: 1 };
-            const expectedErrorMessage = getJoinErrorsMessageByShortCode(meta);
+            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r12', { value: meta.value });
 
             const error = {
               status: '409',

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sup-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sup-test.js
@@ -3,9 +3,11 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 import createComponent from '../../../../../helpers/create-glimmer-component';
+import setupIntl from '../../../../../helpers/setup-intl';
 
 describe('Unit | Component | routes/campaigns/restricted/join-sup', function() {
   setupTest();
+  setupIntl();
 
   let component;
   let storeStub;

--- a/mon-pix/tests/unit/components/update-expired-password_test.js
+++ b/mon-pix/tests/unit/components/update-expired-password_test.js
@@ -4,7 +4,7 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import Service from '@ember/service';
 
-const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
 
 const VALIDATION_MAP = {
   default: {

--- a/mon-pix/tests/unit/utils/errors-messages-test.js
+++ b/mon-pix/tests/unit/utils/errors-messages-test.js
@@ -2,9 +2,7 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
 import {
-  getJoinErrors,
   getJoinErrorsMessageByShortCode,
-  getRegisterErrors,
   getRegisterErrorsMessageByShortCode,
 } from 'mon-pix/utils/errors-messages';
 
@@ -13,45 +11,19 @@ describe('Unit | Utility | errors-messages', function() {
   const JOIN_SHORT_CODES_ERRORS = [ 'R11', 'R12', 'R13', 'R31', 'R32', 'R33' ];
   const REGISTER_SHORT_CODES_ERRORS = [ 'S51', 'S52', 'S53', 'S61', 'S62', 'S63' ];
 
-  describe('#getJoinErrors', () => {
-
-    it('should retrieve array of all join errors', () => {
-      // when
-      const errors = getJoinErrors();
-
-      // then
-      const shortCodes = errors.map((error) => error.shortCode);
-      expect(shortCodes).to.deep.equal(JOIN_SHORT_CODES_ERRORS);
-    });
-  });
-
   describe('#getJoinErrorsMessageByShortCode', () => {
 
     it('should retrieve all messages by shortCode with value', () => {
       // given
-      const value = 'someData';
-
-      const expectedMessages = getJoinErrors()
-        .map(({ message }) => message.replace('#VALUE#', value));
+      const expectedMessages = JOIN_SHORT_CODES_ERRORS
+        .map((shortCode) => 'api-error-messages.join-error.' + shortCode.toLowerCase());
 
       // when
       const messages = JOIN_SHORT_CODES_ERRORS
-        .map((shortCode) => getJoinErrorsMessageByShortCode({ shortCode, value }));
+        .map((shortCode) => getJoinErrorsMessageByShortCode({ shortCode }));
 
       // then
       expect(messages).to.deep.equal(expectedMessages);
-    });
-  });
-
-  describe('#getRegisterErrors', () => {
-
-    it('should retrieve array of all register errors', () => {
-      // when
-      const errors = getRegisterErrors();
-
-      // then
-      const shortCodes = errors.map((error) => error.shortCode);
-      expect(shortCodes).to.deep.equal(REGISTER_SHORT_CODES_ERRORS);
     });
   });
 
@@ -59,14 +31,12 @@ describe('Unit | Utility | errors-messages', function() {
 
     it('should retrieve all messages by shortCode with values', () => {
       // given
-      const value = 'someData';
-
-      const expectedMessages = getRegisterErrors()
-        .map(({ message }) => message.replace('#VALUE#', value));
+      const expectedMessages = REGISTER_SHORT_CODES_ERRORS
+        .map((shortCode) => 'api-error-messages.register-error.' + shortCode.toLowerCase());
 
       // when
       const messages = REGISTER_SHORT_CODES_ERRORS
-        .map((shortCode) => getRegisterErrorsMessageByShortCode({ shortCode, value }));
+        .map((shortCode) => getRegisterErrorsMessageByShortCode({ shortCode }));
 
       // then
       expect(messages).to.deep.equal(expectedMessages);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -481,6 +481,11 @@
       "obtained-level": "Level { level } succeeded!"
     },
 
+    "not-connected": {
+      "title": "",
+      "message": ""
+    },
+
     "password-reset-demand": {
       "title": "Forgotten your password?",
       "actions": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -486,6 +486,74 @@
       "obtained-level": "Level { level } succeeded!"
     },
 
+    "login-or-register": {
+      "title": "",
+      "invitation": "",
+      "login-form": {
+        "button": "",
+        "error": "",
+        "fields": {
+          "login": {
+            "label": ""
+          },
+          "password": {
+            "label": ""
+          }
+        },
+        "forgotten-password": {
+          "email": "",
+          "instruction": "",
+          "other-identity": "",
+          "reset-link": ""
+        },
+        "title": "",
+        "unexpected-user-account-error": ""
+      },
+      "register-form": {
+        "button": "",
+        "button-form": "",
+        "fields": {
+          "birthdate": {
+            "label": "",
+            "day-error": "",
+            "month-error": "",
+            "year-error": ""
+          },
+          "cgu": "",
+          "email": {
+            "error": "",
+            "help": "",
+            "label": ""
+          },
+          "firstname": {
+            "error": "",
+            "label": ""
+          },
+          "lastname": {
+            "error": "",
+            "label": ""
+          },
+          "password": {
+            "error": "",
+            "help": "",
+            "label": "",
+            "show-button": ""
+          },
+          "username": {
+            "label": ""
+          }
+        },
+        "legal-text": "",
+        "not-me": "",
+        "options": {
+          "email": "",
+          "text": "",
+          "username": ""
+        },
+        "title": ""
+      }
+    },
+
     "not-connected": {
       "title": "",
       "message": ""

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -20,7 +20,8 @@
       "error": "error",
       "mandatory": "required",
       "mandatory-fields": "The fields marked '<abbr title=\"required\" class=\"mandatory-mark\">'*'</abbr>' are required",
-      "success": "success"
+      "success": "success",
+      "visible-password": ""
     },
     "french-republic": "French Republic",
     "level": "level",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -891,6 +891,20 @@
       }
     },
 
+    "update-expired-password": {
+      "title": "",
+      "button": "",
+      "fields": {
+        "error": "",
+        "help": "",
+        "label": ""
+      },
+      "first-title": "",
+      "go-to-login": "",
+      "subtitle": "",
+      "validation": ""
+    },
+
     "warning": {
       "action": "Start",
       "instructions": "You have '<span class=\"challenge-item-warning__instruction-time\">'{time}'</span>' to complete the next question.",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -148,7 +148,10 @@
         },
         "fields": {
           "birth-date": "Date of birth",
+          "birth-day": "",
+          "birth-month": "",
           "birth-name": "Given name",
+          "birth-year": "",
           "first-name": "First name",
           "session-number": "Session number"
         }

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -477,6 +477,48 @@
       "first-title": "Oops, an error occurred!"
     },
 
+    "join": {
+      "title": "",
+      "button": "",
+      "fields": {
+        "birthdate": {
+          "label": "",
+          "day-error": "",
+          "day-format":"",
+          "month-error": "",
+          "month-format": "",
+          "year-error": "",
+          "year-format": ""
+        },
+        "firstname": {
+          "error": "",
+          "label": ""
+        },
+        "lastname": {
+          "error": "",
+          "label": ""
+        }
+      },
+      "first-title":"",
+      "sco": {
+        "continue-with-pix": "",
+        "error-not-found": "",
+        "login-information-title": ""
+      },
+      "subtitle": "",
+      "sup": {
+        "error": "",
+        "fields": {
+          "student-number": {
+            "error": "",
+            "label": "",
+            "modify": "",
+            "not-existing": ""
+          }
+        }
+      }
+    },
+
     "learning-more": {
       "title": "To find out more",
       "info": "These tutorial links have been suggested by Pix users."

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -2,7 +2,24 @@
   "api-error-messages": {
     "bad-request-error": "The data entered was not in the correct format.",
     "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
-    "login-unauthorized-error": "There was an error in the email address or username/password entered."
+    "join-error": {
+      "r11": "",
+      "r12": "",
+      "r13": "",
+      "r31": "",
+      "r32": "",
+      "r33": ""
+    },
+    "login-unauthorized-error": "There was an error in the email address or username/password entered.",
+    "register-error": {
+      "s51": "",
+      "s52": "",
+      "s53": "",
+      "s61": "",
+      "s62": "",
+      "s63": ""
+    }
+
   },
 
   "application": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -11,6 +11,7 @@
 
   "common": {
     "actions": {
+      "back": "",
       "cancel": "Cancel",
       "close": "Close",
       "quit": "Exit"
@@ -688,6 +689,16 @@
       "try-again": {
         "title": "Want to improve your results?",
         "description": "You can retake some of the questions"
+      }
+    },
+
+    "terms-of-service": {
+      "title": "",
+      "cgu": "",
+      "message": "",
+      "form": {
+        "button": "",
+        "error-message": ""
       }
     },
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -752,6 +752,7 @@
         "image-link": "images/user-tutorials/illustration.svg",
         "title": "You haven’t saved anything yet"
       },
+      "label": "",
       "list": {
         "title": "My list",
         "tutorial": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -753,6 +753,7 @@
         "image-link": "images/user-tutorials/illustration.svg",
         "title": "Vous n'avez encore rien enregistré"
       },
+      "label": "tutoriels",
       "list": {
         "title": "Ma liste",
         "tutorial": {
@@ -772,7 +773,7 @@
           },
           "source": "Par"
         }
-      }
+      },
     },
 
     "fill-in-campaign-code": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -149,7 +149,10 @@
         },
         "fields": {
           "birth-date": "Date de naissance",
+          "birth-day": "jour de naissance (JJ)",
+          "birth-month": "mois de naissance (MM)",
           "birth-name": "Nom de naissance",
+          "birth-year": "année de naissance (AAAA)",
           "first-name": "Prénom",
           "session-number": "Numéro de session"
         }
@@ -773,7 +776,7 @@
           },
           "source": "Par"
         }
-      },
+      }
     },
 
     "fill-in-campaign-code": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -482,6 +482,11 @@
       "obtained-level": "Niveau { level } gagné !"
     },
 
+    "not-connected": {
+      "title": "Déconnecté",
+      "message": "Vous êtes bien déconnecté(e).'<br>'Merci, à bientôt."
+    },
+
     "password-reset-demand": {
       "title": "Mot de passe oublié ?",
       "actions": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -487,6 +487,74 @@
       "obtained-level": "Niveau { level } gagné !"
     },
 
+    "login-or-register": {
+      "title": "",
+      "invitation": "{ organizationName } vous invite à rejoindre Pix",
+      "login-form": {
+        "button": "Se connecter",
+        "error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects",
+        "fields": {
+          "login": {
+            "label": "Adresse e-mail ou identifiant"
+          },
+          "password": {
+            "label": "Mot de passe"
+          }
+        },
+        "forgotten-password": {
+          "email": "Une Adresse e-mail :",
+          "instruction": "Mot de passe oublié ? Vous avez un compte Pix avec :",
+          "other-identity": "Un identifiant : Contactez votre enseignant pour le réinitialiser",
+          "reset-link": "Cliquez ici pour le réinitialiser"
+        },
+        "title": "J’ai déjà un compte Pix",
+        "unexpected-user-account-error": "L'adresse e-mail ou l'identifiant est incorrect. Pour continuer, vous devez vous connecter à votre compte qui est sous la forme : "
+      },
+      "register-form": {
+        "button": "S'inscrire",
+        "button-form": "Je m'inscris",
+        "fields": {
+          "birthdate": {
+            "label": "Date de naissance (JJ/MM/AAAA)",
+            "day-error": "Votre jour de naissance n’est pas valide.",
+            "month-error": "Votre mois de naissance n’est pas valide.",
+            "year-error": "Votre année de naissance n’est pas valide."
+          },
+          "cgu": "J’accepte les '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\" rel=\"noopener noreferrer\">'conditions d’utilisation de Pix'</a>'",
+          "email": {
+            "error": "Votre email n’est pas valide.",
+            "help": "(ex: nom@exemple.fr)",
+            "label": "Adresse e-mail"
+          },
+          "firstname": {
+            "error": "Votre prénom n’est pas renseigné.",
+            "label": "Prénom"
+          },
+          "lastname": {
+            "error": "Votre nom n’est pas renseigné.",
+            "label": "Nom"
+          },
+          "password": {
+            "error": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+            "help": "(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)",
+            "label": "Mot de passe",
+            "show-button": "rendre le mot de passe lisible"
+          },
+          "username": {
+            "label": "Mon identifiant"
+          }
+        },
+        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « informatique et libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr.",
+        "not-me": "Ce n'est pas moi",
+        "options": {
+          "email": "Mon adresse e-mail",
+          "text": "Je m'inscris avec :",
+          "username": "Mon identifiant"
+        },
+        "title": "Je m’inscris sur Pix"
+      }
+    },
+
     "not-connected": {
       "title": "Déconnecté",
       "message": "Vous êtes bien déconnecté(e).'<br>'Merci, à bientôt."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -478,6 +478,48 @@
       "first-title": "Oups, une erreur est survenue !"
     },
 
+    "join": {
+      "title": "Rejoindre",
+      "button": "C'est parti !",
+      "fields": {
+        "birthdate": {
+          "label": "Date de naissance",
+          "day-error": "Votre jour de naissance n’est pas valide.",
+          "day-format":"JJ",
+          "month-error": "Votre mois de naissance n’est pas valide.",
+          "month-format": "MM",
+          "year-error": "Votre année de naissance n’est pas valide.",
+          "year-format": "AAAA"
+        },
+        "firstname": {
+          "error": "Votre prénom n’est pas renseigné.",
+          "label": "Prénom"
+        },
+        "lastname": {
+          "error": "Votre nom n’est pas renseigné.",
+          "label": "Nom"
+        }
+      },
+      "first-title":"Rejoignez l'organisation { organizationName }",
+      "sco": {
+        "continue-with-pix": "Continuer avec mon compte Pix",
+        "error-not-found": "Vous êtes un élève ? '<br/>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br/><br/>' Vous êtes un enseignant ? '<br/>' L‘accès à un parcours n‘est pas disponible pour le moment.",
+        "login-information-title": "Information de connexion"
+      },
+      "subtitle": "Remplissez les informations manquantes",
+      "sup": {
+        "error": "Veuillez vérifier les informations saisies, ou si vous avez déjà un compte Pix, connectez-vous avec celui-ci.",
+        "fields": {
+          "student-number": {
+            "error": "Votre numéro étudiant n’est pas renseigné.",
+            "label": "Numéro étudiant",
+            "modify": "Modifier le numéro étudiant",
+            "not-existing": "Je n'ai pas de numéro étudiant"
+          }
+        }
+      }
+    },
+
     "learning-more": {
       "title": "Pour en apprendre davantage",
       "info": "Ces liens vers les tutos ont été proposés par des utilisateurs de Pix."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -892,6 +892,20 @@
       }
     },
 
+    "update-expired-password": {
+      "title": "Changer mon mot de passe",
+      "button": "Réinitialiser",
+      "fields": {
+        "error": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.",
+        "help": "(8 caractères minimum, dont une majuscule, une minuscule et un chiffre)",
+        "label": "Mot de passe"
+      },
+      "first-title": "Réinitialiser le mot de passe",
+      "go-to-login": "Je me connecte",
+      "subtitle": "Choisissez un nouveau mot de passe pour continuer",
+      "validation": "Votre mot de passe a été mis à jour."
+    },
+
     "warning": {
       "action": "Commencer",
       "instructions": "Vous disposerez de '<span class=\"challenge-item-warning__instruction-time\">'{time}'</span>' pour réussir la question suivante.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -2,7 +2,23 @@
   "api-error-messages": {
     "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
     "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
-    "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects."
+    "join-error": {
+      "r11": "Vous possédez déjà un compte Pix avec l’adresse e-mail '<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R11)",
+      "r12": "Vous possédez déjà un compte Pix utilisé avec l’identifiant '<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R12)",
+      "r13": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.",
+      "r31": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R31)",
+      "r32": "Vous possédez déjà un compte Pix utilisé avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R32)",
+      "r33": "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours."
+    },
+    "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
+    "register-error": {
+      "s51": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S51)",
+      "s52": "Vous possédez déjà un compte Pix avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S52)",
+      "s53": "Vous possédez déjà un compte Pix via l’ENT.'<br>'Utilisez-le pour rejoindre le parcours.",
+      "s61": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S61)",
+      "s62": "Vous possédez déjà un compte Pix utilisé avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S62)",
+      "s63": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.'<br>'(Code S63)"
+    }
   },
 
   "application": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -20,7 +20,8 @@
       "error": "erreur",
       "mandatory": "obligatoire",
       "mandatory-fields": "Les champs marqués de '<abbr title=\"obligatoire\" class=\"mandatory-mark\">'*'</abbr>' sont obligatoires",
-      "success": "correct"
+      "success": "correct",
+      "visible-password": "afficher le mot de passe"
     },
     "french-republic": "République française",
     "level": "niveau",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -11,6 +11,7 @@
 
   "common": {
     "actions": {
+      "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
       "quit": "Quitter"
@@ -689,6 +690,16 @@
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",
         "description": "Vous pouvez retenter certaines questions"
+      }
+    },
+
+    "terms-of-service": {
+      "title": "Conditions d'utilisation",
+      "cgu": "J'accepte les '<a href=\"https://pix.fr/conditions-generales-d-utilisation\" class=\"link\" target=\"_blank\">'conditions d'utilisation de Pix'</a>'",
+      "message": "Nous avons mis à jour nos conditions d'utilisation. Veuillez les accepter afin de pouvoir continuer votre expérience sur Pix.",
+      "form": {
+        "button": "Je continue",
+        "error-message": "Vous devez accepter les conditions d’utilisation de Pix."
       }
     },
 


### PR DESCRIPTION
## :unicorn: Problème
- Pix va devenir un site de plus en plus international
- Par habitude, on risque encore de mettre des textes sans possibilité de les traduire

## :robot: Solution
- Ajout d'une règle de linter pour interdire les textes simples dans les .hbs
- Ajouter des clés pour les textes actuelles

## :rainbow: Remarques
- Le linter ne peut voir que les textes dans les .hbs, pas dans les .js, donc il peut rester du texte non traduit, il faut faire attention
- Le texte en anglais est vide, permettant de savoir qu'il n'a pas encore de traduction

## :100: Pour tester
- Lancer le site et vérifier que les pages de connexion ou de campagnes ont toujours leurs textes