### PR TITLE
[FEATURE] Révision de la bannière d'import du SCO (PIX-1313).

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -1,7 +1,11 @@
 {{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
-  <PixBanner @actionLabel='Importer la base Élèves' @actionUrl='authenticated.sco-students'>
+  <PixBanner>
     <FaIcon @icon="exclamation-triangle" class="warning-icon" />
-    Rentrée 2020 : l’administrateur doit <strong>importer ou ré-importer la base</strong> élèves pour initialiser Pix Orga. Plus d’info
+    Rentrée 2020 : l’<strong>administrateur</strong> doit
+    <LinkTo @route="authenticated.sco-students" class="link link-dark">
+      importer ou ré-importer la base élèves
+    </LinkTo>
+    pour initialiser Pix Orga. Plus d’info
     <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link-dark" target="_blank" rel="noopener noreferrer">
       collège
       <FaIcon @icon="external-link-alt" />

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -25,7 +25,6 @@ module('Integration | Component | information-banner', function(hooks) {
           await render(hbs`<InformationBanner/>`);
 
           // then
-          assert.contains('Importer la base Élèves');
           assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
           assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"]').exists();
           assert.dom('.pix-banner').includesText('Rentrée 2020 : l’administrateur doit importer ou ré-importer la base élèves pour initialiser Pix Orga. Plus d’info collège et lycée (GT et Pro)');


### PR DESCRIPTION
## :unicorn: Problème
Le bouton du bandeau “Importer la base élèves”, une fois cliqué devient orange/jaune. Il est beaucoup plus visible que le second bouton “Importer (.xml)” qui lui fait véritablement l’import. 

Les utilisateurs cliquent donc sur le bouton le plus visible mais il ne se passe rien, forcément, il redirige juste vers la page sur laquelle ils sont déjà.

## :robot: Solution
Supprimer le bouton et remplacer le wording.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter  à Pix Orga avec admin.sco2@example.net, et voir le bandeau remasterisé.
