### PR TITLE
[BUGFIX] Envoyer l'assessmentId lorsqu'on modifie une certification (PIX-1421)

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -48,6 +48,12 @@ class AlreadyRatedAssessmentError extends DomainError {
   }
 }
 
+class AssessmentResultNotCreatedError extends DomainError {
+  constructor(message = 'L\'assessment result n\'a pas pu être généré.') {
+    super(message);
+  }
+}
+
 class AlreadyRegisteredEmailError extends DomainError {
   constructor(message = 'Cet email est déjà utilisé.') {
     super(message);
@@ -430,6 +436,12 @@ class MissingOrInvalidCredentialsError extends DomainError {
   }
 }
 
+class MissingAssessmentId extends DomainError {
+  constructor(message = 'AssessmentId manquant ou incorrect') {
+    super(message);
+  }
+}
+
 class AssessmentNotCompletedError extends DomainError {
   constructor(message = 'Cette évaluation n\'est pas terminée.') {
     super(message);
@@ -626,6 +638,7 @@ module.exports = {
   NoCampaignParticipationForUserAndCampaign,
   AssessmentEndedError,
   AssessmentNotCompletedError,
+  AssessmentResultNotCreatedError,
   CampaignAlreadyArchivedError,
   CampaignCodeError,
   CertificateVerificationCodeGenerationTooManyTrials,
@@ -660,6 +673,7 @@ module.exports = {
   MembershipCreationError,
   MembershipUpdateError,
   MissingOrInvalidCredentialsError,
+  MissingAssessmentId,
   NotEligibleCandidateError,
   NotFoundError,
   ObjectValidationError,

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -1,5 +1,6 @@
 const CertificationResult = require('../models/CertificationResult');
 const Assessment = require('../models/Assessment');
+const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const certificationAssessmentRepository = require('../../../lib/infrastructure/repositories/certification-assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
 const certificationCourseRepository = require('../../infrastructure/repositories/certification-course-repository');
@@ -20,13 +21,14 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
   const certificationCourseId = certificationCourse.id;
   const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
   let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
+  const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
   if (!lastAssessmentResultFull) {
     lastAssessmentResultFull = { competenceMarks: [], status: Assessment.states.STARTED };
   }
 
   return new CertificationResult({
     id: certificationCourse.id,
-    assessmentId: lastAssessmentResultFull.assessmentId,
+    assessmentId,
     firstName: certificationCourse.firstName,
     lastName: certificationCourse.lastName,
     birthdate: certificationCourse.birthdate,

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -81,7 +81,7 @@ module.exports = {
 
   getIdByCertificationCourseId(certificationCourseId) {
     return BookshelfAssessment
-      .where({ certificationCourseId, type: 'CERTIFICATION' })
+      .where({ certificationCourseId, type: Assessment.types.CERTIFICATION })
       .fetch({ columns: 'id' })
       .then((result) => result ? result.attributes.id : null);
   },

--- a/api/tests/integration/domain/services/certification-service_test.js
+++ b/api/tests/integration/domain/services/certification-service_test.js
@@ -2,6 +2,7 @@ const { expect, databaseBuilder } = require('../../../test-helper');
 const { getCertificationResult } = require('../../../../lib/domain/services/certification-service');
 const { statuses } = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
+const Assessment = require('../../../../lib/domain/models/Assessment');
 const Badge = require('../../../../lib/domain/models/Badge');
 
 describe('Integration | Service | certification-service', () => {
@@ -14,23 +15,45 @@ describe('Integration | Service | certification-service', () => {
 
     beforeEach(async () => {
       certificationCourse = databaseBuilder.factory.buildCertificationCourse();
-      assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });
+      assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id, type: Assessment.types.CERTIFICATION });
       badge = databaseBuilder.factory.buildBadge({ key: Badge.keys.PIX_EMPLOI_CLEA });
       databaseBuilder.factory.buildPartnerCertification({ certificationCourseId: certificationCourse.id, partnerKey: badge.key, acquired: hasAcquiredClea });
-      databaseBuilder.factory.buildAssessmentResult({ assessmentId: assessment.id, createdAt: date });
 
       await databaseBuilder.commit();
     });
 
-    it('should return certification result', async () => {
-      // when
-      const result = await getCertificationResult(certificationCourse.id);
+    describe('when the certif status is not started', () => {
 
-      // then
-      expect(result).to.be.instanceOf(CertificationResult);
-      expect(result.isPublished).to.equal(certificationCourse.isPublished);
-      expect(result.resultCreatedAt).to.deep.equal(date);
-      expect(result.cleaCertificationStatus).to.equal(statuses.ACQUIRED);
+      beforeEach(async () => {
+        databaseBuilder.factory.buildAssessmentResult({ assessmentId: assessment.id, createdAt: date });
+        await databaseBuilder.commit();
+      });
+
+      it('should return certification result', async () => {
+        // when
+        const result = await getCertificationResult(certificationCourse.id);
+
+        // then
+        expect(result).to.be.instanceOf(CertificationResult);
+        expect(result.assessmentId).to.equal(assessment.id);
+        expect(result.isPublished).to.equal(certificationCourse.isPublished);
+        expect(result.resultCreatedAt).to.deep.equal(date);
+        expect(result.cleaCertificationStatus).to.equal(statuses.ACQUIRED);
+      });
+    });
+
+    describe('when the certif status is started', () => {
+
+      it('should return certification result with correct assessmentId', async () => {
+        // when
+        const result = await getCertificationResult(certificationCourse.id);
+
+        // then
+        expect(result).to.be.instanceOf(CertificationResult);
+        expect(result.assessmentId).to.equal(assessment.id);
+        expect(result.isPublished).to.equal(certificationCourse.isPublished);
+        expect(result.cleaCertificationStatus).to.equal(statuses.ACQUIRED);
+      });
     });
   });
 });

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -5,6 +5,7 @@ const AssessmentResult = require('../../../../../lib/domain/models/AssessmentRes
 const CompetenceMarks = require('../../../../../lib/domain/models/CompetenceMark');
 const CertificationCourse = require('../../../../../lib/domain/models/CertificationCourse');
 
+const assessmentRepository = require('../../../../../lib/infrastructure/repositories/assessment-repository');
 const assessmentResultRepository = require('../../../../../lib/infrastructure/repositories/assessment-result-repository');
 const certificationAssessmentRepository = require('../../../../../lib/infrastructure/repositories/certification-assessment-repository');
 const certificationCourseRepository = require('../../../../../lib/infrastructure/repositories/certification-course-repository');
@@ -62,6 +63,8 @@ describe('Unit | Service | Certification Service', function() {
 
     beforeEach(() => {
       sinon.stub(cleaCertificationStatusRepository, 'getCleaCertificationStatus').resolves(cleaCertificationStatus);
+      sinon.stub(assessmentRepository, 'getIdByCertificationCourseId')
+        .withArgs(certificationCourseId).resolves(assessmentId);
     });
 
     context('when certification is finished', () => {

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -17,9 +17,9 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
   const cleaCertifications = [ 'acquired', 'rejected', 'not_passed'];
   const assessmentsIds = [ 1, 2, 3 ];
 
-  const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi' });
-  const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', commentForCandidate: 'Son ordinateur a explosé' });
-  const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi' });
+  const assessmentResult1 = domainBuilder.buildAssessmentResult({ pixScore: 500, competenceMarks: [], createdAt: 'lundi', assessmentId: assessmentsIds[0] });
+  const assessmentResult2 = domainBuilder.buildAssessmentResult({ pixScore: 10, competenceMarks: [], createdAt: 'mardi', assessmentId: assessmentsIds[1], commentForCandidate: 'Son ordinateur a explosé' });
+  const assessmentResult3 = domainBuilder.buildAssessmentResult({ pixScore: 400, competenceMarks: [], createdAt: 'mercredi', assessmentId: assessmentsIds[2] });
 
   const firstCertifResult = _buildCertificationResult(certifCourse1, assessmentResult1, cleaCertifications[0]);
   const secondCertifResult = _buildCertificationResult(certifCourse2, assessmentResult2, cleaCertifications[1]);


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix Admin lorsqu'on modifie une certification au status started et qu'on enregistre cela n'enregistre pas les changements.

En effet, lorsqu'on modifie une certification un nouveau assessmentResult est créé.
Ici on ne passait pas à la requête l'assessmentId, ce qui avait pour conséquence de créer un assessmentResult sans assessmentId et on ne pouvait pas observer les changements sur PixAdmin.
Cela était du au fait que lorsqu'on récupérait les résultats d'une certification on n'obtenait pas l'assessmentId associé (car la certif étant restée au status "started").

## :robot: Solution
Aller chercher l'assessmentId à partir du certifCourseId lorsque la certif est restée en "started" (cad quand la certification n'a pas d'assessemnt-result encore).

Le premier commit permet au front de récupérer une erreur plus parlante dans le front en cas de soucis : 
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/38167520/96134201-7f48f500-0efb-11eb-9fd3-7c459e413e8a.png">

Le deuxième commit répare le bug.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur mon-pix : 
- lancer un test de certif avec n'importe qui et ne répondre à aucune question (2, anne, success, 01/01/2000, ANNE02)
- noter son numéro de certif
Sur admin : 
- aller dans l'onglet certification et mettre l'id de certif noté précédemment
- constater que l'état de la certif est en "started" dans les infos
- aller dans l'onglet "Détail"
- scroller en bas + cliquer sur "enregistrer"
- scroller en haut, modifier le status de "started" à "validated"
- scroller en bas + cliquer sur "enregistre"
- rafraîchir la page et constater que le status de la certif est bien changé (validated)