### PR TITLE
[FEATURE] Ajouter un message d'avertissement avant de réconcilier un élève (PIX-1391).

### DIFF
--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -10,10 +10,11 @@ module.exports = {
     return schoolingRegistrationSerializer.serialize(schoolingRegistration);
   },
 
-  async reconcileSchoolingRegistrationManually(request) {
+  async reconcileSchoolingRegistrationManually(request, h) {
     const authenticatedUserId = request.auth.credentials.userId;
     const payload = request.payload.data.attributes;
     const campaignCode = payload['campaign-code'];
+    const withReconciliation = request.query.withReconciliation === 'true';
 
     const reconciliationInfo = {
       id: authenticatedUserId,
@@ -22,9 +23,13 @@ module.exports = {
       birthdate: payload['birthdate'],
     };
 
-    const schoolingRegistration = await usecases.reconcileSchoolingRegistration({ campaignCode, reconciliationInfo });
+    const schoolingRegistration = await usecases.reconcileSchoolingRegistration({ campaignCode, reconciliationInfo, withReconciliation });
 
-    return schoolingRegistrationSerializer.serialize(schoolingRegistration);
+    if (withReconciliation) {
+      return schoolingRegistrationSerializer.serialize(schoolingRegistration);
+    }
+
+    return h.response().code(204);
   },
 
   async reconcileHigherSchoolingRegistration(request, h) {

--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -4,6 +4,7 @@ const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
 module.exports = async function reconcileSchoolingRegistration({
   campaignCode,
   reconciliationInfo,
+  withReconciliation,
   campaignRepository,
   schoolingRegistrationRepository,
   studentRepository,
@@ -29,11 +30,12 @@ module.exports = async function reconcileSchoolingRegistration({
 
   await _checkIfAnotherStudentIsAlreadyReconciledWithTheSameOrganizationAndUser(reconciliationInfo.id, campaign.organizationId, schoolingRegistrationRepository);
 
-  return schoolingRegistrationRepository.reconcileUserToSchoolingRegistration({
-    userId: reconciliationInfo.id,
-    schoolingRegistrationId: matchedSchoolingRegistration.id,
-  });
-
+  if (withReconciliation) {
+    return schoolingRegistrationRepository.reconcileUserToSchoolingRegistration({
+      userId: reconciliationInfo.id,
+      schoolingRegistrationId: matchedSchoolingRegistration.id,
+    });
+  }
 };
 
 async function _checkIfAnotherStudentIsAlreadyReconciledWithTheSameOrganizationAndUser(userId, organizationId, schoolingRegistrationRepository) {

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -22,7 +22,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
       // given
       options = {
         method: 'POST',
-        url: '/api/schooling-registration-user-associations/',
+        url: '/api/schooling-registration-user-associations',
         headers: {},
         payload: {},
       };
@@ -47,6 +47,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             'birthdate': schoolingRegistration.birthdate,
           },
         };
+        options.url += '?withReconciliation=true';
 
         // when
         const response = await server.inject(options);
@@ -395,6 +396,35 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
           // then
           expect(response.statusCode).to.equal(422);
+        });
+      });
+
+      context('When withReconciliation query param is set to false', () => {
+
+        it('should not reconcile user and return a 204 No Content', async () => {
+          // given
+          options.headers.authorization = generateValidRequestAuthorizationHeader(user.id);
+          options.payload.data = {
+            attributes: {
+              'campaign-code': campaign.code,
+              'first-name': schoolingRegistration.firstName,
+              'last-name': schoolingRegistration.lastName,
+              'birthdate': schoolingRegistration.birthdate,
+            },
+          };
+          options.url += '?withReconciliation=false';
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+          const schoolingRegistrationInDB = await knex('schooling-registrations').where({
+            firstName: schoolingRegistration.firstName,
+            lastName: schoolingRegistration.lastName,
+            birthdate: schoolingRegistration.birthdate,
+          }).select();
+          expect(schoolingRegistrationInDB.userId).to.be.undefined;
         });
       });
     });

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -46,6 +46,7 @@ Fonctionnalité: Campagne d'évaluation
     Et je saisis "Targaryen" dans le champ "Nom"
     Et je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
