### PR TITLE
[FEATURE] Ajout d'une variable d'environnement pour identifier une organization "Agri" (PIX-1350)

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -55,6 +55,10 @@ class Organization {
   get isPro() {
     return this.type === types.PRO;
   }
+
+  get isAgriculture() {
+    return this.isSco && process.env['AGRICULTURE_ORGANIZATION_ID'] === this.id.toString();
+  }
 }
 
 Organization.types = types;

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -8,9 +8,15 @@ module.exports = {
       transform: (record) => {
         const recordWithoutClass = { ... record };
         recordWithoutClass.memberships.forEach((membership) => {
-          membership.organization = { ... membership.organization };
+          membership.organization = { 
+            ... membership.organization,
+            isAgriculture: membership.organization.isAgriculture,
+          };
         });
-        recordWithoutClass.userOrgaSettings.organization = { ... recordWithoutClass.userOrgaSettings.currentOrganization };
+        recordWithoutClass.userOrgaSettings.organization = {
+          ...recordWithoutClass.userOrgaSettings.currentOrganization,
+          isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization,
+        };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
 
         return recordWithoutClass;
@@ -25,7 +31,7 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations', 'isAgriculture'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -52,6 +52,7 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
             'is-managing-students': organization.isManagingStudents,
             'name': organization.name,
             'type': organization.type,
+            'is-agriculture': false,
           },
           relationships: {
             memberships: {

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -103,4 +103,38 @@ describe('Unit | Domain | Models | Organization', () => {
     });
   });
 
+  describe('get#isAgriculture', () => {
+    beforeEach(() => {
+      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
+    });
+
+    afterEach(() => {
+      process.env['AGRICULTURE_ORGANIZATION_ID'] = null;
+    });
+
+    it('should return true when organization is of type SCO and id match Environnement variable AGRICULTURE_ORGANIZATION_ID', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ id: '1', type: 'SCO' });
+
+      // when / then
+      expect(organization.isAgriculture).is.true;
+    });
+
+    it('should return false when when organization is of type SCO and id doesnt match Environnement variable AGRICULTURE_ORGANIZATION_ID', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ id: '2', type: 'SCO' });
+
+      // when / then
+      expect(organization.isAgriculture).is.false;
+    });
+
+    it('should return false when when organization is not of type SCO', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ id: '1', type: 'SUP' });
+
+      // when / then
+      expect(organization.isAgriculture).is.false;
+    });
+  });
+
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -42,6 +42,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
             'name': organization.name,
             'type': organization.type,
             'credit': organization.credit,
+            'is-agriculture': organization.isAgriculture,
           },
           relationships: {
             memberships: {

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -10,6 +10,7 @@ export default class Organization extends Model {
   @attr('number') credit;
   @attr('boolean') isManagingStudents;
   @attr('boolean') canCollectProfiles;
+  @attr('boolean') isAgriculture;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -12,6 +12,7 @@ export default class CurrentUserService extends Service {
   @tracked isAdminInOrganization;
   @tracked isSCOManagingStudents;
   @tracked isSUPManagingStudents;
+  @tracked isAgriculture;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -75,5 +76,6 @@ export default class CurrentUserService extends Service {
     this.isAdminInOrganization = isAdminInOrganization;
     this.isSCOManagingStudents = isSCOManagingStudents;
     this.isSUPManagingStudents = isSUPManagingStudents;
+    this.isAgriculture = organization.isAgriculture;
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

Pour la mise en place des fonctionnalités spécifiques aux organisations SCO Agri, nous avons besoin des "tags" d'organisation. Mais les tags ne sont pas encore opérationels.

## :robot: Solution

En attendant que les tags soient opérationels, nous mettons en place une variable d'environnement temporaire et uniquement pour nos environnements RA / Integration et tests afin de pouvoir avancer sur les fonctionnalités SCO Agri.

Cette variable `AGRICULTURE_ORGANIZATION_ID` contiendra l'id d'une organisation de test SCO AGRI. 

Plus tard, cette variable sera remplacé par les tags d'organisation.

## :rainbow: Remarques
N/A

## :100: Pour tester

