### PR TITLE
[FEATURE] Afficher la liste des étudiants SCO pour l'ajout des candidats (PIX-1373)

### DIFF
--- a/api/db/seeds/data/certification/certification-centers-builder.js
+++ b/api/db/seeds/data/certification/certification-centers-builder.js
@@ -8,12 +8,14 @@ const SUP_CERTIF_CENTER_ID = 3;
 const SUP_CERTIF_CENTER_NAME = 'Centre SUP des Anne-Étoiles';
 const NONE_CERTIF_CENTER_ID = 4;
 const NONE_CERTIF_CENTER_NAME = 'Centre NOTYPE des Anne-Étoiles';
+const SCO_EXTERNAL_ID = '1237457A';
 
 function certificationCentersBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildCertificationCenter({
     id: SCO_CERTIF_CENTER_ID,
     name: SCO_CERTIF_CENTER_NAME,
+    externalId: SCO_EXTERNAL_ID,
     type: 'SCO',
   });
 

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -2,6 +2,7 @@ const Membership = require('../../../lib/domain/models/Membership');
 
 module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   const defaultPassword = 'pix123';
+  const SCO_EXTERNAL_ID = '1237457A';
 
   /* COLLEGE */
   const scoUser1 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
@@ -31,7 +32,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     isManagingStudents: true,
     canCollectProfiles: true,
     email: 'sco.generic.account@example.net',
-    externalId: '1237457A',
+    externalId: SCO_EXTERNAL_ID,
     provinceCode: '12',
   });
 

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -1,6 +1,7 @@
 const usecases = require('../../domain/usecases');
 const certificationCenterSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-serializer');
 const sessionSerializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
