### PR TITLE
[INFRA] Ne pas autoriser les appels à la base de donnée pour les tests unitaires dans la cible `test` de l'API

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -118,7 +118,7 @@
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
-    "test:api": "npm run test:api:path -- tests",
+    "test:api": "npm run test:api:unit && for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir ; done ;",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
     "test:api:unit": "TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",


### PR DESCRIPTION
## :unicorn: Problème

On a régulièrement (1 fois par mois ?) des tests unitaires de l'API qui font des appels à la base de donnée car un stub / mock est oublié qui arrivent en dev.

La cible `test:api:unit` n'autorise déjà pas ces appels base de donnée, mais la cible `test:api` qui est appelée par la CI lance mocha sur tout le répertoire `tests` et ne passe pas par la cible `test:api:unit`.

## :robot: Solution

Changer la cible `test:api` de l'API pour qu'elle ne fasse plus un appel général à mocha sur tout le répertoire `tests`, mais qu'elle :
- lance la cible `test:api:unit` <-- échouera en cas de nouveau test unitaire qui appelle la base de donnée
- lance la cible `test:api:path` sur tout les répertoires autres que `tests/unit`

## :rainbow: Remarques

Est-ce que la boucle `for` sur un `find -type d -not -path` (ou pipé dans un `grep -v`) c'est trop à maintenir ? Je me rends pas bien compte, moi je suis ok.

Autres bénéfices :
- lancer `npm t` donnera un feedback plus rapide car il fait tourner les ~2800 tests unitaires en premier en quelques secondes
- lancer `npm t` donnera des stats sur les tests, mocha faisant un décompte par répertoire, du style :

```
> NODE_ENV=test mocha --exit --recursive --reporter=dot "tests/unit"
․․․
  2843 passing (4s)

> NODE_ENV=test mocha --exit --recursive --reporter=dot "tests/acceptance"
․․․
  532 passing (59s)

> NODE_ENV=test mocha --exit --recursive --reporter=dot "tests/docs"
․․․
  20 passing (15ms)

> NODE_ENV=test mocha --exit --recursive --reporter=dot "tests/integration"
․․․
  1108 passing (24s)

> NODE_ENV=test mocha --exit --recursive --reporter=dot "tests/tooling"
․․․
  6 passing (58ms)
```

## :100: Pour tester

Faire un appel à un répository non stubé ni mocké dans un test unitaire et lancer `npm t`, ça doit échouer rapidement.