### PR TITLE
[BUGFIX] Déplacement d'acquis mal pris en compte dans l'export CSV des campagnes d'évaluation et dans le calcul du résultat individuel (PIX-1346)

### DIFF
--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -42,6 +42,21 @@ class TargetProfileWithLearningContent {
 
     return area || null;
   }
+
+  groupKnowledgeElementsByCompetence(knowledgeElements) {
+    const knowledgeElementsGroupedByCompetence = {};
+    for (const competenceId of this.competenceIds) {
+      knowledgeElementsGroupedByCompetence[competenceId] = [];
+    }
+    for (const knowledgeElement of knowledgeElements) {
+      const competenceId = this.getCompetenceIdOfSkill(knowledgeElement.skillId);
+      if (competenceId) {
+        knowledgeElementsGroupedByCompetence[competenceId].push(knowledgeElement);
+      }
+    }
+
+    return knowledgeElementsGroupedByCompetence;
+  }
 }
 
 module.exports = TargetProfileWithLearningContent;

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -43,19 +43,23 @@ class TargetProfileWithLearningContent {
     return area || null;
   }
 
-  groupKnowledgeElementsByCompetence(knowledgeElements) {
+  filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements, knowledgeElementFilter = () => true) {
     const knowledgeElementsGroupedByCompetence = {};
     for (const competenceId of this.competenceIds) {
       knowledgeElementsGroupedByCompetence[competenceId] = [];
     }
     for (const knowledgeElement of knowledgeElements) {
       const competenceId = this.getCompetenceIdOfSkill(knowledgeElement.skillId);
-      if (competenceId) {
+      if (competenceId && knowledgeElementFilter(knowledgeElement)) {
         knowledgeElementsGroupedByCompetence[competenceId].push(knowledgeElement);
       }
     }
 
     return knowledgeElementsGroupedByCompetence;
+  }
+
+  filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements) {
+    return this.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements, (knowledgeElement) => knowledgeElement.isValidated);
   }
 }
 