+const studentCertificationSerializer = require('../../infrastructure/serializers/jsonapi/student-certification-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 
 module.exports = {
@@ -30,5 +31,12 @@ module.exports = {
 
     return usecases.findSessionsForCertificationCenter({ userId, certificationCenterId })
       .then((sessions) => sessionSerializer.serialize(sessions));
+  },
+
+  async getSchoolingRegistrations(request) {
+    const certificationCenterId = parseInt(request.params.id);
+    const userId = parseInt(request.auth.credentials.userId);
+    const schoolingRegistrations = await usecases.findStudentsFromCertificationCenterId({ userId, certificationCenterId });
+    return studentCertificationSerializer.serialize(schoolingRegistrations);
   },
 };

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -33,10 +33,10 @@ module.exports = {
       .then((sessions) => sessionSerializer.serialize(sessions));
   },
 
-  async getSchoolingRegistrations(request) {
+  async getStudents(request) {
     const certificationCenterId = parseInt(request.params.id);
     const userId = parseInt(request.auth.credentials.userId);
-    const schoolingRegistrations = await usecases.findStudentsFromCertificationCenterId({ userId, certificationCenterId });
-    return studentCertificationSerializer.serialize(schoolingRegistrations);
+    const students = await usecases.findStudentsFromCertificationCenterId({ userId, certificationCenterId });
+    return studentCertificationSerializer.serialize(students);
   },
 };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -57,14 +57,14 @@ exports.register = async function(server) {
     },
     {
       method: 'GET',
-      path: '/api/certification-centers/{id}/schooling-registrations',
+      path: '/api/certification-centers/{id}/students',
       config: {
-        handler: certificationCenterController.getSchoolingRegistrations,
+        handler: certificationCenterController.getStudents,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Récupération d\'une liste d\'élèves SCO à partir d\' un identifiant de centre de certification',
         ],
-        tags: ['api', 'certification-center', 'schooling-registration'],
+        tags: ['api', 'certification-center', 'students'],
       },
     },
     {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -57,6 +57,18 @@ exports.register = async function(server) {
     },
     {
       method: 'GET',
+      path: '/api/certification-centers/{id}/schooling-registrations',
+      config: {
+        handler: certificationCenterController.getSchoolingRegistrations,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération d\'une liste d\'élèves SCO à partir d\' un identifiant de centre de certification',
+        ],
+        tags: ['api', 'certification-center', 'schooling-registration'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/certification-centers/{id}/sessions',
       config: {
         handler: certificationCenterController.getSessions,

--- a/api/lib/domain/usecases/find-students-from-certification-center-id.js
+++ b/api/lib/domain/usecases/find-students-from-certification-center-id.js
@@ -1,0 +1,21 @@
+const { ForbiddenAccess } = require('../../domain/errors');
+const { NotFoundError } = require('../../domain/errors');
+
+module.exports = async function findStudentsFromCertificationCenterId({
+  userId,
+  certificationCenterId,
+  organizationRepository,
+  schoolingRegistrationRepository,
+  certificationCenterMembershipRepository,
+}) {
+  const hasAccess = await certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter(userId, certificationCenterId);
+  if (!hasAccess) throw new ForbiddenAccess(`User ${userId} is not a member of certification center ${certificationCenterId}`);
+
+  try {
+    const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
+    return schoolingRegistrationRepository.findByOrganizationIdOrderByDivision({ organizationId });
+  } catch (error) {
+    if (error instanceof NotFoundError) return [];
+    throw error;
+  }
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -131,6 +131,7 @@ module.exports = injectDependencies({
   findPaginatedFilteredUsers: require('./find-paginated-filtered-users'),
   findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
   findSessionsForCertificationCenter: require('./find-sessions-for-certification-center'),
+  findStudentsFromCertificationCenterId: require('./find-students-from-certification-center-id'),
   findCampaignAssessments: require('./find-campaign-assessments'),
   findTutorials: require('./find-tutorials'),
   findUserTutorials: require('./find-user-tutorials'),

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -94,6 +94,19 @@ module.exports = {
       });
   },
 
+  async getIdByCertificationCenterId(certificationCenterId) {
+    const bookshelfOrganization = await BookshelfOrganization
+      .query((qb) => {
+        qb.join('certification-centers', 'certification-centers.externalId', 'organizations.externalId');
+        qb.where('certification-centers.id', '=', certificationCenterId);
+      })
+      .fetch({ columns: ['organizations.id'] });
+
+    const id = _.get(bookshelfOrganization, 'attributes.id');
+    if (id) return id;
+    throw new NotFoundError(`Not found organization for certification center id ${certificationCenterId}`);
+  },
+
   findByExternalIdsFetchingIdsOnly(externalIds) {
     return BookshelfOrganization
       .where('externalId', 'in', externalIds)

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -46,14 +46,20 @@ function _isReconciled(schoolingRegistration) {
 
 module.exports = {
 
-  findByOrganizationId({ organizationId }) {
+  _findByOrganizationId({ organizationId, orderByRaw }) {
     return BookshelfSchoolingRegistration
       .where({ organizationId })
-      .query((qb) => {
-        qb.orderByRaw('LOWER("lastName") ASC, LOWER("firstName") ASC');
-      })
+      .query((qb) => qb.orderByRaw(orderByRaw))
       .fetchAll()
       .then((schoolingRegistrations) => bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations));
+  },
+
+  findByOrganizationId({ organizationId }) {
+    return this._findByOrganizationId({ organizationId, orderByRaw: 'LOWER("lastName") ASC, LOWER("firstName") ASC' });
+  },
+
+  findByOrganizationIdOrderByDivision({ organizationId }) {
+    return this._findByOrganizationId({ organizationId, orderByRaw: 'LOWER("division") ASC, LOWER("lastName") ASC, LOWER("firstName") ASC' });
   },
 
   async findByUserId({ userId }) {

--- a/api/lib/infrastructure/serializers/jsonapi/student-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-certification-serializer.js
@@ -1,0 +1,11 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(students) {
+    return new Serializer('students', {
+      attributes: [
+        'lastName', 'firstName', 'birthdate', 'division',
+      ],
+    }).serialize(students);
+  },
+};

--- a/api/tests/unit/domain/usecases/find-students-from-certification-center-id_test.js
+++ b/api/tests/unit/domain/usecases/find-students-from-certification-center-id_test.js
@@ -1,0 +1,117 @@
+const _ = require('lodash');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const usecases = require('../../../../lib/domain/usecases');
+const { ForbiddenAccess, NotFoundError } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | find-students-from-certification-center-id', () => {
+
+  const certificationCenterId = 1;
+  const userId = 'userId';
+  let organization;
+
+  const organizationRepository = {
+    getIdByCertificationCenterId: sinon.stub(),
+  };
+  const schoolingRegistrationRepository = {
+    findByOrganizationIdOrderByDivision: sinon.stub(),
+  };
+
+  const certificationCenterMembershipRepository = {
+    doesUserHaveMembershipToCertificationCenter: sinon.stub(),
+  };
+
+  beforeEach(async () => {
+    const externalId = 'AAA111';
+    const certificationCenter = domainBuilder.buildCertificationCenter({ id: certificationCenterId, externalId });
+    organization = domainBuilder.buildOrganization({ externalId });
+
+    organizationRepository.getIdByCertificationCenterId
+      .withArgs(certificationCenter.id).resolves(organization.id);
+
+    certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter
+      .withArgs(userId, certificationCenter.id).resolves(true);
+  });
+
+  describe('when user has access to certification center', () => {
+    describe('when there is no certification center for the organization ', () => {
+      it('should return an empty list of student', async () => {
+        // given
+        organizationRepository.getIdByCertificationCenterId.withArgs(certificationCenterId).rejects(new NotFoundError());
+
+        // when
+        const studentsFounds = await usecases.findStudentsFromCertificationCenterId({
+          userId,
+          certificationCenterId,
+          organizationRepository,
+          schoolingRegistrationRepository,
+          certificationCenterMembershipRepository,
+        });
+
+        // then
+        expect(studentsFounds).to.deep.equal([]);
+      });
+    });
+
+    it('should return all students who belong to the user\'s organization', async () => {
+      // given
+      const expectedStudents = _.times(5, () => domainBuilder.buildSchoolingRegistration({ organization }));
+      schoolingRegistrationRepository.findByOrganizationIdOrderByDivision
+        .withArgs({ organizationId: organization.id }).resolves(expectedStudents);
+
+      // when
+      const studentsFounds = await usecases.findStudentsFromCertificationCenterId({
+        userId,
+        certificationCenterId,
+        organizationRepository,
+        schoolingRegistrationRepository,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(studentsFounds).to.be.deep.equal(expectedStudents);
+    });
+
+    context('when the linked organization has no student', () => {
+
+      it('should return empty array', async () => {
+        // given
+        schoolingRegistrationRepository.findByOrganizationIdOrderByDivision
+          .withArgs({ organizationId: organization.id }).resolves([]);
+
+        // when
+        const studentsFounds = await usecases.findStudentsFromCertificationCenterId({
+          userId,
+          certificationCenterId,
+          organizationRepository,
+          schoolingRegistrationRepository,
+          certificationCenterMembershipRepository,
+        });
+
+        // then
+        expect(studentsFounds).to.be.deep.equal([]);
+      });
+    });
+  });
+
+  describe('when user does not have access to certification center', () => {
+    it('should throw an access error', async () => {
+      // given
+      const wrongCertificationCenterId = 666;
+      certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter
+        .withArgs(userId, wrongCertificationCenterId).resolves(false);
+
+      // when
+      const error = await catchErr(usecases.findStudentsFromCertificationCenterId)({
+        userId,
+        certificationCenterId: wrongCertificationCenterId,
+        organizationRepository,
+        schoolingRegistrationRepository,
+        certificationCenterMembershipRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(ForbiddenAccess);
+    });
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/student-certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/student-certification-serializer_test.js
@@ -1,0 +1,32 @@
+const { domainBuilder, expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/student-certification-serializer');
+
+describe('Unit | Serializer | JSONAPI | student-certification-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should convert a SchoolingRegistration model object into JSON API data', () => {
+      // given
+      const student = domainBuilder.buildSchoolingRegistration();
+
+      const expectedSerializedStudent = {
+        data: {
+          type: 'students',
+          id: `${student.id}`,
+          attributes: {
+            'first-name': student.firstName,
+            'last-name': student.lastName,
+            'birthdate': student.birthdate,
+            'division': student.division,
+          },
+        },
+      };
+
+      // when
+      const json = serializer.serialize(student);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedStudent);
+    });
+  });
+});

--- a/certif/app/adapters/student.js
+++ b/certif/app/adapters/student.js
@@ -1,0 +1,12 @@
+import ApplicationAdapter from './application';
+
+export default class StudentAdapter extends ApplicationAdapter {
+
+  urlForFindAll(modelName, snapshot) {
+    const certificationCenterId = snapshot.adapterOptions && snapshot.adapterOptions.certificationCenterId;
+    if (certificationCenterId) {
+      return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/students`;
+    }
+    return super.urlForFindAll(...arguments);
+  }
+}

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -1,0 +1,24 @@
+<div class="table add-student-list">
+  <table>
+    <thead>
+      <tr>
+        <th class="add-student-list__column-checkbox">▢</th>
+        <th>Classe</th>
+        <th>Nom</th>
+        <th>Prénom</th>
+        <th class="add-student-list__column-birthdate">Date de naissance</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each @studentList as |student|}}
+        <tr>
+          <td class="add-student-list__column-checkbox">▢</td>
+          <td>{{student.division}}</td>
+          <td>{{student.lastName}}</td>
+          <td>{{student.firstName}}</td>
+          <td class="add-student-list__column-birthdate">{{moment-format student.birthdate 'DD/MM/YYYY'}}</td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+</div>

--- a/certif/app/components/certification-candidates-sco.hbs
+++ b/certif/app/components/certification-candidates-sco.hbs
@@ -1,0 +1,9 @@
+<div class="panel">
+  <div class="certification-candidates-sco-actions">
+    <img src="/images/adding_candidate.svg" alt="" role="none">
+    <p>Ajouter une liste d'élèves et c'est partix !</p>
+    <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link">
+      Ajouter des candidats
+    </LinkTo>
+  </div>
+</div>

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -14,11 +14,4 @@ export default class SessionsDetailsController extends Controller {
     const certificationCandidatesCount = this.session.certificationCandidates.length;
     return certificationCandidatesCount > 0 ? `(${certificationCandidatesCount})`  : '';
   }
-
-  get showScoVersion() {
-    const isCertifPrescriptionScoEnabled = this.model.isCertifPrescriptionScoEnabled;
-    const isCertificationCenterSco = this.model.isCertificationCenterSco;
-
-    return isCertifPrescriptionScoEnabled && isCertificationCenterSco;
-  }
 }

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -15,6 +15,9 @@ export default class CertificationCandidatesController extends Controller {
   @service session;
 
   @alias('model.session') currentSession;
+  @alias('model.isCertificationCenterSco') isCertificationCenterSco;
+  @alias('model.isCertifPrescriptionScoEnabled') isCertifPrescriptionScoEnabled;
+
   @tracked candidatesInStaging = [];
 
   @computed('currentSession.certificationCandidates.{[],@each.isLinked}')

--- a/certif/app/models/student.js
+++ b/certif/app/models/student.js
@@ -1,0 +1,8 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class StudentModel extends Model {
+  @attr('string') firstName;
+  @attr('string') lastName;
+  @attr('date-only') birthdate;
+  @attr('string') division;
+}

--- a/certif/app/router.js
+++ b/certif/app/router.js
@@ -27,8 +27,8 @@ Router.map(function() {
       this.route('details', { path: '/:session_id' }, function() {
         this.route('parameters', { path: '/' });
         this.route('certification-candidates', { path: '/candidats' });
-        this.route('certification-candidates-sco', { path: '/candidats-sco' });
       });
+      this.route('add-student', { path: '/:session_id/ajout-eleves' });
     });
   });
 

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
+  async model(params) {
+    const { id: certificationCenterId } = this.modelFor('authenticated');
+    const students = await this.store.findAll('student',
+      { adapterOptions : { certificationCenterId } },
+    );
+    return { sessionId: params.session_id, students };
+  }
+}

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -18,6 +18,7 @@
 @import "pages/login";
 @import "pages/authenticated";
 @import "pages/authenticated/sessions";
+@import "pages/authenticated/sessions/add-student";
 @import "pages/authenticated/sessions/details";
 @import "pages/authenticated/sessions/list-items";
 @import "pages/authenticated/sessions/no-session-panel";

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -26,6 +26,7 @@
 @import "pages/authenticated/sessions/details/certification-candidates-sco";
 @import "pages/authenticated/terms-of-service";
 
+@import "components/add-student-list";
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/login-form";
 @import "components/finalize";

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -1,0 +1,25 @@
+.add-student-list {
+
+  font-size: 0.875rem;
+  position: relative;
+
+  thead tr {
+    background: $grey-10;
+    border-radius: 4px;
+    outline: 4px solid $white;
+    outline-offset: -4px;
+    border-bottom: 4px solid $grey-10;
+  }
+
+  tr {
+    background-color: $white;
+  }
+
+  th, td {
+    text-align: left;
+    padding-left: 30px;
+  }
+
+  &__column-checkbox { width: 30px; }
+  &__column-birthdate { width: 60%; }
+}

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,0 +1,13 @@
+.add-student {
+
+  &__return-to span {
+    color: $blue-zodia;
+  }
+
+  &__title {
+    color: $grey-70;
+    font-family: $open-sans;
+    font-size: 2.25rem;
+    font-weight: 300;
+  }
+}

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -1,0 +1,10 @@
+<div class="add-student">
+
+  <PixReturnTo
+    @route="authenticated.sessions.details.certification-candidates"
+    @model={{@model.sessionId}}
+    class="add-student__return-to">Retour à la session</PixReturnTo>
+
+  <h1 class="add-student__title">Ajouter des candidats</h1>
+
+</div>

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -7,4 +7,5 @@
 
   <h1 class="add-student__title">Ajouter des candidats</h1>
 
+  <AddStudentList @studentList={{@model.students}} />
 </div>

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -35,16 +35,9 @@
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">
         Détails
       </LinkTo>
-
-      {{#if this.showScoVersion}}
-        <LinkTo @route="authenticated.sessions.details.certification-candidates-sco" class="navbar-item">
-          Candidats {{this.certificationCandidatesCount}}
-        </LinkTo>
-      {{else}}
-        <LinkTo @route="authenticated.sessions.details.certification-candidates" class="navbar-item">
-          Candidats {{this.certificationCandidatesCount}}
-        </LinkTo>
-      {{/if}}
+      <LinkTo @route="authenticated.sessions.details.certification-candidates" class="navbar-item">
+        Candidats {{this.certificationCandidatesCount}}
+      </LinkTo>
     </nav>
 
   </div>

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates-sco.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates-sco.hbs
@@ -1,9 +1,0 @@
-<div class="panel">
-  <div class="certification-candidates-sco-actions">
-    <img src="/images/adding_candidate.svg" alt="" role="none">
-    <p>Ajouter une liste d'elèves et c'est partix !</p>
-    <button class="button button--link" type="button">
-      Ajouter des candidats
-    </button>
-  </div>
-</div>

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -1,3 +1,6 @@
+{{#if (and this.isCertificationCenterSco this.isCertifPrescriptionScoEnabled)}}
+  <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>
+{{else}}
 <div class="panel panel-actions">
   <div class="content-text context-text--small">
     <div class="panel-actions__header">
@@ -19,9 +22,9 @@
         </div>
         <div class="panel-actions__button">
           <a data-test-id="attendance_sheet_download_button"
-            class="button button--link button--with-icon"
-            href="{{this.currentSession.urlToDownloadCandidatesImportTemplate}}" target="_blank" rel="noopener noreferrer" download>
-              Télécharger (.ods)<FaIcon @icon='file-download' />
+             class="button button--link button--with-icon"
+             href="{{this.currentSession.urlToDownloadCandidatesImportTemplate}}" target="_blank" rel="noopener noreferrer" download>
+            Télécharger (.ods)<FaIcon @icon='file-download' />
           </a>
         </div>
       </div>
@@ -38,60 +41,60 @@
         </div>
         <div class="panel-actions__button">
           <a data-test-id="attendance_sheet_download_button"
-            class="button button--link button--with-icon"
-            href="{{this.currentSession.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
-              Télécharger (.ods)<FaIcon @icon='file-download' />
+             class="button button--link button--with-icon"
+             href="{{this.currentSession.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
+            Télécharger (.ods)<FaIcon @icon='file-download' />
           </a>
         </div>
       </div>
     {{/if}}
-      <div class="panel-actions__action-row">
-        {{#if this.importAllowed}}
-          <div class="panel-actions__action-icon">
-            <FaIcon @icon="cloud-upload-alt" />
-          </div>
-          <div class="panel-actions__description">
-            {{#if this.isResultRecipientEmailVisible}}
-              <div class="panel-actions__title">Importer la liste des candidats</div>
-              <div class="panel-actions__subtitle">
-                Sélectionnez la liste des candidats préalablement remplie.
-                <br>
-                <strong>
-                    Attention, tout nouvel import efface la liste des candidats existante.
-                </strong>
-              </div>
-            {{else}}
-              <div class="panel-actions__title">Importer le PV de session</div>
-              <div class="panel-actions__subtitle">
-                Sélectionnez le PV de session préalablement rempli.
-                <br>
-                <strong>
-                    Attention, tout nouvel import efface la liste des candidats existante.
-                </strong>
-              </div>
-            {{/if}}
-          </div>
-          <div class="panel-actions__button">
-            <FileUpload @name="file-upload" @for="upload-attendance-sheet" @accept=".ods" @multiple={{false}} @onfileadd={{this.importCertificationCandidates}}>
+    <div class="panel-actions__action-row">
+      {{#if this.importAllowed}}
+        <div class="panel-actions__action-icon">
+          <FaIcon @icon="cloud-upload-alt" />
+        </div>
+        <div class="panel-actions__description">
+          {{#if this.isResultRecipientEmailVisible}}
+            <div class="panel-actions__title">Importer la liste des candidats</div>
+            <div class="panel-actions__subtitle">
+              Sélectionnez la liste des candidats préalablement remplie.
+              <br>
+              <strong>
+                Attention, tout nouvel import efface la liste des candidats existante.
+              </strong>
+            </div>
+          {{else}}
+            <div class="panel-actions__title">Importer le PV de session</div>
+            <div class="panel-actions__subtitle">
+              Sélectionnez le PV de session préalablement rempli.
+              <br>
+              <strong>
+                Attention, tout nouvel import efface la liste des candidats existante.
+              </strong>
+            </div>
+          {{/if}}
+        </div>
+        <div class="panel-actions__button">
+          <FileUpload @name="file-upload" @for="upload-attendance-sheet" @accept=".ods" @multiple={{false}} @onfileadd={{this.importCertificationCandidates}}>
             <span data-test-id="attendance_sheet_upload_button"
                   class="button button--with-icon"
                   role="button"
                   tabindex="0">
               Importer (.ods)<FaIcon @icon='cloud-upload-alt' />
             </span>
-            </FileUpload>
-          </div>
-        {{else}}
-          <div class="panel-actions__action-icon">
-            <FaIcon @icon='exclamation-circle' class="panel-actions__warning-icon" />
-          </div>
-          <div class="panel-actions__description">
-            <strong class="panel-actions__warning">
-                La session a débuté, vous ne pouvez plus importer une liste de candidats.<br>Si vous souhaitez modifier la liste, vous pouvez ajouter un candidat directement dans le tableau ci-dessous.
-            </strong>
-          </div>
-        {{/if}}
-      </div>
+          </FileUpload>
+        </div>
+      {{else}}
+        <div class="panel-actions__action-icon">
+          <FaIcon @icon='exclamation-circle' class="panel-actions__warning-icon" />
+        </div>
+        <div class="panel-actions__description">
+          <strong class="panel-actions__warning">
+            La session a débuté, vous ne pouvez plus importer une liste de candidats.<br>Si vous souhaitez modifier la liste, vous pouvez ajouter un candidat directement dans le tableau ci-dessous.
+          </strong>
+        </div>
+      {{/if}}
+    </div>
   </div>
 </div>
 
@@ -105,7 +108,7 @@
     </div>
     <div data-test-id="add-certification-candidate-staging__button" class="panel-header__action" {{on 'click' this.addCertificationCandidateInStaging}} >
       <div class="certification-candidates-add-button__text">
-          Ajouter un candidat
+        Ajouter un candidat
       </div>
       <PixActionButton @icon='plus' />
     </div>
@@ -114,99 +117,99 @@
     {{#if (or this.currentSession.certificationCandidates this.candidatesInStaging)}}
       <table>
         <thead>
-          <tr>
-            <th class="certification-candidates-table__column-last-name">
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Nom de naissance
-            </th>
-            <th class="certification-candidates-table__column-first-name">
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Prénom
-            </th>
-            <th>
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Date de naissance
-            </th>
-            <th>
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Commune de naissance
-            </th>
-            <th>
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Département de naissance
-            </th>
-            <th>
-              {{#if this.isCandidateBeingAdded}}
-                  *
-              {{/if}}
-                Pays de naissance
-            </th>
-            {{#if this.isResultRecipientEmailVisible}}
-            <th>Adresse e-mail du destinataire des résultats</th>
+        <tr>
+          <th class="certification-candidates-table__column-last-name">
+            {{#if this.isCandidateBeingAdded}}
+              *
             {{/if}}
-            <th>Adresse e-mail de convocation</th>
-            <th>Identifiant externe</th>
-            <th class="certification-candidates-table__column-time">Temps majoré</th>
-            <th width="185"></th>
-          </tr>
+            Nom de naissance
+          </th>
+          <th class="certification-candidates-table__column-first-name">
+            {{#if this.isCandidateBeingAdded}}
+              *
+            {{/if}}
+            Prénom
+          </th>
+          <th>
+            {{#if this.isCandidateBeingAdded}}
+              *
+            {{/if}}
+            Date de naissance
+          </th>
+          <th>
+            {{#if this.isCandidateBeingAdded}}
+              *
+            {{/if}}
+            Commune de naissance
+          </th>
+          <th>
+            {{#if this.isCandidateBeingAdded}}
+              *
+            {{/if}}
+            Département de naissance
+          </th>
+          <th>
+            {{#if this.isCandidateBeingAdded}}
+              *
+            {{/if}}
+            Pays de naissance
+          </th>
+          {{#if this.isResultRecipientEmailVisible}}
+            <th>Adresse e-mail du destinataire des résultats</th>
+          {{/if}}
+          <th>Adresse e-mail de convocation</th>
+          <th>Identifiant externe</th>
+          <th class="certification-candidates-table__column-time">Temps majoré</th>
+          <th width="185"></th>
+        </tr>
         </thead>
         <tbody>
-          {{#each this.candidatesInStaging as |candidateInStaging|}}
-            <CertificationCandidateInStagingItem
-                    @candidateData={{candidateInStaging}}
-                    @onClickSave={{this.addCertificationCandidate}}
-                    @onClickCancel={{this.removeCertificationCandidateFromStaging}}
-                    @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingBirthdate}}
-                    @updateCandidateData={{this.updateCertificationCandidateInStagingField}}
-            />
-          {{/each}}
-          {{#each this.currentSession.certificationCandidates as |candidate|}}
-            <tr>
-              <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
-              <td data-test-id='panel-candidate__firstName__{{candidate.id}}'>{{candidate.firstName}}</td>
-              <td data-test-id='panel-candidate__birthdate__{{candidate.id}}'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
-              <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
-              <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
-              <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
-              {{#if this.isResultRecipientEmailVisible}}
+        {{#each this.candidatesInStaging as |candidateInStaging|}}
+          <CertificationCandidateInStagingItem
+                  @candidateData={{candidateInStaging}}
+                  @onClickSave={{this.addCertificationCandidate}}
+                  @onClickCancel={{this.removeCertificationCandidateFromStaging}}
+                  @updateCandidateBirthdate={{this.updateCertificationCandidateInStagingBirthdate}}
+                  @updateCandidateData={{this.updateCertificationCandidateInStagingField}}
+          />
+        {{/each}}
+        {{#each this.currentSession.certificationCandidates as |candidate|}}
+          <tr>
+            <td data-test-id='panel-candidate__lastName__{{candidate.id}}'>{{candidate.lastName}}</td>
+            <td data-test-id='panel-candidate__firstName__{{candidate.id}}'>{{candidate.firstName}}</td>
+            <td data-test-id='panel-candidate__birthdate__{{candidate.id}}'>{{moment-format candidate.birthdate 'DD/MM/YYYY'}}</td>
+            <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
+            <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
+            <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
+            {{#if this.isResultRecipientEmailVisible}}
               <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
-              {{/if}}
-              <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
-              <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
-              <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
-              <td>
-                <div class="certification-candidates-actions">
-                  <div class="certification-candidates-actions__delete">
-                    {{#if candidate.isLinked}}
-                      <PixActionButton
-                        @icon="trash-alt"
-                        class="certification-candidates-actions__delete-button--disabled"
-                        data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
-                      <div class="certification-candidates-actions__delete-tooltip">
-                        Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.
-                      </div>
-                    {{else}}
-                      <PixActionButton
-                        @icon="trash-alt"
-                        {{on 'click' (fn this.deleteCertificationCandidate candidate)}}
-                        class="certification-candidates-actions__delete__button"
-                        data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
-                    {{/if}}
-                  </div>
+            {{/if}}
+            <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+            <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
+            <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>
+            <td>
+              <div class="certification-candidates-actions">
+                <div class="certification-candidates-actions__delete">
+                  {{#if candidate.isLinked}}
+                    <PixActionButton
+                            @icon="trash-alt"
+                            class="certification-candidates-actions__delete-button--disabled"
+                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
+                    <div class="certification-candidates-actions__delete-tooltip">
+                      Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.
+                    </div>
+                  {{else}}
+                    <PixActionButton
+                            @icon="trash-alt"
+                      {{on 'click' (fn this.deleteCertificationCandidate candidate)}}
+                            class="certification-candidates-actions__delete__button"
+                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
+                  {{/if}}
                 </div>
-              </td>
-            </tr>
-          {{/each}}
+              </div>
+            </td>
+          </tr>
+        {{/each}}
         </tbody>
       </table>
     {{else}}
@@ -216,3 +219,4 @@
     {{/if}}
   </div>
 </div>
+{{/if}}

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -21,6 +21,10 @@ export default function() {
     return schema.sessions.where({ certificationCenterId });
   });
 
+  this.get('/certification-centers/:id/students', (schema) => {
+    return schema.students.all();
+  });
+
   this.post('/revoke', () => {});
 
   this.post('/token', (schema, request) => {

--- a/certif/mirage/factories/student.js
+++ b/certif/mirage/factories/student.js
@@ -1,0 +1,23 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+import moment from 'moment';
+
+export default Factory.extend({
+
+  firstName() {
+    return faker.name.firstName();
+  },
+
+  lastName() {
+    return faker.name.lastName();
+  },
+
+  birthdate() {
+    return moment(faker.date.past(30)).format('YYYY-MM-DD');
+  },
+
+  division() {
+    return faker.random.word();
+  },
+
+});

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -59,6 +59,21 @@ module('Acceptance | Session Candidates', function(hooks) {
       assert.equal(currentURL(), '/sessions/liste');
     });
 
+    module('add students list sco', function(hooks) {
+      hooks.beforeEach(function() {
+        user = createScoUserWithMembershipAndTermsOfServiceAccepted();
+        server.createList('student', 10);
+      });
+
+      test('it should display the list of students for session', async function(assert) {
+        // when
+        await visit(`/sessions/${session.id}/ajout-eleves`);
+
+        // then
+        assert.dom('table tbody tr').exists({ count: 10 });
+      });
+    });
+
     module('candidates list', function(hooks) {
       let existingCandidates;
 

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -23,6 +23,7 @@ module('Acceptance | Session Candidates', function(hooks) {
   const validBirthdate = '01021990';
 
   hooks.beforeEach(function() {
+    server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
     createSession();
   });
 
@@ -102,7 +103,29 @@ module('Acceptance | Session Candidates', function(hooks) {
         assert.dom('table tbody tr').exists({ count: 2 });
       });
 
-      module('add candidate', function(hooks) {
+      module('add candidate', function() {
+
+        module('when user is SCO', function() {
+
+          module('add students list sco', function() {
+
+            test('it should display the list of students for session', async function(assert) {
+              // given
+              certificationCenter.update({ type: 'SCO' });
+              server.createList('student', 10);
+
+              // when
+              await visit(`/sessions/${session.id}/candidats`);
+              await click('.button.button--link');
+
+              // then
+              assert.equal(currentURL(), `/sessions/${session.id}/ajout-eleves`);
+              assert.dom('table tbody tr').exists({ count: 10 });
+            });
+          });
+        });
+
+        module('when user is not SCO', function(hooks) {
 
         hooks.beforeEach(async function() {
           await visit(`/sessions/${session.id}/candidats`);
@@ -110,63 +133,64 @@ module('Acceptance | Session Candidates', function(hooks) {
 
         module('when candidate data not valid', function() {
 
-          test('it should leave the line up for modification', async function(assert) {
-            this.server.post('/sessions/:id/certification-candidates', () => ({
-              errors: ['Invalid data'],
-            }), 400);
-            // when
-            await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await _fillFormWithCorrectData();
-            await click('[data-test-id="panel-candidate__action__save"]');
+            test('it should leave the line up for modification', async function(assert) {
+              this.server.post('/sessions/:id/certification-candidates', () => ({
+                errors: ['Invalid data'],
+              }), 400);
+              // when
+              await click('[data-test-id="add-certification-candidate-staging__button"]');
+              await _fillFormWithCorrectData();
+              await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
             assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').exists();
           });
 
-          test('it should display notification error', async function(assert) {
-            this.server.post('/sessions/:id/certification-candidates', () => ({
-              errors: ['Invalid data'],
-            }), 400);
-            // when
-            await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await _fillFormWithCorrectData();
-            await click('[data-test-id="panel-candidate__action__save"]');
+            test('it should display notification error', async function(assert) {
+              this.server.post('/sessions/:id/certification-candidates', () => ({
+                errors: ['Invalid data'],
+              }), 400);
+              // when
+              await click('[data-test-id="add-certification-candidate-staging__button"]');
+              await _fillFormWithCorrectData();
+              await click('[data-test-id="panel-candidate__action__save"]');
 
             // then
             assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat.');
           });
         });
 
-        module('when candidate data is valid', function() {
+          module('when candidate data is valid', function() {
 
-          test('it remove the editable line', async function(assert) {
-            // when
-            await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await _fillFormWithCorrectData();
-            await click('[data-test-id="panel-candidate__action__save"]');
+            test('it remove the editable line', async function(assert) {
+              // when
+              await click('[data-test-id="add-certification-candidate-staging__button"]');
+              await _fillFormWithCorrectData();
+              await click('[data-test-id="panel-candidate__action__save"]');
 
-            // then
-            assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').doesNotExist();
-          });
+              // then
+              assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').doesNotExist();
+            });
 
-          test('it should display notification success', async function(assert) {
-            // when
-            await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await _fillFormWithCorrectData();
-            await click('[data-test-id="panel-candidate__action__save"]');
+            test('it should display notification success', async function(assert) {
+              // when
+              await click('[data-test-id="add-certification-candidate-staging__button"]');
+              await _fillFormWithCorrectData();
+              await click('[data-test-id="panel-candidate__action__save"]');
 
-            // then
-            assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
-          });
+              // then
+              assert.dom('[data-test-notification-message="success"]').hasText('Le candidat a été ajouté avec succès.');
+            });
 
-          test('it should add a new candidate entry', async function(assert) {
-            // when
-            await click('[data-test-id="add-certification-candidate-staging__button"]');
-            await _fillFormWithCorrectData();
-            await click('[data-test-id="panel-candidate__action__save"]');
+            test('it should add a new candidate entry', async function(assert) {
+              // when
+              await click('[data-test-id="add-certification-candidate-staging__button"]');
+              await _fillFormWithCorrectData();
+              await click('[data-test-id="panel-candidate__action__save"]');
 
-            // then
-            assert.dom('table tbody tr').exists({ count: 5 });
+              // then
+              assert.dom('table tbody tr').exists({ count: 5 });
+            });
           });
         });
       });
@@ -268,4 +292,3 @@ module('Acceptance | Session Candidates', function(hooks) {
     session = server.create('session', { certificationCenterId: certificationCenter.id });
   }
 });
-

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { createUserAndMembershipAndTermsOfServiceAccepted, authenticateSession } from '../helpers/test-init';
+import {
+  createUserAndMembershipAndTermsOfServiceAccepted,
+  authenticateSession } from '../helpers/test-init';
 import { upload } from 'ember-file-upload/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -60,27 +62,12 @@ module('Acceptance | Session Candidates', function(hooks) {
       assert.equal(currentURL(), '/sessions/liste');
     });
 
-    module('add students list sco', function(hooks) {
-      hooks.beforeEach(function() {
-        user = createScoUserWithMembershipAndTermsOfServiceAccepted();
-        server.createList('student', 10);
-      });
-
-      test('it should display the list of students for session', async function(assert) {
-        // when
-        await visit(`/sessions/${session.id}/ajout-eleves`);
-
-        // then
-        assert.dom('table tbody tr').exists({ count: 10 });
-      });
-    });
-
     module('candidates list', function(hooks) {
       let existingCandidates;
 
       hooks.beforeEach(function() {
         existingCandidates = server.createList('certification-candidate', 4, { isLinked: false });
-        session.update({ certificationCandidates : existingCandidates });
+        session.update({ certificationCandidates: existingCandidates });
       });
 
       test('it should list the existing candidates in the session', async function(assert) {
@@ -127,11 +114,11 @@ module('Acceptance | Session Candidates', function(hooks) {
 
         module('when user is not SCO', function(hooks) {
 
-        hooks.beforeEach(async function() {
-          await visit(`/sessions/${session.id}/candidats`);
-        });
+          hooks.beforeEach(async function() {
+            await visit(`/sessions/${session.id}/candidats`);
+          });
 
-        module('when candidate data not valid', function() {
+          module('when candidate data not valid', function() {
 
             test('it should leave the line up for modification', async function(assert) {
               this.server.post('/sessions/:id/certification-candidates', () => ({
@@ -142,9 +129,9 @@ module('Acceptance | Session Candidates', function(hooks) {
               await _fillFormWithCorrectData();
               await click('[data-test-id="panel-candidate__action__save"]');
 
-            // then
-            assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').exists();
-          });
+              // then
+              assert.dom('[data-test-id="panel-candidate__lastName__add-staging"]').exists();
+            });
 
             test('it should display notification error', async function(assert) {
               this.server.post('/sessions/:id/certification-candidates', () => ({
@@ -155,10 +142,10 @@ module('Acceptance | Session Candidates', function(hooks) {
               await _fillFormWithCorrectData();
               await click('[data-test-id="panel-candidate__action__save"]');
 
-            // then
-            assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat.');
+              // then
+              assert.dom('[data-test-notification-message="error"]').hasText('Une erreur s\'est produite lors de l\'ajout du candidat.');
+            });
           });
-        });
 
           module('when candidate data is valid', function() {
 
@@ -202,7 +189,7 @@ module('Acceptance | Session Candidates', function(hooks) {
         hooks.beforeEach(async function() {
           linkedCertificationCandidate = server.create('certification-candidate', { isLinked: true });
           notLinkedCertificationCandidate = server.create('certification-candidate', { isLinked: false });
-          session.update({ certificationCandidates : [linkedCertificationCandidate, notLinkedCertificationCandidate] });
+          session.update({ certificationCandidates: [linkedCertificationCandidate, notLinkedCertificationCandidate] });
           await visit(`/sessions/${session.id}/candidats`);
         });
 
@@ -292,3 +279,4 @@ module('Acceptance | Session Candidates', function(hooks) {
     session = server.create('session', { certificationCenterId: certificationCenter.id });
   }
 });
+

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -353,5 +353,4 @@ module('Acceptance | Session Details', function(hooks) {
       });
     });
   });
-
 });

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -330,6 +330,7 @@ module('Acceptance | Session Details', function(hooks) {
       { isFeatureToggleEnabled: false, isUserSco: false },
       { isFeatureToggleEnabled: true, isUserSco: false },
       { isFeatureToggleEnabled: false, isUserSco: true },
+      { isFeatureToggleEnabled: true, isUserSco: true },
     ].forEach(({ isFeatureToggleEnabled, isUserSco }) => {
       module(`when certification prescription sco feature toggle is ${isFeatureToggleEnabled ? 'enabled' : 'disabled'} and the user is ${isUserSco ? 'SCO' : 'not SCO'}`, () => {
 
@@ -349,24 +350,6 @@ module('Acceptance | Session Details', function(hooks) {
           // then
           assert.equal(currentURL(), '/sessions/1/candidats');
         });
-      });
-    });
-
-    module('when certification prescription sco feature toggle is enabled and the user is SCO',  () => {
-      test('it should redirect to the sco candidates detail view', async (assert) => {
-        // given
-        server.create('feature-toggle', {
-          certifPrescriptionSco: true,
-        });
-        const scoUser = createScoUserWithMembershipAndTermsOfServiceAccepted();
-        await authenticateSession(scoUser.id);
-
-        // when
-        await visit(`/sessions/${sessionFinalized.id}`);
-        await click(linkToCandidate);
-
-        // then
-        assert.equal(currentURL(), '/sessions/1/candidats-sco');
       });
     });
   });

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -1,0 +1,48 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | add-student-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  module('when there is no student', () => {
+    test('it shows an empty table', async function(assert) {
+
+      await render(hbs`<AddStudentList />`);
+
+      assert.dom('.table.add-student-list tbody tr td').doesNotExist();
+    });
+  });
+
+  module('when there are students', () => {
+    test('it shows student information in the table', async function(assert) {
+      // given
+      const birthdate = new Date('2018-01-12T09:29:16Z');
+      const firstStudent =  _buildStudent('firstName', 'lastName', 'division',birthdate);
+      await render(hbs`<AddStudentList />`);
+      const tableRow = '.table.add-student-list tbody tr';
+      this.set('students', [
+        firstStudent,
+        _buildStudent(),
+      ]);
+
+      // when
+      await render(hbs`<AddStudentList @studentList={{this.students}}></AddStudentList>`);
+
+      // then
+      assert.dom(tableRow).exists({ count: 2 });
+      assert.dom(tableRow + ':nth-child(1) td:nth-child(2)').includesText(firstStudent.division);
+      assert.dom(tableRow + ':nth-child(1) td:nth-child(3)').includesText(firstStudent.lastName);
+      assert.dom(tableRow + ':nth-child(1) td:nth-child(4)').includesText(firstStudent.firstName);
+      assert.dom(tableRow + ':nth-child(1) td:nth-child(5)').includesText('12/01/2018');
+    });
+  });
+
+  function _buildStudent(firstName, lastName, division, birthdate) {
+    return {
+      firstName, lastName, division, birthdate,
+    };
+  }
+
+});

--- a/certif/tests/unit/adapters/student-test.js
+++ b/certif/tests/unit/adapters/student-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { resolve } from 'rsvp';
+
+module('Unit | Adapter | student', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:student');
+    const ajaxStub = () => resolve();
+    adapter.ajax = ajaxStub;
+  });
+
+  module('#urlForFindAll', function() {
+
+    test('should build query url from student id', async function(assert) {
+      // given
+      const certificationCenterId = 1;
+      const adapterOptions = { certificationCenterId };
+
+      // when
+      const url = await adapter.urlForFindAll(undefined, { adapterOptions });
+
+      // then
+      assert.equal(url.endsWith(`certification-centers/${certificationCenterId}/students`), true);
+    });
+  });
+});

--- a/certif/tests/unit/models/student-test.js
+++ b/certif/tests/unit/models/student-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import pick from 'lodash/pick';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | student', function(hooks) {
+  setupTest(hooks);
+
+  test('it creates a StudentModel', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const data = {
+      firstName: 'firstName',
+      lastName: 'lastName',
+      birthdate: new Date(),
+      division: '4e',
+    };
+    const model = store.createRecord('student', data);
+    assert.deepEqual(_pickModelData(data), _pickModelData(model));
+  });
+
+  function _pickModelData(student) {
+    return pick(student, ['firstName', 'lastName', 'birthdate', 'division']);
+  }
+});

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
+  setupTest(hooks);
+  let route;
+
+  module('#model', function(hooks) {
+    const session_id = 1;
+    const certificationCenterId = Symbol('certificationCenterId');
+    const students = Symbol('students');
+    const expectedModel = {
+      sessionId: session_id,
+      students,
+    };
+
+    hooks.beforeEach(function() {
+      route = this.owner.lookup('route:authenticated/sessions/add-student');
+    });
+
+    test('it should return the session', async function(assert) {
+      // given
+      route.modelFor = sinon.stub().returns({ id: certificationCenterId });
+      route.store.findAll = sinon.stub().resolves(students);
+
+      // when
+      const actualModel = await route.model({ session_id });
+
+      // then
+      sinon.assert.calledWith(route.modelFor, 'authenticated');
+      sinon.assert.calledWith(route.store.findAll, 'student', { adapterOptions : { certificationCenterId } });
+      assert.deepEqual(actualModel, expectedModel);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Pour les centres de certifications SCO, l'ajout de candidat à une session doit être spécifique.

## :robot: Solution
On affiche la liste des candidats avec leur _classe, nom, prenom, date de naissance_, 
trié par classe/nom/prénom

## :rainbow: Remarques
On a remis la page d'ajout des candidats (SCO/non SCO) sur la même URL _/sessions/:id/candidats_

Pour le cas où le centre de certif n'aurait pas le même externalId qu'une organisation nous affichons une liste vide pour l'ajout des candidats. Ce cas ne devrait jamais arriver mais dans le cas où ça arrive les utilisateurs de Pix Certif verrons aucun candidats et devrons faire une requête support.

Pour alléger cette PR nous avons séparer les BSR dans une autre PR : https://github.com/1024pix/pix/pull/2028

## :100: Pour tester
S'assurer que le flag `FT_CERTIF_PRESCRIPTION_SCO=true` est positionné en **variable d'environnement de l'API**
Choisir un utilisateur sco (i.e. certifsco@example.net)
=> Le choix des candidat se fait via une liste d'étudiant

Choisir un utilisateur pro (i.e. certifpro@example.net)
=> Le choix des candidats se fait via un import de fichier

TODO
- [x] API ajouter test acceptance route pour la 200 retour vide
- [x] API ajouter des seeds
- [x] FRONT gérer le cas où pas d'organisation avec le même externalID => l'api retourne une 404
- [x] FRONT style du composant liste des élèves
- [x] FRONT tests à ajouter
