### PR TITLE
[TECH] Utiliser une version stable de la dépendance jwt-decode.

### DIFF
--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -40280,9 +40280,9 @@
       "dev": true
     },
     "jwt-decode": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0-beta.2.tgz",
-      "integrity": "sha512-AnENY5syz7PzgpTzos9sxkqKTmHU0JeJOXZFHUc41bDyybC2yzZ+1r43ZLhk7+JCwF0yjISPuVK9ZWfA1nCUPA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.0.0.tgz",
+      "integrity": "sha512-RBQv2MTm3FNKQkdzhEyQwh5MbdNgMa+FyIJIK5RMWEn6hRgRHr7j55cRxGhRe6vGJDElyi6f6u/yfkP7AoXddA==",
       "dev": true
     },
     "keyv": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -103,7 +103,7 @@
     "eslint-plugin-node": "^10.0.0",
     "faker": "^4.1.0",
     "js-yaml": "^3.13.1",
-    "jwt-decode": "^3.0.0-beta.2",
+    "jwt-decode": "^3.0.0",
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",


### PR DESCRIPTION
## :unicorn: Problème
On utilise une version beta de la librairie jwt-decode

## :robot: Solution
Utiliser la version stable 3.0.0

## :100: Pour tester
Vérifier que la connexion depuis le GAR se passe bien.
