### PR TITLE
[BUGFIX] La colonne updatedAt de la table schooling-registrations n'est pas mise à jour (PIX-1315)

### DIFF
--- a/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/higher-schooling-registration-repository.js
@@ -44,7 +44,7 @@ module.exports = {
       return registrationToSave;
     });
 
-    return upsert(registrationDataToSave);
+    return _upsert(registrationDataToSave);
   },
 
   async findByOrganizationIdAndStudentNumber({ organizationId, studentNumber }) {
@@ -80,7 +80,7 @@ module.exports = {
   },
 };
 
-async function upsert(registrationDataToSave) {
+async function _upsert(registrationDataToSave) {
   const baseQuery = _getBaseQueryForUpsert();
   const registrationDataChunks = _chunkRegistrations(registrationDataToSave);
   const trx = await knex.transaction();
@@ -103,8 +103,9 @@ function _chunkRegistrations(registrations) {
 }
 
 function _getBaseQueryForUpsert() {
-  const update = ATTRIBUTES_TO_SAVE
+  let update = ATTRIBUTES_TO_SAVE
     .map((key) => `"${key}" = EXCLUDED."${key}"`)
     .join(', ');
+  update += ', "updatedAt" = CURRENT_TIMESTAMP';
   return `? ON CONFLICT ("organizationId", "studentNumber") WHERE "isSupernumerary" IS FALSE DO UPDATE SET ${update}`;
 }

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -88,12 +88,13 @@ module.exports = {
     try {
       await Promise.all([
         bluebird.mapSeries(schoolingRegistrationsToUpdate, async (schoolingRegistrationToUpdate) => {
+          const attributesToUpdate = _.omit(schoolingRegistrationToUpdate, ['id', 'createdAt']);
           await trx('schooling-registrations')
             .where({
               'organizationId': organizationId,
               'nationalStudentId': schoolingRegistrationToUpdate.nationalStudentId,
             })
-            .update(_.omit(schoolingRegistrationToUpdate, ['id', 'createdAt']));
+            .update({ ...attributesToUpdate, updatedAt: Bookshelf.knex.raw('CURRENT_TIMESTAMP') });
         }),
         trx.batchInsert('schooling-registrations', schoolingRegistrationsToCreate),
       ]);

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -372,7 +372,7 @@ module.exports = {
       const updatedSchoolingRegistrationsCount = await trx('schooling-registrations')
         .where('id', schoolingRegistrationId)
         .whereNull('userId')
-        .update({ userId });
+        .update({ userId, updatedAt: Bookshelf.knex.raw('CURRENT_TIMESTAMP') });
 
       if (updatedSchoolingRegistrationsCount !== 1) {
         throw new SchoolingRegistrationAlreadyLinkedToUserError(`L'inscription ${schoolingRegistrationId} est déjà rattachée à un compte utilisateur.`);

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -154,7 +154,7 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
         await higherSchoolingRegistrationRepository.saveSet(higherSchoolingRegistrationSet, organization.id);
         const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
 
-        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+        expect(afterUpdatedAt).to.be.above(beforeUpdatedAt);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/higher-schooling-registration-repository_test.js
@@ -126,6 +126,36 @@ describe('Integration | Infrastructure | Repository | higher-schooling-registrat
         expect(higherSchoolingRegistrations).to.have.lengthOf(1);
         expect(higherSchoolingRegistrations[0].preferredLastName).to.equal(registration.preferredLastName);
       });
+      it('should update updatedAt column', async function() {
+
+        const organization = databaseBuilder.factory.buildOrganization();
+        const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
+          preferredLastName: 'Sidewinder',
+          studentNumber: '12',
+          organizationId: organization.id,
+        }).id;
+
+        await databaseBuilder.commit();
+        await knex('schooling-registrations').update({ updatedAt: new Date('2019-01-01') }).where({ id: schoolingRegistrationId });
+        const { updatedAt: beforeUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+
+        const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
+        const registration = {
+          preferredLastName: 'California Mountain Snake',
+          studentNumber: '12',
+          firstName: 'Elle',
+          lastName: 'Driver',
+          birthdate: '2020-01-01',
+          organizationId: organization.id,
+        };
+
+        higherSchoolingRegistrationSet.addRegistration(registration);
+
+        await higherSchoolingRegistrationRepository.saveSet(higherSchoolingRegistrationSet, organization.id);
+        const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+
+        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+      });
     });
 
     context('when there is schooling registration with the same student number for another organization', () => {

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -511,7 +511,7 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         // then
         const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
 
-        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+        expect(afterUpdatedAt).to.be.above(beforeUpdatedAt);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -482,6 +482,38 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
         expect(error.message).to.equal('L’INE SAMEID123 est déjà présent pour cette organisation.');
       });
     });
