### PR TITLE
[REFACTO] Centraliser l'authentification des élèves venant du GAR (PIX-1422).

### DIFF
--- a/api/db/seeds/data/seed-pix1321-builder.js
+++ b/api/db/seeds/data/seed-pix1321-builder.js
@@ -1,0 +1,33 @@
+function usersPix1321Builder({ databaseBuilder }) {
+
+  // Creation user
+  const userBugPix1321 = {
+    id: 999999,
+    firstName: 'vincent',
+    lastName: 'youness',
+    email: null,
+    username: 'vincent.youness123',
+    rawPassword: 'Password123',
+    cgu: false,
+    shouldChangePassword: true,
+  };
+
+  databaseBuilder.factory.buildUser.withUnencryptedPassword(userBugPix1321);
+
+  // Type: SCO
+
+  databaseBuilder.factory.buildSchoolingRegistration({
+    firstName: userBugPix1321.firstName,
+    lastName: userBugPix1321.lastName,
+    birthdate: '2010-10-10',
+    organizationId: 3,
+    userId: 999999,
+    nationalStudentId: '999999999B',
+  });
+
+}
+
+module.exports = {
+  usersPix1321Builder,
+};
+

--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -27,6 +27,7 @@ const targetProfilesBuilder = require('./data/target-profiles-builder');
 const { usersBuilder } = require('./data/users-builder');
 const usersPixRolesBuilder = require('./data/users_pix_roles-builder');
 const stagesBuilder = require('./data/stages-builder');
+const { usersPix1321Builder } = require('./data/seed-pix1321-builder');
 
 const SEQUENCE_RESTART_AT_NUMBER = 10000000;
 const SEED_NUMBER = 20110228;
