### PR TITLE
[FEATURE] Réconcilier un élève avec un match strict, et dans un second temps avec une distance d'édition si pas de match (PIX-1401).

### DIFF
--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -225,6 +225,20 @@ describe('Unit | Service | user-reconciliation-service', () => {
             // then
             expect(result).to.equal(schoolingRegistrations[0].id);
           });
+
+          it('...a mistake', async () => {
+            // given
+            user.firstName = 'Joey';
+
+            schoolingRegistrations[0].firstName = 'Joe';
+            schoolingRegistrations[0].lastName = user.lastName;
+
+            // when
+            const result = await userReconciliationService.findMatchingCandidateIdForGivenUser(schoolingRegistrations, user);
+
+            // then
+            expect(result).to.equal(schoolingRegistrations[0].id);
+          });
         });
 
         context('When multiple matches', () => {
@@ -272,6 +286,25 @@ describe('Unit | Service | user-reconciliation-service', () => {
 
             // then
             expect(result).to.equal(null);
+          });
+        });
+
+        context('When two schoolingRegistrations are close', () => {
+          const twin1 = { firstName: 'allan', lastName: 'Poe' };
+          const twin2 = { firstName: 'alian', lastName: 'Poe' };
+
+          it('should prefer the firstName that match perfectly', async () => {
+            // given
+            schoolingRegistrations[0].firstName = twin1.firstName;
+            schoolingRegistrations[0].lastName = twin1.lastName;
+            schoolingRegistrations[1].firstName = twin2.firstName;
+            schoolingRegistrations[1].lastName = twin2.lastName;
+
+            // when
+            const result = await userReconciliationService.findMatchingCandidateIdForGivenUser(schoolingRegistrations, twin1);
+
+            // then
+            expect(result).to.equal(schoolingRegistrations[0].id);
           });
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
La réconciliation SCO consiste à trouver dans la base élève correspondant au nom, prénom et date de naissance saisis par un utilisateur (et propriétaire d'un compte Pix). Cette réconciliation prend une distance d'édition, c'est à dire qu'on autorise un élève à un certain taux d'erreur par rapport au nombre de lettres. Or, certains élèves, jumeaux, sont nés le même jour (donc ont la même date de naissance) et ont le même nom de famille. La différentiation se fait alors uniquement sur le prénom. S'il s'avère que ces prénoms sont suffisamment proches, alors Pix n'est pas capable de dire si l'élève a fait une faute ou s'il a saisi le bon prénom.
L'élève ne peut donc pas se réconcilier et donc ne peut pas accéder à son parcours.

## :robot: Solution
1 - Garder la méthode actuelle avec la distance de levenshtein
2 - Si pas de match unique, alors on applique le match strict (hors accentuation et caractères spéciaux) 

## :rainbow: Remarques
Depuis le début, on a eu 20 à 30 cas.

## :100: Pour tester
- Avoir 2 inscriptions d'élèves dont le prénom fait au moins 5 lettres (Allan et Alian par exemple) ;
- Essayer de se réconcilier depuis le compte userpix1@example.net avec Allan ;
- Vérifier que l'on accède bien au parcours.