--- a/api/lib/domain/read-models/CampaignAssessmentParticipationCompetenceResult.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipationCompetenceResult.js
@@ -1,5 +1,6 @@
 class CampaignAssessmentParticipationCompetenceResult {
   constructor({
+    targetedArea,
     targetedCompetence,
     targetedSkillsCount,
     validatedTargetedKnowledgeElementsCount,
@@ -7,7 +8,7 @@ class CampaignAssessmentParticipationCompetenceResult {
     this.id = targetedCompetence.id;
     this.name = targetedCompetence.name;
     this.index = targetedCompetence.index;
-    this.areaColor = targetedCompetence.area && targetedCompetence.area.color;
+    this.areaColor = targetedArea.color;
     this.targetedSkillsCount = targetedSkillsCount;
     this.validatedSkillsCount = validatedTargetedKnowledgeElementsCount;
   }

--- a/api/lib/domain/read-models/CampaignAssessmentParticipationResult.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipationResult.js
@@ -17,9 +17,11 @@ class CampaignAssessmentParticipationResult {
     } else {
       this.competenceResults = targetedCompetences
         .map((targetedCompetence) => {
+          const targetedArea = targetProfile.getAreaOfCompetence(targetedCompetence.id);
           return new CampaignAssessmentParticipationCompetenceResult({
+            targetedArea,
             targetedCompetence,
-            targetedSkillsCount: targetProfile.getSkillCountForCompetence(targetedCompetence.id),
+            targetedSkillsCount: targetedCompetence.skillCount,
             validatedTargetedKnowledgeElementsCount : validatedTargetedKnowledgeElementsByCompetenceId[targetedCompetence.id].length,
           });
         });

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -1,13 +1,12 @@
 const CampaignAssessmentParticipationResult = require('../../../lib/domain/read-models/CampaignAssessmentParticipationResult');
 const { NotFoundError } = require('../../../lib/domain/errors');
 const { knex } = require('../bookshelf');
-const competenceRepository = require('./competence-repository');
 const knowledgeElementRepository = require('./knowledge-element-repository');
-const targetProfileRepository = require('./target-profile-repository');
+const targetProfileWithLearningContentRepository = require('./target-profile-with-learning-content-repository');
 
 module.exports = {
   async getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId }) {
-    const targetProfile = await targetProfileRepository.getByCampaignId(campaignId);
+    const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
 
     const result = await _fetchCampaignAssessmentParticipationResultAttributesFromCampaignParticipation(campaignId, campaignParticipationId);
 
@@ -49,13 +48,10 @@ async function _buildCampaignAssessmentParticipationResults(result, targetProfil
     .findValidatedTargetedGroupedByCompetencesForUsers({ [result.userId]: result.sharedAt }, targetProfile);
   const validatedTargetedKnowledgeElementsByCompetenceId = validatedTargetedKnowledgeElementsByUserIdAndCompetenceId[result.userId];
 
-  const competences = await competenceRepository.list();
-  const targetedCompetences = targetProfile.getTargetedCompetences(competences);
-
   return new CampaignAssessmentParticipationResult({
     ...result,
-    targetedCompetences,
-    targetProfile,
+    targetedCompetences: targetProfile.competences,
     validatedTargetedKnowledgeElementsByCompetenceId,
+    targetProfile,
   });
 }

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -58,18 +58,6 @@ async function _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, 
   });
 }
 
-function _filterValidatedTargetedKnowledgeElements(knowledgeElements, targetProfile) {
-  return _.filter(knowledgeElements, (knowledgeElement) => {
-    return knowledgeElement.isValidated && targetProfile.hasSkill(knowledgeElement.skillId);
-  });
-}
-
-function _filterTargetedKnowledgeElements(knowledgeElements, targetProfile) {
-  return _.filter(knowledgeElements, (knowledgeElement) => {
-    return targetProfile.hasSkill(knowledgeElement.skillId);
-  });
-}
-
 async function _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate }) {
   const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
   if (limitDate) {
@@ -174,8 +162,7 @@ module.exports = {
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
-      const validatedTargetedKnowledgeElements = _filterValidatedTargetedKnowledgeElements(knowledgeElements, targetProfile);
-      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.groupKnowledgeElementsByCompetence(validatedTargetedKnowledgeElements);
+      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
     }
 
     return knowledgeElementsGroupedByUserAndCompetence;
@@ -186,8 +173,7 @@ module.exports = {
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
-      const targetedKnowledgeElements = _filterTargetedKnowledgeElements(knowledgeElements, targetProfile);
-      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.groupKnowledgeElementsByCompetence(targetedKnowledgeElements);
+      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
     }
 
     return knowledgeElementsGroupedByUserAndCompetence;

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -173,7 +173,7 @@ module.exports = {
     const knowledgeElementsGroupedByUser = await _findSnapshotsForUsers(userIdsAndDates);
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
-    const competenceIds = targetProfile.getCompetenceIds();
+    const competenceIds = targetProfile.competenceIds;
 
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
       const validatedTargetedKnowledgeElements = _filterValidatedTargetedKnowledgeElements(knowledgeElements, targetProfile);

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -173,15 +173,9 @@ module.exports = {
     const knowledgeElementsGroupedByUser = await _findSnapshotsForUsers(userIdsAndDates);
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
-    const competenceIds = targetProfile.competenceIds;
-
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
       const validatedTargetedKnowledgeElements = _filterValidatedTargetedKnowledgeElements(knowledgeElements, targetProfile);
-      const knowledgeElementsByCompetenceId = _.groupBy(validatedTargetedKnowledgeElements, 'competenceId');
-      knowledgeElementsGroupedByUserAndCompetence[userId] = {};
-      for (const competenceId of competenceIds) {
-        knowledgeElementsGroupedByUserAndCompetence[userId][competenceId] = knowledgeElementsByCompetenceId[competenceId] || [];
-      }
+      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.groupKnowledgeElementsByCompetence(validatedTargetedKnowledgeElements);
     }
 
     return knowledgeElementsGroupedByUserAndCompetence;
@@ -191,15 +185,9 @@ module.exports = {
     const knowledgeElementsGroupedByUser = await _findSnapshotsForUsers(userIdsAndDates);
     const knowledgeElementsGroupedByUserAndCompetence  = {};
 
-    const competenceIds = targetProfile.competenceIds;
-
     for (const [userId, knowledgeElements] of Object.entries(knowledgeElementsGroupedByUser)) {
       const targetedKnowledgeElements = _filterTargetedKnowledgeElements(knowledgeElements, targetProfile);
-      const knowledgeElementsByCompetenceId = _.groupBy(targetedKnowledgeElements, 'competenceId');
-      knowledgeElementsGroupedByUserAndCompetence[userId] = {};
-      for (const competenceId of competenceIds) {
-        knowledgeElementsGroupedByUserAndCompetence[userId][competenceId] = knowledgeElementsByCompetenceId[competenceId] || [];
-      }
+      knowledgeElementsGroupedByUserAndCompetence[userId] = targetProfile.groupKnowledgeElementsByCompetence(targetedKnowledgeElements);
     }
 
     return knowledgeElementsGroupedByUserAndCompetence;

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -852,14 +852,20 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should return knowledge elements within respective dates grouped by userId the competenceId within target profile of campaign', async () => {
       // given
-      // Learning content
-      const competence1 = domainBuilder.buildCompetence({ skillIds: ['skill1', 'skill2'] });
-      const competence2 = domainBuilder.buildCompetence({ skillIds: ['skill3'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
-      const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence1.id });
-      const skill3 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence2.id });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1, skill2, skill3] });
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'skill1', tubeId: 'tube1' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'skill2', tubeId: 'tube1' });
+      const skill3 = domainBuilder.buildTargetedSkill({ id: 'skill3', tubeId: 'tube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skill1, skill2], competenceId: 'competence1' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'tube1', skills: [skill3], competenceId: 'competence2' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'competence1', tubes: [tube1], areaId: 'area1' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'competence2', tubes: [tube2], areaId: 'area1' });
+      const area = domainBuilder.buildTargetedArea({ id: 'area1', competences: [competence1, competence2] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area],
+      });
       const userId1 = databaseBuilder.factory.buildUser().id;
       const userId2 = databaseBuilder.factory.buildUser().id;
       const dateUserId1 = new Date('2020-01-03');
@@ -888,23 +894,23 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should return the knowledge elements in the snapshot when user has a snapshot for this date', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
       const dateUserId = new Date('2020-01-03');
-      const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, competenceId: competence.id, skillId: skill.id });
+      const knowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        competenceId: targetProfile.competences[0].id,
+        skillId: targetProfile.skills[0].id,
+      });
       databaseBuilder.factory.buildKnowledgeElementSnapshot({ userId, snappedAt: dateUserId, snapshot: JSON.stringify([knowledgeElement]) });
       await databaseBuilder.commit();
 
       // when
       const knowledgeElementsByUserIdAndCompetenceId =
