### PR TITLE
[TECH] Petite optimisation de code pour récupérer la date du KE le plus récent (PIX-1300)

### DIFF
--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -81,9 +81,9 @@ class KnowledgeElement {
   }
 
   static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
-    const lastKnowledgeElement = _(knowledgeElements).sortBy('createdAt').last();
+    const lastCreatedAt = _(knowledgeElements).map('createdAt').max();
     const precise = true;
-    return moment().diff(lastKnowledgeElement.createdAt, 'days', precise);
+    return moment().diff(lastCreatedAt, 'days', precise);
   }
 
   static findDirectlyValidatedFromGroups(knowledgeElementsByCompetence) {


### PR DESCRIPTION
## :unicorn: Problème
Un certain @jonathanperret avait détecté une petite optimisation de code à faire autour de la récupération de la date du knowledge-element le plus récent.
Je l'avais noté dans mes fameux "post-its" que je viens de dépiler, donc je fais une petite PR ;)

Il avait identifié que le code actuel pour récupérer la date du KE le plus récent pouvait être amélioré. En effet, aujourd'hui le code procède d'abord au tri complet de la collection de KE (potentiellement plusieurs centaines d'objets) avant de récupérer le KE à l'extrémité du tri. L'algo de tri derrière la fonction utilisée est peut-être très optimisée (on n'en doute pas), mais il n'en reste pas moins que c'est dommage de devoir tout trier :
```js
  static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
    const lastKnowledgeElement = _(knowledgeElements).sortBy('createdAt').last();
    const precise = true;
    return moment().diff(lastKnowledgeElement.createdAt, 'days', precise);
  }
```

Précision : Cette fonction est par contre appelé seulement pour afficher les jours restant avant retenter/remettre à zéro (et pas dans tous les calculs de KE)

## :robot: Solution
Il est plus efficace de faire deux parcours, 1) pour récupérer les dates, 2) pour prendre la plus grande :
```js
  static computeDaysSinceLastKnowledgeElement(knowledgeElements) {
    const lastCreatedAt = _(knowledgeElements).map('createdAt').max();
    const precise = true;
    return moment().diff(lastCreatedAt, 'days', precise);
  } 
```

## :rainbow: Remarques
Le code était testé, non régression sur les tests donc on est très content ! + entre le moment où j'ai ajouté l'optim à faire dans ma todo list et maintenant, il s'est écoulé + de deux mois. Je sais bien que ma technique de post-it n'est pas la meilleure, mais vaut mieux tard que jamais. Et surtout, la prochaine fois, vu la taille de la modif, je ne procrastinerai pas !

## :100: Pour tester
