### PR TITLE
[CLEANUP] Retrait de la route API dépréciée POST /api/organizations/{id}/import-students pour l'import SIECLE (PIX-TODO)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -146,33 +146,6 @@ exports.register = async (server) => {
     },
     {
       method: 'POST',
-      path: '/api/organizations/{id}/import-students',
-      config: {
-        pre: [{
-          method: securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
-          assign: 'isAdminInOrganizationManagingStudents',
-        }],
-        validate: {
-          params: Joi.object({
-            id: Joi.number().integer().required(),
-          }),
-        },
-        payload: {
-          maxBytes: 1048576 * 10, // 10MB
-          parse: 'gunzip',
-        },
-        handler: organizationController.importSchoolingRegistrationsFromSIECLE,
-        notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés et responsables de l\'organisation**\n' +
-          '- Elle permet d\'importer des inscriptions d\'élèves, en masse, depuis un fichier au format SIECLE\n' +
-          '- Elle ne retourne aucune valeur de retour' +
-          '- L\'utilisation de cette route est dépréciée. Utiliser \'/api/organizations/{id}/schooling-registrations/import-siecle\'',
-        ],
-        tags: ['api', 'students'],
-      },
-    },
-    {
-      method: 'POST',
       path: '/api/organizations/{id}/schooling-registrations/import-siecle',
       config: {
         pre: [{

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -93,7 +93,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should throw an error when id is invalid', async () => {
       // given
       const method = 'POST';
-      const url = '/api/organizations/wrongId/import-students';
+      const url = '/api/organizations/wrongId/schooling-registrations/import-siecle';
       const payload = {};
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle route API a été créée il y a quelques temps pour réaliser un import SIECLE. En attendant, l'ancienne route fonctionnait toujours mais avait été marquée comme dépréciée.
Cela fait un moment, on peut la retirer.

## :robot: Solution
Vérification via Datadog pour démontrer que la route n'est bien plus utilisée :
![checkdatadogsiecle](https://user-images.githubusercontent.com/48727874/95453357-fb2ac680-096a-11eb-9728-b1ee1488f62f.png)

On retire la route de l'index.js + on corrige un petit test qui en faisait encore mention.

## :rainbow: Remarques
Vérifiez aussi de votre côté sur Datadog, peut-être que je me suis trompée en cherchant (la confiance n'exclut pas le contrôle ;) )

## :100: Pour tester

