### PR TITLE
[FEATURE] Amélioration des choix d'épreuves (PIX-1345).

### DIFF
--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -9,18 +9,19 @@ module.exports = {
     if (skills.length === 0) {
       return UNEXISTING_ITEM;
     }
-    const key = Math.abs(hashInt(randomSeed));
-    const chosenSkill = skills[key % skills.length];
+    const keyForSkill = Math.abs(hashInt(randomSeed));
+    const keyForChallenge = Math.abs(hashInt(randomSeed + 1));
+    const chosenSkill = skills[keyForSkill % skills.length];
 
-    return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, key)
-        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_SPOKEN, key)
-        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_FRANCE, key);
+    return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge)
+        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_SPOKEN, keyForChallenge)
+        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_FRANCE, keyForChallenge);
   },
 };
 
 function _pickLocaleChallengeAtIndex(challenges, locale, index) {
   const localeChallenges = _.filter(challenges, ((challenge) => _.includes(challenge.locales, locale)));
-  const possibleChallenges = _findPreferablyValidatedChallenges(localeChallenges, locale)
+  const possibleChallenges = _findPreferablyValidatedChallenges(localeChallenges, locale);
   return _.isEmpty(possibleChallenges) ? null : _pickChallengeAtIndex(possibleChallenges, index);
 }
 

--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const hashInt = require('hash-int');
 const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../constants').LOCALE;
 const UNEXISTING_ITEM = null;
+const VALIDATED_STATUSES = ['validé', 'validé sans test', 'pré-validé'];
 
 module.exports = {
   pickChallenge({ skills, randomSeed, locale }) {
@@ -19,10 +20,15 @@ module.exports = {
 
 function _pickLocaleChallengeAtIndex(challenges, locale, index) {
   const localeChallenges = _.filter(challenges, ((challenge) => _.includes(challenge.locales, locale)));
-  const challenge = _.isEmpty(localeChallenges) ? null : _pickChallengeAtIndex(localeChallenges, index);
-  return challenge;
+  const possibleChallenges = _findPreferablyValidatedChallenges(localeChallenges, locale)
+  return _.isEmpty(possibleChallenges) ? null : _pickChallengeAtIndex(possibleChallenges, index);
 }
 
 function _pickChallengeAtIndex(challenges, index) {
   return challenges[index % challenges.length];
+}
+
+function _findPreferablyValidatedChallenges(localeChallenges) {
+  const validatedChallenges = _.filter(localeChallenges, ((challenge) => _.includes(VALIDATED_STATUSES, challenge.status)));
+  return validatedChallenges.length > 0 ? validatedChallenges : localeChallenges;
 }

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -10,6 +10,9 @@ describe('Unit | Service | PickChallengeService', () => {
     const frenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
     const otherFrenchSpokenChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_SPOKEN] });
     const frenchChallenge = domainBuilder.buildChallenge({ locales: [FRENCH_FRANCE] });
+    const validatedChallenge = domainBuilder.buildChallenge({ status: 'validé' });
+    const archivedChallenge = domainBuilder.buildChallenge({ status: 'archivé' });
+
     const randomSeed = 'some-random-seed';
 
     context('when challenge in selected locale exists', () => {
@@ -47,7 +50,25 @@ describe('Unit | Service | PickChallengeService', () => {
         expect(challenges).to.not.contains(frenchChallenge);
       });
 
-      context('when no challenge in selected locale', () => {
+    });
+
+    context('when challenge in selected locale does not exists', () => {
+
+      it('should return challenge in other locale', async () => {
+        // given
+        const skills = [{ challenges: [frenchChallenge] }];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: FRENCH_SPOKEN,
+        });
+
+        // then
+        expect(challenge).to.equal(frenchChallenge);
+      });
+      context('when no challenge in selected non-french locale', () => {
         it('should return FR challenge', async () => {
           // given
           const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
@@ -80,24 +101,6 @@ describe('Unit | Service | PickChallengeService', () => {
           });
         });
       });
-    });
-
-    context('when challenge in selected locale does not exists', () => {
-
-      it('should return challenge in other locale', async () => {
-        // given
-        const skills = [{ challenges: [frenchChallenge] }];
-
-        // when
-        const challenge = await pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN,
-        });
-
-        // then
-        expect(challenge).to.equal(frenchChallenge);
-      });
 
     });
 
