### PR TITLE
[CLEANUP] Mise à jour de la couleur verte dans Pix App et Pix Orga (PIX-1335).

### DIFF
--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -11,7 +11,7 @@ $dark-blue-pro: #1A38A0;
 $green-certif: #1A8C89;
 $dark-orga: #0095C0;
 $orga: #00DDFF;
-$green: #20BF55;
+$green: #038A25;
 $green-hover: darken($green, 4%);
 $red: #D63F00;
 $red-hover: darken($red, 4%);

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -12,8 +12,8 @@ $dark-blue-pro: #1A38A0;
 $dark-green-certif: #1A8C89;
 $dark-green-certif-light: adjust-color($dark-green-certif, $alpha: -0.9);
 $dark-orga: #0095C0;
-$green: #20BF55;
-$green-hover: #058931;
+$green: #038A25;
+$green-hover: darken($green, 4%);
 $orga: #00DDFF;
 $purple: #8A49FF;
 // gradients


### PR DESCRIPTION
## :unicorn: Problème
- Les boutons verts actuels n'ont pas le bon contraste

## :robot: Solution
- Utiliser la nouvelle couleure de bouton disponible dans ZeroHeight

## :100: Pour tester
- Voir les boutons verts de la PR