@@ -71,6 +72,9 @@ exports.seed = (knex) => {
 
   // Éléments de parcours pour l'utilisateur Pix Aile
   buildPixAileProfile({ databaseBuilder });
+
+  // bug seed 1321
+  usersPix1321Builder({ databaseBuilder });
 
   return databaseBuilder.commit()
     .then(() => alterSequenceIfPG(knex));

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -50,6 +50,28 @@ exports.register = async (server) => {
         tags: ['api'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/token-from-external-user',
+      config: {
+        auth: false,
+        validate: {
+          payload: Joi.object({
+            data: {
+              type: Joi.string().valid('external-user-authentication-requests').required(),
+              attributes: {
+                username: Joi.string().required(),
+                password: Joi.string().required(),
+                'external-user-token': Joi.string().required(),
+                'expected-user-id': Joi.number().positive().required(),
+              },
+            },
+          }),
+        },
+        handler: AuthenticationController.authenticateExternalUser,
+        tags: ['api'],
+      },
+    },
 
   ]);
 };

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -23,6 +23,7 @@ function _checkUserAccessScope(scope, user) {
 module.exports = async function authenticateUser({
   password,
   scope,
+  source,
   tokenService,
   username,
   userRepository,
@@ -32,7 +33,7 @@ module.exports = async function authenticateUser({
 
     if (!foundUser.shouldChangePassword) {
       _checkUserAccessScope(scope, foundUser);
-      return tokenService.createAccessTokenFromUser(foundUser, 'pix');
+      return tokenService.createAccessTokenFromUser(foundUser, source);
     } else {
       throw new UserShouldChangePasswordError();
     }

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -218,4 +218,70 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     });
   });
 
+  describe('POST /api/token-from-external-user', function() {
+
+    let options;
+
+    beforeEach(async () => {
+      options = {
+        method: 'POST',
+        url: '/api/token-from-external-user',
+        payload: {
+          data: {
+            attributes: {
+              username: 'saml.jackson0101',
+              password: 'password',
+              'external-user-token': 'expectedExternalToken',
+              'expected-user-id': 1,
+            },
+            type: 'external-user-authentication-requests',
+          },
+        },
+      };
+    });
+
+    it('should return a 400 BAd Request if username is missing', async () => {
+      // given
+      options.payload.data.attributes.username = undefined;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return a 400 BAd Request if password is missing', async () => {
+      // given
+      options.payload.data.attributes.password = undefined;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return a 400 BAd Request if external-user-token is missing', async () => {
+      // given
+      options.payload.data.attributes['external-user-token'] = undefined;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return a 400 BAd Request if expected-user-id is missing', async () => {
+      // given
+      options.payload.data.attributes['expected-user-id'] = undefined;
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -27,18 +27,19 @@ describe('Unit | Application | Use Case | authenticate-user', () => {
   it('should resolves a valid JWT access token when authentication succeeded', async () => {
     // given
     const accessToken = 'jwt.access.token';
+    const source = 'pix';
     const user = domainBuilder.buildUser({ email: userEmail, password: userPassword, shouldChangePassword: false });
     authenticationService.getUserByUsernameAndPassword.resolves(user);
     tokenService.createAccessTokenFromUser.returns(accessToken);
 
     // when
-    await authenticateUser({ username: userEmail, password: userPassword, userRepository, tokenService });
+    await authenticateUser({ username: userEmail, password: userPassword, source, userRepository, tokenService });
 
     // then
     expect(authenticationService.getUserByUsernameAndPassword).to.have.been.calledWithExactly({
       username: userEmail, password: userPassword, userRepository,
     });
-    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWithExactly(user, 'pix');
+    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWithExactly(user, source);
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async () => {

--- a/mon-pix/app/adapters/external-user-authentication-request.js
+++ b/mon-pix/app/adapters/external-user-authentication-request.js
@@ -1,0 +1,10 @@
+import classic from 'ember-classic-decorator';
+import ApplicationAdapter from './application';
+
+@classic
+export default class ExternalUserAuthenticationRequest extends ApplicationAdapter {
+
+  urlForCreateRecord() {
+    return `${this.host}/${this.namespace}/token-from-external-user`;
+  }
+}

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.js
@@ -41,6 +41,6 @@ export default class JoinScoInformationModal extends Component {
   @action
   async goToCampaignConnectionForm() {
     await this.session.invalidate();
-    return this.router.replaceWith('campaigns.restricted.login-or-register-to-access', { queryParams: { displayRegisterForm: false } });
+    return this.router.replaceWith('campaigns.start-or-resume', this.args.campaignCode,  { queryParams: { hasUserSeenJoinPage: true } });
   }
 }

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.hbs
@@ -64,6 +64,7 @@
 </form>
 {{#if this.displayInformationModal}}
   <Routes::Campaigns::Restricted::JoinScoInformationModal
+          @campaignCode={{@campaignCode}}
           @reconciliationError={{this.reconciliationError}}
           @reconciliationWarning={{this.reconciliationWarning}}
           @closeModal={{this.closeModal}}

--- a/mon-pix/app/components/update-expired-password-form.js
+++ b/mon-pix/app/components/update-expired-password-form.js
@@ -87,6 +87,8 @@ export default class UpdateExpiredPasswordForm extends Component {
       await this.session.authenticate('authenticator:oauth2', {
         login, password,  scope: SCOPE_MON_PIX,
       });
+      this.session.set('data.externalUser', null);
+      this.session.set('data.expectedUserId', null);
     } catch (errorResponse) {
       this.authenticationHasFailed = true;
     }

--- a/mon-pix/app/models/external-user-authentication-request.js
+++ b/mon-pix/app/models/external-user-authentication-request.js
@@ -1,0 +1,10 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ExternalUserAuthenticationRequest extends Model {
+
+  @attr() username;
+  @attr() password;
+  @attr() externalUserToken;
+  @attr() expectedUserId;
+  @attr() accessToken;
+}

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -151,7 +151,7 @@ export default Factory.extend({
     password: faker.internet.password(),
   }),
   withUsername: trait({
-    username: faker.internet.exampleEmail(),
+    username: faker.internet.userName(),
     password: faker.internet.password(),
   }),
   external: trait({

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -1,7 +1,30 @@
 import postAuthentications from './post-authentications';
+import { Response } from 'ember-cli-mirage';
 
 export default function index(config) {
   config.post('/revoke', () => {});
 
   config.post('/token', postAuthentications);
+
+  config.post('/token-from-external-user', (schema, request) => {
+    const attrs = JSON.parse(request.requestBody).data.attributes;
+    let foundUser = schema.users.findBy({ email: attrs.username });
+    if (!foundUser) {
+      foundUser = schema.users.findBy({ username: attrs.username });
+    }
+
+    if (foundUser.shouldChangePassword) {
+      return new Response(401, {}, { errors: [ { title: 'PasswordShouldChange' } ] });
+    }
+
+    const response = {
+      data: {
+        attributes: {
+          'access-token': 'aaa.' + btoa(`{"user_id":${foundUser.id},"source":"external","iat":1545321469,"exp":4702193958}`) + '.bbb',
+        },
+        type: 'external-user-authentication-requests',
+      },
+    };
+    return new Response(200, {}, response);
+  });
 }

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -886,7 +886,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             const errorsApi = new Response(400, {}, {
               errors: [{ status: 400 }],
             });
-            server.patch('/users/:id/authentication-methods/saml', () => errorsApi);
+            server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
             await click('.fill-in-campaign-code__start-button');
@@ -919,7 +919,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
                 meta: { value: expectedObfuscatedConnectionMethod },
               }],
             });
-            server.patch('/users/:id/authentication-methods/saml', () => errorsApi);
+            server.post('/token-from-external-user', () => errorsApi);
 
             await fillIn('#campaign-code', campaign.code);
             await click('.fill-in-campaign-code__start-button');
@@ -944,7 +944,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           it('should display the default error message if GAR authentication method adding has failed with others http statusCode', async () => {
             // given
             const expectedErrorMessage = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
-            server.patch('/users/:id/authentication-methods/saml', () => new Response(500));
+            server.post('/token-from-external-user', () => new Response(500));
 
             await fillIn('#campaign-code', campaign.code);
             await click('.fill-in-campaign-code__start-button');
@@ -1014,17 +1014,11 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
               await click('.button');
 
               // then
-              const session = currentSession();
-              expect(session.data.authenticated.source).to.equal(AUTHENTICATED_SOURCE_FROM_MEDIACENTRE);
-
               expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
               expect(contains('Commencez votre parcours')).to.exist;
             });
-
           });
-
         });
-
       });
     });
   });

