### PR TITLE
[FEATURE] Editer le champ crédits d'une organisation (PIX-1296).

### DIFF
--- a/admin/app/components/organization-information-section.hbs
+++ b/admin/app/components/organization-information-section.hbs
@@ -71,6 +71,18 @@
                  class={{if (v-get this.form 'email' 'isInvalid') "form-control is-invalid" "form-control"}}
                  @value={{this.form.email}} />
         </div>
+        <div class="form-field">
+          <label for="credits" class="form-field__label">Crédits</label>
+          {{#if (v-get this.form 'credit' 'isInvalid')}}
+            <div class="form-field__error">
+              {{v-get this.form 'credit' 'message'}}
+            </div>
+          {{/if}}
+          <Input id="credit"
+                 @type="number"
+                 class={{if (v-get this.form 'credit' 'isInvalid') "form-control is-invalid" "form-control"}}
+                 @value={{this.form.credit}} />
+        </div>
         {{#if (or @organization.isOrganizationSCO @organization.isOrganizationSUP)}}
           <div class="form-field organization-edit-form__checkbox">
             <label for="isManagingStudents" class="form-field__label">Gestion d’élèves/étudiants</label>

--- a/admin/app/components/organization-information-section.js
+++ b/admin/app/components/organization-information-section.js
@@ -51,6 +51,16 @@ const Validations = buildValidations({
       }),
     ],
   },
+  credit: {
+    validators: [
+      validator('number', {
+        allowString: true,
+        integer: true,
+        positive: true,
+        message: 'Le nombre de crédits doit être un nombre supérieur ou égal à 0.',
+      }),
+    ],
+  },
   isManagingStudents: {
     validators: [
       validator('inclusion', {
@@ -72,6 +82,7 @@ class Form extends Object.extend(Validations) {
   @tracked externalId;
   @tracked provinceCode;
   @tracked email;
+  @tracked credit;
   @tracked isManagingStudents;
   @tracked canCollectProfiles;
 }
@@ -130,6 +141,7 @@ export default class OrganizationInformationSection extends Component {
     this.args.organization.set('externalId', !this.form.externalId ? null : this.form.externalId.trim());
     this.args.organization.set('provinceCode', !this.form.provinceCode ? null : this.form.provinceCode.trim());
     this.args.organization.set('email', !this.form.email ? null : this.form.email.trim());
+    this.args.organization.set('credit', !this.form.credit ? null : this.form.credit);
     this.args.organization.set('isManagingStudents', this.form.isManagingStudents);
     this.args.organization.set('canCollectProfiles', this.form.canCollectProfiles);
 
@@ -142,6 +154,7 @@ export default class OrganizationInformationSection extends Component {
     this.form.externalId = this.args.organization.externalId;
     this.form.provinceCode = this.args.organization.provinceCode;
     this.form.email = this.args.organization.email;
+    this.form.credit = this.args.organization.credit;
     this.form.isManagingStudents = this.args.organization.isManagingStudents;
     this.form.canCollectProfiles = this.args.organization.canCollectProfiles;
   }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -74,16 +74,7 @@ export default function() {
     return membership.update({ disabledAt: new Date() });
   });
 
-  this.patch('/organizations/:id', (schema, request) => {
-    const organizationId = request.params.id;
-    const params = JSON.parse(request.requestBody);
-    const name = params.data.attributes.name;
-    const externalId = params.data.attributes['external-id'];
-    const provinceCode = params.data.attributes['province-code'];
-
-    const organization = schema.organizations.findBy({ id: organizationId });
-    return organization.update({ name, externalId, provinceCode });
-  });
+  this.patch('/organizations/:id');
 
   this.patch('/admin/users/:id', (schema, request) => {
     const userId = request.params.id;

--- a/admin/mirage/factories/organization.js
+++ b/admin/mirage/factories/organization.js
@@ -1,0 +1,10 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  canCollectProfiles() {
+    return false;
+  },
+  isManagingStudents() {
+    return false;
+  },
+});

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -14,32 +14,18 @@ module('Acceptance | organization information management', function(hooks) {
 
   module('editing organization', function() {
 
-    test('should edit organization\'s name, externalId, provinceCode and email', async function(assert) {
+    test('should be able to edit organization information', async function(assert) {
       // given
-      const organization = this.server.create('organization', {
-        name: 'oldOrganizationName',
-        externalId: 'oldOrganizationExternalId',
-        provinceCode: 'oldProvinceCode',
-        canCollectProfiles: true,
-        isManagingStudents: true,
-      });
+      const organization = this.server.create('organization', { name: 'oldOrganizationName' });
       await visit(`/organizations/${organization.id}`);
       await click('button[aria-label="Editer"]');
 
       // when
       await fillIn('#name', 'newOrganizationName');
-      await fillIn('#externalId', 'newOrganizationExternalId');
-      await fillIn('#provinceCode', 'newOrganizationProvinceCode');
-      await fillIn('#email', 'sco.generic.newaccount@example.net');
-
       await click('button[aria-label="Enregistrer"]');
 
       // then
       assert.contains('newOrganizationName');
-      assert.contains('newOrganizationExternalId');
-      assert.contains('newOrganizationProvinceCode');
-      assert.contains('sco.generic.newaccount@example.net');
-
     });
   });
 });

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -57,6 +57,7 @@ module('Integration | Component | organization-information-section', function(ho
         canCollectProfiles: false,
         isOrganizationSCO: true,
         isManagingStudents: false,
+        credit: 0,
       });
       this.set('organization', organization);
     });
@@ -92,6 +93,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('input#externalId').hasValue(organization.externalId);
       assert.dom('input#provinceCode').hasValue(organization.provinceCode);
       assert.dom('input#email').hasValue(organization.email);
+      assert.dom('input#credit').hasValue(organization.credit.toString());
       assert.dom('input#canCollectProfiles').isNotChecked();
       assert.dom('input#isManagingStudents').isNotChecked();
     });
@@ -168,6 +170,18 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('div[aria-label="Message d\'erreur du champ adresse email"]').hasText('L\'e-mail n\'a pas le bon format.');
     });
 
+    test('it should show error message if organization\'s credit is not valid', async function(assert) {
+      // given
+      await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
+
+      // when
+      await click('button[aria-label=\'Editer\'');
+      await fillIn('#credit', 'credit');
+
+      // then
+      assert.contains('Le nombre de crédits doit être un nombre supérieur ou égal à 0.');
+    });
+
     test('it should toggle display mode on click to cancel button', async function(assert) {
       // given
       await render(hbs`<OrganizationInformationSection @organization={{this.organization}} />`);
@@ -210,6 +224,7 @@ module('Integration | Component | organization-information-section', function(ho
       await fillIn('input#name', 'new name');
       await fillIn('input#externalId', 'new externalId');
       await fillIn('input#provinceCode', '  ');
+      await fillIn('input#credit', 50);
       await click('input#isManagingStudents');
       await click('input#canCollectProfiles');
 
@@ -220,6 +235,7 @@ module('Integration | Component | organization-information-section', function(ho
       assert.dom('.organization__name').hasText('new name');
       assert.dom('.organization__externalId').hasText('new externalId');
       assert.dom('.organization__provinceCode').doesNotExist();
+      assert.dom('.organization__credit').hasText('50');
       assert.dom('.organization__canCollectProfiles').hasText('Oui');
       assert.dom('.organization__isManagingStudents').hasText('Oui');
     });

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -41,6 +41,7 @@ module.exports = {
       name,
       type,
       email,
+      credit,
       'logo-url': logoUrl,
       'external-id': externalId,
       'province-code': provinceCode,
@@ -48,7 +49,7 @@ module.exports = {
       'can-collect-profiles': canCollectProfiles,
     } = request.payload.data.attributes;
 
-    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, canCollectProfiles, email })
+    return usecases.updateOrganizationInformation({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, canCollectProfiles, email, credit })
       .then(organizationSerializer.serialize);
   },
 

--- a/api/lib/domain/usecases/update-organization-information.js
+++ b/api/lib/domain/usecases/update-organization-information.js
@@ -8,6 +8,7 @@ module.exports = async function updateOrganizationInformation({
   isManagingStudents,
   canCollectProfiles,
   email,
+  credit,
   organizationRepository,
 }) {
   const organization = await organizationRepository.get(id);
@@ -16,6 +17,7 @@ module.exports = async function updateOrganizationInformation({
   if (type) organization.type = type;
   if (logoUrl) organization.logoUrl = logoUrl;
   organization.email = email;
+  organization.credit = credit;
   organization.externalId = externalId;
   organization.provinceCode = provinceCode;
   organization.isManagingStudents = isManagingStudents;

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -66,7 +66,7 @@ module.exports = {
 
   update(organization) {
 
-    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'canCollectProfiles', 'email']);
+    const organizationRawData = _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'isManagingStudents', 'canCollectProfiles', 'email', 'credit']);
 
     return new BookshelfOrganization({ id: organization.id })
       .save(organizationRawData, { patch: true })

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -180,6 +180,7 @@ describe('Acceptance | Application | organization-controller', () => {
             'external-id': '0446758F',
             'province-code': '044',
             'email': 'sco.generic.newaccount@example.net',
+            'credit': 50,
             'can-collect-profiles': 'true',
           },
         },
@@ -208,6 +209,8 @@ describe('Acceptance | Application | organization-controller', () => {
       expect(response.result.data.attributes['external-id']).to.equal('0446758F');
       expect(response.result.data.attributes['province-code']).to.equal('044');
       expect(response.result.data.attributes['can-collect-profiles']).to.equal('true');
+      expect(response.result.data.attributes['email']).to.equal('sco.generic.newaccount@example.net');
+      expect(response.result.data.attributes['credit']).to.equal(50);
       expect(parseInt(response.result.data.id)).to.equal(organization.id);
     });
 

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -51,6 +51,7 @@ describe('Integration | Application | Organizations | organization-controller', 
           'external-id': '02A2145V',
           'province-code': '02A',
           'email': 'sco.generic.newaccount@example.net',
+          'credit': 10,
         },
       },
     };

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -90,6 +90,8 @@ describe('Integration | Repository | Organization', function() {
       organization.provinceCode = '999';
       organization.isManagingStudents = true;
       organization.canCollectProfiles = true;
+      organization.credit = 50;
+      organization.email = 'email@example.net';
 
       // when
       const organizationSaved = await organizationRepository.update(organization);
@@ -103,6 +105,8 @@ describe('Integration | Repository | Organization', function() {
       expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
       expect(organizationSaved.isManagingStudents).to.equal(organization.isManagingStudents);
       expect(organizationSaved.canCollectProfiles).to.equal(organization.canCollectProfiles);
+      expect(organizationSaved.credit).to.equal(organization.credit);
+      expect(organizationSaved.email).to.equal(organization.email);
     });
   });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -126,6 +126,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
               'external-id': '02A2145V',
               'province-code': '02A',
               email: 'sco.generic.newaccount@example.net',
+              credit: 50,
             },
           },
         },
