### PR TITLE
[FEATURE] Affichage de la liste filtrée et paginée des profils cibles dans Pix Admin (PIX-1322).

### DIFF
--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class TargetProfileAdapter extends ApplicationAdapter {
+
+  urlForQuery() {
+    return `${this.host}/${this.namespace}/admin/target-profiles`;
+  }
+}

--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -37,6 +37,13 @@
       </PixTooltip>
     </li>
     <li class="menu-bar__entry">
+      <PixTooltip @text='Profils cibles' @position='right' @inline={{true}}>
+        <LinkTo @route="authenticated.target-profiles.list" class="menu-bar__link menu-bar__link--target-profiles">
+          <FaIcon @icon="clipboard-list"></FaIcon>
+        </LinkTo>
+      </PixTooltip>
+    </li>
+    <li class="menu-bar__entry">
       <PixTooltip @text='Outils' @position='right'>
         <LinkTo @route="authenticated.tools" class="menu-bar__link menu-bar__link--tools">
           <FaIcon @icon="tools"></FaIcon>

--- a/admin/app/components/target-profiles/list-items.hbs
+++ b/admin/app/components/target-profiles/list-items.hbs
@@ -1,0 +1,47 @@
+<div class="content-text content-text--small">
+  <div class="table-admin">
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nom</th>
+        </tr>
+        <tr>
+          <th>
+            <input id="id"
+                   type="text"
+                   value={{unbound @id}}
+                   oninput={{perform @triggerFiltering 'id'}}
+                   class="table-admin-input" />
+          </th>
+          <th>
+            <input id="name"
+                   type="text"
+                   value={{unbound @name}}
+                   oninput={{perform @triggerFiltering 'name'}}
+                   class="table-admin-input" />
+          </th>
+        </tr>
+      </thead>
+
+      {{#if @targetProfiles}}
+        <tbody>
+        {{#each @targetProfiles as |targetProfile|}}
+          <tr aria-label="Profil cible">
+            <td>{{targetProfile.id}}</td>
+            <td>{{targetProfile.name}}</td>
+          </tr>
+        {{/each}}
+        </tbody>
+      {{/if}}
+    </table>
+
+    {{#unless @targetProfiles}}
+      <div class="table__empty content-text">Aucun résultat</div>
+    {{/unless}}
+  </div>
+</div>
+
+{{#if @targetProfiles}}
+  <PaginationControl @pagination={{@targetProfiles.meta}} />
+{{/if}}

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -1,0 +1,27 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { task, timeout } from 'ember-concurrency';
+import config from 'pix-admin/config/environment';
+
+const DEFAULT_PAGE_NUMBER = 1;
+
+export default class ListController extends Controller {
+
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name'];
+  DEBOUNCE_MS = config.pagination.debounce;
+
+  @tracked pageNumber = DEFAULT_PAGE_NUMBER;
+  @tracked pageSize = 10;
+  @tracked id = null;
+  @tracked name = null;
+  pendingFilters = {};
+
+  @(task(function * (fieldName, event) {
+    const value = event.target.value;
+    this.pendingFilters[fieldName] = value;
+    yield timeout(this.DEBOUNCE_MS);
+    this.setProperties(this.pendingFilters);
+    this.pendingFilters = {};
+    this.pageNumber = DEFAULT_PAGE_NUMBER;
+  }).restartable()) triggerFiltering;
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -59,6 +59,10 @@ Router.map(function() {
       });
     });
 
+    this.route('target-profiles', function() {
+      this.route('list');
+    });
+
     this.route('tools');
   });
 });

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -1,0 +1,46 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import { isEmpty } from 'lodash';
+
+export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
+  @service notifications;
+
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+    id: { refreshModel: true },
+    name: { refreshModel: true },
+  };
+
+  async model(params) {
+    let targetProfiles;
+    try {
+      targetProfiles = await this.store.query('target-profile', {
+        filter: {
+          id: params.id ? params.id.trim() : '',
+          name: params.name ? params.name.trim() : '',
+        },
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+      });
+    } catch (errorResponse) {
+      if (!isEmpty(errorResponse)) {
+        errorResponse.errors.forEach((error) => this.notifications.error(error.detail));
+      }
+      return [];
+    }
+    return targetProfiles;
+  }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 10;
+      controller.id = null;
+      controller.name = null;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/target-profiles.hbs
+++ b/admin/app/templates/authenticated/target-profiles.hbs
@@ -1,0 +1,3 @@
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -1,0 +1,15 @@
+<header class="page-header">
+  <div class="page-title">Tous les profils cibles</div>
+  <div class="page-actions">
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <TargetProfiles::ListItems
+      @targetProfiles={{@model}}
+      @id={{this.id}}
+      @name={{this.name}}
+      @triggerFiltering={{this.triggerFiltering}} />
+  </section>
+</main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -44,6 +44,7 @@ export default function() {
   this.get('/organizations/:id/memberships', findPaginatedOrganizationMemberships);
   this.get('/organizations/:id/target-profiles', getOrganizationTargetProfiles);
   this.post('/organizations/:id/target-profiles', attachTargetProfiles);
+  this.get('/admin/target-profiles');
 
   this.get('/admin/certifications/:id');
 

--- a/admin/tests/acceptance/target-profiles-list-test.js
+++ b/admin/tests/acceptance/target-profiles-list-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Target Profiles List', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function() {
+
+    test('it should not be accessible by an unauthenticated user', async function(assert) {
+      // when
+      await visit('/target-profiles/list');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function(hooks) {
+
+    hooks.beforeEach(async () => {
+      await createAuthenticateSession({ userId: 1 });
+    });
+
+    test('it should be accessible for an authenticated user', async function(assert) {
+      // when
+      await visit('/target-profiles/list');
+
+      // then
+      assert.equal(currentURL(), '/target-profiles/list');
+    });
+
+    test('it should list target profiles', async function(assert) {
+      // given
+      server.createList('target-profile', 12);
+
+      // when
+      await visit('/target-profiles/list');
+
+      // then
+      assert.dom('[aria-label="Profil cible"]').exists({ count: 12 });
+    });
+
+    module('when filters are used', function(hooks) {
+
+      hooks.beforeEach(async () => {
+        server.createList('target-profile', 12);
+      });
+
+      test('it should display the current filter when target profiles are filtered by name', async function(assert) {
+        // when
+        await visit('/target-profiles/list?name=sav');
+
+        // then
+        assert.dom('input#name').hasValue('sav');
+      });
+
+      test('it should display the current filter when target profiles are filtered by id', async function(assert) {
+        // when
+        await visit('/target-profiles/list?id=123');
+
+        // then
+        assert.dom('input#id').hasValue('123');
+      });
+    });
+  });
+});

--- a/admin/tests/integration/components/menu-bar-test.js
+++ b/admin/tests/integration/components/menu-bar-test.js
@@ -38,6 +38,14 @@ module('Integration | Component | menu-bar', function(hooks) {
     assert.dom('a.menu-bar__link--certifications').exists();
   });
 
+  test('should contain link to "target-profiles" management page', async function(assert) {
+    // when
+    await render(hbs`{{menu-bar}}`);
+
+    // then
+    assert.dom('a.menu-bar__link--target-profiles').exists();
+  });
+
   test('should contain link to "tools" management page', async function(assert) {
     // when
     await render(hbs`{{menu-bar}}`);

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.js
@@ -1,0 +1,67 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/target-profiles | list-items', function(hooks) {
+
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(async function() {
+    const triggerFiltering = function() {};
+    this.triggerFiltering = triggerFiltering;
+  });
+
+  test('it should display header with name and id', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
+
+    // then
+    assert.contains('ID');
+    assert.contains('Nom');
+  });
+
+  test('if should display search inputs', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::ListItems @triggerFiltering={{this.triggerFiltering}} />`);
+
+    // then
+    assert.dom('input#name').exists();
+    assert.dom('input#id').exists();
+
+  });
+
+  test('it should display target profiles list', async function(assert) {
+    // given
+    const targetProfiles = [
+      { id: 1 },
+      { id: 2 },
+    ];
+    targetProfiles.meta = {
+      rowCount: 2,
+    };
+    this.targetProfiles = targetProfiles;
+
+    // when
+    await render(hbs`<TargetProfiles::ListItems @targetProfiles={{this.targetProfiles}} @triggerFiltering={{this.triggerFiltering}} />`);
+
+    // then
+    assert.dom('[aria-label="Profil cible"]').exists({ count: 2 });
+  });
+
+  test('it should display target profile data', async function(assert) {
+    // given
+    const targetProfiles = [{ id: 123, name: 'Profile Cible 1' }];
+    targetProfiles.meta = {
+      rowCount: 2,
+    };
+    this.targetProfiles = targetProfiles;
+
+    // when
+    await render(hbs`<TargetProfiles::ListItems @targetProfiles={{this.targetProfiles}} @triggerFiltering={{this.triggerFiltering}} />`);
+
+    // then
+    assert.dom('[aria-label="Profil cible"]').containsText(123);
+    assert.dom('[aria-label="Profil cible"]').containsText('Profile Cible 1');
+  });
+});

--- a/admin/tests/unit/adapters/target-profile-test.js
+++ b/admin/tests/unit/adapters/target-profile-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | Target Profile', function(hooks) {
+  setupTest(hooks);
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:target-profile');
+  });
+
+  module('#urlForQuery', function() {
+
+    test('should add /admin inside the default query url', function(assert) {
+      // when
+      const url = adapter.urlForQuery();
+
+      // then
+      assert.ok(url.endsWith('/api/admin/target-profiles'));
+    });
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/target-profiles/list', function(hooks) {
+  setupTest(hooks);
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated.target-profiles.list');
+  });
+
+  module('#triggerFiltering task', function() {
+
+    module('updating name', function() {
+
+      test('it should update controller name field', async function(assert) {
+        // given
+        controller.name = 'someName';
+        const expectedValue = 'someOtherName';
+
+        // when
+        await controller.triggerFiltering.perform('name', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.name, expectedValue);
+      });
+    });
+
+    module('updating id', function() {
+
+      test('it should update controller id field', async function(assert) {
+        // given
+        controller.id = 'someId';
+        const expectedValue = 'someOtherId';
+
+        // when
+        await controller.triggerFiltering.perform('id', { target: { value: expectedValue } });
+
+        // then
+        assert.equal(controller.id, expectedValue);
+      });
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
@@ -1,0 +1,105 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
+  setupTest(hooks);
+  let route;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/target-profiles/list');
+  });
+
+  module('#model', function(hooks) {
+    const params = {};
+    const expectedQueryArgs = {};
+
+    hooks.beforeEach(function() {
+      route.store.query = sinon.stub().resolves();
+      params.pageNumber = 'somePageNumber';
+      params.pageSize = 'somePageSize';
+      expectedQueryArgs.page = {
+        number: 'somePageNumber',
+        size: 'somePageSize',
+      };
+    });
+
+    module('when queryParams filters are falsy', function() {
+
+      test('it should call store.query with no filters on name and id', async function(assert) {
+        // when
+        await route.model(params);
+        expectedQueryArgs.filter = {
+          name: '',
+          id: '',
+        };
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'target-profile', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams filters are truthy', function() {
+
+      test('it should call store.query with filters containing trimmed values', async function(assert) {
+        // given
+        params.name = ' someName';
+        params.id = 'someId ';
+        expectedQueryArgs.filter = {
+          name: 'someName',
+          id: 'someId',
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'target-profile', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+  });
+
+  module('#resetController', function(hooks) {
+    let controller;
+
+    hooks.beforeEach(function() {
+      controller = {
+        pageNumber: 'somePageNumber',
+        pageSize: 'somePageSize',
+        name: 'someName',
+        id: 'someId',
+      };
+    });
+
+    module('when route is exiting', function() {
+
+      test('it should reset controller', function(assert) {
+        // when
+        route.resetController(controller, true);
+
+        // then
+        assert.equal(controller.pageNumber, 1);
+        assert.equal(controller.pageSize, 10);
+        assert.equal(controller.name, null);
+        assert.equal(controller.id, null);
+      });
+    });
+
+    module('when route is not exiting', function() {
+
+      test('it should not reset controller', function(assert) {
+        // when
+        route.resetController(controller, false);
+
+        // then
+        assert.equal(controller.pageNumber, 'somePageNumber');
+        assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.name, 'someName');
+        assert.equal(controller.id, 'someId');
+      });
+    });
+  });
+});

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -1,0 +1,42 @@
+const Joi = require('@hapi/joi');
+const { sendJsonApiError, BadRequestError } = require('../http-errors');
+const securityPreHandlers = require('../security-pre-handlers');
+const targetProfileController = require('./target-profile-controller');
+
+exports.register = async (server) => {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/target-profiles',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          query: Joi.object({
+            'filter[id]': Joi.number().integer().empty('').allow(null).optional(),
+            'filter[name]': Joi.string().empty('').allow(null).optional(),
+            'page[number]': Joi.number().integer().empty('').allow(null).optional(),
+            'page[size]': Joi.number().integer().empty('').allow(null).optional(),
+          }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new BadRequestError('Un des champs de recherche saisis est invalide.'), h);
+          },
+        },
+        handler: targetProfileController.findPaginatedFilteredTargetProfiles,
+        tags: ['api', 'target-profiles'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de récupérer & chercher une liste de profils cible\n' +
+          '- Cette liste est paginée et filtrée selon un **id** et/ou un **name** donnés',
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'target-profiles-api';

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -1,0 +1,13 @@
+const usecases = require('../../domain/usecases');
+const targetProfileSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-serializer');
+const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
+
+module.exports = {
+
+  async findPaginatedFilteredTargetProfiles(request) {
+    const options = queryParamsUtils.extractParameters(request.query);
+
+    const { models: targetProfiles, pagination } = await usecases.findPaginatedFilteredTargetProfiles({ filter: options.filter, page: options.page });
+    return targetProfileSerializer.serialize(targetProfiles, pagination);
+  },
+};

--- a/api/lib/domain/usecases/find-paginated-filtered-target-profiles.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-target-profiles.js
@@ -1,0 +1,3 @@
+module.exports = function findPaginatedFilteredTargetProfiles({ filter, page, targetProfileRepository }) {
+  return targetProfileRepository.findPaginatedFiltered({ filter, page });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -126,6 +126,7 @@ module.exports = injectDependencies({
   findPaginatedFilteredOrganizationCampaigns: require('./find-paginated-filtered-organization-campaigns'),
   findPaginatedFilteredOrganizationMemberships: require('./find-paginated-filtered-organization-memberships'),
   findPaginatedFilteredOrganizations: require('./find-paginated-filtered-organizations'),
+  findPaginatedFilteredTargetProfiles: require('./find-paginated-filtered-target-profiles'),
   findPaginatedFilteredUsers: require('./find-paginated-filtered-users'),
   findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
   findSessionsForCertificationCenter: require('./find-sessions-for-certification-center'),

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -1,9 +1,10 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(targetProfile) {
+  serialize(targetProfiles, meta) {
     return new Serializer('target-profiles', {
       attributes: ['name'],
-    }).serialize(targetProfile);
+      meta,
+    }).serialize(targetProfiles);
   },
 };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -31,6 +31,7 @@ module.exports = [
   require('./application/student-dependent-users'),
   require('./application/student-user-associations'),
   require('./application/system'),
+  require('./application/target-profiles'),
   require('./application/tutorial-evaluations'),
   require('./application/user-orga-settings'),
   require('./application/user-tutorials'),

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -1,0 +1,80 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const targetProfileController = require('../../../../lib/application/target-profiles/target-profile-controller');
+const moduleUnderTest = require('../../../../lib/application/target-profiles');
+
+describe('Integration | Application | Target Profiles | Routes', () => {
+
+  let httpTestServer;
+
+  beforeEach(() => {
+    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+    sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfiles').callsFake((request, h) => h.response('ok').code(200));
+
+    httpTestServer = new HttpTestServer(moduleUnderTest);
+  });
+
+  describe('GET /api/target-profiles', () => {
+
+    it('should resolve when there is no filter nor pagination', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/target-profiles';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should resolve when there are filters and pagination', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/target-profiles?filter[id]=1&filter[name]=azerty&page[size]=10&page[number]=1';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should reject request with HTTP code 400, when id is not an integer', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/target-profiles?filter[id]=azerty';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should reject request with HTTP code 400, when page size is not an integer', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/target-profiles?page[size]=azerty';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should reject request with HTTP code 400, when page number is not an integer', async () => {
+      // given
+      const method = 'GET';
+      const url = '/api/admin/target-profiles?page[number]=azerty';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-target-profiles_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-target-profiles_test.js
@@ -1,0 +1,33 @@
+const { expect, sinon } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const TargetProfile = require('../../../../lib/domain/models/TargetProfile');
+
+describe('Unit | UseCase | find-paginated-filtered-target-profiles', () => {
+
+  it('should result target profiles with filtering and pagination', async () => {
+    // given
+    const filter = { name: 'Dragon' };
+    const page = { number: 1, size: 2 };
+
+    const resolvedPagination = { page: 1, pageSize: 2, itemsCount: 3, pagesCount: 2 };
+    const matchingTargetProfiles = [
+      new TargetProfile({ id: 1 }),
+      new TargetProfile({ id: 2 }),
+      new TargetProfile({ id: 3 }),
+    ];
+    const targetProfileRepository = {
+      findPaginatedFiltered: sinon.stub(),
+    };
+    targetProfileRepository.findPaginatedFiltered.withArgs({ filter, page }).resolves({ models: matchingTargetProfiles, pagination: resolvedPagination });
+
+    // when
+    const response = await usecases.findPaginatedFilteredTargetProfiles({ filter, page, targetProfileRepository });
+
+    // then
+    expect(response.models).to.equal(matchingTargetProfiles);
+    expect(response.pagination.page).to.equal(resolvedPagination.page);
+    expect(response.pagination.pageSize).to.equal(resolvedPagination.pageSize);
+    expect(response.pagination.itemsCount).to.equal(resolvedPagination.itemsCount);
+    expect(response.pagination.pagesCount).to.equal(resolvedPagination.pagesCount);
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -8,6 +8,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function() {
     it('should serialize target profile to JSONAPI', function() {
       // given
       const targetProfile = domainBuilder.buildTargetProfile({ id: 132, name: 'Les compétences de BRO 2.0' });
+      const meta = { some: 'meta' };
 
       const expectedTargetProfile = {
         data: {
@@ -17,10 +18,11 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function() {
             name: targetProfile.name,
           },
         },
+        meta,
       };
 
       // when
-      const serializedTargetProfile = serializer.serialize(targetProfile);
+      const serializedTargetProfile = serializer.serialize(targetProfile, meta);
 
       // then
       return expect(serializedTargetProfile).to.deep.equal(expectedTargetProfile);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les membres de Pix ne peuvent pas voir quels profils cible existent, ne peuvent pas rechercher un profil cible précisément.

## :robot: Solution
Rendre accessible une page qui liste les profils cible, avec une recherche possible sur l'ID et le nom du profil cible.

## :rainbow: Remarques
D'autres améliorations viendront par la suite (affichage du détail, création de profil cible).

## :100: Pour tester
Se connecter à Pix Admin, aller dans le menu "Profils cible" et voir affiché la liste des profils cible. Filtrer et paginer et s'assurer que tout fonctionne correctement.
