### PR TITLE
[FEATURE] Ajout du bouton de téléchargement du PV de session dans le header (PIX-985)

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -105,7 +105,7 @@
               Enregistrer
           </button>
       {{/if}}
-        <PixActionButton 
+        <PixActionButton
           @icon='times'
           class="certification-candidates-row-actions__close"
           @triggerAction={{this.cancel}}

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -1,8 +1,11 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
+import config from 'pix-certif/config/environment';
 
 export default class SessionsDetailsController extends Controller {
+
+  isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
 
   @alias('model') session;
 

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -36,6 +36,11 @@ export default class Session extends Model {
         || this.status === PROCESSED;
   }
 
+  @computed('certificationCandidates.length')
+  get hasOneOrMoreCandidates() {
+    return this.certificationCandidates.length > 0;
+  }
+
   @computed('certificationCandidates.@each.isLinked')
   get hasStarted() {
     return this.certificationCandidates.isAny('isLinked');

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -42,7 +42,7 @@ export default class Session extends Model {
   }
 
   @computed('id', 'session.data.authenticated.access_token')
-  get urlToDownload() {
+  get urlToDownloadAttendanceSheet() {
     return `${ENV.APP.API_HOST}/api/sessions/${this.id}/attendance-sheet?accessToken=${this.session.data.authenticated.access_token}`;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/details.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details.scss
@@ -9,6 +9,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   margin: 1em 0;
 }
 
@@ -16,6 +17,11 @@
   &__title {
     display: flex;
     align-items: center;
+    min-width: 300px;
+
+    .button {
+      margin-left: 50px;
+    }
   }
 
   &__datetime {

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -3,6 +3,12 @@
     <div class="session-details-header__title">
       <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
       <h1 class="page-title">Session {{this.session.id}}</h1>
+      {{#if this.isResultRecipientEmailVisible}}
+        <a  class="button button--link"
+            href="{{this.session.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
+              Télécharger le PV
+        </a>
+      {{/if}}
     </div>
 
     <div class="session-details-header__datetime">

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -4,10 +4,12 @@
       <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
       <h1 class="page-title">Session {{this.session.id}}</h1>
       {{#if this.isResultRecipientEmailVisible}}
+      {{#if this.session.hasOneOrMoreCandidates}}
         <a  class="button button--link"
             href="{{this.session.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
               Télécharger le PV
         </a>
+      {{/if}}
       {{/if}}
     </div>
 

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -19,7 +19,7 @@
       <div class="panel-actions__button">
         <a data-test-id="attendance_sheet_download_button"
           class="button button--link button--with-icon"
-          href="{{this.currentSession.urlToDownload}}" target="_blank" rel="noopener noreferrer" download>
+          href="{{this.currentSession.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
             Télécharger (.ods)<FaIcon @icon='file-download' />
         </a>
       </div>

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -110,14 +110,14 @@ module('Acceptance | Session Details', function(hooks) {
         await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
 
         // then
-        assert.dom('[data-test-id="panel-candidate__lastName__1"]').hasText(`${candidateInSession.lastName}`);
-        assert.dom('[data-test-id="panel-candidate__firstName__1"]').hasText(`${candidateInSession.firstName}`);
-        assert.dom('[data-test-id="panel-candidate__birthdate__1"]').hasText(`${moment(candidateInSession.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
-        assert.dom('[data-test-id="panel-candidate__birthCity__1"]').hasText(`${candidateInSession.birthCity}`);
-        assert.dom('[data-test-id="panel-candidate__birthProvinceCode__1"]').hasText(`${candidateInSession.birthProvinceCode}`);
-        assert.dom('[data-test-id="panel-candidate__birthCountry__1"]').hasText(`${candidateInSession.birthCountry}`);
-        assert.dom('[data-test-id="panel-candidate__email__1"]').hasText(`${candidateInSession.email}`);
-        assert.dom('[data-test-id="panel-candidate__externalId__1"]').hasText(`${candidateInSession.externalId}`);
+        assert.dom(`[data-test-id="panel-candidate__lastName__${candidateInSession.id}"]`).hasText(`${candidateInSession.lastName}`);
+        assert.dom(`[data-test-id="panel-candidate__firstName__${candidateInSession.id}"]`).hasText(`${candidateInSession.firstName}`);
+        assert.dom(`[data-test-id="panel-candidate__birthdate__${candidateInSession.id}"]`).hasText(`${moment(candidateInSession.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
+        assert.dom(`[data-test-id="panel-candidate__birthCity__${candidateInSession.id}"]`).hasText(`${candidateInSession.birthCity}`);
+        assert.dom(`[data-test-id="panel-candidate__birthProvinceCode__${candidateInSession.id}"]`).hasText(`${candidateInSession.birthProvinceCode}`);
+        assert.dom(`[data-test-id="panel-candidate__birthCountry__${candidateInSession.id}"]`).hasText(`${candidateInSession.birthCountry}`);
+        assert.dom(`[data-test-id="panel-candidate__email__${candidateInSession.id}"]`).hasText(`${candidateInSession.email}`);
+        assert.dom(`[data-test-id="panel-candidate__externalId__${candidateInSession.id}"]`).hasText(`${candidateInSession.externalId}`);
       });
 
       test('it should display a sentence when there is no certification candidates yet', async function(assert) {

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -5,6 +5,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import moment from 'moment';
 import { createUserWithMembershipAndTermsOfServiceAccepted } from '../helpers/test-init';
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
+import config from 'pix-certif/config/environment';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -70,20 +71,62 @@ module('Acceptance | Session Details', function(hooks) {
         assert.dom('.session-details-container .session-details-row:first-child div:nth-child(5) span:first-child').hasText(`${sessionFinalized.accessCode}`);
       });
 
-      test('it should show download button when there is one or more candidate', async function(assert) {
-        // when
-        await visit(`/sessions/${sessionFinalized.id}`);
+      module('when FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE is on', function(hooks) {
 
-        // then
-        assert.dom('.session-details-header__title .button').hasText('Télécharger le PV');
+        const ft = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+
+        hooks.before(() => {
+          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = true;
+        });
+
+        hooks.after(() => {
+          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = ft;
+        });
+
+        test('it should show download button when there is one or more candidate', async function(assert) {
+          // when
+          await visit(`/sessions/${sessionFinalized.id}`);
+
+          // then
+          assert.dom('.session-details-header__title .button').hasText('Télécharger le PV');
+        });
+
+        test('it should not show download button where there is no candidate', async function(assert) {
+          // when
+          await visit(`/sessions/${sessionNotFinalizedWithoutCandidate.id}`);
+
+          // then
+          assert.dom('.session-details-header__title .button').doesNotExist();
+        });
       });
 
-      test('it should not show downlaod button where there is no candidate', async function(assert) {
-        // when
-        await visit(`/sessions/${sessionNotFinalizedWithoutCandidate.id}`);
+      module('when FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE is off', function(hooks) {
 
-        // then
-        assert.dom('.session-details-header__title .button').doesNotExist();
+        const ft = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+
+        hooks.before(() => {
+          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = false;
+        });
+
+        hooks.after(() => {
+          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = ft;
+        });
+
+        test('it should show download button when there is one or more candidate1', async function(assert) {
+          // when
+          await visit(`/sessions/${sessionFinalized.id}`);
+
+          // then
+          assert.dom('.session-details-header__title .button').doesNotExist();
+        });
+
+        test('it should not show download button where there is no candidate1', async function(assert) {
+          // when
+          await visit(`/sessions/${sessionNotFinalizedWithoutCandidate.id}`);
+
+          // then
+          assert.dom('.session-details-header__title .button').doesNotExist();
+        });
       });
     });
 

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -55,7 +55,7 @@ module('Acceptance | Session Details', function(hooks) {
       await visit(`/sessions/${sessionFinalized.id}`);
 
       // then
-      assert.dom('.session-details-header__title').hasText(`Session ${sessionFinalized.id}`);
+      assert.dom('.session-details-header__title h1').hasText(`Session ${sessionFinalized.id}`);
       assert.dom('.session-details-container .session-details-row:first-child div:nth-child(2) span').hasText(`${sessionFinalized.address}`);
       assert.dom('.session-details-container .session-details-row:first-child div:nth-child(3) span').hasText(`${sessionFinalized.room}`);
       assert.dom('.session-details-container .session-details-row:first-child div:nth-child(4) span').hasText(`${sessionFinalized.examiner}`);

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -7,6 +7,30 @@ import { CREATED, FINALIZED } from 'pix-certif/models/session';
 module('Unit | Model | session', function(hooks) {
   setupTest(hooks);
 
+  module('#hasOneOrMoreCandidates', function() {
+
+    test('it should return true if there is one or more candidate', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const candidate = run(() => store.createRecord('certification-candidate', {
+        firstName: 'Anne',
+        lastName: 'So',
+      }));
+      const session = run(() => store.createRecord('session', {
+        id: 123,
+        certificationCandidates: [ candidate ],
+      }));
+
+      assert.equal(session.hasOneOrMoreCandidates, true);
+    });
+
+    test('it should return false if there is no candidate', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const session = run(() => store.createRecord('session', { id: 123 }));
+
+      assert.equal(session.hasOneOrMoreCandidates, false);
+    });
+  });
+
   module('#displayStatus', function() {
 
     test('it should return the correct displayName', function(assert) {

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -25,7 +25,7 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#urlToDownload', function() {
+  module('#urlToDownloadAttendanceSheet', function() {
 
     test('it should return the correct urlToUpload', function(assert) {
       const store = this.owner.lookup('service:store');
@@ -34,12 +34,12 @@ module('Unit | Model | session', function(hooks) {
       assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
     });
 
-    test('it should return the correct urlToDownload', function(assert) {
+    test('it should return the correct urlToDownloadAttendanceSheet', function(assert) {
       const store = this.owner.lookup('service:store');
       const model = run(() => store.createRecord('session', { id: 1 }));
       model.session = { data: { authenticated: { access_token: '123' } } };
 
-      assert.equal(model.urlToDownload, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
+      assert.equal(model.urlToDownloadAttendanceSheet, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
     });
   });
 });

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -7,33 +7,39 @@ import { CREATED, FINALIZED } from 'pix-certif/models/session';
 module('Unit | Model | session', function(hooks) {
   setupTest(hooks);
 
-  test('it should return the correct displayName', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model1 = run(() => store.createRecord('session', {
-      id: 123,
-      status: CREATED,
-    }));
-    const model2 = run(() => store.createRecord('session', {
-      id: 1234,
-      status: FINALIZED,
-    }));
+  module('#displayStatus', function() {
 
-    assert.equal(model1.displayStatus, 'Créée');
-    assert.equal(model2.displayStatus, 'Finalisée');
+    test('it should return the correct displayName', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model1 = run(() => store.createRecord('session', {
+        id: 123,
+        status: CREATED,
+      }));
+      const model2 = run(() => store.createRecord('session', {
+        id: 1234,
+        status: FINALIZED,
+      }));
+
+      assert.equal(model1.displayStatus, 'Créée');
+      assert.equal(model2.displayStatus, 'Finalisée');
+    });
   });
 
-  test('it should return the correct urlToUpload', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('session', { id: 1 }));
+  module('#urlToDownload', function() {
 
-    assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
-  });
+    test('it should return the correct urlToUpload', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('session', { id: 1 }));
 
-  test('it should return the correct urlToDownload', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('session', { id: 1 }));
-    model.session = { data: { authenticated: { access_token: '123' } } };
+      assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
+    });
 
-    assert.equal(model.urlToDownload, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
+    test('it should return the correct urlToDownload', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('session', { id: 1 }));
+      model.session = { data: { authenticated: { access_token: '123' } } };
+
+      assert.equal(model.urlToDownload, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Un nouveau modèle d’import de la liste des candidats a été créé afin d’y ajouter la colonne `Adresse email du destinataire des résultats`. Cette colonne ne devant pas apparaître dans le PV de session, il s’agit maintenant de permettre aux utilisateurs de télécharger le PV de session (inchangé pour le moment).

## :robot: Solution
Pour les sessions avec au moins un candidat (ne pas afficher pour les sessions sans candidat) : 
- ajouter un bouton “Télécharger le PV” : 
- cliquer sur ce bouton permet de télécharger le PV de session

<img width="1544" alt="image" src="https://user-images.githubusercontent.com/38167520/94669845-174aba00-0312-11eb-9870-6540a64d1f53.png">

## :rainbow: Remarques
Cette feature est soumise à un FEATURE TOGGLE.

## :100: Pour tester
- Lancer Pix Certif : `FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE=true npm start`
- Aller sur le détail d'une session avec au moins 1 candidat
- Constater qu'il y a un bouton "Télécharger le PV" dans le header
- Aller sur le détail d'une session sans candidat
- Constater qu'il n'y a plus le bouton "Télécharger le PV" dans le header
