### PR TITLE
[TECH ] Retirer le feature toggle du telechargement de l'attestation

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -2,7 +2,6 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import config from 'mon-pix/config/environment';
 
 export default class UserCertificationsDetailHeader extends Component {
   @service intl;
@@ -10,7 +9,6 @@ export default class UserCertificationsDetailHeader extends Component {
   @service session;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
-  isCertificateAttestationActive = config.APP.FT_IS_CERTIFICATE_ATTESTATION_ACTIVE;
 
   get birthdate() {
     return this.intl.formatDate(this.args.certification.birthdate, { format: 'LL' });

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -26,12 +26,10 @@
   </div>
   {{#if @certification.verificationCode}}
     <div class="attestation-and-verification-code">
-        {{#if this.isCertificateAttestationActive}}
         <div class="attestation">
           <button class="button" type="button" {{on "click" (fn this.downloadAttestation)}}>{{t "pages.certificate.attestation"}}</button>
         </div>
         <hr>
-        {{/if}}
         <div class="verification-code">
           <h2 class="verification-code__title">
             {{t "pages.certificate.verification-code.title"}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -50,7 +50,6 @@ module.exports = function(environment) {
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
-      FT_IS_CERTIFICATE_ATTESTATION_ACTIVE: _isFeatureEnabled(process.env.FT_IS_CERTIFICATE_ATTESTATION_ACTIVE),
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {


### PR DESCRIPTION
## :unicorn: Problème
Le téléchargement de l'attestation est dépendant de l'activation d'un feature toggle

## :robot: Solution
Cette fonctionnalité est validé en production. Le feature toggle est désormé inutile

## :100: Pour tester
- Retirer le feature toggle _FT_IS_CERTIFICATE_ATTESTATION_ACTIVE_ des variables d'environnements
- Le bouton de téléchargement de l'attestation est visible et fonctionnel