+
+    context('whenever a schooling-registration is updated', () => {
+
+      it('should update the updatedAt column in row', async () => {
+        // given
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const baseSchoolingRegistration = {
+          firstName: 'Lucy',
+          lastName: 'Handmade',
+          birthdate: '1990-12-31',
+          nationalStudentId: 'INE1',
+          organizationId,
+        };
+        const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration(baseSchoolingRegistration).id;
+        await databaseBuilder.commit();
+        await knex('schooling-registrations').update({ updatedAt: new Date('2019-01-01') }).where({ id: schoolingRegistrationId });
+        const { updatedAt: beforeUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+
+        const schoolingRegistration_updated = new SchoolingRegistration({
+          ...baseSchoolingRegistration,
+          firstName: 'Lili',
+        });
+
+        // when
+        await schoolingRegistrationRepository.addOrUpdateOrganizationSchoolingRegistrations([schoolingRegistration_updated], organizationId);
+
+        // then
+        const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+
+        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+      });
+    });
   });
 
   describe('#findByOrganizationIdAndBirthdate', () => {

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1301,7 +1301,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
-        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+        expect(afterUpdatedAt).to.be.above(beforeUpdatedAt);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -1290,6 +1290,19 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         const foundSchoolingRegistrations = await knex('schooling-registrations').where('id', schoolingRegistrationId);
         expect(foundSchoolingRegistrations[0].userId).to.not.be.undefined;
       });
+
+      it('should update updatedAt column in schooling-registration row', async () => {
+        // given
+        await knex('schooling-registrations').update({ updatedAt: new Date('2019-01-01') }).where({ id: schoolingRegistrationId });
+        const { updatedAt: beforeUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+
+        // when
+        await userRepository.createAndReconcileUserToSchoolingRegistration({ domainUser, schoolingRegistrationId });
+
+        // then
+        const { updatedAt: afterUpdatedAt } = await knex.select('updatedAt').from('schooling-registrations').where({ id: schoolingRegistrationId }).first();
+        expect(beforeUpdatedAt.toString()).to.not.equal(afterUpdatedAt.toString());
+      });
     });
 
     context('when creation succeeds and association fails', () => {


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on a des opérations un peu complexe de mises à jour de lignes en BDD, on préfère éviter _Bookshelf_ et utiliser directement _Knex_. Par contre, on a oublié que si les déclarations des modèles _Bookshelf_ permettent d'automatiser la mise à jour des colonnes timestamps `updatedAt` et `createdAt`, ce n'est plus le cas lorsqu'on bascule sur _Knex_.

## :robot: Solution
En scannant tout le code et en regardant les schémas des tables :
- La colonne `createdAt` est initialisée correctement car on précise sa valeur par défaut dans le schéma :tada: 
- Pareil pour la colonne `updatedAt` lors de la **création** de la ligne en BDD.
- La seule table avec laquelle le boulot de mise à jour consécutive de la colonne `updatedAt` n'est pas fait c'est `schooling-registrations`
On ajoute donc cet attribut en mise à jour dans les différents repositories concernés. On met la valeur `knex.raw('CURRENT_TIMESTAMP')` pour laisser le soin à la BDD de mettre à jour avec le timestamp précis du moment de la mise à jour.

## :rainbow: Remarques
Info du jour : au sein d'une même transaction, CURRENT_TIMESTAMP a toujours la même valeur !

## :100: Pour tester
Le plus simple est de tester une réconciliation. Pour une schooling-registration non réconciliée, noter la date `updatedAt` quelque part. Se réconcilier ensuite avec cette schooling-registration va mettre à jour la colonne.
