### PR TITLE
[BUGFIX] Corriger l'affichage des barres situées dans l'onglet analyse et résultats collectifs (PIX-1317)

### DIFF
--- a/orga/app/styles/globals/competences.scss
+++ b/orga/app/styles/globals/competences.scss
@@ -22,22 +22,27 @@
 
     &--jaffa {
       border-color: $information-light;
+      background: $information-light;
     }
 
     &--emerald {
       border-color: $content-light;
+      background: $content-light;
     }
 
     &--cerulean {
       border-color: $communication-light;
+      background: $communication-light;
     }
 
     &--wild-strawberry {
       border-color: $security-light;
+      background: $security-light;
     }
 
     &--butterfly-bush {
       border-color: $environment-light;
+      background: $environment-light;
     }
 
     &--bottom {


### PR DESCRIPTION
## :unicorn: Problème
Problème d'affichage des barres dans les onglets analyse et résultats collectifs, seul les bordures sont visible.

<img width="699" alt="Capture d’écran 2020-09-25 à 11 45 04" src="https://user-images.githubusercontent.com/13931126/95608034-e29ad900-0a5c-11eb-800e-24998bf5f177.png">

<img width="1667" alt="Capture d’écran 2020-09-25 à 11 44 59" src="https://user-images.githubusercontent.com/13931126/95608042-e595c980-0a5c-11eb-8575-8ddda84307c1.png">


## :robot: Solution
Ajouter une propriété background pour chaque classe de couleur dans le fichier competences.scss

## :rainbow: Remarques
Affichage testé sous : 
- Safari 14
- Chrome 85
- Firefox 81.0.1
- Edge 85

## :100: Pour tester
Se rendre dans une campagne ayant des participants