### PR TITLE
[FEATURE] Création du mail d'envoi des résultats de certif (PIX-978)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -80,6 +80,7 @@ module.exports = (function() {
           organizationInvitationTemplateId: process.env.SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID,
           organizationInvitationScoTemplateId: process.env.SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID,
           passwordResetTemplateId: process.env.SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID,
+          certificationResultTemplateId: process.env.SENDINBLUE_CERTIFICATION_RESULT_TEMPLATE_ID,
         },
       },
     },
@@ -175,6 +176,8 @@ module.exports = (function() {
     config.mailing.sendinblue.templates.accountCreationTemplateId = 'test-account-creation-template-id';
     config.mailing.sendinblue.templates.organizationInvitationTemplateId = 'test-organization-invitation-demand-template-id';
     config.mailing.sendinblue.templates.organizationInvitationScoTemplateId = 'test-organization-invitation-sco-demand-template-id';
+    config.mailing.sendinblue.templates.certificationResultTemplateId = 'test-certification-result-template-id';
+
     config.mailing.sendinblue.templates.passwordResetTemplateId = 'test-password-reset-template-id';
 
     config.captcha.enabled = false;

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -34,24 +34,24 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
 }
 
 function sendCertificationResultEmail({
-  email, 
-  sessionId, 
-  sessionDate, 
+  email,
+  sessionId,
+  sessionDate,
   certificationCenterName,
-  link, 
+  link,
 }) {
-
+  const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
   const variables = {
     link,
+    sessionId,
+    sessionDate: formatedSessionDate,
+    certificationCenterName,
   };
-
-  const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
     fromName: PIX_NAME,
     to: email,
-    subject: `[Pix] Résultats certifications ${sessionId} du ${formatedSessionDate} à ${certificationCenterName}`,
     template: mailer.certificationResultTemplateId,
     variables,
   });

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,5 +1,6 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
+const moment = require('moment');
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_NAME = 'PIX - Ne pas répondre';
@@ -28,6 +29,30 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
     to: email,
     subject: 'Création de votre compte PIX',
     template: mailer.accountCreationTemplateId,
+    variables,
+  });
+}
+
+function sendCertificationResultEmail({
+  email, 
+  sessionId, 
+  sessionDate, 
+  certificationCenterName,
+  link, 
+}) {
+
+  const variables = {
+    link,
+  };
+
+  const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
+
+  return mailer.sendEmail({
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME,
+    to: email,
+    subject: `[Pix] Résultats certifications ${sessionId} du ${formatedSessionDate} à ${certificationCenterName}`,
+    template: mailer.certificationResultTemplateId,
     variables,
   });
 }
