### PR TITLE
 [BUGFIX] Empêcher une erreur 500 suite à une violation de contrainte lors d'une réconciliation d'un élève (PIX-1367)

### DIFF
--- a/api/db/seeds/data/organizations-builder.js
+++ b/api/db/seeds/data/organizations-builder.js
@@ -207,6 +207,22 @@ module.exports = function organizationsBuilder({ databaseBuilder }) {
     organizationId: 3,
   });
 
+  databaseBuilder.factory.buildSchoolingRegistration({
+    userId: null,
+    firstName: 'USER1',
+    lastName: 'USER1',
+    birthdate: '2001-01-01',
+    organizationId: 3,
+  });
+
+  databaseBuilder.factory.buildSchoolingRegistration({
+    userId: null,
+    firstName: 'USER1234',
+    lastName: 'USER1234',
+    birthdate: '2001-01-01',
+    organizationId: 3,
+  });
+
   // Type: SCO
 
   // id=5 is already used in dragon-and-co-builder

--- a/api/lib/domain/constants.js
+++ b/api/lib/domain/constants.js
@@ -46,6 +46,8 @@ module.exports = {
         email: { shortCode: 'R31', code: 'ACCOUNT_WITH_EMAIL_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         username: { shortCode: 'R32', code: 'ACCOUNT_WITH_USERNAME_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
         samlId: { shortCode: 'R33', code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION' },
+        anotherStudentIsAlreadyReconciled: { shortCode: 'R70', code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' },
+
       },
     },
     LOGIN_OR_REGISTER: {

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -204,6 +204,9 @@ export default class JoinSco extends Component {
     errorResponse.errors.forEach((error) => {
       if (error.status === '409') {
         const message = this._showErrorMessageByShortCode(error.meta);
+        if ('USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION' === error.code) {
+          return this.errorMessage = message;
+        }
         this.displayModal = true;
         this.displayContinueButton = !ACCOUNT_WITH_SAMLID_ALREADY_EXISTS_ERRORS.includes(error.meta.shortCode);
         this.session.set('data.expectedUserId', error.meta.userId);

--- a/mon-pix/app/utils/errors-messages.js
+++ b/mon-pix/app/utils/errors-messages.js
@@ -29,6 +29,11 @@ const JOIN_ERRORS = [
     message: 'api-error-messages.join-error.r33',
     code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
   },
+  {
+    shortCode: 'R70',
+    message: 'api-error-messages.join-error.r70',
+    code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION',
+  },
 ];
 
 const REGISTER_ERRORS = [

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -456,6 +456,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
     });
 
     describe('Errors', function() {
+
       beforeEach(function() {
         component.firstName = 'pix';
         component.lastName = 'aile';
@@ -686,7 +687,37 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
             expect(component.displayContinueButton).to.be.true;
           });
         });
+
       });
+
+      describe('When another student is already reconciled on the same organization', async function() {
+
+        it('should return a conflict error and display the error message related to the short code R70)', async function() {
+
+          // given
+          const meta = { shortCode: 'R70' };
+          const expectedErrorMessage = this.intl.t('api-error-messages.join-error.r70');
+
+          const error = {
+            status: '409',
+            code: 'USER_ALREADY_RECONCILED_IN_THIS_ORGANIZATION',
+            title: 'Conflict',
+            detail: 'Une erreur est survenue. Déconnectez-vous et recommencez.',
+            meta,
+          };
+
+          onSubmitToReconcileStub.rejects({ errors: [error] });
+
+          // when
+          await component.actions.submit.call(component, eventStub);
+
+          // then
+          expect(component.errorMessage).to.equal(expectedErrorMessage);
+
+        });
+
+      });
+
     });
   });
 });

--- a/mon-pix/tests/unit/utils/errors-messages-test.js
+++ b/mon-pix/tests/unit/utils/errors-messages-test.js
@@ -8,7 +8,7 @@ import {
 
 describe('Unit | Utility | errors-messages', function() {
 
-  const JOIN_SHORT_CODES_ERRORS = [ 'R11', 'R12', 'R13', 'R31', 'R32', 'R33' ];
+  const JOIN_SHORT_CODES_ERRORS = [ 'R11', 'R12', 'R13', 'R31', 'R32', 'R33', 'R70' ];
   const REGISTER_SHORT_CODES_ERRORS = [ 'S51', 'S52', 'S53', 'S61', 'S62', 'S63' ];
 
   describe('#getJoinErrorsMessageByShortCode', () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -8,7 +8,8 @@
       "r13": "",
       "r31": "",
       "r32": "",
-      "r33": ""
+      "r33": "",
+      "r70": ""
     },
     "login-unauthorized-error": "There was an error in the email address or username/password entered.",
     "register-error": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -8,7 +8,8 @@
       "r13": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.",
       "r31": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R31)",
       "r32": "Vous possédez déjà un compte Pix utilisé avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R32)",
-      "r33": "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours."
+      "r33": "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.",
+      "r70": "Une erreur est survenue. Déconnectez-vous et recommencez."
     },
     "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
     "register-error": {


### PR DESCRIPTION
## :unicorn: Problème

462 erreurs de violations de "students_userid_organizationid_unique" durant le dernier mois.

[Lien Datadog](https://app.datadoghq.eu/logs?cols=host%2Cservice%2C%40request_id%2C%40http.referer%2C%40http.status_code&from_ts=1599996298734&index=main%2Cmain&live=true&messageDisplay=inline&query=students_userid_organizationid_unique&stream_sort=desc&to_ts=1602588298734)

Ceci est à cause d'une règle de gestion manquante, vérifier qu'il n'y a pas d'inscription d'un autre élève déjà réconcilié avec le même compte et dans la même organisation.

Scénario de reproduction:

Pré-requis:

Une organisation de type SCO avec is_managing_students = true et deux inscriptions non réconciliées.
Un utilisateur (hors GAR, ex: email) non réconcilié sur cette organisation.

Etapes:

1. Se connecter (hors GAR)
2. Accéder à la page de réconciliation ===>dupliquer l'onglet <===
3. Sur chaque onglet, entrer l'un des information d'inscriptions
4. Soumettre le premier onglet (inscription 1) => OK, l’utilisateur est réconcilié
5. Soumettre le deuxième onglet (inscription 2)=> KO, erreur 500 [Object, object]

## :robot: Solution
Rajouter un check pour vérifier si un autre élève a déjà été réconcilié dans la même organisation et avec le même compte utilisateur.

## :100: Pour tester

Se connecter avec l'utilisateur sco@example.net.
Saisir la campagne 'RESTRICTD'.
Accéder à la page de réconciliation en dupliquant l'onglet.
Se réconcilier avec les infos ( 'USER1' , 'USER1', 01-01-2001) et vérifier qu'on accède bien à la page de présentation.
Dans l'autre onglet : se réconcilier avec les infos ( 'USER1234' , 'USER1234', 01-01-2001) et vérifier qu'on a plus l'erreur 500 mais plutôt le message ''Une erreur est survenue. Déconnectez-vous et recommencez."

Après le test, relancer les seeds.
`scalingo --app pix-api-review-pr2005 --region osc-fr1 run "npm run db:seed"`
