### PR TITLE
[TECH] Création d'un modèle TargetProfileWithLearningContent (PIX-1301-1)

### DIFF
--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -1,0 +1,19 @@
+class TargetProfileWithLearningContent {
+  constructor({
+    id,
+    name,
+    skills = [],
+    tubes = [],
+    competences = [],
+    areas = [],
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.skills = skills;
+    this.tubes = tubes;
+    this.competences = competences;
+    this.areas = areas;
+  }
+}
+
+module.exports = TargetProfileWithLearningContent;

--- a/api/lib/domain/models/TargetedArea.js
+++ b/api/lib/domain/models/TargetedArea.js
@@ -1,0 +1,13 @@
+class TargetedArea {
+  constructor({
+    id,
+    title,
+    competences = [],
+  } = {}) {
+    this.id = id;
+    this.title = title;
+    this.competences = competences;
+  }
+}
+
+module.exports = TargetedArea;

--- a/api/lib/domain/models/TargetedCompetence.js
+++ b/api/lib/domain/models/TargetedCompetence.js
@@ -1,0 +1,17 @@
+class TargetedCompetence {
+  constructor({
+    id,
+    name,
+    index,
+    areaId,
+    tubes = [],
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.index = index;
+    this.areaId = areaId;
+    this.tubes = tubes;
+  }
+}
+
+module.exports = TargetedCompetence;

--- a/api/lib/domain/models/TargetedSkill.js
+++ b/api/lib/domain/models/TargetedSkill.js
@@ -1,0 +1,13 @@
+class TargetedSkill {
+  constructor({
+    id,
+    name,
+    tubeId,
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.tubeId = tubeId;
+  }
+}
+
+module.exports = TargetedSkill;

--- a/api/lib/domain/models/TargetedTube.js
+++ b/api/lib/domain/models/TargetedTube.js
@@ -1,0 +1,15 @@
+class TargetedTube {
+  constructor({
+    id,
+    practicalTitle,
+    competenceId,
+    skills = [],
+  } = {}) {
+    this.id = id;
+    this.practicalTitle = practicalTitle;
+    this.competenceId = competenceId;
+    this.skills = skills;
+  }
+}
+
+module.exports = TargetedTube;

--- a/api/lib/infrastructure/datasources/airtable/area-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/area-datasource.js
@@ -29,5 +29,10 @@ module.exports = datasource.extend({
     };
   },
 
+  async findByRecordIds(areaIds) {
+    const areas = await this.list();
+    return areas.filter(({ id }) => areaIds.includes(id));
+  },
+
 });
 

--- a/api/lib/infrastructure/datasources/airtable/competence-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/competence-datasource.js
@@ -36,5 +36,10 @@ module.exports = datasource.extend({
     };
   },
 
+  async findByRecordIds(competenceIds) {
+    const competences = await this.list();
+    return competences.filter(({ id }) => competenceIds.includes(id));
+  },
+
 });
 

