### PR TITLE
[FEATURE] Ajouter un feature flipping sur le boutton de dissociation des élèves SCO dans PixOrga (PIX-1303)

### DIFF
--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -64,9 +64,11 @@
                     Gérer le compte
                   </Dropdown::Item>
                   {{#if this.currentUser.isAdminInOrganization}}
+                    {{#if this.isDissociateButtonEnabled}}
                     <Dropdown::Item @onClick={{fn this.openDissociateModal student}}>
                       Dissocier le compte
                     </Dropdown::Item>
+                    {{/if}}
                   {{/if}}
                 </Dropdown::IconTrigger>
               {{/if}}

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import ENV from 'pix-orga/config/environment';
 
 export default class ListItems extends Component {
 
@@ -13,6 +14,7 @@ export default class ListItems extends Component {
   @tracked student = null;
   @tracked isShowingAuthenticationMethodModal = false;
   @tracked isShowingDissociateModal = false;
+  @tracked isDissociateButtonEnabled = ENV.APP.IS_DISSOCIATE_BUTTON_ENABLED;
 
   @action
   openAuthenticationMethodModal(student) {

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function(environment) {
       HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
+      IS_DISSOCIATE_BUTTON_ENABLED : process.env.IS_DISSOCIATE_BUTTON_ENABLED === 'true',
     },
 
     googleFonts: [
@@ -88,6 +89,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     ENV.APP.API_HOST = 'http://localhost:3000';
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
+    ENV.APP.IS_DISSOCIATE_BUTTON_ENABLED = true;
 
     // Testem prefers this...
     ENV.locationType = 'none';


### PR DESCRIPTION
## :unicorn: Problème
Le bouton de dissociation de compte (dans l'espace Elève de PixOrga SCO) provoque des soucis : les profs se bloquent eux-mêmes et ne peuvent plus aider leurs élèves après avoir utilisé ce bouton.

## :robot: Solution
Faire un feature flipping pour cacher temporairement le bouton de dissociation, en attendant de modifier/améliorer les règles derrière ce bouton.

## :100: Pour tester
En local : 

- Démarrer Pix Orga avec la variable suivante : `IS_DISSOCIATE_BUTTON_ENABLED=false  npm start`
- Le bouton "Dissocier le compte" n'apparaît plus 
- Démarrer Pix Orga avec la variable suivante : `IS_DISSOCIATE_BUTTON_ENABLED=true npm start`
- Le bouton apparaît.

En RA : 

Faire les changements via Scalingo/Environnement. 

⚠️ Une fois la valeur modifiée en RA, il faut redéployer pour que le changement soit pris en compte ! 