### PR TITLE
[TECH] Refacto du certification result

### DIFF
--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -2,7 +2,7 @@ class CertificationResult {
   constructor(
     {
       id,
-      lastAssessmentResultFull,
+      lastAssessmentResult,
       firstName,
       lastName,
       birthplace,
@@ -27,22 +27,22 @@ class CertificationResult {
     this.externalId = externalId;
     this.completedAt = completedAt;
     this.createdAt = createdAt;
-    this.resultCreatedAt = lastAssessmentResultFull.createdAt;
+    this.resultCreatedAt = lastAssessmentResult.createdAt;
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
     this.cleaCertificationStatus = cleaCertificationStatus;
-    this.pixScore = lastAssessmentResultFull.pixScore;
-    this.status = lastAssessmentResultFull.status;
-    this.emitter = lastAssessmentResultFull.emitter;
-    this.commentForCandidate = lastAssessmentResultFull.commentForCandidate;
-    this.commentForJury = lastAssessmentResultFull.commentForJury;
-    this.commentForOrganization = lastAssessmentResultFull.commentForOrganization;
-    this.competencesWithMark = lastAssessmentResultFull.competenceMarks;
+    this.pixScore = lastAssessmentResult.pixScore;
+    this.status = lastAssessmentResult.status;
+    this.emitter = lastAssessmentResult.emitter;
+    this.commentForCandidate = lastAssessmentResult.commentForCandidate;
+    this.commentForJury = lastAssessmentResult.commentForJury;
+    this.commentForOrganization = lastAssessmentResult.commentForOrganization;
+    this.competencesWithMark = lastAssessmentResult.competenceMarks;
     this.examinerComment = examinerComment;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     // references
     this.assessmentId = assessmentId;
-    this.juryId = lastAssessmentResultFull.juryId;
+    this.juryId = lastAssessmentResult.juryId;
     this.sessionId = sessionId;
   }
 }

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -2,7 +2,7 @@ class CertificationResult {
   constructor(
     {
       id,
-      // attributes
+      lastAssessmentResultFull,
       firstName,
       lastName,
       birthplace,
@@ -10,22 +10,12 @@ class CertificationResult {
       externalId,
       completedAt,
       createdAt,
-      resultCreatedAt,
       isPublished,
       isV2Certification,
       cleaCertificationStatus,
-      pixScore,
-      status,
-      emitter,
-      commentForCandidate,
-      commentForJury,
-      commentForOrganization,
-      competencesWithMark,
       examinerComment,
       hasSeenEndTestScreen,
-      // references
       assessmentId,
-      juryId,
       sessionId,
     } = {}) {
     this.id = id;
@@ -37,22 +27,22 @@ class CertificationResult {
     this.externalId = externalId;
     this.completedAt = completedAt;
     this.createdAt = createdAt;
-    this.resultCreatedAt = resultCreatedAt;
+    this.resultCreatedAt = lastAssessmentResultFull.createdAt;
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
     this.cleaCertificationStatus = cleaCertificationStatus;
-    this.pixScore = pixScore;
-    this.status = status;
-    this.emitter = emitter;
-    this.commentForCandidate = commentForCandidate;
-    this.commentForJury = commentForJury;
-    this.commentForOrganization = commentForOrganization;
-    this.competencesWithMark = competencesWithMark;
+    this.pixScore = lastAssessmentResultFull.pixScore;
+    this.status = lastAssessmentResultFull.status;
+    this.emitter = lastAssessmentResultFull.emitter;
+    this.commentForCandidate = lastAssessmentResultFull.commentForCandidate;
+    this.commentForJury = lastAssessmentResultFull.commentForJury;
+    this.commentForOrganization = lastAssessmentResultFull.commentForOrganization;
+    this.competencesWithMark = lastAssessmentResultFull.competenceMarks;
     this.examinerComment = examinerComment;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     // references
     this.assessmentId = assessmentId;
-    this.juryId = juryId;
+    this.juryId = lastAssessmentResultFull.juryId;
     this.sessionId = sessionId;
   }
 }

--- a/api/lib/domain/models/CertificationResult.js
+++ b/api/lib/domain/models/CertificationResult.js
@@ -1,3 +1,5 @@
+const Assessment = require('./Assessment');
+
 class CertificationResult {
   constructor(
     {
@@ -19,7 +21,6 @@ class CertificationResult {
       sessionId,
     } = {}) {
     this.id = id;
-    // attributes
     this.lastName = lastName;
     this.firstName = firstName;
     this.birthplace = birthplace;
@@ -27,23 +28,35 @@ class CertificationResult {
     this.externalId = externalId;
     this.completedAt = completedAt;
     this.createdAt = createdAt;
-    this.resultCreatedAt = lastAssessmentResult.createdAt;
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
     this.cleaCertificationStatus = cleaCertificationStatus;
-    this.pixScore = lastAssessmentResult.pixScore;
-    this.status = lastAssessmentResult.status;
-    this.emitter = lastAssessmentResult.emitter;
-    this.commentForCandidate = lastAssessmentResult.commentForCandidate;
-    this.commentForJury = lastAssessmentResult.commentForJury;
-    this.commentForOrganization = lastAssessmentResult.commentForOrganization;
-    this.competencesWithMark = lastAssessmentResult.competenceMarks;
     this.examinerComment = examinerComment;
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
-    // references
     this.assessmentId = assessmentId;
-    this.juryId = lastAssessmentResult.juryId;
     this.sessionId = sessionId;
+    
+    if (lastAssessmentResult) {
+      this.resultCreatedAt = lastAssessmentResult.createdAt;
+      this.pixScore = lastAssessmentResult.pixScore;
+      this.status = lastAssessmentResult.status;
+      this.emitter = lastAssessmentResult.emitter;
+      this.commentForCandidate = lastAssessmentResult.commentForCandidate;
+      this.commentForJury = lastAssessmentResult.commentForJury;
+      this.commentForOrganization = lastAssessmentResult.commentForOrganization;
+      this.competencesWithMark = lastAssessmentResult.competenceMarks;
+      this.juryId = lastAssessmentResult.juryId;
+    } else {
+      this.resultCreatedAt = undefined;
+      this.pixScore = undefined;
+      this.status = Assessment.states.STARTED;
+      this.emitter = undefined;
+      this.commentForCandidate = undefined;
+      this.commentForJury = undefined;
+      this.commentForOrganization = undefined;
+      this.competencesWithMark = [];
+      this.juryId = undefined;
+    }
   }
 }
 

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -27,6 +27,7 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
   }
 
   return new CertificationResult({
+    lastAssessmentResultFull,
     id: certificationCourse.id,
     assessmentId,
     firstName: certificationCourse.firstName,
@@ -36,20 +37,11 @@ async function getCertificationResultByCertifCourse({ certificationCourse }) {
     externalId: certificationCourse.externalId,
     completedAt: certificationCourse.completedAt,
     createdAt: certificationCourse.createdAt,
-    resultCreatedAt: lastAssessmentResultFull.createdAt,
     isPublished: certificationCourse.isPublished,
     isV2Certification: certificationCourse.isV2Certification,
     cleaCertificationStatus,
-    pixScore: lastAssessmentResultFull.pixScore,
-    status: lastAssessmentResultFull.status,
-    emitter: lastAssessmentResultFull.emitter,
-    commentForCandidate: lastAssessmentResultFull.commentForCandidate,
-    commentForJury: lastAssessmentResultFull.commentForJury,
-    commentForOrganization: lastAssessmentResultFull.commentForOrganization,
     examinerComment: certificationCourse.examinerComment,
     hasSeenEndTestScreen: certificationCourse.hasSeenEndTestScreen,
-    competencesWithMark: lastAssessmentResultFull.competenceMarks,
-    juryId: lastAssessmentResultFull.juryId,
     sessionId: certificationCourse.sessionId,
   });
 }

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -20,14 +20,14 @@ async function getCertificationResult(certificationCourseId) {
 async function getCertificationResultByCertifCourse({ certificationCourse }) {
   const certificationCourseId = certificationCourse.id;
   const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
-  let lastAssessmentResultFull = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
+  let lastAssessmentResult = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
   const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
-  if (!lastAssessmentResultFull) {
-    lastAssessmentResultFull = { competenceMarks: [], status: Assessment.states.STARTED };
+  if (!lastAssessmentResult) {
+    lastAssessmentResult = { competenceMarks: [], status: Assessment.states.STARTED };
   }
 
   return new CertificationResult({
-    lastAssessmentResultFull,
+    lastAssessmentResult,
     id: certificationCourse.id,
     assessmentId,
     firstName: certificationCourse.firstName,

--- a/api/lib/domain/services/certification-service.js
+++ b/api/lib/domain/services/certification-service.js
@@ -1,5 +1,4 @@
 const CertificationResult = require('../models/CertificationResult');
-const Assessment = require('../models/Assessment');
 const assessmentRepository = require('../../../lib/infrastructure/repositories/assessment-repository');
 const certificationAssessmentRepository = require('../../../lib/infrastructure/repositories/certification-assessment-repository');
 const assessmentResultRepository = require('../../infrastructure/repositories/assessment-result-repository');
@@ -20,11 +19,8 @@ async function getCertificationResult(certificationCourseId) {
 async function getCertificationResultByCertifCourse({ certificationCourse }) {
   const certificationCourseId = certificationCourse.id;
   const cleaCertificationStatus = await cleaCertificationStatusRepository.getCleaCertificationStatus(certificationCourseId);
-  let lastAssessmentResult = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
+  const lastAssessmentResult = await assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks({ certificationCourseId });
   const assessmentId = await assessmentRepository.getIdByCertificationCourseId(certificationCourseId);
-  if (!lastAssessmentResult) {
-    lastAssessmentResult = { competenceMarks: [], status: Assessment.states.STARTED };
-  }
 
   return new CertificationResult({
     lastAssessmentResult,

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -29,13 +29,13 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       });
 
       const certifResult1 = domainBuilder.buildCertificationResult({
-        lastAssessmentResultFull: lastAssessmentResult1,
+        lastAssessmentResult: lastAssessmentResult1,
         firstName: 'Lili',
         birthdate,
         createdAt,
       });
       const certifResult2 = domainBuilder.buildCertificationResult({
-        lastAssessmentResultFull: lastAssessmentResult2,
+        lastAssessmentResult: lastAssessmentResult2,
         firstName: 'Tom',
         birthdate,
         createdAt,

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -19,19 +19,26 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       ];
       const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
 
-      const certifResult1 = domainBuilder.buildCertificationResult({
-        firstName: 'Lili',
+      const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
         status: 'validated',
+        competenceMarks: competencesWithMark1,
+      });
+      const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+        status: 'rejected',
+        competenceMarks: competencesWithMark2,
+      });
+
+      const certifResult1 = domainBuilder.buildCertificationResult({
+        lastAssessmentResultFull: lastAssessmentResult1,
+        firstName: 'Lili',
         birthdate,
         createdAt,
-        competencesWithMark: competencesWithMark1,
       });
       const certifResult2 = domainBuilder.buildCertificationResult({
+        lastAssessmentResultFull: lastAssessmentResult2,
         firstName: 'Tom',
-        status: 'rejected',
         birthdate,
         createdAt,
-        competencesWithMark: competencesWithMark2,
       });
 
       const certificationResults = [ certifResult1, certifResult2 ];

--- a/api/tests/tooling/domain-builder/factory/build-assessment-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-assessment-result.js
@@ -1,16 +1,18 @@
+const faker = require('faker');
+const { status: assessmentStatuses } = require('../../../../lib/domain/models/AssessmentResult');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 
 module.exports = function buildAssessmentResult({
   pixScore = 31,
-  status = 'validated',
+  status = faker.random.objectElement(assessmentStatuses),
   emitter = 'PIX-ALGO',
   commentForJury = 'Comment for Jury',
   commentForCandidate = 'Comment for Candidate',
   commentForOrganization = 'Comment for Organization',
-  id = 1,
+  id = faker.random.number(),
   createdAt = new Date('2018-01-12T01:02:03Z'),
   juryId = 1,
-  assessmentId = 2,
+  assessmentId = faker.random.number(),
   competenceMarks = [],
 } = {}) {
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -1,10 +1,11 @@
 const faker = require('faker');
 const CertificationResult = require('../../../../lib/domain/models/CertificationResult');
 const { statuses: cleaStatuses } = require('../../../../lib/infrastructure/repositories/clea-certification-status-repository');
-const { status: assessmentStatuses } = require('../../../../lib/domain/models/AssessmentResult');
+const buildAssessmentResult = require('./build-assessment-result');
 
 module.exports = function buildCertificationResult({
   id = faker.random.uuid(),
+  lastAssessmentResultFull,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   birthplace = faker.address.city(),
@@ -12,47 +13,31 @@ module.exports = function buildCertificationResult({
   externalId = faker.random.number(),
   completedAt = faker.date.past(),
   createdAt = faker.date.past(),
-  resultCreatedAt = faker.date.past(),
   isPublished = faker.random.boolean(),
   isV2Certification = true,
   cleaCertificationStatus = faker.random.objectElement(cleaStatuses),
-  pixScore = faker.random.number(500),
-  status = faker.random.objectElement(assessmentStatuses),
-  emitter = faker.name.firstName(),
-  commentForCandidate = faker.lorem.sentences(),
-  commentForJury = faker.lorem.sentences(),
-  commentForOrganization = faker.lorem.sentences(),
-  competencesWithMark = [],
   examinerComment = faker.lorem.sentences(),
   hasSeenEndTestScreen = faker.random.boolean(),
   assessmentId,
-  juryId,
   sessionId,
 } = {}) {
+  lastAssessmentResultFull = buildAssessmentResult({ ...lastAssessmentResultFull });
   return new CertificationResult({
     id,
+    lastAssessmentResultFull,
     firstName,
     lastName,
     birthdate,
     birthplace,
     externalId,
     completedAt,
-    pixScore,
     createdAt,
-    resultCreatedAt,
     isPublished,
     isV2Certification,
     cleaCertificationStatus,
-    status,
-    emitter,
-    commentForCandidate,
-    commentForJury,
-    commentForOrganization,
-    competencesWithMark,
     examinerComment,
     hasSeenEndTestScreen,
     assessmentId,
-    juryId,
     sessionId,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -5,7 +5,7 @@ const buildAssessmentResult = require('./build-assessment-result');
 
 module.exports = function buildCertificationResult({
   id = faker.random.uuid(),
-  lastAssessmentResultFull,
+  lastAssessmentResult,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
   birthplace = faker.address.city(),
@@ -21,10 +21,10 @@ module.exports = function buildCertificationResult({
   assessmentId,
   sessionId,
 } = {}) {
-  lastAssessmentResultFull = buildAssessmentResult({ ...lastAssessmentResultFull });
+  lastAssessmentResult = buildAssessmentResult({ ...lastAssessmentResult });
   return new CertificationResult({
     id,
-    lastAssessmentResultFull,
+    lastAssessmentResult,
     firstName,
     lastName,
     birthdate,

--- a/api/tests/unit/domain/services/certification/certification-service_test.js
+++ b/api/tests/unit/domain/services/certification/certification-service_test.js
@@ -16,11 +16,10 @@ function _buildCompetenceMarks(level, score, area_code, competence_code, compete
   return new CompetenceMarks({ level, score, area_code, competence_code, competenceId });
 }
 
-function _buildAssessmentResult(pixScore, level) {
+function _buildAssessmentResult(pixScore) {
   return new AssessmentResult({
     id: 'assessment_result_id',
     pixScore,
-    level,
     emitter: 'PIX-ALGO',
   });
 }
@@ -85,7 +84,7 @@ describe('Unit | Service | Certification Service', function() {
           hasSeenEndTestScreen: true,
         });
         sinon.stub(certificationCourseRepository, 'get').resolves(certificationCourse);
-        const assessmentResult = _buildAssessmentResult(20, 3);
+        const assessmentResult = _buildAssessmentResult(20);
         assessmentResult.competenceMarks = [_buildCompetenceMarks(3, 27, '2', '2.1', 'rec2.1')];
         sinon.stub(assessmentResultRepository, 'findLatestByCertificationCourseIdWithCompetenceMarks')
           .withArgs({ certificationCourseId }).resolves({ ...assessmentResult, assessmentId });

--- a/api/tests/unit/domain/usecases/get-certification-attestation_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-attestation_test.js
@@ -11,14 +11,17 @@ describe('Unit | UseCase | getCertificationAttestation', async () => {
   let certificate;
   const deliveredAt = new Date('2020-09-17T01:02:03Z');
   const cleaCertificationStatus = 'someStatus';
+  let assessmentResult;
+  const assessmentResultId = 1;
 
   beforeEach(() => {
     certificate = domainBuilder.buildPrivateCertificate({
       userId,
       id: certificationId,
       deliveredAt,
+      status: 'validated',
     });
-    const assessmentResult = domainBuilder.buildAssessmentResult();
+    assessmentResult = domainBuilder.buildAssessmentResult({ id: assessmentResultId, status: 'validated' });
     assessmentResult.competenceMarks = [domainBuilder.buildCompetenceMark({ assessmentResultId: assessmentResult.id })];
     const competenceTree = domainBuilder.buildCompetenceTree();
     const certificationRepository = {
@@ -110,6 +113,7 @@ describe('Unit | UseCase | getCertificationAttestation', async () => {
         'userId': 2,
         'verificationCode': 'P-BBBCCCDD',
       });
+
       // when
       const result = await getCertificationAttestation({ certificationId, userId, ...dependencies });
 

--- a/api/tests/unit/domain/usecases/get-private-certificate_test.js
+++ b/api/tests/unit/domain/usecases/get-private-certificate_test.js
@@ -69,6 +69,7 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
 
   context('when the user is owner of the certification', async () => {
 
+    const assessmentResultId = 123;
     let assessmentResult;
     let certificate;
     let competenceTree;
@@ -81,7 +82,7 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
       });
       certificationRepository.getPrivateCertificateByCertificationCourseId.resolves(certificate);
 
-      assessmentResult = domainBuilder.buildAssessmentResult();
+      assessmentResult = domainBuilder.buildAssessmentResult({ id: assessmentResultId });
       assessmentResult.competenceMarks = [domainBuilder.buildCompetenceMark()];
       assessmentResultRepository.findLatestByCertificationCourseIdWithCompetenceMarks.resolves(assessmentResult);
 
@@ -125,7 +126,7 @@ describe('Unit | UseCase | getPrivateCertificate', async () => {
             'title': 'Information et données',
           },
         ],
-        'id': '23-1',
+        'id': '23-123',
       };
 
       // when

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -88,18 +88,11 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
 });
 
-function _buildCertificationResult(certifCourse, assessmentResult, cleaCertification) {
+function _buildCertificationResult(certifCourse, lastAssessmentResultFull, cleaCertification) {
   return domainBuilder.buildCertificationResult({
     ...certifCourse,
-    assessmentId: assessmentResult.assessmentId,
-    pixScore: assessmentResult.pixScore,
-    commentForCandidate: assessmentResult.commentForCandidate,
-    commentForJury: assessmentResult.commentForJury,
-    commentForOrganization: assessmentResult.commentForOrganization,
-    emitter: assessmentResult.emitter,
-    resultCreatedAt: assessmentResult.createdAt,
-    juryId: assessmentResult.juryId,
-    status: assessmentResult.status,
+    lastAssessmentResultFull,
+    assessmentId: lastAssessmentResultFull.assessmentId,
     cleaCertificationStatus: cleaCertification,
     competencesWithMark: [],
   });

--- a/api/tests/unit/domain/usecases/get-session-results_test.js
+++ b/api/tests/unit/domain/usecases/get-session-results_test.js
@@ -88,11 +88,11 @@ describe('Unit | Domain | Use Cases | get-session-results', () => {
 
 });
 
-function _buildCertificationResult(certifCourse, lastAssessmentResultFull, cleaCertification) {
+function _buildCertificationResult(certifCourse, lastAssessmentResult, cleaCertification) {
   return domainBuilder.buildCertificationResult({
     ...certifCourse,
-    lastAssessmentResultFull,
-    assessmentId: lastAssessmentResultFull.assessmentId,
+    lastAssessmentResult,
+    assessmentId: lastAssessmentResult.assessmentId,
     cleaCertificationStatus: cleaCertification,
     competencesWithMark: [],
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../../test-helper');
+const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-result-serializer');
 const CertificationResult = require('../../../../../lib/domain/models/CertificationResult');
 
@@ -8,8 +8,20 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
 
     it('should serialize results of a certification', function() {
       // given
+      const lastAssessmentResultFull = domainBuilder.buildAssessmentResult({
+        createdAt: new Date('2017-02-20T01:02:03Z'),
+        pixScore: 30,
+        status: 'validated',
+        emitter: 'PIX_ALGO',
+        commentForCandidate: null,
+        commentForJury: 'Salut',
+        commentForOrganization: '',
+        competenceMarks: [],
+        juryId: 21,
+      });
       const certificationResult = new CertificationResult({
         id: 1,
+        lastAssessmentResultFull,
         firstName: 'Guy-Manuel',
         lastName: 'De Homem Christo',
         birthdate: '1974-02-08',
@@ -17,20 +29,11 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
         externalId: 'Grammys2016',
         createdAt: new Date('2017-02-20T01:02:03Z'),
         completedAt: new Date('2017-02-20T01:02:03Z'),
-        resultCreatedAt: new Date('2017-02-20T01:02:03Z'),
         isPublished: true,
         isV2Certification: true,
-        pixScore: 30,
-        status: 'validated',
-        emitter: 'PIX_ALGO',
-        commentForCandidate: null,
-        commentForJury: 'Salut',
-        commentForOrganization: '',
         examinerComment: 'un commentaire',
         hasSeenEndTestScreen: true,
         cleaCertificationStatus: 'acquired',
-        competencesWithMark: [],
-        juryId: 21,
         sessionId: 22,
         assessmentId: 99,
       });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
@@ -8,7 +8,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
 
     it('should serialize results of a certification', function() {
       // given
-      const lastAssessmentResultFull = domainBuilder.buildAssessmentResult({
+      const lastAssessmentResult = domainBuilder.buildAssessmentResult({
         createdAt: new Date('2017-02-20T01:02:03Z'),
         pixScore: 30,
         status: 'validated',
@@ -21,7 +21,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
       });
       const certificationResult = new CertificationResult({
         id: 1,
-        lastAssessmentResultFull,
+        lastAssessmentResult,
         firstName: 'Guy-Manuel',
         lastName: 'De Homem Christo',
         birthdate: '1974-02-08',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -183,6 +183,8 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
 
     context('the entry data is one certification with a resultCompetenceTree set', () => {
 
+      const assessmentResultId = 1;
+
       const JsonCertificationList = {
         'data': {
           'attributes': {
@@ -292,7 +294,9 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
 
       it('should serialize to JSON with included relationships', () => {
         // given
+        const assessmentResult = domainBuilder.buildAssessmentResult({ id: assessmentResultId });
         const receivedCertificate = domainBuilder.buildPrivateCertificateWithCompetenceTree({
+          assessmentResults: [assessmentResult],
           pixScore: 23,
           status: 'rejected',
           commentForCandidate: 'Vous auriez dû travailler plus.',
@@ -308,6 +312,8 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
   });
 
   describe('#serializeForSharing', () => {
+
+    const assessmentResultId = 1;
 
     const JsonCertificationList = {
       'data': {
@@ -416,7 +422,9 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
 
     it('should serialize certification into JSON data without examinerComment', () => {
       // given
+      const assessmentResult = domainBuilder.buildAssessmentResult({ id: assessmentResultId });
       const receivedCertificate = domainBuilder.buildPrivateCertificateWithCompetenceTree({
+        assessmentResults: [assessmentResult],
         pixScore: 23,
         status: 'rejected',
         commentForCandidate: 'Vous auriez dû travailler plus.',


### PR DESCRIPTION
## :unicorn: Problème
Le certification service renvoie un model CertificationResult. Or ce dernier est complexe et prend des informations d'un certificationCourse, d'un assessment et d'un assessment result.
La complexité du certification service nous a même créé un bug récemment : https://github.com/1024pix/pix/pull/2013 

## :robot: Solution
Pour simplifier l'utilisation et la compréhension de ce model nous proposons de lui passer tout un assessmentResult et qu'il décide lui même des valeurs par défaut à mettre.

## :rainbow: Remarques
Il reste encore du travail à faire pour simplifier le certification-service ainsi que le CertificationResult.
Par exemple une idée serait de permettre au CertificationResult de prendre directement un CertificationCourse (et de set ses valeurs par défaut en cas de besoin).

## :100: Pour tester
- Aller sur Pix Admin dans le détail des certifs et vérifier que rien n'a été changé
- Aller sur mon-pix regarder le résultat d'une certif
