### PR TITLE
[FEATURE] Ajouter une documentation pour les organisation SCO-AGRI (PIX-1335)

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -5,6 +5,10 @@ export default class SidebarMenu extends Component {
   @service currentUser;
 
   get documentationUrl() {
+    if (this.currentUser.isSCOManagingStudents && this.currentUser.isAgriculture) {
+      return 'https://view.genial.ly/5f85a0b87812e90d12b7b593';
+    }
+
     if (this.currentUser.isSCOManagingStudents) {
       return 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f';
     }

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -7,7 +7,7 @@ import Service from '@ember/service';
 module('Integration | Component | sidebar-menu', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it should display documentation a pro organization', async function(assert) {
+  test('it should display documentation for a pro organization', async function(assert) {
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, isPro: true });
     }
@@ -20,7 +20,7 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     assert.dom('a[href="https://cloud.pix.fr/s/cwZN2GAbqSPGnw4"]').exists();
   });
 
-  test('it should display documentation a sco organization', async function(assert) {
+  test('it should display documentation for a sco organization', async function(assert) {
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });
       isSCOManagingStudents = true;
@@ -32,6 +32,21 @@ module('Integration | Component | sidebar-menu', function(hooks) {
 
     // then
     assert.dom('a[href="https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f"]').exists();
+  });
+
+  test('it should display documentation for a sco agriculture organization', async function(assert) {
+    class CurrentUserStub extends Service {
+      organization = Object.create({ id: 1, type: 'SCO' });
+      isSCOManagingStudents = true;
+      isAgriculture = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('a[href="https://view.genial.ly/5f85a0b87812e90d12b7b593"]').exists();
   });
 
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
On a une documentation pour le SCO mais on va avoir une documentation pour le SCO AGRI (car nouveau système d'import).

## :robot: Solution
Ajouter un lien à la documentation quand une organisation est de type SCO et AGRI

## :rainbow: Remarques
Actuellement la mise en place des tags n'est pas encore effective, pour cela nous utilisons une variable d'environnement **AGRICULTURE_ORGANIZATION_ID** qui détermine si l'organisation est AGRI. 
Elle prend en valeur l'id de l'organisation, si la valeur est la même alors l'organisation est de "type" AGRI

## :100: Pour tester
Se rendre dans une organisation SCO et ajouter la variable d'env **AGRICULTURE_ORGANIZATION_ID** , lui assigné l'id de l'organisation. 
Cliquez sur Documentation, une documentation ayant pour titre "Documentation AGRI" s'ouvre.

