### PR TITLE
[FEATURE] Ajout du numéro étudiant dans l'export csv d'une campagne de collecte de profils (PIX-1139).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -53,6 +53,7 @@ module.exports = {
       (qb) => {
         qb.select([
           'campaign-participations.*',
+          'schooling-registrations.studentNumber',
           knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
           knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
         ])
@@ -194,6 +195,7 @@ function _rowToResult(row) {
     participantExternalId: row.participantExternalId,
     userId: row.userId,
     isCompleted: row.state === 'completed',
+    studentNumber: row.studentNumber,
     participantFirstName: row.firstName,
     participantLastName: row.lastName,
   };

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -18,24 +18,25 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
     let organization;
     let user;
     let participant;
+    let schoolingRegistration;
     let campaign;
     let campaignParticipation;
     let writableStream;
     let csvPromise;
+    const createdAt = new Date('2019-02-25T10:00:00Z');
 
     beforeEach(async () => {
-      organization = databaseBuilder.factory.buildOrganization();
       user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
+      organization = databaseBuilder.factory.buildOrganization();
       const skillWeb1 = airtableBuilder.factory.buildSkill({ id: 'recSkillWeb1', nom: '@web1', ['compétenceViaTube']: ['recCompetence1'] });
       const skillWeb2 = airtableBuilder.factory.buildSkill({ id: 'recSkillWeb2', nom: '@web2', ['compétenceViaTube']: ['recCompetence1'] });
       const skillWeb3 = airtableBuilder.factory.buildSkill({ id: 'recSkillWeb3', nom: '@web3', ['compétenceViaTube']: ['recCompetence1'] });
       const skillUrl1 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl1', nom: '@url1', ['compétenceViaTube']: ['recCompetence2'] });
       const skillUrl8 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl8', nom: '@url8', ['compétenceViaTube']: ['recCompetence2'] });
       const skills = [skillWeb1, skillWeb2, skillWeb3, skillUrl1, skillUrl8];
-
-      participant = databaseBuilder.factory.buildUser({ firstName: '@Jean', lastName: '=Bono' });
-      const createdAt = new Date('2019-02-25T10:00:00Z');
+  
+      participant = databaseBuilder.factory.buildUser();
+      
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
@@ -88,28 +89,9 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         userId: participant.id,
         createdAt,
       });
-
-      campaign = databaseBuilder.factory.buildCampaign({
-        name: '@Campagne de Test N°2',
-        code: 'QWERTY456',
-        organizationId: organization.id,
-        idPixLabel: 'Mail Perso',
-        targetProfileId: null,
-        type: 'PROFILES_COLLECTION',
-        title: null,
-      });
-
-      campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
-        createdAt,
-        sharedAt: new Date('2019-03-01T23:04:05Z'),
-        participantExternalId: '+Mon mail pro',
-        campaignId: campaign.id,
-        isShared: true,
-        userId: participant.id,
-      });
-
+    
       await databaseBuilder.commit();
-
+  
       const competence1 = airtableBuilder.factory.buildCompetence({
         id: 'recCompetence1',
         titre: 'Competence1',
@@ -117,7 +99,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         domaineIds: ['recArea1'],
         acquisViaTubes: [skillWeb1, skillWeb2, skillWeb3].map((skill) => skill.id),
       });
-
+  
       const competence2 = airtableBuilder.factory.buildCompetence({
         id: 'recCompetence2',
         titre: 'Competence2',
@@ -125,14 +107,14 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         domaineIds: ['recArea3'],
         acquisViaTubes: [skillUrl1.id, skillUrl8.id],
       });
-
+  
       const area1 = airtableBuilder.factory.buildArea({ id: 'recArea1', code: '1', titre: 'Domain 1' });
       const area3 = airtableBuilder.factory.buildArea({ id: 'recArea3', code: '3', title: 'Domain 3' });
-
+  
       airtableBuilder.mockList({ tableName: 'Competences' }).returns([competence1, competence2]).activate();
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns(skills).activate();
       airtableBuilder.mockList({ tableName: 'Domaines' }).returns([area1, area3]).activate();
-
+  
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
     });
@@ -142,45 +124,150 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
       return cache.flushAll();
     });
 
