### PR TITLE
[FEATURE] Ajouter le focus dans le premier champ des pages de parcours de réconciliation. (PIX-1377)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
+++ b/mon-pix/app/components/routes/campaigns/fill-in-participant-external-id.hbs
@@ -8,7 +8,7 @@
     <div class="fill-in-participant-external-id-form__section">
       <div class="fill-in-participant-external-id__form-field">
         <label for="id-pix-label">{{@campaign.idPixLabel}}</label>
-        <Input required @id="id-pix-label" @value={{this.participantExternalId}} />
+        <Input {{autofocus}} required @id="id-pix-label" @value={{this.participantExternalId}} />
       </div>
 
       <button type="submit" disabled={{this.isLoading}} class="button button--big">

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -1,7 +1,7 @@
 <form>
   <div class="join-restricted-campaign__row">
     <label class="join-restricted-campaign__label">{{t 'pages.join.fields.firstname.label'}}</label>
-    <Input
+    <Input  {{autofocus}}
             @id="firstName"
             @type="text"
             @value={{this.firstName}}
@@ -36,7 +36,7 @@
   <div class="join-restricted-campaign__row">
     <label class="join-restricted-campaign__label">{{t 'pages.join.fields.birthdate.label'}}</label>
     <div class="join-restricted-campaign__birthdate">
-      <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder={{t 'pages.join.fields.birthdate.day-format'}} class={{if this.validation.dayOfBirth "input--error"}} @focusOut={{ fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth }} />
+      <Input @id="dayOfBirth" @type="text" @value={{this.dayOfBirth}} placeholder={{t 'pages.join.fields.birthdate.day-format'}} class={{if this.validation.dayOfBirth "input--error"}} @focusOut={{ fn this.triggerInputDayValidation "dayOfBirth" this.dayOfBirth }} autofocus={{this.isDisabled}} />
       <Input @id="monthOfBirth" @type="text" @value={{this.monthOfBirth}} placeholder={{t 'pages.join.fields.birthdate.month-format'}} class={{if this.validation.monthOfBirth "input--error"}} @focusOut={{ fn this.triggerInputMonthValidation "monthOfBirth" this.monthOfBirth }} />
       <Input @id="yearOfBirth" @type="text" @value={{this.yearOfBirth}} placeholder={{t 'pages.join.fields.birthdate.year-format'}} class={{if this.validation.yearOfBirth "input--error"}} @focusOut={{ fn this.triggerInputYearValidation "yearOfBirth" this.yearOfBirth }} />
     </div>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sup.hbs
@@ -1,7 +1,7 @@
 <form>
   <div class="join-restricted-campaign__row">
     <label class="join-restricted-campaign__label">{{t 'pages.join.sup.fields.student-number.label'}}</label>
-    <Input
+    <Input  {{autofocus}}
             @id="studentNumber"
             @type="text"
             @name="studentNumber"

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -17,7 +17,7 @@
         <form class="fill-in-campaign-code__form" autocomplete="off">
 
           <div class="fill-in-campaign-code__form-field">
-            <Input required
+            <Input {{autofocus}} required
               @id="campaign-code"
               class="input-code"
               @type="text"

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -54,6 +54,9 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           // then
           expect(find('.fill-in-campaign-code__start-button').textContent).to.contains('Commencer');
+          const focusedElement = document.activeElement;
+          expect(focusedElement).to.be.not.null;
+          expect(focusedElement.id).to.equal('campaign-code', 'The campaign code was not focused');
         });
       });
 
@@ -751,7 +754,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
           });
 
