### PR TITLE
[TECH] Utilisation du modèle TargetProfileWithLearningContent dans le calcul des résultats collectifs

### DIFF
--- a/api/lib/domain/models/CampaignCompetenceCollectiveResult.js
+++ b/api/lib/domain/models/CampaignCompetenceCollectiveResult.js
@@ -1,22 +1,17 @@
 class CampaignCompetenceCollectiveResult {
 
   constructor({
-    // attributes
     campaignId,
-    competenceId,
-    competenceIndex,
-    competenceName,
-    areaColor,
-    targetedSkillsCount,
+    targetedArea,
+    targetedCompetence,
     averageValidatedSkills,
   } = {}) {
-    // attributes
     this.campaignId = campaignId;
-    this.competenceId = competenceId;
-    this.competenceIndex = competenceIndex;
-    this.competenceName = competenceName;
-    this.areaColor = areaColor;
-    this.targetedSkillsCount = targetedSkillsCount;
+    this.competenceId = targetedCompetence.id;
+    this.competenceIndex = targetedCompetence.index;
+    this.competenceName = targetedCompetence.name;
+    this.areaColor = targetedArea.color;
+    this.targetedSkillsCount = targetedCompetence.skillCount;
     this.averageValidatedSkills = averageValidatedSkills;
   }
 

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -36,6 +36,12 @@ class TargetProfileWithLearningContent {
 
     return skillTube ? skillTube.competenceId : null;
   }
+
+  getAreaOfCompetence(competenceId) {
+    const area = this.areas.find((area) => area.hasCompetence(competenceId));
+
+    return area || null;
+  }
 }
 
 module.exports = TargetProfileWithLearningContent;

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -19,6 +19,10 @@ class TargetProfileWithLearningContent {
     return this.skills.map((skill) => skill.name);
   }
 
+  get skillIds() {
+    return this.skills.map((skill) => skill.id);
+  }
+
   get competenceIds() {
     return this.competences.map((competences) => competences.id);
   }

--- a/api/lib/domain/models/TargetedArea.js
+++ b/api/lib/domain/models/TargetedArea.js
@@ -2,10 +2,12 @@ class TargetedArea {
   constructor({
     id,
     title,
+    color,
     competences = [],
   } = {}) {
     this.id = id;
     this.title = title;
+    this.color = color;
     this.competences = competences;
   }
 

--- a/api/lib/domain/models/TargetedArea.js
+++ b/api/lib/domain/models/TargetedArea.js
@@ -8,6 +8,10 @@ class TargetedArea {
     this.title = title;
     this.competences = competences;
   }
+
+  hasCompetence(competenceId) {
+    return this.competences.some((competence) => competence.id === competenceId);
+  }
 }
 
 module.exports = TargetedArea;

--- a/api/lib/domain/usecases/compute-campaign-collective-result.js
+++ b/api/lib/domain/usecases/compute-campaign-collective-result.js
@@ -6,7 +6,7 @@ module.exports = async function computeCampaignCollectiveResult(
     campaignId,
     campaignRepository,
     campaignCollectiveResultRepository,
-    competenceRepository,
+    targetProfileWithLearningContentRepository,
   } = {}) {
 
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
@@ -15,7 +15,6 @@ module.exports = async function computeCampaignCollectiveResult(
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
   }
 
-  const competences = await competenceRepository.list();
-
-  return campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+  const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
+  return campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 };

