### PR TITLE
[TECH] Utilisation du modèle TargetProfileWithLearningContent dans le usecase d'export CSV de campagnes d'évaluation (PIX-1301-2)

### DIFF
--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 class TargetProfile {
   constructor({
     id,
@@ -19,15 +17,6 @@ class TargetProfile {
     this.skills = skills;
     this.stages = stages;
     this.organizationId = organizationId;
-
-    this.skillsByCompetenceId = _.groupBy(this.skills, 'competenceId');
-  }
-
-  getSkillsForCompetence(competenceId) {
-    if (!(competenceId in this.skillsByCompetenceId)) {
-      return [];
-    }
-    return this.skillsByCompetenceId[competenceId];
   }
 
   hasSkill(skillId) {
@@ -43,10 +32,6 @@ class TargetProfile {
   getTargetedCompetences(competences) {
     const targetedCompetenceIds = this.getCompetenceIds();
     return competences.filter((competence) => targetedCompetenceIds.includes(competence.id));
-  }
-
-  getSkillNames() {
-    return this.skills.map((skill) => skill.name);
   }
 
   getSkillIds() {

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -14,6 +14,24 @@ class TargetProfileWithLearningContent {
     this.competences = competences;
     this.areas = areas;
   }
+
+  get skillNames() {
+    return this.skills.map((skill) => skill.name).sort();
+  }
+
+  get competenceIds() {
+    return this.competences.map((competences) => competences.id).sort();
+  }
+
+  hasSkill(skillId) {
+    return this.skills.some((skill) => skill.id === skillId);
+  }
+
+  getCompetenceIdOfSkill(skillId) {
+    const skillTube = this.tubes.find((tube) => tube.hasSkill(skillId));
+
+    return skillTube ? skillTube.competenceId : null;
+  }
 }
 
 module.exports = TargetProfileWithLearningContent;

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -16,11 +16,11 @@ class TargetProfileWithLearningContent {
   }
 
   get skillNames() {
-    return this.skills.map((skill) => skill.name).sort();
+    return this.skills.map((skill) => skill.name);
   }
 
   get competenceIds() {
-    return this.competences.map((competences) => competences.id).sort();
+    return this.competences.map((competences) => competences.id);
   }
 
   hasSkill(skillId) {

--- a/api/lib/domain/models/TargetedCompetence.js
+++ b/api/lib/domain/models/TargetedCompetence.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 class TargetedCompetence {
   constructor({
     id,
@@ -11,6 +13,10 @@ class TargetedCompetence {
     this.index = index;
     this.areaId = areaId;
     this.tubes = tubes;
+  }
+
+  get skillCount() {
+    return _.sumBy(this.tubes, (tube) => tube.skills.length);
   }
 }
 

--- a/api/lib/domain/models/TargetedTube.js
+++ b/api/lib/domain/models/TargetedTube.js
@@ -10,6 +10,10 @@ class TargetedTube {
     this.competenceId = competenceId;
     this.skills = skills;
   }
+
+  hasSkill(skillId) {
+    return this.skills.some((skill) => skill.id === skillId);
+  }
 }
 
 module.exports = TargetedTube;

--- a/api/lib/domain/services/campaign-csv-export-service.js
+++ b/api/lib/domain/services/campaign-csv-export-service.js
@@ -9,8 +9,6 @@ module.exports = {
 function createOneCsvLine({
   organization,
   campaign,
-  areas,
-  competences,
   campaignParticipationInfo,
   targetProfile,
   participantKnowledgeElementsByCompetenceId,
@@ -18,8 +16,6 @@ function createOneCsvLine({
   const line = new CampaignAssessmentCsvLine({
     organization,
     campaign,
-    areas,
-    competences,
     campaignParticipationInfo,
     targetProfile,
     participantKnowledgeElementsByCompetenceId,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -65,6 +65,7 @@ const dependencies = {
   studentRepository: require('../../infrastructure/repositories/student-repository'),
   schoolingRegistrationsXmlService: require('../../domain/services/schooling-registrations-xml-service'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
+  targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   targetProfileShareRepository: require('../../infrastructure/repositories/target-profile-share-repository'),
   tokenService: require('../../domain/services/token-service'),
   tubeRepository: require('../../infrastructure/repositories/tube-repository'),

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -173,13 +173,13 @@ module.exports = {
     const knowledgeElementsGroupedByUser = await _findSnapshotsForUsers(userIdsAndDates);
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
-    const competencesIds = targetProfile.getCompetenceIds();
+    const competenceIds = targetProfile.getCompetenceIds();
 
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
       const validatedTargetedKnowledgeElements = _filterValidatedTargetedKnowledgeElements(knowledgeElements, targetProfile);
       const knowledgeElementsByCompetenceId = _.groupBy(validatedTargetedKnowledgeElements, 'competenceId');
       knowledgeElementsGroupedByUserAndCompetence[userId] = {};
-      for (const competenceId  of competencesIds) {
+      for (const competenceId of competenceIds) {
         knowledgeElementsGroupedByUserAndCompetence[userId][competenceId] = knowledgeElementsByCompetenceId[competenceId] || [];
       }
     }
@@ -191,13 +191,13 @@ module.exports = {
     const knowledgeElementsGroupedByUser = await _findSnapshotsForUsers(userIdsAndDates);
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
-    const competencesIds = targetProfile.getCompetenceIds();
+    const competenceIds = targetProfile.competenceIds;
 
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
       const targetedKnowledgeElements = _filterTargetedKnowledgeElements(knowledgeElements, targetProfile);
       const knowledgeElementsByCompetenceId = _.groupBy(targetedKnowledgeElements, 'competenceId');
       knowledgeElementsGroupedByUserAndCompetence[userId] = {};
-      for (const competenceId  of competencesIds) {
+      for (const competenceId of competenceIds) {
         knowledgeElementsGroupedByUserAndCompetence[userId][competenceId] = knowledgeElementsByCompetenceId[competenceId] || [];
       }
     }

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -250,6 +250,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       await databaseBuilder.commit();
 
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([airtableBuilder.factory.buildSkill()]).activate();
+      airtableBuilder.mockList({ tableName: 'Tubes' }).returns([airtableBuilder.factory.buildTube()]).activate();
       airtableBuilder.mockList({ tableName: 'Competences' }).returns([airtableBuilder.factory.buildCompetence()]).activate();
       airtableBuilder.mockList({ tableName: 'Domaines' }).returns([airtableBuilder.factory.buildArea()]).activate();
     });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1109,19 +1109,14 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should return the knowledge elements in the snapshot when user has a snapshot for this date', async () => {
       // given
-      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-        skills: [skill],
-        tubes: [tube],
-        competences: [competence],
-        areas: [area],
-      });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
       const dateUserId = new Date('2020-01-03');
-      const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, competenceId: competence.id, skillId: skill.id });
+      const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        competenceId: targetProfile.competences[0].id,
+        skillId: targetProfile.skills[0].id,
+      });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: dateUserId, snapshot: JSON.stringify([knowledgeElement]) });
       await databaseBuilder.commit();
 
@@ -1130,7 +1125,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         await knowledgeElementRepository.findTargetedGroupedByCompetencesForUsers({ [userId]: dateUserId }, targetProfile);
 
       // then
-      expect(knowledgeElementsByUserIdAndCompetenceId[userId][competence.id][0]).to.deep.equal(knowledgeElement);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId][targetProfile.competences[0].id][0]).to.deep.equal(knowledgeElement);
     });
 
     context('when user does not have a snapshot for this date', () => {
@@ -1139,18 +1134,14 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements with limit date as now', async () => {
           // given
-          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-            skills: [skill],
-            tubes: [tube],
-            competences: [competence],
-            areas: [area],
-          });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -1159,24 +1150,20 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
           // then
           expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-            [competence.id]: [expectedKnowledgeElement],
+            [targetProfile.competences[0].id]: [expectedKnowledgeElement],
           });
         });
 
         it('should not trigger snapshotting', async () => {
           // given
-          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-            skills: [skill],
-            tubes: [tube],
-            competences: [competence],
-            areas: [area],
-          });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -1192,44 +1179,36 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements at date', async () => {
           // given