+    Et je clique sur le bouton "Associer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "Je commence"
     Alors je vois la page de "didacticiel" de la campagne

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -39,6 +39,7 @@ Fonctionnalité: Campagne de collecte de profils
     Et je saisis "Targaryen" dans le champ "Nom"
     Et je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
+    Et je clique sur le bouton "Associer"
     Alors je vois la page de "presentation" de la campagne
     Lorsque je clique sur "C’est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne

--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -89,3 +89,7 @@ then(`je vois que le sujet {string} est {string}`, (tubeName, recommendationLeve
 when(`je retourne au détail de la campagne`, () => {
   cy.get('[aria-label="Retourner au détail de la campagne"]').click();
 });
+
+when('je clique sur le bouton "Associer"', () => {
+  cy.get('[aria-label="Associer"]').click();
+});

--- a/mon-pix/app/adapters/schooling-registration-user-association.js
+++ b/mon-pix/app/adapters/schooling-registration-user-association.js
@@ -22,7 +22,7 @@ export default class SchoolingRegistrationUserAssociation extends ApplicationAda
   }
 
   createRecord(store, type, snapshot) {
-    const url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
+    let url = this.buildURL(type.modelName, null, snapshot, 'createRecord');
     const data = this.serialize(snapshot);
 
     if (snapshot.adapterOptions && snapshot.adapterOptions.searchForMatchingStudent) {
@@ -34,6 +34,11 @@ export default class SchoolingRegistrationUserAssociation extends ApplicationAda
       delete snapshot.adapterOptions.tryReconciliation;
       delete data.data.attributes['first-name'];
       delete data.data.attributes['last-name'];
+    }
+
+    if (snapshot.adapterOptions && snapshot.adapterOptions.withReconciliation !== undefined) {
+      url += `?withReconciliation=${snapshot.adapterOptions.withReconciliation}`;
+      delete snapshot.adapterOptions.withReconciliation;
     }
 
     delete data.data.attributes.username;

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
@@ -13,10 +13,15 @@
   </div>
 
   <div class="join-error-modal__footer">
-    <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
-      {{t 'common.actions.quit'}}</button>
-    {{#if this.displayContinueButton}}
-      <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>{{t 'pages.join.sco.continue-with-pix'}}</button>
+    {{#if this.isInformationMode}}
+      <button class="button button--grey" type="button" {{on 'click' this.goToHome}}>{{t 'common.actions.sign-out'}}</button>
+      <button class="button" type="button" aria-label={{t 'pages.join.sco.associate'}} {{on 'click' @associate}}>{{t 'pages.join.sco.associate'}}</button>
+    {{else}}
+      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
+        {{t 'common.actions.quit'}}</button>
+      {{#if this.displayContinueButton}}
+        <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>{{t 'pages.join.sco.continue-with-pix'}}</button>
+      {{/if}}
     {{/if}}
   </div>
 </PixModal>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
@@ -1,0 +1,22 @@
+<PixModal @containerClass="join-error-modal" @onClose={{action @closeModal}}>
+  <div class="join-error-modal__header">
+    <div class="join-error-modal-header__title">
+      <h1 class="join-error-modal-header-title__text">{{t 'pages.join.sco.login-information-title'}}</h1>
+    </div>
+    <div class="join-error-modal-header__close" aria-label={{t "common.actions.close"}} {{on 'click' @closeModal}}>
+      <img src="/images/icons/icon-croix.svg" alt={{t 'common.actions.close'}} class="join-error-modal-header-close__icon">
+    </div>
+  </div>
+
+  <div class="join-error-modal__body">
+    <div class="join-error-modal-body__message" aria-live="polite">{{this.message}}</div>
+  </div>
+
+  <div class="join-error-modal__footer">
+    <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
+      {{t 'common.actions.quit'}}</button>
+    {{#if this.displayContinueButton}}
+      <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>{{t 'pages.join.sco.continue-with-pix'}}</button>
+    {{/if}}
+  </div>
+</PixModal>

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
@@ -19,11 +19,16 @@ export default class JoinScoInformationModal extends Component {
 
   constructor(owner, args) {
     super(owner, args);
+    if (this.args.reconciliationWarning) {
+      this.isInformationMode = true;
+      this.message = this.intl.t('pages.join.sco.login-information-message', { ...this.args.reconciliationWarning, htmlSafe: true });
+    }
     if (this.args.reconciliationError) {
+      this.isInformationMode = false;
       const error = this.args.reconciliationError;
       this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
       const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
-      this.message = this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htlmSafe: true })  || defaultMessage;
+      this.message = this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htmlSafe: true })  || defaultMessage;
     }
   }
 

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
@@ -1,0 +1,41 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import ENV from 'mon-pix/config/environment';
+import { getJoinErrorsMessageByShortCode } from '../../../../utils/errors-messages';
+
+const ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS = ['R13', 'R33'];
+
+export default class JoinScoInformationModal extends Component {
+
+  @service session;
+  @service router;
+  @service url;
+  @service intl;
+
+  @tracked message = null;
+  @tracked displayContinueButton = true;
+
+  constructor(owner, args) {
+    super(owner, args);
+    if (this.args.reconciliationError) {
+      const error = this.args.reconciliationError;
+      this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
+      const defaultMessage = this.intl.t(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
+      this.message = this.intl.t(getJoinErrorsMessageByShortCode(error.meta), { value: error.meta.value, htlmSafe: true })  || defaultMessage;
+    }
+  }
+
+  @action
+  async goToHome() {
+    await this.session.invalidate();
+    return window.location.replace(this.url.homeUrl);
+  }
+
+  @action
+  async goToCampaignConnectionForm() {
+    await this.session.invalidate();
+    return this.router.replaceWith('campaigns.restricted.login-or-register-to-access', { queryParams: { displayRegisterForm: false } });
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -62,27 +62,9 @@
     </button>
   {{/if}}
 </form>
-{{#if this.displayModal}}
-  <PixModal @containerClass="join-error-modal" @onClose={{action this.closeModal}}>
-    <div class="join-error-modal__header">
-      <div class="join-error-modal-header__title">
-        <h1 class="join-error-modal-header-title__text">{{t 'pages.join.sco.login-information-title'}}</h1>
-      </div>
-      <div class="join-error-modal-header__close" aria-label={{t "common.actions.close"}} {{on 'click' this.closeModal}}>
-        <img src="/images/icons/icon-croix.svg" alt={{t 'common.actions.close'}} class="join-error-modal-header-close__icon">
-      </div>
-    </div>
-
-    <div class="join-error-modal__body">
-      <div class="join-error-modal-body__message" aria-live="polite">{{{this.modalErrorMessage}}}</div>
-    </div>
-
-    <div class="join-error-modal__footer">
-      <button class="button {{if this.displayContinueButton "button--grey"}}" type="button" {{on 'click' this.goToHome}}>
-          {{t 'common.actions.quit'}}</button>
-      {{#if this.displayContinueButton}}
-        <button class="button" type="button" aria-label={{t 'pages.join.sco.continue-with-pix'}} {{on 'click' this.goToCampaignConnectionForm}}>{{t 'pages.join.sco.continue-with-pix'}}</button>
-      {{/if}}
-    </div>
-  </PixModal>
+{{#if this.displayInformationModal}}
+  <Routes::Campaigns::Restricted::JoinScoInformationModal
+          @reconciliationError={{this.reconciliationError}}
+          @closeModal={{this.closeModal}}
+  />
 {{/if}}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -65,6 +65,8 @@
 {{#if this.displayInformationModal}}
   <Routes::Campaigns::Restricted::JoinScoInformationModal
           @reconciliationError={{this.reconciliationError}}
+          @reconciliationWarning={{this.reconciliationWarning}}
           @closeModal={{this.closeModal}}
+          @associate={{this.associate}}
   />
 {{/if}}

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -12,11 +12,16 @@ export default class JoinRestrictedCampaignController extends Controller {
   @service currentUser;
 
   @action
-  reconcile(schoolingRegistration, adapterOptions) {
-    return schoolingRegistration.save({ adapterOptions }).then(() => {
-      this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
-        queryParams: { associationDone: true, participantExternalId: this.participantExternalId },
-      });
+  async reconcile(schoolingRegistration, adapterOptions) {
+    const mustNotRedirectAfterSave = adapterOptions.withReconciliation === false;
+    await schoolingRegistration.save({ adapterOptions });
+
+    if (mustNotRedirectAfterSave) {
+      return;
+    }
+
+    return this.transitionToRoute('campaigns.start-or-resume', this.model.code, {
+      queryParams: { associationDone: true, participantExternalId: this.participantExternalId },
     });
   }
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -108,6 +108,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
               await click('.button');
+              await click('button[aria-label="Associer"]');
               await click('.campaign-landing-page__start-button');
             });
 
@@ -189,6 +190,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
+            await click('button[aria-label="Associer"]');
             await click('.button');
             await fillIn('#id-pix-label', 'truc');
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
@@ -101,6 +101,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
               await fillIn('#monthOfBirth', '12');
               await fillIn('#yearOfBirth', '2000');
               await click('.button');
+              await click('button[aria-label="Associer"]');
               await click('.campaign-landing-page__start-button');
             });
 
@@ -181,6 +182,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
+            await click('button[aria-label="Associer"]');
             await click('.button');
             await fillIn('#id-pix-label', 'truc');
 

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -126,7 +126,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             campaign = server.create('campaign', { isRestricted: true, organizationType: 'SCO' });
           });
 
-          context('When the student has an account but is not reconcilied', function() {
+          context('When the student has an account but is not reconciled', function() {
 
             it('should redirect to reconciliation page', async function() {
               // given
@@ -299,7 +299,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/rejoindre`);
           });
 
-          it('should redirect to landing page when fields are filled in', async function() {
+          it('should redirect to landing page when fields are filled in and associate button is clicked', async function() {
             // given
             await visit(`/campagnes/${campaign.code}`);
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/privee/identification`);
@@ -318,6 +318,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
 
             await click('.button');
+
+            await click('button[aria-label="Associer"]');
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -583,7 +585,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             expect(find('#lastName').value).to.equal('');
           });
 
-          it('should redirect to landing page when fields are filled in', async function() {
+          it('should redirect to landing page when fields are filled in and associate button is clicked', async function() {
             // given
             await visit(`/campagnes/${campaign.code}/privee/rejoindre`);
 
@@ -595,6 +597,8 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
 
             await click('.button');
+
+            await click('button[aria-label="Associer"]');
 
             //then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
@@ -609,6 +613,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#monthOfBirth', '12');
             await fillIn('#yearOfBirth', '2000');
             await click('.button');
+            await click('button[aria-label="Associer"]');
 
             // when
             await click('.button');

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-information-modal_test.js
@@ -17,15 +17,23 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco-information-mo
       meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
     };
 
+    it('should set is isInformationMode to false', function() {
+      // when
+      const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationError });
+
+      // then
+      expect(component.isInformationMode).to.be.false;
+    });
+
     it('should display error message', function() {
       // given
-      const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', { value: reconciliationError.meta.value });
+      const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', { value: reconciliationError.meta.value, htmlSafe: true });
 
       // when
       const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationError });
 
       // then
-      expect(component.message).to.equal(expectedErrorMessage);
+      expect(component.message).to.deep.equal(expectedErrorMessage);
     });
 
     describe('When error is not related to samlId', function() {
@@ -54,6 +62,34 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco-information-mo
         // then
         expect(component.displayContinueButton).to.be.false;
       });
+    });
+  });
+
+  describe('When reconciliation warning is provided', function() {
+
+    const reconciliationWarning = {
+      connectionMethod: 'test@example.net',
+      firstName: 'John',
+      lastName: 'Doe',
+    };
+
+    it('should set is isInformationMode to true', function() {
+      // when
+      const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationWarning });
+
+      // then
+      expect(component.isInformationMode).to.be.true;
+    });
+
+    it('should display an information message', function() {
+      // given
+      const expectedWarningMessage = this.intl.t('pages.join.sco.login-information-message', { ...reconciliationWarning, htmlSafe: true });
+
+      // when
+      const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationWarning });
+
+      // then
+      expect(component.message).to.deep.equal(expectedWarningMessage);
     });
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-information-modal_test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-information-modal_test.js
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+import createComponent from '../../../../../helpers/create-glimmer-component';
+import setupIntl from '../../../../../helpers/setup-intl';
+
+describe('Unit | Component | routes/campaigns/restricted/join-sco-information-modal', function() {
+
+  setupTest();
+  setupIntl();
+
+  describe('When reconciliation error is provided', function() {
+
+    const reconciliationError = {
+      status: '409',
+      meta: { shortCode: 'R11', value: 'j***@example.net', userId: 1 },
+    };
+
+    it('should display error message', function() {
+      // given
+      const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', { value: reconciliationError.meta.value });
+
+      // when
+      const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationError });
+
+      // then
+      expect(component.message).to.equal(expectedErrorMessage);
+    });
+
+    describe('When error is not related to samlId', function() {
+
+      it('should display continue button', function() {
+        // given
+        reconciliationError.meta.shortCode = 'R12';
+
+        // when
+        const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationError });
+
+        // then
+        expect(component.displayContinueButton).to.be.true;
+      });
+    });
+
+    describe('When error is related to samlId', function() {
+
+      it('should not display continue button', function() {
+        // given
+        reconciliationError.meta.shortCode = 'R13';
+
+        // when
+        const component = createComponent('component:routes/campaigns/restricted/join-sco-information-modal', { reconciliationError });
+
+        // then
+        expect(component.displayContinueButton).to.be.false;
+      });
+    });
+  });
+});

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -477,215 +477,23 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/><br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
       });
 
-      describe('When student is already reconciled in others organization', async function() {
+      describe('When student is already reconciled', () => {
 
-        describe('When student account is authenticated by email only', async function() {
+        it('should open information modal and set reconciliationError', async function() {
+          // given
+          const error = { status: '409', meta: { userId: 1 } };
 
-          it('should return a conflict error and display the error message related to the short code R11)', async function() {
-            // given
-            const meta = { shortCode: 'R11', value: 'j***@example.net', userId: 1 };
-            const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r11', { value: meta.value });
+          onSubmitToReconcileStub.rejects({ errors: [error] });
 
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
+          // when
+          await component.actions.submit.call(component, eventStub);
 
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.true;
-          });
-
-        });
-
-        describe('When student account is authenticated by username only', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R12)', async function() {
-            // given
-            const meta = { shortCode: 'R12', value: 'j***.h***2', userId: 1 };
-            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r12', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.true;
-          });
-
-        });
-
-        describe('When student account is authenticated by SamlId only', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R13)', async function() {
-            // given
-            const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.false;
-          });
-
-        });
-
-        describe('When student account is authenticated by SamlId and username', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R13)', async function() {
-            // given
-            const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.false;
-          });
-
-        });
-
-        describe('When student account is authenticated by SamlId and email', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R13)', async function() {
-            // given
-            const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.false;
-          });
-
-        });
-
-        describe('When student account is authenticated by SamlId, username and email', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R13)', async function() {
-            // given
-            const meta = { shortCode: 'R13', value: undefined, userId: 1 };
-            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r13', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.false;
-          });
-
-        });
-
-        describe('When student account is authenticated by username and email', async function() {
-
-          it('should return a conflict error and display the error message related to the short code R12)', async function() {
-            // given
-            const meta = { shortCode: 'R12', value: 'j***.h***2', userId: 1 };
-            const expectedErrorMessage =  this.intl.t('api-error-messages.join-error.r12', { value: meta.value });
-
-            const error = {
-              status: '409',
-              code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_ANOTHER_ORGANIZATION',
-              title: 'Conflict',
-              detail: 'Un compte existe déjà pour l‘élève dans un autre établissement.',
-              meta,
-            };
-
-            onSubmitToReconcileStub.rejects({ errors: [error] });
-
-            // when
-            await component.actions.submit.call(component, eventStub);
-
-            // then
-            sinon.assert.calledOnce(record.unloadRecord);
-            sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', meta.userId);
-            expect(component.modalErrorMessage).to.equal(expectedErrorMessage);
-            expect(component.isLoading).to.be.false;
-            expect(component.displayContinueButton).to.be.true;
-          });
+          // then
+          sinon.assert.calledOnce(record.unloadRecord);
+          expect(component.displayInformationModal).to.be.true;
+          expect(component.reconciliationError).to.equal(error);
+          expect(component.isLoading).to.be.false;
+          sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', error.meta.userId);
         });
 
       });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/join-test.js