-          await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: dateUserId }, targetProfile);
+        await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: dateUserId }, targetProfile);
 
       // then
-      expect(knowledgeElementsByUserIdAndCompetenceId[userId][competence.id][0]).to.deep.equal(knowledgeElement);
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId][targetProfile.competences[0].id][0]).to.deep.equal(knowledgeElement);
     });
 
     context('when user does not have a snapshot for this date', () => {
@@ -913,13 +919,14 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements with limit date as now', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -928,19 +935,20 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
           // then
           expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-            [competence.id]: [expectedKnowledgeElement],
+            [targetProfile.competences[0].id]: [expectedKnowledgeElement],
           });
         });
 
         it('should not trigger snapshotting', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -956,33 +964,36 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
         it('should return the knowledge elements at date', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
+
           // when
           const knowledgeElementsByUserIdAndCompetenceId =
             await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: new Date('2018-02-01') }, targetProfile);
 
           // then
           expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-            [competence.id]: [expectedKnowledgeElement],
+            [targetProfile.competences[0].id]: [expectedKnowledgeElement],
           });
         });
 
         it('should save a snasphot', async () => {
           // given
-          // Learning content
-          const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-          const skill = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-          // Other data
-          const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
           const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill.id });
+          databaseBuilder.factory.buildKnowledgeElement({
+            userId,
+            createdAt: new Date('2018-01-01'),
+            competenceId: targetProfile.competences[0].id,
+            skillId: targetProfile.skills[0].id,
+          });
           await databaseBuilder.commit();
 
           // when
