### PR TITLE
[BSR] Utiliser uniquement le helper HttpTestServer pour les tests d'intégration et les tests unitaires de l'API (PIX-1423).

### DIFF
--- a/api/tests/integration/application/campaignParticipations/index_test.js
+++ b/api/tests/integration/application/campaignParticipations/index_test.js
@@ -1,10 +1,16 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  sinon,
+  HttpTestServer,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/campaignParticipations');
+
 const campaignParticipationController = require('../../../../lib/application/campaignParticipations/campaign-participation-controller');
 
 describe('Integration | Application | Route | campaignParticipationRouter', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(campaignParticipationController, 'shareCampaignResult').callsFake((request, h) => h.response('ok').code(201));
@@ -13,23 +19,14 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
     sinon.stub(campaignParticipationController, 'getCampaignAssessmentParticipation').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(campaignParticipationController, 'getCampaignAssessmentParticipationResult').callsFake((request, h) => h.response('ok').code(200));
 
-    server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/campaignParticipations'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/campaign-participations?filter[assessmentId]={id}', () => {
 
     it('should exist', async () => {
       // when
-      const response = await server.inject({
-        method: 'GET',
-        url: '/api/campaign-participations',
-      });
+      const response = await httpTestServer.request('GET', '/api/campaign-participations');
 
       // then
       expect(response.statusCode).to.equal(201);
@@ -39,19 +36,18 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
   describe('PATCH /api/campaign-participations/{id}', () => {
 
     it('should exist', async () => {
-      // when
-      const response = await server.inject({
-        method: 'PATCH',
-        url: '/api/campaign-participations/FAKE_ID',
-        payload: {
-          data: {
-            type: 'campaign-participation',
-            attributes: {
-              isShared: true,
-            },
+      // given
+      const payload = {
+        data: {
+          type: 'campaign-participation',
+          attributes: {
+            isShared: true,
           },
         },
-      });
+      };
+
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/campaign-participations/FAKE_ID', payload);
 
       // then
       expect(response.statusCode).to.equal(201);
@@ -60,46 +56,40 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
 
   describe('GET /api/campaign-participations/{id}/analyses', () => {
 
+    const method = 'GET';
+
     context('when id is not an integer', () => {
 
       it('should return 400 - Bad request', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaign-participations/FAKE_ID/analyses',
-        });
+        const response = await httpTestServer.request(method, '/api/campaign-participations/FAKE_ID/analyses');
 
         // then
         expect(response.statusCode).to.equal(400);
       });
-
     });
 
     context('when id is an integer', () => {
 
       it('should return 200', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaign-participations/12/analyses',
-        });
+        const response = await httpTestServer.request(method, '/api/campaign-participations/12/analyses');
 
         // then
         expect(response.statusCode).to.equal(200);
       });
-
     });
   });
 
   describe('GET /api/campaigns/{campaignId}/assessment-participations/{campaignParticipationId}', () => {
 
+    const method = 'GET';
+
     context('when campaignId is not an integer', () => {
+
       it('should return 400 - Bad request', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/FAKE_ID/assessment-participations/1',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/FAKE_ID/assessment-participations/1');
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -107,12 +97,10 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
     });
 
     context('when campaignParticipationId is not an integer', () => {
+
       it('should return 400 - Bad request', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/1/assessment-participations/FAKE_ID',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/1/assessment-participations/FAKE_ID');
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -120,12 +108,10 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
     });
 
     context('when campaignId and campaignParticipationId are integers', () => {
+
       it('should return 200', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/1/assessment-participations/1',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/1/assessment-participations/1');
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -135,13 +121,13 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
 
   describe('GET /api/campaigns/{campaignId}/assessment-participations/{campaignParticipationId}/results', () => {
 
+    const method = 'GET';
+
     context('when campaignId is not an integer', () => {
+
       it('should return 400 - Bad request', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/FAKE_ID/assessment-participations/1/results',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/FAKE_ID/assessment-participations/1/results');
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -149,12 +135,10 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
     });
 
     context('when campaignParticipationId is not an integer', () => {
+
       it('should return 400 - Bad request', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/1/assessment-participations/FAKE_ID/results',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/1/assessment-participations/FAKE_ID/results');
 
         // then
         expect(response.statusCode).to.equal(400);
@@ -162,12 +146,10 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
     });
 
     context('when campaignId and campaignParticipationId are integers', () => {
+
       it('should return 200', async () => {
         // when
-        const response = await server.inject({
-          method: 'GET',
-          url: '/api/campaigns/1/assessment-participations/1/results',
-        });
+        const response = await httpTestServer.request(method, '/api/campaigns/1/assessment-participations/1/results');
 
         // then
         expect(response.statusCode).to.equal(200);

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -1,9 +1,16 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/campaigns');
+
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
 
 describe('Integration | Application | Route | campaignRouter', () => {
-  let server;
+
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
@@ -13,82 +20,50 @@ describe('Integration | Application | Route | campaignRouter', () => {
     sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
     sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
 
-    server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/campaigns'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('POST /api/campaigns', () => {
 
-    it('should exist', function() {
+    it('should exist', async () => {
       // when
-      const promise = server.inject({
-        method: 'POST',
-        url: '/api/campaigns',
-      });
+      const response = await httpTestServer.request('POST', '/api/campaigns');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(201);
-      });
-
+      expect(response.statusCode).to.equal(201);
     });
-
   });
 
   describe('GET /api/campaigns/{id}/csv-assessment-results', () => {
 
-    it('should exist', () => {
+    it('should exist', async () => {
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/campaigns/FAKE_ID/csv-assessment-results',
-      });
+      const response = await httpTestServer.request('GET', '/api/campaigns/FAKE_ID/csv-assessment-results');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
-
+      expect(response.statusCode).to.equal(200);
     });
-
   });
 
   describe('GET /api/campaigns/{id}/csv-profiles-collection-results', () => {
 
-    it('should exist', () => {
+    it('should exist', async () => {
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/campaigns/FAKE_ID/csv-profiles-collection-results',
-      });
+      const response = await httpTestServer.request('GET', '/api/campaigns/FAKE_ID/csv-profiles-collection-results');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
-
+      expect(response.statusCode).to.equal(200);
     });
-
   });
 
   describe('GET /api/campaigns/{id}', () => {
 
-    it('should return a 200', function() {
+    it('should return a 200', async () => {
       // when
-      const promise = server.inject({
-        method: 'GET',
-        url: '/api/campaigns/1',
-      });
+      const response = await httpTestServer.request('GET', '/api/campaigns/1');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 
@@ -99,10 +74,10 @@ describe('Integration | Application | Route | campaignRouter', () => {
       const campaignId = 1;
 
       // when
-      const result = await server.inject({ method: 'GET', url: `/api/campaigns/${campaignId}/analyses` });
+      const response = await httpTestServer.request('GET', `/api/campaigns/${campaignId}/analyses`);
 
       // then
-      expect(result.statusCode).to.equal(200);
+      expect(response.statusCode).to.equal(200);
     });
 
     it('should return 400', async () => {
@@ -110,28 +85,21 @@ describe('Integration | Application | Route | campaignRouter', () => {
       const campaignId = 'wrongId';
 
       // when
-      const result = await server.inject({ method: 'GET', url: `/api/campaigns/${campaignId}/analyses` });
+      const response = await httpTestServer.request('GET', `/api/campaigns/${campaignId}/analyses`);
 
       // then
-      expect(result.statusCode).to.equal(400);
+      expect(response.statusCode).to.equal(400);
     });
   });
 
   describe('PATCH /api/campaigns/{id}', () => {
 
-    it('should exist', function() {
+    it('should exist', async () => {
       // when
-      const promise = server.inject({
-        method: 'PATCH',
-        url: '/api/campaigns/FAKE_ID',
-      });
+      const response = await httpTestServer.request('PATCH', '/api/campaigns/FAKE_ID');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(201);
-      });
+      expect(response.statusCode).to.equal(201);
     });
-
   });
-
 });

--- a/api/tests/integration/application/certifications/index_test.js
+++ b/api/tests/integration/application/certifications/index_test.js
@@ -1,60 +1,46 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+const moduleUnderTest = require('../../../../lib/application/certifications');
+
 const certificationController = require('../../../../lib/application/certifications/certification-controller');
 
 describe('Integration | Application | Route | Certifications', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(certificationController, 'findUserCertifications').returns('ok');
     sinon.stub(certificationController, 'getCertification').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
-    server = Hapi.server();
-    return server.register(require('../../../../lib/application/certifications'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/certifications', () => {
 
-    it('should exist', function() {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/certifications',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/certifications');
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 
   describe('GET /api/certifications/:id', () => {
 
-    it('should exist', function() {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/certifications/1',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/certifications/1');
 
       // then
-      return promise.then((response) => {
-        expect(response.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -37,8 +37,8 @@ class HttpTestServer {
     this.hapiServer.register(moduleUnderTest);
   }
 
-  request(method, url, payload, auth) {
-    return this.hapiServer.inject({ method, url, payload, auth });
+  request(method, url, payload, auth, headers) {
+    return this.hapiServer.inject({ method, url, payload, auth, headers });
   }
 }
 

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -1,38 +1,31 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/answers');
+
 const AnswerController = require('../../../../lib/application/answers/answer-controller');
 
 describe('Unit | Router | answer-router', function() {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(function() {
-
     sinon.stub(AnswerController, 'save').callsFake((request, h) => h.response().code(201));
     sinon.stub(AnswerController, 'get').callsFake((request, h) => h.response().code(200));
     sinon.stub(AnswerController, 'find').callsFake((request, h) => h.response().code(200));
     sinon.stub(AnswerController, 'update').callsFake((request, h) => h.response().code(204));
 
-    server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/answers'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('POST /api/answers', function() {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'POST',
-        url: '/api/answers',
-      };
-
       // when
-      const result = await server.inject(options);
+      const result = await httpTestServer.request('POST', '/api/answers');
 
       // then
       expect(result.statusCode).to.equal(201);
@@ -42,14 +35,8 @@ describe('Unit | Router | answer-router', function() {
   describe('GET /api/answers/{id}', function() {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/answers/answer_id',
-      };
-
       // when
-      const result = await server.inject(options);
+      const result = await httpTestServer.request('GET', '/api/answers/answer_id');
 
       // then
       expect(result.statusCode).to.equal(200);
@@ -59,14 +46,8 @@ describe('Unit | Router | answer-router', function() {
   describe('GET /api/answers?assessment=<assessment_id>&challenge=<challenge_id>', function() {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/answers',
-      };
-
       // when
-      const result = await server.inject(options);
+      const result = await httpTestServer.request('GET', '/api/answers');
 
       // then
       expect(result.statusCode).to.equal(200);
@@ -76,14 +57,8 @@ describe('Unit | Router | answer-router', function() {
   describe('PATCH /api/answers/{id}', function() {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'PATCH',
-        url: '/api/answers/answer_id',
-      };
-
       // when
-      const result = await server.inject(options);
+      const result = await httpTestServer.request('PATCH', '/api/answers/answer_id');
 
       // then
       expect(result.statusCode).to.equal(204);

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -1,101 +1,83 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
-const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const assessmentAuthorization = require('../../../../lib/application/preHandlers/assessment-authorization');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 
+const moduleUnderTest = require('../../../../lib/application/assessments');
+
+const assessmentController = require('../../../../lib/application/assessments/assessment-controller');
+
 describe('Integration | Route | AssessmentRoute', () => {
 
-  let server;
-
-  function _expectRouteToExist(routeOptions) {
-    // when
-    const promise = server.inject(routeOptions);
-
-    // then
-    return promise.then((res) => {
-      expect(res.statusCode).to.equal(200);
-    });
-  }
+  let httpTestServer;
 
   beforeEach(() => {
-    // stub dependencies
-    sinon.stub(assessmentController, 'save');
-    sinon.stub(assessmentController, 'getNextChallenge');
-    sinon.stub(assessmentController, 'findByFilters');
-    sinon.stub(assessmentController, 'get');
-    sinon.stub(assessmentAuthorization, 'verify');
+    sinon.stub(assessmentController, 'save').returns('ok');
+    sinon.stub(assessmentController, 'getNextChallenge').returns('ok');
+    sinon.stub(assessmentController, 'findByFilters').returns('ok');
+    sinon.stub(assessmentController, 'get').returns('ok');
+    sinon.stub(assessmentAuthorization, 'verify').returns('userId');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
 
-    // instance server
-    server = this.server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/assessments'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('POST /api/assessments', () => {
 
-    beforeEach(() => {
-      assessmentController.save.returns('ok');
-    });
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('POST', '/api/assessments');
 
-    it('should exist', () => {
-      return _expectRouteToExist({ method: 'POST', url: '/api/assessments' });
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 
   describe('GET /api/assessments/assessment_id/next', () => {
 
-    beforeEach(() => {
-      assessmentController.getNextChallenge.returns('ok');
-    });
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/assessments/assessment_id/next');
 
-    it('should exist', () => {
-      return _expectRouteToExist({ method: 'GET', url: '/api/assessments/assessment_id/next' });
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 
   describe('GET /api/assessments', () => {
 
-    beforeEach(() => {
-      assessmentController.findByFilters.returns('ok');
-    });
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/assessments');
 
-    it('should exist', () => {
-      return _expectRouteToExist({ method: 'GET', url: '/api/assessments' });
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 
   describe('GET /api/assessments/{id}', () => {
 
-    let options;
+    const method = 'GET';
+    const url = '/api/assessments/assessment_id';
 
-    beforeEach(() => {
-      options = {
-        method: 'GET',
-        url: '/api/assessments/assessment_id',
-      };
-
-      assessmentController.get.returns('ok');
-      assessmentAuthorization.verify.returns('userId');
-    });
-
-    it('should exist', () => {
-      return _expectRouteToExist(options);
-    });
-
-    it('should call pre-handler', () => {
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request(method,url);
 
       // then
-      return promise.then(() => {
-        sinon.assert.called(assessmentAuthorization.verify);
-      });
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should call pre-handler', async () => {
+      // when
+      await httpTestServer.request(method,url);
+
+      // then
+      sinon.assert.called(assessmentAuthorization.verify);
     });
   });
 });

--- a/api/tests/unit/application/cache/index_test.js
+++ b/api/tests/unit/application/cache/index_test.js
@@ -1,57 +1,46 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
-const cacheController = require('../../../../lib/application/cache/cache-controller');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+const moduleUnderTest = require('../../../../lib/application/cache');
+
+const cacheController = require('../../../../lib/application/cache/cache-controller');
 
 describe('Unit | Router | cache-router', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(cacheController, 'refreshCacheEntries').callsFake((request, h) => h.response().code(204));
     sinon.stub(cacheController, 'refreshCacheEntry').callsFake((request, h) => h.response().code(204));
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
 
-    server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/cache'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('DELETE /api/cache/{cachekey}', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'DELETE',
-        url: '/api/cache/Table_recXYZ1234',
-      };
-
       // when
-      const result = await server.inject(options);
+      const response = await httpTestServer.request('DELETE', '/api/cache/Table_recXYZ1234');
+
       // then
-      expect(result.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(204);
     });
   });
 
   describe('PATCH /api/cache', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'PATCH',
-        url: '/api/cache',
-      };
-
       // when
-      const result = await server.inject(options);
+      const response = await httpTestServer.request('PATCH', '/api/cache');
 
       // then
-      expect(result.statusCode).to.equal(204);
+      expect(response.statusCode).to.equal(204);
     });
   });
-
 });

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -1,80 +1,72 @@
-const { expect, sinon, hFake, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+  generateValidRequestAuthorizationHeader,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/campaigns');
+
 const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
-const route = require('../../../../lib/application/campaigns');
 
 describe('Unit | Application | Router | campaign-router ', function() {
 
-  let server;
   const userId = 1;
+
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(campaignController, 'getCollectiveResult').returns('ok');
     sinon.stub(campaignController, 'archiveCampaign').returns('ok');
     sinon.stub(campaignController, 'unarchiveCampaign').returns('ok');
 
-    server = Hapi.server();
-
-    return server.register(route);
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/campaigns/{id}/collective-results', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/campaigns/1/collective-results',
-      };
-
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/collective-results');
 
       // then
       expect(response.statusCode).to.equal(200);
     });
-
   });
 
   describe('PUT /api/campaigns/{id}/archive', () => {
 
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'PUT',
-        url: '/api/campaigns/{id}/archive',
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(userId),
-        },
+      const method = 'PUT';
+      const url = '/api/campaigns/{id}/archive';
+      const headers = {
+        authorization: generateValidRequestAuthorizationHeader(userId),
       };
 
       // when
-      const response = await server.inject(options, hFake);
+      const response = await httpTestServer.request(method, url, null, null, headers);
 
       // then
       expect(response.statusCode).to.equal(200);
     });
-
   });
 
   describe('DELETE /api/campaigns/{id}/archive', () => {
 
     it('should exist', async () => {
       // given
-      const options = {
-        method: 'DELETE',
-        url: '/api/campaigns/{id}/archive',
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(userId),
-        },
+      const method = 'DELETE';
+      const url = '/api/campaigns/{id}/archive';
+      const headers = {
+        authorization: generateValidRequestAuthorizationHeader(userId),
       };
 
       // when
-      const response = await server.inject(options, hFake);
+      const response = await httpTestServer.request(method, url, null, null, headers);
 
       // then
       expect(response.statusCode).to.equal(200);
     });
-
   });
 });

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -1,14 +1,19 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const moduleUnderTest = require('../../../../lib/application/certification-courses');
+
 const certificationCoursesController = require('../../../../lib/application/certification-courses/certification-course-controller');
 
 describe('Unit | Application | Certifications Course | Route', function() {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
-
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(certificationCoursesController, 'getResult').returns('ok');
     sinon.stub(certificationCoursesController, 'update').returns('ok');
@@ -16,40 +21,25 @@ describe('Unit | Application | Certifications Course | Route', function() {
     sinon.stub(certificationCoursesController, 'save').returns('ok');
     sinon.stub(certificationCoursesController, 'get').returns('ok');
 
-    server = Hapi.server();
-
-    return server.register(require('../../../../lib/application/certification-courses'));
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/admin/certifications/{id}/details', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/admin/certifications/1234/details',
-      };
-
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/admin/certifications/1234/details');
 
       // then
       expect(response.statusCode).to.equal(200);
     });
-
   });
 
   describe('GET /api/admin/certifications/id', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/admin/certifications/1234',
-      };
-
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/admin/certifications/1234');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -59,14 +49,8 @@ describe('Unit | Application | Certifications Course | Route', function() {
   describe('PATCH /api/certification-courses/id', () => {
 
     it('should exist', async () => {
-      // given
-      const options = {
-        method: 'PATCH',
-        url: '/api/certification-courses/1234',
-      };
-
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('PATCH', '/api/certification-courses/1234');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -75,39 +59,23 @@ describe('Unit | Application | Certifications Course | Route', function() {
 
   describe('POST /api/certification-courses', () => {
 
-    it('should exist', () => {
-      // given
-      const options = {
-        method: 'POST',
-        url: '/api/certification-courses',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('POST', '/api/certification-courses');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 
   describe('GET /api/certification-courses/{id}', () => {
 
-    it('should exist', () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/certification-courses/1234',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/certification-courses/1234');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/challenges/challenge-controller_test.js
+++ b/api/tests/unit/application/challenges/challenge-controller_test.js
@@ -1,20 +1,26 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const ChallengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
 const ChallengeSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/challenge-serializer');
 
+const moduleUnderTest = require('../../../../lib/application/challenges');
+
 describe('Unit | Controller | challenge-controller', function() {
 
-  let server;
+  let httpTestServer;
+
   let ChallengeRepoStub;
   let ChallengeSerializerStub;
 
   beforeEach(function() {
     ChallengeRepoStub = sinon.stub(ChallengeRepository, 'get');
     ChallengeSerializerStub = sinon.stub(ChallengeSerializer, 'serialize');
-    server = Hapi.server();
 
-    return server.register(require('../../../../lib/application/challenges'));
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('#get', function() {
@@ -27,7 +33,7 @@ describe('Unit | Controller | challenge-controller', function() {
       ChallengeSerializerStub.resolves({ serialized: challenge });
 
       // when
-      const response = await server.inject({ method: 'GET', url: '/api/challenges/challenge_id' });
+      const response = await httpTestServer.request('GET', '/api/challenges/challenge_id');
 
       // then
       expect(response.result).to.deep.equal({ serialized: challenge });

--- a/api/tests/unit/application/courses/course-controller_test.js
+++ b/api/tests/unit/application/courses/course-controller_test.js
@@ -1,21 +1,21 @@
-const { expect, sinon, hFake, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  hFake,
+  sinon,
+  generateValidRequestAuthorizationHeader,
+} = require('../../../test-helper');
 
-const courseController = require('../../../../lib/application/courses/course-controller');
 const Course = require('../../../../lib/domain/models/Course');
 const courseService = require('../../../../lib/domain/services/course-service');
 const courseSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/course-serializer');
 
-describe('Unit | Controller | course-controller', () => {
+const courseController = require('../../../../lib/application/courses/course-controller');
 
-  let server;
+describe('Unit | Controller | course-controller', () => {
 
   beforeEach(() => {
     sinon.stub(courseService, 'getCourse');
     sinon.stub(courseSerializer, 'serialize');
-
-    server = this.server = Hapi.server();
-    return server.register(require('../../../../lib/application/courses'));
   });
 
   describe('#get', () => {
@@ -48,5 +48,4 @@ describe('Unit | Controller | course-controller', () => {
       expect(response).to.deep.equal(course);
     });
   });
-
 });

--- a/api/tests/unit/application/courses/index_test.js
+++ b/api/tests/unit/application/courses/index_test.js
@@ -1,36 +1,34 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+const moduleUnderTest = require('../../../../lib/application/courses');
+
 const courseController = require('../../../../lib/application/courses/course-controller');
 
-describe('Integration | Router | course-router', () => {
+describe('Unit | Router | course-router', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
     sinon.stub(courseController, 'get').returns('ok');
 
-    server = this.server = Hapi.server();
-    return server.register(require('../../../../lib/application/courses'));
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/courses/{id}', () => {
 
-    it('should exist', () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/courses/course_id',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/courses/course_id');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/feedbacks/feedback-controller_test.js
+++ b/api/tests/unit/application/feedbacks/feedback-controller_test.js
@@ -1,19 +1,27 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
-const _ = require('lodash');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const { cloneDeep } = require('lodash');
+
 const Feedback = require('../../../../lib/infrastructure/data/feedback');
-const route = require('../../../../lib/application/feedbacks');
+
+const moduleUnderTest = require('../../../../lib/application/feedbacks');
 
 describe('Unit | Controller | feedback-controller', function() {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(function() {
-    server = Hapi.server();
-    return server.register(route);
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('#save', function() {
+
+    const method = 'POST';
+    const url = '/api/feedbacks';
 
     const jsonFeedback = {
       data: {
@@ -48,23 +56,25 @@ describe('Unit | Controller | feedback-controller', function() {
     });
 
     it('should return a successful response with HTTP code 201 when feedback was saved', async function() {
+      // given
+      const payload = jsonFeedback;
+
       // when
-      const res = await server.inject({ method: 'POST', url: '/api/feedbacks', payload: jsonFeedback });
+      const response = await httpTestServer.request(method, url, payload);
 
       // then
-      expect(res.statusCode).to.equal(201);
+      expect(response.statusCode).to.equal(201);
     });
 
     it('should persist feedback data into the Feedback Repository', async function() {
       // given
-      const payload = _.cloneDeep(jsonFeedback);
+      const payload = cloneDeep(jsonFeedback);
 
       // when
-      await server.inject({ method: 'POST', url: '/api/feedbacks', payload });
+      await httpTestServer.request(method, url, payload);
 
       // then
       expect(Feedback.prototype.save).to.have.been.calledOnce;
     });
-
   });
 });

--- a/api/tests/unit/application/feedbacks/index_test.js
+++ b/api/tests/unit/application/feedbacks/index_test.js
@@ -1,38 +1,31 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/feedbacks');
+
 const feedbackController = require('../../../../lib/application/feedbacks/feedback-controller');
-const route = require('../../../../lib/application/feedbacks');
 
 describe('Unit | Router | feedback-router', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
-    server = Hapi.server();
+    sinon.stub(feedbackController, 'save').returns('ok');
+
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('POST /api/feedbacks', () => {
 
-    beforeEach(() => {
-      sinon.stub(feedbackController, 'save').returns('ok');
-      return server.register(route);
-    });
-
-    it('should exist', () => {
-      // given
-      const options = {
-        method: 'POST',
-        url: '/api/feedbacks',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('POST', '/api/feedbacks');
 
       // then
-      return promise.then((result) => {
-        expect(result.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
-
 });

--- a/api/tests/unit/application/healthcheck/index_test.js
+++ b/api/tests/unit/application/healthcheck/index_test.js
@@ -1,26 +1,31 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/healthcheck');
+
 const healthcheckController = require('../../../../lib/application/healthcheck/healthcheck-controller');
-const route = require('../../../../lib/application/healthcheck');
 
 describe('Unit | Router | HealthcheckRouter', function() {
 
-  let server;
+  let httpTestServer;
 
-  beforeEach(function() {
-    server = this.server = Hapi.server();
+  beforeEach(() => {
+    sinon.stub(healthcheckController, 'get').returns('ok');
+
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api', function() {
 
-    beforeEach(function() {
-      sinon.stub(healthcheckController, 'get').returns('ok');
-      return server.register(route);
-    });
-
     it('should exist', async function() {
-      const res = await server.inject({ method: 'GET', url: '/api' });
-      expect(res.statusCode).to.equal(200);
+      // when
+      const response = await httpTestServer.request('GET', '/api');
+
+      // then
+      expect(response.statusCode).to.equal(200);
     });
   });
 });

--- a/api/tests/unit/application/organization-invitations/index_test.js
+++ b/api/tests/unit/application/organization-invitations/index_test.js
@@ -1,45 +1,43 @@
-const { expect, sinon, hFake } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/organization-invitations');
+
 const organizationInvitationController = require('../../../../lib/application/organization-invitations/organization-invitation-controller');
 
-let server;
-
-function startServer() {
-  server = Hapi.server();
-  return server.register(require('../../../../lib/application/organization-invitations'));
-}
-
 describe('Unit | Router | organization-invitation-router', () => {
+
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(organizationInvitationController, 'acceptOrganizationInvitation').callsFake((request, h) => h.response().code(204));
     sinon.stub(organizationInvitationController, 'getOrganizationInvitation').callsFake((request, h) => h.response().code(200));
 
-    startServer();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('POST /api/organization-invitations/{id}/response', () => {
 
     it('should exists', async () => {
       // given
-      const options = {
-        method: 'POST',
-        url: '/api/organization-invitations/1/response',
-        payload: {
-          data: {
-            id: '100047_DZWMP7L5UM',
-            type: 'organization-invitation-responses',
-            attributes: {
-              code: 'DZWMP7L5UM',
-              email: 'user@example.net',
-            },
-
+      const method = 'POST';
+      const url = '/api/organization-invitations/1/response';
+      const payload = {
+        data: {
+          id: '100047_DZWMP7L5UM',
+          type: 'organization-invitation-responses',
+          attributes: {
+            code: 'DZWMP7L5UM',
+            email: 'user@example.net',
           },
         },
       };
 
       // when
-      const response = await server.inject(options, hFake);
+      const response = await httpTestServer.request(method, url, payload);
 
       // then
       expect(response.statusCode).to.equal(204);
@@ -48,15 +46,14 @@ describe('Unit | Router | organization-invitation-router', () => {
 
   describe('GET /api/organization-invitations/{id}', () => {
 
+    const method = 'GET';
+
     it('should exists', async () => {
       // given
-      const options = {
-        method: 'GET',
-        url: '/api/organization-invitations/1?code=DZWMP7L5UM',
-      };
+      const url = '/api/organization-invitations/1?code=DZWMP7L5UM';
 
       // when
-      const response = await server.inject(options, hFake);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -64,17 +61,13 @@ describe('Unit | Router | organization-invitation-router', () => {
 
     it('should return Bad Request Error when invitation identifier is not a number', async () => {
       // given
-      const options = {
-        method: 'GET',
-        url: '/api/organization-invitations/XXXXXXXXXXXXXXXX15812?code=DZWMP7L5UM',
-      };
+      const url = '/api/organization-invitations/XXXXXXXXXXXXXXXX15812?code=DZWMP7L5UM';
 
       // when
-      const response = await server.inject(options, hFake);
+      const response = await httpTestServer.request(method, url);
 
       // then
       expect(response.statusCode).to.equal(400);
     });
   });
-
 });

--- a/api/tests/unit/application/prescribers/index_test.js
+++ b/api/tests/unit/application/prescribers/index_test.js
@@ -1,37 +1,34 @@
-const Hapi = require('@hapi/hapi');
-
-const { expect, sinon } = require('../../../test-helper');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+
+const moduleUnderTest = require('../../../../lib/application/prescribers');
+
 const prescriberController = require('../../../../lib/application/prescribers/prescriber-controller');
 
-let server;
-
-function startServer() {
-  server = Hapi.server();
-  return server.register(require('../../../../lib/application/prescribers'));
-}
-
 describe('Unit | Router | prescriber-router', () => {
+
+  let httpTestServer;
 
   describe('GET /api/prescription/prescribers/{id}', () => {
 
     beforeEach(() => {
       sinon.stub(prescriberController, 'get').returns('ok');
       sinon.stub(securityPreHandlers, 'checkRequestedUserIsAuthenticatedUser').callsFake((request, h) => h.response(true));
-      startServer();
+
+      httpTestServer = new HttpTestServer(moduleUnderTest);
     });
 
     it('should exist', async () => {
-      // given
-      const options = { method: 'GET', url: '/api/prescription/prescribers/1' };
-
       // when
-      const response = await server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/prescription/prescribers/1');
 
       // then
       expect(response.statusCode).to.equal(200);
     });
   });
-
 });

--- a/api/tests/unit/application/progressions/index_test.js
+++ b/api/tests/unit/application/progressions/index_test.js
@@ -1,38 +1,31 @@
-const { expect, sinon } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/progressions');
+
 const progressionController = require('../../../../lib/application/progressions/progression-controller');
 
 describe('Unit | Router | progression-router', () => {
 
-  let server;
+  let httpTestServer;
 
   beforeEach(() => {
     sinon.stub(progressionController, 'get').callsFake((request, h) => h.response().code(200));
 
-    server = Hapi.server();
-    return server.register(require('../../../../lib/application/progressions'));
-  });
-
-  afterEach(() => {
-    server.stop();
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/progressions/{id}', function() {
 
-    it('should exist', () => {
-      // given
-      const options = {
-        method: 'GET',
-        url: '/api/progressions/1',
-      };
-
+    it('should exist', async () => {
       // when
-      const promise = server.inject(options);
+      const response = await httpTestServer.request('GET', '/api/progressions/1');
 
       // then
-      return promise.then((res) => {
-        expect(res.statusCode).to.equal(200);
-      });
+      expect(response.statusCode).to.equal(200);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans quelques tests d'intégration (voir quelques TU), la fonction Hapi.server() est utilisée directement pour créer un objet server, et réaliser les actions attendues.

Cependant, un helper spécifique a été implémenté, qui possède entre autres une partie de la configuration de "production" cf. server.js.

## :robot: Solution
Uniformiser l'utilisation du helper dans ces tests.

## :rainbow: Remarques
Les modifications apportées ne concernent que les tests, sans modifications fonctionnelles.

## :100: Pour tester
Simplement, exécuter les tests API.