-          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-            skills: [skill],
-            tubes: [tube],
-            competences: [competence],
-            areas: [area],
-          });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
+
           // when
           const knowledgeElementsByUserIdAndCompetenceId =
             await knowledgeElementRepository.findTargetedGroupedByCompetencesForUsers({ [userId]: new Date('2018-02-01') }, targetProfile);
 
           // then
           expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-            [competence.id]: [expectedKnowledgeElement],
+            [targetProfile.competences[0].id]: [expectedKnowledgeElement],
           });
         });
 
         it('should save a snasphot', async () => {
           // given
-          // Learning content
-          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-            skills: [skill],
-            tubes: [tube],
-            competences: [competence],
-            areas: [area],
-          });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -1244,18 +1223,14 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should avoid returning non targeted knowledge elements when there are knowledge elements that are not in the target profile', async () => {
       // given
-      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-        skills: [skill],
-        tubes: [tube],
-        competences: [competence],
-        areas: [area],
-      });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: 'otherSkill' });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: targetProfile.competences[0].id,
+        skillId: 'id_de_skill_improbable_et_different_de_celui_du_builder',
+      });
       await databaseBuilder.commit();
 
       // when
@@ -1264,24 +1239,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence.id]: [],
+        [targetProfile.competences[0].id]: [],
       });
     });
 
     it('should even return non validated knowledge elements', async () => {
       // given
-      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-        skills: [skill],
-        tubes: [tube],
-        competences: [competence],
-        areas: [area],
-      });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
-      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id, status: 'invalidated' });
+      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: targetProfile.competences[0].id,
+        skillId: targetProfile.skills[0].id,
+        status: 'invalidated',
+      });
       await databaseBuilder.commit();
 
       // when
@@ -1290,22 +1262,13 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence.id]: [expectedKnowledgeElement],
+        [targetProfile.competences[0].id]: [expectedKnowledgeElement],
       });
     });
 
     it('should return an empty array on competence that does not have any targeted knowledge elements', async () => {
       // given
-      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
-      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
-      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-        skills: [skill],
-        tubes: [tube],
-        competences: [competence],
-        areas: [area],
-      });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
 
@@ -1315,7 +1278,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence.id]: [],
+        [targetProfile.competences[0].id]: [],
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const moment = require('moment');
-const { expect, knex, domainBuilder, databaseBuilder, airtableBuilder, sinon } = require('../../../test-helper');
-const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
+const { expect, knex, domainBuilder, databaseBuilder, sinon } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
 const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-snapshot-repository');
@@ -848,8 +847,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
   describe('#findValidatedTargetedGroupedByCompetencesForUsers', () => {
 
     afterEach(() => {
-      airtableBuilder.cleanAll();
-      cache.flushAll();
       return knex('knowledge-element-snapshots').delete();
     });
 
@@ -861,12 +858,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
       const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence1.id });
       const skill3 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence2.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence1 });
-      const airtableCompetence2 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence2 });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      const airtableSkill2 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill2 });
-      const airtableSkill3 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill3 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1, airtableSkill2, airtableSkill3], competence: [airtableCompetence1, airtableCompetence2] });
       // Other data
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1, skill2, skill3] });
       const userId1 = databaseBuilder.factory.buildUser().id;
@@ -900,9 +891,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       // Learning content
       const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
       const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
       // Other data
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
       const userId = databaseBuilder.factory.buildUser().id;
@@ -928,9 +916,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           // Learning content
           const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
           const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
           // Other data
           const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
           const userId = databaseBuilder.factory.buildUser().id;
@@ -952,9 +937,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           // Learning content
           const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
           const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
           // Other data
           const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
           const userId = databaseBuilder.factory.buildUser().id;
@@ -977,9 +959,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           // Learning content
           const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
           const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
           // Other data
           const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
           const userId = databaseBuilder.factory.buildUser().id;
@@ -1000,9 +979,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           // Learning content
           const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
           const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
           // Other data
           const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
           const userId = databaseBuilder.factory.buildUser().id;
@@ -1025,10 +1001,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
       const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      const airtableSkill2 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill2 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1, airtableSkill2], competence: [airtableCompetence1] });
       // Other data
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
       const userId = databaseBuilder.factory.buildUser().id;
@@ -1050,9 +1022,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       // Learning content
       const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
       // Other data
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
       const userId = databaseBuilder.factory.buildUser().id;
@@ -1074,9 +1043,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       // Learning content
       const competence1 = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
       const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence1 });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
       // Other data
       const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
       const userId = databaseBuilder.factory.buildUser().id;
@@ -1096,27 +1062,25 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
   describe('#findTargetedGroupedByCompetencesForUsers', () => {
 
     afterEach(() => {
-      airtableBuilder.cleanAll();
-      cache.flushAll();
       return knex('knowledge-element-snapshots').delete();
     });
 
     it('should return knowledge elements within respective dates grouped by userId the competenceId within target profile of campaign', async () => {
       // given
-      // Learning content
-      const competence1 = domainBuilder.buildCompetence({ skillIds: ['skill1', 'skill2'] });
-      const competence2 = domainBuilder.buildCompetence({ skillIds: ['skill3'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
-      const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence1.id });
-      const skill3 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence2.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence1 });
-      const airtableCompetence2 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence2 });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      const airtableSkill2 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill2 });
-      const airtableSkill3 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill3 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1, airtableSkill2, airtableSkill3], competence: [airtableCompetence1, airtableCompetence2] });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1, skill2, skill3] });
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'skill1', tubeId: 'tube1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'skill2', tubeId: 'tube1' });
+      const skill3 = domainBuilder.buildTargetedSkill({ id: 'skill3', tubeId: 'tube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skill1, skill2], competenceId: 'competence1' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skill3], competenceId: 'competence2' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'competence1', tubes: [tube1], areaId: 'area1' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'competence2', tubes: [tube2], areaId: 'area1' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area1', competences: [competence1, competence2] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area],
+      });
       const userId1 = databaseBuilder.factory.buildUser().id;
       const userId2 = databaseBuilder.factory.buildUser().id;
       const dateUserId1 = new Date('2020-01-03');
@@ -1145,14 +1109,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should return the knowledge elements in the snapshot when user has a snapshot for this date', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill],
+        tubes: [tube],
+        competences: [competence],
+        areas: [area],
+      });
       const userId = databaseBuilder.factory.buildUser().id;
       const dateUserId = new Date('2020-01-03');
       const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, competenceId: competence.id, skillId: skill.id });
@@ -1173,14 +1139,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements with limit date as now', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+            skills: [skill],
+            tubes: [tube],
+            competences: [competence],
+            areas: [area],
+          });
           const userId = databaseBuilder.factory.buildUser().id;
           const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
           await databaseBuilder.commit();
@@ -1197,14 +1165,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should not trigger snapshotting', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+            skills: [skill],
+            tubes: [tube],
+            competences: [competence],
+            areas: [area],
+          });
           const userId = databaseBuilder.factory.buildUser().id;
           databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
           await databaseBuilder.commit();
@@ -1222,14 +1192,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements at date', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+            skills: [skill],
+            tubes: [tube],
+            competences: [competence],
+            areas: [area],
+          });
           const userId = databaseBuilder.factory.buildUser().id;
           const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
           await databaseBuilder.commit();
@@ -1246,13 +1218,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         it('should save a snasphot', async () => {
           // given
           // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-          const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill });
-          airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+          const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+          const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+          const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+            skills: [skill],
+            tubes: [tube],
+            competences: [competence],
+            areas: [area],
+          });
           const userId = databaseBuilder.factory.buildUser().id;
           databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
           await databaseBuilder.commit();