@@ -997,35 +1008,37 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
     it('should avoid returning non targeted knowledge elements when there are knowledge elements that are not in the target profile', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      const skill2 = domainBuilder.buildSkill({ id: 'skill2', competenceId: competence.id });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill2.id });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: targetProfile.competences[0].id,
+        skillId: 'id_de_skill_improbable_et_different_de_celui_du_builder',
+      });
       await databaseBuilder.commit();
 
       // when
       const knowledgeElementsByUserIdAndCompetenceId =
-          await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: null }, targetProfile);
+        await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: null }, targetProfile);
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence.id]: [],
+        [targetProfile.competences[0].id]: [],
       });
     });
 
     it('should avoid returning non validated knowledge elements when there are knowledge elements that are not validated', async () => {
       // given
-      // Learning content
-      const competence = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence.id });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildKnowledgeElement({ userId, createdAt: new Date('2018-01-01'), competenceId: competence.id, skillId: skill1.id, status: 'BLABLA' });
+      databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: targetProfile.competences[0].id,
+        skillId: targetProfile.skills[0].id,
+        status: 'invalidated',
+      });
       await databaseBuilder.commit();
 
       // when
@@ -1034,17 +1047,13 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence.id]: [],
+        [targetProfile.competences[0].id]: [],
       });
     });
 
-    it('should return an empty array on competence that does not have any validated targeted knowledge elements', async () => {
+    it('should return an empty array on competence that does not have any targeted knowledge elements', async () => {
       // given
-      // Learning content
-      const competence1 = domainBuilder.buildCompetence({ skillIds: ['skill1'] });
-      const skill1 = domainBuilder.buildSkill({ id: 'skill1', competenceId: competence1.id });
-      // Other data
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const userId = databaseBuilder.factory.buildUser().id;
       await databaseBuilder.commit();
 
@@ -1054,7 +1063,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
-        [competence1.id]: [],
+        [targetProfile.competences[0].id]: [],
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -1028,6 +1028,28 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       });
     });
 
+    it('should requalify knowledgeElement under actual targeted competence of skill disregarding indicated competenceId', async () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+      const userId = databaseBuilder.factory.buildUser().id;
+      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: 'competence_depuis_laquelle_lacquis_a_pu_etre_retire',
+        skillId: targetProfile.skills[0].id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const knowledgeElementsByUserIdAndCompetenceId =
+        await knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers({ [userId]: null }, targetProfile);
+
+      // then
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
+        [targetProfile.competences[0].id]: [expectedKnowledgeElement],
+      });
+    });
+
     it('should avoid returning non validated knowledge elements when there are knowledge elements that are not validated', async () => {
       // given
       const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
@@ -1249,6 +1271,28 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
       // then
       expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
         [targetProfile.competences[0].id]: [],
+      });
+    });
+
+    it('should requalify knowledgeElement under actual targeted competence of skill disregarding indicated competenceId', async () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+      const userId = databaseBuilder.factory.buildUser().id;
+      const expectedKnowledgeElement = databaseBuilder.factory.buildKnowledgeElement({
+        userId,
+        createdAt: new Date('2018-01-01'),
+        competenceId: 'competence_depuis_laquelle_lacquis_a_pu_etre_retire',
+        skillId: targetProfile.skills[0].id,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const knowledgeElementsByUserIdAndCompetenceId =
+        await knowledgeElementRepository.findTargetedGroupedByCompetencesForUsers({ [userId]: null }, targetProfile);
+
+      // then
+      expect(knowledgeElementsByUserIdAndCompetenceId[userId]).to.deep.equal({
+        [targetProfile.competences[0].id]: [expectedKnowledgeElement],
       });
     });
 

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -139,4 +139,79 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     });
   });
 
