### PR TITLE
[BUGFIX] Permettre à la CI de détecter les erreurs de tests. 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -118,7 +118,7 @@
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",
-    "test:api": "npm run test:api:unit && for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir ; done ;",
+    "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "NODE_ENV=test mocha --exit --recursive --reporter=dot",
     "test:api:unit": "TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",


### PR DESCRIPTION
## :unicorn: Problème
Depuis la PR #1927, la CI ne détectait plus les erreurs des tests autres que unitaires 😨 (cf: [ici.](https://app.circleci.com/pipelines/github/1024pix/pix/15663/workflows/e8e4030f-c96f-481c-92e5-0be99035f038/jobs/142428)). 
De plus, il n'affichait plus toutes les erreurs mais s'arrêtait au premier groupe qui échoue. 

### Pourquoi ? 
Les tests s'exécutent dans une boucle `for` depuis la PR #1927 et il se trouve que la boucle `for` bash ne retourne pas l'erreur.   

## :robot: Solution
Nous avons mis en place une variable, définie à 0 et qui passe à 1 dès qu'il y a une erreur. A la fin des tests le script renvoie la valeur de cette variable. 

## :100: Pour tester
- Vérifier en faisant planter un test d'acceptance et intégration que le status de la commande `npm tests` est différent de 0 (pour ceux qui n'ont pas le code de retour dans leur terminal : `echo $?`). 