@@ -1269,18 +1244,18 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should avoid returning non targeted knowledge elements when there are knowledge elements that are not in the target profile', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      const airtableSkill2 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill2 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1, airtableSkill2], competence: [airtableCompetence1] });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill],
+        tubes: [tube],
+        competences: [competence],
+        areas: [area],
+      });
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill2.id });
+      databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: 'otherSkill' });
       await databaseBuilder.commit();
 
       // when
@@ -1295,16 +1270,18 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should even return non validated knowledge elements', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill],
+        tubes: [tube],
+        competences: [competence],
+        areas: [area],
+      });
       const userId = databaseBuilder.factory.buildUser().id;
-      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill1.id, status: 'invalidated' });
+      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id, status: 'invalidated' });
       await databaseBuilder.commit();
 
       // when
@@ -1319,14 +1296,16 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should return an empty array on competence that does not have any targeted knowledge elements', async () => {
       // given
-      // Learning content
-      const competence1 = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
-      const airtableCompetence1 = airtableBuilder.factory.buildCompetence.fromDomain({ domainCompetence: competence1 });
-      const airtableSkill1 = airtableBuilder.factory.buildSkill.fromDomain({ domainSkill: skill1 });
-      airtableBuilder.mockLists({ skills: [airtableSkill1], competence: [airtableCompetence1] });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'competence' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'competence', tubes: [tube], areaId: 'area' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill],
+        tubes: [tube],
+        competences: [competence],
+        areas: [area],
+      });
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
 
@@ -1336,7 +1315,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence1.id]: [],
+        [competence.id]: [],
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
@@ -1,6 +1,10 @@
 const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
+const buildTargetedSkill = require('./build-targeted-skill');
+const buildTargetedTube = require('./build-targeted-tube');
+const buildTargetedCompetence = require('./build-targeted-competence');
+const buildTargetedArea = require('./build-targeted-area');
 
-module.exports = function buildTargetProfileWithLearningContent({
+const buildTargetProfileWithLearningContent = function buildTargetProfileWithLearningContent({
   id = 123,
   name = 'Pour les champions du monde 1998 !! Merci Aimé',
   skills = [],
@@ -17,3 +21,23 @@ module.exports = function buildTargetProfileWithLearningContent({
     areas,
   });
 };
+
+buildTargetProfileWithLearningContent.withSimpleLearningContent = function withSimpleLearningContent({
+  id = 123,
+  name = 'Pour les champions du monde 1998 !! Merci Aimé',
+} = {}) {
+  const skill = buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
+  const tube = buildTargetedTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
+  const competence = buildTargetedCompetence({ id: 'competenceId', areaId: 'areaId', tubes: [tube] });
+  const area = buildTargetedArea({ id: 'areaId', competences: [competence] });
+  return new TargetProfileWithLearningContent({
+    id,
+    name,
+    skills: [skill],
+    tubes: [tube],
+    competences: [competence],
+    areas: [area],
+  });
+};
+
+module.exports = buildTargetProfileWithLearningContent;

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -46,7 +46,7 @@ describe('Unit | Domain | Models | Organization', () => {
 
   });
 
-  describe('getter#isSco', () => {
+  describe('get#isSco', () => {
 
     it('should return true when organization is of type SCO', () => {
       // given
@@ -65,7 +65,7 @@ describe('Unit | Domain | Models | Organization', () => {
     });
   });
 
-  describe('getter#isSup', () => {
+  describe('get#isSup', () => {
 
     it('should return true when organization is of type SUP', () => {
       // given
@@ -84,7 +84,7 @@ describe('Unit | Domain | Models | Organization', () => {
     });
   });
 
-  describe('getter#isPro', () => {
+  describe('get#isPro', () => {
 
     it('should return true when organization is of type PRO', () => {
       // given

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -4,17 +4,17 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
   describe('get#skillNames', () => {
 
-    it('should return an array with targeted skill names order by name', () => {
+    it('should return an array with targeted skill names', () => {
       // given
-      const skill1 = domainBuilder.buildTargetedSkill({ name: 'Zacquis1' });
-      const skill2 = domainBuilder.buildTargetedSkill({ name: 'Aacquis2' });
+      const skill1 = domainBuilder.buildTargetedSkill({ name: '@acquis1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ name: '@acquis2' });
       const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill1, skill2] });
 
       // when
       const targetedSkillNames = targetProfile.skillNames;
 
       // then
-      expect(targetedSkillNames).to.exactlyContainInOrder(['Aacquis2', 'Zacquis1']);
+      expect(targetedSkillNames).to.exactlyContainInOrder(['@acquis1', '@acquis2']);
     });
   });
 
@@ -22,15 +22,15 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
     it('should return an array with targeted competence ids order by id', () => {
       // given
-      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'ZCompId' });
-      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'ACompId' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'compId1' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'compId2' });
       const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [competence1, competence2] });
 
       // when
       const targetedCompetenceIds = targetProfile.competenceIds;
 
       // then
-      expect(targetedCompetenceIds).to.exactlyContainInOrder(['ACompId', 'ZCompId']);
+      expect(targetedCompetenceIds).to.exactlyContainInOrder(['compId1', 'compId2']);
     });
   });
 

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -1,0 +1,95 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
+
+  describe('get#skillNames', () => {
+
+    it('should return an array with targeted skill names order by name', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ name: 'Zacquis1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ name: 'Aacquis2' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill1, skill2] });
+
+      // when
+      const targetedSkillNames = targetProfile.skillNames;
+
+      // then
+      expect(targetedSkillNames).to.exactlyContainInOrder(['Aacquis2', 'Zacquis1']);
+    });
+  });
+
+  describe('get#competenceIds', () => {
+
+    it('should return an array with targeted competence ids order by id', () => {
+      // given
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'ZCompId' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'ACompId' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [competence1, competence2] });
+
+      // when
+      const targetedCompetenceIds = targetProfile.competenceIds;
+
+      // then
+      expect(targetedCompetenceIds).to.exactlyContainInOrder(['ACompId', 'ZCompId']);
+    });
+  });
+
+  describe('hasSkill', () => {
+
+    it('should return true when the skill is in target profile', () => {
+      // given
+      const skill = domainBuilder.buildTargetedSkill();
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill] });
+
+      // when
+      const isIncluded = targetProfile.hasSkill(skill.id);
+
+      // then
+      expect(isIncluded).to.be.true;
+    });
+
+    it('should return false when the skill is not in target profile', () => {
+      // given
+      const skill = domainBuilder.buildTargetedSkill({ id: 'someId' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill] });
+
+      // when
+      const isIncluded = targetProfile.hasSkill('someOtherId');
+
+      // then
+      expect(isIncluded).to.be.false;
+    });
+  });
+
+  describe('getCompetenceIdOfSkill()', () => {
+
+    const expectedCompetenceId = 'compId';
+    const skillId = 'skillId';
+    let targetProfile;
+
+    beforeEach(() => {
+      const skillNotInCompetence = domainBuilder.buildTargetedSkill({ id: 'otherSkillId', tubeId: 'tube1' });
+      const skillInCompetence = domainBuilder.buildTargetedSkill({ id: skillId, tubeId: 'tube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skillNotInCompetence], competence: 'otherCompId' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'tube2', skills: [skillInCompetence], competenceId: expectedCompetenceId });
+      targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skillNotInCompetence, skillInCompetence], tubes: [tube1, tube2] });
+    });
+
+    it('should return competenceId of skill', () => {
+      // when
+      const competenceId = targetProfile.getCompetenceIdOfSkill(skillId);
+
+      // then
+      expect(competenceId).to.equal(expectedCompetenceId);
+    });
+
+    it('should return null when competenceId of skill is not found', () => {
+      // when
+      const competenceId = targetProfile.getCompetenceIdOfSkill('@mamèreenslip');
+
+      // then
+      expect(competenceId).to.be.null;
+    });
+  });
+
+});

