### PR TITLE
[BUGFIX] Gérer l'erreur date de naissance obligatoire lors de l'import des élèves d'une organisation SUP (PIX-1257).

### DIFF
--- a/api/lib/domain/validators/higher-education-registration-validator.js
+++ b/api/lib/domain/validators/higher-education-registration-validator.js
@@ -20,7 +20,7 @@ const validationSchema = Joi.object({
   thirdName: Joi.string().max(MAX_LENGTH).optional(),
   lastName: Joi.string().max(MAX_LENGTH).required(),
   preferredLastName: Joi.string().max(MAX_LENGTH).optional(),
-  birthdate: Joi.date().required().format('YYYY-MM-DD'),
+  birthdate: Joi.date().required().format('YYYY-MM-DD').empty(null),
   email: Joi.string().max(MAX_LENGTH).email().optional(),
   diploma: Joi.string().max(MAX_LENGTH).optional(),
   department: Joi.string().max(MAX_LENGTH).optional(),

--- a/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-education-registration-parser.js
@@ -123,7 +123,7 @@ class HigherEducationRegistrationParser {
       registrationAttributes[attribute] = value;
     });
 
-    registrationAttributes['birthdate'] = convertDateValue({ dateString: line[COLUMN_NAME_BY_ATTRIBUTE.birthdate], inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
+    registrationAttributes['birthdate'] =  this._buildBirthdateAttribute(line[COLUMN_NAME_BY_ATTRIBUTE.birthdate]);
     registrationAttributes['organizationId'] = this._organizationId;
 
     return registrationAttributes;
@@ -141,6 +141,11 @@ class HigherEducationRegistrationParser {
     if (columns.some((column) => !expectedColumns.includes(column))) {
       throw new CsvImportError('Les entêtes de colonnes doivent être identiques à celle du modèle.');
     }
+  }
+
+  _buildBirthdateAttribute(birthdate) {
+    const convertedDate = convertDateValue({ dateString: birthdate, inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
+    return convertedDate || birthdate;
   }
 
 }

--- a/api/tests/unit/domain/models/HigherEducationRegistration_test.js
+++ b/api/tests/unit/domain/models/HigherEducationRegistration_test.js
@@ -140,7 +140,7 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
         const error = await catchErr(buildRegistration)({ ...validAttributes, birthdate: null });
 
         expect(error.key).to.equal('birthdate');
-        expect(error.why).to.equal('not_a_date');
+        expect(error.why).to.equal('required');
       });
     });
 
@@ -150,6 +150,15 @@ describe('Unit | Domain | Models | HigherEducationRegistration', () => {
 
         expect(error.key).to.equal('birthdate');
         expect(error.why).to.equal('date_format');
+      });
+    });
+
+    context('when birthdate is null', () => {
+      it('throws an error', async () => {
+        const error = await catchErr(buildRegistration)({ ...validAttributes, birthdate: null });
+
+        expect(error.key).to.equal('birthdate');
+        expect(error.why).to.equal('required');
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-education-registration-parser_test.js
@@ -132,7 +132,7 @@ describe('Unit | Infrastructure | HigherEducationRegistrationParser', () => {
 
     it('should throw an error if the birthdate does not have the right format', async () => {
       const input = `Premier prénom;Deuxième prénom;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime
-      Beatrix;The;Bride;Kiddo;Black Mamba;1970-01-01;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
+      Beatrix;The;Bride;Kiddo;Black Mamba;1970/01/01;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
       const encodedInput = iconv.encode(input, 'utf8');
       const parser = new HigherEducationRegistrationParser(encodedInput, organizationId);
 
@@ -181,7 +181,7 @@ describe('Unit | Infrastructure | HigherEducationRegistrationParser', () => {
     const input = `Premier prénom;Deuxième prénom;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime
           Éçéà niño véga;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
         `;
-       
+
     it('should parse UTF-8 encoding', () => {
       const encodedInput = iconv.encode(input, 'utf8');
       const parser = new HigherEducationRegistrationParser(encodedInput, 123);
@@ -189,7 +189,7 @@ describe('Unit | Infrastructure | HigherEducationRegistrationParser', () => {
       const registrations = higherEducationRegistrationSet.registrations;
       expect(registrations[0].firstName).to.equal('Éçéà niño véga');
     });
-           
+
     it('should parse win1252 encoding (CSV WIN/MSDOS)', () => {
       const encodedInput = iconv.encode(input, 'win1252');
       const parser = new HigherEducationRegistrationParser(encodedInput, 123);
@@ -197,7 +197,7 @@ describe('Unit | Infrastructure | HigherEducationRegistrationParser', () => {
       const registrations = higherEducationRegistrationSet.registrations;
       expect(registrations[0].firstName).to.equal('Éçéà niño véga');
     });
-               
+
     it('should parse macintosh encoding', () => {
       const encodedInput = iconv.encode(input, 'macintosh');
       const parser = new HigherEducationRegistrationParser(encodedInput, 123);


### PR DESCRIPTION
## :unicorn: Problème
Lors de l'import des élèves pour une organisation SUP si la date de naissance n'est pas donnée pour un élèves il y a une erreur "La date de naissance n'est pas au bon format". Ce qui n'est pas la bonne erreur.

## :robot: Solution
Renvoyer une erreur 'Ligne X : Le champ "Date de naissance (jj/mm/aaaa)" est obligatoire'.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix-Orga avec le compte sup@example.net
Faire un import d'élève avec un fichier ou il manque la date de naissance d'un élève.
Vérifier que l'erreur 'Ligne X : Le champ "Date de naissance (jj/mm/aaaa)" est obligatoire'.  est affichée.

[modele-import (3).txt](https://github.com/1024pix/pix/files/5254284/modele-import.3.txt)
Attention il faut changer l'extension du fichier par CSV