### PR TITLE
[TECH] Ajouter une validation front lors de l'ajout de candidat [PIX-1362]

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -2,51 +2,70 @@
   <td data-test-id='panel-candidate__lastName__add-staging'>
     <div class="certification-candidates-input-wrapper">
       <input
+        type="text"
+        required
         value="{{@candidateData.lastName}}"
-        class="certification-candidates-input"
+        class="certification-candidates-input {{if this.lastNameFocused 'focused'}}"
+        {{on 'focus' this.focusLastName}}
         {{on 'input' (fn @updateCandidateData @candidateData 'lastName')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__firstName__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.firstName}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'firstName')}} >
+      <input
+        type="text"
+        required
+        value="{{@candidateData.firstName}}"
+        class="certification-candidates-input {{if this.firstNameFocused 'focused'}}"
+        {{on 'focus' this.focusFirstName}}
+        {{on 'input' (fn @updateCandidateData @candidateData 'firstName')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__birthdate__add-staging'>
-      <div class="certification-candidates-input-wrapper">
-        <OneWayDateMask
-            @placeholder='dd/mm/yyyy'
-            @options={{hash inputFormat='dd/mm/yyyy' outputFormat='yyyy-mm-dd'}}
-            @class='certification-candidates-input'
-            @update={{this.updateCandidateDataBirthdate}}>
-        </OneWayDateMask>
-      </div>
+    <div class="certification-candidates-input-wrapper">
+      <OneWayDateMask
+          required
+          pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}"
+          @placeholder='dd/mm/yyyy'
+          @options={{hash inputFormat='dd/mm/yyyy' outputFormat='yyyy-mm-dd'}}
+          @class="certification-candidates-input {{if this.birthdateFocused 'focused'}}"
+          {{on 'focus' this.focusBirthdate}}
+          @update={{this.updateCandidateDataBirthdate}}>
+      </OneWayDateMask>
+    </div>
   </td>
   <td data-test-id='panel-candidate__birthCity__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.birthCity}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'birthCity')}} >
+      <input
+        type="text"
+        required
+        value="{{@candidateData.birthCity}}"
+        class="certification-candidates-input {{if this.birthCityFocused 'focused'}}"
+        {{on 'focus' this.focusBirthCity}}
+        {{on 'input' (fn @updateCandidateData @candidateData 'birthCity')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__birthProvinceCode__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.birthProvinceCode}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'birthProvinceCode')}} >
+      <input
+        pattern="{{birthProvinceCodePattern}}"
+        required
+        title="Exemples: 75 pour Paris, 972 pour la Martinique, 2A pour la Corse-du-Sud... Veuillez mettre 99 si le pays de naissance n'est pas la France."
+        value="{{@candidateData.birthProvinceCode}}"
+        class="certification-candidates-input {{if this.birthProvinceCodeFocused 'focused'}}"
+        {{on 'focus' this.focusBirthProvinceCode}}
+        {{on 'input' (fn @updateCandidateData @candidateData 'birthProvinceCode')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__birthCountry__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.birthCountry}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'birthCountry')}} >
+      <input
+        type="text"
+        required
+        {{on 'focus' this.focusBirthCountry}}
+        value="{{@candidateData.birthCountry}}"
+        class="certification-candidates-input {{if this.birthCountryFocused 'focused'}}"
+        {{on 'input' (fn @updateCandidateData @candidateData 'birthCountry')}} >
     </div>
   </td>
   {{#if this.isResultRecipientEmailVisible}}
@@ -62,26 +81,29 @@
   {{/if}}
   <td data-test-id='panel-candidate__email__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.email}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'email')}} >
+      <input
+        type="email"
+        value="{{@candidateData.email}}"
+        class="certification-candidates-input"
+        {{on 'input' (fn @updateCandidateData @candidateData 'email')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__externalId__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.externalId}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'externalId')}} >
+      <input
+        type="text"
+        value="{{@candidateData.externalId}}"
+        class="certification-candidates-input"
+        {{on 'input' (fn @updateCandidateData @candidateData 'externalId')}} >
     </div>
   </td>
   <td data-test-id='panel-candidate__extraTimePercentage__add-staging'>
     <div class="certification-candidates-input-wrapper">
