### PR TITLE
[FEATURE] Accessibilité de la page de résultat de campagne (PIX-1183)

### DIFF
--- a/mon-pix/app/components/reached-stage.js
+++ b/mon-pix/app/components/reached-stage.js
@@ -3,12 +3,41 @@ import range from 'lodash/range';
 
 export default class ReachedStage extends Component {
 
-  get acquiredStars() {
-    return range(1, this.args.starCount);
+  get firstStar() {
+    return this._stars[0];
   }
 
-  get unacquiredStars() {
-    return range(this.args.starCount, this.args.stageCount);
+  get otherStars() {
+    return this._stars.slice(1);
+  }
+
+  get acquiredStarsCount() {
+    return this._acquiredStars.length;
+  }
+
+  get totalStarsCount() {
+    return this._stars.length;
+  }
+
+  get _stars() {
+    return this._acquiredStars.concat(this._unacquiredStars);
+  }
+
+  get _acquiredStars() {
+    if (this.args.starCount < 1) {
+      return [];
+    }
+    return range(1, this.args.starCount)
+      .map(() => {
+        return { status: 'acquired', imageSrc: 'stage-plain-star.svg' };
+      });
+  }
+
+  get _unacquiredStars() {
+    return range(this.args.starCount, this.args.stageCount)
+      .map(() => {
+        return { status: 'unacquired', imageSrc: 'stage-clear-star.svg' };
+      });
   }
 }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -229,6 +229,7 @@
 
   &__button {
     letter-spacing: 0.031rem;
+    min-width: 100px;
   }
 
   &__legal {

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -86,6 +86,7 @@
 
     <div class="skill-review-result__dash-line"></div>
 
+    <main>
      <div class="skill-review-result__table-header">
         <h2 class="skill-review-result__subtitle">
           {{t 'pages.skill-review.details.title'}}
@@ -102,6 +103,7 @@
        @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
        @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}}
      />
+    </main>
 
     <div class="skill-review-result__information">
       {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -106,7 +106,7 @@
     </main>
 
     <div class="skill-review-result__information">
-      {{fa-icon 'info-circle' class='skill-review-information__info-icon'}}
+      <FaIcon @icon='info-circle' class='skill-review-information__info-icon' aria-hidden="true"/>
       <div class="skill-review-information__text">
         {{t 'pages.skill-review.information'}}
       </div>

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -15,9 +15,10 @@
   {{/if}}
 
   {{#if @displayLoadingButton}}
-    <button type="button" disabled class="button button--green button--round skill-review-share__button">
+    <div class="button button--green button--round skill-review-share__button" aria-hidden="true">
       <span class="loader-in-button">&nbsp;</span>
-    </button>
+    </div>
+    <span class="sr-only">{{t 'pages.skill-review.send-status.in-progress'}}</span>
   {{else}}
     <button class="button button--green button--round skill-review-share__button" {{on "click" @shareCampaignParticipation}} type="button">
       {{t 'pages.skill-review.actions.send'}}

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -3,7 +3,7 @@
     {{t 'pages.skill-review.already-shared'}}
   </div>
   <LinkTo @route="index" class="skill-review-share__back-to-home link">
-    <FaIcon @icon='arrow-right'></FaIcon>
+    <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
     {{t 'pages.skill-review.actions.continue'}}
   </LinkTo>
 {{else}}

--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -17,7 +17,7 @@
         <td>
           <ProgressionGauge @total={{partnerCompetence.totalSkillsCountPercentage}}
                             @value={{partnerCompetence.masteryPercentage}}>
-            {{t 'pages.skill-review.details.skill-progress' percentage=partnerCompetence.masteryPercentage skill=partnerCompetence.name htmlSafe=true}}
+            {{partnerCompetence.masteryPercentage}}%
           </ProgressionGauge>
         </td>
       </tr>
@@ -32,7 +32,7 @@
         <td>
           <ProgressionGauge @total={{competence.totalSkillsCountPercentage}}
                             @value={{competence.masteryPercentage}}>
-            {{t 'pages.skill-review.details.skill-progress' percentage=competence.masteryPercentage skill=competence.name htmlSafe=true}}
+            {{competence.masteryPercentage}}%
           </ProgressionGauge>
         </td>
       </tr>

--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -11,7 +11,7 @@
     {{#each @partnerCompetenceResults as |partnerCompetence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <td>
-          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}">&#8226;</span>
+          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}" aria-hidden="true">&#8226;</span>
           <span>{{partnerCompetence.name}}</span>
         </td>
         <td>
@@ -26,7 +26,7 @@
     {{#each @competenceResults as |competence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <td>
-          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}">&#8226;</span>
+          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}" aria-hidden="true">&#8226;</span>
           <span>{{competence.name}}</span>
         </td>
         <td>

--- a/mon-pix/app/templates/components/reached-stage.hbs
+++ b/mon-pix/app/templates/components/reached-stage.hbs
@@ -1,18 +1,19 @@
   <div class="reached-stage">
     <div class="reached-stage__score">
       <div class="reached-stage-score__stars">
-        {{#each this.acquiredStars as |star|}}
+        {{#if this.firstStar}}
           <img
-            id="acquired-star-{{star}}"
-            src="{{this.rootURL}}/images/stage-plain-star.svg"
-            alt={{t 'pages.skill-review.stage.alt.acquiredStar' index=star}}/>
-        {{/each}}
-        {{#each this.unacquiredStars as |star|}}
-          <img
-            id="unacquired-star-{{star}}"
-            src="{{this.rootURL}}/images/stage-clear-star.svg"
-            alt={{t 'pages.skill-review.stage.alt.unacquiredStar' index=star}}/>
-        {{/each}}
+              data-test-status="{{this.firstStar.status}}"
+              src="{{this.rootURL}}/images/{{this.firstStar.imageSrc}}"
+              alt="{{t 'pages.skill-review.stage.starsAcquired' acquired=this.acquiredStarsCount total=this.totalStarsCount}}"/>
+          {{#each this.otherStars as |star|}}
+            <img
+              data-test-status="{{star.status}}"
+              src="{{this.rootURL}}/images/{{star.imageSrc}}"
+              alt=""
+              role="none"/>
+          {{/each}}
+        {{/if}}
       </div>
       <div class="reached-stage-score__percentage-text">
         {{t 'pages.skill-review.stage.masteryPercentage' percentage=@percentage}}

--- a/mon-pix/tests/integration/components/reached-stage-test.js
+++ b/mon-pix/tests/integration/components/reached-stage-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { find, findAll, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 describe('Integration | Component | reached-stage', function() {
@@ -49,12 +49,10 @@ describe('Integration | Component | reached-stage', function() {
 });
 
 function _expectStars(starCount, stageCount) {
-  for (let index = 1 ; index < starCount ; index ++) {
-    expect(find(`#acquired-star-${index}`)).to.exist;
-    expect(find(`#unacquired-star-${index}`)).to.not.exist;
-  }
-  for (let index = starCount ; index < stageCount ; index ++) {
-    expect(find(`#acquired-star-${index}`)).to.not.exist;
-    expect(find(`#unacquired-star-${index}`)).to.exist;
-  }
+  const fullStarCount = starCount > 0 ? starCount - 1 : 0;
+  const fullStarElement = findAll('.reached-stage-score__stars img[data-test-status=\'acquired\']');
+  const emptyStarElement = findAll('.reached-stage-score__stars img[data-test-status=\'unacquired\']');
+
+  expect(fullStarElement.length).to.equal(fullStarCount);
+  expect(emptyStarElement.length).to.equal(stageCount - starCount);
 }

--- a/mon-pix/tests/unit/components/reached-stage-test.js
+++ b/mon-pix/tests/unit/components/reached-stage-test.js
@@ -7,35 +7,134 @@ describe('Unit | Component | reached-stage', function() {
 
   setupTest();
 
-  [
-    { starCount: 1, stageCount: 1, acquiredStars: [], unacquiredStars: [] },
-    { starCount: 5, stageCount: 5, acquiredStars: [1, 2, 3, 4], unacquiredStars: [] },
-    { starCount: 5, stageCount: 6, acquiredStars: [1, 2, 3, 4], unacquiredStars: [5] },
-    { starCount: 2, stageCount: 10, acquiredStars: [1], unacquiredStars: [2, 3, 4, 5, 6, 7, 8, 9] },
-    { starCount: 2, stageCount: 3, acquiredStars: [1], unacquiredStars: [2] },
-    { starCount: 4, stageCount: 5, acquiredStars: [1, 2, 3], unacquiredStars: [4] },
-  ].map(({ starCount, stageCount, acquiredStars, unacquiredStars }) => {
-    context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
-      describe('#get acquiredStars', function() {
-        it(`should return ${JSON.stringify(acquiredStars)}`, function() {
-          // given
-          const component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+  const acquiredStarImgSrc = 'stage-plain-star.svg';
+  const unacquiredStarImgSrc = 'stage-clear-star.svg';
+  let component;
 
-          // then
-          expect(component.acquiredStars).to.deep.equal(acquiredStars);
+  [
+    { starCount: 1, stageCount: 3, expectedAcquiredStarsCount: 0, expectedUnacquiredStarsCount: 2 },
+    { starCount: 5, stageCount: 5, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 0 },
+    { starCount: 5, stageCount: 6, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 1 },
+    { starCount: 2, stageCount: 10, expectedAcquiredStarsCount: 1, expectedUnacquiredStarsCount: 8 },
+  ].map(({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
+    context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+
+      beforeEach(function() {
+        component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+      });
+
+      describe('#get totalStarsCount', function() {
+        it(`should return ${expectedAcquiredStarsCount + expectedUnacquiredStarsCount}`, function() {
+          const totalStarsCount = component.totalStarsCount;
+
+          const totalStars = expectedAcquiredStarsCount + expectedUnacquiredStarsCount;
+          expect(totalStarsCount).to.equal(totalStars);
         });
       });
 
-      describe('#get unacquiredStars', function() {
-        it(`should return ${JSON.stringify(unacquiredStars)}`, function() {
+      describe('#get acquiredStarsCount', function() {
+        it(`should return ${expectedAcquiredStarsCount}`, function() {
           // given
           const component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
 
           // then
-          expect(component.unacquiredStars).to.deep.equal(unacquiredStars);
+          expect(component.acquiredStarsCount).to.deep.equal(expectedAcquiredStarsCount);
         });
       });
     });
   });
+
+  context('has no acquired star', () => {
+    [
+      { starCount: 1, stageCount: 3, expectedAcquiredStarsCount: 0, expectedUnacquiredStarsCount: 2 },
+    ].map(({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
+      context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+
+        beforeEach(function() {
+          component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+        });
+
+        describe('#get firstStar', function() {
+          it('should return first star with its image', function() {
+            const firstStar = component.firstStar;
+
+            expect(firstStar.imageSrc).to.equal(unacquiredStarImgSrc);
+          });
+        });
+
+        describe('#get otherStars', function() {
+          let otherStars;
+
+          beforeEach(function() {
+            otherStars = component.otherStars;
+          });
+
+          it('should return correct count of stars minus the first one', function() {
+            const totalStars = expectedAcquiredStarsCount + expectedUnacquiredStarsCount;
+
+            expect(otherStars.length).to.equal(totalStars - 1);
+          });
+
+          it('should return correct image for each star', function() {
+            const firstStarCount = 1;
+            const acquiredStarsCount = otherStars.filter((star) => star.imageSrc === acquiredStarImgSrc).length;
+            const unacquiredStarsCount = otherStars.filter((star) => star.imageSrc === unacquiredStarImgSrc).length;
+
+            expect(acquiredStarsCount).to.equal(expectedAcquiredStarsCount);
+            expect(unacquiredStarsCount + firstStarCount).to.equal(expectedUnacquiredStarsCount);
+          });
+        });
+      });
+    });
+  });
+
+  context('has acquired at least one star', () => {
+    [
+      { starCount: 5, stageCount: 5, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 0 },
+      { starCount: 5, stageCount: 6, expectedAcquiredStarsCount: 4, expectedUnacquiredStarsCount: 1 },
+      { starCount: 2, stageCount: 10, expectedAcquiredStarsCount: 1, expectedUnacquiredStarsCount: 8 },
+      { starCount: 2, stageCount: 3, expectedAcquiredStarsCount: 1, expectedUnacquiredStarsCount: 1 },
+      { starCount: 4, stageCount: 5, expectedAcquiredStarsCount: 3, expectedUnacquiredStarsCount: 1 },
+    ].map(({ starCount, stageCount, expectedAcquiredStarsCount, expectedUnacquiredStarsCount }) => {
+      context(`starCount=${starCount} and stageCount=${stageCount}`, () => {
+
+        beforeEach(function() {
+          component = createGlimmerComponent('component:reached-stage', { starCount, stageCount });
+        });
+
+        describe('#get firstStar', function() {
+          it('should return first star with its image', function() {
+            const firstStar = component.firstStar;
+
+            expect(firstStar.imageSrc).to.equal(acquiredStarImgSrc);
+          });
+        });
+
+        describe('#get otherStars', function() {
+          let otherStars;
+
+          beforeEach(function() {
+            otherStars = component.otherStars;
+          });
+
+          it('should return correct count of stars minus the first one', function() {
+            const totalStars = expectedAcquiredStarsCount + expectedUnacquiredStarsCount;
+
+            expect(otherStars.length).to.equal(totalStars - 1);
+          });
+
+          it('should return correct image for each star', function() {
+            const firstStarCount = 1;
+            const acquiredStarsCount = otherStars.filter((star) => star.imageSrc === acquiredStarImgSrc).length;
+            const unacquiredStarsCount = otherStars.filter((star) => star.imageSrc === unacquiredStarImgSrc).length;
+
+            expect(acquiredStarsCount + firstStarCount).to.equal(expectedAcquiredStarsCount);
+            expect(unacquiredStarsCount).to.equal(expectedUnacquiredStarsCount);
+          });
+        });
+      });
+    });
+  });
+
 });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -818,10 +818,7 @@
       "send-title": "Submit your results",
       "stage": {
         "masteryPercentage": "Success rate: {percentage} %",
-        "alt": {
-          "acquiredStar": "Stage no. {index} reached",
-          "unacquiredStar": "Stage no. {index} not reached"
-        }
+        "starsAcquired": "{acquired, plural, =0 {no star} other {# stars}} acquired over {total}"
       },
       "try-again": {
         "title": "Want to improve your results?",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -812,6 +812,9 @@
       "information": "If you have already completed courses on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",
       "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
       "send-results": "Don't forget to submit your results.",
+      "send-status": {
+        "in-progress": "Results are being shared..."
+      },
       "send-title": "Submit your results",
       "stage": {
         "masteryPercentage": "Success rate: {percentage} %",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -807,7 +807,6 @@
         "header-result": "Results",
         "result": "Overall result",
         "result-by-skill": "Your results for the skill",
-        "skill-progress": "'<p class=\"sr-only\">'You have completed '</p>'{percentage}%'<p class=\"sr-only\">' of the skill {skill}.'</p>'",
         "title": "Your results by skill"
       },
       "information": "If you have already completed courses on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -807,7 +807,6 @@
         "header-result": "Résultats",
         "result": "Résultat global",
         "result-by-skill": "Votre résultat pour la compétence",
-        "skill-progress": "'<p class=\"sr-only\">'Vous avez validé '</p>'{percentage}%'<p class=\"sr-only\">' de la compétence {skill}.'</p>'",
         "title": "Vos résultats par compétence"
       },
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -812,6 +812,9 @@
       "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
       "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
       "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
+      "send-status": {
+        "in-progress": "Envoi en cours"
+      },
       "send-title": "Envoyez vos résultats",
       "stage": {
         "masteryPercentage": "{percentage} % de réussite",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -818,10 +818,7 @@
       "send-title": "Envoyez vos résultats",
       "stage": {
         "masteryPercentage": "{percentage} % de réussite",
-        "alt": {
-          "acquiredStar": "Palier n°{index} atteint",
-          "unacquiredStar": "Palier n°{index} non atteint"
-        }
+        "starsAcquired": "{acquired, plural, =0 {aucune étoile acquise} other {# étoiles acquises}} sur {total}"
       },
       "try-again": {
         "title": "Envie d'améliorer vos résultats ?",


### PR DESCRIPTION
## :unicorn: Problème
Des personnes en situations de handicap doivent pouvoir terminer une campagne et envoyer leur résultats.

## :robot: Solution
- Ajouter un bloc main sur toute la partie avec les résultats
- Supprimer les sr-only inutiles sur le % du résultat de chaque compétence (cf. rapport INJA)
- Mettre `aria-hidden` sur les icons descriptives
- Mettre une alternative textuelle sur une icône de chargement
- Pour les groupes d'images (par exemple, le score avec les étoiles), la recommendation est de mettre un alt seulement sur la première étoile (cf. https://www.w3.org/WAI/tutorials/images/groups/)

## :rainbow: Remarques
`starCount` représente le nombre de palier atteint.
Le palier peut avoir un threshold de 0. Ce qui fait que ce palier est atteint, mais une étoile n'est pas accordée dans ce cas.

## :100: Pour tester
Faire un parcours (ex: BADGES789) et vérifier que la page est accessible.