@@ -118,6 +121,40 @@ describe('Unit | Service | PickChallengeService', () => {
         expect(challenge).to.be.null;
       });
 
+    });
+
+    context('when skills have validated and archived challenges', () => {
+      it('should return validated challenge', async () => {
+        // given
+        const skills = [{ challenges: [archivedChallenge, validatedChallenge] }];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: FRENCH_FRANCE,
+        });
+
+        // then
+        expect(challenge).to.equal(validatedChallenge);
+      });
+    });
+
+    context('when skills only have archived challenges', () => {
+      it('should return archived challenge', async () => {
+        // given
+        const skills = [{ challenges: [archivedChallenge] }];
+
+        // when
+        const challenge = await pickChallengeService.pickChallenge({
+          skills,
+          randomSeed,
+          locale: FRENCH_FRANCE,
+        });
+
+        // then
+        expect(challenge).to.equal(archivedChallenge);
+      });
     });
 
   });

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -157,6 +157,31 @@ describe('Unit | Service | PickChallengeService', () => {
       });
     });
 
+    context('when picking a lot of challenges', () => {
+      it('should return all challenges propose', async ()=> {
+        // given
+        const challengeOneForSkillOne = domainBuilder.buildChallenge();
+        const challengeTwoForSkillOne = domainBuilder.buildChallenge();
+        const challengeOneForSkillTwo = domainBuilder.buildChallenge();
+        const challengeTwoForSkillTwo = domainBuilder.buildChallenge();
+        const skillOne = { challenges: [challengeOneForSkillOne, challengeTwoForSkillOne] };
+        const skillTwo = { challenges: [challengeOneForSkillTwo, challengeTwoForSkillTwo] };
+        const skills = [skillOne, skillTwo];
+
+        const pickChallengePromises = _.times(50, (time) => pickChallengeService.pickChallenge({
+          skills,
+          randomSeed: time,
+          locale: FRENCH_SPOKEN,
+        }));
+        const challenges = await Promise.all(pickChallengePromises);
+
+        // then
+        expect(challenges).to.contains(challengeOneForSkillOne);
+        expect(challenges).to.contains(challengeTwoForSkillOne);
+        expect(challenges).to.contains(challengeOneForSkillTwo);
+        expect(challenges).to.contains(challengeTwoForSkillTwo);
+      });
+    });
   });
 })
 ;

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -17,12 +17,12 @@ describe('Unit | Service | PickChallengeService', () => {
 
     context('when challenge in selected locale exists', () => {
 
-      it('should return challenge in selected locale', async () => {
+      it('should return challenge in selected locale', () => {
         // given
         const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, englishSpokenChallenge] }];
 
         // when
-        const challenge = await pickChallengeService.pickChallenge({
+        const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: ENGLISH_SPOKEN,
@@ -32,17 +32,16 @@ describe('Unit | Service | PickChallengeService', () => {
         expect(challenge).to.equal(englishSpokenChallenge);
       });
 
-      it('should always return the same challenge in selected locale', async () => {
+      it('should always return the same challenge in selected locale', () => {
         // given
         const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge, otherFrenchSpokenChallenge] }];
 
         // when
-        const pickChallengePromises = _.times(5, () => pickChallengeService.pickChallenge({
+        const challenges = _.times(5, () => pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: FRENCH_SPOKEN,
         }));
-        const challenges = await Promise.all(pickChallengePromises);
 
         // then
         expect(challenges).to.contains(frenchSpokenChallenge);
@@ -52,14 +51,14 @@ describe('Unit | Service | PickChallengeService', () => {
 
     });
 
-    context('when challenge in selected locale does not exists', () => {
+    context('when challenge in selected locale does not exist', () => {
 
-      it('should return challenge in other locale', async () => {
+      it('should return challenge in other locale', () => {
         // given
         const skills = [{ challenges: [frenchChallenge] }];
 
         // when
-        const challenge = await pickChallengeService.pickChallenge({
+        const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: FRENCH_SPOKEN,
@@ -69,12 +68,12 @@ describe('Unit | Service | PickChallengeService', () => {
         expect(challenge).to.equal(frenchChallenge);
       });
       context('when no challenge in selected non-french locale', () => {
-        it('should return FR challenge', async () => {
+        it('should return FR challenge', () => {
           // given
           const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
 
           // when
-          const challenge = await pickChallengeService.pickChallenge({
+          const challenge = pickChallengeService.pickChallenge({
             skills,
             randomSeed,
             locale: ENGLISH_SPOKEN,
@@ -85,12 +84,12 @@ describe('Unit | Service | PickChallengeService', () => {
         });
 
         context('and no FR challenge', () => {
-          it('should return FR-FR challenge', async () => {
+          it('should return FR-FR challenge', () => {
             // given
             const skills = [{ challenges: [frenchChallenge] }];
 
             // when
-            const challenge = await pickChallengeService.pickChallenge({
+            const challenge = pickChallengeService.pickChallenge({
               skills,
               randomSeed,
               locale: ENGLISH_SPOKEN,
@@ -106,12 +105,12 @@ describe('Unit | Service | PickChallengeService', () => {
 
     context('when there is no skills', () => {
 
-      it('should return null', async () => {
+      it('should return null', () => {
         // given
         const skills = [];
 
         // when
-        const challenge = await pickChallengeService.pickChallenge({
+        const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: FRENCH_SPOKEN,
@@ -124,12 +123,12 @@ describe('Unit | Service | PickChallengeService', () => {
     });
 
     context('when skills have validated and archived challenges', () => {
-      it('should return validated challenge', async () => {
+      it('should return validated challenge', () => {
         // given
         const skills = [{ challenges: [archivedChallenge, validatedChallenge] }];
 
         // when
-        const challenge = await pickChallengeService.pickChallenge({
+        const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: FRENCH_FRANCE,
@@ -141,12 +140,12 @@ describe('Unit | Service | PickChallengeService', () => {
     });
 
     context('when skills only have archived challenges', () => {
-      it('should return archived challenge', async () => {
+      it('should return archived challenge', () => {
         // given
         const skills = [{ challenges: [archivedChallenge] }];
 
         // when
-        const challenge = await pickChallengeService.pickChallenge({
+        const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
           locale: FRENCH_FRANCE,
@@ -158,7 +157,7 @@ describe('Unit | Service | PickChallengeService', () => {
     });
 
     context('when picking a lot of challenges', () => {
-      it('should return all challenges propose', async ()=> {
+      it('should return all challenges propose', ()=> {
         // given
         const challengeOneForSkillOne = domainBuilder.buildChallenge();
         const challengeTwoForSkillOne = domainBuilder.buildChallenge();
@@ -168,12 +167,11 @@ describe('Unit | Service | PickChallengeService', () => {
         const skillTwo = { challenges: [challengeOneForSkillTwo, challengeTwoForSkillTwo] };
         const skills = [skillOne, skillTwo];
 
-        const pickChallengePromises = _.times(50, (time) => pickChallengeService.pickChallenge({
+        const challenges = _.times(50, (time) => pickChallengeService.pickChallenge({
           skills,
           randomSeed: time,
           locale: FRENCH_SPOKEN,
         }));
-        const challenges = await Promise.all(pickChallengePromises);
 
         // then
         expect(challenges).to.contains(challengeOneForSkillOne);


### PR DESCRIPTION
## :unicorn: Problème
Deux problèmes ont été remontés : 
- En campagne, on peut jouer des épreuves validées ou archivées. S'il y a beaucoup d'épreuves archivées, alors les utilisateurs ne verront pas beaucoup les nouvelles épreuves "validées".
- Les épreuves ne sont pas toutes proposées à part égale. Ce problème a été remonté et expliqué par @jonathanperret 

## :robot: Solution
- Préférer les questions au statut validé s'il y en a
- Changer la façon dont on choisit les challenges, ainsi que l'ajout d'un test qui nous a permis d'observer le problème et de le corriger

## :rainbow: Remarques
- https://1024pix.slack.com/archives/CHF56ALC8/p1600277031174900

## :100: Pour tester