### PR TITLE
[FEATURE] Déconnecter l'utilisateur s'il veut se connecter depuis le GAR (PIX-1291).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -19,8 +19,16 @@ export default Route.extend(ApplicationRouteMixin, {
     this.splash.hide();
   },
 
-  _checkForURLAuthentication(transition) {
+  async _checkForURLAuthentication(transition) {
+
+    if (transition.to.queryParams && transition.to.queryParams.externalUser) {
+      // Logout user when a new external user is authenticated.
+      await this._logoutUser();
+    }
+
     if (transition.to.queryParams && transition.to.queryParams.token) {
+      // Logout user when existing external user is authenticated.
+      await this._logoutUser();
       return this.session.authenticate(
         'authenticator:oauth2', { token: transition.to.queryParams.token },
       );
@@ -55,6 +63,12 @@ export default Route.extend(ApplicationRouteMixin, {
 
   _loadCurrentUser() {
     return this.currentUser.load().catch(() => this.session.invalidate());
+  },
+
+  _logoutUser() {
+    delete this.session.data.expectedUserId;
+    delete this.session.data.externalUser;
+    return this.session.invalidate();
   },
 
 });

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -11,6 +11,9 @@ export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) 
 
   @action
   async authenticate(login, password) {
+
+    await this._removeExternalUserContext();
+
     const scope = 'mon-pix';
     const trimedLogin = login ? login.trim() : '';
     return this.session.authenticate('authenticator:oauth2', { login: trimedLogin, password, scope });
@@ -20,5 +23,14 @@ export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) 
   async updateExpiredPassword(username, password) {
     this.store.createRecord('user', { username, password });
     return this.replaceWith('update-expired-password');
+  }
+
+  async _removeExternalUserContext() {
+    if (this.session.data && this.session.expectedUserId) {
+      delete this.session.data.expectedUserId;
+    }
+    if (this.session.data && this.session.data.externalUser) {
+      delete this.session.data.externalUser;
+    }
   }
 }

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -11,6 +11,7 @@ export default class LogoutRoute extends Route {
   beforeModel() {
     const session = this.session;
     this.source = session.data.authenticated.source;
+    delete session.data.externalUser;
     if (session.get('isAuthenticated')) {
       return session.invalidate();
     }


### PR DESCRIPTION
## :unicorn: Problème
Si l'utilisateur 
- est connecté par email dans un onglet
- dans un autre onglet, se connecte au GAR et clique sur le lien Pix 
- alors il est connecté dans Pix avec son email, et possède des informations GAR  (ID ou ACCESS token).

Cela a pour conséquence qu'il peut rejoindre la page de réconciliation 

## :robot: Solution
Quand l'utilisateur essaye de se connecter alors qu'il est déjà connecté (route "application" + transitionTo alimenté), alors
- supprimer l'ID Token précédent (en supprimant le externalUser du storage)
- supprimer l'ACESS Token précédent (en invalidant la session)

## :rainbow: Remarques
Le externalUser du storage est aussi supprimé lors de la déconnexion
Le ticket étant prioritaire et les test difficiels à écrire, ils feront partie d'un autre ticket.

## :100: Pour tester
Actions à faire sur le même ordinateur, même navigateur

GAR
* ancien utilisateur =  utilisateur qui s'est déjà connecté (il existe un enregistrement sur users.samlId )
* nouveau utilisateur = utilisateur qui se connecte pour la première fois  (pas d'neregistrement sur users.samlId )


Scénario 1:  Concurrence d'accès avec deux nouveaux utilisateurs GAR.

1- Se connecter via le GAR avec un utilisateur 1
2- Se réconcilier
3- Vérifier que l'utilisateur s'est bien connecté.
4- Se connecter avec un utilisateur 2 via le GAR
     Sur la page de réconciliation:
      - Vérifier que le nom et prénom du formulaire sont bien ceux de l'utilisateur 2.
      - Le burger menu ne s'affiche pas.
5- Vérifier que l'utilisateur 1 est bien déconnecté dans l'autre onglet

Scénario 2:  Concurrence d'accès entre un nouveau utilisateur GAR et un ancien utilisateur GAR.
  Idem 

Scénario 3:   Concurrence d'accès entre un nouveau utilisateur GAR 1 et un utilisateur avec email.2
L'utilisateur GAR va sur la page de réconciliation mais ne se réconcilie pas
L'utilisateur mail se connecte et va sur la  page de réconciliation
Les nom/prénom de l'utilisateur doivent être vide

Scénario 4:  Concurrence d'accès entre un nouveau utilisateur GAR et un ancien utilisateur GAR.
  Idem 

Scénario 5: La déconnexion d'un utilisateur GAR, connexion d'un utilisateur hors GAR dans la double mire.
1- Se connecter via le GAR avec un nouveau utilisateur 1 qui existe.
2- Vérifier que l'utilisateur s'est bien connecté.
3- Déconnecter l'utilisateur connecté via le GAR.
4- Aller dans la page de campagne et saisir RESTRICTD 
5- Vérifier que la double mire est affichée

Scénario n°6
1 se connecter avec email
2 aller sur la page https://app-pr1909.review.pix.fr en tapant l'URL
3 vérifiez que l'on est pas déconnecté
