### PR TITLE
[TECH] Utiliser le nouveau modèle de TargetProfile dans l'analyse de campagne (PIX-1388)

### DIFF
--- a/api/lib/domain/models/CampaignAnalysis.js
+++ b/api/lib/domain/models/CampaignAnalysis.js
@@ -1,38 +1,33 @@
-const CampaignTubeRecommendation = require('./CampaignTubeRecommendation');
-
 const _ = require('lodash');
+const CampaignTubeRecommendation = require('./CampaignTubeRecommendation');
 
 class CampaignAnalysis {
 
   constructor({
     campaignId,
-    // attributes
-    tubes,
-    competences,
-    skills,
+    targetProfile,
     validatedKnowledgeElements,
     participantsCount,
     tutorials,
   } = {}) {
     this.id = campaignId;
-    // attributes
-    this.campaignTubeRecommendations = this._buildCampaignTubeRecommendations({ campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount, tutorials });
+    this.campaignTubeRecommendations = this._buildCampaignTubeRecommendations({ campaignId, targetProfile, validatedKnowledgeElements, participantsCount, tutorials });
   }
 
-  _buildCampaignTubeRecommendations({ campaignId, competences, tubes, skills, validatedKnowledgeElements, participantsCount, tutorials }) {
-    const { difficulty: maxSkillLevelInTargetProfile } =  _.maxBy(skills, 'difficulty');
-    return tubes.map((tube) => {
-      const competence = _.find(competences, { id: tube.competenceId });
-      const tubeSkills = _.filter(skills, { tubeId: tube.id });
-      const tubeSkillIds = _.map(tubeSkills, ({ id }) => id);
+  _buildCampaignTubeRecommendations({ campaignId, targetProfile, validatedKnowledgeElements, participantsCount, tutorials }) {
+    const maxSkillLevelInTargetProfile = targetProfile.maxSkillDifficulty;
+    return targetProfile.tubes.map((tube) => {
+      const competence = targetProfile.getCompetence(tube.competenceId);
+      const area = targetProfile.getArea(competence.areaId);
+      const tubeSkillIds = _.map(tube.skills, ({ id }) => id);
       const validatedKnowledgeElementsOfTube = _.filter(validatedKnowledgeElements, (knowledgeElement) => tubeSkillIds.includes(knowledgeElement.skillId));
-      const tutorialIds = _.uniq(_.flatMap(tubeSkills, 'tutorialIds'));
+      const tutorialIds = _.uniq(_.flatMap(tube.skills, 'tutorialIds'));
       const tubeTutorials = _.filter(tutorials, (tutorial) => tutorialIds.includes(tutorial.id));
       return new CampaignTubeRecommendation({
         campaignId: campaignId,
+        area,
         competence,
         tube,
-        skills: tubeSkills,
         validatedKnowledgeElements: validatedKnowledgeElementsOfTube,
         participantsCount,
         maxSkillLevelInTargetProfile,

--- a/api/lib/domain/models/CampaignTubeRecommendation.js
+++ b/api/lib/domain/models/CampaignTubeRecommendation.js
@@ -1,30 +1,27 @@
-const recommendationService = require('../services/recommendation-service');
-
 const _ = require('lodash');
+const recommendationService = require('../services/recommendation-service');
 
 class CampaignTubeRecommendation {
 
   constructor({
-    // attributes
     campaignId,
+    area,
     tube,
     competence,
-    skills,
     validatedKnowledgeElements,
     participantsCount,
     maxSkillLevelInTargetProfile,
     tutorials,
   } = {}) {
-    // attributes
     this.campaignId = campaignId;
     this.tubeId = tube.id;
     this.competenceId = competence.id;
     this.competenceName = competence.name;
     this.tubePracticalTitle = tube.practicalTitle;
-    this.areaColor = competence.area.color;
+    this.areaColor = area.color;
     this.averageScore = null;
     if (participantsCount) {
-      this.averageScore = this._computeAverageScore(validatedKnowledgeElements, skills, participantsCount, maxSkillLevelInTargetProfile);
+      this.averageScore = this._computeAverageScore(validatedKnowledgeElements, tube.skills, participantsCount, maxSkillLevelInTargetProfile);
     }
     this.tutorials = tutorials;
   }

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -1,3 +1,5 @@
+const _ = require('lodash');
+
 class TargetProfileWithLearningContent {
   constructor({
     id,
@@ -37,6 +39,16 @@ class TargetProfileWithLearningContent {
     return skillTube ? skillTube.competenceId : null;
   }
 
+  getCompetence(competenceId) {
+    const foundCompetence = _.find(this.competences, (competence) => competence.id === competenceId);
+    return foundCompetence || null;
+  }
+
+  getArea(areaId) {
+    const foundArea = _.find(this.areas, (area) => area.id === areaId);
+    return foundArea || null;
+  }
+
   getAreaOfCompetence(competenceId) {
     const area = this.areas.find((area) => area.hasCompetence(competenceId));
 
@@ -60,6 +72,11 @@ class TargetProfileWithLearningContent {
 
   filterValidatedTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements) {
     return this.filterTargetedKnowledgeElementAndGroupByCompetence(knowledgeElements, (knowledgeElement) => knowledgeElement.isValidated);
+  }
+
+  get maxSkillDifficulty() {
+    const skillMaxDifficulty = _.maxBy(this.skills, 'difficulty');
+    return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;
   }
 }
 

--- a/api/lib/domain/models/TargetedSkill.js
+++ b/api/lib/domain/models/TargetedSkill.js
@@ -8,6 +8,10 @@ class TargetedSkill {
     this.name = name;
     this.tubeId = tubeId;
   }
+
+  get difficulty() {
+    return parseInt(this.name.slice(-1));
+  }
 }
 
 module.exports = TargetedSkill;

--- a/api/lib/domain/models/TargetedSkill.js
+++ b/api/lib/domain/models/TargetedSkill.js
@@ -3,10 +3,12 @@ class TargetedSkill {
     id,
     name,
     tubeId,
+    tutorialIds,
   } = {}) {
     this.id = id;
     this.name = name;
     this.tubeId = tubeId;
+    this.tutorialIds = tutorialIds;
   }
 
   get difficulty() {

--- a/api/tests/integration/domain/models/CampaignAnalysis_test.js
+++ b/api/tests/integration/domain/models/CampaignAnalysis_test.js
@@ -1,12 +1,12 @@
 const CampaignAnalysis = require('../../../../lib/domain/models/CampaignAnalysis');
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Integration | Domain | Models | CampaignAnalysis', () => {
 
   describe('id', () => {
     it('returns the campaignId', () => {
-      const skills = [{ id: 1, difficulty: 1, tubeId: 1 } ];
-      const campaignAnalysis = new CampaignAnalysis({ campaignId: 12, competences: [], tubes: [], skills, validatedKnowledgeElements: [], participantsCount: 0  });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+      const campaignAnalysis = new CampaignAnalysis({ campaignId: 12, targetProfile, validatedKnowledgeElements: [], participantsCount: 0  });
 
       expect(campaignAnalysis.id).to.equal(12);
     });
@@ -14,176 +14,174 @@ describe('Integration | Domain | Models | CampaignAnalysis', () => {
 
   describe('campaignTubeRecommendations', () => {
     it('computes a recommendation for each tube', () => {
-      const competences = [
-        { id: 1, name: 'Competence1Name', area: { color: 'black' } },
-        { id: 2, name: 'Competence2Name', area: { color: 'white' } },
-      ];
-
-      const tubes = [
-        { id: 1, competenceId: 1 },
-        { id: 2, competenceId: 2 },
-      ];
-
-      const skills = [
-        { id: 1, difficulty: 1, tubeId: 1 },
-        { id: 2, difficulty: 2, tubeId: 1 },
-        { id: 3, difficulty: 3, tubeId: 2 },
-      ];
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@difficulty1', tubeId: 'recTube1' });
+      const skill2Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill12', name: '@difficulty2', tubeId: 'recTube1' });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@difficulty3', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence1', practicalTitle: 'TubeName1', skills: [skill1Tube1, skill2Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence2', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+      const competence1 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName1', id: 'recCompetence1', areaId: 'recArea1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName2', id: 'recCompetence2', areaId: 'recArea2', tubes: [tube2] });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1], color: 'black' });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2], color: 'black' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill2Tube1, skill1Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area1, area2],
+      });
 
       const validatedKnowledgeElements = [
-        { skillId: 1 },
-        { skillId: 2 },
-        { skillId: 3 },
+        { skillId: 'recSkill11' },
+        { skillId: 'recSkill12' },
+        { skillId: 'recSkill21' },
       ];
 
       const participantsCount = 1;
 
-      const campaignAnalysis = new CampaignAnalysis({ competences, tubes, skills, validatedKnowledgeElements, participantsCount  });
+      const campaignAnalysis = new CampaignAnalysis({ targetProfile, validatedKnowledgeElements, participantsCount  });
 
       expect(campaignAnalysis.campaignTubeRecommendations).to.have.lengthOf(2);
     });
 
     it('compute the recommendation for each tube using knowledge element from the right tube skills', () => {
-      const tubes = [
-        { id: 1, competenceId: 1 },
-        { id: 2, competenceId: 2 },
-      ];
-
-      const competences = [
-        { id: 1, name: 'Competence1Name', area: { color: 'black' } },
-        { id: 2, name: 'Competence2Name', area: { color: 'white' } },
-      ];
-
-      const skills = [
-        { id: 1, difficulty: 1, tubeId: 1 },
-        { id: 2, difficulty: 2, tubeId: 1 },
-        { id: 3, difficulty: 1, tubeId: 2 },
-        { id: 4, difficulty: 5, tubeId: 2 },
-      ];
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@difficulty1', tubeId: 'recTube1' });
+      const skill2Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill12', name: '@difficulty2', tubeId: 'recTube1' });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@difficulty1', tubeId: 'recTube2' });
+      const skill2Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill22', name: '@difficulty5', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence1', practicalTitle: 'TubeName1', skills: [skill1Tube1, skill2Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence2', practicalTitle: 'TubeName2', skills: [skill1Tube2, skill2Tube2] });
+      const competence1 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName1', id: 'recCompetence1', areaId: 'recArea1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName2', id: 'recCompetence2', areaId: 'recArea2', tubes: [tube2] });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1], color: 'black' });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2], color: 'black' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill2Tube1, skill1Tube2, skill2Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area1, area2],
+      });
 
       const validatedKnowledgeElements = [
-        { skillId: 1, userId: 1 },
-        { skillId: 2, userId: 1 },
-        { skillId: 3, userId: 1 },
+        { skillId: 'recSkill11', userId: 1 },
+        { skillId: 'recSkill12', userId: 1 },
+        { skillId: 'recSkill21', userId: 1 },
       ];
 
       const participantsCount = 1;
 
-      const campaignAnalysis = new CampaignAnalysis({ competences, tubes, skills, validatedKnowledgeElements, participantsCount });
+      const campaignAnalysis = new CampaignAnalysis({ targetProfile, validatedKnowledgeElements, participantsCount });
       const campaignTubeRecommendations = campaignAnalysis.campaignTubeRecommendations;
 
-      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 1);
-      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 2);
+      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube1');
+      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube2');
 
       expect(tube1Recommendation.averageScore).to.equal(82);
       expect(tube2Recommendation.averageScore).to.equal(50);
     });
 
     it('compute a recommendation for each tube using the right tube', () => {
-      const competences = [
-        { id: 1, name: 'Competence1Name', area: { color: 'black' } },
-        { id: 2, name: 'Competence2Name', area: { color: 'white' } },
-      ];
-
-      const tubes = [
-        { id: 1, competenceId: 1, practicalTitle: 'Tube1Name' },
-        { id: 2, competenceId: 2, practicalTitle: 'Tube2Name' },
-      ];
-
-      const skills = [
-        { id: 1, difficulty: 1, tubeId: 1 },
-        { id: 1, difficulty: 1, tubeId: 2 },
-      ];
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@difficulty1', tubeId: 'recTube1' });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@difficulty1', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence1', practicalTitle: 'TubeName1', skills: [skill1Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence2', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+      const competence1 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName1', id: 'recCompetence1', areaId: 'recArea1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName2', id: 'recCompetence2', areaId: 'recArea2', tubes: [tube2] });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1], color: 'black' });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2], color: 'black' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill1Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area1, area2],
+      });
 
       const validatedKnowledgeElements = [];
 
       const participantsCount = 1;
 
-      const campaignAnalysis = new CampaignAnalysis({ competences, tubes, skills, validatedKnowledgeElements, participantsCount });
+      const campaignAnalysis = new CampaignAnalysis({ targetProfile, validatedKnowledgeElements, participantsCount });
       const campaignTubeRecommendations = campaignAnalysis.campaignTubeRecommendations;
 
-      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 1);
-      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 2);
+      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube1');
+      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube2');
 
-      expect(tube1Recommendation.tubePracticalTitle).to.equal('Tube1Name');
-      expect(tube2Recommendation.tubePracticalTitle).to.equal('Tube2Name');
+      expect(tube1Recommendation.tubePracticalTitle).to.equal('TubeName1');
+      expect(tube2Recommendation.tubePracticalTitle).to.equal('TubeName2');
     });
 
     it('compute a recommendation for each tube using the right competence', () => {
-      const tubes = [
-        { id: 1, competenceId: 1 },
-        { id: 2, competenceId: 2 },
-      ];
-
-      const competences = [
-        { id: 1, name: 'Competence1Name', area: { color: 'black' } },
-        { id: 2, name: 'Competence2Name', area: { color: 'white' } },
-      ];
-
-      const skills = [
-        { id: 1, difficulty: 1, tubeId: 1 },
-        { id: 1, difficulty: 1, tubeId: 2 },
-      ];
-
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@difficulty1', tubeId: 'recTube1' });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@difficulty1', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence1', practicalTitle: 'TubeName1', skills: [skill1Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence2', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+      const competence1 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName1', id: 'recCompetence1', areaId: 'recArea1', tubes: [tube1] });
+      const competence2 = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName2', id: 'recCompetence2', areaId: 'recArea2', tubes: [tube2] });
+      const area1 = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence1], color: 'black' });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'recArea2', competences: [competence2], color: 'white' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill1Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence1, competence2],
+        areas: [area1, area2],
+      });
       const validatedKnowledgeElements = [];
 
       const participantsCount = 1;
 
-      const campaignAnalysis = new CampaignAnalysis({ competences, tubes, skills, validatedKnowledgeElements, participantsCount });
+      const campaignAnalysis = new CampaignAnalysis({ targetProfile, validatedKnowledgeElements, participantsCount });
       const campaignTubeRecommendations = campaignAnalysis.campaignTubeRecommendations;
 
-      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 1);
-      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 2);
+      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube1');
+      const tube2Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube2');
 
-      expect(tube1Recommendation.competenceId).to.equal(1);
-      expect(tube1Recommendation.competenceName).to.equal('Competence1Name');
+      expect(tube1Recommendation.competenceId).to.equal('recCompetence1');
+      expect(tube1Recommendation.competenceName).to.equal('CompetenceName1');
       expect(tube1Recommendation.areaColor).to.equal('black');
 
-      expect(tube2Recommendation.competenceId).to.equal(2);
-      expect(tube2Recommendation.competenceName).to.equal('Competence2Name');
+      expect(tube2Recommendation.competenceId).to.equal('recCompetence2');
+      expect(tube2Recommendation.competenceName).to.equal('CompetenceName2');
       expect(tube2Recommendation.areaColor).to.equal('white');
     });
 
     it('compute a recommendation for each tube when participant have the same knowledge elements', () => {
-      const tubes = [
-        { id: 1, competenceId: 1 },
-        { id: 2, competenceId: 1 },
-      ];
-
-      const competences = [
-        { id: 1, name: 'Competence1Name', area: { color: 'black' } },
-      ];
-
-      const skills = [
-        { id: 1, difficulty: 1, tubeId: 1 },
-        { id: 2, difficulty: 2, tubeId: 1 },
-        { id: 3, difficulty: 3, tubeId: 1 },
-        { id: 4, difficulty: 4, tubeId: 1 },
-        { id: 5, difficulty: 5, tubeId: 1 },
-        { id: 6, difficulty: 6, tubeId: 2 },
-      ];
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@difficulty1', tubeId: 'recTube1' });
+      const skill2Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill12', name: '@difficulty2', tubeId: 'recTube1' });
+      const skill3Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill13', name: '@difficulty3', tubeId: 'recTube1' });
+      const skill4Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill14', name: '@difficulty4', tubeId: 'recTube1' });
+      const skill5Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill15', name: '@difficulty5', tubeId: 'recTube1' });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@difficulty6', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence', practicalTitle: 'TubeName1', skills: [skill1Tube1, skill2Tube1, skill3Tube1, skill4Tube1, skill5Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetence', areaId: 'recArea', tubes: [tube1, tube2] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence], color: 'black' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill2Tube1, skill3Tube1, skill4Tube1, skill5Tube1, skill1Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence],
+        areas: [area],
+      });
 
       const validatedKnowledgeElements = [
-        { skillId: 1, userId: 1 },
-        { skillId: 2, userId: 1 },
-        { skillId: 3, userId: 1 },
-        { skillId: 1, userId: 2 },
-        { skillId: 2, userId: 2 },
-        { skillId: 3, userId: 2 },
-        { skillId: 1, userId: 3 },
-        { skillId: 2, userId: 3 },
-        { skillId: 3, userId: 3 },
-        { skillId: 1, userId: 4 },
-        { skillId: 2, userId: 4 },
-        { skillId: 3, userId: 4 },
+        { skillId: 'recSkill11', userId: 1 },
+        { skillId: 'recSkill12', userId: 1 },
+        { skillId: 'recSkill13', userId: 1 },
+        { skillId: 'recSkill11', userId: 2 },
+        { skillId: 'recSkill12', userId: 2 },
+        { skillId: 'recSkill13', userId: 2 },
+        { skillId: 'recSkill11', userId: 3 },
+        { skillId: 'recSkill12', userId: 3 },
+        { skillId: 'recSkill13', userId: 3 },
+        { skillId: 'recSkill11', userId: 4 },
+        { skillId: 'recSkill12', userId: 4 },
+        { skillId: 'recSkill13', userId: 4 },
       ];
 
       const participantsCount = 4;
 
