### PR TITLE
[TECH] Suppression de directives .editorconfig inutiles.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,23 +14,11 @@ indent_style = space
 indent_size = 2
 
 [*.js]
-indent_style = space
-indent_size = 2
 quote_type = single
 spaces_around_brackets = both
 
 [*.hbs]
 insert_final_newline = false
-indent_style = space
-indent_size = 2
-
-[*.css]
-indent_style = space
-indent_size = 2
-
-[*.html]
-indent_style = space
-indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
## :unicorn: Problème
L'exemple ci-dessous tiré de la doc [editorconfig](https://editorconfig.org/) montre qu'il n'est pas nécessaire de répéter les propriétés pour chaque type de fichier s'il est déjà défini pour le niveau global
>Below is an example .editorconfig file setting end-of-line and indentation styles for Python and JavaScript files.

```
# top-most EditorConfig file
root = true

# Unix-style newlines with a newline ending every file
[*]
end_of_line = lf
insert_final_newline = true
```

## :robot: Solution
Suppression des directives redéfinies avec la même valeur plus bas

## :rainbow: Remarques
Pourquoi y a-t-il un fichier .editorconfig pour chaque application Ember si la configuration est la même ?
Ex: `mon-pix/.editorconfig`

La  [doc editorconfig](https://editorconfig.org/) indique que ce n'est pas nécessaire
> EditorConfig files are read top to bottom and the most recent rules found take precedence.  Properties from matching EditorConfig sections are applied in the order they were read, so properties in closer files take precedence.

> When opening a file, EditorConfig plugins look for a file named .editorconfig in the directory of the opened file and in every parent directory. A search for .editorconfig files will stop if the root filepath is reached or an EditorConfig file with root=true is found.

La cause est peut être que ce fichier est généré par Ember à chaque création d'application et n'a pas été supprimé.
Qu'en pensez-vous ?

## :100: Pour tester
Sur la branche en local, sur un fichier CSS/JS/HTML, taper Tab et vérifier que l'indentation est de 2 espaces
