### PR TITLE
[TECH] Sortir de la CI dès qu'une erreur de catégorie de lint est rencontrée.

### DIFF
--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember server",
-    "lint": "eslint ./*.js app config mirage tests ; npm run lint:hbs ; npm run lint:scss",
+    "lint": "eslint ./*.js app config mirage tests && npm run lint:hbs && npm run lint:scss",
     "lint:fix": "npm run lint -- --fix",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",


### PR DESCRIPTION
## :unicorn: Problème
La CI démarre l'analyse de code statique (lint) via une tâche npm.
`    "lint": "eslint ./*.js app config mirage tests; npm run lint:hbs; npm run lint:scss",`

Celle-ci exécute toutes les catégories de linter (js, ember js, ember hbs). Même si l'une d'elles sort en erreur (code retour <> 0), elle exécute les suivantes. L'étape est considérée comme `failed` (j'imagine que le stdout/stderr est parsé par CircleCI, même si je ne trouve pas de mention dans la doc), mais elle aurait pû s'arrêter immédiatement pour ne pas consommer de temps machine.

De plus, si un développeur (moi :smile: ) veut activer en local un hook de pre-commit (`.git/hooks/pre-commit`) sur le lint (sans installer husky),  s'il y une erreur de lint, le code retour est zéro (sauf si la dernière étape est KO), et le commit est accepté à tord. Cela ouvre la possibilité de pusher un commit qui cassera le build, alors que le problème aurait pu être évité en local et ne pas consommer de CI.

## :robot: Solution
Conditionner l'exécution de chaque sous-catégorie au succès de la catégorie précédente
`    "lint": "eslint ./*.js app config mirage tests && npm run lint:hbs && npm run lint:scss",`

## :rainbow: Remarques
On pourrait aussi, pour gagner du temps, lancer ces catégories en parallèle et sortir en erreur si l'une d'elles sort en erreur 
https://github.com/mysticatea/npm-run-all/blob/master/docs/run-p.md
Si cela vous semble utile, faites un retour et je l'implémenterai.

Une fois cette PR approuvée, j'implémenterai la même solution sur les autres applications

## :100: Pour tester
Etapes:
- dans un fichier existant js (ex: mon-pix/app/app.js), introduire une erreur de formatage autofixable (ex: indentation)
- exécuter le linter:` npm run lint`
- vérifier qu'il sort en erreur dès la première étape
- vérifier que le code retour est différent de zéro `echo $?`