-      const campaignAnalysis = new CampaignAnalysis({ competences, tubes, skills, validatedKnowledgeElements, participantsCount });
+      const campaignAnalysis = new CampaignAnalysis({ targetProfile, validatedKnowledgeElements, participantsCount });
       const campaignTubeRecommendations = campaignAnalysis.campaignTubeRecommendations;
 
-      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 1);
+      const tube1Recommendation = campaignTubeRecommendations.find(({ tubeId }) => tubeId === 'recTube1');
 
       expect(tube1Recommendation.averageScore).to.equal(68.5);
 

--- a/api/tests/integration/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-analysis_test.js
@@ -5,9 +5,7 @@ const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/erro
 describe('Integration | UseCase | compute-campaign-analysis', () => {
 
   let campaignRepository;
-  let competenceRepository;
-  let targetProfileRepository;
-  let tubeRepository;
+  let targetProfileWithLearningContentRepository;
   let knowledgeElementRepository;
   let campaignParticipationRepository;
   let tutorialRepository;
@@ -17,9 +15,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
 
   beforeEach(() => {
     campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
-    competenceRepository = { list: sinon.stub() };
-    targetProfileRepository = { getByCampaignId: sinon.stub() };
-    tubeRepository = { list: sinon.stub() };
+    targetProfileWithLearningContentRepository = { getByCampaignId: sinon.stub() };
     knowledgeElementRepository = { findByCampaignIdForSharedCampaignParticipation: sinon.stub() };
     campaignParticipationRepository = { countSharedParticipationOfCampaign: sinon.stub() };
     tutorialRepository = { list: sinon.stub() };
@@ -28,23 +24,28 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
   context('User has access to this result', () => {
     it('should returns two CampaignTubeRecommendations but with two skills in the same tube', async () => {
       // given
-      const area = domainBuilder.buildArea();
-      const competence = domainBuilder.buildCompetence({ area });
-      const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
-      const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
       const tutorial = domainBuilder.buildTutorial({ id: 'recTuto1' });
-      const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId', tutorialIds: [tutorial.id] });
-      const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
-      const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
-      const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
-      const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
+      const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@url1', tubeId: 'recTube1', tutorialIds: [tutorial.id] });
+      const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@url2', tubeId: 'recTube2' });
+      const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence', practicalTitle: 'TubeName1', skills: [skill1Tube1] });
+      const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', areaId: 'recArea', tubes: [tube1, tube2] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence], color: 'black' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1Tube1, skill1Tube2],
+        tubes: [tube1, tube2],
+        competences: [competence],
+        areas: [area],
+      });
+      const knowledgeElementSkill1 = { skillId: 'recSkill11', userId: 1 };
+      const knowledgeElementSkill2 = { skillId: 'recSkill21', userId: 1 };
 
       const campaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
         campaignId,
-        tube,
+        area,
         competence,
+        tube: tube1,
         validatedKnowledgeElements: [knowledgeElementSkill1],
-        skills: [skill],
         maxSkillLevelInTargetProfile: 2,
         participantsCount: 1,
         tutorials: [tutorial],
@@ -52,22 +53,20 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
 
       const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
         campaignId,
-        tube: otherTube,
+        area,
         competence,
+        tube: tube2,
         validatedKnowledgeElements: [knowledgeElementSkill2],
-        skills: [skill2],
         maxSkillLevelInTargetProfile: 2,
         participantsCount: 1,
         tutorials: [],
       });
 
-      targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
-      competenceRepository.list.resolves([competence]);
+      targetProfileWithLearningContentRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
       knowledgeElementRepository.findByCampaignIdForSharedCampaignParticipation.resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
       campaignParticipationRepository.countSharedParticipationOfCampaign.resolves(1);
-      tubeRepository.list.resolves([tube, otherTube]);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+      targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId }).resolves(targetProfile);
       tutorialRepository.list.resolves([tutorial]);
 
       const expectedResult = {
@@ -80,9 +79,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
         userId,
         campaignId,
         campaignRepository,
-        competenceRepository,
-        targetProfileRepository,
-        tubeRepository,
+        targetProfileWithLearningContentRepository,
         knowledgeElementRepository,
         campaignParticipationRepository,
         tutorialRepository,
@@ -104,9 +101,7 @@ describe('Integration | UseCase | compute-campaign-analysis', () => {
         userId,
         campaignId,
         campaignRepository,
-        competenceRepository,
-        targetProfileRepository,
-        tubeRepository,
+        targetProfileWithLearningContentRepository,
         knowledgeElementRepository,
       });
 

--- a/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/integration/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -6,9 +6,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
 
   let campaignRepository;
   let campaignParticipationRepository;
-  let competenceRepository;
-  let targetProfileRepository;
-  let tubeRepository;
+  let targetProfileWithLearningContentRepository;
   let knowledgeElementRepository;
   let tutorialRepository;
 
@@ -20,9 +18,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
   beforeEach(() => {
     campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
     campaignParticipationRepository = { get: sinon.stub() };
-    competenceRepository = { list: sinon.stub() };
-    targetProfileRepository = { getByCampaignId: sinon.stub() };
-    tubeRepository = { list: sinon.stub() };
+    targetProfileWithLearningContentRepository = { getByCampaignId: sinon.stub() };
     knowledgeElementRepository = { findByCampaignIdAndUserIdForSharedCampaignParticipation: sinon.stub() };
     tutorialRepository = { list: sinon.stub() };
 
@@ -33,23 +29,28 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
     context('Participant has shared its results', () => {
       it('should returns two CampaignTubeRecommendations but with two skills in the same tube', async () => {
         // given
-        const area = domainBuilder.buildArea();
-        const competence = domainBuilder.buildCompetence({ area });
-        const tutorial = domainBuilder.buildTutorial({ id: 'recTutorial1', duration: '00:01:30', format: 'video', link: 'https://youtube.fr', source: 'Youtube', title: 'Savoir regarder des vidéos youtube.' });
-        const skill = domainBuilder.buildSkill({ id: 'skillId', name: '@url1', competenceId: competence.id, tubeId: 'tubeId', tutorialIds: [tutorial.id] });
-        const skill2 = domainBuilder.buildSkill({ id: 'skillId2', name: '@url2', competenceId: competence.id, tubeId: 'otherTubeId' });
-        const knowledgeElementSkill1 = { skillId: 'skillId', userId: 1 };
-        const knowledgeElementSkill2 = { skillId: 'skillId2', userId: 1 };
+        const tutorial = domainBuilder.buildTutorial({ id: 'recTuto1' });
+        const skill1Tube1 = domainBuilder.buildTargetedSkill({ id: 'recSkill11', name: '@url1', tubeId: 'recTube1', tutorialIds: [tutorial.id] });
+        const skill1Tube2 = domainBuilder.buildTargetedSkill({ id: 'recSkill21', name: '@url2', tubeId: 'recTube2' });
+        const tube1 = domainBuilder.buildTargetedTube({ id: 'recTube1', competenceId: 'recCompetence', practicalTitle: 'TubeName1', skills: [skill1Tube1] });
+        const tube2 = domainBuilder.buildTargetedTube({ id: 'recTube2', competenceId: 'recCompetence', practicalTitle: 'TubeName2', skills: [skill1Tube2] });
+        const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence', areaId: 'recArea', tubes: [tube1, tube2] });
+        const area = domainBuilder.buildTargetedArea({ id: 'recArea', competences: [competence], color: 'black' });
+        const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+          skills: [skill1Tube1, skill1Tube2],
+          tubes: [tube1, tube2],
+          competences: [competence],
+          areas: [area],
+        });
+        const knowledgeElementSkill1 = { skillId: 'recSkill11', userId: 1 };
+        const knowledgeElementSkill2 = { skillId: 'recSkill21', userId: 1 };
 
-        const targetProfile = domainBuilder.buildTargetProfile({ skills: [skill, skill2] });
-        const tube = domainBuilder.buildTube({ id: 'tubeId', competenceId: competence.id, skills: [skill] });
-        const otherTube = domainBuilder.buildTube({ id: 'otherTubeId', competenceId: competence.id, skills: [skill2] });
         const campaignTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
           campaignId,
-          tube,
+          tube: tube1,
           competence,
+          area,
           validatedKnowledgeElements: [knowledgeElementSkill1],
-          skills: [skill],
           maxSkillLevelInTargetProfile:  2,
           participantsCount: 1,
           tutorials: [tutorial],
@@ -57,21 +58,19 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
 
         const campaignOtherTubeRecommendation = domainBuilder.buildCampaignTubeRecommendation({
           campaignId,
-          tube: otherTube,
+          tube: tube2,
           competence,
           validatedKnowledgeElements: [knowledgeElementSkill2],
-          skills: [skill2],
+          area,
           maxSkillLevelInTargetProfile:  2,
           participantsCount: 1,
           tutorials: [],
         });
 
-        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
-        competenceRepository.list.resolves([competence]);
+        targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId }).resolves(targetProfile);
         campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-        tubeRepository.list.resolves([tube, otherTube]);
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-        targetProfileRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
+        targetProfileWithLearningContentRepository.getByCampaignId.withArgs(campaignId).resolves(targetProfile);
         knowledgeElementRepository.findByCampaignIdAndUserIdForSharedCampaignParticipation.withArgs({ campaignId, userId: campaignParticipation.userId }).resolves([knowledgeElementSkill1,knowledgeElementSkill2]);
         tutorialRepository.list.resolves([tutorial]);
 
@@ -86,9 +85,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           campaignParticipationId,
           campaignRepository,
           campaignParticipationRepository,
-          competenceRepository,
-          targetProfileRepository,
-          tubeRepository,
+          targetProfileWithLearningContentRepository,
           knowledgeElementRepository,
           tutorialRepository,
         });
@@ -111,9 +108,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
           campaignParticipationId,
           campaignRepository,
           campaignParticipationRepository,
-          competenceRepository,
-          targetProfileRepository,
-          tubeRepository,
+          targetProfileWithLearningContentRepository,
           tutorialRepository,
         });
 
@@ -136,9 +131,7 @@ describe('Integration | UseCase | compute-campaign-participation-analysis', () =
         campaignParticipationId,
         campaignRepository,
         campaignParticipationRepository,
-        competenceRepository,
-        targetProfileRepository,
-        tubeRepository,
+        targetProfileWithLearningContentRepository,
         tutorialRepository,
       });
 

