### PR TITLE
[TECH] Suppression de JQuery dans pix-app

### DIFF
--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
     }],
     /* Recommended rules */
     'ember/no-mixins': 'off',
-    'ember/no-jquery': 'off',
     /* Avoid lodash default import */
     'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
   },

--- a/mon-pix/app/helpers/strip-instruction.js
+++ b/mon-pix/app/helpers/strip-instruction.js
@@ -1,13 +1,17 @@
 import { helper } from '@ember/component/helper';
-import $ from 'jquery';
 import truncate from 'lodash/truncate';
+
+function strip(html) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  return doc.body.textContent || '';
+}
 
 export function stripInstruction(params) {
   let length = 70;
   if (params[1]) {
     length = params[1];
   }
-  const result = $(params[0]).text();
+  const result = strip(params[0]);
 
   return truncate(result, {
     length,


### PR DESCRIPTION
## :unicorn: Problème

`JQuery` est encore utilisé dans le code de pix-app.

## :robot: Solution

Supprimer la dépendance vers `JQuery` et remplacer les fonctions utilisées par du JS natif ou des alternatives.

## :rainbow: Remarques

**Uniquement, 2 changements étaient nécessaires :** 

- L'utilisation d'un strip html (suppression du HTML dans une chaine): Utilisation de la fonction native [`DOMParser. parseFromString`](https://developer.mozilla.org/fr/docs/Web/API/DOMParser) du browser pour remplacer l'utilisation de `JQuery`.

- Chargement du script de Google recaptcha "à la volée":[ une fonction écrite en JS natif](https://stackoverflow.com/questions/16839698/jquery-getscript-alternative-in-native-javascript/28002292#28002292) pour charger le script a été utilisée.

**La règle `eslint` interdisant `JQuery`a été réactivée.**

**⚠️ Malheureusement, pour le moment il n'est pas possible de supprimer la dépendance à `ember/jquery` car il semble que nous utilisons des addons qui utilisent encore jquery** 

Pour info, voici un lien vers les détails de migration pour la suppression de JQuery dans ember: https://deprecations.emberjs.com/v3.x/#toc_jquery-apis

## :100: Pour tester

2 fonctionnalités sont à retester fonctionnellement:
1. L'affichage des résultats intermédiaires lors d'un parcours (les questions affichées doivent être correctement tronquées)
2. Le google recaptcha est actuellement désactivé et je ne suis pas certains qu'il sera réactivé dans le futur. Est-ce nécessaire de le retester ? Peut-être prévoir de le supprimer dans un prochain point tech ?