### PR TITLE
[TECH] Permet de récupérer les éléments dom par une sous chaîne avec la méthode contains.

### DIFF
--- a/mon-pix/tests/helpers/contains.js
+++ b/mon-pix/tests/helpers/contains.js
@@ -2,7 +2,7 @@ import { getRootElement } from '@ember/test-helpers';
 
 function getChildrenThatContainsText(element, text) {
   if (element.children.length === 0) {
-    if (element.textContent.trim() === text) {
+    if (element.textContent.trim().includes(text)) {
       return element;
     }
     return null;

--- a/mon-pix/tests/unit/helpers/contains-test.js
+++ b/mon-pix/tests/unit/helpers/contains-test.js
@@ -29,11 +29,6 @@ describe('Unit | Helpers | contains', function() {
       await render(hbs`<div><span>Goodbye</span></div>`);
       expect(contains('Hello')).not.to.exist;
     });
-
-    it('should return element that contains exactly the text', async function() {
-      await render(hbs`<div>Hellow</div>`);
-      expect(contains('Hello')).not.to.exist;
-    });
   });
 
   describe('containsAll', function() {
@@ -42,8 +37,18 @@ describe('Unit | Helpers | contains', function() {
       expect(containsAll('Hello')).to.have.lengthOf(2);
     });
 
+    it('should find two elements containing Hel', async function() {
+      await render(hbs`<ul><li>Hello</li><li>Hello</li></ul>`);
+      expect(containsAll('Hel')).to.have.lengthOf(2);
+    });
+
+    it('should find element deeply', async function() {
+      await render(hbs`<ul><li><span>He</span><span>llo</span></li><li><span id="found">Hell</span><span>o</span></li></ul>`);
+      expect(containsAll('Hel')[0].getAttribute('id')).to.equal('found');
+    });
+
     it('should not find any elements', async function() {
-      await render(hbs`<ul><li>Goodbye</li><li>Hellow</li></ul>`);
+      await render(hbs`<ul><li>Goodbye</li><li>Helow</li></ul>`);
       expect(containsAll('Hello')).to.have.lengthOf(0);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La méthode contains permet de tester les templates sans utiliser de classes css ou des ids de test rendant les tests plus proche des attentes utilisateurs. Actuellement l'implémentation de la méthode contains permet de récupérer les éléments contenant exactement la chaîne passé en paramètre. Le comportement attendue d'une méthode contains est de permettre la récupération à partir d'une partie de la chaîne de caractère. Ex : 'Hello' devrait être retourné si on appelle la méthode avec 'Hell'.

## :robot: Solution
Au lieu de faire une égalité stricte dans l'implémentation, on utilise la méthode includes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Les tests utilisant cette méthode fonctionnent toujours. J'ai ajouté des tests pour vérifier ce comportement supplémentaire.