--- a/api/tests/unit/domain/models/TargetProfile_test.js
+++ b/api/tests/unit/domain/models/TargetProfile_test.js
@@ -66,22 +66,6 @@ describe('Unit | Domain | Models | TargetProfile', () => {
     });
   });
 
-  describe('getSkillNames', () => {
-
-    it('should return an array with targeted skill names', () => {
-      // given
-      const skill1 = domainBuilder.buildSkill({ name: 'Aacquis2' });
-      const skill2 = domainBuilder.buildSkill({ name: 'Zacquis1' });
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1, skill2] });
-
-      // when
-      const targetedSkillNames = targetProfile.getSkillNames();
-
-      // then
-      expect(targetedSkillNames).to.exactlyContainInOrder(['Aacquis2', 'Zacquis1']);
-    });
-  });
-
   describe('getSkillIds', () => {
 
     it('should return an array with targeted skill ids', () => {
@@ -114,28 +98,6 @@ describe('Unit | Domain | Models | TargetProfile', () => {
 
       // then
       expect(skillCountForCompetence).to.equal(2);
-    });
-  });
-
-  describe('#getSkillsForCompetence()', () => {
-    let expectedSkills;
-    let targetProfile;
-    const competenceId = 'compId';
-
-    beforeEach(() => {
-      const skill1InCompetence = domainBuilder.buildSkill({ competenceId });
-      const skill2InCompetence = domainBuilder.buildSkill({ competenceId });
-      const otherSkill = domainBuilder.buildSkill({ competenceId: 'otherCompId' });
-      targetProfile = domainBuilder.buildTargetProfile({ skills: [ skill1InCompetence, skill2InCompetence, otherSkill ] });
-      expectedSkills = [ skill1InCompetence, skill2InCompetence ];
-    });
-
-    it('should return skills that are in competence', () => {
-      // when
-      const skills = targetProfile.getSkillsForCompetence(competenceId);
-
-      // then
-      expect(skills).to.deep.equal(expectedSkills);
     });
   });
 

--- a/api/tests/unit/domain/models/TargetedCompetence_test.js
+++ b/api/tests/unit/domain/models/TargetedCompetence_test.js
@@ -1,0 +1,23 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Target-Profile/TargetedCompetence', () => {
+
+  describe('get#skillCount', () => {
+
+    it('should return the count of skills across all tubes within competence', () => {
+      // given
+      const skill1a = domainBuilder.buildTargetedSkill({ id: 'recSkill1a', tubeId: 'recTube1' });
+      const skill1b = domainBuilder.buildTargetedSkill({ id: 'recSkill1b', tubeId: 'recTube1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1a, skill1b], competenceId: 'recCompetenceId' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2], competenceId: 'recCompetenceId' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceId', tubes: [tube1, tube2] });
+
+      // when
+      const skillCount = competence.skillCount;
+
+      // then
+      expect(skillCount).to.equal(3);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/TargetedTube_test.js
+++ b/api/tests/unit/domain/models/TargetedTube_test.js
@@ -1,0 +1,31 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Target-Profile/TargetedTube', () => {
+
+  describe('hasSkill', () => {
+
+    it('should return true when the skill is in tube', () => {
+      // given
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tubeId', skills: [skill] });
+
+      // when
+      const isIncluded = tube.hasSkill(skill.id);
+
+      // then
+      expect(isIncluded).to.be.true;
+    });
+
+    it('should return false when the skill is not in tube', () => {
+      // given
+      const skill = domainBuilder.buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'tubeId', skills: [] });
+
+      // when
+      const isIncluded = tube.hasSkill(skill.id);
+
+      // then
+      expect(isIncluded).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -122,16 +122,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     // given
     const idPixLabel = 'Numéro de carte bleue';
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ idPixLabel });
-    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
-    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
-    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-      skills: [skill],
-      tubes: [tube],
-      competences: [competence],
-      areas: [area],
-    });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
@@ -151,13 +142,13 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Partage (O/N)";' +
       '"Date du partage";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
-      `"% de maitrise des acquis de la compétence ${competence.name}";` +
-      `"Nombre d'acquis du profil cible dans la compétence ${competence.name}";` +
-      `"Acquis maitrisés dans la compétence ${competence.name}";` +
-      `"% de maitrise des acquis du domaine ${area.title}";` +
-      `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
-      `"Acquis maitrisés du domaine ${area.title}";` +
-      `"${skill.name}"\n`;
+      `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
+      `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
+      `"Acquis maitrisés dans la compétence ${targetProfile.competences[0].name}";` +
+      `"% de maitrise des acquis du domaine ${targetProfile.areas[0].title}";` +
+      `"Nombre d'acquis du profil cible du domaine ${targetProfile.areas[0].title}";` +
+      `"Acquis maitrisés du domaine ${targetProfile.areas[0].title}";` +
+      `"${targetProfile.skills[0].name}"\n`;
 
     // when
     startWritingCampaignAssessmentResultsToStream({
@@ -181,16 +172,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   it('should contains Numéro Étudiant header when orga is SUP and managing students', async () => {
     // given
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ isManagingStudents: true, type: 'SUP' });
-    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
-    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
-    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-      skills: [skill],
-      tubes: [tube],
-      competences: [competence],
-      areas: [area],
-    });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
@@ -210,13 +192,13 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Partage (O/N)";' +
       '"Date du partage";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
-      `"% de maitrise des acquis de la compétence ${competence.name}";` +
-      `"Nombre d'acquis du profil cible dans la compétence ${competence.name}";` +
-      `"Acquis maitrisés dans la compétence ${competence.name}";` +
-      `"% de maitrise des acquis du domaine ${area.title}";` +
-      `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
-      `"Acquis maitrisés du domaine ${area.title}";` +
-      `"${skill.name}"\n`;
+      `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
+      `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
+      `"Acquis maitrisés dans la compétence ${targetProfile.competences[0].name}";` +
+      `"% de maitrise des acquis du domaine ${targetProfile.areas[0].title}";` +
+      `"Nombre d'acquis du profil cible du domaine ${targetProfile.areas[0].title}";` +
+      `"Acquis maitrisés du domaine ${targetProfile.areas[0].title}";` +
+      `"${targetProfile.skills[0].name}"\n`;
 
     // when
     startWritingCampaignAssessmentResultsToStream({
@@ -240,21 +222,12 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   it('should process result for each participation and add it to csv', async () => {
     // given
     const { user: admin, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
-    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
-    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
-    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
-    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
-    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-      skills: [skill],
-      tubes: [tube],
-      competences: [competence],
-      areas: [area],
-    });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
     const participantInfo = domainBuilder.buildCampaignParticipationInfo({ createdAt: new Date('2020-01-01'), sharedAt: new Date('2020-02-01') });
     const knowledgeElement = domainBuilder.buildKnowledgeElement({
       status: 'validated',
-      skillId: skill.id,
-      competenceId: competence.id,
+      skillId: targetProfile.skills[0].id,
+      competenceId: targetProfile.competences[0].id,
     });
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
@@ -264,7 +237,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([participantInfo]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').resolves({
       [participantInfo.userId] : {
-        [competence.id] : [knowledgeElement],
+        [targetProfile.competences[0].id] : [knowledgeElement],
       },
     });
     const csvHeaderExpected = '\uFEFF"Nom de l\'organisation";' +
@@ -278,13 +251,13 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Partage (O/N)";' +
       '"Date du partage";' +
       '"% maitrise de l\'ensemble des acquis du profil";' +
-      `"% de maitrise des acquis de la compétence ${competence.name}";` +
-      `"Nombre d'acquis du profil cible dans la compétence ${competence.name}";` +
-      `"Acquis maitrisés dans la compétence ${competence.name}";` +
-      `"% de maitrise des acquis du domaine ${area.title}";` +
-      `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
-      `"Acquis maitrisés du domaine ${area.title}";` +
-      `"${skill.name}"`;
+      `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
+      `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
+      `"Acquis maitrisés dans la compétence ${targetProfile.competences[0].name}";` +
+      `"% de maitrise des acquis du domaine ${targetProfile.areas[0].title}";` +
+      `"Nombre d'acquis du profil cible du domaine ${targetProfile.areas[0].title}";` +
+      `"Acquis maitrisés du domaine ${targetProfile.areas[0].title}";` +
+      `"${targetProfile.skills[0].name}"`;
     const csvParticipantResultExpected = `"${organization.name}";` +
       `${campaign.id};` +
       `"${campaign.name}";` +

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -7,8 +7,7 @@ const campaignCsvExportService = require('../../../../lib/domain/services/campai
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', () => {
   const campaignRepository = { get: () => undefined };
   const userRepository = { getWithMemberships: () => undefined };
-  const targetProfileRepository = { get: () => undefined };
-  const competenceRepository = { list: () => undefined };
+  const targetProfileWithLearningContentRepository = { get: () => undefined };
   const organizationRepository = { get: () => undefined };
   const campaignParticipationInfoRepository = { findByCampaignId: () => undefined };
   const knowledgeElementRepository = { findTargetedGroupedByCompetencesForUsers: () => undefined };
@@ -26,8 +25,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     const campaign = domainBuilder.buildCampaign();
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(notAuthorizedUser.id).resolves(notAuthorizedUser);
-    sinon.stub(targetProfileRepository, 'get').rejects();
-    sinon.stub(competenceRepository, 'list').rejects();
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').rejects();
     sinon.stub(organizationRepository, 'get').rejects();
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').rejects();
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
@@ -39,8 +37,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
-      targetProfileRepository,
-      competenceRepository,
+      targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
@@ -52,60 +49,29 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     expect(err.message).to.equal(`User does not have an access to the organization ${campaign.organizationId}`);
   });
 
-  it('should throw an error when target profile presents a competence unknown in the learning content', async () => {
-    // given
-    const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
-    const targetedSkillOfUnknownCompetence = domainBuilder.buildSkill({ competenceId: 'TROLOLOLO' });
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: [targetedSkillOfUnknownCompetence] });
-    campaign.targetProfileId = targetProfile.id;
-    sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
-    sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
-    sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileRepository, 'get').withArgs(campaign.targetProfileId).resolves(targetProfile);
-    sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
-    sinon.stub(competenceRepository, 'list').resolves([domainBuilder.buildCompetence({ id: 'realCompetenceId' })]);
-    sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
-
-    // when
-    const err = await catchErr(startWritingCampaignAssessmentResultsToStream)({
-      userId: user.id,
-      campaignId: campaign.id,
-      writableStream,
-      campaignRepository,
-      userRepository,
-      targetProfileRepository,
-      competenceRepository,
-      organizationRepository,
-      campaignParticipationInfoRepository,
-      knowledgeElementRepository,
-      campaignCsvExportService,
-    });
-
-    // then
-    expect(err).to.be.instanceOf(Error);
-    expect(err.message).to.equal('Unknown competence TROLOLOLO');
-  });
-
   it('should return common parts of header with appropriate info', async () => {
     // given
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
-    const area1 = domainBuilder.buildArea({ code: '1' });
-    const competence1_1 = domainBuilder.buildCompetence({ area: area1, index: '1.1' });
-    const skill1_1_1 = domainBuilder.buildSkill({ competenceId: competence1_1.id, name: '@acquis1' });
-    const competence1_2 = domainBuilder.buildCompetence({ area: area1, index: '1.2' });
-    const skill1_2_1 = domainBuilder.buildSkill({ competenceId: competence1_2.id, name: '@acquis2' });
-    const area2 = domainBuilder.buildArea({ code: '2' });
-    const competence2_1 = domainBuilder.buildCompetence({ area: area2, index: '2.1' });
-    const skill2_1_1 = domainBuilder.buildSkill({ competenceId: competence2_1.id, name: '@acquis3' });
-    const skill2_1_2 = domainBuilder.buildSkill({ competenceId: competence2_1.id, name: '@acquis4' });
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1_1_1, skill1_2_1, skill2_1_1, skill2_1_2] });
+    const skill1_1_1 = domainBuilder.buildTargetedSkill({ id: 'skill1_1_1', tubeId: 'tube1', name: '@acquis1' });
+    const skill2_1_1 = domainBuilder.buildTargetedSkill({ id: 'skill2_1_1', tubeId: 'tube3', name: '@acquis2' });
+    const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skill1_1_1], competenceId: 'comp1_1' });
+    const tube2 = domainBuilder.buildTargetedTube({ id: 'tube3', skills: [skill2_1_1], competenceId: 'comp2_1' });
+    const competence1_1 = domainBuilder.buildTargetedCompetence({ id: 'comp1_1', tubes: [tube1], areaId: 'area1' });
+    const competence2_1 = domainBuilder.buildTargetedCompetence({ id: 'comp2_1', tubes: [tube2], areaId: 'area2' });
+    const area1 = domainBuilder.buildTargetedArea({ id: 'area1', competences: [competence1_1] });
+    const area2 = domainBuilder.buildTargetedArea({ id: 'area2', competences: [competence2_1] });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+      skills: [skill1_1_1, skill2_1_1],
+      tubes: [tube1, tube2],
+      competences: [competence1_1, competence2_1],
+      areas: [area2, area1],
+    });
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileRepository, 'get').withArgs(campaign.targetProfileId).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
-    sinon.stub(competenceRepository, 'list').resolves([competence1_2, competence2_1, competence1_1]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
@@ -121,9 +87,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"% de maitrise des acquis de la compétence ${competence1_1.name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${competence1_1.name}";` +
       `"Acquis maitrisés dans la compétence ${competence1_1.name}";` +
-      `"% de maitrise des acquis de la compétence ${competence1_2.name}";` +
-      `"Nombre d'acquis du profil cible dans la compétence ${competence1_2.name}";` +
-      `"Acquis maitrisés dans la compétence ${competence1_2.name}";` +
       `"% de maitrise des acquis de la compétence ${competence2_1.name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${competence2_1.name}";` +
       `"Acquis maitrisés dans la compétence ${competence2_1.name}";` +
@@ -134,9 +97,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"Nombre d'acquis du profil cible du domaine ${area2.title}";` +
       `"Acquis maitrisés du domaine ${area2.title}";` +
       `"'${skill1_1_1.name}";` +
-      `"'${skill1_2_1.name}";` +
-      `"'${skill2_1_1.name}";` +
-      `"'${skill2_1_2.name}"\n`;
+      `"'${skill2_1_1.name}"\n`;
 
     // when
     startWritingCampaignAssessmentResultsToStream({
@@ -145,8 +106,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
-      targetProfileRepository,
-      competenceRepository,
+      targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
@@ -162,17 +122,22 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     // given
     const idPixLabel = 'Numéro de carte bleue';
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ idPixLabel });
-    const area = domainBuilder.buildArea();
-    const competence = domainBuilder.buildCompetence({ area });
-    const skill = domainBuilder.buildSkill({ competenceId: competence.id });
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
+    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
+    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+      skills: [skill],
+      tubes: [tube],
+      competences: [competence],
+      areas: [area],
+    });
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileRepository, 'get').withArgs(campaign.targetProfileId).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
-    sinon.stub(competenceRepository, 'list').resolves([competence]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
@@ -192,7 +157,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"% de maitrise des acquis du domaine ${area.title}";` +
       `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
       `"Acquis maitrisés du domaine ${area.title}";` +
-      `"'${skill.name}"\n`;
+      `"${skill.name}"\n`;
 
     // when
     startWritingCampaignAssessmentResultsToStream({
@@ -201,8 +166,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
-      targetProfileRepository,
-      competenceRepository,
+      targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
@@ -217,17 +181,22 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   it('should contains Numéro Étudiant header when orga is SUP and managing students', async () => {
     // given
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ isManagingStudents: true, type: 'SUP' });
-    const area = domainBuilder.buildArea();
-    const competence = domainBuilder.buildCompetence({ area });
-    const skill = domainBuilder.buildSkill({ competenceId: competence.id });
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
+    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
+    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+      skills: [skill],
+      tubes: [tube],
+      competences: [competence],
+      areas: [area],
+    });
     campaign.targetProfileId = targetProfile.id;
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileRepository, 'get').withArgs(campaign.targetProfileId).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
-    sinon.stub(competenceRepository, 'list').resolves([competence]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
@@ -247,7 +216,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"% de maitrise des acquis du domaine ${area.title}";` +
       `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
       `"Acquis maitrisés du domaine ${area.title}";` +
-      `"'${skill.name}"\n`;
+      `"${skill.name}"\n`;
 
     // when
     startWritingCampaignAssessmentResultsToStream({
@@ -256,8 +225,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
-      targetProfileRepository,
-      competenceRepository,
+      targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
@@ -272,10 +240,16 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   it('should process result for each participation and add it to csv', async () => {
     // given
     const { user: admin, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign();
-    const area = domainBuilder.buildArea();
-    const competence = domainBuilder.buildCompetence({ area });
-    const skill = domainBuilder.buildSkill({ competenceId: competence.id });
-    const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+    const skill = domainBuilder.buildTargetedSkill({ id: 'skill', tubeId: 'tube' });
+    const tube = domainBuilder.buildTargetedTube({ id: 'tube', skills: [skill], competenceId: 'comp' });
+    const competence = domainBuilder.buildTargetedCompetence({ id: 'comp', tubes: [tube], areaId: 'area' });
+    const area = domainBuilder.buildTargetedArea({ id: 'area', competences: [competence] });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+      skills: [skill],
+      tubes: [tube],
+      competences: [competence],
+      areas: [area],
+    });
     const participantInfo = domainBuilder.buildCampaignParticipationInfo({ createdAt: new Date('2020-01-01'), sharedAt: new Date('2020-02-01') });
     const knowledgeElement = domainBuilder.buildKnowledgeElement({
       status: 'validated',
@@ -286,9 +260,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(admin.id).resolves(admin);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileRepository, 'get').withArgs(campaign.targetProfileId).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([participantInfo]);
-    sinon.stub(competenceRepository, 'list').resolves([competence]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').resolves({
       [participantInfo.userId] : {
         [competence.id] : [knowledgeElement],
@@ -311,7 +284,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"% de maitrise des acquis du domaine ${area.title}";` +
       `"Nombre d'acquis du profil cible du domaine ${area.title}";` +
       `"Acquis maitrisés du domaine ${area.title}";` +
-      `"'${skill.name}"`;
+      `"${skill.name}"`;
     const csvParticipantResultExpected = `"${organization.name}";` +
       `${campaign.id};` +
       `"${campaign.name}";` +
@@ -338,8 +311,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
-      targetProfileRepository,
-      competenceRepository,
+      targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -34,18 +34,14 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
       const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
       const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
       const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ createdAt: new Date('2020-01-01'), isCompleted: false });
-      const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
-      const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
-      const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
-      const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
         organization,
         campaign,
         campaignParticipationInfo,
         targetProfile,
         participantKnowledgeElementsByCompetenceId: {
-          'recCompetence': [],
+          [targetProfile.competences[0].id]: [],
         },
         campaignParticipationService,
       });
@@ -71,18 +67,14 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber' });
-        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
-        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
-        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
-        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
-        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
           campaignParticipationInfo,
           targetProfile,
           participantKnowledgeElementsByCompetenceId: {
-            'recCompetence': [],
+            [targetProfile.competences[0].id]: [],
           },
           campaignParticipationService,
         });