--- a/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-collective-result-repository.js
@@ -82,18 +82,15 @@ function _computeKERankWithinUserAndSkillByDateDescending(qb) {
 function _buildCampaignCompetenceCollectiveResults(campaignId, targetProfile, participantCount, participantsKECountByCompetenceId) {
   return _(targetProfile.competences).map((competence) => {
     let averageValidatedSkills = 0;
-    if (competence.id in participantsKECountByCompetenceId) {
+    if (participantCount && competence.id in participantsKECountByCompetenceId) {
       averageValidatedSkills = participantsKECountByCompetenceId[competence.id] / participantCount;
     }
 
     const area = targetProfile.getAreaOfCompetence(competence.id);
     return new CampaignCompetenceCollectiveResult({
       campaignId,
-      competenceId: competence.id,
-      competenceName: competence.name,
-      competenceIndex: competence.index,
-      areaColor: area.color,
-      targetedSkillsCount: competence.skillCount,
+      targetedArea: area,
+      targetedCompetence: competence,
       averageValidatedSkills,
     });
   })

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -163,10 +163,15 @@ describe('Acceptance | API | Campaign Controller', () => {
         domaineIds: [area.id],
         acquisViaTubes: ['recSkillId1','recSkillId2'],
       });
+      const tube1 = airtableBuilder.factory.buildTube({
+        id: 'recTube1',
+        competences: [competence1.id],
+      });
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns([
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: ['recCompetence1'] }),
-        airtableBuilder.factory.buildSkill({ id: 'recSkillId2', ['compétenceViaTube']: ['recCompetence1'] }),
+        airtableBuilder.factory.buildSkill({ id: 'recSkillId1', ['compétenceViaTube']: ['recCompetence1'], tube: ['recTube1'] }),
+        airtableBuilder.factory.buildSkill({ id: 'recSkillId2', ['compétenceViaTube']: ['recCompetence1'], tube: ['recTube1'] }),
       ]).activate();
+      airtableBuilder.mockList({ tableName: 'Tubes' }).returns([tube1]).activate();
       airtableBuilder.mockList({ tableName: 'Competences' }).returns([competence1]).activate();
       airtableBuilder.mockList({ tableName: 'Domaines' }).returns([area]).activate();
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-collective-result-repository_test.js
@@ -1,7 +1,6 @@
-const { expect, databaseBuilder, domainBuilder, airtableBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, domainBuilder } = require('../../../test-helper');
 const campaignCollectiveResultRepository = require('../../../../lib/infrastructure/repositories/campaign-collective-result-repository');
 const CampaignCollectiveResult = require('../../../../lib/domain/models/CampaignCollectiveResult');
-const cache = require('../../../../lib/infrastructure/caches/learning-content-cache');
 const _ = require('lodash');
 
 function _createUserWithSharedCampaignParticipation(userName, campaignId, sharedAt) {
@@ -28,105 +27,61 @@ function _createUserWithNonSharedCampaignParticipation(userName, campaignId) {
 }
 
 describe('Integration | Repository | Campaign collective result repository', () => {
-  let competences;
-
-  beforeEach(() => {
-    const areas = [airtableBuilder.factory.buildArea()];
-    const skills = [];
-
-    competences = [];
-
-    _.each([
-      {
-        competence: { id: 'recCompetenceA', name: 'Competence A', index: '1.1', area: { color: 'jaffa' } },
-        skillIds: ['recUrl1', 'recUrl2', 'recUrl3', 'recUrl4', 'recUrl5'],
-      }, {
-        competence: { id: 'recCompetenceB', name: 'Competence B', index: '1.2', area: { color: 'jaffa' } },
-        skillIds: ['recFile2', 'recFile3', 'recFile5', 'recText1'],
-      }, {
-        competence: { id: 'recCompetenceC', name: 'Competence C', index: '1.3', area: { color: 'jaffa' } },
-        skillIds: ['recMedia1', 'recMedia2'],
-      }, {
-        competence: { id: 'recCompetenceD', name: 'Competence D', index: '2.1', area: { color: 'emerald' } },
-        skillIds: ['recAlgo1', 'recAlgo2'],
-      }, {
-        competence: { id: 'recCompetenceE', name: 'Competence E', index: '2.2', area: { color: 'emerald' } },
-        skillIds: ['recBrowser1'],
-      }, {
-        competence: { id: 'recCompetenceF', name: 'Competence F', index: '2.3', area: { color: 'emerald' } },
-        skillIds: ['recComputer1'],
-      },
-
-    ], ({ competence, skillIds }) => {
-      competences.push(domainBuilder.buildCompetence({ ...competence, skillIds }));
-
-      _.each(skillIds, (skillId) => skills.push(
-        airtableBuilder.factory.buildSkill({ id: skillId, 'compétenceViaTube': [competence.id] }),
-      ));
-    });
-
-    airtableBuilder
-      .mockList({ tableName: 'Domaines' })
-      .returns(areas)
-      .activate();
-
-    airtableBuilder
-      .mockList({ tableName: 'Acquis' })
-      .returns(skills)
-      .activate();
-  });
-
-  afterEach(() => {
-    airtableBuilder.cleanAll();
-    return cache.flushAll();
-  });
 
   describe('#getCampaignCollectiveResults', () => {
 
     context('in a rich context close to reality', () => {
-
-      let targetProfileId;
+      let targetProfile;
       let campaignId;
-
-      let url1Id, url2Id, url3Id, // comp. A
-        file2Id, file3Id, file5Id, text1Id, // comp. B
-        media1Id, media2Id, // comp. C
-        algo1Id, algo2Id, // comp. D
-        computer1Id; // comp. F
 
       let expectedCampaignCollectiveResult;
 
       beforeEach(async () => {
-
-        targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
-        campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+        campaignId = databaseBuilder.factory.buildCampaign().id;
 
         // Competence A - nobody validated skills @url4 and @url5
-        url1Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recUrl1' }).skillId;
-        url2Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recUrl2' }).skillId;
-        url3Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recUrl3' }).skillId;
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recUrl4' });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recUrl5' });
+        const url1 = domainBuilder.buildTargetedSkill({ id: 'recUrl1', tubeId: 'recTubeA' });
+        const url2 = domainBuilder.buildTargetedSkill({ id: 'recUrl2', tubeId: 'recTubeA' });
+        const url3 = domainBuilder.buildTargetedSkill({ id: 'recUrl3', tubeId: 'recTubeA' });
+        const url4 = domainBuilder.buildTargetedSkill({ id: 'recUrl4', tubeId: 'recTubeA' });
+        const url5 = domainBuilder.buildTargetedSkill({ id: 'recUrl5', tubeId: 'recTubeA' });
+        const tubeA = domainBuilder.buildTargetedTube({ id: 'recTubeA', competenceId: 'recCompetenceA', skills: [url1, url2, url3, url4, url5] });
+        const competenceA = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceA', areaId: 'recArea1', tubes: [tubeA], name: 'Competence A', index: '1.1' });
 
         // Competence B - all skills are validated by different people
-        file2Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recFile2' }).skillId;
-        file3Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recFile3' }).skillId;
-        file5Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recFile5' }).skillId;
-        text1Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recText1' }).skillId;
+        const file2 = domainBuilder.buildTargetedSkill({ id: 'recFile2', tubeId: 'recTubeB' });
+        const file3 = domainBuilder.buildTargetedSkill({ id: 'recFile3', tubeId: 'recTubeB' });
+        const file5 = domainBuilder.buildTargetedSkill({ id: 'recFile5', tubeId: 'recTubeB' });
+        const text1 = domainBuilder.buildTargetedSkill({ id: 'recText1', tubeId: 'recTubeB' });
+        const tubeB = domainBuilder.buildTargetedTube({ id: 'recTubeB', competenceId: 'recCompetenceB', skills: [file2, file3, file5, text1] });
+        const competenceB = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceB', areaId: 'recArea1', tubes: [tubeB], name: 'Competence B', index: '1.2' });
 
         // Competence C - skill @media2 is validated by someone but is not part of campaign target profile
-        media1Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recMedia1' }).skillId;
-        media2Id = 'recMedia2';
+        const media1 = domainBuilder.buildTargetedSkill({ id: 'recMedia1', tubeId: 'recTubeC' });
+        const tubeC = domainBuilder.buildTargetedTube({ id: 'recTubeC', competenceId: 'recCompetenceC', skills: [media1] });
+        const competenceC = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceC', areaId: 'recArea1', tubes: [tubeC], name: 'Competence C', index: '1.3' });
 
         // Competence D - competence D is not covered by campaign target profile
-        algo1Id = 'recAlgo1';
-        algo2Id = 'recAlgo2';
 
         // Competence E - competence E is targeted by campaign but nobody validated its skills
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recBrowser1' });
+        const browser1 = domainBuilder.buildTargetedSkill({ id: 'recBrowser1', tubeId: 'recTubeE' });
+        const tubeE = domainBuilder.buildTargetedTube({ id: 'recTubeE', competenceId: 'recCompetenceE', skills: [browser1] });
+        const competenceE = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceE', areaId: 'recArea2', tubes: [tubeE], name: 'Competence E', index: '2.2' });
 
         // Competence F - skill is validated and then invalidated
-        computer1Id = databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'recComputer1' }).skillId;
+        const computer1 = domainBuilder.buildTargetedSkill({ id: 'recComputer1', tubeId: 'recTubeF' });
+        const tubeF = domainBuilder.buildTargetedTube({ id: 'recTubeF', competenceId: 'recCompetenceF', skills: [computer1] });
+        const competenceF = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceF', areaId: 'recArea2', tubes: [tubeF], name: 'Competence F', index: '2.3' });
+
+        const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competenceA, competenceB, competenceC], color: 'jaffa' });
+        const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competenceE, competenceF], color: 'emerald' });
+
+        targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+          skills: [url1, url2, url3, url4, url5, file2, file3, file5, text1, media1, browser1, computer1],
+          tubes: [tubeA, tubeB, tubeC, tubeE, tubeF],
+          competences: [competenceA, competenceB, competenceC, competenceE, competenceF],
+          areas: [area1, area2],
+        });
 
         expectedCampaignCollectiveResult = Object.freeze(domainBuilder.buildCampaignCollectiveResult({
           id: campaignId,
@@ -183,13 +138,13 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
       context('when there is no participant', () => {
 
-        beforeEach(async () => {
-          await databaseBuilder.commit();
+        beforeEach(() => {
+          return databaseBuilder.commit();
         });
 
         it('should resolves a collective result synthesis with default values for all competences', async () => {
           // when
-          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 
           // then
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
@@ -201,7 +156,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
       context('when there is a participant but she did not share its contribution', () => {
 
-        beforeEach(async () => {
+        beforeEach(() => {
 
           const goliathId = databaseBuilder.factory.buildUser({ firstName: 'Goliath' }).id;
 
@@ -214,18 +169,18 @@ describe('Integration | Repository | Campaign collective result repository', () 
           databaseBuilder.factory.buildKnowledgeElement({
             userId: goliathId,
             competenceId: 'recCompetenceA',
-            skillId: url1Id,
+            skillId: 'recUrl1',
             status: 'validated',
             campaignId,
             createdAt: new Date('2019-02-01'),
           });
 
-          await databaseBuilder.commit();
+          return databaseBuilder.commit();
         });
 
         it('should resolves a collective result synthesis with default values for all competences', async () => {
           // when
-          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 
           // then
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
@@ -237,29 +192,29 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
       context('when there is a single participant who shared its contribution', () => {
 
-        beforeEach(async () => {
+        beforeEach(() => {
           const longTimeAgo = new Date('2018-01-01');
           const beforeCampaignParticipationShareDate = new Date('2019-01-01');
           const userWithCampaignParticipationFred = _createUserWithSharedCampaignParticipation('Fred', campaignId, new Date());
           const fredId = userWithCampaignParticipationFred.userId;
 
           _.each([
-            { userId: fredId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceA', skillId: url3Id, status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceB', skillId: file2Id, status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceB', skillId: text1Id, status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceC', skillId: media1Id, status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
-            { userId: fredId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'validated', campaignId, createdAt: longTimeAgo },
-            { userId: fredId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceA', skillId: 'recUrl3', status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceB', skillId: 'recFile2', status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceB', skillId: 'recText1', status: 'validated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceC', skillId: 'recMedia1', status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
+            { userId: fredId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'validated', campaignId, createdAt: longTimeAgo },
+            { userId: fredId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'invalidated', campaignId, createdAt: beforeCampaignParticipationShareDate },
 
           ], (knownledgeElement) => {
             databaseBuilder.factory.buildKnowledgeElement(knownledgeElement);
           });
 
-          await databaseBuilder.commit();
+          return databaseBuilder.commit();
         });
 
         it('should resolves a collective result synthesis with its results as collective’s ones', async () => {
@@ -316,7 +271,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
           };
 
           // when
-          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 
           // then
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
@@ -328,7 +283,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
       context('when there are multiple participants who shared their participation', () => {
 
-        beforeEach(async () => {
+        beforeEach(() => {
 
           const longTimeAgo = new Date('2018-01-01');
           const campaignParticipationShareDate = new Date('2019-03-01');
@@ -353,7 +308,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
           const danId =  userWithCampaignParticipationDan.userId;
 
           // Elo (participated in another campaign)
-          const anotherCampaignId = databaseBuilder.factory.buildCampaign({ targetProfileId }).id;
+          const anotherCampaignId = databaseBuilder.factory.buildCampaign().id;
           const userWithCampaignParticipationElo = _createUserWithSharedCampaignParticipation('Elo', anotherCampaignId, campaignParticipationShareDate);
           const eloId = userWithCampaignParticipationElo.id;
 
@@ -361,75 +316,75 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
           _.each([
             // Alice
-            { userId: aliceId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceA', skillId: url3Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceA', skillId: 'recUrl3', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: aliceId, competenceId: 'recCompetenceB', skillId: file2Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceB', skillId: text1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceB', skillId: 'recFile2', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceB', skillId: 'recText1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: aliceId, competenceId: 'recCompetenceC', skillId: media1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceC', skillId: 'recMedia1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: aliceId, competenceId: 'recCompetenceD', skillId: algo1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recCompetenceD', skillId: algo2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceD', skillId: 'recAlgo1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceD', skillId: 'recAlgo2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: aliceId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'validated', createdAt: longTimeAgo },
-            { userId: aliceId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'validated', createdAt: longTimeAgo },
+            { userId: aliceId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
             // Bob
-            { userId: bobId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceA', skillId: url3Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceA', skillId: 'recUrl3', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: file2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'validated', createdAt: beforeBeforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'invalidated', createdAt: afterCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceB', skillId: text1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recFile2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'validated', createdAt: beforeBeforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'invalidated', createdAt: afterCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceB', skillId: 'recText1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: bobId, competenceId: 'recCompetenceC', skillId: media1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceC', skillId: 'recMedia1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: bobId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'invalidated', createdAt: longTimeAgo },
-            { userId: bobId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'invalidated', createdAt: longTimeAgo },
+            { userId: bobId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
             // Charlie
-            { userId: charlieId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceA', skillId: url3Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceA', skillId: 'recUrl3', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: charlieId, competenceId: 'recCompetenceB', skillId: file2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceB', skillId: text1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceB', skillId: 'recFile2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceB', skillId: 'recText1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: charlieId, competenceId: 'recCompetenceC', skillId: media1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: charlieId, competenceId: 'recCompetenceC', skillId: media2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceC', skillId: 'recMedia1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceC', skillId: 'recMedia2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: charlieId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'validated', createdAt: longTimeAgo },
-            { userId: charlieId, competenceId: 'recCompetenceF', skillId: computer1Id, status: 'invalidated', createdAt: afterCampaignParticipationShareDate },
+            { userId: charlieId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'validated', createdAt: longTimeAgo },
+            { userId: charlieId, competenceId: 'recCompetenceF', skillId: 'recComputer1', status: 'invalidated', createdAt: afterCampaignParticipationShareDate },
 
             // Dan
-            { userId: danId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: danId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: danId, competenceId: 'recCompetenceA', skillId: url3Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceA', skillId: 'recUrl3', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: danId, competenceId: 'recCompetenceB', skillId: file2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: danId, competenceId: 'recCompetenceB', skillId: file3Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: danId, competenceId: 'recCompetenceB', skillId: file5Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: danId, competenceId: 'recCompetenceB', skillId: text1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceB', skillId: 'recFile2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceB', skillId: 'recFile3', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceB', skillId: 'recFile5', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceB', skillId: 'recText1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
-            { userId: danId, competenceId: 'recCompetenceC', skillId: media1Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: danId, competenceId: 'recCompetenceC', skillId: 'recMedia1', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
 
             // Elo
-            { userId: eloId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: eloId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
           ], (knowledgeElement) => {
             databaseBuilder.factory.buildKnowledgeElement(knowledgeElement);
           });
 
-          await databaseBuilder.commit();
+          return databaseBuilder.commit();
         });
 
         it('should return a correct aggregated synthesis of participants results', async () => {
@@ -486,7 +441,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
           };
 
           // when
-          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 
           // then
           expect(result).to.be.an.instanceof(CampaignCollectiveResult);
@@ -498,7 +453,7 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
       context('when there are multiple participants with validated skills on old competences', () => {
 
-        beforeEach(async () => {
+        beforeEach (() => {
 
           const campaignParticipationShareDate = new Date('2019-03-01');
           const beforeCampaignParticipationShareDate = new Date('2019-02-01');
@@ -515,22 +470,22 @@ describe('Integration | Repository | Campaign collective result repository', () 
 
           _.each([
             // Alice
-            { userId: aliceId, competenceId: 'recOldCompetence', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: aliceId, competenceId: 'recOldCompetence', skillId: url2Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recOldCompetence', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: aliceId, competenceId: 'recOldCompetence', skillId: 'recUrl2', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
 
             // Bob
-            { userId: bobId, competenceId: 'recCompetenceA', skillId: url1Id, status: 'validated', createdAt: beforeCampaignParticipationShareDate },
-            { userId: bobId, competenceId: 'recCompetenceA', skillId: url2Id, status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceA', skillId: 'recUrl1', status: 'validated', createdAt: beforeCampaignParticipationShareDate },
+            { userId: bobId, competenceId: 'recCompetenceA', skillId: 'recUrl2', status: 'invalidated', createdAt: beforeCampaignParticipationShareDate },
           ], (knowledgeElement) => {
             databaseBuilder.factory.buildKnowledgeElement(knowledgeElement);
           });
 
-          await databaseBuilder.commit();
+          return databaseBuilder.commit();
         });
 
         it('should return a correct average validated skills for the competence A', async () => {
           // when
-          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, competences);
+          const result = await campaignCollectiveResultRepository.getCampaignCollectiveResult(campaignId, targetProfile);
 
           // then
           expect(result.campaignCompetenceCollectiveResults[0].averageValidatedSkills).to.equal(3 / 2);

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -82,39 +82,12 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
 
     it('should return target profile filled with objects with appropriate translation', async () => {
       // given
-      const skill1_1_1_1 = domainBuilder.buildTargetedSkill({
-        id: 'recArea1_Competence1_Tube1_Skill1',
-        name: 'skill1_1_1_1_name',
-        tubeId: 'recArea1_Competence1_Tube1',
-      });
-      const tube1_1_1 = domainBuilder.buildTargetedTube({
-        id: 'recArea1_Competence1_Tube1',
-        practicalTitle: 'tube1_1_1_practicalTitle',
-        competenceId: 'recArea1_Competence1',
-        skills: [skill1_1_1_1],
-      });
-      const competence1_1 = domainBuilder.buildTargetedCompetence({
-        id: 'recArea1_Competence1',
-        name: 'competence1_1_name',
-        index: 'competence1_1_index',
-        areaId: 'recArea1',
-        tubes: [tube1_1_1],
-      });
-      const area1 = domainBuilder.buildTargetedArea({
-        id: 'recArea1',
-        title: 'area1_Title',
-        competences: [competence1_1],
-      });
       const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
-      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence1_Tube1_Skill1' });
-      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({
         id: targetProfileDB.id,
         name: targetProfileDB.name,
-        skills: [skill1_1_1_1],
-        tubes: [tube1_1_1],
-        competences: [competence1_1],
-        areas: [area1],
       });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: expectedTargetProfile.skills[0].id });
       const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({
         targetProfile: expectedTargetProfile,
         locale: ENGLISH_SPOKEN,
@@ -133,6 +106,108 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
     it('should throw a NotFoundError when targetProfile does not exists', async () => {
       // when
       const error = await catchErr(targetProfileWithLearningContentRepository.get)({ id: 123 });
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  describe('#getByCampaignId', () => {
+
+    it('should return target profile with learning content', async () => {
+      // given
+      const skill1_1_1_2 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence1_Tube1_Skill2',
+        name: 'skill1_1_1_2_name',
+        tubeId: 'recArea1_Competence1_Tube1',
+      });
+      const skill1_2_1_1 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence2_Tube1_Skill1',
+        name: 'skill1_2_1_1_name',
+        tubeId: 'recArea1_Competence2_Tube1',
+      });
+      const tube1_1_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence1_Tube1',
+        practicalTitle: 'tube1_1_1_practicalTitle',
+        competenceId: 'recArea1_Competence1',
+        skills: [skill1_1_1_2],
+      });
+      const tube1_2_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence2_Tube1',
+        practicalTitle: 'tube1_2_1_practicalTitle',
+        competenceId: 'recArea1_Competence2',
+        skills: [skill1_2_1_1],
+      });
+      const competence1_1 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence1',
+        name: 'competence1_1_name',
+        index: 'competence1_1_index',
+        areaId: 'recArea1',
+        tubes: [tube1_1_1],
+      });
+      const competence1_2 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence2',
+        name: 'competence1_2_name',
+        index: 'competence1_2_index',
+        areaId: 'recArea1',
+        tubes: [tube1_2_1],
+      });
+      const area1 = domainBuilder.buildTargetedArea({
+        id: 'recArea1',
+        title: 'area1_Title',
+        competences: [competence1_1, competence1_2],
+      });
+      const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence1_Tube1_Skill2' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence2_Tube1_Skill1' });
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileDB.id }).id;
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        id: targetProfileDB.id,
+        name: targetProfileDB.name,
+        skills: [skill1_1_1_2, skill1_2_1_1],
+        tubes: [tube1_1_1, tube1_2_1],
+        competences: [competence1_1, competence1_2],
+        areas: [area1],
+      });
+      const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({ targetProfile: expectedTargetProfile });
+      airtableBuilder.mockLists(airtableObjects);
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
+
+      // then
+      expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should return target profile filled with objects with appropriate translation', async () => {
+      // given
+      const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({
+        id: targetProfileDB.id,
+        name: targetProfileDB.name,
+      });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: expectedTargetProfile.skills[0].id });
+      const campaignId = databaseBuilder.factory.buildCampaign({ targetProfileId: targetProfileDB.id }).id;
+      const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({
+        targetProfile: expectedTargetProfile,
+        locale: ENGLISH_SPOKEN,
+      });
+      airtableBuilder.mockLists(airtableObjects);
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale: ENGLISH_SPOKEN });
+
+      // then
+      expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should throw a NotFoundError when targetProfile cannot be found', async () => {
+      // when
+      const error = await catchErr(targetProfileWithLearningContentRepository.getByCampaignId)({ campaignId: 123 });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
@@ -144,6 +144,7 @@ buildLearningContent.fromTargetProfileWithLearningContent = function buildLearni
       id: area.id,
       titreFr: locale === FRENCH_FRANCE ? area.title : null,
       titreEn: locale === ENGLISH_SPOKEN ? area.title : null,
+      couleur: area.color,
       competenceIds: competences.map((competence) => competence.id),
       nomCompetences: competences.map((competence) => competence.name),
     });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-competence-collective-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-competence-collective-result.js
@@ -1,22 +1,18 @@
 const CampaignCompetenceCollectiveResult = require('../../../../lib/domain/models/CampaignCompetenceCollectiveResult');
+const buildTargetedCompetence = require('./build-targeted-competence');
+const buildTargetedArea = require('./build-targeted-area');
 
 module.exports = function buildCampaignCompetenceCollectiveResult(
   {
     campaignId,
-    competenceId,
-    competenceName,
-    competenceIndex,
-    areaColor,
-    targetedSkillsCount,
+    targetedCompetence = buildTargetedCompetence(),
+    targetedArea = buildTargetedArea(),
     averageValidatedSkills,
   } = {}) {
   return new CampaignCompetenceCollectiveResult({
     campaignId,
-    competenceId,
-    competenceName,
-    competenceIndex,
-    areaColor,
-    targetedSkillsCount,
+    targetedCompetence,
+    targetedArea,
     averageValidatedSkills,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-targeted-area.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-area.js
@@ -4,11 +4,13 @@ const buildTargetedCompetence = require('./build-targeted-competence');
 const buildTargetedArea = function buildTargetedArea({
   id = 'someAreaId',
   title = 'someTitle',
+  color = 'someColor',
   competences = [buildTargetedCompetence()],
 } = {}) {
   return new TargetedArea({
     id,
     title,
+    color,
     competences,
   });
 };

--- a/api/tests/unit/domain/models/CampaignCompetenceCollectiveResult_test.js
+++ b/api/tests/unit/domain/models/CampaignCompetenceCollectiveResult_test.js
@@ -1,5 +1,5 @@
 const CampaignCompetenceCollectiveResult = require('../../../../lib/domain/models/CampaignCompetenceCollectiveResult');
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | CampaignCompetenceCollectiveResult', () => {
 
@@ -8,8 +8,9 @@ describe('Unit | Domain | Models | CampaignCompetenceCollectiveResult', () => {
     it('should return a unique identifier that is the concatenation of "campaignId" and "competenceId"', () => {
       // given
       const campaignId = 123;
-      const competenceId = 'recCompetence';
-      const competenceResult = new CampaignCompetenceCollectiveResult({ campaignId, competenceId });
+      const targetedCompetence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence' });
+      const targetedArea = domainBuilder.buildTargetedArea();
+      const competenceResult = new CampaignCompetenceCollectiveResult({ campaignId, targetedCompetence, targetedArea });
 
       // when
       const competenceResultId = competenceResult.id;
@@ -23,8 +24,9 @@ describe('Unit | Domain | Models | CampaignCompetenceCollectiveResult', () => {
 
     it('should return the area index covered by the competence', () => {
       // given
-      const competenceIndex = '1.2';
-      const competenceResult = new CampaignCompetenceCollectiveResult({ competenceIndex });
+      const targetedCompetence = domainBuilder.buildTargetedCompetence({ index: '1.2' });
+      const targetedArea = domainBuilder.buildTargetedArea();
+      const competenceResult = new CampaignCompetenceCollectiveResult({ targetedCompetence, targetedArea });
 
       // when
       const areaCode = competenceResult.areaCode;

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
   describe('get#skillIds', () => {
 
-    it('should return an array with targeted skill names', () => {
+    it('should return an array with targeted skill ids', () => {
       // given
       const skill1 = domainBuilder.buildTargetedSkill({ id: 'acquis1' });
       const skill2 = domainBuilder.buildTargetedSkill({ id: 'acquis2' });
@@ -86,7 +86,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     beforeEach(() => {
       const skillNotInCompetence = domainBuilder.buildTargetedSkill({ id: 'otherSkillId', tubeId: 'tube1' });
       const skillInCompetence = domainBuilder.buildTargetedSkill({ id: skillId, tubeId: 'tube2' });
-      const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skillNotInCompetence], competence: 'otherCompId' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skillNotInCompetence], competenceId: 'otherCompId' });
       const tube2 = domainBuilder.buildTargetedTube({ id: 'tube2', skills: [skillInCompetence], competenceId: expectedCompetenceId });
       targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skillNotInCompetence, skillInCompetence], tubes: [tube1, tube2] });
     });
@@ -105,6 +105,37 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(competenceId).to.be.null;
+    });
+  });
+
+  describe('getAreaOfCompetence()', () => {
+
+    const competenceId = 'competenceId';
+    let expectedArea;
+    let targetProfile;
+
+    beforeEach(() => {
+      const competenceNotInArea = domainBuilder.buildTargetedCompetence({ id: 'otherCompetenceId', areaId: 'area1' });
+      const competenceInArea = domainBuilder.buildTargetedCompetence({ id: competenceId, areaId: 'area2' });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'area1', competences: [competenceNotInArea] });
+      expectedArea = domainBuilder.buildTargetedArea({ id: 'area2', competences: [competenceInArea] });
+      targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [competenceNotInArea, competenceInArea], areas: [expectedArea, area1] });
+    });
+
+    it('should return area of competence', () => {
+      // when
+      const area = targetProfile.getAreaOfCompetence(competenceId);
+
+      // then
+      expect(area).to.deep.equal(expectedArea);
+    });
+
+    it('should return null when area of competence is not found', () => {
+      // when
+      const area = targetProfile.getAreaOfCompetence('recPépite');
+
+      // then
+      expect(area).to.be.null;
     });
   });
 

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -18,6 +18,22 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     });
   });
 
+  describe('get#skillIds', () => {
+
+    it('should return an array with targeted skill names', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'acquis1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'acquis2' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [skill1, skill2] });
+
+      // when
+      const targetedSkillIds = targetProfile.skillIds;
+
+      // then
+      expect(targetedSkillIds).to.exactlyContain(['acquis1', 'acquis2']);
+    });
+  });
+
   describe('get#competenceIds', () => {
 
     it('should return an array with targeted competence ids order by id', () => {

--- a/api/tests/unit/domain/models/TargetedArea_test.js
+++ b/api/tests/unit/domain/models/TargetedArea_test.js
@@ -1,0 +1,30 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Target-Profile/TargetedArea', () => {
+
+  describe('hasCompetence', () => {
+
+    it('should return true when the competence is in area', () => {
+      // given
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'competenceId', areaId: 'areaId' });
+      const area = domainBuilder.buildTargetedArea({ id: 'areaId', competences: [competence] });
+
+      // when
+      const isIncluded = area.hasCompetence(competence.id);
+
+      // then
+      expect(isIncluded).to.be.true;
+    });
+
+    it('should return false when the skill is not in tube', () => {
+      // given
+      const area = domainBuilder.buildTargetedArea({ id: 'areaId', competences: [] });
+
+      // when
+      const isIncluded = area.hasCompetence('someCompetenceId');
+
+      // then
+      expect(isIncluded).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/models/TargetedTube_test.js
+++ b/api/tests/unit/domain/models/TargetedTube_test.js
@@ -18,11 +18,10 @@ describe('Unit | Domain | Models | Target-Profile/TargetedTube', () => {
 
     it('should return false when the skill is not in tube', () => {
       // given
-      const skill = domainBuilder.buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
       const tube = domainBuilder.buildTargetedTube({ id: 'tubeId', skills: [] });
 
       // when
-      const isIncluded = tube.hasSkill(skill.id);
+      const isIncluded = tube.hasSkill('someSkillId');
 
       // then
       expect(isIncluded).to.be.false;

--- a/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
@@ -7,26 +7,26 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
   const campaignId = 'someCampaignId';
   let campaignRepository;
   let campaignCollectiveResultRepository;
-  let competenceRepository;
-  const expectedCompetences = [];
+  let targetProfileWithLearningContentRepository;
+  const targetProfileWithLearningContent = Symbol('targetProfileWithLearningContent');
 
   beforeEach(() => {
     campaignCollectiveResultRepository = { getCampaignCollectiveResult: sinon.stub() };
     campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
-    competenceRepository = { list: sinon.stub() };
+    targetProfileWithLearningContentRepository = { getByCampaignId: sinon.stub() };
   });
 
   context('User has access to this result', () => {
 
     beforeEach(() => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      competenceRepository.list.resolves(expectedCompetences);
+      targetProfileWithLearningContentRepository.getByCampaignId.resolves(targetProfileWithLearningContent);
     });
 
     it('should resolve a CampaignCollectiveResult', async () => {
       // given
       const expectedCampaignCollectiveResult = domainBuilder.buildCampaignCollectiveResult();
-      campaignCollectiveResultRepository.getCampaignCollectiveResult.withArgs(campaignId, expectedCompetences).resolves(expectedCampaignCollectiveResult);
+      campaignCollectiveResultRepository.getCampaignCollectiveResult.withArgs(campaignId, targetProfileWithLearningContent).resolves(expectedCampaignCollectiveResult);
 
       // when
       const actualCampaignCollectiveResult = await computeCampaignCollectiveResult({
@@ -34,11 +34,11 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
         campaignId,
         campaignRepository,
         campaignCollectiveResultRepository,
-        competenceRepository,
+        targetProfileWithLearningContentRepository,
       });
 
       // then
-      expect(competenceRepository.list).to.have.been.calledOnce;
+      expect(targetProfileWithLearningContentRepository.getByCampaignId).to.have.been.calledOnce;
       expect(actualCampaignCollectiveResult).to.equal(expectedCampaignCollectiveResult);
     });
   });
@@ -55,7 +55,7 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
         campaignId,
         campaignRepository,
         campaignCollectiveResultRepository,
-        competenceRepository,
+        targetProfileWithLearningContentRepository,
       });
 
       // then

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-collective-result-serializer_test.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-collective-result-serializer');
 
@@ -9,26 +10,30 @@ describe('Unit | Serializer | JSONAPI | campaign-collective-results-serializer',
       // given
       const campaignId = 123;
 
+      const skillsCompetence1 = _.times(3, domainBuilder.buildTargetedSkill());
+      const targetedTube1 = domainBuilder.buildTargetedTube({ skills: skillsCompetence1 });
+      const targetedCompetence1 = domainBuilder.buildTargetedCompetence({ id: 'rec1', index: '1.2', name: 'Cuisson des legumes d’automne', areaId: 'area1', tubes: [targetedTube1] });
+      const targetedArea1 = domainBuilder.buildTargetedArea({ id: 'area1', color: 'jaffa', competences: [targetedCompetence1] });
+
+      const skillsCompetence2 = _.times(4, domainBuilder.buildTargetedSkill());
+      const targetedTube2 = domainBuilder.buildTargetedTube({ skills: skillsCompetence2 });
+      const targetedCompetence2 = domainBuilder.buildTargetedCompetence({ id: 'rec2', index: '3.4', name: 'Tourner un champignon', areaId: 'area2', tubes: [targetedTube2] });
+      const targetedArea2 = domainBuilder.buildTargetedArea({ id: 'area2', color: 'cerulean', competences: [targetedCompetence2] });
+
       const campaignCollectiveResult = domainBuilder.buildCampaignCollectiveResult({
         id: campaignId,
         campaignCompetenceCollectiveResults: [
           domainBuilder.buildCampaignCompetenceCollectiveResult({
             averageValidatedSkills: 2,
             campaignId: campaignId,
-            competenceId: 'rec1',
-            competenceIndex: '1.2',
-            competenceName: 'Cuisson des legumes d’automne',
-            areaColor: 'jaffa',
-            targetedSkillsCount: 3,
+            targetedCompetence: targetedCompetence1,
+            targetedArea: targetedArea1,
           }),
           domainBuilder.buildCampaignCompetenceCollectiveResult({
             averageValidatedSkills: 1,
             campaignId: campaignId,
-            competenceId: 'rec2',
-            competenceIndex: '3.4',
-            competenceName: 'Tourner un champignon',
-            areaColor: 'cerulean',
-            targetedSkillsCount: 4,
+            targetedCompetence: targetedCompetence2,
+            targetedArea: targetedArea2,
           }),
         ],
       });


### PR DESCRIPTION
## :unicorn: Problème
En préparation à l'amélioration des perfs sur le calcul des résultats collectifs, on se propose de commencer par utiliser le nouveau targetProfile - le targetProfileWithLearningContent - dans le usecase existant.

## :robot: Solution
Faire le remplacement nécessaire !

## :rainbow: Remarques
La majorité du code ajoutée, dans toutes les PRs comprenant le remplacement entre l'ancien targetProfile et le nouveau, comporte beaucoup de diffs au niveau des tests. En effet, on alimente au fur et à mesure le modèle avec des méthodes pratiques (et donc les tests qui vont avec). Sinon, dans les usecases et les répo, le code est clairement allégé !

## :100: Pour tester
Non rég sur l'affichage de résultats collectifs. Le plus simple étant d'ouvrir les résultats collectifs d'une même campagne sur cette RA et une autre RA et de constater la non rég