--- a/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
+++ b/api/tests/tooling/airtable-builder/factory/learning-content/build-learning-content.js
@@ -112,6 +112,7 @@ buildLearningContent.fromTargetProfileWithLearningContent = function buildLearni
               tube: [tube.id],
               compétenceViaTube: [competence.id],
               nom: skill.name,
+              comprendre: skill.tutorialIds,
             },
           );
         });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-tube-recommendation.js
@@ -3,9 +3,9 @@ const CampaignTubeRecommendation = require('../../../../lib/domain/models/Campai
 module.exports = function buildCampaignTubeRecommendation(
   {
     campaignId,
+    area,
     competence,
     tube,
-    skills,
     validatedKnowledgeElements,
     maxSkillLevelInTargetProfile,
     participantsCount,
@@ -15,7 +15,7 @@ module.exports = function buildCampaignTubeRecommendation(
     campaignId,
     tube,
     competence,
-    skills,
+    area,
     validatedKnowledgeElements,
     maxSkillLevelInTargetProfile,
     participantsCount,

--- a/api/tests/tooling/domain-builder/factory/build-targeted-skill.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-skill.js
@@ -4,11 +4,13 @@ const buildTargetedSkill = function buildTargetedSkill({
   id = 'someSkillId',
   name = 'someSkillName5',
   tubeId = 'someTubeId',
+  tutorialIds = [],
 } = {}) {
   return new TargetedSkill({
     id,
     name,
     tubeId,
+    tutorialIds,
   });
 };
 

--- a/api/tests/unit/domain/models/CampaignTubeRecommendation_test.js
+++ b/api/tests/unit/domain/models/CampaignTubeRecommendation_test.js
@@ -1,78 +1,70 @@
 const CampaignTubeRecommendation = require('../../../../lib/domain/models/CampaignTubeRecommendation');
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | CampaignTubeRecommendation', () => {
 
   describe('tube Info', () => {
     it('sets information about tube', () => {
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 12, competenceId: 1, practicalTitle: 'TubeName' };
-      const skills = [{ id: 1, difficulty: 1, tubeId: 1 }];
-
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName' });
+      const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence] });
       const validatedKnowledgeElements = [];
 
-      const campaignTubeRecommendation = new CampaignTubeRecommendation({ competence, tube, skills, validatedKnowledgeElements });
+      const campaignTubeRecommendation = new CampaignTubeRecommendation({ area, competence, tube, validatedKnowledgeElements });
 
-      expect(campaignTubeRecommendation.tubeId).to.equal(12);
+      expect(campaignTubeRecommendation.tubeId).to.equal('recTubeId');
       expect(campaignTubeRecommendation.tubePracticalTitle).to.equal('TubeName');
     });
   });
 
   describe('competence info', () => {
     it('sets information about competence', () => {
-      const competence = { id: 3, name: 'CompetenceName', area: { color: 'Blue' } };
-      const tube = { id: 1, competenceId: 1, practicalTitle: 'TubeName' };
-      const skills = [{ id: 1, difficulty: 1, tubeId: 1 }];
-
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName' });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence] });
       const validatedKnowledgeElements = [];
 
-      const campaignTubeRecommendation = new CampaignTubeRecommendation({ competence, tube, skills, validatedKnowledgeElements });
+      const campaignTubeRecommendation = new CampaignTubeRecommendation({ area, competence, tube, validatedKnowledgeElements });
 
-      expect(campaignTubeRecommendation.competenceId).to.equal(3);
+      expect(campaignTubeRecommendation.competenceId).to.equal('recCompetenceId');
       expect(campaignTubeRecommendation.competenceName).to.equal('CompetenceName');
     });
   });
 
   describe('@id', () => {
-
     it('should return a unique identifier that is the concatenation of "campaignId" and "tubeId"', () => {
       // given
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 'recTube', competenceId: 1, practicalTitle: 'tube' };
-      const skills = [{ id: 1, difficulty: 1, tubeId: 1 }];
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName' });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence] });
       const validatedKnowledgeElements = [];
-      const campaignId = 123;
-      const campaignTubeRecommendation = new CampaignTubeRecommendation({ campaignId, competence, tube, skills, validatedKnowledgeElements });
+      const campaignTubeRecommendation = new CampaignTubeRecommendation({ campaignId: 123, area, competence, tube, validatedKnowledgeElements });
 
       // when
       const campaignTubeRecommendationId = campaignTubeRecommendation.id;
 
       // then
-      expect(campaignTubeRecommendationId).to.equal('123_recTube');
+      expect(campaignTubeRecommendationId).to.equal('123_recTubeId');
     });
   });
 
   describe('averageScore', () => {
     it('computes the average recommendation of participants', () => {
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 1, competenceId: 1, practicalTitle: 'tube' };
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', name: '@difficulty1', tubeId: 'recTubeId' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2', name: '@difficulty2', tubeId: 'recTubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName', skills: [skill1, skill2] });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence], color: 'black' });
       const participantsCount = 2;