@@ -146,6 +171,7 @@ function sendScoOrganizationInvitationEmail({
 
 module.exports = {
   sendAccountCreationEmail,
+  sendCertificationResultEmail,
   sendOrganizationInvitationEmail,
   sendScoOrganizationInvitationEmail,
   sendResetPasswordDemandEmail,

--- a/api/lib/domain/usecases/update-publication-session.js
+++ b/api/lib/domain/usecases/update-publication-session.js
@@ -19,9 +19,10 @@ module.exports = async function updatePublicationSession({
   await certificationRepository.updatePublicationStatusesBySessionId(sessionId, toPublish);
 
   if (toPublish) {
-    await mailService.sendCertificationResultEmail({ 
+
+    await mailService.sendCertificationResultEmail({
       email: process.env.TEMP_EMAIL,
-      sessionId, 
+      sessionId,
       sessionDate: session.date,
       certificationCenterName: session.certificationCenter,
       link: 'toto/pix.fr',

--- a/api/lib/domain/usecases/update-publication-session.js
+++ b/api/lib/domain/usecases/update-publication-session.js
@@ -1,4 +1,5 @@
 const { InvalidParametersForSessionPublication } = require('../../domain/errors');
+const mailService = require('../../domain/services/mail-service');
 
 module.exports = async function updatePublicationSession({
   sessionId,
@@ -14,9 +15,17 @@ module.exports = async function updatePublicationSession({
   }
 
   let session = await sessionRepository.get(sessionId);
+
   await certificationRepository.updatePublicationStatusesBySessionId(sessionId, toPublish);
 
   if (toPublish) {
+    await mailService.sendCertificationResultEmail({ 
+      email: process.env.TEMP_EMAIL,
+      sessionId, 
+      sessionDate: session.date,
+      certificationCenterName: session.certificationCenter,
+      link: 'toto/pix.fr',
+    });
     session = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
   }
 

--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -4,29 +4,29 @@ const SibApiV3Sdk = require('sib-api-v3-sdk');
 const MailingProvider = require('./MailingProvider');
 const { mailing } = require('../../config');
 
-function _formatPayload(options) {
+function _formatPayload({ to, fromName, from, subject, template, variables, tags }) {
   const payload = {
     to: [{
-      email: options.to,
+      email: to,
     }],
     sender: {
-      name: options.fromName,
-      email: options.from,
+      name: fromName,
+      email: from,
     },
-    subject: options.subject || '',
-    templateId: parseInt(options.template),
+    subject,
+    templateId: parseInt(template),
     headers: {
       'content-type': 'application/json',
       'accept': 'application/json',
     },
   };
 
-  if (options.variables) {
-    payload.params = options.variables;
+  if (variables) {
+    payload.params = variables;
   }
 
-  if (_.isArray(options.tags) && !_.isEmpty(options.tags)) {
-    payload.tags = options.tags;
+  if (_.isArray(tags) && !_.isEmpty(tags)) {
+    payload.tags = tags;
   }
 
   return payload;

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -57,6 +57,10 @@ class Mailer extends MailingProvider {
     return mailing[this._providerName].templates.organizationInvitationScoTemplateId;
   }
 
+  get certificationResultTemplateId() {
+    return mailing[this._providerName].templates.certificationResultTemplateId;
+  }
+
 }
 
 module.exports = new Mailer();

--- a/api/tests/tooling/domain-builder/factory/build-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-session.js
@@ -18,6 +18,7 @@ module.exports = function buildSession({
   resultsSentToPrescriberAt = null,
   publishedAt = null,
   assignedCertificationOfficerId,
+  certificationCandidates = [],
 } = {}) {
   return new Session({
     id,
@@ -35,5 +36,6 @@ module.exports = function buildSession({
     resultsSentToPrescriberAt,
     publishedAt,
     assignedCertificationOfficerId,
+    certificationCandidates,
   });
 };

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -78,10 +78,12 @@ describe('Unit | Service | MailService', () => {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',
         to: userEmailAddress,
-        subject: '[Pix] Résultats certifications 3 du 03/10/2020 à Vincennes',
         template: 'test-certification-result-template-id',
         variables: {
           link,
+          sessionId,
+          certificationCenterName,
+          sessionDate: '03/10/2020',
         },
       };
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -66,6 +66,39 @@ describe('Unit | Service | MailService', () => {
     });
   });
 
+  describe('#sendCertificationResultEmail', () => {
+
+    it('should use mailer to send an email with given options', async () => {
+      // given
+      const link = 'pix.fr';
+      const sessionDate = '2020-10-03';
+      const sessionId = '3';
+      const certificationCenterName = 'Vincennes';
+      const expectedOptions = {
+        from: senderEmailAddress,
+        fromName: 'PIX - Ne pas répondre',
+        to: userEmailAddress,
+        subject: '[Pix] Résultats certifications 3 du 03/10/2020 à Vincennes',
+        template: 'test-certification-result-template-id',
+        variables: {
+          link,
+        },
+      };
+
+      // when
+      await mailService.sendCertificationResultEmail({
+        email: userEmailAddress,
+        sessionId,
+        sessionDate,
+        certificationCenterName,
+        link,
+      });
+
+      // then
+      expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+    });
+  });
+
   describe('#sendResetPasswordDemandEmail', () => {
 
     context('when provided passwordResetDemandBaseUrl is not production', () => {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix PIX-121: Envoi automatique des résultats de certif, nous souhaitons permettre à un CDC de spécifier une adresse email de destinataire des résultats pour chaque candidat d’une session afin que celui-ci puisse recevoir les résultats automatiquement une fois la session publiée. Il s’agit ici de créer/envoyer le mail une fois les résultats d’une session publiés.

## :robot: Solution
Lorsqu’une session de certification est publiée, vérifier si une (ou plusieurs) adresse mail de destinataire a été renseignée pour au moins un candidat de la session : 

- si AUCUNE adresse email n’a été renseignée pour aucun des candidats de la session : aucun mail n’est envoyé

- sinon si une ou plusieurs adresses ont été renseignées, un mail doit être envoyé à chaque adresse : 

un seul et unique mail par destinataire par session (car les fichiers de résultats sont agrégés par session et par adresse email, voir PIX-973: Génération d'un lien permettant de télécharger le fichier des résultats de certif


## :rainbow: Remarques
Le lien vers le téléchargement de fichier affiché dans le mail n'est pas encore défini

## :100: Pour tester

On envoi un mail par adresse, on peut donc tester avec nom.prenom+1@pix.fr et nom.prenom+2@pix.fr

- S'assurer que l'envoie des mails est activé via sendinblue ( variable d'environement de la RA `MAILING_ENABLED=true`)

#### Option 1
- Créer des certification-candidates avec des resultRecipientEmail (valides)
- Faire passer la certification à chaque candidat
- Publier la session 
- Constater que vous recevez bien un email

#### Option 2
- Modifier les resultRecipientEmail des certification-candidates pour des candidats qui ont déjà passé une certification
- Publier la session
- Constater que vous recevez bien un email
