### PR TITLE
[BUGFIX] Réparation du bouton de téléchargement de pv de session (PIX-1382)

### DIFF
--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -39,7 +39,7 @@
         <div class="panel-actions__button">
           <a data-test-id="attendance_sheet_download_button"
             class="button button--link button--with-icon"
-            href="{{this.currentSession.urlToDownload}}" target="_blank" rel="noopener noreferrer" download>
+            href="{{this.currentSession.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
               Télécharger (.ods)<FaIcon @icon='file-download' />
           </a>
         </div>


### PR DESCRIPTION
## :unicorn: Problème
Le bouton d'import de pv de session est cassé sur la prod
## :robot: Solution
Utiliser la bonne méthode sur l'action du clic du bouton

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller sur pix certif
- Choisir une session
- Dans l'onglet candidats, cliquer sur le bonton "telecharger"
- Constater que le fichier ods est téléchargé