### PR TITLE
[FEATURE] Filtrer les sessions par type de centre de certification (PIX-1341)

### DIFF
--- a/admin/app/components/sessions/list-items.hbs
+++ b/admin/app/components/sessions/list-items.hbs
@@ -27,24 +27,28 @@
                  oninput={{perform @triggerFiltering 'certificationCenterName'}}
                  class="table-admin-input" />
         </th>
-        <th></th>
+        <th>
+          <XSelect id='certificationCenterType' @value={{@certificationCenterType}} @onChange={{perform @triggerFiltering 'certificationCenterType'}} as |xs|>
+            {{#each @certificationCenterTypeAndLabels as |certificationCenterTypeAndLabel| }}
+              <xs.option @value={{certificationCenterTypeAndLabel.certificationCenterType}}>{{certificationCenterTypeAndLabel.label}}</xs.option>
+            {{/each}}
+          </XSelect>
+        </th>
         <th></th>
         <th>
           <XSelect id='status' @value={{@status}} @onChange={{perform @triggerFiltering 'status'}} as |xs|>
-            <xs.option @value={{@sessionStatusAndLabels.[0].status}}>{{@sessionStatusAndLabels.[0].label}}</xs.option>
-            <xs.option @value={{@sessionStatusAndLabels.[1].status}}>{{@sessionStatusAndLabels.[1].label}}</xs.option>
-            <xs.option @value={{@sessionStatusAndLabels.[2].status}}>{{@sessionStatusAndLabels.[2].label}}</xs.option>
-            <xs.option @value={{@sessionStatusAndLabels.[3].status}}>{{@sessionStatusAndLabels.[3].label}}</xs.option>
-            <xs.option @value={{@sessionStatusAndLabels.[4].status}}>{{@sessionStatusAndLabels.[4].label}}</xs.option>
+            {{#each @sessionStatusAndLabels as |sessionStatusAndLabel|}}
+              <xs.option @value={{sessionStatusAndLabel.status}}>{{sessionStatusAndLabel.label}}</xs.option>
+            {{/each}}
           </XSelect>
         </th>
         <th></th>
         <th></th>
         <th>
           <XSelect id='resultsSentToPrescriberAt' @value={{@resultsSentToPrescriberAt}} @onChange={{perform @triggerFiltering 'resultsSentToPrescriberAt'}} as |xs|>
-            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[0].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[0].label}}</xs.option>
-            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[1].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[1].label}}</xs.option>
-            <xs.option @value={{@sessionResultsSentToPrescriberAtAndLabels.[2].value}}>{{@sessionResultsSentToPrescriberAtAndLabels.[2].label}}</xs.option>
+            {{#each @sessionResultsSentToPrescriberAtAndLabels as |sessionResultsSentToPrescriberAtAndLabel|}}
+              <xs.option @value={{sessionResultsSentToPrescriberAtAndLabel.value}}>{{sessionResultsSentToPrescriberAtAndLabel.label}}</xs.option>
+            {{/each}}
           </XSelect>
         </th>
         <th></th>

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -16,6 +16,7 @@ export default class SessionListController extends Controller {
   @tracked pageSize = 10;
   @tracked id = null;
   @tracked certificationCenterName = null;
+  @tracked certificationCenterType = null;
   @tracked status = FINALIZED;
   @tracked resultsSentToPrescriberAt = null;
   @tracked assignedToSelfOnly = false;
@@ -24,7 +25,14 @@ export default class SessionListController extends Controller {
 
   sessionStatusAndLabels = [
     { status: null, label: 'Tous' },
-    ..._.map(statusToDisplayName, (label, status) => ({ status, label })),
+    ...(_.map(statusToDisplayName, (label, status) => ({ status, label }))),
+  ];
+
+  certificationCenterTypeAndLabels = [
+    { certificationCenterType: null, label: 'Toutes' },
+    { certificationCenterType: 'SCO', label: 'Sco' },
+    { certificationCenterType: 'SUP', label: 'Sup' },
+    { certificationCenterType: 'PRO', label: 'Pro' },
   ];
 
   sessionResultsSentToPrescriberAtAndLabels = [
@@ -42,6 +50,7 @@ export default class SessionListController extends Controller {
         value = param.target.value; // param is an InputEvent
         break;
       case 'status':
+      case 'certificationCenterType':
       case 'resultsSentToPrescriberAt':
       case 'assignedToSelfOnly':
         debounceDuration = 0;
@@ -52,6 +61,7 @@ export default class SessionListController extends Controller {
     }
     this.pendingFilters[fieldName] = value;
     yield timeout(debounceDuration);
+
     this.setProperties(this.pendingFilters);
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -9,6 +9,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
     pageSize: { refreshModel: true },
     id: { refreshModel: true },
     certificationCenterName: { refreshModel: true },
+    certificationCenterType: { refreshModel: true },
     status: { refreshModel: true },
     resultsSentToPrescriberAt: { refreshModel: true },
     assignedToSelfOnly: { refreshModel: true },
@@ -21,6 +22,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
         filter: {
           id: trim(params.id) || undefined,
           certificationCenterName: trim(params.certificationCenterName) || undefined,
+          certificationCenterType: params.certificationCenterType || undefined,
           status: params.status || undefined,
           resultsSentToPrescriberAt: params.resultsSentToPrescriberAt || undefined,
           assignedToSelfOnly: params.assignedToSelfOnly,
@@ -43,6 +45,7 @@ export default Route.extend(AuthenticatedRouteMixin, {
       controller.pageSize = 10;
       controller.id = null;
       controller.certificationCenterName = null;
+      controller.certificationCenterType = null;
       controller.status = FINALIZED;
       controller.resultsSentToPrescriberAt = null;
       controller.assignedToSelfOnly = false;

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -19,6 +19,7 @@
         @certificationCenterName={{this.certificationCenterName}}
         @status={{this.status}}
         @sessionStatusAndLabels={{this.sessionStatusAndLabels}}
+        @certificationCenterTypeAndLabels={{this.certificationCenterTypeAndLabels}}
         @resultsSentToPrescriberAt={{this.resultsSentToPrescriberAt}}
         @sessionResultsSentToPrescriberAtAndLabels={{this.sessionResultsSentToPrescriberAtAndLabels}}
         @triggerFiltering={{this.triggerFiltering}} />

--- a/admin/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -70,5 +70,20 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
         assert.equal(controller.resultsSentToPrescriberAt, expectedValue);
       });
     });
+
+    module('when fieldName is certificationCenterType', function() {
+
+      test('should update controller certificationCenterType field', async function(assert) {
+        // given
+        controller.certificationCenterType = 'someType';
+
+        // when
+        const expectedValue = 'newType';
+        await controller.triggerFiltering.perform('certificationCenterType', expectedValue);
+
+        // then
+        assert.equal(controller.certificationCenterType, expectedValue);
+      });
+    });
   });
 });

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -33,6 +33,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
+          certificationCenterType: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
           assignedToSelfOnly: undefined,
@@ -52,6 +53,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: 'someId',
           certificationCenterName: undefined,
+          certificationCenterType: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
           assignedToSelfOnly: undefined,
@@ -74,6 +76,30 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: 'someName',
+          certificationCenterType: undefined,
+          status: undefined,
+          resultsSentToPrescriberAt: undefined,
+          assignedToSelfOnly: undefined,
+        };
+
+        // when
+        await route.model(params);
+
+        // then
+        sinon.assert.calledWith(route.store.query, 'session', expectedQueryArgs);
+        assert.ok(true);
+      });
+    });
+
+    module('when queryParams certificationCenterType is truthy', function() {
+
+      test('it should call store.query with a filter with trimmed certificationCenterType', async function(assert) {
+        // given
+        params.certificationCenterType = 'SCO';
+        expectedQueryArgs.filter = {
+          id: undefined,
+          certificationCenterName: undefined,
+          certificationCenterType: 'SCO',
           status: undefined,
           resultsSentToPrescriberAt: undefined,
           assignedToSelfOnly: undefined,
@@ -96,6 +122,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
+          certificationCenterType: undefined,
           status: 'someStatus',
           resultsSentToPrescriberAt: undefined,
           assignedToSelfOnly: undefined,
@@ -118,6 +145,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
+          certificationCenterType: undefined,
           status: undefined,
           resultsSentToPrescriberAt: true,
           assignedToSelfOnly: undefined,
@@ -140,6 +168,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         expectedQueryArgs.filter = {
           id: undefined,
           certificationCenterName: undefined,
+          certificationCenterType: undefined,
           status: undefined,
           resultsSentToPrescriberAt: undefined,
           assignedToSelfOnly: true,
@@ -191,6 +220,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         pageSize: 'somePageSize',
         id: 'someId',
         certificationCenterName: 'someName',
+        certificationCenterType: 'someType',
         status: 'someStatus',
         resultsSentToPrescriberAt: 'someValue',
       };
@@ -207,6 +237,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         assert.equal(controller.pageSize, 10);
         assert.equal(controller.id, null);
         assert.equal(controller.certificationCenterName, null);
+        assert.equal(controller.certificationCenterType, null);
         assert.equal(controller.status, 'finalized');
         assert.equal(controller.resultsSentToPrescriberAt, null);
       });
@@ -224,6 +255,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
         assert.equal(controller.id, 'someId');
         assert.equal(controller.certificationCenterName, 'someName');
         assert.equal(controller.status, 'someStatus');
+        assert.equal(controller.certificationCenterType, 'someType');
         assert.equal(controller.resultsSentToPrescriberAt, 'someValue');
       });
     });

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -1,3 +1,13 @@
+const SUP = 'SUP';
+const SCO = 'SCO';
+const PRO = 'PRO';
+
+const types = {
+  SUP,
+  SCO,
+  PRO,
+};
+
 class CertificationCenter {
 
   constructor({
@@ -22,3 +32,4 @@ class CertificationCenter {
 }
 
 module.exports = CertificationCenter;
+module.exports.types = types;

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,5 +1,7 @@
 const Joi = require('@hapi/joi');
 const { statuses } = require('../models/Session');
+const { types } = require('../models/CertificationCenter');
+
 const { EntityValidationError } = require('../errors');
 const { idSpecification } = require('./id-specification');
 
@@ -49,6 +51,8 @@ const sessionFiltersValidationSchema = Joi.object({
   resultsSentToPrescriberAt: Joi.boolean().optional(),
   assignedToSelfOnly: Joi.boolean().optional(),
   certificationCenterName: Joi.string().trim().optional(),
+  certificationCenterType: Joi.string().trim()
+    .valid(types.SUP, types.SCO, types.PRO).optional(),
 });
 
 module.exports = {
@@ -61,7 +65,7 @@ module.exports = {
   },
 
   validateAndNormalizeFilters(filters, assignedCertificationOfficerId) {
-    const { value, error } = sessionFiltersValidationSchema.validate(filters, validationConfiguration);
+    const { value, error } = sessionFiltersValidationSchema.validate(filters, { abortEarly: true });
 
     if (error) {
       throw EntityValidationError.fromJoiErrors(error.details);

--- a/api/lib/infrastructure/repositories/jury-session-repository.js
+++ b/api/lib/infrastructure/repositories/jury-session-repository.js
@@ -95,13 +95,18 @@ function _toDomain(jurySessionFromDB) {
 }
 
 function _setupFilters(query, filters) {
-  const { id, certificationCenterName, status, resultsSentToPrescriberAt, assignedCertificationOfficerId } = filters;
+  const { id, certificationCenterName, status, resultsSentToPrescriberAt, assignedCertificationOfficerId, certificationCenterType } = filters;
 
   if (id) {
     query.where('sessions.id', id);
   }
+
   if (certificationCenterName) {
     query.whereRaw('LOWER("certificationCenter") LIKE ?', `%${certificationCenterName.toLowerCase()}%`);
+  }
+
+  if (certificationCenterType) {
+    query.where('certification-centers.type', certificationCenterType);
   }
 
   if (assignedCertificationOfficerId) {

--- a/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/jury-session-repository_test.js
@@ -254,6 +254,66 @@ describe('Integration | Repository | JurySession', function() {
         });
       });
 
+      context('when there is a filter on the certificationCenterType', () => {
+        let expectedSCOSession;
+        let expectedSUPSession;
+        let expectedPROSession;
+
+        beforeEach(() => {
+          const certificationCenterSCO = databaseBuilder.factory.buildCertificationCenter({ type: 'SCO' });
+          expectedSCOSession = databaseBuilder.factory.buildSession({
+            certificationCenter: certificationCenterSCO.name,
+            certificationCenterId: certificationCenterSCO.id,
+          });
+
+          const certificationCenterSUP = databaseBuilder.factory.buildCertificationCenter({ type: 'SUP' });
+          expectedSUPSession = databaseBuilder.factory.buildSession({
+            certificationCenter: certificationCenterSUP.name,
+            certificationCenterId: certificationCenterSUP.id,
+          });
+
+          const certificationCenterPRO = databaseBuilder.factory.buildCertificationCenter({ type: 'PRO' });
+          expectedPROSession = databaseBuilder.factory.buildSession({
+            certificationCenter: certificationCenterPRO.name,
+            certificationCenterId: certificationCenterPRO.id,
+          });
+
+          return databaseBuilder.commit();
+        });
+
+        it('it should find sessions by part of their certification type', async () => {
+          // given
+          const filters = { certificationCenterType: 'SCO' };
+          const page = { number: 1, size: 10 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 1 };
+
+          // when
+          const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+
+          // then
+          expect(pagination).to.deep.equal(expectedPagination);
+          expect(jurySessions[0].id).to.equal(expectedSCOSession.id);
+          expect(jurySessions).to.have.length(1);
+        });
+
+        it('it should return all sessions if certification type filter is null', async () => {
+          // given
+          const filters = { certificationCenterType: null };
+          const page = { number: 1, size: 10 };
+          const expectedPagination = { page: page.number, pageSize: page.size, pageCount: 1, rowCount: 3 };
+
+          // when
+          const { jurySessions, pagination } = await jurySessionRepository.findPaginatedFiltered({ filters, page });
+
+          // then
+          expect(pagination).to.deep.equal(expectedPagination);
+          expect(jurySessions[0].id).to.equal(expectedSCOSession.id);
+          expect(jurySessions[1].id).to.equal(expectedSUPSession.id);
+          expect(jurySessions[2].id).to.equal(expectedPROSession.id);
+          expect(jurySessions).to.have.length(3);
+        });
+      });
+
       context('when there is a filter regarding session status', () => {
 
         context('when there is a filter on created sessions', () => {


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre du lancement de la certification Pix dans les établissements scolaires, des évolutions vont être implémentées sur nos app (notamment Pix Certif et Pix Admin) afin de faciliter l’organisation de sessions pour nos utilisateurs SCO Pix certif d’une part, et d’automatiser certaines tâches opérées manuellement pas le pôle certif d’autre part. Ce dernier point permettra au pôle certif d’absorber plus facilement la masse des certifications attendue avec le SCO (1400000 certifs !). Néanmoins, pour des raisons de temps, certaines de ces améliorations dans le traitement des certifs vont devoir être décalées. Le pôle certif en accord avec le pôle SCO a donc décidé de décaler le traitement des sessions certif de type SCO dans le temps, mais les certifs du SUP et du PRO doivent continuer à être gérées.

Il n’est aujourd’hui pas possible de filtrer la liste des sessions de certification dans Pix Admin sur la catégorie du centre de certification.

## :robot: Solution
Ajouter un filtre sur la colonne “Catégorie” sur la liste des sessions de certification dans Pix Certif 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Se connecter sur pix Admin

- Se rendre dans l'onglet sessions de certifications

- Constater qu'il est desormais possible de filtrer les résultats par catégorie de centre de certification

![image](https://user-images.githubusercontent.com/37305474/96273012-234fa080-0fcf-11eb-917a-7689befc7bca.png)
