### PR TITLE
[BUG] Rediriger les utilisateurs authentifiés depuis le médiacentre vers la page de déconnexion (pix-1284)

### DIFF
--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -7,6 +7,9 @@ import classic from 'ember-classic-decorator';
 import Component from '@ember/component';
 import { inject } from '@ember/service';
 import { action, computed } from '@ember/object';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 @classic
 export default class LoginForm extends Component {
@@ -69,6 +72,9 @@ export default class LoginForm extends Component {
 
     try {
       await this.session.authenticate('authenticator:oauth2', { login, password, scope });
+      if (this.externalUserToken) {
+        this.session.set('data.authenticated.source', AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
+      }
     } catch (err) {
       const title = ('errors' in err) ? err.errors.get('firstObject').title : null;
       if (title === 'PasswordShouldChange') {

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -10,6 +10,7 @@ import get from 'lodash/get';
 import ENV from 'mon-pix/config/environment';
 
 const ERROR_PASSWORD_MESSAGE = 'pages.update-expired-password.fields.error';
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 const VALIDATION_MAP = {
   default: {
@@ -69,6 +70,9 @@ export default class UpdateExpiredPasswordForm extends Component {
       this.validation = SUBMISSION_MAP['default'];
       await this.user.unloadRecord();
       await this._authenticateWithUpdatedPassword({ login: this.user.username, password: this.newPassword });
+      if (this.session.get('data.externalUser')) {
+        this.session.data.authenticated.source = AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+      }
     } catch (err) {
       this.validation = SUBMISSION_MAP['error'];
     } finally {

--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -1,6 +1,9 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { isEmpty } from '@ember/utils';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 export default class JoinRoute extends Route {
   @service currentUser;
@@ -28,7 +31,7 @@ export default class JoinRoute extends Route {
 
   setupController(controller) {
     super.setupController(...arguments);
-    if (this.session.data.authenticated.source === 'external') {
+    if (this.session.data.authenticated.source === AUTHENTICATED_SOURCE_FROM_MEDIACENTRE) {
       controller.set('firstName', this.currentUser.user.firstName);
       controller.set('lastName', this.currentUser.user.lastName);
     }

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -1,7 +1,9 @@
 import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
-
 import Route from '@ember/routing/route';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 @classic
 export default class LogoutRoute extends Route {
@@ -18,7 +20,7 @@ export default class LogoutRoute extends Route {
   }
 
   afterModel() {
-    if (this.source === 'external') {
+    if (this.source === AUTHENTICATED_SOURCE_FROM_MEDIACENTRE) {
       return this._redirectToDisconnectedPage();
     } else {
       return this._redirectToHome();

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -74,6 +74,7 @@ module.exports = function(environment) {
           MESSAGE: 'api-error-messages.internal-server-error',
         },
       },
+      AUTHENTICATED_SOURCE_FROM_MEDIACENTRE: 'external',
     },
 
     googleFonts: [

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -11,6 +11,10 @@ import { contains } from '../helpers/contains';
 
 import { authenticateByEmail, authenticateByGAR } from '../helpers/authentication';
 import { startCampaignByCode, startCampaignByCodeAndExternalId } from '../helpers/campaign';
+import { currentSession } from 'ember-simple-auth/test-support';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
@@ -782,7 +786,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           let garUser;
 
           beforeEach(async function() {
-            garUser = server.create('user', 'external');
+            garUser = server.create('user', AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
             await authenticateByGAR(garUser);
             server.create('schooling-registration-user-association', {
               campaignCode: campaign.code,
@@ -862,6 +866,9 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#login', prescritUser.email);
             await fillIn('#password', prescritUser.password);
             await click('#submit-connexion');
+
+            const session = currentSession();
+            expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
 
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -999,8 +1006,11 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
               // when
               await fillIn('#password', 'newPass12345!');
-
               await click('.button');
+
+              // then
+              const session = currentSession();
+              expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
 
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
               expect(contains('Commencez votre parcours')).to.exist;

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
@@ -4,6 +4,9 @@ import Service from '@ember/service';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 describe('Unit | Route | campaigns/restricted/join', function() {
   setupTest();
@@ -38,7 +41,7 @@ describe('Unit | Route | campaigns/restricted/join', function() {
       const route = this.owner.lookup('route:campaigns.restricted.join');
       const controller = EmberObject.create();
       route.set('session', Service.create({
-        data: { authenticated: { source: 'external' } },
+        data: { authenticated: { source: AUTHENTICATED_SOURCE_FROM_MEDIACENTRE } },
       }));
       const firstName = 'firstName', lastName = 'lastName';
       route.set('currentUser', Service.create({

--- a/mon-pix/tests/unit/routes/logout-test.js
+++ b/mon-pix/tests/unit/routes/logout-test.js
@@ -2,6 +2,9 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import ENV from 'mon-pix/config/environment';
+
+const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
 describe('Unit | Route | logout', () => {
   setupTest();
@@ -13,7 +16,7 @@ describe('Unit | Route | logout', () => {
     const invalidateStub = sinon.stub();
     sessionStub = Service.create({ isAuthenticated: true, invalidate: invalidateStub, data: {
       authenticated: {
-        source: 'external',
+        source: AUTHENTICATED_SOURCE_FROM_MEDIACENTRE,
       },
     },
     });
@@ -55,7 +58,7 @@ describe('Unit | Route | logout', () => {
     const route = this.owner.lookup('route:logout');
     route.set('session', sessionStub);
     route._redirectToDisconnectedPage = sinon.stub();
-    route.source = 'external';
+    route.source = AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
 
     // When
     route.afterModel();


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs authentifiés depuis le médiacentre sont redirigés vers la page de /connexion lors de la déconnexion au lieu de la page /nonconnecte. Ce bug est reproductible dans les scénarios suivants:

- Première connexion d'un utilisateur authentifié depuis le médiacentre et qui est déjà réconcilié avec un autre compte.
- Idem mais avec un changement de mot de passe expiré.

## :robot: Solution
Rajouter la source 'external' lorsqu'on authentifie un utilisateur externe qui doit se reconnecter avec son compte [email/username] existant.
La route de déconnexion permet de rediriger vers la page de déconnexion quand l'attribut source=external est présent.

## :rainbow: Remarques
Pour accéder à une session depuis un test d'acceptance, utiliser le helper [currentSession](https://github.com/simplabs/ember-simple-auth/blob/master/packages/test-app/tests/acceptance/authentication-test.js)
Une mutualisation de la constante 'external' comme BSR pour eviter les magic string. 
Un fichier constants.js a été créé mais n'est pas chargé correctement par Ember. Une autre option est d'utiliser le fichier environnement.js. Voir ici https://discuss.emberjs.com/t/where-would-i-put-a-global-constants-file/8425.
Need validation avant de généraliser le BSR pour les autres constantes présente dans le code.


## :100: Pour tester
Se connecter avec le bouchon du [GAR](https://test-idp.integration.pix.fr/) avec le nom : first prénom: last . 
Saisir la date de naissance 10-10-2010 pour se réconcilier.
Se connecter avec le bon compte [first.last@example.net]
Vérifier que lors de la déconnexion on arrive bien à la page /nonconnecte.
