### PR TITLE
[FEATURE] Logguer en console les résultats mockés d'un participant à une campagne d'évaluation Pôle Emploi (PIX-1393).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -77,7 +77,7 @@ module.exports = {
 
     await DomainTransaction.execute(async (domainTransaction) => {
       const event = await usecases.completeAssessment({ domainTransaction, assessmentId });
-      await events.eventDispatcher.dispatch(domainTransaction, event);
+      await events.eventDispatcher.dispatch(event, domainTransaction);
     });
 
     return null;

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -1,4 +1,5 @@
 const usecases = require('../../domain/usecases');
+const events = require('../../domain/events');
 
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const serializer = require('../../infrastructure/serializers/jsonapi/campaign-participation-serializer');
@@ -36,15 +37,16 @@ module.exports = {
     return serializer.serialize(campaignParticipations);
   },
 
-  shareCampaignResult(request) {
+  async shareCampaignResult(request) {
     const userId = request.auth.credentials.userId;
     const campaignParticipationId = parseInt(request.params.id);
 
-    return usecases.shareCampaignResult({
+    const event = await usecases.shareCampaignResult({
       userId,
       campaignParticipationId,
-    })
-      .then(() => null);
+    });
+    await events.eventDispatcher.dispatch(event);
+    return null;
   },
 
   async beginImprovement(request) {

--- a/api/lib/domain/events/CampaignParticipationResultsShared.js
+++ b/api/lib/domain/events/CampaignParticipationResultsShared.js
@@ -1,0 +1,11 @@
+class CampaignParticipationResultsShared {
+  constructor({ campaignId, isAssessment, campaignParticipationId, userId, organizationId } = {}) {
+    this.campaignId = campaignId;
+    this.isAssessment = isAssessment;
+    this.campaignParticipationId = campaignParticipationId;
+    this.userId = userId;
+    this.organizationId = organizationId;
+  }
+}
+
+module.exports = CampaignParticipationResultsShared;

--- a/api/lib/domain/events/handle-campaign-participation-results-sending.js
+++ b/api/lib/domain/events/handle-campaign-participation-results-sending.js
@@ -1,0 +1,19 @@
+const { checkEventType } = require('./check-event-type');
+const CampaignParticipationResultsShared = require('./CampaignParticipationResultsShared');
+
+const eventType = CampaignParticipationResultsShared;
+
+async function handleCampaignParticipationResultsSending({
+  event,
+  organizationRepository,
+}) {
+  checkEventType(event, eventType);
+
+  const organization = await organizationRepository.get(event.organizationId);
+  if (event.isAssessment && organization.isPoleEmploi) {
+    console.log('resultats mockés');
+  }
+}
+
+handleCampaignParticipationResultsSending.eventType = eventType;
+module.exports = handleCampaignParticipationResultsSending;

--- a/api/lib/domain/events/handle-campaign-participation-results-sending.js
+++ b/api/lib/domain/events/handle-campaign-participation-results-sending.js
@@ -11,7 +11,50 @@ async function handleCampaignParticipationResultsSending({
 
   const organization = await organizationRepository.get(event.organizationId);
   if (event.isAssessment && organization.isPoleEmploi) {
-    console.log('resultats mockés');
+
+    const resultsToSend = {
+      resultatIndividu: {
+        campagne: {
+          nom: 'Campagne Pôle Emploi',
+          dateDebut: new Date('2020-01-01'),
+          dateFin: new Date('2020-02-01'),
+          typeCampagne: 'EVALUATION',
+          idCampagne: 11223344,
+          codeCampagne: 'CODEPE123',
+          URLCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+          nomOrganisme: 'Pix',
+          typeOrganisme: 'externe',
+        },
+        individu: {
+          nom: 'Bonneau',
+          prenom: 'Jean',
+        },
+        test: {
+          etat: 4,
+          progression: 100,
+          typeTest: 'DI',
+          referenceExterne: 55667788,
+          dateDebut: new Date('2020-01-02'),
+          dateModification: new Date('2020-01-03'),
+          dateValidation: new Date('2020-01-03'),
+          evaluationCible: 42.5,
+          uniteValidation: 'A',
+          elementsEvalues: [{
+            libelle: 'Gérer des données',
+            categorie: 'compétence',
+            type: 'compétence Pix',
+            domaineRattachement: 'Information et données',
+            nbSousElements: 3,
+            evaluation: {
+              scoreObtenu: 14.2,
+              uniteScore: 'A',
+              nbSousElementValide: 2,
+            },
+          }],
+        },
+      },
+    };
+    console.log(JSON.stringify(resultsToSend));
   }
 }
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -4,15 +4,16 @@ const _ = require('lodash');
 
 const dependencies = {
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
-  certificationAssessmentRepository: require('../../infrastructure/repositories/certification-assessment-repository'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   badgeCriteriaService: require('../services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
   campaignParticipationResultRepository: require('../../infrastructure/repositories/campaign-participation-result-repository'),
+  certificationAssessmentRepository: require('../../infrastructure/repositories/certification-assessment-repository'),
   certificationCourseRepository: require('../../infrastructure/repositories/certification-course-repository'),
   competenceMarkRepository: require('../../infrastructure/repositories/competence-mark-repository'),
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
+  organizationRepository: require('../../infrastructure/repositories/organization-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
 };
@@ -25,6 +26,7 @@ dependencies.partnerCertificationRepository = partnerCertificationRepository;
 
 const handlersToBeInjected = {
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
+  handleCampaignParticipationResultsSending: require('./handle-campaign-participation-results-sending'),
   handleCertificationScoring: require('./handle-certification-scoring'),
   handlePartnerCertifications: require('./handle-partner-certification'),
 };

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -1,4 +1,5 @@
 const { UserNotAuthorizedToAccessEntity, AssessmentNotCompletedError, CampaignAlreadyArchivedError } = require('../errors');
+const CampaignParticipationResultsShared = require('../events/CampaignParticipationResultsShared');
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
 
@@ -45,5 +46,13 @@ module.exports = async function shareCampaignResult({
     }
   }
 
-  return campaignParticipationRepository.share(campaignParticipation);
+  await campaignParticipationRepository.share(campaignParticipation);
+
+  return new CampaignParticipationResultsShared({
+    campaignId: campaign.id,
+    isAssessment: campaign.isAssessment(),
+    campaignParticipationId: campaignParticipation.id,
+    userId,
+    organizationId: campaign.organizationId,
+  });
 };

--- a/api/lib/infrastructure/events/EventDispatcher.js
+++ b/api/lib/infrastructure/events/EventDispatcher.js
@@ -17,12 +17,12 @@ class EventDispatcher {
     }
   }
 
-  async dispatch(domainTransaction, dispatchedEvent) {
+  async dispatch(dispatchedEvent, domainTransaction) {
     const subscriptions = this._subscriptions.filter(({ event }) => dispatchedEvent instanceof event);
 
     for (const { eventHandler } of subscriptions) {
       const returnedEvent = await eventHandler({ domainTransaction, event: dispatchedEvent });
-      await this.dispatch(domainTransaction, returnedEvent);
+      await this.dispatch(returnedEvent, domainTransaction);
     }
   }
 }

--- a/api/tests/integration/infrastructure/event-dispatcher_test.js
+++ b/api/tests/integration/infrastructure/event-dispatcher_test.js
@@ -24,7 +24,7 @@ describe('Integration | Infrastructure | EventHandler', () => {
     eventDispatcher.subscribe(TestEvent, eventHandler);
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
@@ -51,7 +51,7 @@ describe('Integration | Infrastructure | EventHandler', () => {
     eventDispatcher.subscribe(TestEvent, eventHandler_2);
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(eventHandler_1).to.have.been.calledWith({ domainTransaction, event });
@@ -66,8 +66,8 @@ describe('Integration | Infrastructure | EventHandler', () => {
     eventDispatcher.subscribe(TestEvent, eventHandler);
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
-    await eventDispatcher.dispatch(domainTransaction, otherEvent);
+    await eventDispatcher.dispatch(event, domainTransaction);
+    await eventDispatcher.dispatch(otherEvent, domainTransaction);
 
     // then
     expect(eventHandler).to.have.been.calledWith({ domainTransaction, event });
@@ -83,7 +83,7 @@ describe('Integration | Infrastructure | EventHandler', () => {
     eventDispatcher.subscribe(AnotherTestEvent, eventHandler);
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(eventHandler).to.have.been.calledWith({ domainTransaction, event:returnedEvent });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -169,7 +169,7 @@ describe('Unit | Controller | assessment-controller', function() {
       await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(domainTransaction, assessmentCompletedEvent);
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent, domainTransaction);
     });
   });
 });

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -3,8 +3,10 @@ const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 const campaignParticipationController = require('../../../../lib/application/campaignParticipations/campaign-participation-controller');
 const serializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
+const events = require('../../../../lib/domain/events');
 const usecases = require('../../../../lib/domain/usecases');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
+const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 
 describe('Unit | Application | Controller | Campaign-Participation', () => {
 
@@ -86,6 +88,19 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
       const updateCampaignParticiaption = usecases.shareCampaignResult.firstCall.args[0];
       expect(updateCampaignParticiaption).to.have.property('campaignParticipationId');
       expect(updateCampaignParticiaption).to.have.property('userId');
+    });
+
+    it('should dispatch the campaign participation results shared event', async () => {
+      // given
+      const campaignParticipationResultsSharedEvent = new CampaignParticipationResultsShared();
+      usecases.shareCampaignResult.resolves(campaignParticipationResultsSharedEvent);
+      sinon.stub(events.eventDispatcher, 'dispatch');
+
+      // when
+      await campaignParticipationController.shareCampaignResult(request, hFake);
+
+      // then
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(campaignParticipationResultsSharedEvent);
     });
 
     context('when the request comes from a different user', () => {

--- a/api/tests/unit/domain/events/event-choregraphy-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-badge-acquisition_test.js
@@ -10,7 +10,7 @@ describe('Event Choregraphy | Badge Acquisition', function() {
     const domainTransaction = Symbol('a transaction');
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(handlerStubs.handleBadgeAcquisition).to.have.been.calledWith({ domainTransaction, event });

--- a/api/tests/unit/domain/events/event-choregraphy-campaign-participation-results-sending_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-campaign-participation-results-sending_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
+
+describe('Event Choregraphy | Campaign Participation Results Sending', function() {
+  it('Should trigger Campaign Participation Results Sending handler on CampaignParticipationResultsShared event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new CampaignParticipationResultsShared();
+    const domainTransaction = Symbol('a transaction');
+
+    // when
+    await eventDispatcher.dispatch(domainTransaction, event);
+
+    // then
+    expect(handlerStubs.handleCampaignParticipationResultsSending).to.have.been.calledWith({ event, domainTransaction });
+  });
+});

--- a/api/tests/unit/domain/events/event-choregraphy-campaign-participation-results-sending_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-campaign-participation-results-sending_test.js
@@ -10,7 +10,7 @@ describe('Event Choregraphy | Campaign Participation Results Sending', function(
     const domainTransaction = Symbol('a transaction');
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(handlerStubs.handleCampaignParticipationResultsSending).to.have.been.calledWith({ event, domainTransaction });

--- a/api/tests/unit/domain/events/event-choregraphy-score-certification_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-score-certification_test.js
@@ -10,7 +10,7 @@ describe('Event Choregraphy | Score Certification', function() {
     const domainTransaction = Symbol('a transaction');
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, event);
+    await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
     expect(handlerStubs.handleCertificationScoring).to.have.been.calledWith({ domainTransaction, event });

--- a/api/tests/unit/domain/events/event-choregraphy-score-partner-certification_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-score-partner-certification_test.js
@@ -18,7 +18,7 @@ describe('Event Choregraphy | Score Partner Certification', function() {
     );
 
     // when
-    await eventDispatcher.dispatch(domainTransaction, assessmentCompleted);
+    await eventDispatcher.dispatch(assessmentCompleted, domainTransaction);
 
     // then
     expect(handlerStubs.handlePartnerCertifications).to.have.been.calledWith({ domainTransaction, event:certificationScoringCompleted });

--- a/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
+++ b/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
@@ -1,0 +1,106 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const { handleCampaignParticipationResultsSending } = require('../../../../lib/domain/events')._forTestOnly.handlers;
+
+describe('Unit | Domain | Events | handle-campaign-participation-results-sending', () => {
+  let event;
+
+  const dependencies = {
+    organizationRepository,
+  };
+
+  it('fails when event is not of correct type', async () => {
+    // given
+    const event = 'not an event of the correct type';
+    // when / then
+    const error = await catchErr(handleCampaignParticipationResultsSending)(
+      { event, ...dependencies },
+    );
+
+    // then
+    expect(error).not.to.be.null;
+  });
+
+  context('#handleCampaignParticipationResultsSending', () => {
+    const campaignParticipationId = Symbol('campaignParticipationId');
+    const campaignId = Symbol('campaignId');
+    const userId = Symbol('userId');
+    const organizationId = Symbol('organizationId');
+
+    context('when campaign is of type ASSESSMENT and organization is Pole Emploi', () => {
+      beforeEach(() => {
+        event = new CampaignParticipationResultsShared({
+          campaignId,
+          isAssessment: true,
+          campaignParticipationId,
+          userId,
+          organizationId,
+        });
+
+        sinon.stub(organizationRepository, 'get').withArgs(organizationId).resolves({ isPoleEmploi: true });
+        sinon.stub(console, 'log').resolves();
+      });
+
+      it('it should console.log results', async () => {
+        // when
+        await handleCampaignParticipationResultsSending({
+          event, ...dependencies,
+        });
+
+        // then
+        expect(console.log).to.have.been.calledWithMatch('resultats mockés');
+      });
+    });
+
+    context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {
+      beforeEach(() => {
+        event = new CampaignParticipationResultsShared({
+          campaignId,
+          isAssessment: true,
+          campaignParticipationId,
+          userId,
+          organizationId,
+        });
+
+        sinon.stub(organizationRepository, 'get').withArgs(organizationId).resolves({ isPoleEmploi: false });
+        sinon.stub(console, 'log').resolves();
+      });
+
+      it('it should console.log results', async () => {
+        // when
+        await handleCampaignParticipationResultsSending({
+          event, ...dependencies,
+        });
+
+        // then
+        sinon.assert.notCalled(console.log);
+      });
+    });
+
+    context('when organization is Pole Emploi but campaign is of type PROFILES_COLLECTION', () => {
+      beforeEach(() => {
+        event = new CampaignParticipationResultsShared({
+          campaignId,
+          isAssessment: false,
+          campaignParticipationId,
+          userId,
+          organizationId,
+        });
+
+        sinon.stub(organizationRepository, 'get').withArgs(organizationId).resolves({ isPoleEmploi: true });
+        sinon.stub(console, 'log').resolves();
+      });
+
+      it('it should console.log results', async () => {
+        // when
+        await handleCampaignParticipationResultsSending({
+          event, ...dependencies,
+        });
+
+        // then
+        sinon.assert.notCalled(console.log);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
+++ b/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
@@ -10,6 +10,49 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
     organizationRepository,
   };
 
+  const expectedResults = '{' +
+    '"resultatIndividu":{' +
+      '"campagne":{' +
+        '"nom":"Campagne Pôle Emploi",' +
+        '"dateDebut":"2020-01-01T00:00:00.000Z",' +
+        '"dateFin":"2020-02-01T00:00:00.000Z",' +
+        '"typeCampagne":"EVALUATION",' +
+        '"idCampagne":11223344,' +
+        '"codeCampagne":"CODEPE123",' +
+        '"URLCampagne":"https://app.pix.fr/campagnes/CODEPE123",' +
+        '"nomOrganisme":"Pix",' +
+        '"typeOrganisme":"externe"' +
+      '},' +
+      '"individu":{' +
+        '"nom":"Bonneau",' +
+        '"prenom":"Jean"' +
+      '},' +
+      '"test":{' +
+        '"etat":4,' +
+        '"progression":100,' +
+        '"typeTest":"DI",' +
+        '"referenceExterne":55667788,' +
+        '"dateDebut":"2020-01-02T00:00:00.000Z",' +
+        '"dateModification":"2020-01-03T00:00:00.000Z",' +
+        '"dateValidation":"2020-01-03T00:00:00.000Z",' +
+        '"evaluationCible":42.5,' +
+        '"uniteValidation":"A",' +
+        '"elementsEvalues":[{' +
+          '"libelle":"Gérer des données",' +
+          '"categorie":"compétence",' +
+          '"type":"compétence Pix",' +
+          '"domaineRattachement":"Information et données",' +
+          '"nbSousElements":3,' +
+          '"evaluation":{' +
+            '"scoreObtenu":14.2,' +
+            '"uniteScore":"A",' +
+            '"nbSousElementValide":2' +
+          '}' +
+        '}]' +
+      '}' +
+    '}' +
+  '}';
+
   it('fails when event is not of correct type', async () => {
     // given
     const event = 'not an event of the correct type';
@@ -49,7 +92,9 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
         });
 
         // then
-        expect(console.log).to.have.been.calledWithMatch('resultats mockés');
+        expect(console.log).to.have.been.calledOnce;
+        const results = console.log.firstCall.args[0];
+        expect(results).to.deep.equal(expectedResults);
       });
     });
 
@@ -67,7 +112,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
         sinon.stub(console, 'log').resolves();
       });
 
-      it('it should console.log results', async () => {
+      it('it should not console.log results', async () => {
         // when
         await handleCampaignParticipationResultsSending({
           event, ...dependencies,
@@ -92,7 +137,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
         sinon.stub(console, 'log').resolves();
       });
 
-      it('it should console.log results', async () => {
+      it('it should not console.log results', async () => {
         // when
         await handleCampaignParticipationResultsSending({
           event, ...dependencies,


### PR DESCRIPTION
## :unicorn: Problème
En temps que Partenaire de Pôle Emploi, Pix doit pouvoir envoyer les résultats d'un participant à une campagne d'évaluation Pôle Emploi. Pour l'instant les environnement de test de Pôle Emploi ne sont pas prêts, mais ils souhaitent quand même pouvoir tester l'intégration de nos 2 Systèmes d'Information.

## :robot: Solution
Logguer en console des résultats (mockés dans un premier temps) lié à une campagne d'une organisation Pôle Emploi (identifée pour l'instant par une variable d'environnement `POLE_EMPLOI_ORGANIZATION_ID`), et ainsi pouvoir récupérer les résultats et les envoyer par mail manuellement.

## :rainbow: Remarques
NA

## :100: Pour tester
Participer à la campagne `QWERTY789`, partager ses résultats, et récupérer en console sur Scalingo les résultats mockés.
