### PR TITLE
[FEATURE] Ne pas afficher les paliers quand on a obtenu le badge CléA (PIX-1383).

### DIFF
--- a/mon-pix/app/controllers/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/assessment/skill-review.js
@@ -12,6 +12,15 @@ export default class SkillReviewController extends Controller {
     return !!cleaBadge;
   }
 
+  get _isCleaBadgeAcquired() {
+    const pixEmploiClea = 'PIX_EMPLOI_CLEA';
+    return this.acquiredBadges.some((badge) => badge.key === pixEmploiClea);
+  }
+
+  get hideBadgesTitle() {
+    return this._isCleaBadgeAcquired && this.acquiredBadges.length === 1;
+  }
+
   get showBadges() {
     return this.acquiredBadges.length > 0;
   }
@@ -19,6 +28,10 @@ export default class SkillReviewController extends Controller {
   get acquiredBadges() {
     const badges = this.model.campaignParticipation.campaignParticipationResult.get('campaignParticipationBadges');
     return badges.filter((badge) => badge.isAcquired);
+  }
+
+  get showStages() {
+    return this.stageCount && !this._isCleaBadgeAcquired;
   }
 
   get reachedStage() {

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -22,7 +22,7 @@
     {{else}}
       <div class="skill-review__result-and-action">
         <h2 class="sr-only">{{t 'pages.skill-review.abstract-title'}}</h2>
-        {{#if this.reachedStage}}
+        {{#if this.showStages}}
           <ReachedStage
             @stageCount={{this.stageCount}}
             @starCount={{this.reachedStage.starCount}}
@@ -33,7 +33,7 @@
 
           <div class="skill-review__share">
 
-            {{#if this.reachedStage}}
+            {{#if this.showStages}}
               <div class="skill-review-share__stage-congrats">
                 <div class="stage-congrats__title">
                   {{this.reachedStage.title}}
@@ -49,7 +49,7 @@
             {{/if}}
             <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
 
-            <div class="skill-review-result__share-container {{if this.reachedStage "skill-review-result__share-container--left"}}">
+            <div class="skill-review-result__share-container {{if this.showStages "skill-review-result__share-container--left"}}">
               <CampaignShareButton
                 @isShared={{this.model.campaignParticipation.isShared}}
                 @displayErrorMessage={{this.displayErrorMessage}}
@@ -61,9 +61,11 @@
       </div>
 
       {{#if this.showBadges}}
-        <h2 class="skill-review-result__badge-subtitle">
-          {{t 'pages.skill-review.badges-title'}}
-        </h2>
+        {{#unless this.hideBadgesTitle}}
+          <h2 class="skill-review-result__badge-subtitle">
+            {{t 'pages.skill-review.badges-title'}}
+          </h2>
+        {{/unless}}
         <div class="badge-acquired-container">
           {{#each this.acquiredBadges as |badge|}}
             <BadgeAcquiredCard


### PR DESCRIPTION
## :unicorn: Problème
On affiche le palier obtenu que l'on soit certifiable CléA ou non. On veut les afficher seulement pour les campagnes hors CléA.

## :robot: Solution
On n'affiche pas les paliers lorsque le badge CléA est obtenu.

## :rainbow: Remarques


## :100: Pour tester
Terminer la campagne `QWERTY789` avec un palier, mais sans obtenir le badge.
Terminer la campagne `QWERTY789` en obtenant le badge CléA (au moins 85% de réussite au total et 75% dans chaque compétence).
