### PR TITLE
[BUGFIX] Ajout d'un await sur la creation de snapshots KE lors du partage de participation

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -131,7 +131,7 @@ module.exports = {
     const savedCampaignParticipation = _toDomain(savedBookshelfCampaignParticipation);
 
     const knowledgeElements = await knowledgeElementRepository.findUniqByUserId({ userId: savedCampaignParticipation.userId, limitDate: savedCampaignParticipation.sharedAt });
-    knowledgeElementSnapshotRepository.save({ userId: savedCampaignParticipation.userId, snappedAt: savedCampaignParticipation.sharedAt, knowledgeElements });
+    await knowledgeElementSnapshotRepository.save({ userId: savedCampaignParticipation.userId, snappedAt: savedCampaignParticipation.sharedAt, knowledgeElements });
 
     return savedCampaignParticipation;
   },


### PR DESCRIPTION
## :unicorn: Problème
Au partage d'une participation, une erreur non catché peut être déclenchée.

L'erreur a été découverte via sentry
https://sentry.io/organizations/pix/issues/1936426783/?project=1398749&referrer=slack

L'erreur vient d'un `await` manquant au moment de la génération des snapshot KE.
https://github.com/1024pix/pix/blob/cbf308eb1676142f311d35a4fcd4f8b68b499f31/api/lib/infrastructure/repositories/campaign-participation-repository.js#L134

## :robot: Solution
Ajouter un `await` lors de la creation des snapshots KE dans le partage de campagne participations.

## :rainbow: Remarques
N/A

## :100: Pour tester
Test de non regression:
Partager les résultats d'une campagne (AZERTY123) et vérifier qu'ils ont bien été reçu.