-    it('should return the complete line', async () => {
-      // given
-      const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
-      const expectedCsvSecondLine = `"${organization.name}";` +
-        `${campaign.id};` +
-        `"'${campaign.name}";` +
-        `"'${participant.lastName}";` +
-        `"'${participant.firstName}";` +
-        `"'${campaignParticipation.participantExternalId}";` +
-        '"Oui";' +
-        '2019-03-01;' +
-        '52;' +
-        '"Non";' +
-        '2;' +
-        '1;' +
-        '12;' +
-        '5;' +
-        '40';
+    context('When the organization is not SUP', () => {
 
-      // when
-      startWritingCampaignProfilesCollectionResultsToStream({
-        userId: user.id,
-        campaignId: campaign.id,
-        writableStream,
-        campaignRepository,
-        userRepository,
-        competenceRepository,
-        organizationRepository,
-        campaignParticipationRepository,
-        placementProfileService,
+      beforeEach(async () => {
+        organization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
+        databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
+
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, firstName: '@Jean', lastName: '=Bono' });
+
+        campaign = databaseBuilder.factory.buildCampaign({
+          name: '@Campagne de Test N°2',
+          code: 'QWERTY456',
+          organizationId: organization.id,
+          idPixLabel: 'Mail Perso',
+          targetProfileId: null,
+          type: 'PROFILES_COLLECTION',
+          title: null,
+        });
+    
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          createdAt,
+          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          participantExternalId: '+Mon mail pro',
+          campaignId: campaign.id,
+          isShared: true,
+          userId: participant.id,
+        });
+
+        await databaseBuilder.commit();
       });
 
-      const csv = await csvPromise;
-      const csvLines = csv.split('\n');
-      const csvFirstLineCells = csvLines[0].split(';');
+      it('should return the complete line', async () => {
+        // given
+        const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
+        const expectedCsvSecondLine = `"${organization.name}";` +
+          `${campaign.id};` +
+          `"'${campaign.name}";` +
+          `"'${schoolingRegistration.lastName}";` +
+          `"'${schoolingRegistration.firstName}";` +
+          `"'${campaignParticipation.participantExternalId}";` +
+          '"Oui";' +
+          '2019-03-01;' +
+          '52;' +
+          '"Non";' +
+          '2;' +
+          '1;' +
+          '12;' +
+          '5;' +
+          '40';
+  
+        // when
+        startWritingCampaignProfilesCollectionResultsToStream({
+          userId: user.id,
+          campaignId: campaign.id,
+          writableStream,
+          campaignRepository,
+          userRepository,
+          competenceRepository,
+          organizationRepository,
+          campaignParticipationRepository,
+          placementProfileService,
+        });
+  
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+        const csvFirstLineCells = csvLines[0].split(';');
+  
+        // then
+        expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
+        expect(csvLines[1]).to.equal(expectedCsvSecondLine);
+      });
+    });
 
-      // then
-      expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
-      expect(csvLines[1]).to.equal(expectedCsvSecondLine);
+    context('When the organization is SUP and isManagingStudent', () => {
+      
+      beforeEach(async () => {
+        organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
+
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, studentNumber: '12345A', firstName: '@Jean', lastName: '=Bono' });
+
+        campaign = databaseBuilder.factory.buildCampaign({
+          name: '@Campagne de Test N°2',
+          code: 'QWERTY456',
+          organizationId: organization.id,
+          idPixLabel: 'Mail Perso',
+          targetProfileId: null,
+          type: 'PROFILES_COLLECTION',
+          title: null,
+        });
+    
+        campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
+          createdAt,
+          sharedAt: new Date('2019-03-01T23:04:05Z'),
+          participantExternalId: '+Mon mail pro',
+          campaignId: campaign.id,
+          isShared: true,
+          userId: participant.id,
+        });
+
+        await databaseBuilder.commit();
+      });
+  
+      it('should return the complete line with student number', async () => {
+        // given
+        const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
+        const expectedCsvSecondLine = `"${organization.name}";` +
+          `${campaign.id};` +
+          `"'${campaign.name}";` +
+          `"'${schoolingRegistration.lastName}";` +
+          `"'${schoolingRegistration.firstName}";` +
+          `"${schoolingRegistration.studentNumber}";` +
+          `"'${campaignParticipation.participantExternalId}";` +
+          '"Oui";' +
+          '2019-03-01;' +
+          '52;' +
+          '"Non";' +
+          '2;' +
+          '1;' +
+          '12;' +
+          '5;' +
+          '40';
+  
+        // when
+        startWritingCampaignProfilesCollectionResultsToStream({
+          userId: user.id,
+          campaignId: campaign.id,
+          writableStream,
+          campaignRepository,
+          userRepository,
+          competenceRepository,
+          organizationRepository,
+          campaignParticipationRepository,
+          placementProfileService,
+        });
+  
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+        const csvFirstLineCells = csvLines[0].split(';');
+  
+        // then
+        expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
+        expect(csvLines[1]).to.equal(expectedCsvSecondLine);
+      });
     });
   });
