### PR TITLE
[FEATURE] Amélioration de l’accessibilité de la modal Résultats et tutos (PIX-1182).

### DIFF
--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -1,5 +1,5 @@
 .feedback-panel {
-  color: $grey-50;
+  color: $grey-60;
   font-size: 0.938rem;
   margin-top: -18px;
 }
@@ -33,7 +33,7 @@
   font-size: 1.25rem;
 
   & .link {
-    color: $blue-hover;
+    color: $dark-blue-pro;
 
     &:hover {
       color: $dark-blue-pro;

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -18,7 +18,7 @@
 }
 
 .learning-more-panel__tutorial-info {
-  color: $grey-40;
+  color: $grey-50;
   font-size: 0.813rem;
   line-height: 1.25rem;
   margin: 5px;

--- a/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_learning-more-tutorial-panel.scss
@@ -6,7 +6,11 @@
 }
 
 .learning-more-panel__container {
-  margin: 20px 0 40px;
+  margin: 25px 15px;
+
+  @include device-is('desktop') {
+    margin: 25px 40px;
+  }
 }
 
 .learning-more-panel__hint-title {
@@ -18,20 +22,4 @@
   font-size: 0.813rem;
   line-height: 1.25rem;
   margin: 5px;
-}
-
-.learning-more-panel__hint-container-header {
-  margin: 25px 15px;
-
-  @include device-is('desktop') {
-    margin: 25px 40px;
-  }
-}
-
-.learning-more-panel__list-container {
-  margin: 0 15px;
-
-  @include device-is('desktop') {
-    margin: 0 40px;
-  }
 }

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -45,7 +45,7 @@
 .result-item__correction-button {
   font-weight: $font-normal;
   font-size: 0.875rem;
-  color: $blue;
+  color: $blue-hover;
   border: none;
   outline: none;
   background-color: transparent;
@@ -53,7 +53,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $blue-hover;
+    color: $dark-blue-pro;
     cursor: pointer;
     text-decoration: underline;
   }

--- a/mon-pix/app/styles/components/_tutorial-item.scss
+++ b/mon-pix/app/styles/components/_tutorial-item.scss
@@ -44,7 +44,7 @@
     font-size: 0.875rem;
     font-family: $font-roboto;
     font-weight: $font-normal;
-    color: $grey-45;
+    color: $grey-50;
     line-height: 1.5rem;
     margin: 0 0 14px;
 
@@ -74,7 +74,7 @@
   &__save {
     font-size: 0.813rem;
     font-weight: $font-medium;
-    color: $grey-45;
+    color: $grey-50;
     letter-spacing: 0.028rem;
     margin: 0 0 16px;
     background: transparent;
@@ -101,7 +101,7 @@
   &__evaluate {
     font-size: 0.813rem;
     font-weight: $font-medium;
-    color: $grey-45;
+    color: $grey-50;
     letter-spacing: 0.028rem;
     margin: 0 0 16px;
     background: transparent;

--- a/mon-pix/app/styles/components/_tutorial-panel.scss
+++ b/mon-pix/app/styles/components/_tutorial-panel.scss
@@ -34,7 +34,7 @@
 }
 
 .tutorial-panel__tutorial-info {
-  color: $grey-40;
+  color: $grey-50;
   font-size: 0.813rem;
   line-height: 1.25rem;
   margin: -5px 5px 0;

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -24,8 +24,10 @@ $pix-modal-border-radius: 5px;
 
     .pix-modal__close-link {
       color: $white;
+      background: transparent;
+      border: none;
       text-align: right;
-      margin-bottom: 5px;
+      margin: 5px 0 5px auto;
       display: flex;
       justify-content: flex-end;
       align-items: center;

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -24,12 +24,12 @@
     </div>
 
 
-    <div class="rounded-panel rounded-panel--strong checkpoint__content">
+    <main class="rounded-panel rounded-panel--strong checkpoint__content">
       {{#if this.shouldDisplayAnswers}}
         <div class="rounded-panel-one-line-header">
-          <h1 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-title--all-small-caps">
+          <h2 class="rounded-panel-header-text__content rounded-panel-title rounded-panel-title--all-small-caps">
             {{t 'pages.checkpoint.answers.header'}}
-          </h1>
+          </h2>
         </div>
 
         <div class="assessment-results__list">
@@ -49,7 +49,7 @@
           <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />
         </div>
       {{/if}}
-    </div>
+    </main>
   </div>
 
   {{#if this.isShowingModal}}

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -1,9 +1,9 @@
 <PixModal @class="comparison-window-modal" @onClose={{@closeComparisonWindow}}>
 
-  <div class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{action (action @closeComparisonWindow)}}>
+  <button type="button" class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{on "click" @closeComparisonWindow}}>
     <span>{{t "common.actions.close"}}</span>
-    <FaIcon @icon="times-circle" class="logged-user-menu__icon"></FaIcon>
-  </div>
+    <FaIcon @icon="times-circle" class="logged-user-menu__icon" aria-hidden="true"></FaIcon>
+  </button>
 
   <div class="pix-modal__container comparison-window">
 
@@ -91,4 +91,10 @@
       </div>
     </div>
   </div>
+
+  <button type="button" class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{on "click" @closeComparisonWindow}}>
+    <span>{{t "common.actions.close"}}</span>
+    <FaIcon @icon="times-circle" class="logged-user-menu__icon" aria-hidden="true"></FaIcon>
+  </button>
+
 </PixModal>

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -15,7 +15,7 @@
                alt={{t this.resultItem.tooltip}}>
         </div>
       </div>
-      <div class="comparison-window__title-text">{{t this.resultItem.title}}</div>
+      <h3 class="comparison-window__title-text">{{t this.resultItem.title}}</h3>
     </div>
 
     <div class="comparison-window--content">

--- a/mon-pix/app/templates/components/feedback-panel.hbs
+++ b/mon-pix/app/templates/components/feedback-panel.hbs
@@ -1,5 +1,5 @@
 <div class="feedback-panel">
-  <h2 class="sr-only">{{t 'pages.challenge.parts.feedback'}}</h2>
+  <h3 class="sr-only">{{t 'pages.challenge.parts.feedback'}}</h3>
   <div class="feedback-panel__view feedback-panel__view--link">
     <button class="feedback-panel__open-button"
       {{on "click" this.toggleFeedbackForm}}

--- a/mon-pix/app/templates/components/learning-more-panel.hbs
+++ b/mon-pix/app/templates/components/learning-more-panel.hbs
@@ -1,10 +1,7 @@
 {{#if this.hasLearningMoreItems}}
   <div class="learning-more-panel">
     <div class="learning-more-panel__container">
-      <header class="learning-more-panel__hint-container-header">
-        <h4 class="learning-more-panel__hint-title"><span>{{t "pages.learning-more.title"}}</span></h4>
-      </header>
-
+        <h3 class="learning-more-panel__hint-title"><span>{{t "pages.learning-more.title"}}</span></h3>
       <div class="learning-more-panel__list-container">
         {{#each @learningMoreTutorials as |learningMoreTutorial|}}
           <TutorialItem @tutorial={{learningMoreTutorial}} />

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -6,19 +6,19 @@
         <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{inputClass}}"
                   rows="5"
                   value="{{answerToDisplay}}"
-                  ariaLabel="réponse donnée"
+                  aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
                   disabled>
         </textarea>
       {{else if (eq answer.challenge.format 'phrase')}}
         <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{inputClass}}"
                value="{{answerToDisplay}}"
-               ariaLabel="réponse donnée"
+               aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
                disabled>
       {{else}}
         <input class="correction-qroc-box-answer {{inputClass}}"
                size="{{get-qroc-input-size answer.challenge.format}}"
                value="{{answerToDisplay}}"
-               ariaLabel="réponse donnée"
+               aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
                disabled>
       {{/if}}
     </div>

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -26,6 +26,7 @@
     {{#unless isResultOk}}
       <div class="correction-qroc-box__solution">
         <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
+        <span class="sr-only">{{t 'pages.comparison-window.results.the-answer-was'}}</span>
         <div class="correction-qroc-box__solution-text">{{solutionToDisplay}}</div>
       </div>
     {{/unless}}

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -6,19 +6,19 @@
         <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{inputClass}}"
                   rows="5"
                   value="{{answerToDisplay}}"
-                  aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
+                  aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                   disabled>
         </textarea>
       {{else if (eq answer.challenge.format 'phrase')}}
         <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{inputClass}}"
                value="{{answerToDisplay}}"
-               aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
+               aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                disabled>
       {{else}}
         <input class="correction-qroc-box-answer {{inputClass}}"
                size="{{get-qroc-input-size answer.challenge.format}}"
                value="{{answerToDisplay}}"
-               aria-label={{t 'pages.comparison-window.results.aria-label-given-answer'}}
+               aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                disabled>
       {{/if}}
     </div>
@@ -26,7 +26,7 @@
     {{#unless isResultOk}}
       <div class="correction-qroc-box__solution">
         <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
-        <span class="sr-only">{{t 'pages.comparison-window.results.the-answer-was'}}</span>
+        <span class="sr-only">{{t 'pages.comparison-window.results.a11y.the-answer-was'}}</span>
         <div class="correction-qroc-box__solution-text">{{solutionToDisplay}}</div>
       </div>
     {{/unless}}

--- a/mon-pix/app/templates/components/tutorial-panel.hbs
+++ b/mon-pix/app/templates/components/tutorial-panel.hbs
@@ -2,9 +2,7 @@
 
   {{#if this.shouldDisplayHintOrTuto}}
     <div class="tutorial-panel__hint-container">
-      <header class="tutorial-panel__hint-container-header">
-        <h3 class="tutorial-panel__hint-title"><span>{{t "pages.tutorial-panel.title"}}</span></h3>
-      </header>
+      <h3 class="tutorial-panel__hint-title"><span>{{t "pages.tutorial-panel.title"}}</span></h3>
 
       {{#if this.shouldDisplayHint}}
         <div class="tutorial-panel__hint-container-body">

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -192,7 +192,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
 
-        const goodAnswer = find('.correction-qroc-box__solution');
+        const goodAnswer = find('.correction-qroc-box__solution-text');
         const badAnswerFromUserResult = find('.correction-qroc-box-answer');
         expect(goodAnswer.textContent.trim()).to.equal('Mangue');
         expect(badAnswerFromUserResult.className).contains('correction-qroc-box-answer--wrong');
@@ -367,7 +367,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
         expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qrocChallenge.instruction);
 
-        const goodAnswer = find('.correction-qroc-box__solution');
+        const goodAnswer = find('.correction-qroc-box__solution-text');
         const badAnswerFromUserResult = find('.correction-qroc-box-answer');
         expect(goodAnswer.textContent.trim()).to.equal('Mangue');
         expect(badAnswerFromUserResult.className).contains('correction-qroc-box-answer--wrong');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -414,33 +414,13 @@
     "comparison-window": {
       "upcoming-tutorials": "You will soon find tutorials here to help you answer correctly to this type of question!!",
       "results": {
-        "ok": {
-          "title": "You got the right answer!",
-          "tooltip": "Correct answer"
-        },
-        "ko": {
-          "title": "That’s not the right answer",
-          "tooltip": "Incorrect answer"
+        "a11y": {
+          "the-answer-was": "The answer was",
+          "given-answer": "given answer"
         },
         "aband": {
           "title": "You did not answer",
           "tooltip": "No answer"
-        },
-        "partially": {
-          "title": "You gave an incomplete answer",
-          "tooltip": "Incomplete answer"
-        },
-        "timedout": {
-          "title": "You ran out of time",
-          "tooltip": "Out of time"
-        },
-        "okAutoReply": {
-          "title": "You correctly answered the question",
-          "tooltip": "Question answered correctly "
-        },
-        "koAutoReply": {
-          "title": "You did not correctly answer the question",
-          "tooltip": "Question answered incorrectly"
         },
         "abandAutoReply": {
           "title": "You have skipped the question",
@@ -450,8 +430,30 @@
           "title": "",
           "tooltip": "Auto-correct under development ;)"
         },
-        "the-answer-was": "The answer was",
-        "aria-label-given-answer": "given answer"
+        "ko": {
+          "title": "That’s not the right answer",
+          "tooltip": "Incorrect answer"
+        },
+        "koAutoReply": {
+          "title": "You did not correctly answer the question",
+          "tooltip": "Question answered incorrectly"
+        },
+        "ok": {
+          "title": "You got the right answer!",
+          "tooltip": "Correct answer"
+        },
+        "okAutoReply": {
+          "title": "You correctly answered the question",
+          "tooltip": "Question answered correctly "
+        },
+        "partially": {
+          "title": "You gave an incomplete answer",
+          "tooltip": "Incomplete answer"
+        },
+        "timedout": {
+          "title": "You ran out of time",
+          "tooltip": "Out of time"
+        }
       }
     },
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -449,7 +449,8 @@
         "default": {
           "title": "",
           "tooltip": "Auto-correct under development ;)"
-        }
+        },
+        "the-answer-was": "The answer was"
       }
     },
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -450,7 +450,8 @@
           "title": "",
           "tooltip": "Auto-correct under development ;)"
         },
-        "the-answer-was": "The answer was"
+        "the-answer-was": "The answer was",
+        "aria-label-given-answer": "given answer"
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -450,7 +450,8 @@
           "title": "",
           "tooltip": "Correction automatique en cours de développement ;)"
         },
-        "the-answer-was": "La bonne réponse était"
+        "the-answer-was": "La bonne réponse était",
+        "aria-label-given-answer": "réponse donnée"
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -414,33 +414,13 @@
     "comparison-window": {
       "upcoming-tutorials": "Bientôt ici des tutoriels pour vous aider à réussir ce type d'épreuves !!",
       "results": {
-        "ok": {
-          "title": "Vous avez la bonne réponse !",
-          "tooltip": "Réponse correcte"
-        },
-        "ko": {
-          "title": "Vous n’avez pas la bonne réponse",
-          "tooltip": "Réponse incorrecte"
+        "a11y": {
+          "the-answer-was": "La bonne réponse était",
+          "given-answer": "réponse donnée"
         },
         "aband": {
           "title": "Vous n’avez pas donné de réponse",
           "tooltip": "Sans réponse"
-        },
-        "partially": {
-          "title": "Vous avez donné une réponse partielle",
-          "tooltip": "Réponse partielle"
-        },
-        "timedout": {
-          "title": "Vous avez dépassé le temps imparti",
-          "tooltip": "Temps dépassé"
-        },
-        "okAutoReply": {
-          "title": "Vous avez réussi l’épreuve",
-          "tooltip": "Épreuve réussie"
-        },
-        "koAutoReply": {
-          "title": "Vous n’avez pas réussi l’épreuve",
-          "tooltip": "Épreuve non réussie"
         },
         "abandAutoReply": {
           "title": "Vous avez passé l’épreuve",
@@ -450,8 +430,30 @@
           "title": "",
           "tooltip": "Correction automatique en cours de développement ;)"
         },
-        "the-answer-was": "La bonne réponse était",
-        "aria-label-given-answer": "réponse donnée"
+        "ko": {
+          "title": "Vous n’avez pas la bonne réponse",
+          "tooltip": "Réponse incorrecte"
+        },
+        "koAutoReply": {
+          "title": "Vous n’avez pas réussi l’épreuve",
+          "tooltip": "Épreuve non réussie"
+        },
+        "ok": {
+          "title": "Vous avez la bonne réponse !",
+          "tooltip": "Réponse correcte"
+        },
+        "okAutoReply": {
+          "title": "Vous avez réussi l’épreuve",
+          "tooltip": "Épreuve réussie"
+        },
+        "partially": {
+          "title": "Vous avez donné une réponse partielle",
+          "tooltip": "Réponse partielle"
+        },
+        "timedout": {
+          "title": "Vous avez dépassé le temps imparti",
+          "tooltip": "Temps dépassé"
+        }
       }
     },
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -449,7 +449,8 @@
         "default": {
           "title": "",
           "tooltip": "Correction automatique en cours de développement ;)"
-        }
+        },
+        "the-answer-was": "La bonne réponse était"
       }
     },
 


### PR DESCRIPTION
## :unicorn: Problème
Il y a plusieurs soucis d’accessibilité sur la modal de la page de résultats.

## :robot: Solution
- Problème de structure : meilleure organisation des titres pour les lecteurs à synthèse vocale
- Problèmes de contraste : utilisation de couleurs plus adaptées sur les textes et liens
- Rajout d’un bouton fermer en bas de modal

## :rainbow: Remarques
- Les boutons fermer `pix-modal__close-link` ont été transformés en `<button>` pour devenir focusables. 
- Problème de focus : le focus devrait se faire directement sur la modal au clic sur `Réponses et tutos` et les éléments en background ne devraient plus être focusable (sera fait dans une prochaine PR).

## :100: Pour tester
Lancer une compétence et aller jusqu’à la page de checkpoint. Cliquer sur `Réponses et tutos`.