--- a/mon-pix/tests/integration/components/routes/login-form-test.js
+++ b/mon-pix/tests/integration/components/routes/login-form-test.js
@@ -208,24 +208,6 @@ describe('Integration | Component | routes/login-form', function() {
       addGarAuthenticationMethodToUserStub = sinon.stub();
     });
 
-    it('should prevent redirection and update user authentication method', async function() {
-      // given
-      const sessionServiceObserver = this.owner.lookup('service:session');
-      this.set('addGarAuthenticationMethodToUser', addGarAuthenticationMethodToUserStub);
-
-      await render(hbs`<Routes::LoginForm @addGarAuthenticationMethodToUser={{this.addGarAuthenticationMethodToUser}} />`);
-
-      await fillIn('#login', 'pix@example.net');
-      await fillIn('#password', 'JeMeLoggue1024');
-
-      // when
-      await click('#submit-connexion');
-
-      // then
-      sinon.assert.calledWith(sessionServiceObserver.set, 'attemptedTransition');
-      sinon.assert.calledWith(addGarAuthenticationMethodToUserStub, externalUserToken);
-    });
-
     it('should display the specific error message if update fails with http error 4xx', async function() {
       // given
       const expectedErrorMessage = 'Les données que vous avez soumises ne sont pas au bon format.';

--- a/mon-pix/tests/unit/components/routes/login-form-test.js
+++ b/mon-pix/tests/unit/components/routes/login-form-test.js
@@ -87,15 +87,6 @@ describe('Unit | Component | routes/login-form', function() {
         sessionStub.get.withArgs('data.expectedUserId').returns(expectedUserId);
       });
 
-      it('should prevent redirection and update user authentication method', async () => {
-        // when
-        await component.authenticate();
-
-        // then
-        sinon.assert.calledWith(component.session.set, 'attemptedTransition');
-        sinon.assert.calledWith(component.addGarAuthenticationMethodToUser, externalUserToken);
-      });
-
       context('when update user authentication method fails', () => {
 
         it('should display an error message', async () => {
@@ -108,17 +99,6 @@ describe('Unit | Component | routes/login-form', function() {
           // then
           expect(component.isErrorMessagePresent).to.be.false;
           expect(component.hasUpdateUserError).to.be.true;
-        });
-
-        it('should invalidate the session', async () => {
-          // given
-          component.addGarAuthenticationMethodToUser.rejects(new Error());
-
-          // when
-          await component.authenticate();
-
-          // then
-          sinon.assert.calledOnce(sessionStub.invalidate);
         });
       });
     });

--- a/mon-pix/tests/unit/controllers/campaigns/restricted/login-or-register-to-access-test.js
+++ b/mon-pix/tests/unit/controllers/campaigns/restricted/login-or-register-to-access-test.js
@@ -38,14 +38,16 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
 
     it('should redirect to campaigns.start-or-resume', async () => {
       // given
-      const externalUserToken = 'ABCD';
+      const externallUserAuthenticationRequest = {
+        save: sinon.stub(),
+      };
 
       const saveStub = sinon.stub();
       const storeStub = { createRecord: sinon.stub().returns({ save: saveStub }) };
       controller.set('store', storeStub);
 
       // when
-      await controller.actions.addGarAuthenticationMethodToUser.call(controller, externalUserToken, expectedUserId);
+      await controller.actions.addGarAuthenticationMethodToUser.call(controller, externallUserAuthenticationRequest);
 
       // then
       sinon.assert.calledWith(controller.transitionToRoute, 'campaigns.start-or-resume');
@@ -56,12 +58,12 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
       // given
       const externalUserToken = 'ABCD';
 
-      const expectedOptions = {
-        adapterOptions: {
-          authenticationMethodsSaml: true,
-          externalUserToken,
-          expectedUserId,
-        },
+      const expectedExternalUserAuthenticationRequest = {
+        externalUserToken,
+        expectedUserId,
+        username: 'saml',
+        password: 'jackson',
+        save: sinon.stub(),
       };
 
       const saveStub = sinon.stub();
@@ -69,18 +71,19 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
       controller.set('store', storeStub);
 
       // when
-      await controller.actions.addGarAuthenticationMethodToUser.call(controller, externalUserToken, expectedUserId);
+      await controller.actions.addGarAuthenticationMethodToUser.call(controller, expectedExternalUserAuthenticationRequest);
 
       // then
-      sinon.assert.calledOnce(currentUserStub.load);
-      sinon.assert.calledWith(currentUserStub.user.save, expectedOptions);
-
+      sinon.assert.calledOnce(expectedExternalUserAuthenticationRequest.save);
       sinon.assert.calledWith(sessionStub.set, 'data.externalUser', null);
+      sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', null);
     });
 
     it('should reconcile user', async () => {
       // given
-      const externalUserToken = 'ABCD';
+      const expectedExternalUserAuthenticationRequest = {
+        save: sinon.stub(),
+      };
 
       const expectedCampaignCode = campaignCode;
 
@@ -92,7 +95,7 @@ describe('Unit | Controller | campaigns/restricted/login-or-register-to-access',
       controller.set('store', storeStub);
 
       // when
-      await controller.actions.addGarAuthenticationMethodToUser.call(controller, externalUserToken, expectedUserId);
+      await controller.actions.addGarAuthenticationMethodToUser.call(controller, expectedExternalUserAuthenticationRequest);
 
       // then
       sinon.assert.calledWith(storeStub.createRecord, expectedStoreOptions.arg1, expectedStoreOptions.arg2);


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, dans Pix App, lorsqu'un utilisateur provient du GAR et est déjà réconcilié, nous lui proposons de se connecter avec son compte existant. Cela nous permet de vérifier son identité et ainsi pouvoir ajouter ce nouveau moyen de connexion (GAR) à son compte. 

https://github.com/1024pix/pix/blob/85bdb9c7f4e153543cfd8b3f7047e453a031ed7f/mon-pix/app/components/routes/login-form.js#L43-L58

Le problème qui survient avec ce code, c'est que l'enchainement de cette logique dans le front implique une bonne gestion des erreurs. 
- 1. Si on n'arrive pas à ajouter la nouvelle méthode d'authentification alors nous devons déconnecter l'utilisateur. 
- 2. Quand l'utilisateur se connecte avec son compte et doit changer son mot de passe alors on n'ajoute pas la nouvelle méthode d'authentification. 

## :robot: Solution
Nous avons voulu décaler cette logique dans le back afin de faciliter la gestion d'erreur dans le front. 
Pour cela, nous avons créé un nouvel endpoint authentification `/api/token-from-external-user`, qui permet d'ajouter le `samlId` au compte avec lequel l'utilisateur se connecte et de l'authentifier.  

https://github.com/1024pix/pix/blob/c0b83d975fb3b42059680feeeb3c445027caff6b/api/lib/application/authentication/authentication-controller.js#L33-L46

De plus, nous avons voulu nous rapprocher de la gestion des `attemptedTransition` d'[ember-simple-auth](https://github.com/simplabs/ember-simple-auth), pour cela au lieu de rediriger directement sur la double mire d'authentification  : 
https://github.com/1024pix/pix/blob/85bdb9c7f4e153543cfd8b3f7047e453a031ed7f/mon-pix/app/components/routes/campaigns/restricted/join-sco.js#L96-L99
Nous prévilégions de repasser par la route `start-or-resume` qui orchestre l'accès aux campagnes dans son `beforeModel`  : 
https://github.com/1024pix/pix/blob/42a82a3ba676ac69f38519ef7b8e5737e601501e/mon-pix/app/components/routes/campaigns/restricted/join-sco.js#L96-L99
https://github.com/1024pix/pix/blob/42a82a3ba676ac69f38519ef7b8e5737e601501e/mon-pix/app/routes/campaigns/start-or-resume.js#L19-L24

## :100: Pour tester
- Utiliser [Pix Saml IDP](https://test-idp.integration.pix.fr) avec l'élève youness vincent.
- Entre le code campagne RESTRICTD.
- Se connecter avec le compte vincent.youness123/Password123.
- Changer le mot de passe.
- Vous devez arriver sur la page de présentation du parcours.
+ Vérifier que tous les cas de connexion du GAR fonctionne toujours.  

Lancer la commande `scalingo -a pix-api-review-pr2016 --region osc-fr1 run "npm run db:seed"` pour revenir à l'état initial.