+
 });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -6,10 +6,17 @@ const PlacementProfile = require('../../../../lib/domain/models/PlacementProfile
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
 
+  const user = domainBuilder.buildUser({ firstName: '@Jean', lastName: '=Bono' });
+  const organization = user.memberships[0].organization;
+  let campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection({
+    name: '@Campagne de Test N°2',
+    code: 'QWERTY456',
+    organizationId: organization.id,
+    idPixLabel: null,
+  });
+
   describe('#startWritingCampaignProfilesCollectionResultsToStream', () => {
 
-    const user = domainBuilder.buildUser({ firstName: '@Jean', lastName: '=Bono' });
-    const organization = user.memberships[0].organization;
     const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
     const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
 
@@ -25,13 +32,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
         skillIds: listSkills2.map((skill) => skill.id),
       },
     ];
-
-    const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection({
-      name: '@Campagne de Test N°2',
-      code: 'QWERTY456',
-      organizationId: organization.id,
-      idPixLabel: 'Mail Perso',
-    });
 
     const placementProfile = new PlacementProfile({
       userId: 123,
@@ -60,88 +60,505 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
     beforeEach(() => {
       sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(competences);
       sinon.stub(userRepository, 'getWithMemberships').resolves(user);
-      sinon.stub(organizationRepository, 'get').resolves(organization);
       findProfilesCollectionResultDataByCampaignIdStub = sinon.stub(campaignParticipationRepository, 'findProfilesCollectionResultDataByCampaignId');
       sinon.stub(campaignRepository, 'get').resolves(campaign);
       sinon.stub(placementProfileService, 'getPlacementProfilesWithSnapshotting').resolves([placementProfile]);
-
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
     });
 
-    it('should return the header in CSV styles with all competences', async () => {
-      // given
-      const csvExpected = '\uFEFF"Nom de l\'organisation";' +
-        '"ID Campagne";' +
-        '"Nom de la campagne";' +
-        '"Nom du Participant";' +
-        '"Prénom du Participant";' +
-        '"Mail Perso";' +
-        '"Envoi (O/N)";' +
-        '"Date de l\'envoi";' +
-        '"Nombre de pix total";' +
-        '"Certifiable (O/N)";' +
-        '"Nombre de compétences certifiables";' +
-        '"Niveau pour la compétence Competence1";' +
-        '"Nombre de pix pour la compétence Competence1";' +
-        '"Niveau pour la compétence Competence2";' +
-        '"Nombre de pix pour la compétence Competence2"\n';
-      findProfilesCollectionResultDataByCampaignIdStub.resolves([]);
-
-      // when
-      startWritingCampaignProfilesCollectionResultsToStream({
-        userId: user.id,
-        campaignId: campaign.id,
-        writableStream,
-        campaignRepository,
-        userRepository,
-        competenceRepository,
-        organizationRepository,
-        campaignParticipationRepository,
-        placementProfileService,
+    context('When organization is not SUP', () => {
+      beforeEach(() => {
+        organization.type = 'SCO';
+        sinon.stub(organizationRepository, 'get').resolves(organization);
       });
 
-      const csv = await csvPromise;
+      it('should return the header in CSV styles with all competences', async () => {
+        // given
+        const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
+          '"ID Campagne";' +
+          '"Nom de la campagne";' +
+          '"Nom du Participant";' +
+          '"Prénom du Participant";' +
+          '"Envoi (O/N)";' +
+          '"Date de l\'envoi";' +
+          '"Nombre de pix total";' +
+          '"Certifiable (O/N)";' +
+          '"Nombre de compétences certifiables";' +
+          '"Niveau pour la compétence Competence1";' +
+          '"Nombre de pix pour la compétence Competence1";' +
+          '"Niveau pour la compétence Competence2";' +
+          '"Nombre de pix pour la compétence Competence2"\n';
+        findProfilesCollectionResultDataByCampaignIdStub.resolves([]);
+  
+        // when
+        startWritingCampaignProfilesCollectionResultsToStream({
+          userId: user.id,
+          campaignId: campaign.id,
+          writableStream,
+          campaignRepository,
+          userRepository,
+          competenceRepository,
+          organizationRepository,
+          campaignParticipationRepository,
+          placementProfileService,
+        });
+  
+        const csv = await csvPromise;
+  
+        // then
+        expect(csv).to.equal(expectedHeader);
+      });
+  
+      context('when isShared is true', () => {
+  
+        it('should return the complete line with 1 certifiable competence', async () => {
+          // given
+          sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
+          sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(1);
+  
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: true,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+          };
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine = `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            '"Oui";' +
+            '2019-03-01;' +
+            '13;' +
+            '"Non";' +
+            '1;' +
+            '1;' +
+            '9;' +
+            '0;' +
+            '4';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+  
+        it('should return the complete line with 5 certifiable competence', async () => {
+          // given
+          sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
+          sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
+  
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: true,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+          };
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine = `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            '"Oui";' +
+            '2019-03-01;' +
+            '13;' +
+            '"Oui";' +
+            '5;' +
+            '1;' +
+            '9;' +
+            '0;' +
+            '4';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+      });
+  
+      context('when isShared is false', () => {
+  
+        it('should return the beginning of the line with user information for her participation', async () => {
+          // given
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: false,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            participantExternalId: '-Mon mail pro',
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+          };
+  
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+      });
+    });
+    
+    context('When organization is SUP and isManagingStudent', () => {
+      beforeEach(() => {
+        organization.type = 'SUP';
+        organization.isManagingStudents = true;
+        sinon.stub(organizationRepository, 'get').resolves(organization);
+      });
 
-      // then
-      expect(csv).to.equal(csvExpected);
+      it('should return the header in CSV with Student Number', async () => {
+        // given
+        const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
+          '"ID Campagne";' +
+          '"Nom de la campagne";' +
+          '"Nom du Participant";' +
+          '"Prénom du Participant";' +
+          '"Numéro Étudiant";' +
+          '"Envoi (O/N)";' +
+          '"Date de l\'envoi";' +
+          '"Nombre de pix total";' +
+          '"Certifiable (O/N)";' +
+          '"Nombre de compétences certifiables";' +
+          '"Niveau pour la compétence Competence1";' +
+          '"Nombre de pix pour la compétence Competence1";' +
+          '"Niveau pour la compétence Competence2";' +
+          '"Nombre de pix pour la compétence Competence2"';
+  
+        // when
+        startWritingCampaignProfilesCollectionResultsToStream({
+          userId: user.id,
+          campaignId: campaign.id,
+          writableStream,
+          campaignRepository,
+          userRepository,
+          competenceRepository,
+          organizationRepository,
+          campaignParticipationRepository,
+          placementProfileService,
+        });
+  
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+  
+        // then
+        expect(csvLines[0]).to.equal(expectedHeader);
+      });
+  
+      context ('when the participant does not have a student number', () => {
+        it('should return the csv without student number information', async () => {
+          // given
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: false,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+            studentNumber: '',
+          };
+  
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            `"${campaignParticipationResultData.studentNumber}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+      });
+  
+      context ('when the participant have a student number', () => {
+        it('should return the csv with student number information', async () => {
+          // given
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: false,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+            studentNumber: '12345A',
+          };
+  
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            `"${campaignParticipationResultData.studentNumber}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+      });
     });
 
-    context('when isShared is true', () => {
-
-      it('should return the complete line with 1 certifiable competence', async () => {
+    context('When organization is SUP and not isManagingStudent', () => {
+      beforeEach(() => {
+        organization.type = 'SUP';
+        organization.isManagingStudents = false;
+        sinon.stub(organizationRepository, 'get').resolves(organization);
+      });
+  
+      it('should return the header in CSV without Student Number', async () => {
         // given
-        sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
-        sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(1);
+        const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
+            '"ID Campagne";' +
+            '"Nom de la campagne";' +
+            '"Nom du Participant";' +
+            '"Prénom du Participant";' +
+            '"Envoi (O/N)";' +
+            '"Date de l\'envoi";' +
+            '"Nombre de pix total";' +
+            '"Certifiable (O/N)";' +
+            '"Nombre de compétences certifiables";' +
+            '"Niveau pour la compétence Competence1";' +
+            '"Nombre de pix pour la compétence Competence1";' +
+            '"Niveau pour la compétence Competence2";' +
+            '"Nombre de pix pour la compétence Competence2"';
+    
+        // when
+        startWritingCampaignProfilesCollectionResultsToStream({
+          userId: user.id,
+          campaignId: campaign.id,
+          writableStream,
+          campaignRepository,
+          userRepository,
+          competenceRepository,
+          organizationRepository,
+          campaignParticipationRepository,
+          placementProfileService,
+        });
+    
+        const csv = await csvPromise;
+        const csvLines = csv.split('\n');
+    
+        // then
+        expect(csvLines[0]).to.equal(expectedHeader);
+      });
 
-        const campaignParticipationResultData = {
-          id: 1,
-          isShared: true,
-          isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
-          participantExternalId: '+Mon mail pro',
-          userId: 123,
-          participantFirstName: user.firstName,
-          participantLastName: user.lastName,
-        };
-        findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+      context ('when the participant have a student number', () => {
+        it('should return the csv without student number information', async () => {
+          // given
+          const campaignParticipationResultData = {
+            id: 1,
+            isShared: false,
+            isCompleted: true,
+            createdAt: new Date('2019-02-25T10:00:00Z'),
+            sharedAt: new Date('2019-03-01T23:04:05Z'),
+            userId: 123,
+            participantFirstName: user.firstName,
+            participantLastName: user.lastName,
+            studentNumber: '12345A',
+          };
+  
+          findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
+  
+          const csvSecondLine =
+            `"${organization.name}";` +
+            `${campaign.id};` +
+            `"'${campaign.name}";` +
+            `"'${user.lastName}";` +
+            `"'${user.firstName}";` +
+            '"Non";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA";' +
+            '"NA"';
+  
+          // when
+          startWritingCampaignProfilesCollectionResultsToStream({
+            userId: user.id,
+            campaignId: campaign.id,
+            writableStream,
+            campaignRepository,
+            userRepository,
+            competenceRepository,
+            organizationRepository,
+            campaignParticipationRepository,
+            placementProfileService,
+          });
+  
+          const csv = await csvPromise;
+          const csvLines = csv.split('\n');
+  
+          // then
+          expect(csvLines[1]).to.equal(csvSecondLine);
+        });
+      });
+    });
+    
+    context('When campaign has an idPixLabel', () => {
+      beforeEach(() => {
+        organization.type = 'SCO';
+        campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection({
+          name: '@Campagne test idPixLabel',
+          code: 'AZERTY123',
+          organizationId: organization.id,
+          idPixLabel: 'Mail Pro',
+        });
 
-        const csvSecondLine = `"${organization.name}";` +
-          `${campaign.id};` +
-          `"'${campaign.name}";` +
-          `"'${user.lastName}";` +
-          `"'${user.firstName}";` +
-          `"'${campaignParticipationResultData.participantExternalId}";` +
-          '"Oui";' +
-          '2019-03-01;' +
-          '13;' +
-          '"Non";' +
-          '1;' +
-          '1;' +
-          '9;' +
-          '0;' +
-          '4';
+        campaignRepository.get.resolves(campaign);
+        sinon.stub(organizationRepository, 'get').resolves(organization);
+      });
+
+      it('should return the header in CSV styles with all competence, domain and skills', async () => {
+        // given
+        const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
+          '"ID Campagne";' +
+          '"Nom de la campagne";' +
+          '"Nom du Participant";' +
+          '"Prénom du Participant";' +
+          '"Mail Pro";' +
+          '"Envoi (O/N)";' +
+          '"Date de l\'envoi";' +
+          '"Nombre de pix total";' +
+          '"Certifiable (O/N)";' +
+          '"Nombre de compétences certifiables";' +
+          '"Niveau pour la compétence Competence1";' +
+          '"Nombre de pix pour la compétence Competence1";' +
+          '"Niveau pour la compétence Competence2";' +
+          '"Nombre de pix pour la compétence Competence2"';
 
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
@@ -160,69 +577,11 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
         const csvLines = csv.split('\n');
 
         // then
-        expect(csvLines[1]).to.equal(csvSecondLine);
+        expect(csvLines[0]).to.equal(expectedHeader);
       });
 
-      it('should return the complete line with 5 certifiable competence', async () => {
+      it('should return the csv with external id label', async () => {
         // given
-        sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
-        sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
-
-        const campaignParticipationResultData = {
-          id: 1,
-          isShared: true,
-          isCompleted: true,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          sharedAt: new Date('2019-03-01T23:04:05Z'),
-          participantExternalId: '+Mon mail pro',
-          userId: 123,
-          participantFirstName: user.firstName,
-          participantLastName: user.lastName,
-        };
-        findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-
-        const csvSecondLine = `"${organization.name}";` +
-          `${campaign.id};` +
-          `"'${campaign.name}";` +
-          `"'${user.lastName}";` +
-          `"'${user.firstName}";` +
-          `"'${campaignParticipationResultData.participantExternalId}";` +
-          '"Oui";' +
-          '2019-03-01;' +
-          '13;' +
-          '"Oui";' +
-          '5;' +
-          '1;' +
-          '9;' +
-          '0;' +
-          '4';
-
-        // when
-        startWritingCampaignProfilesCollectionResultsToStream({
-          userId: user.id,
-          campaignId: campaign.id,
-          writableStream,
-          campaignRepository,
-          userRepository,
-          competenceRepository,
-          organizationRepository,
-          campaignParticipationRepository,
-          placementProfileService,
-        });
-
-        const csv = await csvPromise;
-        const csvLines = csv.split('\n');
-
-        // then
-        expect(csvLines[1]).to.equal(csvSecondLine);
-      });
-    });
-
-    context('when isShared is false', () => {
-
-      it('should return the beginning of the line with user information for her participation', async () => {
-        // given
-
         const campaignParticipationResultData = {
           id: 1,
           isShared: false,
@@ -272,67 +631,6 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
 
         // then
         expect(csvLines[1]).to.equal(csvSecondLine);
-      });
-    });
-
-    context('when campaign do not have a idPixLabel', () => {
-
-      beforeEach(() => {
-        const campaignParticipationResultData = {
-          id: 1,
-          isShared: false,
-          createdAt: new Date('2019-02-25T10:00:00Z'),
-          userId: 123,
-          participantFirstName: user.firstName,
-          participantLastName: user.lastName,
-        };
-
-        findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-
-        const campaignWithoutIdPixLabel = domainBuilder.buildCampaign.ofTypeProfilesCollection({
-          name: 'CampaignName',
-          code: 'AZERTY123',
-          organizationId: organization.id,
-          idPixLabel: null,
-        });
-        campaignRepository.get.resolves(campaignWithoutIdPixLabel);
-      });
-
-      it('should return the header in CSV styles with all competence, domain and skills', async () => {
-        // given
-        const csvExpected = '\uFEFF"Nom de l\'organisation";' +
-          '"ID Campagne";' +
-          '"Nom de la campagne";' +
-          '"Nom du Participant";' +
-          '"Prénom du Participant";' +
-          '"Envoi (O/N)";' +
-          '"Date de l\'envoi";' +
-          '"Nombre de pix total";' +
-          '"Certifiable (O/N)";' +
-          '"Nombre de compétences certifiables";' +
-          '"Niveau pour la compétence Competence1";' +
-          '"Nombre de pix pour la compétence Competence1";' +
-          '"Niveau pour la compétence Competence2";' +
-          '"Nombre de pix pour la compétence Competence2"';
-
-        // when
-        startWritingCampaignProfilesCollectionResultsToStream({
-          userId: user.id,
-          campaignId: campaign.id,
-          writableStream,
-          campaignRepository,
-          userRepository,
-          competenceRepository,
-          organizationRepository,
-          campaignParticipationRepository,
-          placementProfileService,
-        });
-
-        const csv = await csvPromise;
-        const csvLines = csv.split('\n');
-
-        // then
-        expect(csvLines[0]).to.equal(csvExpected);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les orgas SUP peuvent gérer leurs étudiants.
Nous permettons la réconciliation entre le compte utilisateur et les personnes importées. Nous pourrions afficher pour un besoin de clarté pour nos prescripteurs le numéro étudiant saisi dans la table schooling registration.

## :robot: Solution
Afficher dans les exports csv le numéro étudiant de l'étudiant présent dans la schooling registration (pour ceux qui en ont seulement, sinon laisser le champ vide pour les surnuméraires qui n’auraient pas saisi de numéro étudiant).

<img width="764" alt="Capture d’écran 2020-10-06 à 17 32 28" src="https://user-images.githubusercontent.com/13931126/95226284-09f36b00-07fd-11eb-89aa-8fd5b25cfe24.png">

<img width="789" alt="Capture d’écran 2020-10-06 à 17 37 19" src="https://user-images.githubusercontent.com/13931126/95226304-0eb81f00-07fd-11eb-9007-9b8877d65fd0.png">

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre dans une organisation SUP disposant des droits de collecte de profil.
Créer une campagne de collecte de profil (un avec étudiant sans numéro et un avec numéro)
Se rendre sur mon-pix est rejoindre l'organisation via le code et envoyer son profil
Se rendre sur pix-orga exporter le fichier .csv
