### PR TITLE
[BUGFIX] Remettre la pagination à zéro sur la page équipe de Pix Orga (PIX-1281).

### DIFF
--- a/orga/app/routes/authenticated/team/list.js
+++ b/orga/app/routes/authenticated/team/list.js
@@ -27,4 +27,11 @@ export default class ListRoute extends Route {
       organization,
     });
   }
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.pageNumber = 1;
+      controller.pageSize = 10;
+    }
+  }
 }


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on accède à la deuxième page équipe de Pix Orga, que l'on change de route et qu'on retourne sur la page équipe, on est toujours sur la deuxième page.    

## :robot: Solution
Remettre à zéro la pagination de la page équipe lorsque l'on change de page. 

## :100: Pour tester

- Se connecter au compte sco@example.net.
- Aller sur la page Equipe et aller sur la page 2 de la liste des membres.
- Cliquer sur le menu ‘Campagnes’.
- Cliquer sur le menu 'Equipe' et vérifier que l'on est bien sur la première page.