--- a/api/lib/infrastructure/datasources/airtable/tube-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/tube-datasource.js
@@ -39,4 +39,9 @@ module.exports = datasource.extend({
     return tubes.filter((tubeData) => _.includes(tubeNames, tubeData.name));
   },
 
+  async findByRecordIds(tubeIds) {
+    const tubes = await this.list();
+    return tubes.filter(({ id }) => tubeIds.includes(id));
+  },
+
 });

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -1,0 +1,100 @@
+const _ = require('lodash');
+const { knex } = require('../bookshelf');
+const TargetProfileWithLearningContent = require('../../domain/models/TargetProfileWithLearningContent');
+const TargetedSkill = require('../../domain/models/TargetedSkill');
+const TargetedTube = require('../../domain/models/TargetedTube');
+const TargetedCompetence = require('../../domain/models/TargetedCompetence');
+const TargetedArea = require('../../domain/models/TargetedArea');
+const skillDatasource = require('../../infrastructure/datasources/airtable/skill-datasource');
+const tubeDatasource = require('../../infrastructure/datasources/airtable/tube-datasource');
+const competenceDatasource = require('../../infrastructure/datasources/airtable/competence-datasource');
+const areaDatasource = require('../../infrastructure/datasources/airtable/area-datasource');
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = {
+
+  async get(id) {
+    const results = await knex('target-profiles')
+      .leftJoin('target-profiles_skills', 'target-profiles_skills.targetProfileId', 'target-profiles.id')
+      .select('target-profiles.id', 'target-profiles.name', 'target-profiles_skills.skillId')
+      .where('target-profiles.id', id);
+
+    if (_.isEmpty(results)) {
+      throw new NotFoundError(`Le profil cible ${id} n'existe pas`);
+    }
+
+    const skillIds = _.compact(results.map(({ skillId }) => skillId));
+    const {
+      skills,
+      tubes,
+      competences,
+      areas,
+    } = await _getTargetedLearningContent(skillIds);
+
+    return new TargetProfileWithLearningContent({
+      id: results[0].id,
+      name: results[0].name,
+      skills,
+      tubes,
+      competences,
+      areas,
+    });
+  },
+};
+
+async function _getTargetedLearningContent(skillIds) {
+  const skills = await _findTargetedSkills(skillIds);
+  const tubes = await _findTargetedTubes(skills);
+  const competences = await _findTargetedCompetences(tubes);
+  const areas = await _findTargetedAreas(competences);
+
+  return {
+    skills,
+    tubes,
+    competences,
+    areas,
+  };
+}
+
+async function _findTargetedSkills(skillIds) {
+  const airtableSkills = await skillDatasource.findOperativeByRecordIds(skillIds);
+  return airtableSkills.map((airtableSkill) => {
+    return new TargetedSkill(airtableSkill);
+  });
+}
+
+async function _findTargetedTubes(skills) {
+  const skillsByTubeId = _.groupBy(skills, 'tubeId');
+  const airtableTubes = await tubeDatasource.findByRecordIds(Object.keys(skillsByTubeId));
+  return airtableTubes.map((airtableTube) => {
+    return new TargetedTube({
+      ...airtableTube,
+      practicalTitle: airtableTube.practicalTitleFrFr,
+      skills: skillsByTubeId[airtableTube.id],
+    });
+  });
+}
+
+async function _findTargetedCompetences(tubes) {
+  const tubesByCompetenceId = _.groupBy(tubes, 'competenceId');
+  const airtableCompetences = await competenceDatasource.findByRecordIds(Object.keys(tubesByCompetenceId));
+  return airtableCompetences.map((airtableCompetence) => {
+    return new TargetedCompetence({
+      ...airtableCompetence,
+      name: airtableCompetence.nameFrFr,
+      tubes: tubesByCompetenceId[airtableCompetence.id],
+    });
+  });
+}
+
+async function _findTargetedAreas(competences) {
+  const competencesByAreaId = _.groupBy(competences, 'areaId');
+  const airtableAreas = await areaDatasource.findByRecordIds(Object.keys(competencesByAreaId));
+  return airtableAreas.map((airtableArea) => {
+    return new TargetedArea({
+      ...airtableArea,
+      title: airtableArea.titleFrFr,
+      competences: competencesByAreaId[airtableArea.id],
+    });
+  });
+}

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -1,0 +1,155 @@
+const { expect, databaseBuilder, airtableBuilder, domainBuilder, catchErr } = require('../../../test-helper');
+const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
+const targetProfileWithLearningContentRepository = require('../../../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
+const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | Target-profile-with-learning-content', () => {
+
+  afterEach(() => {
+    airtableBuilder.cleanAll();
+    return cache.flushAll();
+  });
+
+  describe('#get', () => {
+
+    it('should return target profile with learning content', async () => {
+      // given
+      const learningContent = [
+        {
+          id: 'recArea1',
+          titleFr: 'area1_TitleFr',
+          competences: [
+            {
+              id: 'recArea1_Competence1',
+              name: 'competence1_1_name',
+              index: 'competence1_1_index',
+              tubes: [
+                {
+                  id: 'recArea1_Competence1_Tube1',
+                  practicalTitle: 'tube1_1_1_practicalTitle',
+                  skills: [
+                    {
+                      id: 'recArea1_Competence1_Tube1_Skill1',
+                      nom: 'skill1_1_1_1_name',
+                      challenges: [],
+                    },
+                    {
+                      id: 'recArea1_Competence1_Tube1_Skill2',
+                      nom: 'skill1_1_1_2_name',
+                      challenges: [],
+                    },
+                  ],
+                },
+                {
+                  id: 'recArea1_Competence1_Tube2',
+                  practicalTitle: 'tube1_1_2_practicalTitle',
+                  skills: [
+                    {
+                      id: 'recArea1_Competence1_Tube2_Skill1',
+                      nom: 'skill1_1_2_1_name',
+                      challenges: [],
+                    },
+                    {
+                      id: 'recArea1_Competence1_Tube2_Skill2',
+                      nom: 'skill1_1_2_2_name',
+                      challenges: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              id: 'recArea1_Competence2',
+              name: 'competence1_2_name',
+              index: 'competence1_2_index',
+              tubes: [
+                {
+                  id: 'recArea1_Competence2_Tube1',
+                  practicalTitle: 'tube1_2_1_practicalTitle',
+                  skills: [
+                    {
+                      id: 'recArea1_Competence2_Tube1_Skill1',
+                      nom: 'skill1_2_1_1_name',
+                      challenges: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ];
+      const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
+      airtableBuilder.mockLists(airtableObjects);
+      const skill1_1_1_2 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence1_Tube1_Skill2',
+        name: 'skill1_1_1_2_name',
+        tubeId: 'recArea1_Competence1_Tube1',
+      });
+      const skill1_2_1_1 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence2_Tube1_Skill1',
+        name: 'skill1_2_1_1_name',
+        tubeId: 'recArea1_Competence2_Tube1',
+      });
+      const tube1_1_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence1_Tube1',
+        practicalTitle: 'tube1_1_1_practicalTitle',
+        competenceId: 'recArea1_Competence1',
+        skills: [skill1_1_1_2],
+      });
+      const tube1_2_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence2_Tube1',
+        practicalTitle: 'tube1_2_1_practicalTitle',
+        competenceId: 'recArea1_Competence2',
+        skills: [skill1_2_1_1],
+      });
+      const competence1_1 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence1',
+        name: 'competence1_1_name',
+        index: 'competence1_1_index',
+        areaId: 'recArea1',
+        tubes: [tube1_1_1],
+      });
+      const competence1_2 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence2',
+        name: 'competence1_2_name',
+        index: 'competence1_2_index',
+        areaId: 'recArea1',
+        tubes: [tube1_2_1],
+      });
+      const area1 = domainBuilder.buildTargetedArea({
+        id: 'recArea1',
+        title: 'area1_TitleFr',
+        competences: [competence1_1, competence1_2],
+      });
+      const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence1_Tube1_Skill2' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence2_Tube1_Skill1' });
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        id: targetProfileDB.id,
+        name: targetProfileDB.name,
+        skills: [skill1_1_1_2, skill1_2_1_1],
+        tubes: [tube1_1_1, tube1_2_1],
+        competences: [competence1_1, competence1_2],
+        areas: [area1],
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.get(targetProfileDB.id);
+
+      // then
+      expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should throw a NotFoundError when targetProfile does not exists', async () => {
+      // when
+      const error = await catchErr(targetProfileWithLearningContentRepository.get)(123);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -15,73 +15,6 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
 
     it('should return target profile with learning content', async () => {
       // given
-      const learningContent = [
-        {
-          id: 'recArea1',
-          titleFr: 'area1_TitleFr',
-          competences: [
-            {
-              id: 'recArea1_Competence1',
-              name: 'competence1_1_name',
-              index: 'competence1_1_index',
-              tubes: [
-                {
-                  id: 'recArea1_Competence1_Tube1',
-                  practicalTitle: 'tube1_1_1_practicalTitle',
-                  skills: [
-                    {
-                      id: 'recArea1_Competence1_Tube1_Skill1',
-                      nom: 'skill1_1_1_1_name',
-                      challenges: [],
-                    },
-                    {
-                      id: 'recArea1_Competence1_Tube1_Skill2',
-                      nom: 'skill1_1_1_2_name',
-                      challenges: [],
-                    },
-                  ],
-                },
-                {
-                  id: 'recArea1_Competence1_Tube2',
-                  practicalTitle: 'tube1_1_2_practicalTitle',
-                  skills: [
-                    {
-                      id: 'recArea1_Competence1_Tube2_Skill1',
-                      nom: 'skill1_1_2_1_name',
-                      challenges: [],
-                    },
-                    {
-                      id: 'recArea1_Competence1_Tube2_Skill2',
-                      nom: 'skill1_1_2_2_name',
-                      challenges: [],
-                    },
-                  ],
-                },
-              ],
-            },
-            {
-              id: 'recArea1_Competence2',
-              name: 'competence1_2_name',
-              index: 'competence1_2_index',
-              tubes: [
-                {
-                  id: 'recArea1_Competence2_Tube1',
-                  practicalTitle: 'tube1_2_1_practicalTitle',
-                  skills: [
-                    {
-                      id: 'recArea1_Competence2_Tube1_Skill1',
-                      nom: 'skill1_2_1_1_name',
-                      challenges: [],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ];
-      const airtableObjects = airtableBuilder.factory.buildLearningContent(learningContent);
-      airtableBuilder.mockLists(airtableObjects);
       const skill1_1_1_2 = domainBuilder.buildTargetedSkill({
         id: 'recArea1_Competence1_Tube1_Skill2',
         name: 'skill1_1_1_2_name',
@@ -134,6 +67,8 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
         competences: [competence1_1, competence1_2],
         areas: [area1],
       });
+      const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({ targetProfile: expectedTargetProfile });
+      airtableBuilder.mockLists(airtableObjects);
       await databaseBuilder.commit();
 
       // when

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -2,6 +2,7 @@ const { expect, databaseBuilder, airtableBuilder, domainBuilder, catchErr } = re
 const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
 const targetProfileWithLearningContentRepository = require('../../../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
 const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const { ENGLISH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | Target-profile-with-learning-content', () => {
@@ -53,7 +54,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       });
       const area1 = domainBuilder.buildTargetedArea({
         id: 'recArea1',
-        title: 'area1_TitleFr',
+        title: 'area1_Title',
         competences: [competence1_1, competence1_2],
       });
       const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
@@ -72,7 +73,57 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       await databaseBuilder.commit();
 
       // when
-      const targetProfile = await targetProfileWithLearningContentRepository.get(targetProfileDB.id);
+      const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id });
+
+      // then
+      expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should return target profile filled with objects with appropriate translation', async () => {
+      // given
+      const skill1_1_1_1 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence1_Tube1_Skill1',
+        name: 'skill1_1_1_1_name',
+        tubeId: 'recArea1_Competence1_Tube1',
+      });
+      const tube1_1_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence1_Tube1',
+        practicalTitle: 'tube1_1_1_practicalTitle',
+        competenceId: 'recArea1_Competence1',
+        skills: [skill1_1_1_1],
+      });
+      const competence1_1 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence1',
+        name: 'competence1_1_name',
+        index: 'competence1_1_index',
+        areaId: 'recArea1',
+        tubes: [tube1_1_1],
+      });
+      const area1 = domainBuilder.buildTargetedArea({
+        id: 'recArea1',
+        title: 'area1_Title',
+        competences: [competence1_1],
+      });
+      const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence1_Tube1_Skill1' });
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        id: targetProfileDB.id,
+        name: targetProfileDB.name,
+        skills: [skill1_1_1_1],
+        tubes: [tube1_1_1],
+        competences: [competence1_1],
+        areas: [area1],
+      });
+      const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({
+        targetProfile: expectedTargetProfile,
+        locale: ENGLISH_SPOKEN,
+      });
+      airtableBuilder.mockLists(airtableObjects);
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id, locale: ENGLISH_SPOKEN });
 
       // then
       expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