+  describe('groupKnowledgeElementsByCompetence()', () => {
+
+    it('should return knowledge elements of targeted skill by targeted competence id', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
+      const skill2_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_2', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1, skill2_2], competenceId: 'recCompetence2' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2_1, skill2_2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recSkill1' });
+      const knowledgeElement2_1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence2', skillId: 'recSkill2_1' });
+      const knowledgeElement2_2 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence2', skillId: 'recSkill2_2' });
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2_1, knowledgeElement2_2];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement1],
+        'recCompetence2': [knowledgeElement2_1, knowledgeElement2_2],
+      });
+    });
+
+    it('should categorize knowledgeElement to actual competenceId and not based on the declared one', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recOldCompetence', skillId: 'recSkill1' });
+      const knowledgeElements = [knowledgeElement1];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement1],
+      });
+    });
+
+    it('should set an empty array to a targeted competence id when no knowledge element belongs to it', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recOtherSkill' });
+      const knowledgeElements = [knowledgeElement1];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [],
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -139,7 +139,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     });
   });
 
-  describe('groupKnowledgeElementsByCompetence()', () => {
+  describe('filterTargetedKnowledgeElementAndGroupByCompetence()', () => {
 
     it('should return knowledge elements of targeted skill by targeted competence id', () => {
       // given
@@ -161,7 +161,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
       const knowledgeElements = [knowledgeElement1, knowledgeElement2_1, knowledgeElement2_2];
 
       // when
-      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+      const knowledgeElementsByCompetence = targetProfile.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
 
       // then
       expect(knowledgeElementsByCompetence).to.deep.equal({
@@ -184,7 +184,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
       const knowledgeElements = [knowledgeElement1];
 
       // when
-      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+      const knowledgeElementsByCompetence = targetProfile.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
 
       // then
       expect(knowledgeElementsByCompetence).to.deep.equal({
@@ -206,11 +206,156 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
       const knowledgeElements = [knowledgeElement1];
 
       // when
-      const knowledgeElementsByCompetence = targetProfile.groupKnowledgeElementsByCompetence(knowledgeElements);
+      const knowledgeElementsByCompetence = targetProfile.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
 
       // then
       expect(knowledgeElementsByCompetence).to.deep.equal({
         'recCompetence1': [],
+      });
+    });
+
+    it('should filter out non targeted knowledge element', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recOtherSkill' });
+      const knowledgeElement2 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: skill1.id });
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement2],
+      });
+    });
+  });
+
+  describe('filterValidatedTargetedKnowledgeElementAndGroupByCompetence()', () => {
+
+    it('should return knowledge elements of targeted skill by targeted competence id', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const skill2_1 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_1', tubeId: 'recTube2' });
+      const skill2_2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2_2', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', skills: [skill2_1, skill2_2], competenceId: 'recCompetence2' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence2', tubes: [tube2] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2_1, skill2_2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recSkill1' });
+      const knowledgeElement2_1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence2', skillId: 'recSkill2_1' });
+      const knowledgeElement2_2 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence2', skillId: 'recSkill2_2' });
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2_1, knowledgeElement2_2];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement1],
+        'recCompetence2': [knowledgeElement2_1, knowledgeElement2_2],
+      });
+    });
+
+    it('should categorize knowledgeElement to actual competenceId and not based on the declared one', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recOldCompetence', skillId: 'recSkill1' });
+      const knowledgeElements = [knowledgeElement1];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement1],
+      });
+    });
+
+    it('should set an empty array to a targeted competence id when no knowledge element belongs to it', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recOtherSkill' });
+      const knowledgeElements = [knowledgeElement1];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [],
+      });
+    });
+
+    it('should filter out non targeted knowledge element', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: 'recOtherSkill' });
+      const knowledgeElement2 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: skill1.id });
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement2],
+      });
+    });
+
+    it('should filter out non validated knowledge element', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', tubeId: 'recTube1' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1], competenceId: 'recCompetence1' });
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube1] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1],
+        tubes: [tube1],
+        competences: [competence1],
+      });
+      const knowledgeElement1 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: skill1.id, status: 'not_validated' });
+      const knowledgeElement2 = domainBuilder.buildKnowledgeElement({ competenceId: 'recCompetence1', skillId: skill1.id });
+      const knowledgeElements = [knowledgeElement1, knowledgeElement2];
+
+      // when
+      const knowledgeElementsByCompetence = targetProfile.filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements);
+
+      // then
+      expect(knowledgeElementsByCompetence).to.deep.equal({
+        'recCompetence1': [knowledgeElement2],
       });
     });
   });