-        <input
-          value="{{@candidateData.extraTimePercentage}}"
-          class="certification-candidates-input"
-          {{on 'input' (fn @updateCandidateData @candidateData 'extraTimePercentage')}} >
+      <input
+        type="text"
+        value="{{@candidateData.extraTimePercentage}}"
+        class="certification-candidates-input"
+        {{on 'input' (fn @updateCandidateData @candidateData 'extraTimePercentage')}} >
       <span class="certification-candidates-percentage">
         %
       </span>
@@ -89,27 +111,19 @@
   </td>
   <td>
     <div class="certification-candidates-input-wrapper certification-candidates-row-actions">
-{{#if (and
-        @candidateData.firstName
-        @candidateData.lastName
-        (is-after @candidateData.birthdate '1900-01-01')
-        @candidateData.birthCity
-        @candidateData.birthProvinceCode
-        @candidateData.birthCountry
-        )}}
-          <button data-test-id='panel-candidate__action__save' class="button button--row-item" type="button" {{on "click" (fn @onClickSave @candidateData)}}>
-              Enregistrer
-          </button>
-      {{else}}
-          <button data-test-id='panel-candidate__action__save' class="button button--row-item button--disabled" type="button" disabled="true">
-              Enregistrer
-          </button>
-      {{/if}}
-        <PixActionButton
-          @icon='times'
-          class="certification-candidates-row-actions__close"
-          @triggerAction={{this.cancel}}
-          data-test-id="panel-candidate__action__cancel" />
+      <button data-test-id='panel-candidate__action__save'
+        disabled={{if this.isDisabled true null}}
+        class="button button--row-item {{if this.isDisabled 'button--disabled'}}"
+        type="button"
+        {{on "click" (fn @onClickSave @candidateData)}}
+      >
+          Enregistrer
+      </button>
+      <PixActionButton
+        @icon='times'
+        class="certification-candidates-row-actions__close"
+        @triggerAction={{this.cancel}}
+        data-test-id="panel-candidate__action__cancel" />
     </div>
   </td>
 </tr>

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -1,10 +1,83 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { computed } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
 import config from 'pix-certif/config/environment';
