### PR TITLE
[FEATURE] Permettre de réinviter un membre d'une organisation désactivé (PIX-813).

### DIFF
--- a/api/db/migrations/20200929142112_update-constraint-memberships_userid_organizationid_unique.js
+++ b/api/db/migrations/20200929142112_update-constraint-memberships_userid_organizationid_unique.js
@@ -1,0 +1,19 @@
+const TABLE_NAME = 'memberships';
+const USERID_COLUMN = 'userId';
+const ORGANIZATIONID_COLUMN = 'organizationId';
+const DISABLEDAT_COLUMN = 'disabledAt';
+const NEW_CONSTRAINT_NAME = 'memberships_userid_organizationid_disabledAt_unique';
+
+exports.up = async function(knex) {
+  await knex.schema.table(TABLE_NAME, function(table) {
+    table.dropUnique([USERID_COLUMN, ORGANIZATIONID_COLUMN]);
+  });
+  return knex.raw(`CREATE UNIQUE INDEX ${NEW_CONSTRAINT_NAME} ON ${TABLE_NAME} ("${USERID_COLUMN}", "${ORGANIZATIONID_COLUMN}") WHERE "${DISABLEDAT_COLUMN}" IS NULL;`);
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropUnique(null, NEW_CONSTRAINT_NAME);
+    table.unique([USERID_COLUMN, ORGANIZATIONID_COLUMN]);
+  });
+};


### PR DESCRIPTION
## :unicorn: Problème
Depuis la mise en place de la suppression logique des memberships (grâce à la colonne `disabledAt`) il n'est plus possible de réinviter un membership désactivé. En effet, il existe une contrainte d'unicité sur les colonnes `userId` et `organizationId`.

## :robot: Solution
Modifier la contrainte d'unicité afin de prendre en compte la date de désactivation.

## :rainbow: Remarques
La nouvelle contrainte s'assure qu'il n'y aura, à un instant T, qu'un seul utilisateur non désactivé lié à une organisation.

## :100: Pour tester
- Aller dans Pix Admin.
- Désactiver un membre d'une organisation.
- Le réinviter et vérifier qu'il est bien rajouté à l'organisation. 
