### PR TITLE
[TECH] Mise en place d'un Feature Toggle pour spécifier quelle organisation est Pôle Emploi (Pix-1392).

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -59,6 +59,10 @@ class Organization {
   get isAgriculture() {
     return this.isSco && process.env['AGRICULTURE_ORGANIZATION_ID'] === this.id.toString();
   }
+
+  get isPoleEmploi() {
+    return process.env['POLE_EMPLOI_ORGANIZATION_ID'] === this.id.toString();
+  }
 }
 
 Organization.types = types;

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -137,4 +137,30 @@ describe('Unit | Domain | Models | Organization', () => {
     });
   });
 
+  describe('get#isPoleEmploi', () => {
+    beforeEach(() => {
+      process.env['POLE_EMPLOI_ORGANIZATION_ID'] = '1';
+    });
+
+    afterEach(() => {
+      process.env['POLE_EMPLOI_ORGANIZATION_ID'] = null;
+    });
+
+    it('should return true when organization id match Environnement variable POLE_EMPLOI_ORGANIZATION_ID', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ id: '1' });
+
+      // when / then
+      expect(organization.isPoleEmploi).is.true;
+    });
+
+    it('should return false when when organization id doesnt match Environnement variable POLE_EMPLOI_ORGANIZATION_ID', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ id: '2' });
+
+      // when / then
+      expect(organization.isPoleEmploi).is.false;
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Pix, doit envoyer les données à Pôle Emploi des demandeurs d'emploi une fois que ceux-ci ont terminé et envoyé leurs résultats. Or actuellement on ne sait pas identifier quelle campagne appartient à Pôle Emploi. 

## :robot: Solution
La solution long terme pourrait être les tags, puisque Pôle Emploi possède plusieurs espaces Orga. 
La solution court terme serait de définir une variable d'environnement, permettant de spécifier quelle organisation est Pôle Emploi (au singulier pour l'instant). De cette façon, cela fonctionnerait sur tous les environnements (local, review app, intégration, recette et même production) sous forme de Feature Toggle : si aucun ID n'est spécifié, pas de fonctionnalité. En revanche si un ID est spécifié, alors dans ce cas on enverrai les données à Pôle Emploi.

## :rainbow: Remarques
Ce feature toggle est temporaire.

## :100: Pour tester
NA