@@ -103,18 +95,14 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: 'I Have One !' });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ participantExternalId: 'someParticipantExternalId' });
-        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
-        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
-        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
-        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
-        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
           campaignParticipationInfo,
           targetProfile,
           participantKnowledgeElementsByCompetenceId: {
-            'recCompetence': [],
+            [targetProfile.competences[0].id]: [],
           },
           campaignParticipationService,
         });
@@ -132,11 +120,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: 'I Have One !' });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber', participantExternalId: 'someParticipantExternalId' });
-        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
-        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
-        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
-        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
-        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
@@ -145,7 +129,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           campaignParticipationInfo,
           targetProfile,
           participantKnowledgeElementsByCompetenceId: {
-            'recCompetence': [],
+            [targetProfile.competences[0].id]: [],
           },
           campaignParticipationService,
         });

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -34,16 +34,19 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
       const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
       const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
       const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ createdAt: new Date('2020-01-01'), isCompleted: false });
-      const skill = domainBuilder.buildSkill({ id: 'recSkill', competenceId: 'recCompetence1' });
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+      const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
+      const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
       const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
         organization,
         campaign,
-        areas: [],
-        competences: [],
         campaignParticipationInfo,
         targetProfile,
-        participantKnowledgeElementsByCompetenceId: [],
+        participantKnowledgeElementsByCompetenceId: {
+          'recCompetence': [],
+        },
         campaignParticipationService,
       });
 
