### PR TITLE
[TECH] Appliquer la règle de lint héritée de la racine dans /api.

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -41,6 +41,7 @@ rules:
   no-restricted-syntax:
     - error
     # Use https://estools.github.io/esquery/ to test selector
+    # These rules are overridden in /api/.eslintrc.yaml - In case adding one here, add it also in /api/.eslintrc.yaml
     - selector: "NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])"
       message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
     - selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -4,8 +4,14 @@ globals:
   include: true
 
 rules:
-  no-restricted-syntax: [error, {
-    selector: "CallExpression[callee.object.name='knex'][callee.property.name='raw'][arguments.0.type='TemplateLiteral']",
-    message: "do not use template strings with knex.raw to avoid SQL injection"
-  }]
   no-sync: error
+  no-restricted-syntax:
+     -  error
+     -  selector: "CallExpression[callee.object.name='knex'][callee.property.name='raw'][arguments.0.type='TemplateLiteral']"
+        message: "do not use template strings with knex.raw to avoid SQL injection"
+     # These 2 selectors are duplicated from ../eslintrc.yaml as they are overridden by default
+     # TODO: find a way to keep without redefining them
+     -  selector: "NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])"
+        message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
+     -  selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
+        message: "Use only faker.internet.exampleEmail()"

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -243,7 +243,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
       databaseBuilder.factory.buildKnowledgeElement({
@@ -251,7 +251,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         status: 'validated',
         userId,
         skillId: 12,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -296,7 +296,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId: otherUserId,
@@ -308,21 +308,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 2,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 3,
         status: 'validated',
         userId: otherUserId,
         skillId: 3,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -341,14 +341,14 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId:  'recSkill1',
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
 
       });
       databaseBuilder.factory.buildKnowledgeElement({
@@ -356,7 +356,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         status: 'invalidated',
         userId,
         skillId:  'recSkill2',
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -374,21 +374,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         skillId:  'recSkill1',
         status: 'validated',
         userId,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         skillId:  'recSkill2',
         status: 'validated',
         userId,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -406,21 +406,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2020-12-12T15:00:34'),
+        createdAt: new Date('2020-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -438,21 +438,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2020-11-11T15:00:34'),
+        createdAt: new Date('2020-11-11T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -472,32 +472,32 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         userId,
         skillId: 12,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId: userId2,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         userId: userId2,
         skillId: 12,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         userId: userId2,
         skillId: 13,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -516,7 +516,7 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
 
       const expectedKeIdUser1 = databaseBuilder.factory.buildKnowledgeElement({
@@ -524,26 +524,26 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         status: 'validated',
         userId,
         skillId: 12,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       }).id;
       databaseBuilder.factory.buildCampaignParticipation({
         userId: userId2,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId: userId2,
         skillId: 12,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'reset',
         userId: userId2,
         skillId: 12,
-        createdAt: new Date('2019-12-25T15:00:34'),
+        createdAt: new Date('2019-12-25T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -575,34 +575,34 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildCampaignParticipation({
         userId: otherUserId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 2,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 3,
         status: 'validated',
         userId: otherUserId,
         skillId: 3,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -620,21 +620,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2020-12-12T15:00:34'),
+        createdAt: new Date('2020-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -652,28 +652,28 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-13T15:00:34'),
+        createdAt: new Date('2019-12-13T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'reset',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 3,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-11T15:00:34'),
+        createdAt: new Date('2019-12-11T15:00:34Z'),
       });
       await databaseBuilder.commit();
 
@@ -691,21 +691,21 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
         userId,
         campaignId,
         isShared: true,
-        sharedAt: new Date('2020-01-01T15:00:34'),
+        sharedAt: new Date('2020-01-01T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 1,
         status: 'reset',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-13T15:00:34'),
+        createdAt: new Date('2019-12-13T15:00:34Z'),
       });
       databaseBuilder.factory.buildKnowledgeElement({
         id: 2,
         status: 'validated',
         userId,
         skillId: 1,
-        createdAt: new Date('2019-12-12T15:00:34'),
+        createdAt: new Date('2019-12-12T15:00:34Z'),
       });
       await databaseBuilder.commit();
 

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -10,8 +10,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
       const session = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
 
-      const birthdate = new Date('01/01/1990');
-      const createdAt = new Date('01/01/2020');
+      const birthdate = new Date('1990-01-01');
+      const createdAt = new Date('2020-01-01');
 
       const competencesWithMark1 = [
         { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
@@ -42,10 +42,10 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       });
 
       const certificationResults = [ certifResult1, certifResult2 ];
-  
+
       // when
       const result = await getCertificationResultsCsv({ session, certificationResults });
-  
+
       // then
       const expectedBirthDate = '01/01/1990';
       const expectedCreatedAt = '01/01/2020';

--- a/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/jury-session-serializer_test.js
@@ -44,9 +44,9 @@ describe('Unit | Serializer | JSONAPI | jury-session-serializer', function() {
             status: 'someStatus',
             description: 'someDescription',
             'examiner-global-comment': 'someComment',
-            'finalized-at': new Date('2020-02-17T14:23:56.000Z'),
-            'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56.000Z'),
-            'published-at': new Date('2020-02-21T14:23:56.000Z'),
+            'finalized-at': new Date('2020-02-17T14:23:56Z'),
+            'results-sent-to-prescriber-at': new Date('2020-02-20T14:23:56Z'),
+            'published-at': new Date('2020-02-21T14:23:56Z'),
           },
           relationships: {
             'jury-certification-summaries': {


### PR DESCRIPTION
## :unicorn: Problème
La règle [no-restricted-syntax](https://eslint.org/docs/rules/no-restricted-syntax) définie dans la racine du repository est redéfinie dans l'API, ce qui empêche la règle définie dans la racine de s'appliquer, par exemple sur le format de date UTC

## :robot: Solution
**Solution de contournement**
Redéfinir manuellement la règle dans l'API
En attendant la solution définitive, des commentaires ont été ajoutés pour indiquer la duplication à apporter en cas d'ajout de sélecteur

**Solution définitive**
Elle permettrait de ne pas devoir la redéfinir, en supprimant ainsi la duplication entre deux fichiers et les incohérences qu'elles peuvent entraîner. Je n'ai pas trouvé cette solution pour l'instant.

## :rainbow: Remarques
Merci à @jonathanperret qui a trouvé le bug

## :100: Pour tester
Dans un fichier de l'API, ajouter cette instruction
`new Date('2020-02-17T14:23:56'),`

Vérifier que `npm run lint` renvoie un code retour <> 0
