### PR TITLE
[FEATURE] Rendre réutilisable le parser CSV HigherSchoolingRegistrationParser (PIX-1351)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
@@ -1,0 +1,138 @@
+const papa = require('papaparse');
+const iconv = require('iconv-lite');
+const { convertDateValue } = require('../../utils/date-utils');
+const { CsvImportError } = require('../../../../lib/domain/errors');
+
+const PARSING_OPTIONS = {
+  header: true,
+  skipEmptyLines: 'greedy',
+  transform: (value) => {
+    if (typeof value === 'string') {
+      value = value.trim();
+      return value.length ? value : undefined;
+    }
+    return value;
+  },
+};
+
+class CsvColumn {
+  constructor({ name, label, isRequired = false, isDate = false, checkEncoding = false }) {
+    this.name = name;
+    this.label = label;
+    this.isRequired = isRequired;
+    this.isDate = isDate;
+    this.checkEncoding = checkEncoding;
+  }
+}
+
+class CsvRegistrationParser {
+
+  constructor(input, organizationId, columns) {
+    this._input = input;
+    this._organizationId = organizationId;
+    this._columns = columns;
+  }
+
+  parse({ registrationSet, onParseLineError }) {
+    const encoding = this._getFileEncoding();
+    const { registrationLines, fields } = this._parse(encoding);
+
+    if (!encoding) {
+      throw new CsvImportError('Encodage du fichier non supporté.');
+    }
+
+    this._checkColumns(fields);
+    registrationLines.forEach((line, index) => {
+      const registrationAttributes = this._lineToRegistrationAttributes(line);
+      try {
+        registrationSet.addRegistration(registrationAttributes);
+      } catch (err) {
+        onParseLineError(err, index);
+      }
+    });
+    return registrationSet;
+  }
+
+  /**
+   * Identify which encoding has the given file.
+   * To check it, we decode and parse the first line of the file with supported encodings.
+   * If there is one with at least "First name" or "Student number" correctly parsed and decoded.
+   */
+  _getFileEncoding() {
+    const supported_encodings = ['utf-8', 'win1252', 'macintosh'];
+    const checkedColumns = this._getEncodingColumns();
+    for (const encoding of supported_encodings) {
+      const decodedInput = iconv.decode(this._input, encoding);
+      const { meta: { fields } } = papa.parse(decodedInput, { ...PARSING_OPTIONS, preview: 1 });
+      if (fields.some((value) => checkedColumns.includes(value))) {
+        return encoding;
+      }
+    }
+  }
+
+  _getEncodingColumns() {
+    const checkedColumns = this._columns.filter((c) => c.checkEncoding).map((c) => c.label);
+    if (checkedColumns.length === 0) {
+      return this._columns.map((c) => c.label);
+    }
+    return checkedColumns;
+  }
+
+  _parse(encoding = 'utf8') {
+    const decodedInput = iconv.decode(this._input, encoding);
+    const { data: registrationLines, meta: { fields }, errors } = papa.parse(decodedInput, PARSING_OPTIONS);
+
+    if (errors.length) {
+      const hasDelimiterError = errors.some((error) => error.type === 'Delimiter');
+      if (hasDelimiterError) {
+        throw new CsvImportError('Le fichier doit être au format csv avec séparateur virgule ou point-virgule.');
+      }
+    }
+
+    return { registrationLines, fields };
+  }
+
+  _lineToRegistrationAttributes(line) {
+    const registrationAttributes = {
+      organizationId: this._organizationId,
+    };
+
+    this._columns.forEach((column) => {
+      const value = line[column.label];
+      if (column.isDate) {
+        registrationAttributes[column.name] = this._buildDateAttribute(value);
+      } else {
+        registrationAttributes[column.name] = value;
+      }
+    });
+
+    return registrationAttributes;
+  }
+
+  _checkColumns(parsedColumns) {
+    // Required columns
+    const missingMandatoryColumn = this._columns
+      .filter((c) => c.isRequired)
+      .find((c) => !parsedColumns.includes(c.label));
+    if (missingMandatoryColumn)  {
+      throw new CsvImportError(`La colonne "${missingMandatoryColumn.label}" est obligatoire.`);
+    }
+  
+    // Expected columns
+    if (this._columns.some((column) => !parsedColumns.includes(column.label))) {
+      throw new CsvImportError('Les entêtes de colonnes doivent être identiques à celle du modèle.');
+    }
+  }
+
+  _buildDateAttribute(dateString) {
+    const convertedDate = convertDateValue({ dateString, inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
+    return convertedDate || dateString;
+  }
+
+}
+
+module.exports = {
+  CsvColumn,
+  CsvRegistrationParser,
+};
+

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
@@ -1,105 +1,45 @@
-const papa = require('papaparse');
-const iconv = require('iconv-lite');
 const HigherSchoolingRegistrationSet = require('../../../../lib/domain/models/HigherSchoolingRegistrationSet');
-const { convertDateValue } = require('../../utils/date-utils');
 const { CsvImportError } = require('../../../../lib/domain/errors');
-const PARSING_OPTIONS = {
-  header: true,
-  skipEmptyLines: 'greedy',
-  transform: (value) => {
-    if (typeof value === 'string') {
-      value = value.trim();
-      return value.length ? value : undefined;
-    }
-    return value;
-  },
-};
-const COLUMN_NAME_BY_ATTRIBUTE = {
-  firstName: 'Premier prénom',
-  middleName: 'Deuxième prénom',
-  thirdName: 'Troisième prénom',
-  lastName: 'Nom de famille',
-  preferredLastName: 'Nom d’usage',
-  studentNumber: 'Numéro étudiant',
-  email: 'Email',
-  diploma: 'Diplôme',
-  department: 'Composante',
-  educationalTeam: 'Équipe pédagogique',
-  group: 'Groupe',
-  studyScheme: 'Régime',
-  birthdate: 'Date de naissance (jj/mm/aaaa)',
-};
 
-class HigherSchoolingRegistrationParser {
+const { CsvRegistrationParser, CsvColumn } = require('./csv-registration-parser');
+
+const COLUMNS = [
+  new CsvColumn({ name: 'firstName', label: 'Premier prénom', isRequired: true, checkEncoding: true }),
+  new CsvColumn({ name: 'middleName', label:'Deuxième prénom' }),
+  new CsvColumn({ name: 'thirdName', label:'Troisième prénom' }),
+  new CsvColumn({ name: 'lastName', label:'Nom de famille', isRequired: true }),
+  new CsvColumn({ name: 'preferredLastName', label:'Nom d’usage' }),
+  new CsvColumn({ name: 'studentNumber', label:'Numéro étudiant', isRequired: true, checkEncoding: true }),
+  new CsvColumn({ name: 'email', label:'Email' }),
+  new CsvColumn({ name: 'diploma', label:'Diplôme' }),
+  new CsvColumn({ name: 'department', label:'Composante' }),
+  new CsvColumn({ name: 'educationalTeam', label:'Équipe pédagogique' }),
+  new CsvColumn({ name: 'group', label:'Groupe' }),
+  new CsvColumn({ name: 'studyScheme', label:'Régime' }),
+  new CsvColumn({ name: 'birthdate', label:'Date de naissance (jj/mm/aaaa)', isRequired: true, isDate: true }),
+];
+
+class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
 
   constructor(input, organizationId) {
-    this._input = input;
-    this._organizationId = organizationId;
+    super(input, organizationId, COLUMNS);
   }
 
   parse() {
-    const higherSchoolingRegistrationSet = new HigherSchoolingRegistrationSet();
-
-    const encoding = this._getFileEncoding();
-    const { registrationLines, fields } = this._parse(encoding);
-
-    if (!encoding) {
-      throw new CsvImportError('Encodage du fichier non supporté.');
-    }
-
-    this._checkColumns(fields);
-
-    registrationLines.forEach((line, index) => {
-      const registrationAttributes = this._lineToRegistrationAttributes(line);
-      try {
-        higherSchoolingRegistrationSet.addRegistration(registrationAttributes);
-      } catch (err) {
-        this._handleError(err, index);
-      }
+    const registrationSet = new HigherSchoolingRegistrationSet();
+    return super.parse({
+      registrationSet,
+      onParseLineError: this._handleError,
     });
-
-    return higherSchoolingRegistrationSet;
-  }
-
-  /**
-   * Identify which encoding has the given file.
-   * To check it, we decode and parse the first line of the file with supported encodings.
-   * If there is one with at least "First name" or "Student number" correctly parsed and decoded.
-   */
-  _getFileEncoding() {
-    const supported_encodings = ['utf-8', 'win1252', 'macintosh'];
-    const { firstName, studentNumber } = COLUMN_NAME_BY_ATTRIBUTE;
-    for (const encoding of supported_encodings) {
-      const decodedInput = iconv.decode(this._input, encoding);
-      const { meta: { fields } } = papa.parse(decodedInput, { ...PARSING_OPTIONS, preview: 1 });
-      if (fields.some((value) => value === firstName || value === studentNumber)) {
-        return encoding;
-      }
-    }
-  }
-
-  _parse(encoding = 'utf8') {
-    const decodedInput = iconv.decode(this._input, encoding);
-    const { data: registrationLines, meta: { fields }, errors } = papa.parse(decodedInput, PARSING_OPTIONS);
-
-    if (errors.length) {
-      errors.forEach((error) => {
-        if (error.type === 'Delimiter') {
-          throw new CsvImportError('Le fichier doit être au format csv avec séparateur virgule ou point-virgule.');
-        }
-      });
-    }
-
-    return { registrationLines, fields };
   }
 
   _handleError(err, index) {
-    const column = COLUMN_NAME_BY_ATTRIBUTE[err.key];
+    const column = COLUMNS.find((column) => column.name === err.key);
     if (err.why === 'uniqueness') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “Numéro étudiant” doit être unique au sein du fichier.`);
     }
     if (err.why === 'max_length') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column}” doit être inférieur à 255 caractères.`);
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” doit être inférieur à 255 caractères.`);
     }
     if (err.why === 'not_a_date' || err.why === 'date_format') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “Date de naissance” doit être au format jj/mm/aaaa.`);
@@ -108,46 +48,10 @@ class HigherSchoolingRegistrationParser {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “numéro étudiant” ne doit pas avoir de caractères spéciaux.`);
     }
     if (err.why === 'required') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column}” est obligatoire.`);
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” est obligatoire.`);
     }
     throw err;
   }
-
-  _lineToRegistrationAttributes(line) {
-    const registrationAttributes = {};
-
-    Object.keys(COLUMN_NAME_BY_ATTRIBUTE).map((attribute) => {
-      const column = COLUMN_NAME_BY_ATTRIBUTE[attribute];
-      const value = line[column];
-
-      registrationAttributes[attribute] = value;
-    });
-
-    registrationAttributes['birthdate'] =  this._buildBirthdateAttribute(line[COLUMN_NAME_BY_ATTRIBUTE.birthdate]);
-    registrationAttributes['organizationId'] = this._organizationId;
-
-    return registrationAttributes;
-  }
-
-  _checkColumns(columns) {
-    const { firstName, lastName, birthdate, studentNumber } = COLUMN_NAME_BY_ATTRIBUTE;
-    const requiredColumns = [firstName, lastName, birthdate, studentNumber];
-    requiredColumns.forEach((column) => {
-      if (!columns.includes(column)) {
-        throw new CsvImportError(`La colonne "${column}" est obligatoire.`);
-      }
-    });
-    const expectedColumns = Object.values(COLUMN_NAME_BY_ATTRIBUTE);
-    if (columns.some((column) => !expectedColumns.includes(column))) {
-      throw new CsvImportError('Les entêtes de colonnes doivent être identiques à celle du modèle.');
-    }
-  }
-
-  _buildBirthdateAttribute(birthdate) {
-    const convertedDate = convertDateValue({ dateString: birthdate, inputFormat: 'DD/MM/YYYY', alternativeInputFormat: 'DD/MM/YY', outputFormat: 'YYYY-MM-DD' });
-    return convertedDate || birthdate;
-  }
-
 }
 
 module.exports = HigherSchoolingRegistrationParser;

--- a/api/tests/unit/infrastructure/serializers/csv/csv-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-registration-parser_test.js
@@ -1,0 +1,199 @@
+const iconv = require('iconv-lite');
+const { sinon, expect, catchErr } = require('../../../../test-helper');
+const { CsvRegistrationParser, CsvColumn } = require('../../../../../lib/infrastructure/serializers/csv/csv-registration-parser');
+
+class FakeRegistrationSet {
+  constructor() {
+    this.registrations = [];
+  }
+  addRegistration(registration) {
+    this.registrations.push(registration);
+  }
+}
+
+describe('Unit | Infrastructure | CsvRegistrationParser', () => {
+  const organizationId = 123;
+  let registrationSet;
+  
+  beforeEach(() => {
+    registrationSet = new FakeRegistrationSet();
+  });
+
+  context('when the header is correctly formed', () => {
+    context('when there are lines', () => {
+      const columns = [
+        new CsvColumn({ name: 'col1', label: 'Column 1' }),
+        new CsvColumn({ name: 'col2', label: 'Column 2' }),
+      ];
+
+      it('returns a HigherSchoolingRegistrationSet with a schooling registration for each line', () => {
+        const input = `Column 1;Column 2;
+        Beatrix;The;
+        O-Ren;;
+        `;
+        const encodedInput = iconv.encode(input, 'utf8');
+        const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+        parser.parse({
+          registrationSet,
+          onParseLineError: sinon.stub(),
+        });
+
+        expect(registrationSet.registrations).to.have.lengthOf(2);
+      });
+    });
+
+    context('when there are different date formats', () => {
+      const columns = [
+        new CsvColumn({ name: 'col1', label: 'Column 1' }),
+        new CsvColumn({ name: 'col2', label: 'Column 2', isDate: true }),
+      ];
+      
+      it('should parse different date formats', () => {
+        const input = `Column 1;Column 2;
+        O-Ren;2010-01-20;
+        O-Ren;20/01/2010;
+        O-Ren;20/01/10;
+        `;
+        const encodedInput = iconv.encode(input, 'utf8');
+        const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+        parser.parse({
+          registrationSet,
+          onParseLineError: sinon.stub(),
+        });
+
+        expect(registrationSet.registrations[0].col2).to.equal('2010-01-20');
+        expect(registrationSet.registrations[1].col2).to.equal('2010-01-20');
+        expect(registrationSet.registrations[2].col2).to.equal('2010-01-20');
+      });
+    });
+
+    context('when there are a validation error', () => {
+      const columns = [
+        new CsvColumn({ name: 'col1', label: 'Column 1' }),
+        new CsvColumn({ name: 'col2', label: 'Column 2' }),
+      ];
+      
+      it('should parse different date formats', () => {
+        const input = `Column 1;Column 2;
+        O-Ren;2010-01-20;
+        `;
+        const encodedInput = iconv.encode(input, 'utf8');
+        const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+        const onParseLineError = sinon.stub();
+        const error = new Error('error');
+        registrationSet.addRegistration = () => {
+          throw error;
+        };
+
+        parser.parse({ registrationSet, onParseLineError });
+
+        expect(onParseLineError).to.calledOnceWithExactly(error, 0);
+      });
+    });
+  });
+
+  context('When file does not match requirements', () => {
+    const columns = [
+      new CsvColumn({ name: 'col1', label: 'Column 1',  isRequired: true }),
+      new CsvColumn({ name: 'col2', label: 'Column 2' }),
+    ];
+  
+    it('should throw an error if the file is not csv', async () => {
+      const input = `Column 1\\Column 2\\
+      Beatrix\\The\\`;
+      const encodedInput = iconv.encode(input, 'utf8');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+      const error = await catchErr(parser.parse, parser)({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+
+      expect(error.message).to.equal('Le fichier doit être au format csv avec séparateur virgule ou point-virgule.');
+    });
+
+    it('should throw an error if a column is not recognized', async () => {
+      const input = `Column 1;BAD Column 2;
+        Beatrix;The;
+        O-Ren;;
+      `;
+      const encodedInput = iconv.encode(input, 'utf8');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+      const error = await catchErr(parser.parse, parser)({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+
+      expect(error.message).to.equal('Les entêtes de colonnes doivent être identiques à celle du modèle.');
+    });
+
+    it('should throw an error if a required column is missing', async () => {
+      const input = `Column 2;
+      The;`;
+      const encodedInput = iconv.encode(input, 'utf8');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+
+      const error = await catchErr(parser.parse, parser)({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+
+      expect(error.message).to.equal('La colonne "Column 1" est obligatoire.');
+    });
+
+  });
+
+  context('When the file has different encoding', () => {
+    const columns = [
+      new CsvColumn({ name: 'firstName', label: 'Prénom',  isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'lastName', label: 'Nom' }),
+    ];
+
+    const input = `Prénom;Nom;
+      Éçéà niño véga;The;
+    `;
+
+    it('should parse UTF-8 encoding', () => {
+      const encodedInput = iconv.encode(input, 'utf8');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+      parser.parse({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+      expect(registrationSet.registrations[0].firstName).to.equal('Éçéà niño véga');
+    });
+
+    it('should parse win1252 encoding (CSV WIN/MSDOS)', () => {
+      const encodedInput = iconv.encode(input, 'win1252');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+      parser.parse({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+      expect(registrationSet.registrations[0].firstName).to.equal('Éçéà niño véga');
+    });
+
+    it('should parse macintosh encoding', () => {
+      const encodedInput = iconv.encode(input, 'macintosh');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+      parser.parse({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      });
+      expect(registrationSet.registrations[0].firstName).to.equal('Éçéà niño véga');
+    });
+
+    it('should throw an error if encoding not supported', () => {
+      const encodedInput = iconv.encode(input, 'utf16');
+      const parser = new CsvRegistrationParser(encodedInput, organizationId, columns);
+      expect(() => parser.parse({
+        registrationSet,
+        onParseLineError: sinon.stub(),
+      })).to.throw('Encodage du fichier non supporté.');
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
@@ -79,43 +79,6 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
     });
   });
 
-  context('When file does not match requirements', () => {
-    const organizationId = 123;
-    it('should throw an error if the file is not csv', async () => {
-      const input = `Premier prénom\\Deuxième prénom\\Troisième prénom\\Nom de famille\\Nom d’usage\\Date de naissance (jj/mm/aaaa)\\Email\\Numéro étudiant\\Composante\\Équipe pédagogique\\Groupe\\Diplôme\\Régime
-      Beatrix\\The\\Bride\\Kiddo\\Black Mamba\\01/01/1970\\thebride@example.net\\12346\\Assassination Squad\\Hattori Hanzo\\Deadly Viper Assassination Squad\\Master\\hello darkness my old friend\\`;
-      const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
-
-      const error = await catchErr(parser.parse, parser)();
-
-      expect(error.message).to.equal('Le fichier doit être au format csv avec séparateur virgule ou point-virgule.');
-    });
-
-    it('should throw an error if a column is not recognized', async () => {
-      const input = `Premier prénom;Deuxième prénom2;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime
-      Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
-      const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
-
-      const error = await catchErr(parser.parse, parser)();
-
-      expect(error.message).to.equal('Les entêtes de colonnes doivent être identiques à celle du modèle.');
-    });
-
-    it('should throw an error if a required column is missing', async () => {
-      const input = `Deuxième prénom;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime
-      The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
-      const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
-
-      const error = await catchErr(parser.parse, parser)();
-
-      expect(error.message).to.equal('La colonne "Premier prénom" est obligatoire.');
-    });
-
-  });
-
   context('When a column value does not match requirements', () => {
     const organizationId = 123;
 
@@ -174,42 +137,6 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
       const error = await catchErr(parser.parse, parser)();
 
       expect(error.message).to.contain('Ligne 3 :');
-    });
-  });
-
-  context('When the file has different encoding', () => {
-    const input = `Premier prénom;Deuxième prénom;Troisième prénom;Nom de famille;Nom d’usage;Date de naissance (jj/mm/aaaa);Email;Numéro étudiant;Composante;Équipe pédagogique;Groupe;Diplôme;Régime
-          Éçéà niño véga;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;12346;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
-        `;
-
-    it('should parse UTF-8 encoding', () => {
-      const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, 123);
-      const higherSchoolingRegistrationSet = parser.parse();
-      const registrations = higherSchoolingRegistrationSet.registrations;
-      expect(registrations[0].firstName).to.equal('Éçéà niño véga');
-    });
-
-    it('should parse win1252 encoding (CSV WIN/MSDOS)', () => {
-      const encodedInput = iconv.encode(input, 'win1252');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, 123);
-      const higherSchoolingRegistrationSet = parser.parse();
-      const registrations = higherSchoolingRegistrationSet.registrations;
-      expect(registrations[0].firstName).to.equal('Éçéà niño véga');
-    });
-
-    it('should parse macintosh encoding', () => {
-      const encodedInput = iconv.encode(input, 'macintosh');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, 123);
-      const higherSchoolingRegistrationSet = parser.parse();
-      const registrations = higherSchoolingRegistrationSet.registrations;
-      expect(registrations[0].firstName).to.equal('Éçéà niño véga');
-    });
-
-    it('should throw an error if encoding not supported', () => {
-      const encodedInput = iconv.encode(input, 'utf16');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, 123);
-      expect(() => parser.parse()).to.throw('Encodage du fichier non supporté.');
     });
   });
 });


### PR DESCRIPTION
**Cette PR est la première de plusieurs à venir basée sur la feature branche `pix-1351-feature-import-csv-sco-agri`** pour réaliser l'import SCO Agri.

## :unicorn: Problème

Il faut pouvoir importer les élèves de SCO Agri. Mais les organismes SCO Agri n'ont pas accès au format XML SIECLE.
Il a été proposé d'utiliser un format CSV (comme pour le SUP) mais ce fichier comportera en colonne les données équivalentes au fichier SIECLE.
Voici le format du fichier CSV :
```csv
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
```

## :robot: Solution

Le fichier est proche du format de CSV de l'import de SUP. Nous allons rendre réutilisable ce parser CSV pour éviter de recoder plusieurs fonctionnalités communes: 
- Gestion des encodages des différents types de CSV
- Gestion des erreurs de format CSV
- Gestion le parsing des types dates

## :rainbow: Remarques

- Le parser des fichier CSV SUP a été refactoré et rendu générique pour être réutilisé (`CsvRegistrationParser`).
- Le parser CSV SUP utilise désormais le parser CSV générique (`HigherSchoolingRegistrationParser`)

## :100: Pour tester

Non régression de l'import d'étudiants via un fichier CSV SUP.