-
-      const skills = [
-        { id: 1, difficulty: 1 },
-        { id: 2, difficulty: 2 },
-      ];
-
       const validatedKnowledgeElements = [
-        { skillId: 1, userId: 1 },
-        { skillId: 1, userId: 2 },
-        { skillId: 2, userId: 2 },
+        { skillId: 'recSkill1', userId: 1 },
+        { skillId: 'recSkill1', userId: 2 },
+        { skillId: 'recSkill2', userId: 2 },
       ];
-
       const maxSkillLevelInTargetProfile = 2;
 
       const campaignTubeRecommendation = new CampaignTubeRecommendation({
-        skills,
+        area,
         validatedKnowledgeElements,
         participantsCount,
         maxSkillLevelInTargetProfile,
@@ -84,23 +76,20 @@ describe('Unit | Domain | Models | CampaignTubeRecommendation', () => {
     });
 
     it('computes average recommendation when some participants does not have knowledge element', () => {
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 1, competenceId: 1, practicalTitle: 'tube' };
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', name: '@difficulty1', tubeId: 'recTubeId' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2', name: '@difficulty2', tubeId: 'recTubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName', skills: [skill1, skill2] });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence], color: 'black' });
       const participantsCount = 2;
-
-      const skills = [
-        { id: 1, difficulty: 1 },
-        { id: 2, difficulty: 2 },
-      ];
-
       const validatedKnowledgeElements = [
-        { skillId: 1, userId: 1 },
+        { skillId: 'recSkill1', userId: 1 },
       ];
 
       const maxSkillLevelInTargetProfile = 2;
 
       const campaignTubeRecommendation = new CampaignTubeRecommendation({
-        skills,
+        area,
         validatedKnowledgeElements,
         participantsCount,
         maxSkillLevelInTargetProfile,
@@ -112,19 +101,16 @@ describe('Unit | Domain | Models | CampaignTubeRecommendation', () => {
     });
 
     it('returns null when there is no participant', () => {
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 1, competenceId: 1, practicalTitle: 'tube' };
+      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', name: '@difficulty1', tubeId: 'recTubeId' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2', name: '@difficulty2', tubeId: 'recTubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName', skills: [skill1, skill2] });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence], color: 'black' });
+      const maxSkillLevelInTargetProfile = 2;
       const participantsCount = 0;
 
