### PR TITLE
[FEATURE] Suppression du picto dans la modal d'information de connexion du formulaire de réconciliation (PIX-1337).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -66,7 +66,6 @@
   <PixModal @containerClass="join-error-modal" @onClose={{action this.closeModal}}>
     <div class="join-error-modal__header">
       <div class="join-error-modal-header__title">
-        <FaIcon @icon="times-circle" class="join-error-modal-header-title__icon"></FaIcon>
         <h1 class="join-error-modal-header-title__text">Information de connexion</h1>
       </div>
       <div class="join-error-modal-header__close" aria-label={{t "common.actions.close"}} {{on 'click' this.closeModal}}>


### PR DESCRIPTION
## :unicorn: Problème
Le pictogramme (croix rouge) dans la modal d'information de connexion du formulaire de réconciliation indique une erreur grave alors que ce n'est pas le cas.  

## :robot: Solution
Supprimer le pictogramme.

## :100: Pour tester
- Rejoindre la campagne RESTRICTD
- Se connecter avec le compte sco@example.net
- Remplir les informations de réconciliation pour l'élève First Last (10/10/2010)
- Vérifier que le pictogramme n'est plus présent dans la modal d'information de connexion.
