### PR TITLE
[BUGFIX] Amélioration de la gestion du cache de premier niveau.

### DIFF
--- a/api/lib/infrastructure/caches/InMemoryCache.js
+++ b/api/lib/infrastructure/caches/InMemoryCache.js
@@ -6,23 +6,45 @@ class InMemoryCache extends Cache {
   constructor() {
     super();
     this._cache = new NodeCache({ useClones: false });
+    this._queue = Promise.resolve();
   }
 
   async get(key, generator) {
-    const value = this._cache.get(key);
-    if (value) return value;
-    return this.set(key, await generator());
+    return this._syncGet(key, () => this._chainPromise(() => {
+      return this._syncGet(key, () => this._generateAndSet(key, generator));
+    }));
   }
 
   async set(key, value) {
-    this._cache.set(key, value);
-    return value;
+    return this._chainPromise(() => {
+      this._cache.set(key, value);
+      return value;
+    });
   }
 
   async flushAll() {
-    return this._cache.flushAll();
+    return this._chainPromise(() => {
+      this._cache.flushAll();
+    });
   }
 
+  async _generateAndSet(key, generator) {
+    const generatedValue = await generator();
+    this._cache.set(key, generatedValue);
+    return generatedValue;
+  }
+
+  async _chainPromise(fn) {
+    const queuedPromise = this._queue.then(fn);
+    this._queue = queuedPromise.catch(() => {});
+    return queuedPromise;
+  }
+
+  _syncGet(key, generator) {
+    const value = this._cache.get(key);
+    if (value) return value;
+    return generator();
+  }
 }
 
 module.exports = InMemoryCache;