@@ -149,7 +150,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
         // then
         expect(usecases.updateOrganizationInformation).to.have.been.calledOnce;
-        expect(usecases.updateOrganizationInformation).to.have.been.calledWithMatch({ id: organization.id, name: 'Acme', type: 'SCO', logoUrl: 'logo', externalId: '02A2145V', provinceCode: '02A', email: 'sco.generic.newaccount@example.net' });
+        expect(usecases.updateOrganizationInformation).to.have.been.calledWithMatch({ id: organization.id, name: 'Acme', type: 'SCO', logoUrl: 'logo', externalId: '02A2145V', provinceCode: '02A', email: 'sco.generic.newaccount@example.net', credit: 50 });
       });
 
       it('should serialized organization into JSON:API', async () => {

--- a/api/tests/unit/domain/usecases/update-organization-information_test.js
+++ b/api/tests/unit/domain/usecases/update-organization-information_test.js
@@ -17,6 +17,7 @@ describe('Unit | UseCase | update-organization-information', () => {
       isManagingStudents: true,
       canCollectProfiles: true,
       email: null,
+      credit: null,
     });
     organizationRepository = {
       get: sinon.stub().resolves(originalOrganization),
@@ -168,6 +169,21 @@ describe('Unit | UseCase | update-organization-information', () => {
 
       // then
       expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, email: newEmail });
+    });
+
+    it('should allow to update the organization credit', async () => {
+      // given
+      const newCredit = 100;
+
+      // when
+      await updateOrganizationInformation({
+        id: originalOrganization.id,
+        credit: newCredit,
+        organizationRepository,
+      });
+
+      // then
+      expect(organizationRepository.update).to.have.been.calledWithMatch({ ...originalOrganization, credit: newCredit });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Côté Pix Admin et côté Pix Orga, on affiche le nombre de crédits. Or il n'existe aucun moyen d'éditer ces crédits.

## :robot: Solution
Ajouter un champ d'édition des crédits côté Pix Admin.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix Admin, aller dans le menu "Organisations" et choisir une organisation. Cliquer sur "Editer" et remplir le champ "crédits". Cliquer sur "Valider" et vérifier que ce champ a bien été mis à jour.
