### PR TITLE
[FEATURE] Ajout de formats pour les épreuves QROC ().

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -19,9 +19,21 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   _hasError() {
     return this._getAnswerValue().length < 1;
   }
+  _getCorrectFormatValue(answerValue) {
+    if (this.args.challenge.format === 'date') {
+      const dateArray = answerValue.split('-');
+      return dateArray.length === 3 ? dateArray[2] + '/' + dateArray[1] + '/' + dateArray[0] : answerValue;
+    }
+    return answerValue;
+  }
 
   _getAnswerValue() {
-    return this.showProposal ? (document.querySelector('[data-uid="qroc-proposal-uid"]')).value : this.autoReplyAnswer;
+    if (this.showProposal) {
+      const answerValue = (document.querySelector('[data-uid="qroc-proposal-uid"]')).value;
+      return this._getCorrectFormatValue(answerValue);
+    }
+    return this.autoReplyAnswer;
+
   }
 
   _getErrorMessage() {

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -40,6 +40,17 @@
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
+      {{else if (eq @format 'date')}}
+        <input class="challenge-response__proposal"
+               type="date"
+               id="qroc_input"
+          {{on 'keydown' this.onInputChange}}
+               name={{block.input}}
+               placeholder={{block.placeholder}}
+               autocomplete="off"
+               value="{{this.userAnswer}}"
+               data-uid="qroc-proposal-uid"
+               disabled={{if @answer true}}>
       {{else}}
         <input class="challenge-response__proposal"
                size="{{get-qroc-input-size @format}}"

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -29,6 +29,17 @@
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
+      {{else if (eq @format 'nombre')}}
+        <input class="challenge-response__proposal"
+               type="number"
+               id="qroc_input"
+          {{on 'keydown' this.onInputChange}}
+               name={{block.input}}
+               placeholder={{block.placeholder}}
+               autocomplete="off"
+               value="{{this.userAnswer}}"
+               data-uid="qroc-proposal-uid"
+               disabled={{if @answer true}}>
       {{else}}
         <input class="challenge-response__proposal"
                size="{{get-qroc-input-size @format}}"

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -58,6 +58,21 @@ describe('Integration | Component | QROC proposal', function() {
     });
   });
 
+  describe('When format is a date', function() {
+
+    it('should display an input with date type', async function() {
+      // given
+      this.set('proposals', '${myInput}');
+      this.set('format', 'date');
+
+      // when
+      await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
+
+      // then
+      expect(find('.challenge-response__proposal').getAttribute('type')).to.equal('date');
+    });
+  });
+
   describe('When format is neither a paragraph nor a phrase', function() {
 
     [

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -43,6 +43,21 @@ describe('Integration | Component | QROC proposal', function() {
     });
   });
 
+  describe('When format is a number', function() {
+
+    it('should display an input with number type', async function() {
+      // given
+      this.set('proposals', '${myInput}');
+      this.set('format', 'nombre');
+
+      // when
+      await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
+
+      // then
+      expect(find('.challenge-response__proposal').getAttribute('type')).to.equal('number');
+    });
+  });
+
   describe('When format is neither a paragraph nor a phrase', function() {
 
     [

--- a/mon-pix/tests/unit/components/challenge-item-qroc-test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc-test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import EmberObject from '@ember/object';
+import { setupTest } from 'ember-mocha';
+
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | challenge item qroc', function() {
+
+  setupTest();
+
+  let component;
+
+  describe('#_getCorrectDateValue', function() {
+    context('when challenge has a date format', function() {
+      beforeEach(function() {
+        const challenge = EmberObject.create({
+          format: 'date',
+          id: 'rec_123',
+        });
+        component = createGlimmerComponent('component:challenge-item-qroc', { challenge });
+      });
+      [
+        { dateGiven: '12102000', expectedDate: '12102000' },
+        { dateGiven: '26/03/1998', expectedDate: '26/03/1998' },
+        { dateGiven: '1998-03-26', expectedDate: '26/03/1998' },
+      ].forEach((data) => {
+        it(`should return ${data.expectedDate} when the answer is ${data.dateGiven}`, function() {
+          // when
+          const answerValue = component._getCorrectFormatValue(data.dateGiven);
+
+          // then
+          expect(answerValue).to.deep.equal(data.expectedDate);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
- Les questions QROC ne peuvent être que de format texte actuellement (avec des longueurs différentes). Des utilisateurs utilisent parfois mal ces champs.

## :robot: Solution
- Ajout du type "nombre" (`number`) pour forcer les nombre
- Ajout du type "date" (`date`) pour forcer les dates.

## :rainbow: Remarques
- Le type `date` n'est pas supporté par tous les navigateurs : dans ce cas, cela devient seulement un type `input` texte simple
- Le type date renvoie toujours une date au format YYYY-MM-DD, ce qui oblige a transformé la réponse pour la remettre dans un format qu'on a l'habitude d'utiliser
- TODO : vérifier comment bien gérer les formats de date pour pas avoir de problème (surtout à l'i18n).

## :100: Pour tester
Une question avec nombre : https://app-pr2002.review.pix.fr/challenges/recAsQI8VNgXcme11/preview
Une question avec date : https://app-pr2002.review.pix.fr/challenges/recIjOKuKKfg2lUJA/preview
