### PR TITLE
[TECH] Améliore la gestion des exceptions dans le database-builder (PIX-1306)

### DIFF
--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -27,6 +27,9 @@ const { environment } = require('../lib/config');
 const knexConfig = knexConfigs[environment];
 const knex = require('knex')(knexConfig);
 
+async function disconnect() {
+  return knex.destroy();
+}
 const _databaseName = knex.client.database();
 
 const _dbSpecificQueries = {
@@ -59,50 +62,8 @@ async function emptyAllTables() {
   return knex.raw(`${query}${tables}`);
 }
 
-async function listTablesByDependencyOrderDesc() {
-  // See this link : https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres
-  const resultSet = await knex.raw('with recursive fk_tree as ( ' +
-    'select t.oid as reloid, ' +
-    't.relname as table_name, ' +
-    's.nspname as schema_name, ' +
-    'null::name as referenced_table_name, ' +
-    'null::name as referenced_schema_name, ' +
-    '1 as level ' +
-    'from pg_class t ' +
-    'join pg_namespace s on s.oid = t.relnamespace ' +
-    'where relkind = \'r\' ' +
-    'and not exists (select * ' +
-    'from pg_constraint ' +
-    'where contype = \'f\' ' +
-    'and conrelid = t.oid) ' +
-    'and s.nspname = \'public\' ' +
-    'union all ' +
-    'select ref.oid, ' +
-    'ref.relname, ' +
-    'rs.nspname, ' +
-    'p.table_name, ' +
-    'p.schema_name, ' +
-    'p.level + 1 ' +
-    'from pg_class ref ' +
-    'join pg_namespace rs on rs.oid = ref.relnamespace ' +
-    'join pg_constraint c on c.contype = \'f\' and c.conrelid = ref.oid ' +
-    'join fk_tree p on p.reloid = c.confrelid ), all_tables as ( ' +
-    'select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as ' +
-    'last_table_row from fk_tree ) ' +
-    'select table_name ' +
-    'from all_tables at where last_table_row = 1 order by level DESC;');
-
-  return _.map(resultSet.rows, 'table_name');
-}
-
-async function disconnect() {
-  return knex.destroy();
-}
-
 module.exports = {
   knex,
   disconnect,
-  listAllTableNames,
   emptyAllTables,
-  listTablesByDependencyOrderDesc,
 };

--- a/api/tests/integration/infrastructure/knex-database-connection_test.js
+++ b/api/tests/integration/infrastructure/knex-database-connection_test.js
@@ -14,13 +14,6 @@ describe('Integration | Infrastructure | knex-database-connection', () => {
     expect(resultSet.rows || resultSet).to.deep.equal([{ value: 1 }]);
   });
 
-  it('should list all tables, including the "users" table', async () => {
-    // when
-    const tableNames = await knexDatabaseConnection.listAllTableNames();
-    // then
-    expect(tableNames).to.include('users');
-  });
-
   it('should empty all tables', async () => {
     // given
     const { id } = databaseBuilder.factory.buildUser();

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -1,38 +1,29 @@
-// Chai
+const _ = require('lodash');
 const chai = require('chai');
 const expect = chai.expect;
+const sinon = require('sinon');
 chai.use(require('chai-as-promised'));
 chai.use(require('chai-sorted'));
-// Sinon
-const sinon = require('sinon');
 chai.use(require('sinon-chai'));
-// Other
-const _ = require('lodash');
 
+const { knex, listAllTableNames } = require('../db/knex-database-connection');
+
+const DatabaseBuilder = require('./tooling/database-builder/database-builder');
+const databaseBuilder = new DatabaseBuilder({ knex });
+
+const nock = require('nock');
+nock.disableNetConnect();
+
+const AirtableBuilder = require('./tooling/airtable-builder/airtable-builder');
+const airtableBuilder = new AirtableBuilder({ nock });
+
+const tokenService = require('../lib/domain/services/token-service');
 const EMPTY_BLANK_AND_NULL = ['', '\t \n', null];
 
 afterEach(function() {
   sinon.restore();
   return databaseBuilder.clean();
 });
-
-// Knex
-const { knex, listAllTableNames } = require('../db/knex-database-connection');
-
-// DatabaseBuilder
-const DatabaseBuilder = require('./tooling/database-builder/database-builder');
-const databaseBuilder = new DatabaseBuilder({ knex });
-
-// Nock
-const nock = require('nock');
-nock.disableNetConnect();
-
-// airtableBuilder
-const AirtableBuilder = require('./tooling/airtable-builder/airtable-builder');
-const airtableBuilder = new AirtableBuilder({ nock });
-
-// Security
-const tokenService = require('../lib/domain/services/token-service');
 
 /**
  * @returns string

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.use(require('chai-sorted'));
 chai.use(require('sinon-chai'));
 
-const { knex, listAllTableNames } = require('../db/knex-database-connection');
+const { knex } = require('../db/knex-database-connection');
 
 const DatabaseBuilder = require('./tooling/database-builder/database-builder');
 const databaseBuilder = new DatabaseBuilder({ knex });
@@ -38,20 +38,6 @@ function generateValidRequestAuthorizationHeader(userId = 1234) {
 
 function generateIdTokenForExternalUser(externalUser) {
   return tokenService.createIdTokenForUserReconciliation(externalUser);
-}
-
-async function getCountOfAllRowsInDatabase()
-{
-  const results = [];
-  const tableNames = await listAllTableNames();
-  const promises = _.map(tableNames, (tableName) => {
-    return knex.raw('SELECT COUNT(*) FROM public."' + tableName + '"').then((result) => {
-      results.push({ table : tableName, countRows: _.toInteger(result.rows[0].count) });
-    });
-  });
-  await Promise.all(promises);
-
-  return _.sortBy(results, 'table');
 }
 
 async function insertUserWithRolePixMaster() {
@@ -169,7 +155,6 @@ module.exports = {
   databaseBuilder,
   generateValidRequestAuthorizationHeader,
   generateIdTokenForExternalUser,
-  getCountOfAllRowsInDatabase,
   hFake,
   HttpTestServer: require('./tooling/server/http-test-server'),
   insertUserWithRolePixMaster,

--- a/api/tests/tooling/database-builder/database-buffer.js
+++ b/api/tests/tooling/database-builder/database-buffer.js
@@ -2,7 +2,6 @@ const INITIAL_ID = 100000;
 
 module.exports = {
   objectsToInsert: [],
-  tablesToDelete: [],
   nextId: INITIAL_ID,
 
   pushInsertable({ tableName, values }) {
@@ -16,6 +15,5 @@ module.exports = {
 
   purge() {
     this.objectsToInsert = [];
-    this.tablesToDelete = [];
   },
 };

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -1,7 +1,7 @@
-const databaseBuffer = require('./database-buffer');
-const factory = require('./factory/index');
-const knexDatabaseConnection = require('../../../db/knex-database-connection');
 const _ = require('lodash');
+const factory = require('./factory/index');
+const databaseBuffer = require('./database-buffer');
+const knexDatabaseConnection = require('../../../db/knex-database-connection');
 
 module.exports = class DatabaseBuilder {
   constructor({ knex }) {
@@ -25,7 +25,7 @@ module.exports = class DatabaseBuilder {
     }
     this.databaseBuffer.objectsToInsert = [];
     this.databaseBuffer.tablesToDelete = this._selectDirtyTables();
-    await trx.commit();
+    return trx.commit();
   }
 
   async clean() {
@@ -35,9 +35,9 @@ module.exports = class DatabaseBuilder {
     });
     if (rawQuery !== '') {
       await this.knex.raw(rawQuery, this.databaseBuffer.tablesToDelete);
-      this.databaseBuffer.purge();
-      this._purgeDirtiness();
     }
+    this.databaseBuffer.purge();
+    this._purgeDirtiness();
   }
 
   async _initTablesOrderedByDependencyWithDirtinessMap() {

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const factory = require('./factory/index');
 const databaseBuffer = require('./database-buffer');
-const knexDatabaseConnection = require('../../../db/knex-database-connection');
 
 module.exports = class DatabaseBuilder {
   constructor({ knex }) {
@@ -14,9 +13,7 @@ module.exports = class DatabaseBuilder {
 
   async commit() {
     if (this.isFirstCommit) {
-      this.isFirstCommit = false;
-      await knexDatabaseConnection.emptyAllTables();
-      await this._initTablesOrderedByDependencyWithDirtinessMap();
+      await this._init();
     }
     const trx = await this.knex.transaction();
     for (const objectToInsert of this.databaseBuffer.objectsToInsert) {
@@ -40,11 +37,62 @@ module.exports = class DatabaseBuilder {
     this._purgeDirtiness();
   }
 
+  async _init() {
+    await this._emptyDatabase();
+    await this._initTablesOrderedByDependencyWithDirtinessMap();
+    this.isFirstCommit = false;
+  }
+
+  async _emptyDatabase() {
+    const query = 'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?';
+    const resultSet = await this.knex.raw(query, [this.knex.client.database()]);
+    const rows = resultSet.rows;
+    const tableNames = _.map(rows, 'table_name');
+    const tablesToDelete = _.without(tableNames,
+      'knex_migrations',
+      'knex_migrations_lock',
+      'pix_roles',
+    );
+    const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
+    return this.knex.raw(`TRUNCATE ${tables}`);
+  }
+
   async _initTablesOrderedByDependencyWithDirtinessMap() {
-    const dependencyOrderedTables = await knexDatabaseConnection.listTablesByDependencyOrderDesc();
-    this.tablesOrderedByDependencyWithDirtinessMap = _.map(dependencyOrderedTables, (table) => {
+    // See this link : https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres
+    const results = await this.knex.raw('with recursive fk_tree as ( ' +
+      'select t.oid as reloid, ' +
+      't.relname as table_name, ' +
+      's.nspname as schema_name, ' +
+      'null::name as referenced_table_name, ' +
+      'null::name as referenced_schema_name, ' +
+      '1 as level ' +
+      'from pg_class t ' +
+      'join pg_namespace s on s.oid = t.relnamespace ' +
+      'where relkind = \'r\' ' +
+      'and not exists (select * ' +
+      'from pg_constraint ' +
+      'where contype = \'f\' ' +
+      'and conrelid = t.oid) ' +
+      'and s.nspname = \'public\' ' +
+      'union all ' +
+      'select ref.oid, ' +
+      'ref.relname, ' +
+      'rs.nspname, ' +
+      'p.table_name, ' +
+      'p.schema_name, ' +
+      'p.level + 1 ' +
+      'from pg_class ref ' +
+      'join pg_namespace rs on rs.oid = ref.relnamespace ' +
+      'join pg_constraint c on c.contype = \'f\' and c.conrelid = ref.oid ' +
+      'join fk_tree p on p.reloid = c.confrelid ), all_tables as ( ' +
+      'select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as ' +
+      'last_table_row from fk_tree ) ' +
+      'select table_name ' +
+      'from all_tables at where last_table_row = 1 order by level DESC;');
+
+    this.tablesOrderedByDependencyWithDirtinessMap = _.map(results.rows, ({ table_name }) => {
       return {
-        table,
+        table: table_name,
         isDirty: false,
       };
     });

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -21,17 +21,17 @@ module.exports = class DatabaseBuilder {
       this._setTableAsDirty(objectToInsert.tableName);
     }
     this.databaseBuffer.objectsToInsert = [];
-    this.databaseBuffer.tablesToDelete = this._selectDirtyTables();
     return trx.commit();
   }
 
   async clean() {
     let rawQuery = '';
-    _.times(this.databaseBuffer.tablesToDelete.length, () => {
+    const tablesToDelete = this._selectDirtyTables();
+    _.times(tablesToDelete.length, () => {
       rawQuery += 'DELETE FROM ??;';
     });
     if (rawQuery !== '') {
-      await this.knex.raw(rawQuery, this.databaseBuffer.tablesToDelete);
+      await this.knex.raw(rawQuery, tablesToDelete);
     }
     this.databaseBuffer.purge();
     this._purgeDirtiness();

--- a/api/tests/unit/tooling/database-builder/database-buffer_test.js
+++ b/api/tests/unit/tooling/database-builder/database-buffer_test.js
@@ -1,0 +1,129 @@
+const { expect } = require('../../../test-helper');
+const databaseBuffer = require('../../../tooling/database-builder/database-buffer');
+
+describe('Unit | Tooling | DatabaseBuilder | database-buffer', () => {
+  afterEach(() => {
+    databaseBuffer.objectsToInsert = [];
+    databaseBuffer.tablesToDelete = [];
+  });
+
+  describe('#pushInsertable', () => {
+
+    it('should add an object to insert', () => {
+      // given
+      const tableName = 'someTableName';
+      const values = { id: 123, a: 'aVal', b: 'bVal' };
+
+      // when
+      databaseBuffer.pushInsertable({ tableName, values });
+
+      // then
+      expect(databaseBuffer.objectsToInsert).to.deep.equal([
+        { tableName, values },
+      ]);
+    });
+
+    it('should return inserted values', () => {
+      // given
+      const tableName = 'someTableName';
+      const values = { id: 123, a: 'aVal', b: 'bVal' };
+
+      // when
+      const expectedValues = databaseBuffer.pushInsertable({ tableName, values });
+
+      // then
+      expect(expectedValues).to.deep.equal(values);
+    });
+
+    context('when no id is provided along with the object', () => {
+
+      it('should add an id property along with original properties in the values', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+        const expectedId = databaseBuffer.nextId;
+
+        // when
+        databaseBuffer.pushInsertable({ tableName, values });
+
+        // then
+        expect(databaseBuffer.objectsToInsert).to.deep.equal([
+          { tableName, values: { ...values, id: expectedId } },
+        ]);
+      });
+
+      it('should increment internal id counter', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+
+        // when
+        const { id: initialId } = databaseBuffer.pushInsertable({ tableName, values });
+        const { id: incrementedId } = databaseBuffer.pushInsertable({ tableName, values });
+
+        // then
+        expect(incrementedId).to.equal(initialId + 1);
+      });
+
+      it('should return inserted values with the id in it', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+
+        // when
+        const { id: initialId } = databaseBuffer.pushInsertable({ tableName, values });
+        const expectedValues = databaseBuffer.pushInsertable({ tableName, values });
+
+        // then
+        expect(expectedValues).to.deep.equal({ ...expectedValues, id: initialId + 1 });
+      });
+    });
+  });
+
+  describe('#purge', () => {
+
+    it('should empty both objectsToInsert and tablesToDelete arrays', () => {
+      // given
+      databaseBuffer.objectsToInsert = ['someValue'];
+      databaseBuffer.tablesToDelete = ['someOtherValue'];
+
+      // when
+      databaseBuffer.purge();
+
+      // then
+      expect(databaseBuffer.objectsToInsert).to.be.empty;
+      expect(databaseBuffer.tablesToDelete).to.be.empty;
+    });
+
+    context('when no id is provided along with the object', () => {
+
+      it('should add an id property along with original properties in the values', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+        const expectedId = databaseBuffer.nextId;
+
+        // when
+        databaseBuffer.pushInsertable({ tableName, values });
+
+        // then
+        expect(databaseBuffer.objectsToInsert).to.deep.equal([
+          { tableName, values: { ...values, id: expectedId } },
+        ]);
+      });
+
+      it('should increment internal id counter', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+        const expectedNextIdIncremented = databaseBuffer.nextId + 1;
+
+        // when
+        databaseBuffer.pushInsertable({ tableName, values });
+
+        // then
+        expect(databaseBuffer.nextId).to.equal(expectedNextIdIncremented);
+      });
+    });
+  });
+});

--- a/api/tests/unit/tooling/database-builder/database-buffer_test.js
+++ b/api/tests/unit/tooling/database-builder/database-buffer_test.js
@@ -4,7 +4,6 @@ const databaseBuffer = require('../../../tooling/database-builder/database-buffe
 describe('Unit | Tooling | DatabaseBuilder | database-buffer', () => {
   afterEach(() => {
     databaseBuffer.objectsToInsert = [];
-    databaseBuffer.tablesToDelete = [];
   });
 
   describe('#pushInsertable', () => {
@@ -82,17 +81,15 @@ describe('Unit | Tooling | DatabaseBuilder | database-buffer', () => {
 
   describe('#purge', () => {
 
-    it('should empty both objectsToInsert and tablesToDelete arrays', () => {
+    it('should empty objectsToInsert array', () => {
       // given
       databaseBuffer.objectsToInsert = ['someValue'];
-      databaseBuffer.tablesToDelete = ['someOtherValue'];
 
       // when
       databaseBuffer.purge();
 
       // then
       expect(databaseBuffer.objectsToInsert).to.be.empty;
-      expect(databaseBuffer.tablesToDelete).to.be.empty;
     });
 
     context('when no id is provided along with the object', () => {

--- a/api/tests/unit/tooling/database-builder/database-builder_test.js
+++ b/api/tests/unit/tooling/database-builder/database-builder_test.js
@@ -1,0 +1,273 @@
+const { expect, sinon } = require('../../../test-helper');
+const DatabaseBuilder = require('../../../tooling/database-builder/database-builder');
+
+describe('Unit | Tooling | DatabaseBuilder | database-builder', () => {
+
+  describe('#clean', () => {
+    let databaseBuilder;
+    let knex;
+    const sandbox = sinon.createSandbox();
+
+    beforeEach(function() {
+      knex = { raw: sinon.stub().resolves() };
+      databaseBuilder = new DatabaseBuilder({ knex });
+      sandbox.spy(databaseBuilder.databaseBuffer);
+    });
+
+    afterEach(function() {
+      sandbox.restore();
+    });
+
+    it('should delete content of all tables in databaseBuffer set for deletion when there are some', async () => {
+      // given
+      const knex = { raw: sinon.stub().resolves() };
+      const databaseBuilder = new DatabaseBuilder({ knex });
+      databaseBuilder.databaseBuffer.tablesToDelete = ['table1', 'table2'];
+
+      // when
+      await databaseBuilder.clean();
+
+      // then
+      expect(knex.raw).to.have.been.calledWithExactly('DELETE FROM ??;DELETE FROM ??;', ['table1', 'table2']);
+    });
+
+    it('should avoid deleting anything if not table are set for deletion in database buffer', async () => {
+      // given
+      const knex = { raw: sinon.stub().resolves() };
+      const databaseBuilder = new DatabaseBuilder({ knex });
+      databaseBuilder.databaseBuffer.tablesToDelete = [];
+
+      // when
+      await databaseBuilder.clean();
+
+      // then
+      expect(knex.raw).to.not.have.been.called;
+    });
+
+    it('should reset the dirtyness map', async () => {
+      // given
+      const knex = { raw: sinon.stub().resolves() };
+      const databaseBuilder = new DatabaseBuilder({ knex });
+      databaseBuilder.databaseBuffer.tablesToDelete = ['table1', 'table2'];
+      databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [{
+        table: 'table1',
+        isDirty: true,
+      }, {
+        table: 'table2',
+        isDirty: true,
+      }, {
+        table: 'table3',
+        isDirty: false,
+      }];
+
+      // when
+      await databaseBuilder.clean();
+
+      // then
+      expect(databaseBuilder.tablesOrderedByDependencyWithDirtinessMap).to.deep.equal([{
+        table: 'table1',
+        isDirty: false,
+      }, {
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table3',
+        isDirty: false,
+      }]);
+    });
+
+    it('should purge the databasebuffer', async () => {
+      // given
+      const knex = { raw: sinon.stub().resolves() };
+      const databaseBuilder = new DatabaseBuilder({ knex });
+
+      // when
+      await databaseBuilder.clean();
+
+      // then
+      expect(databaseBuilder.databaseBuffer.purge).to.have.been.called;
+    });
+  });
+
+  describe('#commit', () => {
+    let databaseBuilder;
+
+    beforeEach(() => {
+      databaseBuilder = new DatabaseBuilder({ knex: null });
+    });
+
+    afterEach(() => {
+      databaseBuilder.databaseBuffer.purge();
+    });
+
+    it('should init the database by cleaning it except for specific tables when this is the first call ever to commit()', async () => {
+      // given
+      const insertStub = sinon.stub().resolves();
+      const trxStub = sinon.stub().returns({ insert: insertStub });
+      trxStub.commit = sinon.stub().resolves();
+      const knex = {
+        raw: sinon.stub(),
+        client: { database: sinon.stub().returns() },
+        transaction: sinon.stub().resolves(trxStub),
+      };
+      knex.raw.onCall(0).resolves({
+        rows: [
+          { table_name: 'table1' },
+          { table_name: 'table2' },
+          { table_name: 'knex_migrations' },
+          { table_name: 'knex_migrations_lock' },
+          { table_name: 'pix_roles' },
+        ],
+      });
+      knex.raw.onCall(1).resolves();
+      knex.raw.onCall(2).resolves({
+        rows: [
+          { table_name: 'table2' },
+          { table_name: 'table1' },
+        ],
+      });
+      databaseBuilder.knex = knex;
+      databaseBuilder.isFirstCommit = true;
+
+      // when
+      await databaseBuilder.commit();
+
+      // then
+      const dirtinessMap = databaseBuilder.tablesOrderedByDependencyWithDirtinessMap;
+      expect(knex.raw).to.have.been.calledWithExactly('TRUNCATE "table1","table2"');
+      expect(dirtinessMap).to.deep.equal([{
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table1',
+        isDirty: false,
+      }]);
+    });
+
+    it('should insert values in database buffer into the database', async () => {
+      // given
+      const insertStub = sinon.stub().resolves();
+      const trxStub = sinon.stub().returns({ insert: insertStub });
+      trxStub.commit = sinon.stub().resolves();
+      const knex = {
+        client: { database: sinon.stub().returns() },
+        transaction: sinon.stub().resolves(trxStub),
+      };
+      databaseBuilder.knex = knex;
+      databaseBuilder.isFirstCommit = false;
+      databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [{
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table1',
+        isDirty: false,
+      }];
+      databaseBuilder.databaseBuffer.objectsToInsert = [
+        { tableName: 'table1', values: 'someValuesForTable1' },
+        { tableName: 'table2', values: 'someValuesForTable2' },
+      ];
+
+      // when
+      await databaseBuilder.commit();
+
+      // then
+      expect(trxStub.firstCall.args).to.deep.equal(['table1']);
+      expect(insertStub.firstCall.args).to.deep.equal(['someValuesForTable1']);
+      expect(trxStub.secondCall.args).to.deep.equal(['table2']);
+      expect(insertStub.secondCall.args).to.deep.equal(['someValuesForTable2']);
+    });
+
+    it('should empty objectsToInsert collection in databaseBuffer', async () => {
+      // given
+      const insertStub = sinon.stub().resolves();
+      const trxStub = sinon.stub().returns({ insert: insertStub });
+      trxStub.commit = sinon.stub().resolves();
+      const knex = {
+        client: { database: sinon.stub().returns() },
+        transaction: sinon.stub().resolves(trxStub),
+      };
+      databaseBuilder.knex = knex;
+      databaseBuilder.isFirstCommit = false;
+      databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [{
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table1',
+        isDirty: false,
+      }];
+      databaseBuilder.databaseBuffer.objectsToInsert = [
+        { tableName: 'table1', values: 'someValuesForTable1' },
+        { tableName: 'table2', values: 'someValuesForTable2' },
+      ];
+
+      // when
+      await databaseBuilder.commit();
+
+      // then
+      expect(databaseBuilder.databaseBuffer.objectsToInsert).to.be.empty;
+    });
+
+    it('should fill tablesToDelete collection in databaseBuffer with dirty table order by priority', async () => {
+      // given
+      const insertStub = sinon.stub().resolves();
+      const trxStub = sinon.stub().returns({ insert: insertStub });
+      trxStub.commit = sinon.stub().resolves();
+      const knex = {
+        client: { database: sinon.stub().returns() },
+        transaction: sinon.stub().resolves(trxStub),
+      };
+      databaseBuilder.knex = knex;
+      databaseBuilder.isFirstCommit = false;
+      databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [{
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table1',
+        isDirty: false,
+      }, {
+        table: 'table3',
+        isDirty: false,
+      }];
+      databaseBuilder.databaseBuffer.objectsToInsert = [
+        { tableName: 'table1', values: 'someValuesForTable1' },
+        { tableName: 'table2', values: 'someValuesForTable2' },
+      ];
+
+      // when
+      await databaseBuilder.commit();
+
+      // then
+      expect(databaseBuilder.databaseBuffer.tablesToDelete).to.deep.equal(['table2', 'table1']);
+    });
+
+    it('should commit the transaction', async () => {
+      // given
+      const insertStub = sinon.stub().resolves();
+      const trxStub = sinon.stub().returns({ insert: insertStub });
+      trxStub.commit = sinon.stub().resolves();
+      const knex = {
+        client: { database: sinon.stub().returns() },
+        transaction: sinon.stub().resolves(trxStub),
+      };
+      databaseBuilder.knex = knex;
+      databaseBuilder.isFirstCommit = false;
+      databaseBuilder.tablesOrderedByDependencyWithDirtinessMap = [{
+        table: 'table2',
+        isDirty: false,
+      }, {
+        table: 'table1',
+        isDirty: false,
+      }];
+      databaseBuilder.databaseBuffer.objectsToInsert = [
+        { tableName: 'table1', values: 'someValuesForTable1' },
+        { tableName: 'table2', values: 'someValuesForTable2' },
+      ];
+
+      // when
+      await databaseBuilder.commit();
+
+      // then
+      expect(trxStub.commit).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le database-builder n'est pas très résilient face aux exceptions lors des insertions liées à l'appel de la méthode `commit()`. Je pense que c'est arrivé à certains d'entre nous qu'un test se passe mal et que cela mette le database-builder / la BDD dans un état difficile à recouvrer et donc qui enchaîne les `KNEX 2000ms Timeout`

## :robot: Solution
Plusieurs retouches sur cette PR :
- On fait un peu de ménage dans le `test-helper.js` (réorganisation d'imports + suppression de méthode exportée jamais utilisée)
- On déplace des méthodes uniquement utilisées (et très fortement liées) au database-builder depuis `knex-database-connection.js` vers `database-builder.js`. D'autant que, si on regarde bien, on peut passer un client knex en param du database-builder, donc le plus logique serait que ces requêtes soient effectuées sur ce client-ci, pas le client singleton du `knex-database-connection`
- On ajoute des tests unitaires sur le database-buffer et le database-builder
- On retire une responsabilité du database-buffer : celle de retenir quelles sont les tables à vider lors du `clean()`, le database-builder a déjà cette connaissance
- Et bien sûr, on catch l'erreur potentielle issue d'une insertion / commit qui a mal tourné. Ici, on va simplement l'afficher et ré-initialiser les collections.

## :rainbow: Remarques
- Je voulais décharger (et donc virer) complètement le database-buffer, mais c'est pas évident du premier coup, alors j'essaierai sur une autre PR.
- Je ne suis pas très satisfaite des tests unitaires. Ils me semblent très liés à l'implémentation et j'ai pas su faire moins. Il est recommandé de tester les interfaces publiques pour vérifier qu'un comportement a bien eu lieu, mais le database-builder a une interface publique qui expose peu de choses. J'ai hésité à faire un test unitaire qui combine l'appel de `commit()` puis `clean()` (et inversement), car c'est une bonne manière de vérifier que les collections ont bien été purgées par exemple, mais j'ai pas osé.
