### PR TITLE
[BUG] Amélioration dans Mon-Pix de la gestion des erreurs sur la page Réinitialiser le mot de passe (PIX-1385).

### DIFF
--- a/mon-pix/.template-lintrc.js
+++ b/mon-pix/.template-lintrc.js
@@ -16,5 +16,5 @@ module.exports = {
     'no-unused-block-params': false,
     'style-concatenation': false,
     'no-bare-strings': ['Pix', '&nbsp;', '&#8226;','.', '*', '1024', '/', '•', '-', '%'],
-  }
+  },
 };

--- a/mon-pix/app/templates/components/form-textfield.hbs
+++ b/mon-pix/app/templates/components/form-textfield.hbs
@@ -6,15 +6,15 @@
 
 <div class="form-textfield__input-field-container {{if disabled "form-textfield__input-container--disabled" inputContainerStatusClass}}">
   <Input @type={{textfieldType}}
-         @id={{textfieldName}}
-         @name={{textfieldName}}
+         id={{textfieldName}}
+         name={{textfieldName}}
          @value={{inputBindingValue}}
          @focus-out={{action onValidate textfieldName}}
          class="form-textfield__input {{inputValidationStatus}}"
-         @autocomplete={{autocomplete}}
-         @ariaDescribedBy="validationMessage"
+         autocomplete={{autocomplete}}
+         aria-describedby="validationMessage"
          required={{require}}
-         @disabled={{disabled}} />
+         disabled={{disabled}} />
     <div class="form-textfield__icon">
       {{#if isPassword}}
           <button type="button" aria-label={{t 'common.form.visible-password'}} class="form-textfield-icon__button" {{action 'togglePasswordVisibility'}}>

--- a/mon-pix/app/templates/components/update-expired-password-form.hbs
+++ b/mon-pix/app/templates/components/update-expired-password-form.hbs
@@ -14,6 +14,12 @@
       {{/unless}}
     </div>
 
+    {{#if this.errorMessage}}
+      <div class="update-expired-password-form__notification-message update-expired-password-form__notification-message--error" aria-live="polite">
+        {{this.errorMessage}}
+      </div>
+    {{/if}}
+
     {{#unless this.authenticationHasFailed}}
       <form {{on "submit" this.handleUpdatePasswordAndAuthenticate}} class="update-expired-password-form__body">
 
@@ -25,7 +31,7 @@
                          @onValidate={{this.validatePassword}}
                          @validationStatus={{this.validation.status}}
                          @validationMessage={{this.validationMessage}}
-                         @required="true" />
+                         @required={{true}} />
         </div>
 
         <div class="update-expired-password-form-body__bottom-button update-expired-password-form-body__bottom-button--big">

--- a/mon-pix/tests/integration/components/update-expired-password-form-test.js
+++ b/mon-pix/tests/integration/components/update-expired-password-form-test.js
@@ -1,20 +1,18 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
-import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { resolve, reject } from 'rsvp';
-import {
-  click,
-  fillIn,
-  find,
-  render,
-  triggerEvent,
-} from '@ember/test-helpers';
+
+import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
+
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { contains } from '../../helpers/contains';
 
 const PASSWORD_INPUT_CLASS = '.form-textfield__input';
 
 describe('Integration | Component | update-expired-password-form', function() {
+
   setupIntlRenderingTest();
 
   let isSaveMethodCalled, saveMethodOptions;
@@ -72,13 +70,16 @@ describe('Integration | Component | update-expired-password-form', function() {
   });
 
   context('errors cases', function() {
+
     it('should display an error, when saving fails', async function() {
       // given
+      const expectedErrorMessage = this.intl.t('api-error-messages.internal-server-error');
+
       const user = EmberObject.create({ username: 'toto', password: 'Password123', save: saveWithRejection, unloadRecord });
       this.set('user', user);
       const newPassword = 'Pix12345!';
 
-      await render(hbs `{{update-expired-password-form user=user}}`);
+      await render(hbs `<UpdateExpiredPasswordForm @user={{this.user}} />`);
 
       // when
       await fillIn(PASSWORD_INPUT_CLASS, newPassword);
@@ -88,7 +89,7 @@ describe('Integration | Component | update-expired-password-form', function() {
 
       // then
       expect(isSaveMethodCalled).to.be.true;
-      expect(find('.form-textfield__message--error')).to.exist;
+      expect(contains(expectedErrorMessage)).to.exist;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Il y a des incohérences dans les messages d'erreur sur cette page, perturbant les élèves durant le processus de réinitialisation de mot de passe.

## :robot: Solution
* Lors de la tentative de modification du mot de passe
  * Si le format du mot de passe est erroné, afficher sous le champs de saisi le bon message d'erreur.
  * Si une autre erreur survient, afficher le message adéquat au dessus du formulaire.
* Lors de l'authentification
  * Si une erreur survient, afficher les messages prévus pour rediriger l'élève vers la page de connexion.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1 - Localiser un utilisateur (élève) devant changer son mot de passe 
- OU utiliser la seed `username123/Password123`.
- OU se connecter à pix-orga, Elèves, Gérer le compte, Réinitialiser

2 - Essayer avec un mot de passe erroné, et vérifier que le message d'erreur s'affiche en dessous du champ de saisie.
3 - Utiliser les options de votre navigateur pour le mettre en "Offline".
Faire une tentative de réinitialisation, et vérifier que le message d'erreur s'affiche au dessus du formulaire.
<img src="https://user-images.githubusercontent.com/88607/95556175-2ec12b80-0a13-11eb-9b65-a55b51694d72.png" width="250" />
4 - _La simulation d'une erreur lors de l'authentification est difficilement reproductible, mais en jouant avec les options "Slow 3G" et "Offline", il est possible de simuler une erreur d'authentification !
Dans ce cas, le formulaire ci-dessous doit apparaitre :_ 
<img src="https://user-images.githubusercontent.com/88607/95555738-89a65300-0a12-11eb-9791-40a482a325c1.png" width="250" />

Pour revenir à l'état initial, exécuter la commande : 
```
scalingo -a pix-api-review-pr1986 --region osc-fr1 run "npm run db:seed"
```
