### PR TITLE
[FEATURE] Permettre de modifier la gestion d'élèves d'une organisation depuis Pix Admin (PIX-1340).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -72,6 +72,18 @@
                  @value={{this.form.email}} />
         </div>
         <div class="form-field organization-edit-form__checkbox">
+          <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
+          {{#if (v-get this.form 'isManagingStudents' 'isInvalid')}}
+            <div class="form-field__error">
+              {{v-get this.form 'isManagingStudents' 'message'}}
+            </div>
+          {{/if}}
+          <Input id="isManagingStudents"
+                 @type="checkbox"
+                 class={{if (v-get this.form 'isManagingStudents' 'isInvalid') "form-control is-invalid" "form-control"}}
+                 @checked={{this.form.isManagingStudents}} />
+        </div>
+        <div class="form-field organization-edit-form__checkbox">
           <label for="canCollectProfiles" class="form-field__label">Collecte de profils</label>
           {{#if (v-get this.form 'canCollectProfiles' 'isInvalid')}}
             <div class="form-field__error">
@@ -104,7 +116,7 @@
               Département : <span class="organization__provinceCode">{{@organization.provinceCode}}</span><br>
             {{/if}}
             {{#if @organization.isOrganizationSCO}}
-              Gère des élèves : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
+              Gestion d’élèves/étudiants : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
             {{/if}}
             Adresse e-mail: <span class ="organization'__email">{{@organization.email}}</span><br>
             Collecte de profils : <span class="organization__canCollectProfiles">{{this.canCollectProfiles}}</span><br>

--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -71,18 +71,20 @@
                  class={{if (v-get this.form 'email' 'isInvalid') "form-control is-invalid" "form-control"}}
                  @value={{this.form.email}} />
         </div>
-        <div class="form-field organization-edit-form__checkbox">
-          <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
-          {{#if (v-get this.form 'isManagingStudents' 'isInvalid')}}
-            <div class="form-field__error">
-              {{v-get this.form 'isManagingStudents' 'message'}}
-            </div>
-          {{/if}}
-          <Input id="isManagingStudents"
-                 @type="checkbox"
-                 class={{if (v-get this.form 'isManagingStudents' 'isInvalid') "form-control is-invalid" "form-control"}}
-                 @checked={{this.form.isManagingStudents}} />
-        </div>
+        {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
+          <div class="form-field organization-edit-form__checkbox">
+            <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>
+            {{#if (v-get this.form 'isManagingStudents' 'isInvalid')}}
+              <div class="form-field__error">
+                {{v-get this.form 'isManagingStudents' 'message'}}
+              </div>
+            {{/if}}
+            <Input id="isManagingStudents"
+                   @type="checkbox"
+                   class={{if (v-get this.form 'isManagingStudents' 'isInvalid') "form-control is-invalid" "form-control"}}
+                   @checked={{this.form.isManagingStudents}} />
+          </div>
+        {{/if}}
         <div class="form-field organization-edit-form__checkbox">
           <label for="canCollectProfiles" class="form-field__label">Collecte de profils</label>
           {{#if (v-get this.form 'canCollectProfiles' 'isInvalid')}}
@@ -115,7 +117,7 @@
             {{#if @organization.provinceCode}}
               Département : <span class="organization__provinceCode">{{@organization.provinceCode}}</span><br>
             {{/if}}
-            {{#if @organization.isOrganizationSCO}}
+            {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
               Gestion d’élèves/étudiants : <span class="organization__isManagingStudents">{{this.isManagingStudents}}</span><br>
             {{/if}}
             Adresse e-mail: <span class ="organization'__email">{{@organization.email}}</span><br>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -51,6 +51,13 @@ const Validations = buildValidations({
       }),
     ],
   },
+  isManagingStudents: {
+    validators: [
+      validator('inclusion', {
+        in: [true, false],
+      }),
+    ],
+  },
   canCollectProfiles: {
     validators: [
       validator('inclusion', {
@@ -65,6 +72,7 @@ class Form extends Object.extend(Validations) {
   @tracked externalId;
   @tracked provinceCode;
   @tracked email;
+  @tracked isManagingStudents;
   @tracked canCollectProfiles;
 }
 
@@ -122,6 +130,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('externalId', !this.form.externalId ? null : this.form.externalId.trim());
     this.args.organization.set('provinceCode', !this.form.provinceCode ? null : this.form.provinceCode.trim());
     this.args.organization.set('email', !this.form.email ? null : this.form.email.trim());
+    this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
     this.args.organization.set('canCollectProfiles', this.form.canCollectProfiles);
 
     this.isEditMode = false;
@@ -133,6 +142,7 @@ export default class OrganizationInformationSection extends Component {
     this.form.externalId = this.args.organization.externalId;
     this.form.provinceCode = this.args.organization.provinceCode;
     this.form.email = this.args.organization.email;
+    this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.canCollectProfiles = this.args.organization.canCollectProfiles;
   }
 }

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -15,6 +15,7 @@ export default class Organization extends Model {
   @attr() email;
 
   @equal('type', 'SCO') isOrganizationSCO;
+  @equal('type', 'SUP') isOrganizationSUP;
 
   @hasMany('membership') memberships;
   @hasMany('targetProfile') targetProfiles;

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -16,7 +16,13 @@ module('Acceptance | organization information management', function(hooks) {
 
     test('should edit organization\'s name, externalId, provinceCode and email', async function(assert) {
       // given
-      const organization = this.server.create('organization', { name: 'oldOrganizationName', externalId: 'oldOrganizationExternalId', provinceCode: 'oldProvinceCode', canCollectProfiles: true });
+      const organization = this.server.create('organization', {
+        name: 'oldOrganizationName',
+        externalId: 'oldOrganizationExternalId',
+        provinceCode: 'oldProvinceCode',
+        canCollectProfiles: true,
+        isManagingStudents: true,
+      });
       await visit(`/organizations/${organization.id}`);
       await click('button[aria-label="Editer"]');
 

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -48,7 +48,16 @@ module('Integration | Component | organization-information-section', function(ho
     let organization;
 
     hooks.beforeEach(function() {
-      organization = EmberObject.create({ id: 1, name: 'Organization SCO', externalId: 'VELIT', provinceCode: 'h50', email: 'sco.generic.account@example.net', canCollectProfiles: false });
+      organization = EmberObject.create({
+        id: 1,
+        name: 'Organization SCO',
+        externalId: 'VELIT',
+        provinceCode: 'h50',
+        email: 'sco.generic.account@example.net',
+        canCollectProfiles: false,
+        isOrganizationSCO: true,
+        isManagingStudents: false,
+      });
       this.set('organization', organization);
     });
 
@@ -84,6 +93,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('input#provinceCode').hasValue(organization.provinceCode);
       assert.dom('input#email').hasValue(organization.email);
       assert.dom('input#canCollectProfiles').isNotChecked();
+      assert.dom('input#isManagingStudents').isNotChecked();
     });
 
     test('it should show error message if organization\'s name is empty', async function(assert) {
@@ -173,10 +183,12 @@ module('Integration | Component | organization-information-section', function(ho
     test('it should revert changes on click to cancel button', async function(assert) {
       // given
       await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
       await click('button[aria-label=\'Editer\'');
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', 'new provinceCode');
+      await click('input#isManagingStudents');
       await click('input#canCollectProfiles');
 
       // when
@@ -186,6 +198,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('.organization__name').hasText(organization.name);
       assert.dom('.organization__externalId').hasText(organization.externalId);
       assert.dom('.organization__provinceCode').hasText(organization.provinceCode);
+      assert.dom('.organization__isManagingStudents').hasText('Non');
       assert.dom('.organization__canCollectProfiles').hasText('Non');
     });
 
@@ -197,6 +210,7 @@ module('Integration | Component | organization-information-section', function(ho
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', '  ');
+      await click('input#isManagingStudents');
       await click('input#canCollectProfiles');
 
       // when
@@ -207,6 +221,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('.organization__externalId').hasText('new externalId');
       assert.dom('.organization__provinceCode').doesNotExist();
       assert.dom('.organization__canCollectProfiles').hasText('Oui');
+      assert.dom('.organization__isManagingStudents').hasText('Oui');
     });
   });
 

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -225,7 +225,7 @@ module('Integration | Component | organization-information-section', function(ho
     });
   });
 
-  module('When organization is SCO', function(hooks) {
+  module('When organization is SCO or SUP', function(hooks) {
 
     hooks.beforeEach(function() {
       this.organization = EmberObject.create({ type: 'SCO', isOrganizationSCO: true, isManagingStudents: true });
@@ -264,7 +264,7 @@ module('Integration | Component | organization-information-section', function(ho
   module('When organization is not SCO', function(hooks) {
 
     hooks.beforeEach(function() {
-      this.organization = EmberObject.create({ type: 'PRO', isOrganizationSCO: false });
+      this.organization = EmberObject.create({ type: 'PRO', isOrganizationSCO: false, isOrganizationSUP: false });
     });
 
     test('it should not display if it is managing students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible aujourd'hui, autrement que par une requête en base de données, de modifier le champ `isManagingStudents` d'une organisation.

## :robot: Solution
Ajouter la possibilité de modifier cet attribut depuis la page d'édition d'une organisation dans Pix Admin.

## :rainbow: Remarques
Ajout de  l'affichage de la Gestion d’élèves/étudiants pour les organisations SUP.