@@ -68,15 +71,19 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber' });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [] });
+        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
+        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
+        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
+        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
-          areas: [],
-          competences: [],
           campaignParticipationInfo,
           targetProfile,
-          participantKnowledgeElementsByCompetenceId: [],
+          participantKnowledgeElementsByCompetenceId: {
+            'recCompetence': [],
+          },
           campaignParticipationService,
         });
 
@@ -96,15 +103,19 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: 'I Have One !' });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ participantExternalId: 'someParticipantExternalId' });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [] });
+        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
+        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
+        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
+        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
-          areas: [],
-          competences: [],
           campaignParticipationInfo,
           targetProfile,
-          participantKnowledgeElementsByCompetenceId: [],
+          participantKnowledgeElementsByCompetenceId: {
+            'recCompetence': [],
+          },
           campaignParticipationService,
         });
 
@@ -121,7 +132,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization({ type: 'SUP', isManagingStudents: true });
         const campaign = domainBuilder.buildCampaign({ idPixLabel: 'I Have One !' });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ studentNumber: 'someStudentNumber', participantExternalId: 'someParticipantExternalId' });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [] });
+        const skill = domainBuilder.buildTargetedSkill({ id: 'recSkill', tubeId: 'recTube' });
+        const tube = domainBuilder.buildTargetedTube({ id: 'recTube', skills: [skill], competenceId: 'recCompetence' });
+        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', tubes: [tube], areaId: 'recArea' });
+        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill], tubes: [tube], competences: [competence], areas: [area] });
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
@@ -129,7 +144,9 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           competences: [],
           campaignParticipationInfo,
           targetProfile,
-          participantKnowledgeElementsByCompetenceId: [],
+          participantKnowledgeElementsByCompetenceId: {
+            'recCompetence': [],
+          },
           campaignParticipationService,
         });
 
@@ -149,24 +166,30 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: null });
-        const skill1_1 = domainBuilder.buildSkill({ id: 'recSkill1_1', competenceId: 'recCompetence1' });
-        const skill2_1 = domainBuilder.buildSkill({ id: 'recSkill2_1', competenceId: 'recCompetence2' });
-        const skill2_2 = domainBuilder.buildSkill({ id: 'recSkill2_2', competenceId: 'recCompetence2' });
-        const area1 = domainBuilder.buildArea();
-        const area2 = domainBuilder.buildArea();
-        const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', skillIds: ['recSkill1_1', 'recSkill1_2_not_targeted'], area: area1 });
-        const competence2 = domainBuilder.buildCompetence({ id: 'recCompetence2', skillIds: ['recSkill2_1', 'recSkill2_2'], area: area2 });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1_1, skill2_1, skill2_2] });
-        const areas = [area1, area2];
-        const competences = [competence1, competence2];
+        const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+        const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
+        const skill2_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_2', tubeId: 'recTube2' });
+        const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1_1], competenceId: 'recCompetence1' });
+        const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1, skill2_2], competenceId: 'recCompetence2' });
+        const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1], areaId: 'recArea1' });
+        const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2], areaId: 'recArea2' });
+        const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1] });
+        const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+          skills: [skill1_1, skill2_1, skill2_2],
+          tubes: [tube1, tube2],
+          competences: [competence1, competence2],
+          areas: [area1, area2],
+        });
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
-          areas,
-          competences,
           campaignParticipationInfo,
           targetProfile,