--- a/api/tests/unit/domain/read-models/CampaignAssessmentParticipationCompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentParticipationCompetenceResult_test.js
@@ -5,13 +5,16 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationCompetenceResu
 
   describe('constructor', () => {
     it('should correctly initialize the competence data', () => {
-      const targetedCompetence = domainBuilder.buildCompetence({
+      const targetedCompetence = domainBuilder.buildTargetedCompetence({
         id: 'rec123',
         name: 'competence1',
         index: '1.1',
+        areaId: 'area1',
       });
+      const targetedArea = domainBuilder.buildTargetedArea({ id: 'area1' });
 
       const campaignAssessmentParticipationCompetenceResult = new CampaignAssessmentParticipationCompetenceResult({
+        targetedArea,
         targetedCompetence,
       });
 
@@ -21,11 +24,14 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationCompetenceResu
     });
 
     it('should return the area color', () => {
-      const targetedCompetence = domainBuilder.buildCompetence({
-        area: domainBuilder.buildArea({ color: 'red' }),
+      const targetedCompetence = domainBuilder.buildTargetedCompetence({
+        id: 'rec123',
+        areaId: 'area1',
       });
+      const targetedArea = domainBuilder.buildTargetedArea({ id: 'area1', color: 'red' });
 
       const campaignAssessmentParticipationCompetenceResult = new CampaignAssessmentParticipationCompetenceResult({
+        targetedArea,
         targetedCompetence,
       });
 

--- a/api/tests/unit/domain/read-models/CampaignAssessmentParticipationResult_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentParticipationResult_test.js
@@ -4,10 +4,12 @@ const CampaignAssessmentParticipationResult = require('../../../../lib/domain/re
 describe('Unit | Domain | Models | CampaignAssessmentParticipationResult', () => {
   describe('constructor', () => {
     it('should correctly initialize the information about campaign participation', () => {
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent();
       const campaignAssessmentParticipationResult = new CampaignAssessmentParticipationResult({
         campaignParticipationId: 1,
         campaignId: 2,
         targetedCompetences: [],
+        targetProfile,
       });
 
       expect(campaignAssessmentParticipationResult.campaignParticipationId).equal(1);
@@ -16,15 +18,12 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationResult', () =>
 
     context('when the campaignParticipation is not shared', () => {
       it('does not compute CampaignAssessmentParticipationCompetenceResult', () => {
-        const targetedCompetences = [
-          domainBuilder.buildCompetence({ id: 'competence1' }),
-        ];
-        const targetedSkill = domainBuilder.buildSkill({ competenceId: 'competence1' });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [targetedSkill] });
+        const targetedCompetence = domainBuilder.buildTargetedCompetence({ id: 'competence1', skills: ['oneSkill'] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [targetedCompetence] });
         const campaignAssessmentParticipationResult = new CampaignAssessmentParticipationResult({
           campaignParticipationId: 1,
           campaignId: 2,
-          targetedCompetences,
+          targetedCompetences: [targetedCompetence],
           isShared: false,
           targetProfile,
         });
@@ -36,27 +35,25 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationResult', () =>
 
     context('when the campaignParticipation is shared', () => {
       it('should compute results with targeted competences', () => {
-        const targetedCompetences = [
-          domainBuilder.buildCompetence({ id: 'recTargeted', skillIds: [1] }),
-        ];
-        const targetedSkill = domainBuilder.buildSkill({ competenceId: 'competence1' });
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [targetedSkill] });
+        const targetedCompetence = domainBuilder.buildTargetedCompetence({ id: 'competence1', skills: ['oneSkill'], areaId: 'area1' });
+        const targetedArea = domainBuilder.buildTargetedArea({ id: 'area1', competences: [targetedCompetence] });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [targetedCompetence], areas: [targetedArea] });
         const validatedTargetedKnowledgeElementsByCompetenceId = {
-          recTargeted: [domainBuilder.buildKnowledgeElement({ skillId: targetedSkill.id, competenceId: 'recTargeted' })],
+          competence1: [domainBuilder.buildKnowledgeElement({ skillId: 'someId', competenceId: 'competence1' })],
         };
 
         const campaignAssessmentParticipationResult = new CampaignAssessmentParticipationResult({
           campaignParticipationId: 1,
           campaignId: 2,
-          targetedCompetences,
+          targetedCompetences: [targetedCompetence],
           isShared: true,
-          targetProfile,
           validatedTargetedKnowledgeElementsByCompetenceId,
+          targetProfile,
         });
 
         expect(campaignAssessmentParticipationResult.isShared).equal(true);
         expect(campaignAssessmentParticipationResult.competenceResults.length).equal(1);
-        expect(campaignAssessmentParticipationResult.competenceResults[0].id).equal('recTargeted');
+        expect(campaignAssessmentParticipationResult.competenceResults[0].id).equal('competence1');
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
@@ -10,10 +10,11 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
     let expectedJsonApi;
 
     beforeEach(() => {
-      const competence = domainBuilder.buildCompetence({ skillIds: ['recSkill0'] });
-      const targetedSkill = domainBuilder.buildSkill({ competenceId: competence.id, id: 'recSkill0' });
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [targetedSkill] });
-      const knowledgeElement = domainBuilder.buildKnowledgeElement({ skillId: targetedSkill.id, competenceId: competence.id, status: 'validated' });
+
+      const targetedCompetence = domainBuilder.buildTargetedCompetence({ id: 'competence1', skills: ['oneSkill'], areaId: 'area1' });
+      const targetedArea = domainBuilder.buildTargetedArea({ id: 'area1', competences: [targetedCompetence] });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [targetedCompetence], areas: [targetedArea] });
+      const knowledgeElement = domainBuilder.buildKnowledgeElement({ skillId: 'someSkillId', competenceId: targetedCompetence.id, status: 'validated' });
       expectedJsonApi = {
         data: {
           type: 'campaign-assessment-participation-results',
@@ -24,7 +25,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
           relationships: {
             'competence-results': {
               data: [{
-                id: competence.id,
+                id: targetedCompetence.id,
                 type: 'campaign-assessment-participation-competence-results',
               }],
             },
@@ -32,23 +33,23 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
         },
         included: [{
           type: 'campaign-assessment-participation-competence-results',
-          id: competence.id,
+          id: targetedCompetence.id,
           attributes: {
-            name: competence.name,
-            'index': competence.index,
+            name: targetedCompetence.name,
+            'index': targetedCompetence.index,
             'targeted-skills-count': 1,
             'validated-skills-count': 1,
-            'area-color': competence.area.color,
+            'area-color': targetedArea.color,
           },
         }],
       };
 
       modelCampaignAssessmentParticipationResult = new CampaignAssessmentParticipationResult({
-        targetedCompetences: [competence],
+        targetedCompetences: [targetedCompetence],
         campaignParticipationId: 1,
         campaignId: 2,
         targetProfile,
-        validatedTargetedKnowledgeElementsByCompetenceId: { [competence.id]: [knowledgeElement] },
+        validatedTargetedKnowledgeElementsByCompetenceId: { [targetedCompetence.id]: [knowledgeElement] },
         isShared: true,
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les process de l'équipe contenu s'affinent et se précisent au fil des mois. Une des opérations que peut réaliser l'équipe est le déplacement d'acquis d'une compétence à une autre.
Aujourd'hui, cette opération est effectuée en dupliquant l'acquis d'id recAcquisA (duplicata dont l'id est recAcquisB), en fixant la compétence de l'acquis recAcquisB dans la nouvelle compétence et enfin en archivant l'acquis recAcquisA.
Malheureusement, il y a quelques mois une mauvaise manip' a été réalisée. L'acquis n'a pas été cloné mais carrément déplacé.
Depuis, le motto de l'équipe Prescription c'est :

> "On ne fait pas confiance à la competenceId inscrite dans le knowledge element"

J'ai oublié de respecter ce motto lors des PRs récentes d'utilisation du nouveau TargetProfile. Je corrige le tir.

## :robot: Solution
D'abord pour uniformiser et faciliter le travail, on passe le "nouveau" targetProfile à la méthode `knowledgeElementRepository.findValidatedTargetedGroupedByCompetencesForUsers` (elle prenait encore l'ancien jusqu'à présent).
Ensuite, on remet la responsabilité de tri / filtre / groupement des knowledgeElements au nouveau targetProfile.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
