### PR TITLE
[FEATURE] Changer le nom de l'utilisateur par le nom du candidat en test de certif (PIX-526)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-course-serializer.js
@@ -16,6 +16,8 @@ module.exports = {
         'nbChallenges',
         'examinerComment',
         'hasSeenEndTestScreen',
+        'firstName',
+        'lastName',
       ],
       assessment: {
         ref: 'id',

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -353,6 +353,8 @@ describe('Acceptance | API | Certification Course', () => {
           'examiner-comment': 'il s\'est enfuit de la session',
           'has-seen-end-test-screen': false,
           'nb-challenges': 0,
+          'first-name': certificationCourse.firstName,
+          'last-name': certificationCourse.lastName,
         },
         relationships: {
           assessment: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-course-serializer_test.js
@@ -29,6 +29,8 @@ describe('Unit | Serializer | JSONAPI | certification-course-serializer', functi
             'nb-challenges': 2,
             'examiner-comment': 'Signalement de l\'examinateur',
             'has-seen-end-test-screen': true,
+            'first-name': certificationCourse.firstName,
+            'last-name': certificationCourse.lastName,
           },
           relationships: {
             assessment: {

--- a/mon-pix/app/components/certification-banner.js
+++ b/mon-pix/app/components/certification-banner.js
@@ -1,6 +1,15 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import startCase from 'lodash/startCase';
 
 export default class CertificationBanner extends Component {
-  @service currentUser;
+
+  get candidateFullName() {
+    let fullName = '';
+    if (this.args && this.args.certification) {
+      this.firstName = this.args.certification.get('firstName');
+      this.lastName = this.args.certification.get('lastName');
+      fullName = `${startCase(this.firstName)} ${this.lastName.toUpperCase()}`;
+    }
+    return fullName;
+  }
 }

--- a/mon-pix/app/models/certification-course.js
+++ b/mon-pix/app/models/certification-course.js
@@ -5,6 +5,8 @@ export default class CertificationCourse extends Model {
   // attributes
   @attr('string') accessCode;
   @attr('number') nbChallenges;
+  @attr('string') firstName;
+  @attr('string') lastName;
 
   // references
   @attr('number') sessionId;

--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -3,10 +3,11 @@ import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
 
 export default class ChallengeRoute extends Route {
-  model(params) {
+  async model(params) {
     const store = this.store;
 
-    const assessment = this.modelFor('assessments');
+    const assessment = await this.modelFor('assessments');
+    await assessment.certificationCourse;
     const challengeId = params.challenge_id;
 
     return RSVP.hash({

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -4,7 +4,7 @@
 
   <div class="assessment-challenge__assessment-banner">
     {{#if @model.assessment.isCertification}}
-      <CertificationBanner @certificationNumber={{@model.assessment.certificationNumber}} />
+      <CertificationBanner @certificationNumber={{@model.assessment.certificationNumber}} @certification={{@model.assessment.certificationCourse}} />
     {{else}}
       <AssessmentBanner @title={{@model.assessment.title}} @displayHomeLink={{true}} />
     {{/if}}

--- a/mon-pix/app/templates/components/certification-banner.hbs
+++ b/mon-pix/app/templates/components/certification-banner.hbs
@@ -4,7 +4,7 @@
       <img src="/images/pix-logo-blanc.svg" role="none" alt="">
     </div>
     <div class="assessment-banner__splitter"></div>
-    <h1 class="assessment-banner__title">{{this.currentUser.user.fullName}}</h1>
+    <h1 class="assessment-banner__title">{{this.candidateFullName}}</h1>
 
     <div class="certification-number">
       <div class="certification-number__label">{{t "pages.challenge.certification.banner.certification-number"}}</div>

--- a/mon-pix/mirage/serializers/assessment.js
+++ b/mon-pix/mirage/serializers/assessment.js
@@ -3,5 +3,6 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
   include: [
     'answers',
+    'certificationCourse',
   ],
 });

--- a/mon-pix/mirage/serializers/certification-course.js
+++ b/mon-pix/mirage/serializers/certification-course.js
@@ -5,6 +5,8 @@ export default ApplicationSerializer.extend({
     'nbChallenges',
     'examinerComment',
     'hasSeenEndTestScreen',
+    'firstName',
+    'lastName',
   ],
   links(certificationCourse) {
     return {

--- a/mon-pix/tests/acceptance/certification-course-test.js
+++ b/mon-pix/tests/acceptance/certification-course-test.js
@@ -163,10 +163,12 @@ describe('Acceptance | Certification | Start Certification Course', function() {
             for (let i = 0; i < NB_CHALLENGES; ++i) {
               server.create('challenge', 'forCertification');
             }
-            certificationCourse = server.create('certification-course', {
+            certificationCourse = this.server.create('certification-course', {
               accessCode: 'ABCD12',
               sessionId: 1,
               nbChallenges: NB_CHALLENGES,
+              firstName: 'Laura',
+              lastName: 'Bravo',
             });
             assessment = certificationCourse.assessment;
           });

--- a/mon-pix/tests/integration/components/certification-banner-test.js
+++ b/mon-pix/tests/integration/components/certification-banner-test.js
@@ -1,7 +1,4 @@
-/* eslint ember/no-classic-classes: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import Service from '@ember/service';
+import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -13,20 +10,35 @@ describe('Integration | Component | Certification Banner', function() {
   setupIntlRenderingTest();
 
   context('On component rendering', function() {
-    const fullName = 'shi fu';
-    const certificationNumber = 'certification-number';
+    const firstName = 'tom';
+    const lastName = 'jedusor';
+    const fullName = 'Tom JEDUSOR';
+    const certificationNumber = 100;
 
     beforeEach(function() {
-      this.owner.register('service:currentUser', Service.extend({ user: { fullName } }));
+      // given
+      const certification = EmberObject.create({
+        id: certificationNumber,
+        firstName,
+        lastName,
+      });
+      this.set('certificationNumber', certificationNumber);
+      this.set('certification', certification);
     });
 
-    it('should render component with user fullName and certificationNumber', async function() {
+    it('should render component with user fullName', async function() {
       // when
-      this.set('certificationNumber', certificationNumber);
-      await render(hbs`{{certification-banner certificationNumber=certificationNumber}}`);
+      await render(hbs`<CertificationBanner @certification={{this.certification}} />`);
 
       // then
       expect(find('.assessment-banner__title').textContent.trim()).to.equal(fullName);
+    });
+
+    it('should render component with certificationNumber', async function() {
+      // when
+      await render(hbs`<CertificationBanner @certificationNumber={{this.certificationNumber}} />`);
+
+      // then
       expect(find('.certification-number__value').textContent.trim()).to.equal(`${certificationNumber}`);
     });
   });

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -48,29 +48,27 @@ describe('Unit | Route | Assessments | Challenge', function() {
   });
 
   describe('#model', function() {
-    it('should correctly call the store to find assessment and challenge', function() {
+    it('should correctly call the store to find assessment and challenge', async function() {
       // when
-      route.model(params);
+      await route.model(params);
 
       // then
       sinon.assert.calledWith(route.modelFor, 'assessments');
       sinon.assert.calledWith(findRecordStub, 'challenge', params.challenge_id);
     });
-    it('should call queryRecord to find answer', function() {
+    it('should call queryRecord to find answer', async function() {
       // given
       model.assessment.get.withArgs('isCertification').returns(false);
       model.assessment.get.withArgs('course').returns({ getProgress: sinon.stub().returns('course') });
 
       // when
-      const promise = route.model(params);
+      await route.model(params);
 
       // then
-      return promise.then(() => {
-        sinon.assert.calledOnce(queryRecordStub);
-        sinon.assert.calledWith(queryRecordStub, 'answer', {
-          assessmentId: assessment.id,
-          challengeId: params.challenge_id,
-        });
+      sinon.assert.calledOnce(queryRecordStub);
+      sinon.assert.calledWith(queryRecordStub, 'answer', {
+        assessmentId: assessment.id,
+        challengeId: params.challenge_id,
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, pendant la certification, je vois en haut de la page (header):
- le prénom et nom du candidat indiqué lors de la création de son compte
 
Il serait plus pertinent d'afficher le nom du candidat inscrit à la certification car ces informations là sont à destination du surveillant (qui connait les personnes en tant que candidat et se fiche de connaitre le compte avec lequel elles se sont inscrites).
Nous souhaitons donc afficher plutôt, dans le header du test de certif :
- Prénom NOM du certificationCandidat et non du user (nom en majuscule)

## :robot: Solution
Changer l'affiche du Prénom NOM de l'utilisateur par ceux du candidat de la certification (informations connues du surveillant).

## :rainbow: Remarques
RAS

## :100: Pour tester
- Se connecter sur mon-pix (ex: `certif1@example.net`)
- Lancer un test de certification (`2`, `Anne`, `Success`, `01/01/2000` puis `ANNE02`)
- Vérifier en haut l'affichage du Prénom NOM (en majuscule le nom) avec les données précédemment remplies : Anne SUCCESS.