-      const skills = [
-        { id: 1, difficulty: 1 },
-        { id: 2, difficulty: 2 },
-      ];
-
-      const maxSkillLevelInTargetProfile = 2;
-
       const campaignTubeRecommendation = new CampaignTubeRecommendation({
-        skills,
+        area,
         participantsCount,
         validatedKnowledgeElements: [],
         maxSkillLevelInTargetProfile,
@@ -135,20 +121,16 @@ describe('Unit | Domain | Models | CampaignTubeRecommendation', () => {
       expect(campaignTubeRecommendation.averageScore).to.equal(null);
     });
 
-    it('returns the difficulty score when there are participant but no knowledge elements', () => {
-      const competence = { id: 1, name: 'name', area: { color: 'black' } };
-      const tube = { id: 1, competenceId: 1, practicalTitle: 'tube' };
+    it('returns the difficulty score when there are participant but no knowledge elements', () => {      const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1', name: '@difficulty1', tubeId: 'recTubeId' });
+      const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill2', name: '@difficulty2', tubeId: 'recTubeId' });
+      const tube = domainBuilder.buildTargetedTube({ id: 'recTubeId', competenceId: 'recCompetenceId', practicalTitle: 'TubeName', skills: [skill1, skill2] });
+      const competence = domainBuilder.buildTargetedCompetence({ name: 'CompetenceName', id: 'recCompetenceId', areaId: 'recAreaId', tubes: [tube] });
+      const area = domainBuilder.buildTargetedArea({ id: 'recAreaId', competences: [competence], color: 'black' });
+      const maxSkillLevelInTargetProfile = 4;
       const participantsCount = 2;
 
-      const skills = [
-        { id: 1, difficulty: 1 },
-        { id: 2, difficulty: 2 },
-      ];
-
-      const maxSkillLevelInTargetProfile = 4;
-
       const campaignTubeRecommendation = new CampaignTubeRecommendation({
-        skills,
+        area,
         participantsCount,
         validatedKnowledgeElements: [],
         maxSkillLevelInTargetProfile,

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -77,6 +77,60 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
     });
   });
 
+  describe('getCompetence', () => {
+
+    it('should return the competence when its in the target profile', () => {
+      // given
+      const competence1 = domainBuilder.buildTargetedCompetence({ id: 'comp1' });
+      const competence2 = domainBuilder.buildTargetedCompetence({ id: 'comp2' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [competence1, competence2] });
+
+      // when
+      const actualCompetence = targetProfile.getCompetence('comp2');
+
+      // then
+      expect(actualCompetence).to.deep.equal(competence2);
+    });
+
+    it('should return null if competence not in target profile', () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ competences: [] });
+
+      // when
+      const actualCompetence = targetProfile.getCompetence('comp2');
+
+      // then
+      expect(actualCompetence).to.be.null;
+    });
+  });
+
+  describe('getArea', () => {
+
+    it('should return the area when its in the target profile', () => {
+      // given
+      const area1 = domainBuilder.buildTargetedArea({ id: 'area1' });
+      const area2 = domainBuilder.buildTargetedArea({ id: 'area2' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ areas: [area1, area2] });
+
+      // when
+      const actualArea = targetProfile.getArea('area2');
+
+      // then
+      expect(actualArea).to.deep.equal(area2);
+    });
+
+    it('should return null if area not in target profile', () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ areas: [] });
+
+      // when
+      const actualArea = targetProfile.getArea('area2');
+
+      // then
+      expect(actualArea).to.be.null;
+    });
+  });
+
   describe('getCompetenceIdOfSkill()', () => {
 
     const expectedCompetenceId = 'compId';
@@ -357,6 +411,33 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
       expect(knowledgeElementsByCompetence).to.deep.equal({
         'recCompetence1': [knowledgeElement2],
       });
+    });
+  });
+
+  describe('get#maxSkillDifficulty', () => {
+
+    it('should highest difficulty of target profile skills', () => {
+      // given
+      const mostDifficultSkill = domainBuilder.buildTargetedSkill({ id: '@rechercheNucléaire5' });
+      const lessDifficultSkill = domainBuilder.buildTargetedSkill({ id: '@faireSesLacets1' });
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [mostDifficultSkill, lessDifficultSkill] });
+
+      // when
+      const maxDifficulty = targetProfile.maxSkillDifficulty;
+
+      // then
+      expect(maxDifficulty).to.equal(5);
+    });
+
+    it('should return null when target profile has no skills', () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({ skills: [] });
+
+      // when
+      const maxDifficulty = targetProfile.maxSkillDifficulty;
+
+      // then
+      expect(maxDifficulty).to.be.null;
     });
   });
 });

--- a/api/tests/unit/domain/models/TargetedSkill_test.js
+++ b/api/tests/unit/domain/models/TargetedSkill_test.js
@@ -1,0 +1,14 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Target-Profile/TargetedSkill', () => {
+
+  describe('get#difficulty', () => {
+    it('should return the difficulty of the skill', function() {
+      // given
+      const url1 = domainBuilder.buildTargetedSkill({ name: '@url1' });
+
+      // then
+      expect(url1.difficulty).to.be.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Contexte
On démocratise l'usage du TargetProfileWithLearningContent aux fonctionnalités de calcul de résultats. 

## :robot: Solution
On utilise le targetProfileWithLearningContent dans l'analyse.
Après, on pourra plus facilement enchaîner sur la mise en usage des snapshots KE dans l'analyse.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Non régression des analyses
