### PR TITLE
[CLEANUP] Corriger le contraste de la page profil

### DIFF
--- a/mon-pix/app/styles/components/_competence-card-desktop.scss
+++ b/mon-pix/app/styles/components/_competence-card-desktop.scss
@@ -4,56 +4,71 @@
 
   .competence-card {
     flex-direction: column;
-    width: 210px;
+    width: 212px;
     height: 310px;
   }
 
   .competence-card__title {
-    height: 110px;
+    height: 125px;
     overflow: hidden;
     text-align: center;
     padding: 10px 0;
   }
 
-  .competence-card__color {
+  .competence-card__wrapper {
 
     &::after {
       right: -200px;
       left: -200px;
-      top: -350px;
+      top: -330px;
       bottom: 0;
       width: auto;
     }
 
+    &--jaffa,
     &--jaffa::after {
       background: radial-gradient($information-dark 25%, $information-light 100%);
+      background-color: $information-dark;
     }
 
+    &--emerald,
     &--emerald::after {
       background: radial-gradient($content-dark 25%, $content-light 100%);
+      background-color: $content-dark;
     }
 
+    &--cerulean,
     &--cerulean::after {
-      background: radial-gradient($blue 25%, $communication-light 100%);
+      background: radial-gradient($communication-dark 25%, $communication-light 100%);
+      background-color: $communication-dark;
     }
 
+    &--wild-strawberry,
     &--wild-strawberry::after {
       background: radial-gradient($security-dark 25%, $security-light 100%);
+      background-color: $security-dark;
     }
 
+    &--butterfly-bush,
     &--butterfly-bush::after {
       background: radial-gradient($environment-dark 25%, $environment-light 100%);
+      background-color: $environment-dark;
     }
   }
 
   .competence-card__area-name {
-    font-size: 0.563rem;
+    z-index: 2;
+    font-size: 0.7rem;
+    font-weight: $font-medium;
+    margin: 0;
   }
 
   .competence-card__competence-name {
-    font-size: 1rem;
-    margin: 8px 0;
-    padding: 0 4px;
+    z-index: 2;
+    font-size: 1.17rem;
+    font-weight: $font-bold;
+    margin: 0 3px;
+    padding-top: 10px;
   }
 
   .competence-card__body {

--- a/mon-pix/app/styles/components/_competence-card.scss
+++ b/mon-pix/app/styles/components/_competence-card.scss
@@ -6,7 +6,6 @@
   box-shadow: $box-shadow-competence-cards;
   border: 1px solid $grey-20;
   border-radius: 11px;
-  background-color: $white;
   transition: all 0.1s linear;
   -webkit-tap-highlight-color: rgba($grey-60, 0.3);
   pointer-events: none;
@@ -33,7 +32,7 @@
   width: 100%;
 }
 
-.competence-card__color {
+.competence-card__wrapper {
 
   &::after {
     width: 110%;
@@ -72,6 +71,7 @@
   letter-spacing: 0.031rem;
   opacity: 0.8;
   text-transform: uppercase;
+  font-weight: $font-bold;
   position: relative;
   margin-bottom: 8px;
 }
@@ -94,7 +94,7 @@
   height: 80px;
 
   &--white-background {
-    background-color: $white;
+    background-color: white;
     background-clip: padding-box;
     border-radius: 50%;
     padding: 5px;

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -1,9 +1,10 @@
 <article class="competence-card {{if @interactive "competence-card--interactive"}}">
   <LinkTo @route="competences.details" @model={{@scorecard.competenceId}}>
     <div class="competence-card__title">
-      <span class="competence-card__color competence-card__color--{{@scorecard.area.color}}"></span>
-      <span class="competence-card__area-name">{{@scorecard.area.title}}</span>
-      <span class="competence-card__competence-name">{{@scorecard.name}}</span>
+      <div class="competence-card__wrapper competence-card__wrapper--{{@scorecard.area.color}}">
+        <div class="competence-card__area-name">{{@scorecard.area.title}}</div>
+        <div class="competence-card__competence-name">{{@scorecard.name}}</div>
+      </div>
     </div>
 
     <div class="competence-card__body">

--- a/mon-pix/app/templates/components/competence-card-mobile.hbs
+++ b/mon-pix/app/templates/components/competence-card-mobile.hbs
@@ -1,6 +1,6 @@
 <article class="competence-card {{if @interactive "competence-card--interactive"}}">
   <LinkTo @route="competences.details" @model={{scorecard.competenceId}} class="competence-card__link">
-    <span class="competence-card__color competence-card__color--{{scorecard.area.color}}"></span>
+    <span class="competence-card__wrapper competence-card__wrapper--{{scorecard.area.color}}"></span>
     <div class="competence-card__title">
       <span class="competence-card__area-name">{{scorecard.area.title}}</span>
       <span class="competence-card__competence-name">{{scorecard.name}}</span>

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -41,8 +41,8 @@ describe('Integration | Component | competence-card-default', function() {
       await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
 
       // then
-      expect(find('.competence-card__color').getAttribute('class'))
-        .to.contains('competence-card__color--jaffa');
+      expect(find('.competence-card__wrapper').getAttribute('class'))
+        .to.contains('competence-card__wrapper--jaffa');
     });
 
     it('should display the area name', async function() {

--- a/mon-pix/tests/integration/components/competence-card-mobile-test.js
+++ b/mon-pix/tests/integration/components/competence-card-mobile-test.js
@@ -40,8 +40,8 @@ describe('Integration | Component | competence-card-mobile', function() {
       await render(hbs`{{competence-card-mobile scorecard=scorecard}}`);
 
       // then
-      expect(find('.competence-card__color').getAttribute('class'))
-        .to.contains('competence-card__color--jaffa');
+      expect(find('.competence-card__wrapper').getAttribute('class'))
+        .to.contains('competence-card__wrapper--jaffa');
     });
 
     it('should display the area name', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Il y a des problèmes de contraste sur la page de profil.
Hors, la majorité vienne du fait que les outils de test (comme wave) ne voit pas le fond dégradé sous les noms des compétences.

## :robot: Solution
- Ajouter une background color
- Grossir le texte

## :rainbow: Remarques
- Cette PR est une proposition de solution, à voir avec les UX/UI

## :100: Pour tester
Se connecter à la review app, aller sur le profil et lancer Wave.
Objectifs : 0 erreurs de contraste