-          participantKnowledgeElementsByCompetenceId: [],
+          participantKnowledgeElementsByCompetenceId: {
+            'recCompetence1': [],
+            'recCompetence2': [],
+          },
           campaignParticipationService,
         });
 
@@ -182,19 +205,19 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
 
         let currentColumn = cols.DETAILS_START;
         const STAT_COLS_COUNT = 3;
-        for (let i = 0; i < competences.length; ++i) {
+        for (let i = 0; i < targetProfile.competences.length; ++i) {
           expect(csvLine[currentColumn + i], '% maitrise de la competence').to.equal(EMPTY_CONTENT);
           expect(csvLine[currentColumn + i + 1], 'nb acquis compétence').to.equal(EMPTY_CONTENT);
           expect(csvLine[currentColumn + i + 2], 'nb acquis validés dans la compétence').to.equal(EMPTY_CONTENT);
         }
-        currentColumn = currentColumn + competences.length * STAT_COLS_COUNT;
+        currentColumn = currentColumn + targetProfile.competences.length * STAT_COLS_COUNT;
 
-        for (let i = 0; i < areas.length; ++i) {
+        for (let i = 0; i < targetProfile.areas.length; ++i) {
           expect(csvLine[currentColumn + i], '% maitrise du domaine').to.equal(EMPTY_CONTENT);
           expect(csvLine[currentColumn + i + 1], 'nb acquis domaine').to.equal(EMPTY_CONTENT);
           expect(csvLine[currentColumn + i + 2], 'nb acquis validés dans le domaine').to.equal(EMPTY_CONTENT);
         }
-        currentColumn = currentColumn + areas.length * STAT_COLS_COUNT;
+        currentColumn = currentColumn + targetProfile.areas.length * STAT_COLS_COUNT;
 
         for (let i = 0; i < targetProfile.skills.length; ++i) {
           expect(csvLine[currentColumn + i], 'statut acquis').to.equal(EMPTY_CONTENT);
@@ -211,42 +234,48 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
-        const skill1_1 = domainBuilder.buildSkill({ id: 'recSkill1_1', competenceId: 'recCompetence1' });
-        const skill1_2 = domainBuilder.buildSkill({ id: 'recSkill1_2', competenceId: 'recCompetence1' });
-        const skill2_1 = domainBuilder.buildSkill({ id: 'recSkill2_1', competenceId: 'recCompetence2' });
-        const skill3_1 = domainBuilder.buildSkill({ id: 'recSkill3_1', competenceId: 'recCompetence3' });
-        const skill3_2 = domainBuilder.buildSkill({ id: 'recSkill3_2', competenceId: 'recCompetence3' });
-        const area1 = domainBuilder.buildArea();
-        const area2 = domainBuilder.buildArea();
-        const competence1 = domainBuilder.buildCompetence({ id: 'recCompetence1', skillIds: ['recSkill1_1', 'recSkill1_2', 'recNotTargeted'], area: area1 });
-        const competence2 = domainBuilder.buildCompetence({ id: 'recCompetence2', skillIds: ['recSkill2_1'], area: area1 });
-        const competence3 = domainBuilder.buildCompetence({ id: 'recCompetence3', skillIds: ['recSkill3_1', 'recSkill3_2'], area: area2 });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1_1, skill1_2, skill2_1, skill3_1, skill3_2] });
-        const areas = [area1, area2];
-        const competences = [competence1, competence2, competence3];
+        const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+        const skill1_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+        const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
+        const skill3_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_1', tubeId: 'recTube3' });
+        const skill3_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_2', tubeId: 'recTube3' });
+        const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1_1, skill1_2], competenceId: 'recCompetence1' });
+        const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1], competenceId: 'recCompetence2' });
+        const tube3 = domainBuilder.buildTargetedTube({ id: 'recTube3', skills: [skill3_1, skill3_2], competenceId: 'recCompetence3' });
+        const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1], areaId: 'recArea1' });
+        const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2], areaId: 'recArea1' });
+        const competence3 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence3', tubes: [tube3], areaId: 'recArea2' });
+        const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1, competence2] });
+        const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence3] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+          skills: [skill1_1, skill1_2, skill2_1, skill3_1, skill3_2],
+          tubes: [tube1, tube2, tube3],
+          competences: [competence1, competence2, competence3],
+          areas: [area1, area2],
+        });
         const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
           status: KnowledgeElement.StatusType.VALIDATED,
-          earnedPix: skill1_1.pixValue,
+          earnedPix: 3,
           skillId: skill1_1.id,
-          competenceId: skill1_1.competenceId,
+          competenceId: competence1.id,
         });
         const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
           status: KnowledgeElement.StatusType.INVALIDATED,
-          earnedPix: skill2_1.pixValue,
+          earnedPix: 2,
           skillId: skill2_1.id,
-          competenceId: skill2_1.competenceId,
+          competenceId: competence2.id,
         });
         const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
           status: KnowledgeElement.StatusType.VALIDATED,
-          earnedPix: skill3_1.pixValue,
+          earnedPix: 4,
           skillId: skill3_1.id,
-          competenceId: skill3_1.competenceId,
+          competenceId: competence3.id,
         });
         const knowledgeElement4 = domainBuilder.buildKnowledgeElement({
           status: KnowledgeElement.StatusType.VALIDATED,
-          earnedPix: skill3_2.pixValue,
+          earnedPix: 5,
           skillId: skill3_2.id,
-          competenceId: skill3_2.competenceId,
+          competenceId: competence3.id,
         });
         const participantKnowledgeElementsByCompetenceId = {
           'recCompetence1': [knowledgeElement1],
@@ -256,8 +285,6 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
-          areas,
-          competences,
           campaignParticipationInfo,
           targetProfile,
           participantKnowledgeElementsByCompetenceId,

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -145,34 +145,19 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
     });
 
     context('when participation is not shared', () => {
-      it('should show appropriate content for not shared participation', () => {
+      it('should show informations regarding a not shared participation', () => {
         // given
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: null });
-        const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
-        const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
-        const skill2_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_2', tubeId: 'recTube2' });
-        const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1_1], competenceId: 'recCompetence1' });
-        const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1, skill2_2], competenceId: 'recCompetence2' });
-        const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1], areaId: 'recArea1' });
-        const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2], areaId: 'recArea2' });
-        const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1] });
-        const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2] });
-        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-          skills: [skill1_1, skill2_1, skill2_2],
-          tubes: [tube1, tube2],
-          competences: [competence1, competence2],
-          areas: [area1, area2],
-        });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
           campaignParticipationInfo,
           targetProfile,
           participantKnowledgeElementsByCompetenceId: {
-            'recCompetence1': [],
-            'recCompetence2': [],
+            [targetProfile.competences[0].id]: [],
           },
           campaignParticipationService,
         });
@@ -186,92 +171,30 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Non');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(EMPTY_CONTENT);
         expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(EMPTY_CONTENT);