@@ -21,16 +21,36 @@ describe('Unit | Controller | campaigns/restricted/join', function() {
       schoolingRegistration = { save: sinon.stub() };
     });
 
-    it('should associate user with student and redirect to campaigns.start-or-resume', async function() {
-      // given
-      schoolingRegistration.save.resolves();
+    context('When withReconciliation is false', function() {
 
-      // when
-      await controller.actions.reconcile.call(controller, schoolingRegistration);
+      it('should run reconciliation checks and not redirect', async function() {
+        // given
+        schoolingRegistration.save.resolves();
+        const adapterOptions = { withReconciliation: false };
 
-      // then
-      sinon.assert.calledOnce(schoolingRegistration.save);
-      sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+        // when
+        await controller.actions.reconcile.call(controller, schoolingRegistration, adapterOptions);
+
+        // then
+        sinon.assert.calledOnce(schoolingRegistration.save);
+        sinon.assert.notCalled(controller.transitionToRoute);
+      });
+    });
+
+    context('When withReconciliation is true', function() {
+
+      it('should associate user with student and redirect to campaigns.start-or-resume', async function() {
+        // given
+        schoolingRegistration.save.resolves();
+        const adapterOptions = { withReconciliation: true };
+
+        // when
+        await controller.actions.reconcile.call(controller, schoolingRegistration, adapterOptions);
+
+        // then
+        sinon.assert.calledOnce(schoolingRegistration.save);
+        sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
+      });
     });
   });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -32,7 +32,8 @@
       "back": "",
       "cancel": "Cancel",
       "close": "Close",