+
+const firstOf20thCentury = -2206310961000;
 
 export default class CertificationCandidateInStagingItem extends Component {
 
   isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+
+  birthProvinceCodePattern = '^[0-9][A,a,B,b,0-9][0-9]?$'
+
+  @tracked
+  lastNameFocused = false;
+
+  @tracked
+  firstNameFocused = false;
+
+  @tracked
+  birthdateFocused = false;
+
+  @tracked
+  birthCityFocused = false;
+
+  @tracked
+  birthProvinceCodeFocused = false;
+
+  @tracked
+  birthCountryFocused = false;
+
+  @computed(
+    'args.candidateData.{birthCity,birthCountry,birthProvinceCode,birthdate,firstName,lastName}', 'birthProvinceCodePattern', 'isValidBirthdate',
+  )
+  get isDisabled() {
+    return !(this.args.candidateData.lastName
+      && this.args.candidateData.firstName
+      && this.isValidBirthdate
+      && this.args.candidateData.birthCity
+      && new RegExp(this.birthProvinceCodePattern).test(this.args.candidateData.birthProvinceCode)
+      && this.args.candidateData.birthCountry);
+  }
+
+  get isValidBirthdate() {
+    const [year, month, day] = this.args.candidateData.birthdate.split('-');
+    const inputDate = new Date(year, month, day).getTime();
+    return inputDate > firstOf20thCentury;
+  }
+
+  @action
+  focusLastName() {
+    this.lastNameFocused = true;
+  }
+
+  @action
+  focusFirstName() {
+    this.firstNameFocused = true;
+  }
+
+  @action
+  focusBirthdate() {
+    this.birthdateFocused = true;
+  }
+
+  @action
+  focusBirthCity() {
+    this.birthCityFocused = true;
+  }
+
+  @action
+  focusBirthProvinceCode() {
+    this.birthProvinceCodeFocused = true;
+  }
+
+  @action
+  focusBirthCountry() {
+    this.birthCountryFocused = true;
+  }
 
   @action
   updateCandidateDataBirthdate(value) {

--- a/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
+++ b/certif/app/styles/pages/authenticated/sessions/details/certification-candidates.scss
@@ -139,6 +139,12 @@
   align-items: center;
 }
 
+.certification-candidates-input-wrapper input {
+  &:required.focused:not(:focus):invalid, &:not(:required):not(:focus):invalid {
+    border: 2px solid $error;
+  }
+}
+
 .certification-candidates-input {
   background: $grey-5;
   border-radius: 4px;

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -15,6 +15,13 @@ module('Acceptance | Session Candidates', function(hooks) {
   let user;
   let session;
 
+  const validLastName = 'MonNom';
+  const validFirstName = 'MonPrenom';
+  const validBirthCity = 'MaVille';
+  const validBirthProvinceCode = '974';
+  const validBirthCountry = 'MonPays';
+  const validBirthdate = '01021990';
+
   hooks.beforeEach(function() {
     user = createUserWithMembershipAndTermsOfServiceAccepted();
     const certificationCenterId = user.certificationCenterMemberships.models[0].certificationCenterId;
@@ -101,12 +108,7 @@ module('Acceptance | Session Candidates', function(hooks) {
             }), 400);
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await fillIn('[data-test-id="panel-candidate__lastName__add-staging"] > div > input', 'MonNom');
-            await fillIn('[data-test-id="panel-candidate__firstName__add-staging"] > div > input', 'MonPrenom');
-            await fillIn('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input', 'MaVille');
-            await fillIn('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input', 'MonDép');
-            await fillIn('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input', 'MonPays');
-            await fillIn('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input', '01021990');
+            await _fillFormWithCorrectData();
             await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
@@ -119,16 +121,10 @@ module('Acceptance | Session Candidates', function(hooks) {
             }), 400);
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await fillIn('[data-test-id="panel-candidate__lastName__add-staging"] > div > input', 'MonNom');
-            await fillIn('[data-test-id="panel-candidate__firstName__add-staging"] > div > input', 'MonPrenom');
-            await fillIn('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input', 'MaVille');
-            await fillIn('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input', 'MonDép');
-            await fillIn('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input', 'MonPays');
-            await fillIn('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input', '01021990');
+            await _fillFormWithCorrectData();
             await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
-            assert.dom('[data-test-notification-message="error"]').exists();
             assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat.');
           });
         });