-
-        let currentColumn = cols.DETAILS_START;
-        const STAT_COLS_COUNT = 3;
-        for (let i = 0; i < targetProfile.competences.length; ++i) {
-          expect(csvLine[currentColumn + i], '% maitrise de la competence').to.equal(EMPTY_CONTENT);
-          expect(csvLine[currentColumn + i + 1], 'nb acquis compétence').to.equal(EMPTY_CONTENT);
-          expect(csvLine[currentColumn + i + 2], 'nb acquis validés dans la compétence').to.equal(EMPTY_CONTENT);
-        }
-        currentColumn = currentColumn + targetProfile.competences.length * STAT_COLS_COUNT;
-
-        for (let i = 0; i < targetProfile.areas.length; ++i) {
-          expect(csvLine[currentColumn + i], '% maitrise du domaine').to.equal(EMPTY_CONTENT);
-          expect(csvLine[currentColumn + i + 1], 'nb acquis domaine').to.equal(EMPTY_CONTENT);
-          expect(csvLine[currentColumn + i + 2], 'nb acquis validés dans le domaine').to.equal(EMPTY_CONTENT);
-        }
-        currentColumn = currentColumn + targetProfile.areas.length * STAT_COLS_COUNT;
-
-        for (let i = 0; i < targetProfile.skills.length; ++i) {
-          expect(csvLine[currentColumn + i], 'statut acquis').to.equal(EMPTY_CONTENT);
-        }
-        currentColumn = currentColumn + targetProfile.skills.length;
-
-        expect(csvLine).to.have.lengthOf(currentColumn);
       });
     });
 
     context('when participation is shared', () => {
-      it('should show appropriate content for shared participation', () => {
+      it('should show informations regarding a shared participation', () => {
         // given
         const organization = domainBuilder.buildOrganization();
         const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
         const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
-        const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
-        const skill1_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
-        const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
-        const skill3_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_1', tubeId: 'recTube3' });
-        const skill3_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_2', tubeId: 'recTube3' });
-        const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1_1, skill1_2], competenceId: 'recCompetence1' });
-        const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1], competenceId: 'recCompetence2' });
-        const tube3 = domainBuilder.buildTargetedTube({ id: 'recTube3', skills: [skill3_1, skill3_2], competenceId: 'recCompetence3' });
-        const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1], areaId: 'recArea1' });
-        const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2], areaId: 'recArea1' });
-        const competence3 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence3', tubes: [tube3], areaId: 'recArea2' });
-        const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1, competence2] });
-        const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence3] });
-        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-          skills: [skill1_1, skill1_2, skill2_1, skill3_1, skill3_2],
-          tubes: [tube1, tube2, tube3],
-          competences: [competence1, competence2, competence3],
-          areas: [area1, area2],
-        });
-        const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+        const knowledgeElement = domainBuilder.buildKnowledgeElement({
           status: KnowledgeElement.StatusType.VALIDATED,
           earnedPix: 3,
-          skillId: skill1_1.id,
-          competenceId: competence1.id,
+          skillId: targetProfile.skills[0].id,
+          competenceId: targetProfile.competences[0].id,
         });
-        const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.INVALIDATED,
-          earnedPix: 2,
-          skillId: skill2_1.id,
-          competenceId: competence2.id,
-        });
-        const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.VALIDATED,
-          earnedPix: 4,
-          skillId: skill3_1.id,
-          competenceId: competence3.id,
-        });
-        const knowledgeElement4 = domainBuilder.buildKnowledgeElement({
-          status: KnowledgeElement.StatusType.VALIDATED,
-          earnedPix: 5,
-          skillId: skill3_2.id,
-          competenceId: competence3.id,
-        });
-        const participantKnowledgeElementsByCompetenceId = {
-          'recCompetence1': [knowledgeElement1],
-          'recCompetence2': [knowledgeElement2],
-          'recCompetence3': [knowledgeElement3, knowledgeElement4],
-        };
         const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
           organization,
           campaign,
           campaignParticipationInfo,
           targetProfile,
-          participantKnowledgeElementsByCompetenceId,
+          participantKnowledgeElementsByCompetenceId: {
+            [targetProfile.competences[0].id]: [knowledgeElement],
+          },
           campaignParticipationService,
         });
 
@@ -282,38 +205,106 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const cols = _computeExpectedColumns(campaign, organization);
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Oui');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal('2020-01-01');
-        expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(0.6);
-
-        let currentColumn = cols.DETAILS_START;
-        // First competence
-        expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
-        expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(2);
-        expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(1);
-        // Second competence
-        expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0);
-        expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(1);
-        expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(0);
-        // Third competence
-        expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(1);
-        expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(2);
-        expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(2);
-        // First area
-        expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(0.33);
-        expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(3);
-        expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(1);
-        // Second area
-        expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(1);
-        expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(2);
-        expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(2);
-        // Target profile skills
-        expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
-        expect(csvLine[currentColumn++], 'statut acquis').to.equal('Non testé');
-        expect(csvLine[currentColumn++], 'statut acquis').to.equal('KO');
-        expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
-        expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
-
-        expect(csvLine).to.have.lengthOf(currentColumn);
+        expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(1);
       });
+    });
+
+    it('should show details for each competence, area and skills', () => {
+      // given
+      const organization = domainBuilder.buildOrganization();
+      const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+      const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+      const skill1_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+      const skill1_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+      const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
+      const skill3_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_1', tubeId: 'recTube3' });
+      const skill3_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill3_2', tubeId: 'recTube3' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1_1, skill1_2], competenceId: 'recCompetence1' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1], competenceId: 'recCompetence2' });
+      const tube3 = domainBuilder.buildTargetedTube({ id: 'recTube3', skills: [skill3_1, skill3_2], competenceId: 'recCompetence3' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1], areaId: 'recArea1' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2], areaId: 'recArea1' });
+      const competence3 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence3', tubes: [tube3], areaId: 'recArea2' });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1, competence2] });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence3] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1_1, skill1_2, skill2_1, skill3_1, skill3_2],
+        tubes: [tube1, tube2, tube3],
+        competences: [competence1, competence2, competence3],
+        areas: [area1, area2],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        earnedPix: 3,
+        skillId: skill1_1.id,
+        competenceId: competence1.id,
+      });
+      const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.INVALIDATED,
+        earnedPix: 2,
+        skillId: skill2_1.id,
+        competenceId: competence2.id,
+      });
+      const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        earnedPix: 4,
+        skillId: skill3_1.id,
+        competenceId: competence3.id,
+      });
+      const knowledgeElement4 = domainBuilder.buildKnowledgeElement({
+        status: KnowledgeElement.StatusType.VALIDATED,
+        earnedPix: 5,
+        skillId: skill3_2.id,
+        competenceId: competence3.id,
+      });
+      const participantKnowledgeElementsByCompetenceId = {
+        'recCompetence1': [knowledgeElement1],
+        'recCompetence2': [knowledgeElement2],
+        'recCompetence3': [knowledgeElement3, knowledgeElement4],
+      };
+      const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+        organization,
+        campaign,
+        campaignParticipationInfo,
+        targetProfile,
+        participantKnowledgeElementsByCompetenceId,
+        campaignParticipationService,
+      });
+
+      // when
+      const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+      // then
+      const cols = _computeExpectedColumns(campaign, organization);
+      let currentColumn = cols.DETAILS_START;
+      // First competence
+      expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
+      expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(2);
+      expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(1);
+      // Second competence
+      expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0);
+      expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(1);
+      expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(0);
+      // Third competence
+      expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(1);
+      expect(csvLine[currentColumn++], 'nb acquis compétence').to.equal(2);
+      expect(csvLine[currentColumn++], 'nb acquis validés dans la compétence').to.equal(2);
+      // First area
+      expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(0.33);
+      expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(3);
+      expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(1);
+      // Second area
+      expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(1);
+      expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(2);
+      expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(2);
+      // Target profile skills
+      expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
+      expect(csvLine[currentColumn++], 'statut acquis').to.equal('Non testé');
+      expect(csvLine[currentColumn++], 'statut acquis').to.equal('KO');
+      expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
+      expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
+
+      expect(csvLine).to.have.lengthOf(currentColumn);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Suite de https://github.com/1024pix/pix/pull/1901
On utilise le modèle TargetProfileWithLearningContent dans l'export csv de campagnes d'évaluation.

## :robot: Solution
On remplace l'appel au répo, on déplace de la logique dans les modèles appropriés

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