-      "quit": "Exit"
+      "quit": "Exit",
+      "sign-out": "Sign out"
     },
     "form": {
       "error": "error",
@@ -525,7 +526,9 @@
       "sco": {
         "continue-with-pix": "",
         "error-not-found": "",
-        "login-information-title": ""
+        "login-information-title": "",
+        "login-information-message": "",
+        "associate": ""
       },
       "subtitle": "",
       "sup": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -31,7 +31,8 @@
       "back": "Retour",
       "cancel": "Annuler",
       "close": "Fermer",
-      "quit": "Quitter"
+      "quit": "Quitter",
+      "sign-out": "Se déconnecter"
     },
     "form": {
       "error": "erreur",
@@ -525,7 +526,9 @@
       "sco": {
         "continue-with-pix": "Continuer avec mon compte Pix",
         "error-not-found": "Vous êtes un élève ? '<br/>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br/><br/>' Vous êtes un enseignant ? '<br/>' L‘accès à un parcours n‘est pas disponible pour le moment.",
-        "login-information-title": "Information de connexion"
+        "login-information-title": "Information de connexion",
+        "login-information-message": "Le compte Pix '<b>'{ connectionMethod }'</b>' va être associé à l'élève: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'S’il s’agit bien de vous, cliquez sur \"Associer\", sinon déconnectez-vous.",
+        "associate": "Associer"
       },
       "subtitle": "Remplissez les informations manquantes",
       "sup": {


### PR DESCRIPTION
## :unicorn: Problème
Le processus de réconciliation lie une inscription d'élève (`schooling-registration`) à un utilisateur (`user`) et cette opération est censée être définitive. Cependant, la plupart de nos utilisateurs ne se rendent pas compte de l'impact de cette opération si elle est effectuée avec le mauvais compte utilisateur. C'est notamment le cas pour les professeurs qui se réconcilierait auprès de l'inscription d'un de leurs élèves afin de tester le parcours.   

## :robot: Solution
Afficher dans la modal d'information de connexion un message expliquant les impacts de l'opération de réconcliation.  

## :rainbow: Remarques
C'est durant le processus de réconciliation que nous déterminons si un élève est déjà réconcilié auprès d'un établissement scolaire et, s'il ne l'est pas, nous le réconcilions. Cependant, afin d'éviter (au maximum) d'afficher le message d'information puis ensuite un message d'erreur, une évolution de l'API a été effectuée afin de pouvoir réaliser les vérifications précédentes sans effectuer de réconciliation.

## :100: Pour tester
- Se connecter et tenter de se réconciler.
- Avant de pouvoir réellement le faire, le message d'information doit apparaître.
