### PR TITLE
[FEATURE] Amélioration de l'accessibilité des pages campagne (PIX-1181).

### DIFF
--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -59,6 +59,8 @@
 
   &__announcement {
     font-size: 1.125rem;
+    font-weight: $font-light;
+    margin-top: 16px;
   }
 
   &__legal {

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -12,6 +12,7 @@
   }
 
   &__title {
+    font-weight: $font-light;
     text-align: center;
     margin-bottom: 32px;
   }

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -1,7 +1,9 @@
 {{page-title 'Didacticiel'}}
 
 <div class="campaign-tutorial">
-  <div class="rounded-panel rounded-panel--strong campaign-tutorial__container">
+  <main class="rounded-panel rounded-panel--strong campaign-tutorial__container">
+
+    <h1 class="sr-only">{{t 'pages.tutorial.title'}}</h1>
 
     <div class="campaign-tutorial__title">
       {{@model.title}}
@@ -29,5 +31,5 @@
       <button type="submit" class="button button--extra-big campaign-tutorial__start-campaign-button" {{action "submit"}}>{{t 'pages.tutorial.start'}}</button>
     {{/if}}
     </div>
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -29,9 +29,9 @@
     {{#if @model.isTypeAssessment}}
       <div class="rounded-panel campaign-landing-page__container__details">
         <div class="campaign-landing-page__details__text">
-          <p class="campaign-landing-page__details__text title">
+          <h2 class="campaign-landing-page__details__text title">
             {{t "pages.campaign-landing.assessment.details"}}
-          </p>
+          </h2>
           <hr class="campaign-landing-page__details__line">
 
           <div class="campaign-landing-page__details__measure__container">

--- a/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
+++ b/mon-pix/app/templates/campaigns/fill-in-id-pix.hbs
@@ -1,7 +1,7 @@
 {{page-title (t 'pages.fill-in-id-pix.title')}}
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
+  <main class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner fill-in-id-pix__container">
     <h1 class="fill-in-id-pix-text fill-in-id-pix-text__title">{{t 'pages.fill-in-id-pix.first-title'}}</h1>
     <p class="fill-in-id-pix-text fill-in-id-pix-text__announcement">
       {{t 'pages.fill-in-id-pix.announcement'}}
@@ -35,5 +35,5 @@
         </button>
       {{/if}}
     </form>
-  </div>
+  </main>
 </div>

--- a/mon-pix/app/templates/components/campaign-start-block.hbs
+++ b/mon-pix/app/templates/components/campaign-start-block.hbs
@@ -1,4 +1,4 @@
-<div class="rounded-panel campaign-landing-page__container__start">
+<main class="rounded-panel campaign-landing-page__container__start">
   <div class="campaign-landing-page__start__image__container">
     <div class="campaign-landing-page__pix-logo">
       <img class="campaign-landing-page__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
@@ -10,12 +10,12 @@
     {{/if}}
   </div>
   <div class="campaign-landing-page__start__text">
-    <p class="campaign-landing-page__start__text__title">
+    <h1 class="campaign-landing-page__start__text__title">
       {{@titleText}}
-    </p>
-    <p class="campaign-landing-page__start__text__announcement">
+    </h1>
+    <h2 class="campaign-landing-page__start__text__announcement">
       {{{@announcementText}}}
-    </p>
+    </h2>
 
     <form {{action @startCampaignParticipation on="submit"}}>
       {{#if @isLoading}}
@@ -24,7 +24,7 @@
           </button>
       {{else}}
         <button type="submit" class="campaign-landing-page__start-button button button--big">
-          {{@buttonText}} 
+          {{@buttonText}}
         </button>
       {{/if}}
     </form>
@@ -41,4 +41,4 @@
       <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
     </div>
   {{/if}}
-</div>
+</main>

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -6,11 +6,11 @@
     <div class="background-banner-wrapper">
       <div class="background-banner"></div>
 
-      <div
+      <main
         class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
-        <h3 class="fill-in-campaign-code__title rounded-panel-title">
+        <h1 class="fill-in-campaign-code__title rounded-panel-title">
           {{t 'pages.fill-in-campaign-code.first-title'}}
-        </h3>
+        </h1>
 
         <label for="campaign-code"
           class="fill-in-campaign-code__instruction">{{{t 'pages.fill-in-campaign-code.description'}}}</label>
@@ -21,7 +21,7 @@
               @id="campaign-code"
               class="input-code"
               @type="text"
-              @value={{this.campaignCode}} 
+              @value={{this.campaignCode}}
               @maxlength="9"
               @key-down={{this.clearErrorMessage}} />
           </div>
@@ -33,15 +33,15 @@
           {{/if}}
 
           <div class="fill-in-campaign-code__actions">
-            <button 
+            <button
               type="submit"
-              class="button button--extra-big fill-in-campaign-code__start-button" 
+              class="button button--extra-big fill-in-campaign-code__start-button"
               {{action 'startCampaign'}}>
               {{t 'pages.fill-in-campaign-code.start'}}
             </button>
           </div>
         </form>
-      </div>
+      </main>
     </div>
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -692,6 +692,7 @@
     },
 
     "tutorial": {
+      "title": "Campaign tutorial",
       "next": "Next",
       "pages": {
         "page0": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -693,6 +693,7 @@
     },
 
     "tutorial": {
+      "title": "Didacticiel de la campagne",
       "next": "Suivant",
       "pages": {
         "page0": {


### PR DESCRIPTION
## :unicorn: Problème
La page /campagnes doit être la plus accessible possible.
[Ticket Jira](https://1024pix.atlassian.net/secure/RapidBoard.jspa?rapidView=33&projectKey=PIX&modal=detail&selectedIssue=PIX-1181)

## :robot: Solution
Remplacement des `divs` "principales" par des balises `main`
Remplacement de balises paragraphes `p` par des balises de titres `h1, h2`

## :rainbow: Remarques
Le ticket fait état de l'utilisation de la librairie a11y-slider qui semble à première vue difficile à intégrer.
Passage dans un autre ticket ? 🤔

## :100: Pour tester
Parcourir les pages de la réalisation d'une campagne et : 
- utiliser l'inspecteur Chrome/Firefox pour constater des changements effectués
- utiliser l'extension Wave sur Chrome/Firefox pour vérifier l'absence d'erreurs
