### PR TITLE
[TECH] Ajout d'une route pour télécharger les résultats d'une session (PIX-1359)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -12,33 +12,33 @@ export default class IndexController extends Controller {
   @service currentUser;
   @service notifications;
 
-  @alias('model') session;
+  @alias('model') sessionModel;
 
   @tracked isShowingAssignmentModal = false;
 
-  @computed('session.status')
+  @computed('sessionModel.status')
   get sessionStatusLabel() {
-    return statusToDisplayName[this.session.status];
+    return statusToDisplayName[this.sessionModel.status];
   }
 
-  @computed('currentUser.user', 'session.assignedCertificationOfficer.id')
+  @computed('currentUser.user', 'sessionModel.assignedCertificationOfficer.id')
   get isCurrentUserAssignedToSession() {
     const currentUserId = this.currentUser.user.get('id');
-    const assignedCertificationOfficerId = this.session.assignedCertificationOfficer.get('id');
+    const assignedCertificationOfficerId = this.sessionModel.assignedCertificationOfficer.get('id');
     return assignedCertificationOfficerId != null
       && currentUserId === assignedCertificationOfficerId;
   }
 
-  @computed('session.assignedCertificationOfficer.id')
+  @computed('sessionModel.assignedCertificationOfficer.id')
   get isAssigned() {
-    return this.session.assignedCertificationOfficer.get('id') ? true : false;
+    return this.sessionModel.assignedCertificationOfficer.get('id') ? true : false;
   }
 
   @action
   async downloadSessionResultFile() {
     try {
-      const certifications = await this._loadAllCertifications(this.session);
-      this.sessionInfoService.downloadSessionExportFile({ session: this.session, certifications });
+      const certifications = await this._loadAllCertifications(this.sessionModel);
+      this.sessionInfoService.downloadSessionExportFile({ session: this.sessionModel, certifications });
     } catch (error) {
       this.notifications.error(error);
     }
@@ -47,8 +47,8 @@ export default class IndexController extends Controller {
   @action
   async downloadBeforeJuryFile() {
     try {
-      const certifications = await this._loadAllCertifications(this.session);
-      this.sessionInfoService.downloadJuryFile({ sessionId: this.session.id, certifications });
+      const certifications = await this._loadAllCertifications(this.sessionModel);
+      this.sessionInfoService.downloadJuryFile({ sessionId: this.sessionModel.id, certifications });
     } catch (error) {
       this.notifications.error(error);
     }
@@ -56,7 +56,7 @@ export default class IndexController extends Controller {
 
   @action
   async tagSessionAsSentToPrescriber() {
-    await this.session.save({ adapterOptions: { flagResultsAsSentToPrescriber: true } });
+    await this.sessionModel.save({ adapterOptions: { flagResultsAsSentToPrescriber: true } });
   }
 
   @action
@@ -80,7 +80,7 @@ export default class IndexController extends Controller {
 
   async _assignSessionToCurrentUser() {
     try {
-      await this.session.save({ adapterOptions: { certificationOfficerAssignment: true } });
+      await this.sessionModel.save({ adapterOptions: { certificationOfficerAssignment: true } });
       this.notifications.success('La session vous a correctement été assignée');
     } catch (err) {
       this.notifications.error('Erreur lors de l\'assignation à la session');

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -11,6 +11,8 @@ export default class IndexController extends Controller {
   @service notifications;
   @service currentUser;
   @service notifications;
+  @service fileSaver;
+  @service session;
 
   @alias('model') sessionModel;
 
@@ -37,8 +39,14 @@ export default class IndexController extends Controller {
   @action
   async downloadSessionResultFile() {
     try {
-      const certifications = await this._loadAllCertifications(this.sessionModel);
-      this.sessionInfoService.downloadSessionExportFile({ session: this.sessionModel, certifications });
+      const sessionId = this.sessionModel.id;
+      const url = `/api/admin/sessions/${sessionId}/results`;
+      const fileName = 'resultats-session.csv';
+      let token = '';
+      if (this.session.isAuthenticated) {
+        token = this.session.data.authenticated.access_token;
+      }
+      this.fileSaver.save({ url, fileName, token });
     } catch (error) {
       this.notifications.error(error);
     }

--- a/admin/app/services/file-saver.js
+++ b/admin/app/services/file-saver.js
@@ -1,10 +1,53 @@
 import Service from '@ember/service';
 import FileSaver from 'file-saver';
+import fetch from 'fetch';
 
 export default class FileSaverService extends Service {
 
   saveAs(content, name) {
     const file = new File([content], name, { type: 'text/csv;charset=utf-8' });
     FileSaver.saveAs(file);
+  }
+
+  _downloadFileForIEBrowser({ fileContent, fileName }) {
+    window.navigator.msSaveOrOpenBlob(fileContent, fileName);
+  }
+
+  _downloadFileForModernBrowsers({ fileContent, fileName }) {
+    const link = document.createElement('a');
+    link.style.display = 'none';
+    link.href = URL.createObjectURL(fileContent);
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+
+  _fetchData({ url, token }) {
+    return fetch(url, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+  }
+
+  async save({
+    url,
+    fileName,
+    token,
+    fetcher = this._fetchData,
+    downloadFileForIEBrowser = this._downloadFileForIEBrowser,
+    downloadFileForModernBrowsers = this._downloadFileForModernBrowsers,
+  }) {
+    const response = await fetcher({ url, token });
+
+    if (response.headers && response.headers.get('Content-Disposition')) {
+      const contentDispositionHeader = response.headers.get('Content-Disposition');
+      [, fileName] = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDispositionHeader);
+    }
+    const fileContent = await response.blob();
+
+    const browserIsInternetExplorer = window.document.documentMode;
+    browserIsInternetExplorer
+      ? downloadFileForIEBrowser({ fileContent, fileName })
+      : downloadFileForModernBrowsers({ fileContent, fileName });
   }
 }

--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -17,16 +17,6 @@ export default class SessionInfoServiceService extends Service {
   @service fileSaver;
   @service csvService;
 
-  downloadSessionExportFile({ session, certifications }) {
-    const fileTitle = 'resultats_session';
-    const data = this.buildSessionExportFileData({ session, certifications });
-    const fileHeaders = _buildSessionExportFileHeaders();
-    const csv = json2csv.parse(data, { fields: fileHeaders, delimiter: ';', withBOM: true });
-    const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
-    const fileName = _createFileNameWithDate(dateWithTime, fileTitle, session.id);
-    this.fileSaver.saveAs(csv + '\n', fileName);
-  }
-
   downloadJuryFile({ sessionId, certifications }) {
     const fileTitle = 'jury_session';
     const certificationsForJury = _filterCertificationsEligibleForJury(certifications);
@@ -95,26 +85,6 @@ export default class SessionInfoServiceService extends Service {
     });
   }
 
-}
-
-function _buildSessionExportFileHeaders() {
-  return _.concat(
-    [
-      'Numéro de certification',
-      'Prénom',
-      'Nom',
-      'Date de naissance',
-      'Lieu de naissance',
-      'Identifiant Externe',
-      'Nombre de Pix',
-    ],
-    competenceIndexes,
-    [
-      'Session',
-      'Centre de certification',
-      'Date de passage de la certification',
-    ],
-  );
 }
 
 function _filterCertificationsEligibleForJury(certifications) {

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -1,86 +1,86 @@
 <div class="session-info">
 
   <div class="session-info__certification-officer-assigned">
-    <span>{{this.session.assignedCertificationOfficer.fullName}}</span>
+    <span>{{this.sessionModel.assignedCertificationOfficer.fullName}}</span>
   </div>
 
   <div class="session-info__details">
     <div class="row">
       <div class="col">Centre :</div>
-      <div class="col">{{this.session.certificationCenterName}}</div>
+      <div class="col">{{this.sessionModel.certificationCenterName}}</div>
     </div>
     <div class="row">
       <div class="col">Adresse :</div>
-      <div class="col">{{this.session.address}}</div>
+      <div class="col">{{this.sessionModel.address}}</div>
     </div>
     <div class="row">
       <div class="col">Pièce :</div>
-       <div class="col">{{this.session.room}}</div>
+      <div class="col">{{this.sessionModel.room}}</div>
     </div>
     <div class="row">
       <div class="col">Surveillant :</div>
-      <div class="col">{{this.session.examiner}}</div>
+      <div class="col">{{this.sessionModel.examiner}}</div>
     </div>
     <div class="row">
       <div class="col">Date :</div>
-      <div class="col">{{this.session.displayDate}}</div>
+      <div class="col">{{this.sessionModel.displayDate}}</div>
     </div>
     <div class="row">
       <div class="col">Heure :</div>
-      <div class="col">{{this.session.time}}</div>
+      <div class="col">{{this.sessionModel.time}}</div>
     </div>
     <div class="row">
       <div class="col">Description :</div>
-      <div class="col">{{this.session.description}}</div>
+      <div class="col">{{this.sessionModel.description}}</div>
     </div>
     <div class="row">
       <div class="col">Code d'accès :</div>
-      <div class="col">{{this.session.accessCode}}</div>
+      <div class="col">{{this.sessionModel.accessCode}}</div>
     </div>
     <div class="row">
       <div class="col">Statut :</div>
-      <div class="col">{{this.session.displayStatus}}</div>
+      <div class="col">{{this.sessionModel.displayStatus}}</div>
     </div>
 
-    {{#if this.session.finalizedAt}}
+    {{#if this.sessionModel.finalizedAt}}
       <div class="row">
         <div class="col">Date de finalisation :</div>
-        <div class="col" data-test-id="session-info__finalized-at">{{this.session.displayFinalizationDate}}</div>
+        <div class="col" data-test-id="session-info__finalized-at">{{this.sessionModel.displayFinalizationDate}}</div>
       </div>
     {{/if}}
-    {{#if this.session.publishedAt}}
+    {{#if this.sessionModel.publishedAt}}
       <div class="row">
         <div class="col">Date de publication :</div>
-        <div class="col" data-test-id="session-info__published-at">{{this.session.displayPublishedAtDate}}</div>
+        <div class="col" data-test-id="session-info__published-at">{{this.sessionModel.displayPublishedAtDate}}</div>
       </div>
     {{/if}}
-    {{#if this.session.resultsSentToPrescriberAt}}
+    {{#if this.sessionModel.resultsSentToPrescriberAt}}
       <div class="row">
         <div class="col">Date d'envoi des résultats au prescripteur :</div>
-        <div class="col" data-test-id="session-info__sent-to-prescriber-at">{{this.session.displayResultsSentToPrescriberDate}}</div>
+        <div class="col" data-test-id="session-info__sent-to-prescriber-at">{{this.sessionModel.displayResultsSentToPrescriberDate}}</div>
       </div>
     {{/if}}
   </div>
 
 
-  {{#if this.session.finalizedAt}}
+  {{#if this.sessionModel.finalizedAt}}
   <div class="session-info__stats">
     <div class="row">
       <div class="col">Nombre de signalements :</div>
-      <div class="col" data-test-id="session-info__number-of-report">{{this.session.countExaminerComment}}</div>
+      <div class="col" data-test-id="session-info__number-of-report">{{this.sessionModel.countExaminerComment}}</div>
     </div>
     <div class="row">
       <div class="col">Nombre d'écrans de fin de test non renseignés :</div>
-      <div class="col" data-test-id="session-info__number-of-not-checked-end-screen">{{this.session.countNotCheckedEndScreen}}</div>
+      <div class="col" data-test-id="session-info__number-of-not-checked-end-screen">{{this.sessionModel.countNotCheckedEndScreen}}</div>
     </div>
     <div class="row">
       <div class="col">Nombre de certifications non terminées :</div>
-      <div class="col" data-test-id="session-info__number-of-not-ended-certifications">{{this.session.countNonValidatedCertifications}}</div>
+      <div class="col" data-test-id="session-info__number-of-not-ended-certifications">{{this.sessionModel.countNonValidatedCertifications}}</div>
     </div>
-    {{#if this.session.hasExaminerGlobalComment}}
+    {{#if this.sessionModel.hasExaminerGlobalComment}}
     <div class="row">
       <div class="col">Commentaire global :</div>
-      <div class="col" data-test-id="session-info__examiner-global-comment">{{this.session.examinerGlobalComment}}</div>
+      <div class="col" data-test-id="session-info__examiner-global-comment">{{this.sessionModel.examinerGlobalComment}}</div>
     </div>
     {{/if}}
   </div>
@@ -89,7 +89,7 @@
   <div class="session-info__actions">
     <div class="row row--btn">
 
-      {{#if this.session.finalizedAt}}
+      {{#if this.sessionModel.finalizedAt}}
         {{#if this.isCurrentUserAssignedToSession}}
           <button type="button" class="btn btn-primary btn-disabled">
             Vous êtes assigné à cette session
@@ -109,7 +109,7 @@
         Exporter les résultats
       </button>
 
-      {{#if this.session.areResultsToBeSentToPrescriber}}
+      {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
         <button type="button" class="btn btn-primary" {{on 'click' this.tagSessionAsSentToPrescriber}}>
           Résultats transmis au prescripteur
         </button>
@@ -129,7 +129,7 @@
       <span role="button" {{on 'click' this.cancelAssignment}}>×</span>
     </div>
     <p>
-      L'utilisateur {{this.session.assignedCertificationOfficer.fullName}} s'est déjà assigné cette session.
+      L'utilisateur {{this.sessionModel.assignedCertificationOfficer.fullName}} s'est déjà assigné cette session.
       <br>
       Voulez-vous vous quand même vous assigner cette session ?
     </p>

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -94,7 +94,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
 
     hooks.beforeEach(function() {
       const save = sinon.stub();
-      controller.session = { save };
+      controller.model = { save };
     });
 
     module('when a user is already assigned to session', function() {
@@ -102,14 +102,14 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       test('it should show the modal', async function(assert) {
         //given
         const getId = sinon.stub().returns(true);
-        controller.session.assignedCertificationOfficer = { get: getId };
+        controller.model.assignedCertificationOfficer = { get: getId };
 
         // when
         await controller.actions.checkForAssignment.call(controller);
 
         // then
         assert.equal(controller.isShowingAssignmentModal, true);
-        assert.equal(controller.session.save.notCalled, true);
+        assert.equal(controller.model.save.notCalled, true);
       });
     });
 
@@ -118,14 +118,14 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       test('it should assign user to session', async function(assert) {
         // given
         const getId = sinon.stub().returns(false);
-        controller.session.assignedCertificationOfficer = { get: getId };
-        controller.session.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
+        controller.model.assignedCertificationOfficer = { get: getId };
+        controller.model.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
 
         // when
         await controller.actions.checkForAssignment.call(controller);
 
         // then
-        assert.ok(controller.session.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
+        assert.ok(controller.model.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
         assert.ok(controller.notifications.success.calledWithExactly('La session vous a correctement été assignée'));
         assert.equal(controller.isShowingAssignmentModal, false);
       });
@@ -133,14 +133,14 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       test('it should show a notification error when save failed', async function(assert) {
         // given
         const getId = sinon.stub().returns(false);
-        controller.session.assignedCertificationOfficer = { get: getId };
-        controller.session.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).rejects();
+        controller.model.assignedCertificationOfficer = { get: getId };
+        controller.model.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).rejects();
 
         // when
         await controller.actions.checkForAssignment.call(controller);
 
         // then
-        assert.ok(controller.session.save.calledOnce);
+        assert.ok(controller.model.save.calledOnce);
         assert.ok(controller.notifications.error.calledWithExactly('Erreur lors de l\'assignation à la session'));
         assert.equal(controller.isShowingAssignmentModal, false);
       });
@@ -163,18 +163,18 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     hooks.beforeEach(function() {
       const save = sinon.stub();
       save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
-      controller.session = { save };
+      controller.model = { save };
     });
 
     test('it should assign user to session too', async function(assert) {
       // given
-      controller.session.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
+      controller.model.save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
 
       // when
       await controller.actions.confirmAssignment.call(controller);
 
       // then
-      assert.ok(controller.session.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
+      assert.ok(controller.model.save.calledWithExactly({ adapterOptions: { certificationOfficerAssignment: true } }));
       assert.ok(controller.notifications.success.calledWithExactly('La session vous a correctement été assignée'));
       assert.equal(controller.isShowingAssignmentModal, false);
     });
@@ -183,13 +183,13 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       // given
       const save = sinon.stub();
       save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).rejects();
-      controller.session = { save };
+      controller.model = { save };
 
       // when
       await controller.actions.confirmAssignment.call(controller);
 
       // then
-      assert.ok(controller.session.save.calledOnce);
+      assert.ok(controller.model.save.calledOnce);
       assert.ok(controller.notifications.error.calledWithExactly('Erreur lors de l\'assignation à la session'));
       assert.equal(controller.isShowingAssignmentModal, false);
     });

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -5,66 +5,78 @@ import sinon from 'sinon';
 module('Unit | Controller | authenticated/sessions/session/informations', function(hooks) {
   setupTest(hooks);
 
+  let store;
   let controller;
   let model;
-  let err;
+  const err = { error : 'some error' };
 
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/sessions/session/informations');
+    store = this.owner.lookup('service:store');
 
-    // context for sessionInfoService stub
-    model = { id: Symbol('an id'), juryCertificationSummaries: [{ id: 'juryCertifSummary1' }, { id: 'juryCertifSummary2' }] };
-    err = { error : 'some error' };
+    model = { id: 'an id', juryCertificationSummaries: [{ id: 'juryCertifSummary1' }, { id: 'juryCertifSummary2' }] };
 
-    const store = this.owner.lookup('service:store');
-    sinon.stub(store, 'peekRecord');
-    store.peekRecord.withArgs('certification', 'juryCertifSummary1').returns('certification1');
-    store.peekRecord.withArgs('certification', 'juryCertifSummary2').returns('certification2');
-    const downloadSessionExportFile = sinon.stub();
-    const downloadJuryFile = sinon.stub();
-    downloadSessionExportFile.withArgs({ session: model, certifications: ['certification1', 'certification2'] }).returns();
-    downloadSessionExportFile.withArgs().throws(err);
-    downloadJuryFile.withArgs({ sessionId: model.id, certifications: ['certification1', 'certification2'] }).returns();
-    downloadJuryFile.throws(err);
-    const sessionInfoServiceStub = { downloadSessionExportFile, downloadJuryFile };
-
-    // notifications stub
-    const success = sinon.stub();
-    const error = sinon.stub();
-    success.returns();
-    error.returns();
-
+    const success = sinon.stub().returns();
+    const error = sinon.stub().returns();
     controller.notifications = { success, error };
-    controller.sessionInfoService = sessionInfoServiceStub;
   });
 
   module('#downloadSessionResultFile', function() {
 
+    let url, fileName, validToken;
+    
+    hooks.beforeEach(function() {
+      url = `/api/admin/sessions/${model.id}/results`;
+      fileName = 'resultats-session.csv';
+      validToken = Symbol('my super token');
+
+      const save = sinon.stub();
+      save.withArgs({ url, fileName, token: 'validToken' }).returns();
+      save.throws(err);
+
+      controller.fileSaver = { save };
+    });
+
     test('should launch the download of result file', async function(assert) {
       // given
       controller.model = model;
+      const isAuthenticated = sinon.stub().returns();
+      controller.session = { isAuthenticated, data: { authenticated: { access_token: validToken } } };
 
       // when
       await controller.actions.downloadSessionResultFile.call(controller);
 
       // then
-      assert.ok(controller.sessionInfoService.downloadSessionExportFile.calledWithExactly({ session: model, certifications: ['certification1', 'certification2'] }));
+      assert.ok(controller.fileSaver.save.calledWithExactly({ url, fileName, token: validToken }));
     });
 
     test('should notify error when session result service throws', async function(assert) {
       // given
-      controller.model = { id: 'another model', juryCertificationSummaries: [] };
+      controller.model = { id: 'another model' };
+      const isAuthenticated = sinon.stub().rejects();
+      controller.session = { isAuthenticated, data: { authenticated: { token: '' } } };
 
       // when
       await controller.actions.downloadSessionResultFile.call(controller);
 
       // then
-      assert.ok(controller.sessionInfoService.downloadSessionExportFile.calledOnce);
       assert.ok(controller.notifications.error.calledWithExactly(err));
     });
   });
 
   module('#downloadBeforeJuryFile', function() {
+
+    hooks.beforeEach(function() {
+      sinon.stub(store, 'peekRecord');
+      store.peekRecord.withArgs('certification', 'juryCertifSummary1').returns('certification1');
+      store.peekRecord.withArgs('certification', 'juryCertifSummary2').returns('certification2');
+
+      const downloadJuryFile = sinon.stub();
+      downloadJuryFile.withArgs({ sessionId: model.id, certifications: ['certification1', 'certification2'] }).returns();
+      downloadJuryFile.throws(err);
+
+      controller.sessionInfoService = { downloadJuryFile };
+    });
 
     test('should launch the download of before jury file', async function(assert) {
       // given

--- a/admin/tests/unit/services/file-saver-test.js
+++ b/admin/tests/unit/services/file-saver-test.js
@@ -1,13 +1,80 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Service | file-saver', function(hooks) {
   setupTest(hooks);
+  let fileSaver;
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const service = this.owner.lookup('service:file-saver');
-    assert.ok(service);
+  hooks.beforeEach(function() {
+    fileSaver = this.owner.lookup('service:file-saver');
   });
-});
 
+  module('#save', function() {
+    const id = 123456;
+    const url = `/attestation/${id}`;
+    const token = 'mytoken';
+    const defaultFileName = 'mon-super-fichier.plouf';
+    const responseFileName = 'fichier.plouf';
+    const responseContent = new Blob();
+
+    let fetchStub;
+    let blobStub;
+    let downloadFileForIEBrowserStub;
+    let downloadFileForModernBrowsersStub;
+
+    hooks.beforeEach(function() {
+      fileSaver = this.owner.lookup('service:file-saver');
+      blobStub = sinon.stub().resolves(responseContent);
+      downloadFileForIEBrowserStub = sinon.stub().returns();
+      downloadFileForModernBrowsersStub = sinon.stub().returns();
+    });
+
+    module('when response does have a fileName info in headers', function() {
+      test('should give fileName from response', async function(assert) {
+        // given
+        const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
+        const response = { headers, blob: blobStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        await fileSaver.save({
+          url,
+          fileName: defaultFileName,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: responseFileName };
+        assert.ok(downloadFileForModernBrowsersStub.calledWith(expectedArgs));
+      });
+    });
+
+    module('when response does not have a fileName info in headers', function() {
+      test('should give default fileName', async function(assert) {
+        // given
+        const response = { blob: blobStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        await fileSaver.save({
+          url,
+          fileName: defaultFileName,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: defaultFileName };
+        assert.ok(downloadFileForModernBrowsersStub.calledWith(expectedArgs));
+
+      });
+    });
+  });
+
+});

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -68,66 +68,6 @@ module('Unit | Service | session-info-service', function(hooks) {
     });
   }
 
-  module('#downloadSessionExportFile', function() {
-
-    const sessionId = 555;
-
-    test('it generates well formatted result file', async function(assert) {
-      // given
-      const session = EmberObject.create({
-        id: sessionId,
-        certificationCenterName: 'Certification center',
-      });
-      const certifications = A([
-        buildCertification({ id: '1', sessionId }),
-        buildCertification({ id: '2', sessionId }),
-        buildCertification({ id: '3', sessionId }),
-        buildCertification({ id: '4', sessionId }),
-        buildCertification({ id: '5', sessionId }),
-      ]);
-
-      // when
-      await service.downloadSessionExportFile({ session, certifications });
-
-      // then
-      assert.equal(fileSaverStub.getContent(), '\uFEFF' +
-        '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-        '"1";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"2";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"3";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"4";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '"5";"Toto";"Le héros";"20/03/1986";"une ville";"1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"Certification center";"20/07/2018"\n' +
-        '');
-    });
-
-    module('when data start with illegal characters', function() {
-
-      test('should sanitize session data', async function(assert) {
-        // given
-        const certification = buildCertification({ id: '1', sessionId });
-        certification.set('firstName', '-Toto');
-        certification.set('lastName', '+Le héros');
-        certification.set('birthplace', '=une ville');
-        certification.set('externalId', '@1234');
-
-        const session = EmberObject.create({
-          id: sessionId,
-          certificationCenterName: '@Certification center',
-        });
-        const certifications = A([certification]);
-
-        // when
-        await service.downloadSessionExportFile({ session, certifications });
-
-        // then
-        assert.equal(fileSaverStub.getContent(), '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          '"1";"\'-Toto";"\'+Le héros";"20/03/1986";"\'=une ville";"\'@1234";100;1;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"0";"-";"-";555;"\'@Certification center";"20/07/2018"\n' +
-          '');
-      });
-    });
-  });
-
   module('#downloadJuryFile', function() {
 
     test('should include certification which status is not "validated"', async function(assert) {

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -260,6 +260,27 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/admin/sessions/{id}/results',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: idSpecification,
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.getSessionResults,
+        tags: ['api', 'sessions', 'results'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs ayant le rôle PIXMASTER',
+          'Elle retourne les résultats de certifications d\'une session',
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/sessions/{id}/certification-reports',
       config: {
         validate: {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -12,6 +12,7 @@ const juryCertificationSummaryRepository = require('../../infrastructure/reposit
 const jurySessionRepository = require('../../infrastructure/repositories/jury-session-repository');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
+const { getCertificationResultsCsv } = require('../../infrastructure/utils/csv/certification-results');
 
 module.exports = {
 
@@ -115,6 +116,16 @@ module.exports = {
     const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(sessionId);
 
     return juryCertificationSummarySerializer.serialize(juryCertificationSummaries);
+  },
+
+  async getSessionResults(request, h) {
+    const sessionId = request.params.id;
+    const { session, certificationResults } =  await usecases.getSessionResults({ sessionId });
+    const csvResult = await getCertificationResultsCsv({ session, certificationResults });
+
+    return h.response(csvResult)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', 'attachment; filename=session-results' + sessionId + '.csv');
   },
 
   async getCertificationReports(request) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -120,12 +120,12 @@ module.exports = {
 
   async getSessionResults(request, h) {
     const sessionId = request.params.id;
-    const { session, certificationResults } =  await usecases.getSessionResults({ sessionId });
+    const { session, certificationResults, fileName } =  await usecases.getSessionResults({ sessionId });
     const csvResult = await getCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
-      .header('Content-Disposition', 'attachment; filename=session-results' + sessionId + '.csv');
+      .header('Content-Disposition', `attachment; filename=${fileName}`);
   },
 
   async getCertificationReports(request) {

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -15,6 +15,11 @@ module.exports = {
 
   async getCertificationResult(certificationCourseId) {
     const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+    return this.getCertificationResultByCertifCourse({ certificationCourse });
+  },
+
+  async getCertificationResultByCertifCourse({ certificationCourse }) {
+    const certificationCourseId = certificationCourse.id;
     const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
     let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
     if (!lastAssessmentResultFull) {

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -6,51 +6,54 @@ const certificationCourseRepository = require('../../infrastructure/repositories
 const cleaCertificationStatusRepository = require('../../infrastructure/repositories/clea-certification-status-repository');
 const certificationResultService = require('./certification-result-service');
 
+async function calculateCertificationResultByCertificationCourseId(certificationCourseId) {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
+  return certificationResultService.getCertificationResult({ certificationAssessment, continueOnError: true });
+}
+
+async function getCertificationResult(certificationCourseId) {
+  const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
+  return getCertificationResultByCertifCourse({ certificationCourse });
+}
+
+async function getCertificationResultByCertifCourse({ certificationCourse }) {
+  const certificationCourseId = certificationCourse.id;
+  const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
+  let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
+  if (!lastAssessmentResultFull) {
+    lastAssessmentResultFull = { competenceMarks: [], status: Assessment.states.STARTED };
+  }
+
+  return new CertificationResult({
+    id: certificationCourse.id,
+    assessmentId: lastAssessmentResultFull.assessmentId,
+    firstName: certificationCourse.firstName,
+    lastName: certificationCourse.lastName,
+    birthdate: certificationCourse.birthdate,
+    birthplace: certificationCourse.birthplace,
+    externalId: certificationCourse.externalId,
+    completedAt: certificationCourse.completedAt,
+    createdAt: certificationCourse.createdAt,
+    resultCreatedAt: lastAssessmentResultFull.createdAt,
+    isPublished: certificationCourse.isPublished,
+    isV2Certification: certificationCourse.isV2Certification,
+    cleaCertificationStatus,
+    pixScore: lastAssessmentResultFull.pixScore,
+    status: lastAssessmentResultFull.status,
+    emitter: lastAssessmentResultFull.emitter,
+    commentForCandidate: lastAssessmentResultFull.commentForCandidate,
+    commentForJury: lastAssessmentResultFull.commentForJury,
+    commentForOrganization: lastAssessmentResultFull.commentForOrganization,
+    examinerComment: certificationCourse.examinerComment,
+    hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
+    competencesWithMark: lastAssessmentResultFull.competenceMarks,
+    juryId: lastAssessmentResultFull.juryId,
+    sessionId: certificationCourse.sessionId,
+  });
+}
+
 module.exports = {
-
-  async calculateCertificationResultByCertificationCourseId(certificationCourseId) {
-    const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
-    return certificationResultService.getCertificationResult({ certificationAssessment, continueOnError: true });
-  },
-
-  async getCertificationResult(certificationCourseId) {
-    const certificationCourse = await certificationCourseRepository.get(certificationCourseId);
-    return this.getCertificationResultByCertifCourse({ certificationCourse });
-  },
-
-  async getCertificationResultByCertifCourse({ certificationCourse }) {
-    const certificationCourseId = certificationCourse.id;
-    const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
-    let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
-    if (!lastAssessmentResultFull) {
-      lastAssessmentResultFull = { competenceMarks: [], status: Assessment.states.STARTED };
-    }
-
-    return new CertificationResult({
-      id: certificationCourse.id,
-      assessmentId: lastAssessmentResultFull.assessmentId,
-      firstName: certificationCourse.firstName,
-      lastName: certificationCourse.lastName,
-      birthdate: certificationCourse.birthdate,
-      birthplace: certificationCourse.birthplace,
-      externalId: certificationCourse.externalId,
-      completedAt: certificationCourse.completedAt,
-      createdAt: certificationCourse.createdAt,
-      resultCreatedAt: lastAssessmentResultFull.createdAt,
-      isPublished: certificationCourse.isPublished,
-      isV2Certification: certificationCourse.isV2Certification,
-      cleaCertificationStatus,
-      pixScore: lastAssessmentResultFull.pixScore,
-      status: lastAssessmentResultFull.status,
-      emitter: lastAssessmentResultFull.emitter,
-      commentForCandidate: lastAssessmentResultFull.commentForCandidate,
-      commentForJury: lastAssessmentResultFull.commentForJury,
-      commentForOrganization: lastAssessmentResultFull.commentForOrganization,
-      examinerComment: certificationCourse.examinerComment,
-      hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
-      competencesWithMark: lastAssessmentResultFull.competenceMarks,
-      juryId: lastAssessmentResultFull.juryId,
-      sessionId: certificationCourse.sessionId,
-    });
-  },
+  calculateCertificationResultByCertificationCourseId,
+  getCertificationResult,
+  getCertificationResultByCertifCourse,
 };

--- a/api/lib/domain/usecases/get-session-results.js
+++ b/api/lib/domain/usecases/get-session-results.js
@@ -1,4 +1,6 @@
 const { getCertificationResultByCertifCourse } = require('../../domain/services/certification-service');
+const bluebird = require('bluebird');
+const moment = require('moment');
 
 module.exports = async function getSessionResults({
   sessionId,
@@ -8,9 +10,12 @@ module.exports = async function getSessionResults({
   const session = await sessionRepository.get(sessionId);
   const allCertificationCoursesInSession = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId });
 
-  const certificationResults = await Promise.all(allCertificationCoursesInSession.map(
+  const certificationResults = await bluebird.mapSeries(allCertificationCoursesInSession,
     (certificationCourse) => getCertificationResultByCertifCourse({ certificationCourse }),
-  ));
+  );
 
-  return { session, certificationResults };
+  const dateWithTime = moment(session.date + ' ' + session.time, 'YYYY-MM-DD HH:mm');
+  const fileName = `${dateWithTime.format('YYYYMMDD_HHmm')}_resultats_session_${sessionId}.csv`;
+
+  return { session, certificationResults, fileName };
 };

--- a/api/lib/domain/usecases/get-session-results.js
+++ b/api/lib/domain/usecases/get-session-results.js
@@ -1,0 +1,16 @@
+const { getCertificationResultByCertifCourse } = require('../../domain/services/certification-service');
+
+module.exports = async function getSessionResults({
+  sessionId,
+  sessionRepository,
+  certificationCourseRepository,
+}) {
+  const session = await sessionRepository.get(sessionId);
+  const allCertificationCoursesInSession = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId });
+
+  const certificationResults = await Promise.all(allCertificationCoursesInSession.map(
+    (certificationCourse) => getCertificationResultByCertifCourse({ certificationCourse }),
+  ));
+
+  return { session, certificationResults };
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -171,6 +171,7 @@ module.exports = injectDependencies({
   getSession: require('./get-session'),
   getSessionCertificationCandidates: require('./get-session-certification-candidates'),
   getSessionCertificationReports: require('./get-session-certification-reports'),
+  getSessionResults: require('./get-session-results'),
   getShareableCertificate: require('./certificate/get-shareable-certificate'),
   getTargetProfileDetails: require('./get-target-profile-details'),
   getUserCampaignParticipationToCampaign: require('./get-user-campaign-participation-to-campaign'),

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -90,6 +90,13 @@ module.exports = {
 
     return !exist;
   },
+
+  async findCertificationCoursesBySessionId({ sessionId }) {
+    const bookshelfCertificationCourses = await CertificationCourseBookshelf
+      .where({ sessionId })
+      .fetchAll();
+    return bookshelfToDomainConverter.buildDomainObjects(CertificationCourseBookshelf, bookshelfCertificationCourses);
+  },
 };
 
 function _toDomain(bookshelfCertificationCourse) {

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Acceptance | Controller | session-controller-get-jury-certification-summaries', () => {
 
@@ -57,7 +58,7 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         certif1 = dbf.buildCertificationCourse({ sessionId, lastName: 'AAA' });
         certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
 
-        const badge = dbf.buildBadge();
+        const badge = dbf.buildBadge({ key: Badge.keys.PIX_EMPLOI_CLEA });
 
         const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
         dbf.buildAssessment({ certificationCourseId: certif2.id });

--- a/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-jury-certification-summaries_test.js
@@ -55,16 +55,15 @@ describe('Acceptance | Controller | session-controller-get-jury-certification-su
         const dbf = databaseBuilder.factory;
         pixMasterId = dbf.buildUser.withPixRolePixMaster().id;
         sessionId = dbf.buildSession().id;
-        certif1 = dbf.buildCertificationCourse({ sessionId, lastName: 'AAA' });
-        certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
-
         const badge = dbf.buildBadge({ key: Badge.keys.PIX_EMPLOI_CLEA });
 
+        certif1 = dbf.buildCertificationCourse({ sessionId, lastName: 'AAA' });
+        dbf.buildPartnerCertification({ certificationCourseId: certif1.id, partnerKey: badge.key, acquired: true });
         const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
-        dbf.buildAssessment({ certificationCourseId: certif2.id });
-        dbf.buildPartnerCertification({ certificationCourseId: certif1.id, partnerKey: badge.key });
-
         asr1 = dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
+
+        certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'CCC' });
+        dbf.buildAssessment({ certificationCourseId: certif2.id });
 
         expectedJuryCertifSumm1 = {
           'first-name': certif1.firstName,

--- a/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
@@ -1,0 +1,95 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const moment = require('moment');
+
+describe('Acceptance | Controller | session-controller-get-session-results', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/sessions/{id}/results', function() {
+    let sessionId;
+    let session;
+
+    beforeEach(() => {
+      sessionId = databaseBuilder.factory.buildSession().id;
+
+      return databaseBuilder.commit();
+    });
+
+    context('when user has not the role PixMaster', () => {
+
+      it('should return 403 HTTP status code', async () => {
+        // when
+        const response = await server.inject({
+          method: 'GET',
+          url: `/api/admin/sessions/${sessionId}/results`,
+          payload: {},
+        });
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+
+    });
+
+    context('when user has role PixMaster', () => {
+      let pixMasterId;
+      let certif1;
+      let certif2;
+      let asr1;
+      let request;
+      const birthdate = moment(new Date('1996-01-01')).format('DD/MM/YYYY');
+      const createdAt = moment(new Date('2020-01-01')).format('DD/MM/YYYY');
+
+      beforeEach(() => {
+        const dbf = databaseBuilder.factory;
+        pixMasterId = dbf.buildUser.withPixRolePixMaster().id;
+
+        certif1 = dbf.buildCertificationCourse({ sessionId, lastName: 'Dupont', birthdate, createdAt });
+        certif2 = dbf.buildCertificationCourse({ sessionId, lastName: 'Ducont', birthdate, createdAt });
+
+        const badge = dbf.buildBadge();
+
+        const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
+        dbf.buildAssessment({ certificationCourseId: certif2.id });
+        dbf.buildPartnerCertification({ certificationCourseId: certif1.id, partnerKey: badge.key });
+
+        asr1 = dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
+
+        request = {
+          method: 'GET',
+          url: `/api/admin/sessions/${sessionId}/results`,
+          payload: {},
+          headers: { authorization: generateValidRequestAuthorizationHeader(pixMasterId) },
+        };
+
+        return databaseBuilder.commit();
+      });
+
+      it('should return 200 HTTP status code', async () => {
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+
+      it('should return the expected data', async () => {
+        // when
+        const response = await server.inject(request);
+        
+        // then
+        const expectedResult = '\uFEFF' +
+        '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+        `${certif1.id};"${certif1.firstName}";"${certif1.lastName}";"${birthdate}";"${certif1.birthplace}";"${certif1.externalId}";${asr1.pixScore};"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${sessionId};"${session.certificationCenter}";"${createdAt}"\n` +
+        `${certif2.id};"${certif2.firstName}";"${certif2.lastName}";"${birthdate}";"${certif2.birthplace}";"${certif2.externalId}";;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${sessionId};"${session.certificationCenter}";"${createdAt}"`;
+        expect(response.payload).to.deep.equal(expectedResult);
+      });
+
+    });
+  });
+});

--- a/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results_test.js
@@ -11,11 +11,12 @@ describe('Acceptance | Controller | session-controller-get-session-results', () 
   });
 
   describe('GET /api/admin/sessions/{id}/results', function() {
-    let sessionId;
     let session;
+    let sessionId;
 
     beforeEach(() => {
-      sessionId = databaseBuilder.factory.buildSession().id;
+      session = databaseBuilder.factory.buildSession({ date: '2020/01/01', time: '12:00' });
+      sessionId = session.id;
 
       return databaseBuilder.commit();
     });
@@ -88,6 +89,16 @@ describe('Acceptance | Controller | session-controller-get-session-results', () 
         `${certif1.id};"${certif1.firstName}";"${certif1.lastName}";"${birthdate}";"${certif1.birthplace}";"${certif1.externalId}";${asr1.pixScore};"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${sessionId};"${session.certificationCenter}";"${createdAt}"\n` +
         `${certif2.id};"${certif2.firstName}";"${certif2.lastName}";"${birthdate}";"${certif2.birthplace}";"${certif2.externalId}";;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";${sessionId};"${session.certificationCenter}";"${createdAt}"`;
         expect(response.payload).to.deep.equal(expectedResult);
+      });
+
+      it('should return the correct fileName', async () => {
+        // when
+        const response = await server.inject(request);
+
+        // then
+        const expectedFileName = `20200101_1200_resultats_session_${sessionId}.csv`;
+        const expectedHeader = `attachment; filename=${expectedFileName}`;
+        expect(response.headers['content-disposition']).to.deep.equal(expectedHeader);
       });
 
     });

--- a/api/tests/integration/domain/services/certification-service_test.js
+++ b/api/tests/integration/domain/services/certification-service_test.js
@@ -1,0 +1,36 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const { getCertificationResult } = require('../../../../lib/domain/services/certification-service');
+const { statuses } = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
+const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
+const Badge = require('../../../../lib/domain/models/Badge');
+
+describe('Integration | Service | certification-service', () => {
+  describe('#getCertificationResult', () => {
+    let certificationCourse;
+    let assessment;
+    let badge;
+    const date = new Date();
+    const hasAcquiredClea = true;
+
+    beforeEach(async () => {
+      certificationCourse = databaseBuilder.factory.buildCertificationCourse();
+      assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
+      badge = databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_EMPLOI_CLEA });
+      databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationCourse.id, partnerKey: badge.key, acquired: hasAcquiredClea });
+      databaseBuilder.factory.buildAssessmentResult({ assessmentId: assessment.id, createdAt: date });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return certification result', async () => {
+      // when
+      const result = await getCertificationResult(certificationCourse.id);
+
+      // then
+      expect(result).to.be.instanceOf(CertificationResult);
+      expect(result.isPublished).to.equal(certificationCourse.isPublished);
+      expect(result.resultCreatedAt).to.deep.equal(date);
+      expect(result.cleaCertificationStatus).to.equal(statuses.ACQUIRED);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -359,4 +359,41 @@ describe('Integration | Repository | Certification Course', function() {
       expect(result).to.equal(false);
     });
   });
+
+  describe('#findCertificationCoursesBySessionId', () => {
+    let sessionId;
+    let sessionIdWithoutCertifCourses;
+    let firstCertifCourse;
+    let secondCertifCourse;
+
+    beforeEach(() => {
+      // given
+      sessionId = databaseBuilder.factory.buildSession().id;
+      sessionIdWithoutCertifCourses = databaseBuilder.factory.buildSession().id;
+      firstCertifCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId });
+      secondCertifCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId });
+      return databaseBuilder.commit();
+    });
+
+    function _cleanCertificationCourse(certificationCourse) {
+      return _.omit(certificationCourse, 'assessment', 'challenges', 'updatedAt');
+    }
+    it('should returns all certification courses id with given sessionId', async () => {
+      // when
+      const certificationCourses = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId });
+
+      // then
+      expect(certificationCourses).to.have.lengthOf(2);
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(firstCertifCourse));
+      expect(_cleanCertificationCourse(certificationCourses[1])).to.deep.equal(_cleanCertificationCourse(secondCertifCourse));
+    });
+
+    it('should return empty array when no certification course found', async () => {
+      // when
+      const result = await certificationCourseRepository.findCertificationCoursesBySessionId({ sessionId: sessionIdWithoutCertifCourses });
+
+      // then
+      expect(result).to.be.empty;
+    });
+  });
 });

--- a/api/tests/tooling/database-builder/factory/build-badge.js
+++ b/api/tests/tooling/database-builder/factory/build-badge.js
@@ -1,5 +1,6 @@
 const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
+const buildTargetProfile = require('./build-target-profile');
 
 module.exports = function buildBadge({
   id,
@@ -10,6 +11,7 @@ module.exports = function buildBadge({
   key = faker.random.words(),
   targetProfileId,
 } = {}) {
+  targetProfileId = targetProfileId ? targetProfileId : buildTargetProfile().id;
 
   const values = {
     id,

--- a/api/tests/tooling/database-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/database-builder/factory/build-certification-course.js
@@ -26,7 +26,6 @@ module.exports = function buildCertificationCourse({
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
   sessionId = _.isUndefined(sessionId) ? buildSession().id : sessionId;
-
   const values = {
     id,
     firstName,

--- a/api/tests/tooling/database-builder/factory/build-partner-certification.js
+++ b/api/tests/tooling/database-builder/factory/build-partner-certification.js
@@ -1,11 +1,13 @@
 const faker = require('faker');
 const databaseBuffer = require('../database-buffer');
+const buildBadge = require('./build-badge');
 
 module.exports = function buildPartnerCertification({
   certificationCourseId,
-  partnerKey = faker.lorem.word(),
-  acquired = true,
+  partnerKey,
+  acquired = faker.random.boolean(),
 }) {
+  partnerKey = partnerKey ? partnerKey : buildBadge().key;
   return databaseBuffer.objectsToInsert.push({
     tableName: 'partner-certifications', values : { certificationCourseId, partnerKey, acquired },
   });

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -1,6 +1,7 @@
 const faker = require('faker');
 const moment = require('moment');
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
+const buildAssessment = require('./build-assessment');
 
 module.exports = function buildCertificationCourse(
   {
@@ -21,6 +22,8 @@ module.exports = function buildCertificationCourse(
     verificationCode = `P-${faker.random.alphaNumeric(8).toUpperCase()}`,
     // includes
     acquiredPartnerCertifications = [],
+    assessment = buildAssessment({ certificationCourseId: this.id }),
+    challenges = [],
     // references
     userId = faker.random.number(),
     sessionId = faker.random.number(),
@@ -42,6 +45,8 @@ module.exports = function buildCertificationCourse(
     isPublished,
     verificationCode,
     acquiredPartnerCertifications,
+    assessment,
+    challenges,
     sessionId,
     userId,
   });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -376,6 +376,35 @@ describe('Unit | Controller | sessionController', () => {
 
   });
 
+  describe('#getSessionResults ', () => {
+    let request;
+    const session = { id: 1, date: '2020/01/01', time: '12:00' };
+    const certificationResults = [];
+
+    beforeEach(() => {
+      // given
+      request = {
+        params: { id: session.id },
+        auth: {
+          credentials : {
+            userId,
+          },
+        },
+      };
+      const getSessionResultsReturn = { session, certificationResults };
+      sinon.stub(usecases, 'getSessionResults').withArgs({ sessionId: session.id }).resolves(getSessionResultsReturn);
+    });
+
+    it('should return csv content and fileName', async () => {
+      // when
+      const response = await sessionController.getSessionResults(request, hFake);
+
+      // then
+      const expectedCsv = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"';
+      expect(response.source.trim()).to.deep.equal(expectedCsv.trim());
+    });
+  });
+
   describe('#getCertificationReports', () => {
     let request;
     const sessionId = 1;

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -380,6 +380,7 @@ describe('Unit | Controller | sessionController', () => {
     let request;
     const session = { id: 1, date: '2020/01/01', time: '12:00' };
     const certificationResults = [];
+    const fileName =  `20200101_1200_resultats_session_${session.id}.csv`;
 
     beforeEach(() => {
       // given
@@ -391,17 +392,19 @@ describe('Unit | Controller | sessionController', () => {
           },
         },
       };
-      const getSessionResultsReturn = { session, certificationResults };
+      const getSessionResultsReturn = { session, certificationResults, fileName };
       sinon.stub(usecases, 'getSessionResults').withArgs({ sessionId: session.id }).resolves(getSessionResultsReturn);
     });
 
     it('should return csv content and fileName', async () => {
       // when
       const response = await sessionController.getSessionResults(request, hFake);
-
+      
       // then
       const expectedCsv = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"';
+      const expectedHeader = `attachment; filename=${fileName}`;
       expect(response.source.trim()).to.deep.equal(expectedCsv.trim());
+      expect(response.headers['Content-Disposition']).to.equal(expectedHeader);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -1,0 +1,82 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const cleaCertificationStatusRepository = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const assessmentResultRepository = require('../../../../lib/infrastructure/repositories/assessment-result-repository');
+const getSessionResults = require('../../../../lib/domain/usecases/get-session-results');
+
+describe('Unit | Domain | Use Cases | get-session-results', () => {
+
+  const sessionWith2Candidates = domainBuilder.buildSession();
+  const sessionId = sessionWith2Candidates.id;
+  const certificationCourseRepository = {};
+  const sessionRepositoryStub = {};
+  const certifCourse1 = domainBuilder.buildCertificationCourse();
+  const certifCourse2 = domainBuilder.buildCertificationCourse();
+  const certifCourse3 = domainBuilder.buildCertificationCourse();
+
+  const cleaCertifications = [ 'acquired', 'rejected', 'not_passed'];
+  const assessmentsIds = [ 1, 2, 3 ];
+
+  const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi' });
+  const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', commentForCandidate: 'Son ordinateur a explosé' });
+  const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi' });
+
+  const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertifications[0]);
+  const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertifications[1]);
+  const thirdCertifResult = _buildCertificationResult(certifCourse3, assessmentResult3, cleaCertifications[2]);
+
+  beforeEach(() => {
+    // given
+    sessionRepositoryStub.get = sinon.stub().withArgs(sessionId).resolves(sessionWith2Candidates);
+
+    certificationCourseRepository.findCertificationCoursesBySessionId = sinon.stub().withArgs({ sessionId }).resolves([certifCourse1, certifCourse2, certifCourse3]);
+
+    const cleaCertificationStatusRepositoryStub = sinon.stub(cleaCertificationStatusRepository, 'getCleaCertificationStatus');
+    cleaCertificationStatusRepositoryStub.withArgs(certifCourse1.id).resolves(cleaCertifications[0]);
+    cleaCertificationStatusRepositoryStub.withArgs(certifCourse2.id).resolves(cleaCertifications[1]);
+    cleaCertificationStatusRepositoryStub.withArgs(certifCourse3.id).resolves(cleaCertifications[2]);
+
+    const assessmentRepositoryStub = sinon.stub(assessmentRepository, 'getIdByCertificationCourseId');
+    assessmentRepositoryStub.withArgs(certifCourse1.id).resolves(assessmentsIds[0]);
+    assessmentRepositoryStub.withArgs(certifCourse2.id).resolves(assessmentsIds[1]);
+    assessmentRepositoryStub.withArgs(certifCourse3.id).resolves(assessmentsIds[2]);
+
+    const assessmentResultRepositoryStub = sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks');
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse1.id }).resolves(assessmentResult1);
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse2.id }).resolves(assessmentResult2);
+    assessmentResultRepositoryStub.withArgs({ certificationCourseId: certifCourse3.id }).resolves(assessmentResult3);
+  });
+
+  it('should return all certification results', async () => {
+    // when
+    const { session, certificationResults } = await getSessionResults({
+      sessionId,
+      sessionRepository: sessionRepositoryStub,
+      certificationCourseRepository,
+    });
+
+    // then
+    const expectedSession = sessionWith2Candidates;
+    const expectedCertifResults = [ firstCertifResult, secondCertifResult, thirdCertifResult ];
+    expect(session).to.deep.equal(expectedSession);
+    expect(certificationResults).to.deep.equal(expectedCertifResults);
+  });
+
+});
+
+function _buildCertificationResult(certifCourse, assessmentResult, cleaCertification) {
+  return domainBuilder.buildCertificationResult({
+    ...certifCourse,
+    assessmentId: assessmentResult.assessmentId,
+    pixScore: assessmentResult.pixScore,
+    commentForCandidate: assessmentResult.commentForCandidate,
+    commentForJury: assessmentResult.commentForJury,
+    commentForOrganization: assessmentResult.commentForOrganization,
+    emitter: assessmentResult.emitter,
+    resultCreatedAt: assessmentResult.createdAt,
+    juryId: assessmentResult.juryId,
+    status: assessmentResult.status,
+    cleaCertificationStatus: cleaCertification,
+    competencesWithMark: [],
+  });
+}

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -6,7 +6,7 @@ const getSessionResults = require('../../../../lib/domain/usecases/get-session-r
 
 describe('Unit | Domain | Use Cases | get-session-results', () => {
 
-  const sessionWith2Candidates = domainBuilder.buildSession();
+  const sessionWith2Candidates = domainBuilder.buildSession({ date: '2020/01/01', time: '12:00' });
   const sessionId = sessionWith2Candidates.id;
   const certificationCourseRepository = {};
   const sessionRepositoryStub = {};
@@ -49,7 +49,20 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
   it('should return all certification results', async () => {
     // when
-    const { session, certificationResults } = await getSessionResults({
+    const { certificationResults } = await getSessionResults({
+      sessionId,
+      sessionRepository: sessionRepositoryStub,
+      certificationCourseRepository,
+    });
+
+    // then
+    const expectedCertifResults = [ firstCertifResult, secondCertifResult, thirdCertifResult ];
+    expect(certificationResults).to.deep.equal(expectedCertifResults);
+  });
+
+  it('should return the session', async () => {
+    // when
+    const { session } = await getSessionResults({
       sessionId,
       sessionRepository: sessionRepositoryStub,
       certificationCourseRepository,
@@ -57,9 +70,20 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
     // then
     const expectedSession = sessionWith2Candidates;
-    const expectedCertifResults = [ firstCertifResult, secondCertifResult, thirdCertifResult ];
     expect(session).to.deep.equal(expectedSession);
-    expect(certificationResults).to.deep.equal(expectedCertifResults);
+  });
+
+  it('should return the fileName', async () => {
+    // when
+    const { fileName } = await getSessionResults({
+      sessionId,
+      sessionRepository: sessionRepositoryStub,
+      certificationCourseRepository,
+    });
+
+    // then
+    const expectedFileName = `20200101_1200_resultats_session_${sessionId}.csv`;
+    expect(fileName).to.deep.equal(expectedFileName);
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Une PR a été faite pour générer des fichiers de résultats côté API (https://github.com/1024pix/pix/pull/1963).
Actuellement le bouton "Exporter les résultats" sur Pix Admin créé le fichier côté front.

Pour plus de maintenabilité il est plus simple de ne mettre la génération de fichier qu'à un seul endroit.

## :robot: Solution
Enlever la génération de fichier côté front (admin) et créer une route API qui va créer le fichier csv et le renvoyer.

## :rainbow: Remarques
- Il serait peut être intéressant de faire de même pour le fichier avant jury ?

## :100: Pour tester
- se connecter sur pixAdmin
- aller dans la liste des sessions
- cliquer sur le détail d'une session
- cliquer sur "Exporter les résultats"
- constater que le contenu est correct
