### PR TITLE
[BSR] Factorisation de la fonction du Server FailAction dans API (PIX-1343).

### DIFF
--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const JSONAPIError = require('jsonapi-serializer').Error;
+const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const AuthenticationController = require('./authentication-controller');
 
 exports.register = async (server) => {
@@ -43,13 +43,7 @@ exports.register = async (server) => {
             token_type_hint: 'access_token',
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: 'The server could not understand the request due to invalid syntax.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new BadRequestError('The server could not understand the request due to invalid token.'), h);
           },
         },
         handler: (request, h) => h.response(),

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -19,15 +19,6 @@ exports.register = async (server) => {
             password: Joi.string().required(),
             scope: Joi.string(),
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         handler: AuthenticationController.authenticateUser,
         tags: ['api'],
@@ -54,7 +45,7 @@ exports.register = async (server) => {
           failAction: (request, h) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
+              status: errorHttpStatusCode.toString(),
               title: 'Bad request',
               detail: 'The server could not understand the request due to invalid syntax.',
             });

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -90,6 +90,14 @@ class BadRequestError extends BaseHttpError {
   }
 }
 
+class PayloadTooLargeError extends BaseHttpError {
+  constructor(message = 'La taille du fichier doit être inférieure à 10Mo.') {
+    super(message);
+    this.title = 'Payload too large';
+    this.status = 413;
+  }
+}
+
 function sendJsonApiError(httpError, h) {
   const jsonApiError = new JSONAPIError({
     status: httpError.status.toString(),
@@ -108,6 +116,7 @@ module.exports = {
   MissingQueryParamError,
   NotFoundError,
   PasswordShouldChangeError,
+  PayloadTooLargeError,
   PreconditionFailedError,
   sendJsonApiError,
   UnauthorizedError,

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const JSONAPIError = require('jsonapi-serializer').Error;
+
 const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');
 const { idSpecification } = require('../../domain/validators/id-specification');
@@ -40,15 +40,6 @@ exports.register = async function(server) {
           params: Joi.object({
             id: Joi.number().integer().required(),
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         handler: membershipController.update,
         description: 'Update organization role by admin for a organization members',

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -1,5 +1,4 @@
 const Joi = require('@hapi/joi');
-const JSONAPIError = require('jsonapi-serializer').Error;
 const organizationInvitationController = require('./organization-invitation-controller');
 
 exports.register = async (server) => {
@@ -21,15 +20,6 @@ exports.register = async (server) => {
               },
             },
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         notes: [
           '- Cette route permet d\'accepter l\'invitation à rejoindre une organisation, via un **code** et un **email**',
@@ -55,15 +45,6 @@ exports.register = async (server) => {
                 type: 'sco-organization-invitations',
               },
             }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         notes: [
           '- Cette route permet d\'envoyer une invitation pour rejoindre une organisation de type SCO en tant que ADMIN, en renseignant un **UAI**, un **NOM** et un **PRENOM**',
@@ -84,15 +65,6 @@ exports.register = async (server) => {
           query: Joi.object({
             code: Joi.string().required(),
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         notes: [
           '- Cette route permet de récupérer les détails d\'une invitation selon un **id d\'invitation** et un **code**\n',

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const JSONAPIError = require('jsonapi-serializer').Error;
+const { sendJsonApiError, PayloadTooLargeError } = require('../http-errors');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const organizationController = require('./organization-controller');
@@ -214,12 +214,7 @@ exports.register = async (server) => {
           maxBytes: 1048576 * 10, // 10MB
           parse: 'gunzip',
           failAction: (request, h) => {
-            const jsonApiError = new JSONAPIError({
-              status: '413',
-              title: 'Payload too large',
-              detail: 'La taille du fichier doit être inférieure à 10Mo.',
-            });
-            return h.response(jsonApiError).code(413).takeover();
+            return sendJsonApiError(new PayloadTooLargeError(), h);
           },
         },
         handler: organizationController.importHigherSchoolingRegistrations,

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -58,15 +58,6 @@ exports.register = async function(server) {
               type: 'external-users',
             },
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         notes: [
           'Cette route crée un compte utilisateur suite à une connexion provenant d\'un IDP externe (GAR). ' +
@@ -100,7 +91,7 @@ exports.register = async function(server) {
           failAction: (request, h) => {
             const errorHttpStatusCode = 400;
             const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
+              status: errorHttpStatusCode.toString(),
               title: 'Bad request',
               detail: 'The server could not understand the request due to invalid syntax.',
             });

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -126,15 +126,6 @@ exports.register = async function(server) {
               },
             },
           }),
-          failAction: (request, h, err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              code: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         notes : [
           '- Génère un identifiant pour l\'élève avec un mot de passe temporaire \n' +

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -1,9 +1,11 @@
-const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
-const securityPreHandlers = require('../security-pre-handlers');
-const JSONAPIError = require('jsonapi-serializer').Error;
 const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
-const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
+
+const securityPreHandlers = require('../security-pre-handlers');
+const { sendJsonApiError, BadRequestError } = require('../http-errors');
+const { passwordValidationPattern } = require('../../config').account;
+
+const schoolingRegistrationDependentUserController = require('./schooling-registration-dependent-user-controller');
 
 exports.register = async function(server) {
   server.route([
@@ -89,13 +91,7 @@ exports.register = async function(server) {
             },
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: 'The server could not understand the request due to invalid syntax.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new BadRequestError('The server could not understand the request due to invalid syntax.'), h);
           },
         },
         notes : [

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -1,5 +1,4 @@
 const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
-const JSONAPIError = require('jsonapi-serializer').Error;
 const { sendJsonApiError, UnprocessableEntityError, NotFoundError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const schoolingRegistrationUserAssociationController = require('./schooling-registration-user-association-controller');
@@ -60,13 +59,7 @@ exports.register = async function(server) {
             },
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 422;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Unprocessable entity',
-              detail: 'Un des champs saisis n’est pas valide.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
           },
         },
         notes: [

--- a/api/lib/application/student-user-associations/index.js
+++ b/api/lib/application/student-user-associations/index.js
@@ -1,6 +1,6 @@
 const schoolingRegistrationUserAssociationController = require('./../schooling-registration-user-associations/schooling-registration-user-association-controller');
 const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
-const JSONAPIError = require('jsonapi-serializer').Error;
+const { sendJsonApiError, UnprocessableEntityError } = require('../http-errors');
 
 exports.register = async function(server) {
   server.route([
@@ -24,13 +24,7 @@ exports.register = async function(server) {
             },
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 422;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Unprocessable entity',
-              detail: 'Un des champs saisis n’est pas valide.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
           },
         },
         notes: [
@@ -76,13 +70,7 @@ exports.register = async function(server) {
             },
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 422;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Unprocessable entity',
-              detail: 'Un des champs saisis n’est pas valide.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new UnprocessableEntityError('Un des champs saisis n’est pas valide.'), h);
           },
         },
         notes: [

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -105,15 +105,6 @@ exports.register = async function(server) {
           options: {
             allowUnknown: true,
           },
-          failAction: (request, h , err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         handler: userController.updateUserDetailsForAdministration,
         notes : [
@@ -399,15 +390,6 @@ exports.register = async function(server) {
           params: Joi.object({
             id: Joi.number().integer().positive().required(),
           }),
-          failAction: (request, h , err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         pre: [{
           method: securityPreHandlers.checkUserHasRolePixMaster,

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,7 +1,7 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const userController = require('./user-controller');
 const Joi = require('@hapi/joi');
-const JSONAPIError = require('jsonapi-serializer').Error;
+const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
@@ -55,13 +55,7 @@ exports.register = async function(server) {
             id: Joi.number().integer().required(),
           }),
           failAction: (request, h) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: 'L\'identifiant de l\'utilisateur n\'est pas au bon format.',
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
+            return sendJsonApiError(new BadRequestError('L\'identifiant de l\'utilisateur n\'est pas au bon format.'), h);
           },
         },
         handler: userController.getUserDetailsForAdmin,
@@ -427,15 +421,6 @@ exports.register = async function(server) {
               },
             },
           }),
-          failAction: (request, h , err) => {
-            const errorHttpStatusCode = 400;
-            const jsonApiError = new JSONAPIError({
-              status: errorHttpStatusCode.toString(),
-              title: 'Bad request',
-              detail: err.details[0].message,
-            });
-            return h.response(jsonApiError).code(errorHttpStatusCode).takeover();
-          },
         },
         handler: userController.updateUserSamlId,
         notes: [

--- a/api/lib/validate.js
+++ b/api/lib/validate.js
@@ -1,0 +1,11 @@
+const get = require('lodash/get');
+const { BadRequestError, sendJsonApiError } = require('./application/http-errors');
+
+function handleFailAction(request, h, err) {
+  const message = get(err, 'details[0].message', '');
+  return sendJsonApiError(new BadRequestError(message), h);
+}
+
+module.exports = {
+  handleFailAction,
+};

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,7 @@
 // As early as possible in your application, require and configure dotenv.
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
+
 const Hapi = require('@hapi/hapi');
 
 const preResponseUtils = require('./lib/application/pre-response-utils');
@@ -9,12 +10,16 @@ const routes = require('./lib/routes');
 const plugins = require('./lib/plugins');
 const config = require('./lib/config');
 const security = require('./lib/infrastructure/security');
+const { handleFailAction } = require('./lib/validate');
 
 const createServer = async () => {
 
   const server = new Hapi.server({
     compression: false,
     routes: {
+      validate : {
+        failAction: handleFailAction,
+      },
       cors: {
         origin: ['*'],
         additionalHeaders: ['X-Requested-With'],

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -63,7 +63,7 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
 
         // then
         expect(response.statusCode).to.equal(400);
-        expect(response.result.error).to.equal('Bad Request');
+        expect(response.result.errors[0].title).to.equal('Bad Request');
       });
 
     });

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -1,6 +1,16 @@
 const Hapi = require('@hapi/hapi');
 const Inert = require('@hapi/inert');
+
 const preResponseUtils = require('../../../lib/application/pre-response-utils');
+const { handleFailAction } = require('../../../lib/validate');
+
+const routesConfig = {
+  routes: {
+    validate: {
+      failAction: handleFailAction,
+    },
+  },
+};
 
 /**
  * ⚠️ You must declare your stubs before calling the HttpTestServer constructor (because of Node.Js memoization).
@@ -16,7 +26,8 @@ const preResponseUtils = require('../../../lib/application/pre-response-utils');
 class HttpTestServer {
 
   constructor(moduleUnderTest) {
-    this.hapiServer = Hapi.server();
+    this.hapiServer = Hapi.server(routesConfig);
+
     this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
     this.hapiServer.events.on({ name: 'request', channels: 'error' }, (request, event) => {
       console.error(event.error);

--- a/api/tests/unit/server/server_test.js
+++ b/api/tests/unit/server/server_test.js
@@ -1,0 +1,22 @@
+const { expect } = require('../../test-helper');
+
+const createServer = require ('../../../server');
+
+describe('Unit | Server | server', () => {
+
+  describe('#createServer', () => {
+
+    it('should create server with custom validate.failAction', async () => {
+      // given
+      const expectedFailActionFunctionName = 'handleFailAction';
+
+      // when
+      const server = await createServer();
+
+      // then
+      expect(server.settings.routes.validate.failAction.name).to.equal(expectedFailActionFunctionName);
+    });
+
+  });
+
+});

--- a/api/tests/unit/validate_test.js
+++ b/api/tests/unit/validate_test.js
@@ -1,0 +1,56 @@
+const { pick } = require('lodash');
+
+const { expect, hFake } = require('../test-helper');
+const { BadRequestError } = require('../../lib/application/http-errors');
+
+const { handleFailAction } = require('../../lib/validate');
+
+describe('Unit | Validate', () => {
+
+  let expectedResponse;
+
+  beforeEach(() => {
+    const { title: defaultTitle, status: defaultStatus } = new BadRequestError();
+
+    expectedResponse = {
+      source: {
+        errors: [{
+          status: defaultStatus.toString(),
+          title: defaultTitle,
+        }],
+      },
+      statusCode: defaultStatus,
+    };
+  });
+
+  it('should generate a response with BadRequest default error\'s title, status and statusCode', () => {
+    // given
+    const error = undefined;
+
+    // when
+    const response = handleFailAction(null, hFake, error);
+
+    // then
+    expect(
+      pick(response, ['source', 'statusCode']))
+      .deep.equal(expectedResponse);
+  });
+
+  it('should generate a response with BadRequest default parameters and detail error message', () => {
+    // given
+    const expectedErrorMessage = 'This is a specific error message';
+    const error = {
+      details: [{ message: expectedErrorMessage }],
+    };
+
+    expectedResponse.source.errors[0].detail = expectedErrorMessage;
+
+    // when
+    const response = handleFailAction(null, hFake, error);
+
+    // then
+    expect(
+      pick(response, ['source', 'statusCode']))
+      .deep.equal(expectedResponse);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
La fonction `failAction(request, h, err)` est redéfinie dans plusieurs routes du server.
Ces réplication sont souvent identiques.
cf #1869 

## :robot: Solution
* Factoriser cette fonction, et permettre de la surcharger si besoin.
* Inclure cette fonction dans `HttpTestServer`.

## :100: Pour tester
Tests de non régression sur toutes les applications, notamment la gestion des erreurs (validation des payloads par Joi).
