### PR TITLE
[TECH] Renommer les routes api/jury en api/admin

### DIFF
--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -11,7 +11,7 @@ export default class SessionAdapter extends ApplicationAdapter {
   }
 
   urlForUpdateRecord(id) {
-    return `${this.host}/${this.namespace}/jury/sessions/${id}`;
+    return `${this.host}/${this.namespace}/admin/sessions/${id}`;
   }
 
   updateRecord(store, type, snapshot) {

--- a/admin/app/adapters/session.js
+++ b/admin/app/adapters/session.js
@@ -3,11 +3,11 @@ import ApplicationAdapter from './application';
 export default class SessionAdapter extends ApplicationAdapter {
 
   urlForQuery() {
-    return `${this.host}/${this.namespace}/jury/sessions`;
+    return `${this.host}/${this.namespace}/admin/sessions`;
   }
 
   urlForFindRecord(id) {
-    return `${this.host}/${this.namespace}/jury/sessions/${id}`;
+    return `${this.host}/${this.namespace}/admin/sessions/${id}`;
   }
 
   urlForUpdateRecord(id) {

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -12,7 +12,7 @@ export default function() {
   this.get('/jury/sessions', findPaginatedAndFilteredSessions);
   this.get('/jury/sessions/:id');
   this.get('/admin/sessions/:id/jury-certification-summaries', getJuryCertificationSummariesBySessionId);
-  this.put('/jury/sessions/:id/results-sent-to-prescriber', (schema, request) => {
+  this.put('/admin/sessions/:id/results-sent-to-prescriber', (schema, request) => {
     const sessionId = request.params.id;
     const session = schema.sessions.findBy({ id: sessionId });
     session.update({ resultsSentToPrescriberAt: new Date() });

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -9,8 +9,8 @@ export default function() {
   this.urlPrefix = 'http://localhost:3000';
   this.namespace = 'api';
 
-  this.get('/jury/sessions', findPaginatedAndFilteredSessions);
-  this.get('/jury/sessions/:id');
+  this.get('/admin/sessions', findPaginatedAndFilteredSessions);
+  this.get('/admin/sessions/:id');
   this.get('/admin/sessions/:id/jury-certification-summaries', getJuryCertificationSummariesBySessionId);
   this.put('/admin/sessions/:id/results-sent-to-prescriber', (schema, request) => {
     const sessionId = request.params.id;

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -11,7 +11,7 @@ export default function() {
 
   this.get('/jury/sessions', findPaginatedAndFilteredSessions);
   this.get('/jury/sessions/:id');
-  this.get('/jury/sessions/:id/jury-certification-summaries', getJuryCertificationSummariesBySessionId);
+  this.get('/admin/sessions/:id/jury-certification-summaries', getJuryCertificationSummariesBySessionId);
   this.put('/jury/sessions/:id/results-sent-to-prescriber', (schema, request) => {
     const sessionId = request.params.id;
     const session = schema.sessions.findBy({ id: sessionId });

--- a/admin/mirage/serializers/session.js
+++ b/admin/mirage/serializers/session.js
@@ -5,7 +5,7 @@ export default ApplicationSerializer.extend({
   links(session) {
     const links = {
       'juryCertificationSummaries': {
-        related: `/api/jury/sessions/${session.id}/jury-certification-summaries`,
+        related: `/api/admin/sessions/${session.id}/jury-certification-summaries`,
       },
     };
     return links;

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -32,12 +32,12 @@ module('Unit | Adapter | session', function(hooks) {
   });
 
   module('#urlForUpdateMarks', function() {
-    test('should add /jury inside the default update record url', function(assert) {
+    test('should add /admin inside the default update record url', function(assert) {
       // when
       const url = adapter.urlForUpdateRecord(123);
 
       // then
-      assert.ok(url.endsWith('/jury/sessions/123'));
+      assert.ok(url.endsWith('/admin/sessions/123'));
     });
   });
 
@@ -54,7 +54,7 @@ module('Unit | Adapter | session', function(hooks) {
           adapter.updateRecord(null, { modelName: 'session' }, snapshot);
 
           // then
-          sinon.assert.calledWithExactly(adapter.ajax, 'http://localhost:3000/api/jury/sessions/123/publication', 'PATCH', { data: { data: { attributes: { toPublish: isTrue } } } });
+          sinon.assert.calledWithExactly(adapter.ajax, 'http://localhost:3000/api/admin/sessions/123/publication', 'PATCH', { data: { data: { attributes: { toPublish: isTrue } } } });
           assert.ok(adapter);
         });
       });
@@ -78,7 +78,7 @@ module('Unit | Adapter | session', function(hooks) {
         await adapter.updateRecord(null, { modelName: 'session' }, { id: 123, adapterOptions: { certificationOfficerAssignment: true } });
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/jury/sessions/123/certification-officer-assignment', 'PATCH');
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/admin/sessions/123/certification-officer-assignment', 'PATCH');
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -17,7 +17,7 @@ module('Unit | Adapter | session', function(hooks) {
       const url = adapter.urlForQuery();
 
       // then
-      assert.ok(url.endsWith('/jury/sessions'));
+      assert.ok(url.endsWith('/admin/sessions'));
     });
   });
 
@@ -27,7 +27,7 @@ module('Unit | Adapter | session', function(hooks) {
       const url = adapter.urlForFindRecord(123, 'sessions');
 
       // then
-      assert.ok(url.endsWith('/jury/sessions/123'));
+      assert.ok(url.endsWith('/admin/sessions/123'));
     });
   });
 

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -8,7 +8,7 @@ exports.register = async (server) => {
   server.route([
     {
       method: 'GET',
-      path: '/api/jury/sessions',
+      path: '/api/admin/sessions',
       config: {
         pre: [{
           method: securityPreHandlers.checkUserHasRolePixMaster,
@@ -24,7 +24,7 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
-      path: '/api/jury/sessions/{id}',
+      path: '/api/admin/sessions/{id}',
       config: {
         validate: {
           params: Joi.object({

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -300,7 +300,7 @@ exports.register = async (server) => {
     },
     {
       method: 'PATCH',
-      path: '/api/jury/sessions/{id}/publication',
+      path: '/api/admin/sessions/{id}/publication',
       config: {
         validate: {
           params: Joi.object({
@@ -321,7 +321,7 @@ exports.register = async (server) => {
     },
     {
       method: 'PUT',
-      path: '/api/jury/sessions/{id}/results-sent-to-prescriber',
+      path: '/api/admin/sessions/{id}/results-sent-to-prescriber',
       config: {
         validate: {
           params: Joi.object({
@@ -344,7 +344,7 @@ exports.register = async (server) => {
     },
     {
       method: 'PATCH',
-      path: '/api/jury/sessions/{id}/certification-officer-assignment',
+      path: '/api/admin/sessions/{id}/certification-officer-assignment',
       config: {
         validate: {
           params: Joi.object({

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -239,7 +239,7 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
-      path: '/api/jury/sessions/{id}/jury-certification-summaries',
+      path: '/api/admin/sessions/{id}/jury-certification-summaries',
       config: {
         validate: {
           params: Joi.object({

--- a/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/jury-session-serializer.js
@@ -35,7 +35,7 @@ module.exports = {
         nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/api/jury/sessions/${parent.id}/jury-certification-summaries`;
+            return `/api/admin/sessions/${parent.id}/jury-certification-summaries`;
           },
         },
       },

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -9,7 +9,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
     server = await createServer();
   });
 
-  describe('GET /jury/sessions/{id}/jury-certification-summaries', function() {
+  describe('GET /api/admin/sessions/{id}/jury-certification-summaries', function() {
     let sessionId;
 
     beforeEach(() => {
@@ -30,7 +30,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         // when
         const response = await server.inject({
           method: 'GET',
-          url: `/api/jury/sessions/${sessionId}/jury-certification-summaries`,
+          url: `/api/admin/sessions/${sessionId}/jury-certification-summaries`,
           payload: {},
           headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
         });
@@ -92,7 +92,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
 
         request = {
           method: 'GET',
-          url: `/api/jury/sessions/${sessionId}/jury-certification-summaries`,
+          url: `/api/admin/sessions/${sessionId}/jury-certification-summaries`,
           payload: {},
           headers: { authorization: generateValidRequestAuthorizationHeader(pixMasterId) },
         };

--- a/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-session_test.js
@@ -10,7 +10,7 @@ describe('Acceptance | Controller | session-controller-get-jury-session', () => 
     await insertUserWithRolePixMaster();
   });
 
-  describe('GET /api/jury/sessions/{id}', () => {
+  describe('GET /api/admin/sessions/{id}', () => {
     let expectedJurySession;
 
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe('Acceptance | Controller | session-controller-get-jury-session', () => 
       databaseBuilder.factory.buildSession();
       options = {
         method: 'GET',
-        url: `/api/jury/sessions/${expectedJurySession.id}`,
+        url: `/api/admin/sessions/${expectedJurySession.id}`,
       };
 
       return databaseBuilder.commit();

--- a/api/tests/acceptance/application/session/session-controller-get_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get_test.js
@@ -10,11 +10,11 @@ describe('Acceptance | Controller | session-controller-get', () => {
     await insertUserWithRolePixMaster();
   });
 
-  describe('GET /api/jury/sessions', () => {
+  describe('GET /api/admin/sessions', () => {
     beforeEach(() => {
       options = {
         method: 'GET',
-        url: '/api/jury/sessions',
+        url: '/api/admin/sessions',
         payload: { },
       };
 
@@ -51,7 +51,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should return a 200 status code with paginated and filtered data', async () => {
         // given
-        options.url = '/api/jury/sessions?filter[id]=121&page[number]=1&page[size]=2';
+        options.url = '/api/admin/sessions?filter[id]=121&page[number]=1&page[size]=2';
         const expectedMetaData = { page: 1, pageSize: 2, rowCount: 1, pageCount: 1 };
 
         // when
@@ -66,7 +66,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should return a 200 status code with empty result', async () => {
         // given
-        options.url = '/api/jury/sessions?filter[id]=4&page[number]=1&page[size]=1';
+        options.url = '/api/admin/sessions?filter[id]=4&page[number]=1&page[size]=1';
         const expectedMetaData = { page: 1, pageSize: 1, rowCount: 0, pageCount: 0 };
 
         // when
@@ -80,7 +80,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should signal an entity validation error for an ID that is too large', async () => {
         // given
-        options.url = '/api/jury/sessions?filter[id]=2147483648';
+        options.url = '/api/admin/sessions?filter[id]=2147483648';
 
         // when
         const response = await server.inject(options);
@@ -91,7 +91,7 @@ describe('Acceptance | Controller | session-controller-get', () => {
 
       it('should signal an entity validation error for an ID that is too small', async () => {
         // given
-        options.url = '/api/jury/sessions?filter[id]=-2147483649';
+        options.url = '/api/admin/sessions?filter[id]=-2147483649';
 
         // when
         const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-controller-patch-update-publication-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-update-publication-session_test.js
@@ -3,7 +3,7 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('PATCH /api/jury/sessions/:id/publication', () => {
+describe('PATCH /api/admin/sessions/:id/publication', () => {
   let server;
   const options = { method: 'PATCH' };
   let userId;
@@ -21,7 +21,7 @@ describe('PATCH /api/jury/sessions/:id/publication', () => {
 
     it('should return a 403 error code', async () => {
       // given
-      options.url = '/api/jury/sessions/1/publication';
+      options.url = '/api/admin/sessions/1/publication';
       options.payload = {
         data: { attributes : { toPublish: true } },
       };
@@ -49,7 +49,7 @@ describe('PATCH /api/jury/sessions/:id/publication', () => {
 
       it('should return a 400 error code', async () => {
         // given
-        options.url = '/api/jury/sessions/any/publication';
+        options.url = '/api/admin/sessions/any/publication';
         options.payload = {
           data: { attributes : { toPublish: true } },
         };
@@ -66,7 +66,7 @@ describe('PATCH /api/jury/sessions/:id/publication', () => {
 
       it('should return a 400 error code', async () => {
         // given
-        options.url = '/api/jury/sessions/1/publication';
+        options.url = '/api/admin/sessions/1/publication';
         options.payload = {
           data: { attributes : { toPublish: 'salut' } },
         };
@@ -85,7 +85,7 @@ describe('PATCH /api/jury/sessions/:id/publication', () => {
 
         it('should return a 404 error code', async () => {
           // given
-          options.url = '/api/jury/sessions/1/publication';
+          options.url = '/api/admin/sessions/1/publication';
           options.payload = {
             data: { attributes : { toPublish: true } },
           };
@@ -105,7 +105,7 @@ describe('PATCH /api/jury/sessions/:id/publication', () => {
 
         beforeEach(() => {
           sessionId = databaseBuilder.factory.buildSession({ publishedAt: date }).id;
-          options.url = `/api/jury/sessions/${sessionId}/publication`;
+          options.url = `/api/admin/sessions/${sessionId}/publication`;
           return databaseBuilder.commit();
         });
 

--- a/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-user-assignment_test.js
@@ -3,7 +3,7 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('PATCH /api/jury/sessions/:id/certification-officer-assignment', () => {
+describe('PATCH /api/admin/sessions/:id/certification-officer-assignment', () => {
   let server;
   const options = { method: 'PATCH' };
   let certificationOfficerId;
@@ -21,7 +21,7 @@ describe('PATCH /api/jury/sessions/:id/certification-officer-assignment', () => 
 
     it('should return a 403 error code', async () => {
       // given
-      options.url = '/api/jury/sessions/12/certification-officer-assignment';
+      options.url = '/api/admin/sessions/12/certification-officer-assignment';
       options.headers = { authorization: generateValidRequestAuthorizationHeader(certificationOfficerId) };
 
       // when
@@ -46,7 +46,7 @@ describe('PATCH /api/jury/sessions/:id/certification-officer-assignment', () => 
 
       it('should return a 400 error code', async () => {
         // given
-        options.url = '/api/jury/sessions/test/certification-officer-assignment';
+        options.url = '/api/admin/sessions/test/certification-officer-assignment';
 
         // when
         const response = await server.inject(options);
@@ -62,7 +62,7 @@ describe('PATCH /api/jury/sessions/:id/certification-officer-assignment', () => 
 
         it('should return a 404 error code', async () => {
           // given
-          options.url = '/api/jury/sessions/1/certification-officer-assignment';
+          options.url = '/api/admin/sessions/1/certification-officer-assignment';
 
           // when
           const response = await server.inject(options);
@@ -83,7 +83,7 @@ describe('PATCH /api/jury/sessions/:id/certification-officer-assignment', () => 
 
         it('should return a 200 status code', async () => {
           // given
-          options.url = `/api/jury/sessions/${sessionId}/certification-officer-assignment`;
+          options.url = `/api/admin/sessions/${sessionId}/certification-officer-assignment`;
 
           // when
           const response = await server.inject(options);

--- a/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
+++ b/api/tests/acceptance/application/session/session-controller-put-results-sent-to-prescriber_test.js
@@ -3,7 +3,7 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 
-describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
+describe('PUT /api/admin/sessions/:id/results-sent-to-prescriber', () => {
   let server;
   const options = { method: 'PUT' };
   let userId;
@@ -21,7 +21,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
     it('should return a 403 error code', async () => {
       // given
-      options.url = '/api/jury/sessions/12/results-sent-to-prescriber';
+      options.url = '/api/admin/sessions/12/results-sent-to-prescriber';
       options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
 
       // when
@@ -46,7 +46,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
       it('should return a 400 error code', async () => {
         // given
-        options.url = '/api/jury/sessions/any/results-sent-to-prescriber';
+        options.url = '/api/admin/sessions/any/results-sent-to-prescriber';
 
         // when
         const response = await server.inject(options);
@@ -62,7 +62,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
         it('should return a 404 error code', async () => {
           // given
-          options.url = '/api/jury/sessions/1/results-sent-to-prescriber';
+          options.url = '/api/admin/sessions/1/results-sent-to-prescriber';
 
           // when
           const response = await server.inject(options);
@@ -87,7 +87,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
           it('should return a 200 status code', async () => {
             // given
-            options.url = `/api/jury/sessions/${sessionId}/results-sent-to-prescriber`;
+            options.url = `/api/admin/sessions/${sessionId}/results-sent-to-prescriber`;
 
             // when
             const response = await server.inject(options);
@@ -98,7 +98,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
           it('should return the serialized session with an untouched resultsSentToPrescriberAt date', async () => {
             // given
-            options.url = `/api/jury/sessions/${sessionId}/results-sent-to-prescriber`;
+            options.url = `/api/admin/sessions/${sessionId}/results-sent-to-prescriber`;
 
             // when
             const response = await server.inject(options);
@@ -119,7 +119,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
           it('should return a 201 status code', async () => {
             // given
-            options.url = `/api/jury/sessions/${sessionId}/results-sent-to-prescriber`;
+            options.url = `/api/admin/sessions/${sessionId}/results-sent-to-prescriber`;
 
             // when
             const response = await server.inject(options);
@@ -130,7 +130,7 @@ describe('PUT /api/jury/sessions/:id/results-sent-to-prescriber', () => {
 
           it('should return the serialized session with a defined resultsSentToPrescriberAt date', async () => {
             // given
-            options.url = `/api/jury/sessions/${sessionId}/results-sent-to-prescriber`;
+            options.url = `/api/admin/sessions/${sessionId}/results-sent-to-prescriber`;
 
             // when
             const response = await server.inject(options);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -44,18 +44,18 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
-  describe('GET /api/jury/sessions/{id}', () => {
+  describe('GET /api/admin/sessions/{id}', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/jury/sessions/123' });
+      const res = await server.inject({ method: 'GET', url: '/api/admin/sessions/123' });
       expect(res.statusCode).to.equal(200);
     });
   });
 
-  describe('GET /api/jury/sessions', () => {
+  describe('GET /api/admin/sessions', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/jury/sessions' });
+      const res = await server.inject({ method: 'GET', url: '/api/admin/sessions' });
       expect(res.statusCode).to.equal(200);
     });
   });
@@ -225,8 +225,8 @@ describe('Unit | Application | Sessions | Routes', () => {
     [
       { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut' } },
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999' } },
-      { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/jury/sessions/salut' } },
-      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/jury/sessions/9999999999' } },
+      { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/admin/sessions/salut' } },
+      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/admin/sessions/9999999999' } },
       { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/sessions/salut/attendance-sheet' } },
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/sessions/9999999999/attendance-sheet' } },
       { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/sessions/salut' } },

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -197,26 +197,26 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
-  describe('PATCH /api/jury/sessions/{id}/publication', () => {
+  describe('PATCH /api/admin/sessions/{id}/publication', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'PATCH', url: '/api/jury/sessions/1/publication', payload: { data: { attributes: { toPublish: true } } } });
+      const res = await server.inject({ method: 'PATCH', url: '/api/admin/sessions/1/publication', payload: { data: { attributes: { toPublish: true } } } });
       expect(res.statusCode).to.equal(200);
     });
   });
 
-  describe('PUT /api/jury/sessions/{id}/results-sent-to-prescriber', () => {
+  describe('PUT /api/admin/sessions/{id}/results-sent-to-prescriber', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'PUT', url: '/api/jury/sessions/3/results-sent-to-prescriber' });
+      const res = await server.inject({ method: 'PUT', url: '/api/admin/sessions/3/results-sent-to-prescriber' });
       expect(res.statusCode).to.equal(200);
     });
   });
 
-  describe('PATCH /api/jury/sessions/{id}/certification-officer-assignment', () => {
+  describe('PATCH /api/admin/sessions/{id}/certification-officer-assignment', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'PATCH', url: '/api/jury/sessions/1/certification-officer-assignment' });
+      const res = await server.inject({ method: 'PATCH', url: '/api/admin/sessions/1/certification-officer-assignment' });
       expect(res.statusCode).to.equal(200);
     });
   });
@@ -245,12 +245,12 @@ describe('Unit | Application | Sessions | Routes', () => {
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'POST', url: '/api/sessions/9999999999/candidate-participation' } },
       { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/sessions/salut/finalization' } },
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PUT', url: '/api/sessions/9999999999/finalization' } },
-      { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/jury/sessions/salut/publication', payload: { data: { attributes: { toPublish: true } } } } },
-      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/jury/sessions/9999999999/publication', payload: { data: { attributes: { toPublish: true } } } } },
-      { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/jury/sessions/salut/results-sent-to-prescriber' } },
-      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PUT', url: '/api/jury/sessions/9999999999/results-sent-to-prescriber' } },
-      { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/jury/sessions/salut/certification-officer-assignment' } },
-      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/jury/sessions/9999999999/certification-officer-assignment' } },
+      { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/admin/sessions/salut/publication', payload: { data: { attributes: { toPublish: true } } } } },
+      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/admin/sessions/9999999999/publication', payload: { data: { attributes: { toPublish: true } } } } },
+      { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/admin/sessions/salut/results-sent-to-prescriber' } },
+      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PUT', url: '/api/admin/sessions/9999999999/results-sent-to-prescriber' } },
+      { condition: 'session ID params is not a number', request: { method: 'PATCH', url: '/api/admin/sessions/salut/certification-officer-assignment' } },
+      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'PATCH', url: '/api/admin/sessions/9999999999/certification-officer-assignment' } },
     ].forEach(({ condition, request }) => {
       it(`should return 400 when ${condition}`, async () => {
         const res = await server.inject(request);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -173,10 +173,10 @@ describe('Unit | Application | Sessions | Routes', () => {
     });
   });
 
-  describe('GET /api/jury/sessions/{id}/jury-certification-summaries', () => {
+  describe('GET /api/admin/sessions/{id}/jury-certification-summaries', () => {
 
     it('should exist', async () => {
-      const res = await server.inject({ method: 'GET', url: '/api/jury/sessions/1/jury-certification-summaries' });
+      const res = await server.inject({ method: 'GET', url: '/api/admin/sessions/1/jury-certification-summaries' });
       expect(res.statusCode).to.equal(200);
     });
   });
@@ -239,8 +239,8 @@ describe('Unit | Application | Sessions | Routes', () => {
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'DELETE', url: '/api/sessions/9999999999/certification-candidates/1' } },
       { condition: 'certification candidate ID params is not a number', request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/salut' } },
       { condition: 'certification candidate ID params is out of range for database integer (> 2147483647)', request: { method: 'DELETE', url: '/api/sessions/1/certification-candidates/9999999999' } },
-      { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/jury/sessions/salut/jury-certification-summaries' } },
-      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/jury/sessions/9999999999/jury-certification-summaries' } },
+      { condition: 'session ID params is not a number', request: { method: 'GET', url: '/api/admin/sessions/salut/jury-certification-summaries' } },
+      { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'GET', url: '/api/admin/sessions/9999999999/jury-certification-summaries' } },
       { condition: 'session ID params is not a number', request: { method: 'POST', url: '/api/sessions/salut/candidate-participation' } },
       { condition: 'session ID params is out of range for database integer (> 2147483647)', request: { method: 'POST', url: '/api/sessions/9999999999/candidate-participation' } },
       { condition: 'session ID params is not a number', request: { method: 'PUT', url: '/api/sessions/salut/finalization' } },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -51,7 +51,7 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
           relationships: {
             'jury-certification-summaries': {
               links: {
-                related: '/api/jury/sessions/1/jury-certification-summaries',
+                related: '/api/admin/sessions/1/jury-certification-summaries',
               },
             },
           },


### PR DESCRIPTION
## :unicorn: Problème
Il y a plusieurs mois, lors de la création de routes à destinations du pôle certif, la team certif (dev) avions décider de pré-fixer ces routes là par `api/jury`. 
Aujourd'hui nous avons décidé de mettre le préfixe `api/admin` pour les routes qui concernent les administrateurs de pix (pôle certif compris). Voir discussion : https://1024pix.slack.com/archives/C011L9DJNKH/p1601457435002300 
Notre premier préfixe `jury` porte donc à confusion, il devrait être remplacé avec `admin`.

## :robot: Solution
Remplacer toutes les routes avec le préfixe `api/jury` par `api/admin`

## :rainbow: Remarques
Les routes qui ont été impactées :
```
GET /admin/sessions
GET /admin/sessions/:id
GET /admin/sessions/:id/jury-certification-summaries
PUT /admin/sessions/:id/results-sent-to-prescriber
PATCH /admin/sessions/:id/publication
PATCH /admin/sessions/:id/certification-officer-assignment
```

## :100: Pour tester
- aller sur pixadmin
- aller dans la liste des sessions
- cliquer sur une session
- télécharger le fichier avant jury + résultat : vérifier que tout vas bien
- s'assigner une session : vérifier que le nom de l’utilisateur apparaisse en haut à droite du détail de la session
- publier des résultats d'une session : constater qu'ils se sont bien publié (sur mon-pix ou directement en base)