@@ -81,7 +132,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
 
     it('should throw a NotFoundError when targetProfile does not exists', async () => {
       // when
-      const error = await catchErr(targetProfileWithLearningContentRepository.get)(123);
+      const error = await catchErr(targetProfileWithLearningContentRepository.get)({ id: 123 });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/tooling/airtable-builder/factory/build-competence.js
+++ b/api/tests/tooling/airtable-builder/factory/build-competence.js
@@ -12,6 +12,8 @@ const buildCompetence = function buildCompetence({
   ],
   sousDomaine = '1.1',
   titre = 'Mener une recherche et une veille d’information',
+  titreFrFr = null,
+  titreEnUs = null,
   acquisIdentifiants = [
     'recV11ibSCXvaUzZd',
     'recD01ptfJy7c4Sex',
@@ -72,6 +74,8 @@ const buildCompetence = function buildCompetence({
       'Epreuves': epreuves,
       'Sous-domaine': sousDomaine,
       'Titre': titre,
+      'Titre fr-fr': titreFrFr,
+      'Titre en-us': titreEnUs,
       'Acquis (identifiants)': acquisIdentifiants,
       'Tubes': tubes,
       'Acquis (via Tubes) (id persistant)': acquisViaTubes,

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
@@ -4,6 +4,7 @@ const buildChallenge = require('../build-challenge');
 const buildTube = require('../build-tube');
 const buildCompetence = require('../build-competence');
 const buildArea = require('../build-area');
+const { FRENCH_FRANCE, ENGLISH_SPOKEN } = require('../../../../../lib/domain/constants').LOCALE;
 
 const buildLearningContent = function(learningContent) {
   const allCompetences = [];
@@ -95,6 +96,7 @@ const buildLearningContent = function(learningContent) {
 
 buildLearningContent.fromTargetProfileWithLearningContent = function buildLearningContentFromTargetProfileWithLearningContent({
   targetProfile,
+  locale = FRENCH_FRANCE,
 }) {
   const allCompetences = [];
   const allTubes = [];
@@ -117,7 +119,8 @@ buildLearningContent.fromTargetProfileWithLearningContent = function buildLearni
         return buildTube(
           {
             id: tube.id,
-            titrePratiqueFrFr: tube.practicalTitle,
+            titrePratiqueFrFr: locale === FRENCH_FRANCE ? tube.practicalTitle : null,
+            titrePratiqueEnUs: locale === ENGLISH_SPOKEN ? tube.practicalTitle : null,
             competences: [competence.id],
           },
         );
@@ -131,14 +134,16 @@ buildLearningContent.fromTargetProfileWithLearningContent = function buildLearni
           acquisViaTubes: competence.tubes.flatMap((tube) => tube.skills).map((skill) => skill.id),
           domaineIds: [area.id],
           sousDomaine: competence.index,
-          titre: competence.name,
+          titreFrFr: locale === FRENCH_FRANCE ? competence.name : null,
+          titreEnUs: locale === ENGLISH_SPOKEN ? competence.name : null,
         },
       );
     });
     allCompetences.push(competences);
     return buildArea({
       id: area.id,
-      titreFr: area.title,
+      titreFr: locale === FRENCH_FRANCE ? area.title : null,
+      titreEn: locale === ENGLISH_SPOKEN ? area.title : null,
       competenceIds: competences.map((competence) => competence.id),
       nomCompetences: competences.map((competence) => competence.name),
     });

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
@@ -93,4 +93,62 @@ const buildLearningContent = function(learningContent) {
   };
 };
 
+buildLearningContent.fromTargetProfileWithLearningContent = function buildLearningContentFromTargetProfileWithLearningContent({
+  targetProfile,
+}) {
+  const allCompetences = [];
+  const allTubes = [];
+  const allSkills = [];
+  const areas = targetProfile.areas.map((area) => {
+    const competences = area.competences.map((competence) => {
+      const tubes = competence.tubes.map((tube) => {
+        const skills = tube.skills.map((skill) => {
+          return buildSkill(
+            {
+              id: skill.id,
+              epreuves: [],
+              tube: [tube.id],
+              compétenceViaTube: [competence.id],
+              nom: skill.name,
+            },
+          );
+        });
+        allSkills.push(skills);
+        return buildTube(
+          {
+            id: tube.id,
+            titrePratiqueFrFr: tube.practicalTitle,
+            competences: [competence.id],
+          },
+        );
+      });
+      allTubes.push(tubes);
+      return buildCompetence(
+        {
+          id: competence.id,
+          epreuves: [],
+          tubes: competence.tubes.map((tube) => tube.id),
+          acquisViaTubes: competence.tubes.flatMap((tube) => tube.skills).map((skill) => skill.id),
+          domaineIds: [area.id],
+          sousDomaine: competence.index,
+          titre: competence.name,
+        },
+      );
+    });
+    allCompetences.push(competences);
+    return buildArea({
+      id: area.id,
+      titreFr: area.title,
+      competenceIds: competences.map((competence) => competence.id),
+      nomCompetences: competences.map((competence) => competence.name),
+    });
+  });
+  return {
+    areas,
+    competences: allCompetences.flat(),
+    tubes: allTubes.flat(),
+    skills: allSkills.flat(),
+  };
+};
+
 module.exports = buildLearningContent;

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
@@ -1,0 +1,19 @@
+const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
+
+module.exports = function buildTargetProfileWithLearningContent({
+  id = 123,
+  name = 'Pour les champions du monde 1998 !! Merci Aimé',
+  skills = [],
+  tubes = [],
+  competences = [],
+  areas = [],
+} = {}) {
+  return new TargetProfileWithLearningContent({
+    id,
+    name,
+    skills,
+    tubes,
+    competences,
+    areas,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-targeted-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-area.js
@@ -1,0 +1,16 @@
+const TargetedArea = require('../../../../lib/domain/models/TargetedArea');
+const buildTargetedCompetence = require('./build-targeted-competence');
+
+const buildTargetedArea = function buildTargetedArea({
+  id = 'someAreaId',
+  title = 'someTitle',
+  competences = [buildTargetedCompetence()],
+} = {}) {
+  return new TargetedArea({
+    id,
+    title,
+    competences,
+  });
+};
+
+module.exports = buildTargetedArea;

--- a/api/tests/tooling/domain-builder/factory/build-targeted-competence.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-competence.js
@@ -1,0 +1,20 @@
+const TargetedCompetence = require('../../../../lib/domain/models/TargetedCompetence');
+const buildTargetedTube = require('./build-targeted-tube');
+
+const buildTargetedCompetence = function buildTargetedCompetence({
+  id = 'someCompetenceId',
+  name = 'someName',
+  index = 'someIndex',
+  areaId = 'someAreaId',
+  tubes = [buildTargetedTube()],
+} = {}) {
+  return new TargetedCompetence({
+    id,
+    name,
+    index,
+    areaId,
+    tubes,
+  });
+};
+
+module.exports = buildTargetedCompetence;

--- a/api/tests/tooling/domain-builder/factory/build-targeted-skill.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-skill.js
@@ -1,0 +1,15 @@
+const TargetedSkill = require('../../../../lib/domain/models/TargetedSkill');
+
+const buildTargetedSkill = function buildTargetedSkill({
+  id = 'someSkillId',
+  name = 'someSkillName5',
+  tubeId = 'someTubeId',
+} = {}) {
+  return new TargetedSkill({
+    id,
+    name,
+    tubeId,
+  });
+};
+
+module.exports = buildTargetedSkill;

--- a/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
@@ -1,0 +1,18 @@
+const TargetedTube = require('../../../../lib/domain/models/TargetedTube');
+const buildTargetedSkill = require('./build-targeted-skill');
+
+const buildTargetedTube = function buildTargetedTube({
+  id = 'someTubeId',
+  practicalTitle = 'somePracticalTitle',
+  competenceId = 'someCompetenceId',
+  skills = [buildTargetedSkill()],
+} = {}) {
+  return new TargetedTube({
+    id,
+    practicalTitle,
+    competenceId,
+    skills,
+  });
+};
+
+module.exports = buildTargetedTube;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -53,6 +53,7 @@ module.exports = {
   buildSkillCollection: require('./build-skill-collection'),
   buildSolution: require('./build-solution'),
   buildTargetedSkill: require('./build-targeted-skill'),
+  buildTargetedTube: require('./build-targeted-tube'),
   buildTargetProfile: require('./build-target-profile'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -57,6 +57,7 @@ module.exports = {
   buildTargetedSkill: require('./build-targeted-skill'),
   buildTargetedTube: require('./build-targeted-tube'),
   buildTargetProfile: require('./build-target-profile'),
+  buildTargetProfileWithLearningContent: require('./build-target-profile-with-learning-content'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),
   buildUser: require('./build-user'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -52,6 +52,7 @@ module.exports = {
   buildSkillAirtableDataObject: require('./build-skill-airtable-data-object'),
   buildSkillCollection: require('./build-skill-collection'),
   buildSolution: require('./build-solution'),
+  buildTargetedCompetence: require('./build-targeted-competence'),
   buildTargetedSkill: require('./build-targeted-skill'),
   buildTargetedTube: require('./build-targeted-tube'),
   buildTargetProfile: require('./build-target-profile'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -52,6 +52,7 @@ module.exports = {
   buildSkillAirtableDataObject: require('./build-skill-airtable-data-object'),
   buildSkillCollection: require('./build-skill-collection'),
   buildSolution: require('./build-solution'),
+  buildTargetedArea: require('./build-targeted-area'),
   buildTargetedCompetence: require('./build-targeted-competence'),
   buildTargetedSkill: require('./build-targeted-skill'),
   buildTargetedTube: require('./build-targeted-tube'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -52,6 +52,7 @@ module.exports = {
   buildSkillAirtableDataObject: require('./build-skill-airtable-data-object'),
   buildSkillCollection: require('./build-skill-collection'),
   buildSolution: require('./build-solution'),
+  buildTargetedSkill: require('./build-targeted-skill'),
   buildTargetProfile: require('./build-target-profile'),
   buildTube: require('./build-tube'),
   buildTutorial: require('./build-tutorial'),

--- a/api/tests/tooling/fixtures/infrastructure/areaRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/areaRawAirTableFixture.js
@@ -1,10 +1,10 @@
 const AirtableRecord = require('airtable').Record;
 
-module.exports = function areaRawAirTableFixture() {
-  return new AirtableRecord('Domaine', 'recvoGdo7z2z7pXWa', {
-    'id': 'recvoGdo7z2z7pXWa',
+module.exports = function areaRawAirTableFixture(id = 'recvoGdo7z2z7pXWa') {
+  return new AirtableRecord('Domaine', id, {
+    'id': id,
     'fields': {
-      'id persistant': 'recvoGdo7z2z7pXWa',
+      'id persistant': id,
       'Competences (identifiants) (id persistant)': [
         'recsvLz0W2ShyfD63',
         'recNv8qhaY887jQb2',

--- a/api/tests/tooling/fixtures/infrastructure/competenceRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/competenceRawAirTableFixture.js
@@ -1,10 +1,10 @@
 const AirtableRecord = require('airtable').Record;
 
-module.exports = function competenceRawAirTableFixture() {
-  return new AirtableRecord('Compétence', 'recsvLz0W2ShyfD63', {
-    'id': 'recsvLz0W2ShyfD63',
+module.exports = function competenceRawAirTableFixture(id = 'recsvLz0W2ShyfD63') {
+  return new AirtableRecord('Compétence', id, {
+    'id': id,
     'fields': {
-      'id persistant': 'recsvLz0W2ShyfD63',
+      'id persistant': id,
       'Domaine (id persistant)': [
         'recvoGdo7z2z7pXWa',
       ],

--- a/api/tests/tooling/fixtures/infrastructure/tubeRawAirTableFixture.js
+++ b/api/tests/tooling/fixtures/infrastructure/tubeRawAirTableFixture.js
@@ -1,10 +1,10 @@
 const AirtableRecord = require('airtable').Record;
 
-module.exports = function tubeRawAirTableFixture() {
-  return new AirtableRecord('Tubes', 'recTIddrkopID23Fp',{
-    'id': 'recTIddrkopID23Fp',
+module.exports = function tubeRawAirTableFixture(id = 'recTIddrkopID23Fp') {
+  return new AirtableRecord('Tubes', id,{
+    'id': id,
     'fields': {
-      'id persistant': 'recTIddrkopID23Fp',
+      'id persistant': id,
       'Nom': '@Moteur',
       'Titre': 'Moteur de recherche',
       'Description': 'Connaître le fonctionnement d\'un moteur de recherche',

--- a/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/area-datasource_test.js
@@ -1,6 +1,8 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, domainBuilder, sinon } = require('../../../../test-helper');
 const areaDatasource = require('../../../../../lib/infrastructure/datasources/airtable/area-datasource');
 const areaRawAirTableFixture = require('../../../../tooling/fixtures/infrastructure/areaRawAirTableFixture');
+const makeAirtableFake = require('../../../../tooling/airtable-builder/make-airtable-fake');
+const airtable = require('../../../../../lib/infrastructure/airtable');
 
 describe('Unit | Infrastructure | Datasource | Airtable | AreaDatasource', () => {
 
@@ -15,6 +17,44 @@ describe('Unit | Infrastructure | Datasource | Airtable | AreaDatasource', () =>
 
       // then
       expect(area).to.deep.equal(expectedArea);
+    });
+  });
+
+  describe('#findByRecordIds', () => {
+
+    it('should return an array of matching airtable area data objects', async function() {
+      // given
+      const rawArea1 = areaRawAirTableFixture('RECORD_ID_RAW_AREA_1');
+      const rawArea2 = areaRawAirTableFixture('RECORD_ID_RAW_AREA_2');
+      const rawArea3 = areaRawAirTableFixture('RECORD_ID_RAW_AREA_3');
+      const rawArea4 = areaRawAirTableFixture('RECORD_ID_RAW_AREA_4');
+
+      const records = [rawArea1, rawArea2, rawArea3, rawArea4];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+      const expectedAreaIds = [
+        rawArea1.fields['id persistant'],
+        rawArea2.fields['id persistant'],
+        rawArea4.fields['id persistant'],
+      ];
+
+      // when
+      const foundAreas = await areaDatasource.findByRecordIds(expectedAreaIds);
+      // then
+      expect(foundAreas.map(({ id }) => id)).to.deep.equal(expectedAreaIds);
+    });
+
+    it('should return an empty array when there are no objects matching the ids', async function() {
+      // given
+      const rawArea1 = areaRawAirTableFixture('RECORD_ID_RAW_AREA_1');
+
+      const records = [rawArea1];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+
+      // when
+      const foundAreas = await areaDatasource.findByRecordIds(['some_other_id']);
+
+      // then
+      expect(foundAreas).to.be.empty;
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/competence-datasource_test.js
@@ -1,6 +1,8 @@
-const { expect, domainBuilder } = require('../../../../test-helper');
+const { expect, sinon, domainBuilder } = require('../../../../test-helper');
 const competenceDatasource = require('../../../../../lib/infrastructure/datasources/airtable/competence-datasource');
+const airtable = require('../../../../../lib/infrastructure/airtable');
 const competenceRawAirTableFixture = require('../../../../tooling/fixtures/infrastructure/competenceRawAirTableFixture');
+const makeAirtableFake = require('../../../../tooling/airtable-builder/make-airtable-fake');
 
 describe('Unit | Infrastructure | Datasource | Airtable | CompetenceDatasource', () => {
 
@@ -15,6 +17,44 @@ describe('Unit | Infrastructure | Datasource | Airtable | CompetenceDatasource',
 
       // then
       expect(area).to.deep.equal(expectedCompetence);
+    });
+  });
+
+  describe('#findByRecordIds', () => {
+
+    it('should return an array of matching airtable competence data objects', async function() {
+      // given
+      const rawCompetence1 = competenceRawAirTableFixture('RECORD_ID_RAW_COMPETENCE_1');
+      const rawCompetence2 = competenceRawAirTableFixture('RECORD_ID_RAW_COMPETENCE_2');
+      const rawCompetence3 = competenceRawAirTableFixture('RECORD_ID_RAW_COMPETENCE_3');
+      const rawCompetence4 = competenceRawAirTableFixture('RECORD_ID_RAW_COMPETENCE_4');
+
+      const records = [rawCompetence1, rawCompetence2, rawCompetence3, rawCompetence4];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+      const expectedCompetenceIds = [
+        rawCompetence1.fields['id persistant'],
+        rawCompetence2.fields['id persistant'],
+        rawCompetence4.fields['id persistant'],
+      ];
+
+      // when
+      const foundCompetences = await competenceDatasource.findByRecordIds(expectedCompetenceIds);
+      // then
+      expect(foundCompetences.map(({ id }) => id)).to.deep.equal(expectedCompetenceIds);
+    });
+
+    it('should return an empty array when there are no objects matching the ids', async function() {
+      // given
+      const rawCompetence1 = competenceRawAirTableFixture('RECORD_ID_RAW_COMPETENCE_1');
+
+      const records = [rawCompetence1];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+
+      // when
+      const foundCompetences = await competenceDatasource.findByRecordIds(['some_other_id']);
+
+      // then
+      expect(foundCompetences).to.be.empty;
     });
   });
 

--- a/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/tube-datasource_test.js
@@ -60,4 +60,42 @@ describe('Unit | Infrastructure | Datasource | Airtable | TubeDatasource', () =>
     });
   });
 
+  describe('#findByRecordIds', () => {
+
+    it('should return an array of matching airtable tube data objects', async function() {
+      // given
+      const rawTube1 = tubeRawAirTableFixture('RECORD_ID_RAW_TUBE_1');
+      const rawTube2 = tubeRawAirTableFixture('RECORD_ID_RAW_TUBE_2');
+      const rawTube3 = tubeRawAirTableFixture('RECORD_ID_RAW_TUBE_3');
+      const rawTube4 = tubeRawAirTableFixture('RECORD_ID_RAW_TUBE_4');
+
+      const records = [rawTube1, rawTube2, rawTube3, rawTube4];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+      const expectedTubeIds = [
+        rawTube1.fields['id persistant'],
+        rawTube2.fields['id persistant'],
+        rawTube4.fields['id persistant'],
+      ];
+
+      // when
+      const foundTubes = await tubeDatasource.findByRecordIds(expectedTubeIds);
+      // then
+      expect(foundTubes.map(({ id }) => id)).to.deep.equal(expectedTubeIds);
+    });
+
+    it('should return an empty array when there are no objects matching the ids', async function() {
+      // given
+      const rawTube1 = tubeRawAirTableFixture('RECORD_ID_RAW_TUBE_1');
+
+      const records = [rawTube1];
+      sinon.stub(airtable, 'findRecords').callsFake(makeAirtableFake(records));
+
+      // when
+      const foundTubes = await tubeDatasource.findByRecordIds(['some_other_id']);
+
+      // then
+      expect(foundTubes).to.be.empty;
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans les contextes liés à la prescription (en particulier les fonctionnalités **_PixOrga_**), on fait des calculs et des rendus de résultats en travaillant sur un sous-ensemble du référentiel.
Ce sous-ensemble est délimité par le profil cible de la campagne en question (le `targetProfile`). On pourrait faire une abstraction mentale et dire que finalement, c'est comme si chaque campagne avait son propre référentiel (un sous-ensemble du référentiel complet Pix). On a donc le **référentiel complet** et les **référentiels ciblés**. Il existe autant de référentiels ciblés que de profils cibles en BDD, et _chaque **référentiel ciblé** est en réalité un sous-ensemble du **référentiel complet**_.
De fait il est commun, dans le code lié à ces fonctionnalités, de devoir parcourir ce référentiel ciblé sur plusieurs couches : domaines, compétences, sujet et acquis.
Malheureusement, j'ai l'impression qu'on ne s'est pas encore donné les moyens / les outils (les modèles ?) dédiés à ce genre de traitement, et on se retrouve très souvent à récupérer :
- d'un côté le **référentiel ciblé** tel qu'il est défini dans le code aujourd'hui, à savoir simplement une liste d'acquis
- d'un autre côté le **référentiel complet** par morceau (via competenceRepository, tubeRepository par ex.)

Et donc, dans plusieurs morceaux de code du domaine, on fait plusieurs fois les mêmes opérations d'intersection, de recoupement afin de mieux travailler sur le **référentiel ciblé**. Exemples :
![screen_tp_1](https://user-images.githubusercontent.com/48727874/93874208-52763900-fcd3-11ea-8fc9-ad2e698fcff9.png)
![screen_tp_2](https://user-images.githubusercontent.com/48727874/93874217-54d89300-fcd3-11ea-8512-46ccdbe826e8.png)
![screen_tp_3](https://user-images.githubusercontent.com/48727874/93874221-55712980-fcd3-11ea-80f7-fc55583bebe1.png)
![screen_tp_4](https://user-images.githubusercontent.com/48727874/93874224-56a25680-fcd3-11ea-8847-e0d7784b6609.png)
![screen_tp_5](https://user-images.githubusercontent.com/48727874/93874227-573aed00-fcd3-11ea-98c6-79ba88b4bc18.png)

On retrouve le même morceau de code à plusieurs endroits, et de la logique algorithmique de recoupage de référentiel pas toujours facile à lire.


## :robot: Solution
A mon sens, il manque en fait un modèle, que je vais appeler `TargetProfileWithLearningContent`, qui va en fait représenter ce **référentiel ciblé**, et qui va offrir une interface pour aider à traverser facilement ce référentiel.

Ce modèle va contenir une collection par type d'objet du référentiel (domaines, compétences, sujets et acquis), lesquels ont aussi un lien vers la collection de leurs sous-objets respectifs (un domaine a plusieurs compétences, une compétence a plusieurs sujets, et un sujet a plusieurs acquis). En gros, on va mettre des références dans tous les sens pour pouvoir aisément naviguer dans le **référentiel ciblé**
![tp-full](https://user-images.githubusercontent.com/48727874/93880287-85252f00-fcdd-11ea-94df-6f348f849bab.png)

La construction d'un tel objet est géré par un repository dédié.
L'idée dans cette PR n'est pas de remplacer complètement le modèle TargetProfile existant au profit de celui-ci, mais de remplacer petit à petit là où c'est nécessaire.
Cette PR contient donc :
- Création des modèles adaptées (TargetedSkill, TargetedTube, TargetedCompetence, TargetedArea et TargetProfileWithLearningContent)
- Création d'un répo pour récupérer ce nouveau TargetProfileWithLearningContent "complet" !

On est toujours dans la démarche de déplacer de la logique davantage dans les modèles. On peut le voir avec la version "finale" de cette PR du modèle `TargetProfileWithLearningContent` qui présente pas mal de getters et de fonctions pour facilement manipuler le référentiel.

## :rainbow: Remarques
J'hésite à pousser le bouchon un poil plus loin et de carrément renommer `TargetProfileWithLearningContent` en `TargetedLearningContent`

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._


Voir un exemple d'usage en https://github.com/1024pix/pix/pull/1910