@@ -138,12 +134,7 @@ module('Acceptance | Session Candidates', function(hooks) {
           test('it remove the editable line', async function(assert) {
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await fillIn('[data-test-id="panel-candidate__lastName__add-staging"] > div > input', 'MonNom');
-            await fillIn('[data-test-id="panel-candidate__firstName__add-staging"] > div > input', 'MonPrenom');
-            await fillIn('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input', 'MaVille');
-            await fillIn('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input', 'MonDép');
-            await fillIn('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input', 'MonPays');
-            await fillIn('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input', '01021990');
+            await _fillFormWithCorrectData();
             await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
@@ -153,28 +144,17 @@ module('Acceptance | Session Candidates', function(hooks) {
           test('it should display notification success', async function(assert) {
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await fillIn('[data-test-id="panel-candidate__lastName__add-staging"] > div > input', 'MonNom');
-            await fillIn('[data-test-id="panel-candidate__firstName__add-staging"] > div > input', 'MonPrenom');
-            await fillIn('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input', 'MaVille');
-            await fillIn('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input', 'MonDép');
-            await fillIn('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input', 'MonPays');
-            await fillIn('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input', '01021990');
+            await _fillFormWithCorrectData();
             await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
-            assert.dom('[data-test-notification-message="success"]').exists();
             assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
           });
 
           test('it should add a new candidate entry', async function(assert) {
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await fillIn('[data-test-id="panel-candidate__lastName__add-staging"] > div > input', 'MonNom');
-            await fillIn('[data-test-id="panel-candidate__firstName__add-staging"] > div > input', 'MonPrenom');
-            await fillIn('[data-test-id="panel-candidate__birthCity__add-staging"] > div > input', 'MaVille');
-            await fillIn('[data-test-id="panel-candidate__birthProvinceCode__add-staging"] > div > input', 'MonDép');
-            await fillIn('[data-test-id="panel-candidate__birthCountry__add-staging"] > div > input', 'MonPays');
-            await fillIn('[data-test-id="panel-candidate__birthdate__add-staging"] > div > input', '01021990');
+            await _fillFormWithCorrectData();
             await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
@@ -231,7 +211,6 @@ module('Acceptance | Session Candidates', function(hooks) {
         await upload('#upload-attendance-sheet', file);
 
         // then
-        assert.dom('[data-test-notification-message="success"]').exists();
         assert.dom('[data-test-notification-message="success"]').hasText('La liste des candidats a été importée avec succès.');
       });
 
@@ -244,7 +223,6 @@ module('Acceptance | Session Candidates', function(hooks) {
         await upload('#upload-attendance-sheet', file);
 
         // then
-        assert.dom('[data-test-notification-message="error"]').exists();
         assert.dom('[data-test-notification-message="error"]').hasText('Aucun candidat n’a été importé. Une erreur personnalisée Veuillez modifier votre fichier et l’importer à nouveau.');
       });
 
@@ -257,7 +235,6 @@ module('Acceptance | Session Candidates', function(hooks) {
         await upload('#upload-attendance-sheet', file);
 
         // then
-        assert.dom('[data-test-notification-message="error"]').exists();
         assert.dom('[data-test-notification-message="error"]')
           .hasText('La session a débuté, il n\'est plus possible de modifier la liste des candidats.');
       });
@@ -265,5 +242,18 @@ module('Acceptance | Session Candidates', function(hooks) {
     });
 
   });
+
+  async function _fillFormWithCorrectData() {
+    await _fillCandidateInput('lastName', validLastName);
+    await _fillCandidateInput('firstName', validFirstName);
+    await _fillCandidateInput('birthCity', validBirthCity);
+    await _fillCandidateInput('birthProvinceCode', validBirthProvinceCode);
+    await _fillCandidateInput('birthCountry', validBirthCountry);
+    await _fillCandidateInput('birthdate', validBirthdate);
+  }
+
+  async function _fillCandidateInput(code, value) {
+    await fillIn(`[data-test-id="panel-candidate__${code}__add-staging"] > div > input`, value);
+  }
 
 });

--- a/certif/tests/integration/components/certification-candidate-in-staging-item-test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item-test.js
@@ -5,6 +5,15 @@ import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
+async function renderComponent() {
+  await render(hbs`<CertificationCandidateInStagingItem
+                @candidateData={{this.candidateInStaging}}
+                @onClickSave={{this.saveStub}}
+                @onClickCancel={{this.cancelStub}}
+                @updateCandidateBirthdate={{this.updateBirthdateStub}}
+                @updateCandidateData={{this.updateDataStub}} />`);
+}
+
 module('Integration | Component | certification-candidate-in-staging-item', function(hooks) {
   setupRenderingTest(hooks);
 
@@ -28,16 +37,13 @@ module('Integration | Component | certification-candidate-in-staging-item', func
     this.set('cancelStub', cancelStub);
     this.set('updateBirthdateStub', updateBirthdateStub);
     this.set('updateDataStub', updateDataStub);
-
-    await render(hbs`<CertificationCandidateInStagingItem
-                @candidateData={{this.candidateInStaging}}
-                @onClickSave={{this.saveStub}}
-                @onClickCancel={{this.cancelStub}} 
-                @updateCandidateBirthdate={{this.updateBirthdateStub}} 
-                @updateCandidateData={{this.updateDataStub}} />`);
   });
 
   test('it renders', async function(assert) {
+    // when
+    await renderComponent();
+
+    // then
     assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').exists();
     assert.dom('[data-test-id="panel-candidate__firstName__add-staging"]').exists();
     assert.dom('[data-test-id="panel-candidate__birthCity__add-staging"]').exists();
@@ -52,36 +58,77 @@ module('Integration | Component | certification-candidate-in-staging-item', func
   });
 
   test('it render a disabled saved button', async function(assert) {
+    // when
+    await renderComponent();
+
+    // then
     assert.dom('[data-test-id="panel-candidate__action__save"]').exists();
     assert.dom('[data-test-id="panel-candidate__action__save"]').isDisabled();
   });
 
   test('it calls appropriate method when cancel clicked', async function(assert) {
+    // when
+    await renderComponent();
     await click('[data-test-id="panel-candidate__action__cancel"]');
 
+    // then
     assert.equal(cancelStub.calledWith(candidateInStaging), true);
   });
 
-  module('when filling the line with sufficient data', function(hooks) {
+  module('when filling the line with sufficient correct data', function(hooks) {
     hooks.beforeEach(async () => {
       candidateInStaging.set('firstName', 'Salut');
       candidateInStaging.set('lastName', 'Salut');
       candidateInStaging.set('birthCity', 'Salut');
-      candidateInStaging.set('birthProvinceCode', 'Salut');
+      candidateInStaging.set('birthProvinceCode', 974);
       candidateInStaging.set('birthCountry', 'Salut');
       candidateInStaging.set('birthdate', '1990-01-04');
     });
 
     test('it render a clickable save button', async function(assert) {
+      // when
+      await renderComponent();
+
+      // then
       assert.dom('[data-test-id="panel-candidate__action__save"]').isNotDisabled();
     });
 
     test('it calls appropriate method when save clicked', async function(assert) {
+      // when
+      await renderComponent();
       await click('[data-test-id="panel-candidate__action__save"]');
 
+      // then
       assert.equal(saveStub.calledWith(candidateInStaging), true);
     });
 
+  });
+
+  module('when filling the line with incorrect ', function(hooks) {
+    hooks.beforeEach(async () => {
+      candidateInStaging.set('firstName', 'Salut');
+      candidateInStaging.set('lastName', 'Salut');
+      candidateInStaging.set('birthCity', 'Salut');
+      candidateInStaging.set('birthProvinceCode', 974);
+      candidateInStaging.set('birthCountry', 'Salut');
+      candidateInStaging.set('birthdate', '1990-01-04');
+    });
+
+    [
+      { name: 'birthProvinceCode', value: 'AAAAA' },
+      { name: 'birthdate', value: '1899-12-30' },
+    ].forEach(({ name, value }) =>
+      test(`${name} it disable the save button`, async function(assert) {
+        // given
+        candidateInStaging.set(name, value);
+
+        // when
+        await renderComponent();
+
+        // then
+        assert.dom('[data-test-id="panel-candidate__action__save"]').isDisabled();
+      }),
+    );
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a aucune validation front lors de l'ajout d'un candidat de certification.
Cela peut causer une incompréhension pour l'utilisateur qui peut "enregistrer" son candidat et voir une erreur générale apparaître car il a mal rempli un champ.

## :robot: Solution
Ajouter une validation côté front. A la sortie du champ ajouter une coloration sur la bordure si le champ est mal rempli.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur certif `certifsco@example.net`
- Cliquer sur une session
- Aller dans l'onglet candidats
- Ajouter un candidat
- Mal remplir le champ "email" et constater qu'il s'encadre de rouge à la sortie du champ
