### PR TITLE
[TECH] Remplacer les bidouilles mises dans les transform() des JSONAPI serializers par la mise en place de la config nullIfMissing dans les attributs sérialisés (PIX-1304)

### DIFF
--- a/api/lib/domain/models/Answer.js
+++ b/api/lib/domain/models/Answer.js
@@ -12,7 +12,6 @@ class Answer {
     timeout,
     value,
     // includes
-    correction,
     levelup,
     // references
     assessmentId,
@@ -27,7 +26,6 @@ class Answer {
     this.timeout = timeout;
     this.value = value;
     // includes
-    this.correction = correction;
     this.levelup = levelup;
     // references
     this.assessmentId = assessmentId;

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -23,8 +23,6 @@ class Campaign {
     // includes
     targetProfile,
     campaignReport,
-    campaignCollectiveResult,
-    campaignAnalysis,
     creator,
     // references
     organizationId,
@@ -48,8 +46,6 @@ class Campaign {
     // includes
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;
-    this.campaignCollectiveResult = campaignCollectiveResult;
-    this.campaignAnalysis = campaignAnalysis;
     this.creator = creator;
     // references
     this.organizationId = organizationId;

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -12,9 +12,7 @@ class CampaignParticipation {
     // includes
     assessments,
     campaign,
-    campaignParticipationResult,
     user,
-    campaignAnalysis,
     // references
     assessmentId,
     campaignId,
@@ -26,9 +24,7 @@ class CampaignParticipation {
     this.participantExternalId = participantExternalId;
     this.sharedAt = sharedAt;
     this.campaign = campaign;
-    this.campaignParticipationResult = campaignParticipationResult;
     this.user = user;
-    this.campaignAnalysis = campaignAnalysis;
     this.assessments = assessments;
     this.assessmentId = assessmentId;
     this.campaignId = campaignId;

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -26,6 +26,7 @@ module.exports = {
       },
       correction: {
         ref: 'id',
+        nullIfMissing: true,
         ignoreRelationshipData: true,
         relationshipLinks: {
           related(record, current, parent) {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-serializer.js
@@ -45,6 +45,7 @@ module.exports = {
         campaignParticipationResult: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related(record, current, parent) {
               return `/api/campaign-participations/${parent.id}/campaign-participation-result`;
@@ -54,6 +55,7 @@ module.exports = {
         campaignAnalysis: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related(record, current, parent) {
               return `/api/campaign-participations/${parent.id}/analyses`;

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -44,6 +44,7 @@ module.exports = {
       campaignCollectiveResult: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/campaigns/${parent.id}/collective-results`;
@@ -53,6 +54,7 @@ module.exports = {
       campaignAnalysis: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/campaigns/${parent.id}/analyses`;

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -32,6 +32,7 @@ module.exports = {
       juryCertificationSummaries : {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/jury/sessions/${parent.id}/jury-certification-summaries`;
@@ -46,7 +47,6 @@ module.exports = {
       transform(jurySession) {
         const transformedJurySession = Object.assign({}, jurySession);
         transformedJurySession.status = jurySession.status;
-        transformedJurySession.juryCertificationSummaries = [];
         return transformedJurySession;
       },
       typeForAttribute: function(attribute) {

--- a/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/membership-serializer.js
@@ -10,15 +10,7 @@ module.exports = {
           delete record.user;
         }
 
-        // we add a 'campaigns' attr to the organization so that the serializer
-        // can see there is a 'campaigns' attribute and add the relationship link.
-        if (record.organization) {
-          record.organization.campaigns = [];
-          record.organization.targetProfiles = [];
-          record.organization.memberships = [];
-          record.organization.students = [];
-          record.organization.organizationInvitations = [];
-        } else {
+        if (!record.organization) {
           delete record.organization;
         }
         return record;
@@ -31,6 +23,7 @@ module.exports = {
         campaigns: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/campaigns`;
@@ -40,6 +33,7 @@ module.exports = {
         targetProfiles: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/target-profiles`;
@@ -49,6 +43,7 @@ module.exports = {
         memberships: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/memberships`;
@@ -58,6 +53,7 @@ module.exports = {
         students: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/students`;
@@ -67,6 +63,7 @@ module.exports = {
         organizationInvitations: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/invitations`;

--- a/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/organization-serializer.js
@@ -4,10 +4,6 @@ module.exports = {
 
   serialize(organizations, meta) {
     return new Serializer('organizations', {
-      transform(record) {
-        record.targetProfiles = [];
-        return record;
-      },
       attributes: ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'credit', 'canCollectProfiles', 'email', 'memberships', 'students', 'targetProfiles'],
       memberships: {
         ref: 'id',
@@ -30,6 +26,7 @@ module.exports = {
       targetProfiles: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related: function(record, current, parent) {
             return `/api/organizations/${parent.id}/target-profiles`;

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -9,10 +9,6 @@ module.exports = {
         const recordWithoutClass = { ... record };
         recordWithoutClass.memberships.forEach((membership) => {
           membership.organization = { ... membership.organization };
-          membership.organization.targetProfiles = [];
-          membership.organization.memberships = [];
-          membership.organization.students = [];
-          membership.organization.organizationInvitations = [];
         });
         recordWithoutClass.userOrgaSettings.organization = { ... recordWithoutClass.userOrgaSettings.currentOrganization };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
@@ -33,6 +29,7 @@ module.exports = {
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,
+            nullIfMissing: true,
             relationshipLinks: {
               related: function(record, current, parent) {
                 return `/api/organizations/${parent.id}/memberships`;
@@ -42,6 +39,7 @@ module.exports = {
           organizationInvitations: {
             ref: 'id',
             ignoreRelationshipData: true,
+            nullIfMissing: true,
             relationshipLinks: {
               related: function(record, current, parent) {
                 return `/api/organizations/${parent.id}/invitations`;
@@ -51,6 +49,7 @@ module.exports = {
           students: {
             ref: 'id',
             ignoreRelationshipData: true,
+            nullIfMissing: true,
             relationshipLinks: {
               related: function(record, current, parent) {
                 return `/api/organizations/${parent.id}/students`;
@@ -60,6 +59,7 @@ module.exports = {
           targetProfiles: {
             ref: 'id',
             ignoreRelationshipData: true,
+            nullIfMissing: true,
             relationshipLinks: {
               related: function(record, current, parent) {
                 return `/api/organizations/${parent.id}/target-profiles`;

--- a/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-serializer.js
@@ -40,6 +40,7 @@ module.exports = {
       certificationReports: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
             return `/api/sessions/${parent.id}/certification-reports`;
@@ -58,7 +59,6 @@ module.exports = {
       transform(session) {
         const transformedSession = Object.assign({}, session);
         transformedSession.status = session.status;
-        transformedSession.certificationReports = [];
         transformedSession.certificationCenterName = session.certificationCenter;
         delete transformedSession.certificationCenter;
         if (session.certificationCenterId) {

--- a/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-orga-settings-serializer.js
@@ -10,16 +10,6 @@ module.exports = {
         }
 
         record.organization = record.currentOrganization;
-
-        // we add a 'campaigns' attr to the organization so that the serializer
-        // can see there is a 'campaigns' attribute and add the relationship link.
-        if (record.organization) {
-          record.organization.campaigns = [];
-          record.organization.targetProfiles = [];
-          record.organization.memberships = [];
-          record.organization.students = [];
-          record.organization.organizationInvitations = [];
-        }
         return record;
       },
       attributes: ['organization', 'user'],
@@ -30,6 +20,7 @@ module.exports = {
         campaigns: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/campaigns`;
@@ -39,6 +30,7 @@ module.exports = {
         targetProfiles: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/target-profiles`;
@@ -48,6 +40,7 @@ module.exports = {
         memberships: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/memberships`;
@@ -57,6 +50,7 @@ module.exports = {
         students: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/students`;
@@ -66,6 +60,7 @@ module.exports = {
         organizationInvitations: {
           ref: 'id',
           ignoreRelationshipData: true,
+          nullIfMissing: true,
           relationshipLinks: {
             related: function(record, current, parent) {
               return `/api/organizations/${parent.id}/invitations`;

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -5,11 +5,6 @@ module.exports = {
 
   serialize(users, meta) {
     return new Serializer('user', {
-      transform: (untouchedUser) => {
-        const user = Object.assign({}, untouchedUser);
-        user.isCertifiable = undefined;
-        return user;
-      },
       attributes: [
         'firstName', 'lastName', 'email', 'username',
         'cgu', 'lastTermsOfServiceValidatedAt', 'mustValidateTermsOfService',
@@ -66,6 +61,7 @@ module.exports = {
       isCertifiable: {
         ref: 'id',
         ignoreRelationshipData: true,
+        nullIfMissing: true,
         relationshipLinks: {
           related: function(record, current, parent) {
             return `/api/users/${parent.id}/is-certifiable`;

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -1,6 +1,5 @@
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 const buildCampaign = require('./build-campaign');
-const buildCampaignParticipationResult = require('./build-campaign-participation-result');
 
 const faker = require('faker');
 
@@ -15,7 +14,6 @@ module.exports = function buildCampaignParticipation(
     campaignId = campaign.id,
     assessmentId = null,
     userId = faker.random.number(2),
-    campaignParticipationResult = buildCampaignParticipationResult(),
   } = {}) {
 
   return new CampaignParticipation({
@@ -28,6 +26,5 @@ module.exports = function buildCampaignParticipation(
     campaignId,
     assessmentId,
     userId,
-    campaignParticipationResult,
   });
 };

--- a/api/tests/unit/domain/models/Answer_test.js
+++ b/api/tests/unit/domain/models/Answer_test.js
@@ -17,7 +17,6 @@ describe('Unit | Domain | Models | Answer', () => {
         timeout: 0,
         challengeId: 'redRecordId',
         assessmentId: 82,
-        correction: 'OK',
         levelup: {},
       };
 
@@ -30,7 +29,6 @@ describe('Unit | Domain | Models | Answer', () => {
         timeout: 0,
         challengeId: 'redRecordId',
         assessmentId: 82,
-        correction: 'OK',
         levelup: {},
       };
 


### PR DESCRIPTION
## :unicorn: Problème
La sérialisation en JSONAPI des résultats d'un appel API est géré par la lib **_jsonapi-serializer_**. Une pratique un peu contre-intuitive a été mise en place chez Pix depuis un moment déjà lorsqu'il s'agit d'ajouter un lien dans l'objet sérialisé. Exemple :
dans le modèle sérialisé `JurySession`, on souhaite ajouter un lien vers la collection `JuryCertificationSummaries` associée ( `/api/jury/sessions/${jurySession.id}/jury-certification-summaries` ). Il se trouve que, dans la lib **_jsonapi-serializer_**, si le modèle sérialisé n'a pas l'attribut à partir duquel on souhaite faire le lien, le lien n'est pas fait du tout. Donc, on s'est retrouvé contraint de faire un truc de ce style dans la `transform()` :
```js
      juryCertificationSummaries : {
        ref: 'id',
        ignoreRelationshipData: true,
        relationshipLinks: {
          related(record, current, parent) {
            return `/api/jury/sessions/${parent.id}/jury-certification-summaries`;
          },
        },
      },
      transform(jurySession) {
        const transformedJurySession = Object.assign({}, jurySession);
        transformedJurySession.juryCertificationSummaries = [];
        return transformedJurySession;
      },
```
c'est à dire, d'initialiser un attribut `juryCertificationSummaries` au modèle `jurySession`, auquel cas le lien n'était pas crée. Donc, dans le code on retrouve ces `transform()` qui initialise des attributs à `null`, `undefined` ou `[]`, dont la présence ne sert qu'à faire fonctionner la mise en place du lien.
Pire, cela a parfois dégénérer en mettant carrément l'attribut dans le domainModel, lequel n'a pour seul usage que de faire fonctionner le serializer. Exemple avec le modèle `CampaignParticipation` :
![cp](https://user-images.githubusercontent.com/48727874/93994059-c118cc80-fd8f-11ea-9a98-23041479a0c5.png)

Dont les attributs ne sont visiblement pas utilisés dans le code.
![cp_screen](https://user-images.githubusercontent.com/48727874/93994065-c2e29000-fd8f-11ea-9e7f-4a10b3643e80.png)

En fait, ils ne servent que pour la sérialisation.
![links-cp](https://user-images.githubusercontent.com/48727874/93994070-c413bd00-fd8f-11ea-8979-76a461b22084.png)

## :robot: Solution
J'ai trouvé un petit truc dans la doc :
![nullifmis](https://user-images.githubusercontent.com/48727874/93994230-f4f3f200-fd8f-11ea-972b-1eba2d1bc511.png)
Car là était le problème : vu que l'attribut était `missing`, le serializer ne sérialisait rien du tout. Or, on peut le configurer pour lui dire : si l'attribut est manquant, alors tu mets null. Donc, puisque null est bien une valeur qui indique la présence, alors les liens sont bien ajoutées.

## :rainbow: Remarques
A mon avis, on peut encore trouver des modifs à faire, mais ça me paraissait un poil plus profond et j'étais un peu moins sereine (par exemple, je soupçonne la collection `tutorials` du modèle `Scorecard` d'exister que pour la sérialisation, mais j'avais un test qui cassait quand je l'ai enlevé donc j'ai pas pris le temps d'insister).

Le pattern classique pour détecter ce genre de choses c'est de trouver, dans les serializers, les liens ajoutés dont le contenu dépend uniquement du parent ET dont aucune data n'est inclue :
Un bon candidat :
![candidate](https://user-images.githubusercontent.com/48727874/93994828-a4c95f80-fd90-11ea-9ada-93836e41c4ae.png)

Pas un bon candidat :
![not_candidate](https://user-images.githubusercontent.com/48727874/93994830-a6932300-fd90-11ea-9b41-6853cf69b5eb.png)


## :100: Pour tester
