### PR TITLE
[TECH] Migration de `stats.pix.fr` à `analytics.pix.fr`

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -14,7 +14,7 @@ function _isFeatureEnabled(environmentVariable) {
 }
 
 module.exports = function(environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.SENDING_ANALYTICS_ENABLED);
+  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'pix-admin',
     environment,

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -96,7 +96,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_x4fRiAXl_dev_a6c96fc927042b6f6e773267.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
     }
   }
@@ -126,7 +126,7 @@ module.exports = function(environment) {
   if (environment === 'production') {
     // here you can enable a production-specific feature
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_x4fRiAXl.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }
   }
 

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -90,7 +90,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_cMIdKogu_dev_ace719fc09829675a21c66df.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
     }
   }
@@ -114,7 +114,7 @@ module.exports = function(environment) {
     // here you can enable a production-specific feature
     //ENV.APP.API_HOST = 'https://pix.fr/api';
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_cMIdKogu.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }
   }
 

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -17,7 +17,7 @@ function _isFeatureEnabled(environmentVariable) {
 const ACTIVE_FEATURE_TOGGLES = [];
 
 module.exports = function(environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.SENDING_ANALYTICS_ENABLED);
+  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'pix-certif',
     environment,

--- a/high-level-tests/e2e/cypress.json
+++ b/high-level-tests/e2e/cypress.json
@@ -6,7 +6,7 @@
     "CERTIF_URL": "http://localhost:4203"
   },
   "video": false,
-  "blockHosts": "*stats.pix.fr*",
+  "blockHosts": ["*stats.pix.fr*", "*analytics.pix.fr*"],
   "screenshotsFolder": "cypress/snapshots/actual",
   "trashAssetsBeforeRuns": true,
   "projectId": "g2rfqp",

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -15,7 +15,7 @@ function _isFeatureEnabled(environmentVariable) {
 
 /* eslint max-statements: off */
 module.exports = function(environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.SENDING_ANALYTICS_ENABLED);
+  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'mon-pix',
     environment: environment,

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -127,7 +127,7 @@ module.exports = function(environment) {
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
     ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_jKDD76j4_dev_179474167add1104d6c8a92b.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
     }
     ENV.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
@@ -160,7 +160,7 @@ module.exports = function(environment) {
   if (environment === 'production') {
     // here you can enable a production-specific feature
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_jKDD76j4.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }
   }
   return ENV;

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -14,7 +14,7 @@ function _isFeatureEnabled(environmentVariable) {
 }
 
 module.exports = function(environment) {
-  const analyticsEnabled = _isFeatureEnabled(process.env.SENDING_ANALYTICS_ENABLED);
+  const analyticsEnabled = _isFeatureEnabled(process.env.WEB_ANALYTICS_ENABLED);
   const ENV = {
     modulePrefix: 'pix-orga',
     environment,

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -86,7 +86,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_p3ppIohn_dev_22b0fda418abe8fedbf89e9c.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
     }
   }
@@ -119,7 +119,7 @@ module.exports = function(environment) {
   if (environment === 'production') {
     // here you can enable a production-specific feature
     if (analyticsEnabled) {
-      ENV.matomo.url = 'https://stats.pix.fr/js/container_p3ppIohn.js';
+      ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
     }
   }
 


### PR DESCRIPTION
## :unicorn: Problème

Suite à la généralisation de Pix dans le SCO depuis la rentrée 2020, nous avons rencontré des soucis pour la brique de gestion des Web Analytics (Matomo/OVH), qui nous ont poussé à revoir la façon de gérer et héberger cette brique logicielle. Nous l'avons ainsi migré depuis OVH vers Scalingo.

Au passage, nous en avons profité pour renommer l'URL pour être au plus proche des standards, de stats.pix.fr en analytics.pix.fr.

## :robot: Solution

L'objet de cette PR consiste à prendre en compte ce changement d'URL + conteneurs Matomo.

## :rainbow: Remarques

Cette PR contient les changements suivants : 
- renommage de la variable `SENDING_ANALYTICS_ENABLED` en `WEB_ANALYTICS_ENABLED` pour toutes les apps front Ember
- variabilisation des URL de conteneur Matomo TMS via la variable `WEB_ANALYTICS_URL` pour toutes les apps Ember
- ajout du sous-domaine `*analytics.pix.fr*` en tant que `blockHost` pour Cypress

Autres actions : 
- les variables `WEB_ANALYTICS_ENABLED` et `WEB_ANALYTICS_URL` ont été ajoutées en prévision sur les applications Scalingo idoines
- dans la mesure où stats.pix.fr et d'ores et déjà désactivé, la variable `SENDING_ANALYTICS_ENABLED` a déjà pu être retirée

## :100: Pour tester

S'assurer que les apps front démarrent et que les variables d'environnement sont bien prises en compte.

Atteion ! Comme il s'agit des applis Ember, i lfaut bien penser à re-déployer et pas seulement re-démarrer le conteneur.