### PR TITLE
[FEATURE] Afficher les informations de crédit d'une organisation (PIX-1287)

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -11,6 +11,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     type: 'SUP',
     name: 'Tyrion SUP',
     isManagingStudents: true,
+    credit: 10000,
   });
 
   databaseBuilder.factory.buildMembership({
@@ -56,6 +57,7 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     canCollectProfiles: true,
     email: 'sco.generic.account@example.net',
     externalId: '1237457A',
+    credit: 0,
   });
 
   // Memberships

--- a/api/lib/infrastructure/repositories/prescriber-repository.js
+++ b/api/lib/infrastructure/repositories/prescriber-repository.js
@@ -22,13 +22,14 @@ function _toPrescriberDomain(bookshelfUser) {
 
 function _toMembershipsDomain(membershipsBookshelf) {
   return membershipsBookshelf.map((membershipBookshelf) => {
-    const { id, code, name, type, isManagingStudents, canCollectProfiles, externalId } = membershipBookshelf.related('organization').attributes;
+    const { id, code, credit, name, type, isManagingStudents, canCollectProfiles, externalId } = membershipBookshelf.related('organization').attributes;
     return new Membership({
       id: membershipBookshelf.get('id'),
       organizationRole: membershipBookshelf.get('organizationRole'),
       organization: new Organization({
         id,
         code,
+        credit,
         name,
         type,
         isManagingStudents,

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -25,7 +25,7 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['code', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -47,6 +47,7 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
           type: 'organizations',
           attributes: {
             'can-collect-profiles': organization.canCollectProfiles,
+            'credit': organization.credit,
             'external-id': organization.externalId,
             'is-managing-students': organization.isManagingStudents,
             'name': organization.name,

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -109,6 +109,7 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
         expect(associatedOrganization).to.be.an.instanceof(Organization);
         expect(associatedOrganization.id).to.equal(organization.id);
         expect(associatedOrganization.code).to.equal(organization.code);
+        expect(associatedOrganization.credit).to.equal(organization.credit);
         expect(associatedOrganization.name).to.equal(organization.name);
         expect(associatedOrganization.type).to.equal(organization.type);
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -41,6 +41,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
             'is-managing-students': organization.isManagingStudents,
             'name': organization.name,
             'type': organization.type,
+            'credit': organization.credit,
           },
           relationships: {
             memberships: {

--- a/orga/app/components/organization-credit-info.hbs
+++ b/orga/app/components/organization-credit-info.hbs
@@ -1,0 +1,12 @@
+{{#if this.canShowCredit}}
+<div class="organization-credit-info">
+	<span class="organization-credit-info__label">{{this.credit}}</span>
+	<PixTooltip
+		@text={{this.tooltipContent}}
+		@position='bottom'
+		@inline={{false}}
+		@class="organization-credit-info__tooltip">
+			<FaIcon @icon="info-circle" class="info-icon"/>
+	</PixTooltip>
+</div>
+{{/if}}

--- a/orga/app/components/organization-credit-info.js
+++ b/orga/app/components/organization-credit-info.js
@@ -1,0 +1,20 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/string';
+
+export default class OrganizationCreditInfoComponent extends Component {
+    @service currentUser
+
+    get tooltipContent() {
+      return htmlSafe('Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>');
+    }
+
+    get credit() {
+      const creditText = this.currentUser.organization.credit > 1 ? ' crédits' : ' crédit';
+      return this.currentUser.organization.credit.toLocaleString() + creditText;
+    }
+
+    get canShowCredit() {
+      return this.currentUser.isAdminInOrganization && this.currentUser.organization.credit > 0;
+    }
+}

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -7,6 +7,7 @@ export default class Organization extends Model {
   @attr('string') name;
   @attr('string') type;
   @attr('string') externalId;
+  @attr('number') credit;
   @attr('boolean') isManagingStudents;
   @attr('boolean') canCollectProfiles;
 

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -38,6 +38,7 @@
 @import "components/user-logged-menu";
 @import "components/manage-authentication-method-modal";
 @import "components/modal";
+@import "components/organization-credit-info";
 @import "pages/login";
 @import "pages/join";
 @import "pages/join-request";

--- a/orga/app/styles/components/organization-credit-info.scss
+++ b/orga/app/styles/components/organization-credit-info.scss
@@ -1,0 +1,50 @@
+.organization-credit-info {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+
+	span {
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: $grey-90;
+	}
+
+	.info-icon {
+		color: $grey-40;
+		margin: 0 8px;
+	}
+
+	&__tooltip .pix-tooltip__content {
+		width: 382px;
+		padding: 16px;
+		font-size: 0.875rem;
+		background-color: white;
+		border: 1px solid $grey-40;
+		border-radius: 4px;
+		box-shadow: -2px 4px 4px 2px rgba($black, 0.1);
+	}
+
+	&__tooltip .pix-tooltip__content--bottom::before {
+		top: -5px;
+		left: calc(95% - 4px);
+		border-color: $grey-40 transparent transparent $grey-40;
+		transform: rotate(45deg);
+	}
+
+	&__tooltip .pix-tooltip__content::before {
+		content: "";
+		position: absolute;
+		border-width: 1px;
+		border-style: solid;
+		height: 8px;
+		width: 8px;
+		background-color: white;
+	}
+
+	&__tooltip .pix-tooltip__content--bottom {
+		top: calc(100% + 20px);
+		left: 50%;
+		transform: translate(-95%);
+		padding: 23px 16px;
+	}
+}

--- a/orga/app/styles/pages/authenticated.scss
+++ b/orga/app/styles/pages/authenticated.scss
@@ -70,4 +70,8 @@
     padding: 0 30px;
     border-left: 1px solid $grey-20;
   }
+
+  &__organization-credit-info {
+    padding: 0 30px;
+  }
 }

--- a/orga/app/templates/authenticated.hbs
+++ b/orga/app/templates/authenticated.hbs
@@ -12,6 +12,7 @@
   <div class="app__main-content main-content">
 
     <div class="main-content__topbar topbar">
+      <div class="topbar__organization-credit-info"><OrganizationCreditInfo /></div>
       <div class="topbar__user-logged-menu"><UserLoggedMenu /></div>
     </div>
 

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -14,6 +14,7 @@ module.exports = function() {
       'exclamation-triangle',
       'external-link-alt',
       'hourglass-half',
+      'info-circle',
       'link',
       'power-off',
       'search',

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -133,6 +133,24 @@ export function createUserWithMultipleMemberships() {
   return user;
 }
 
+export function createPrescriberForOrganization(userAttributes = {}, organizationAttributes = {}, organizationRole) {
+  const user = server.create('user', { ...userAttributes, 'pixOrgaTermsOfServiceAccepted': true });
+
+  const organization = server.create('organization', organizationAttributes);
+
+  const membership = server.create('membership', {
+    organizationId: organization.id,
+    userId: user.id,
+    organizationRole,
+  });
+  
+  user.memberships = [membership];
+  user.userOrgaSettings = server.create('user-orga-setting', { organization, user });
+
+  createPrescriberByUser(user);
+  return user;
+}
+
 export function createAdminMembershipWithNbMembers(countMembers) {
 
   const organization = server.create('organization', {

--- a/orga/tests/integration/components/organization-credit-info-test.js
+++ b/orga/tests/integration/components/organization-credit-info-test.js
@@ -1,0 +1,104 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+class CurrentUserStub extends Service {
+  isAdminInOrganization = true
+  organization = {
+    credit: 10000,
+  };
+}
+
+module('Integration | Component | organization-credit-info', function(hooks) {
+  setupRenderingTest(hooks);
+  let currentUserStub;
+
+  hooks.beforeEach(function() {
+    this.owner.register('service:current-user', CurrentUserStub);
+    currentUserStub = this.owner.lookup('service:current-user', CurrentUserStub);
+  });
+
+  test('should display organization credit info', async function(assert) {
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+    const displayedCreditInfo = document.querySelector('.organization-credit-info').textContent;
+  
+    // then
+    assert.contains(displayedCreditInfo.trim());
+  });
+
+  test('should display credit number label', async function(assert) {
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+    const displayedCredit = document.querySelector('.organization-credit-info__label').textContent;
+    const expectedCredit = currentUserStub.organization.credit.toLocaleString() + ' crédits';
+
+    // then
+    assert.contains(expectedCredit);
+    assert.equal(displayedCredit, expectedCredit);
+  });
+  
+  test('should display tooltip info', async function(assert) {
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+    const displayedContentTooltip = document.querySelector('.pix-tooltip__content').textContent;
+
+    // then
+    assert.contains(displayedContentTooltip.trim());
+  });
+
+  test('should change the credit value when changing organization that has credits ', async function(assert) {
+    // given
+    currentUserStub.organization.credit = 500;
+
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+    const displayedCredit = document.querySelector('.organization-credit-info__label').textContent;
+    const expectedCredit = currentUserStub.organization.credit.toLocaleString() + ' crédits';
+
+    // then
+    assert.contains(expectedCredit);
+    assert.equal(displayedCredit, expectedCredit);
+  });
+
+  test('should display "credit" when credit is equal 1', async function(assert) {
+    // given
+    currentUserStub.organization.credit = 1;
+
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+    const displayedCredit = document.querySelector('.organization-credit-info__label').textContent;
+    const expectedCredit = currentUserStub.organization.credit.toLocaleString() + ' crédit';
+
+    // then
+    assert.contains(expectedCredit);
+    assert.equal(displayedCredit, expectedCredit);
+  });
+
+  test('should be hidden when credit is less than 1', async function(assert) {
+    // given
+    currentUserStub.organization.credit = 0;
+
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+
+    // then
+    assert.notContains('crédit');
+  });
+
+  test('should hiden when the prescriber is not ADMIN', async function(assert) {
+    // given
+    currentUserStub.isAdminInOrganization = false;
+
+    // when
+    await render(hbs`<OrganizationCreditInfo />`);
+
+    // then
+    assert.notContains('crédit');
+    assert.notContains('crédits');
+    assert.equal(currentUserStub.isAdminInOrganization, false);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible actuellement de savoir de combien de crédits le client bénéficie.
Ce qui entraine des soucis concernant l'ugap car les clients n'ont pas de "preuve" pour savoir combien de crédits sont déployés sur pix orga.

## :robot: Solution
Afficher dans la top bar à gauche du sélecteur d'organisation les crédits disponible pour une organisation, cet information doit être disponible uniquement si:  

- le prescripteur est ADMIN d'une organisation
- le nombre de crédit est strictement supérieur à 0

<img width="410" alt="Capture d’écran 2020-09-29 à 16 28 56" src="https://user-images.githubusercontent.com/13931126/94572053-e1092e00-0270-11eb-9be3-d9bb7023f596.png">

de plus lors du survole de l'information, un tooltip affiche un texte explicatif. 
<img width="488" alt="Capture d’écran 2020-09-29 à 16 34 17" src="https://user-images.githubusercontent.com/13931126/94572723-a0f67b00-0271-11eb-8039-a8817c1195b7.png">

## :rainbow: Remarques
Concernant la tooltip, on utilise le composant Pix-UI PixTooltip mais le style n'étant pas approprié au style de app Orga, il a donc été décidé de surcharger la classe scss de celle-ci.

voir : **organization-credit-info.scss**

de plus sa conception nous empêche d'étendre sa transition (pas impossible, mais tricky) sur une plus longue durée afin de copier-coller le mail contenu dans le tooltip.

A voir si il faut améliorer le composant Pix-UI pour offrir cette possibilité ? 🤔 

## :100: Pour tester
Se rendre sur une organisation qui: 

- dispose de crédit et le prescripteur est ADMIN => crédit visible
- ne dispose pas de crédit et le prescripteur est ADMIN => crédit non visible
- qui dispose de crédit et le prescripteur est MEMBER => crédit non visible