-          it('should set by default firstName and lastName', async function() {
+          it('should set by default firstName and lastName and focus the day of birth', async function() {
             // when
             await fillIn('#campaign-code', campaign.code);
             await click('.fill-in-campaign-code__start-button');

--- a/mon-pix/tests/integration/components/routes/campaigns/fill-in-participant-external-id-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/fill-in-participant-external-id-test.js
@@ -15,6 +15,18 @@ describe('Integration | Component | routes/campaigns/restricted/fill-in-particip
     this.set('onCancelStub', onCancelStub);
   });
 
+  context('when render', () => {
+    it('should focus the participant externalId input  ', async function() {
+      // given
+      await render(hbs`<Routes::Campaigns::FillInParticipantExternalId @campaign={{campaign}} @onSubmit={{this.onSubmitStub}} @onCancel={{this.onCancelStub}}/>`);
+
+      // then
+      const focusedElement = document.activeElement;
+      expect(focusedElement).to.be.not.null;
+      expect(focusedElement.id).to.equal('id-pix-label', 'The participant external id was not focused');
+    });
+  });
+
   context('when externalIdHelpImageUrl exists', () => {
     it('should display image help', async function() {
       // when

--- a/mon-pix/tests/integration/components/routes/campaigns/restricted/join-sup-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/restricted/join-sup-test.js
@@ -24,6 +24,21 @@ describe('Integration | Component | routes/campaigns/restricted/join-sup', funct
   });
 
   context('when the student number is typed', () => {
+
+    it('should focus the student number input', async function() {
+      // given
+      this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);
+
+      // when
+      await render(hbs`<Routes::Campaigns::Restricted::JoinSup @campaignCode={{123}} @onSubmitToReconcile={{this.onSubmitToReconcileStub}}/>`);
+
+      // then
+      const focusedElement = document.activeElement;
+      expect(focusedElement).to.be.not.null;
+      expect(focusedElement.id).to.equal('studentNumber', 'The studentNumber was not focused');
+
+    });
+
     it('should show user data form', async function() {
       // given
       this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);

--- a/mon-pix/tests/integration/components/routes/campaigns/restricted/join-sup-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/restricted/join-sup-test.js
@@ -27,7 +27,7 @@ describe('Integration | Component | routes/campaigns/restricted/join-sup', funct
 
     it('should focus the student number input', async function() {
       // given
-      this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);
+      this.onSubmitToReconcileStub = onSubmitToReconcileStub;
 
       // when
       await render(hbs`<Routes::Campaigns::Restricted::JoinSup @campaignCode={{123}} @onSubmitToReconcile={{this.onSubmitToReconcileStub}}/>`);
@@ -54,7 +54,7 @@ describe('Integration | Component | routes/campaigns/restricted/join-sup', funct
 
     it('should disable input student number', async function() {
       // when
-      this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);
+      this.onSubmitToReconcileStub = onSubmitToReconcileStub;
 
       // given
       await render(hbs`<Routes::Campaigns::Restricted::JoinSup @campaignCode={{123}} @onSubmitToReconcile={{this.onSubmitToReconcileStub}}/>`);
@@ -71,7 +71,7 @@ describe('Integration | Component | routes/campaigns/restricted/join-sup', funct
   context('when i want change the student number', () => {
     it('should be possible to edit student number when a mistake was done', async function() {
       // when
-      this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);
+      this.onSubmitToReconcileStub = onSubmitToReconcileStub;
 
       // given
       await render(hbs`<Routes::Campaigns::Restricted::JoinSup @campaignCode={{123}} @onSubmitToReconcile={{this.onSubmitToReconcileStub}}/>`);
@@ -88,7 +88,7 @@ describe('Integration | Component | routes/campaigns/restricted/join-sup', funct
   context('when i don’t have a student number', () => {
     it('should display user data form', async function() {
       // when
-      this.set('onSubmitToReconcileStub', onSubmitToReconcileStub);
+      this.onSubmitToReconcileStub = onSubmitToReconcileStub;
 
       // given
       await render(hbs`<Routes::Campaigns::Restricted::JoinSup @campaignCode={{123}} @onSubmitToReconcile={{this.onSubmitToReconcileStub}}/>`);


### PR DESCRIPTION
## :unicorn: Problème
Pour débuter une campagne de test, il faut au moins 32 click pour y accéder.

## :robot: Solution
Réduire le nombre de click, en rajoutant des focus dans pages /campagnes /identifiant /rejoindre.

## :rainbow: Remarques
Pour tester le focus, la fonction document.activeElement renvoie l'élément qui dispose actuellement du focus.
Ce qui permet de faire une assertion dans les tests.
J'ai pris connaissance du modifier autofocus ci-dessous utilisé pour le focus:
```
import { modifier } from 'ember-modifier';

export default modifier((element) => element.focus());
```
Une autre possibilité aurait été d'utiliser [ember-atufocus-modifier](https://github.com/qonto/ember-autofocus-modifier) qui gère les champs désactivés et renvoie le focus vers l'élément parent.
J'ai compensé par l'autofocus native qui permet d'activer le focus que si le champ est à true.

## :100: Pour tester
Accéder à la page [campagne](https://app-pr1985.review.pix.fr/campagnes) : vérifier que le focus est bien présent sur le champ code campagne.
Accéder à la page de réconciliation:
Pour un accès depuis le [GAR](https://app-pr1985.review.pix.fr/campagnes?externalUser=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmaXJzdF9uYW1lIjoiTWF0aGlldSIsImxhc3RfbmFtZSI6IkdVRVJJTiIsInNhbWxfaWQiOiJuZXdzYW1sSUREREREZGRkZHMiLCJpYXQiOjE2MDIxNjU5MzgsImV4cCI6MTYwMjE2OTUzOH0.OjZhAncoBXzGCA4IHa1YPjR_eiOkmPcRlWGLrIWp_AQ): vérifier le focus au niveau du jour de naissance.
Pour un accès username/email: verifier le focus au niveau de prénom.
Accéder à la page /identifiant: vérifier le focus au niveau du champ identifiant du participant.