--- a/api/lib/infrastructure/caches/LayeredCache.js
+++ b/api/lib/infrastructure/caches/LayeredCache.js
@@ -15,8 +15,9 @@ class LayeredCache extends Cache {
   }
 
   async set(key, object) {
+    const cachedObject = await this._secondLevelCache.set(key, object);
     await this._firstLevelCache.flushAll();
-    return this._secondLevelCache.set(key, object);
+    return cachedObject;
   }
 
   async flushAll() {

--- a/api/tests/unit/infrastructure/caches/InMemoryCache_test.js
+++ b/api/tests/unit/infrastructure/caches/InMemoryCache_test.js
@@ -4,24 +4,18 @@ const InMemoryCache = require('../../../../lib/infrastructure/caches/InMemoryCac
 
 describe('Unit | Infrastructure | Cache | in-memory-cache', () => {
 
-  let cache;
   let inMemoryCache;
 
   const CACHE_KEY = 'cache_key';
   const NODE_CACHE_ERROR = new Error('A Node cache error');
 
   beforeEach(() => {
-    cache = {};
     inMemoryCache = new InMemoryCache();
-    inMemoryCache._cache = cache;
   });
 
   describe('#constructor', () => {
 
     it('should create a NodeCache instance', () => {
-      // when
-      const inMemoryCache = new InMemoryCache();
-
       // then
       expect(inMemoryCache._cache).to.be.an.instanceOf(NodeCache);
     });
@@ -29,47 +23,67 @@ describe('Unit | Infrastructure | Cache | in-memory-cache', () => {
 
   describe('#get', () => {
 
-    beforeEach(() => {
-      cache.get = sinon.stub();
-      cache.set = sinon.stub();
-    });
-
-    it('should resolve with the previously cached value when it exists', () => {
+    it('should resolve with the previously cached value when it exists', async () => {
       // given
       const cachedObject = { foo: 'bar' };
-      cache.get.returns(cachedObject);
+      inMemoryCache._cache.set(CACHE_KEY, cachedObject);
 
       // when
-      const promise = inMemoryCache.get(CACHE_KEY);
+      const result = await inMemoryCache.get(CACHE_KEY);
 
       // then
-      return expect(promise).to.have.been.fulfilled
-        .then((result) => {
-          expect(result).to.deep.equal(cachedObject);
-          expect(cache.get).to.have.been.calledWith(CACHE_KEY);
-        });
+      expect(result).to.deep.equal(cachedObject);
     });
 
-    it('should call generator when no object was previously cached for given key', () => {
-      // given
-      const noCachedObject = null;
-      cache.get.returns(noCachedObject);
-      cache.set.returns(true);
-
+    it('should call generator when no object was previously cached for given key', async () => {
       // when
       const generatorStub = sinon.stub().resolves('hello');
+      const result = await inMemoryCache.get(CACHE_KEY, generatorStub);
+
+      // then
+      expect(result).to.equal('hello');
+    });
+
+    it('should reject when generator fails', () => {
+      // given
+      const generatorError = new Error('Generator failed');
+      const generatorStub = sinon.stub().rejects(generatorError);
+
+      // when
       const promise = inMemoryCache.get(CACHE_KEY, generatorStub);
 
       // then
-      return expect(promise).to.have.been.fulfilled
-        .then((result) => {
-          expect(result).to.equal('hello');
-        });
+      return expect(promise).to.have.been.rejectedWith(generatorError);
+    });
+
+    it('should not call generator again if same key is requested while generator is in progress', async () => {
+      // when
+      const generatorStub = sinon.stub().resolves('hello');
+      const generatorStub2 = sinon.stub().resolves('hello');
+      const promise = inMemoryCache.get(CACHE_KEY, generatorStub);
+      const promise2 = inMemoryCache.get(CACHE_KEY, generatorStub2);
+
+      // then
+      await Promise.all([promise, promise2]);
+      expect(generatorStub2).to.not.have.been.called;
+    });
+
+    it('should not throw further get if one generator fails', async () => {
+      // when
+      const generatorError = new Error('Generator failed');
+      const failingGenerator = sinon.stub().rejects(generatorError);
+      const successfulGenerator = sinon.stub().resolves('hello');
+      const promise = inMemoryCache.get(CACHE_KEY, failingGenerator);
+      const promise2 = inMemoryCache.get(CACHE_KEY, successfulGenerator);
+
+      // then
+      await expect(promise).to.have.been.rejectedWith(generatorError);
+      expect(await promise2).to.equal('hello');
     });
 
     it('should reject when the Node cache throws an error', () => {
       // given
-      cache.get.throws(NODE_CACHE_ERROR);
+      inMemoryCache._cache.get = () => { throw NODE_CACHE_ERROR; };
 
       // when
       const promise = inMemoryCache.get(CACHE_KEY);
@@ -83,29 +97,18 @@ describe('Unit | Infrastructure | Cache | in-memory-cache', () => {
 
     const objectToCache = { foo: 'bar' };
 
-    beforeEach(() => {
-      cache.set = sinon.stub();
-    });
-
-    it('should resolve with the object to cache', () => {
-      // given
-      const SUCCESS = true;
-      cache.set.returns(SUCCESS);
-
+    it('should resolve with the object to cache', async () => {
       // when
-      const promise = inMemoryCache.set(CACHE_KEY, objectToCache);
+      const result = await inMemoryCache.set(CACHE_KEY, objectToCache);
 
       // then
-      return expect(promise).to.have.been.fulfilled
-        .then((result) => {
-          expect(result).to.deep.equal(objectToCache);
-          expect(cache.set).to.have.been.calledWith(CACHE_KEY, objectToCache);
-        });
+      expect(result).to.deep.equal(objectToCache);
+      expect(inMemoryCache._cache.get(CACHE_KEY)).to.equal(objectToCache);
     });
 
     it('should reject when the Node cache throws an error', () => {
       // given
-      cache.set.throws(NODE_CACHE_ERROR);
+      inMemoryCache._cache.set = () => { throw NODE_CACHE_ERROR; };
 
       // when
       const promise = inMemoryCache.set(CACHE_KEY, objectToCache);
@@ -117,19 +120,15 @@ describe('Unit | Infrastructure | Cache | in-memory-cache', () => {
 
   describe('#flushAll', () => {
 
-    beforeEach(() => {
-      cache.flushAll = sinon.stub();
-    });
+    it('should resolve', async () => {
+      // given
+      await inMemoryCache.set('foo', 'bar');
 
-    it('should resolve', () => {
       // when
-      const promise = inMemoryCache.flushAll();
+      await inMemoryCache.flushAll();
 
       // then
-      return expect(promise).to.have.been.fulfilled
-        .then(() => {
-          expect(cache.flushAll).to.have.been.called;
-        });
+      expect(inMemoryCache._cache.getStats().keys).to.equal(0);
     });
   });
 

--- a/api/tests/unit/infrastructure/caches/LayeredCache_test.js
+++ b/api/tests/unit/infrastructure/caches/LayeredCache_test.js
@@ -52,6 +52,7 @@ describe('Unit | Infrastructure | Caches | LayeredCache', () => {
       // then
       expect(layeredCacheInstance._firstLevelCache.flushAll).to.have.been.calledOnce;
       expect(result).to.deep.equal(objectToCache);
+      expect(layeredCacheInstance._secondLevelCache.set).to.have.been.calledBefore(layeredCacheInstance._firstLevelCache.flushAll);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un rechargement du cache du référentiel de contenu, on constate deux soucis.
- Les instructions d'invalidation du cache mémoire (`flushAll`) interviennent **avant** le rafraichissement de la clé dans Redis : certains conteneurs rafraichissent donc leur cache avec l'ancienne valeur de la clé.
- En l'absence de mécanisme de verrou, un même conteneur effectue plusieurs fois de suite le même appel à Redis, surchargeant temporairement la mémoire de Redis.

![image (1)](https://user-images.githubusercontent.com/2989532/96002063-fff2ed00-0e38-11eb-9e7d-01197fc4a45d.png)


## :robot: Solution
Intervertir l'invalidation du cache et le rafraichissement de la clé.
Mettre en place un verrou dans `InMemoryCache` pour ne pas faire plusieurs fois l'appel à Redis.

## :rainbow: Remarques
La solution de verrou implémentée ne tient pas compte de la clé demandée. Ainsi, une seule clé à la fois est chargée depuis Redis.
Les temps de chargement étaient minimes, cela ne posera pas de problème.

## :100: Pour tester
Lancer un rafraîchissement du cache et vérifier que chaque container ne fait pas plusieurs fois le même appel à Redis.
