### PR TITLE
[FEATURE] Upload un CSV d'élève pour les orga SCO Agri (PIX-1351)

### DIFF
--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -2,9 +2,15 @@
   <div class="page__title page-title">Élèves</div>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
-      <FileUpload @name="file-upload" @for="students-file-upload" @accept=".xml" @multiple={{false}} @onfileadd={{@importStudents}}>
-        <span class="button" role="button" tabindex="0">Importer (.xml)</span>
-      </FileUpload>
+      {{#if this.currentUser.isAgriculture}}
+        <FileUpload @name="file-upload" @for="students-file-upload" @accept=".csv" @multiple={{false}} @onfileadd={{@importStudents}}>
+          <span class="button" role="button" tabindex="0">Importer (.csv)</span>
+        </FileUpload>
+      {{else}}
+        <FileUpload @name="file-upload" @for="students-file-upload" @accept=".xml" @multiple={{false}} @onfileadd={{@importStudents}}>
+          <span class="button" role="button" tabindex="0">Importer (.xml)</span>
+        </FileUpload>
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -50,9 +50,10 @@ export default class ListController extends Controller {
     this.isLoading = true;
     this.notifications.clearAll();
     const { access_token } = this.session.data.authenticated;
+    const format = this.currentUser.isAgriculture ? 'csv' : 'xml';
 
     try {
-      await file.uploadBinary(`${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-siecle`, {
+      await file.uploadBinary(`${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-siecle?format=${format}`, {
         headers: {
           Authorization: `Bearer ${access_token}`,
         },
@@ -75,7 +76,7 @@ export default class ListController extends Controller {
     }
 
     errorResponse.body.errors.forEach((error) => {
-      if (error.status === '409' || error.status === '422') {
+      if (error.status === '409' || error.status === '422' || error.status === '412') {
         return this.notifications.sendError(error.detail);
       }
       if (error.status === '400') {

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -178,6 +178,10 @@ export default function() {
       return new Promise((resolve) => {
         resolve(new Response(409, {}, { errors: [ { status: '409', detail: '409 - Le détail affiché est envoyé par le back' } ] }));
       });
+    } else if (type === 'file-with-csv-problems') {
+      return new Promise((resolve) => {
+        resolve(new Response(412, {}, { errors: [ { status: '412', detail: '412 - Le détail affiché est envoyé par le back' } ] }));
+      });
     } else if (type === 'file-with-problems') {
       return new Promise((resolve) => {
         resolve(new Response(400, {}, { errors: [ { status: '400', detail: '400 - détail.' } ] }));

--- a/orga/tests/acceptance/sco-student-list-test.js
+++ b/orga/tests/acceptance/sco-student-list-test.js
@@ -357,6 +357,21 @@ module('Acceptance | Sco Student List', function(hooks) {
         assert.dom('[data-test-notification-message="error"]').hasText('409 - Le détail affiché est envoyé par le back');
       });
 
+      test('it should display an error message when uploading a file with csv problems', async function(assert) {
+        // given
+        await visit('/eleves');
+
+        const file = new Blob(['foo'], { type: 'file-with-csv-problems' });
+
+        // when
+        const input = find('#students-file-upload');
+        await triggerEvent(input, 'change', { files: [file] });
+
+        // then
+        assert.dom('[data-test-notification-message="error"]').exists();
+        assert.dom('[data-test-notification-message="error"]').hasText('412 - Le détail affiché est envoyé par le back');
+      });
+
       test('it should display an error message when something unexpected went wrong on the client', async function(assert) {
         // given
         await visit('/eleves');

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -276,24 +276,38 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       ]);
     });
 
-    module('when user is admin in organization', (hooks) => {
+    module('when user is admin in organization', () => {
 
-      hooks.beforeEach(function() {
-        this.set('importStudentsSpy', () => {});
-        this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: true }));
-        return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+      module('when organization is just SCO', (hooks) => {
+        hooks.beforeEach(function() {
+          this.set('importStudentsSpy', () => {});
+          this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: true }));
+          return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+        });
+
+        test('it should display import XML file button', async function(assert) {
+          assert.contains('Importer (.xml)');
+        });
+
+        test('it should display the dissociate action', async function(assert) {
+          // when
+          await click('[aria-label="Afficher les actions"]');
+
+          // then
+          assert.contains('Dissocier le compte');
+        });
       });
 
-      test('it should display import button', async function(assert) {
-        assert.contains('Importer (.xml)');
-      });
+      module('when organization is SCO and tagged as Agriculture', (hooks) => {
+        hooks.beforeEach(function() {
+          this.set('importStudentsSpy', () => {});
+          this.owner.register('service:current-user', Service.extend({ isAdminInOrganization: true, isAgriculture: true }));
+          return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+        });
 
-      test('it should display the dissociate action', async function(assert) {
-        // when
-        await click('[aria-label="Afficher les actions"]');
-
-        // then
-        assert.contains('Dissocier le compte');
+        test('it should display import CSV file button', async function(assert) {
+          assert.contains('Importer (.csv)');
+        });
       });
     });
 
@@ -306,6 +320,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
       test('it should not display import button', async function(assert) {
         assert.notContains('Importer (.xml)');
+        assert.notContains('Importer (.csv)');
       });
 
       test('it should not display the dissociate action', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème

Il faut pouvoir importer les élèves de SCO Agri. Mais les organismes SCO Agri n'ont pas accès au format XML SIECLE.
Il a été proposé d'utiliser un format CSV (comme pour le SUP) mais ce fichier comportera en colonne les données équivalentes au fichier SIECLE.
Voici le format du fichier CSV :

```csv
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
```

## :robot: Solution

Ajouter le bouton "Importer csv" pour les Admin des organisations SCO et Agriculture.

Une erreur globale est déclenchée si: 
- les entêtes de colonnes ne correspondent pas
- le format des colonnes n’est pas le bon (date de naissance en jj/mm/aaaa)
- les données obligatoires sont manquantes
- un identifiant unique est en doublon au sein du fichier
- le format du fichier ne correspond pas à un csv séparateur point virgule (UTF8 de préférence)

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter avec le compte `sco@example.net` (son orga doit être mis en tant qu'organisation agri avec la variable d'env `AGRICULTURE_ORGANIZATION_ID` au niveau de la RA)
2. Importer un fichier respectant le format attendu (voir plus haut)
3. Vérifier les messages d'erreur, la création et la mise à jour d'élèves
