### PR TITLE
[BUGFIX] Ne plus afficher le message d'erreur précédent si l'utilisateur possède un compte Pix (PIX-1246) 

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -102,6 +102,7 @@ export default class JoinSco extends Component {
   async submit(event) {
     event.preventDefault();
     this.isLoading = true;
+    this.errorMessage = null;
     this._validateInputName('firstName', this.firstName);
     this._validateInputName('lastName', this.lastName);
     this._validateInputDay('dayOfBirth', this.dayOfBirth);

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -442,6 +442,17 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         // then
         sinon.assert.calledWith(onSubmitToCreateAndReconcileStub, externalUser);
       });
+
+      it('should reset error message when submit', async () => {
+        // given
+        component.errorMessage = 'Vous êtes un élève ? Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        expect(component.errorMessage).to.equal(null);
+      });
     });
 
     describe('Errors', function() {


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de réconciliation, le message d'erreur d'absence d'inscription, apparaissant lors d'une première tentative, reste même après une deuxième tentative réussie.

## :robot: Solution
Reset l'errorMessage dans le submit du formulaire.
`this.errorMessage = null;`

## :100: Pour tester

- Se rendre dans la page de réconciliation SCO mon-pix
- Entrer des données fausses et submit (le message d'erreur d'absence d'inscription apparaît)
- Entrer les bonnes données et submit à nouveau ( le message n'apparaît plus).
