### PR TITLE
[FEATURE] Utiliser les tags pour définir si une organisation est de type "Agriculture" (PIX-1354).

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -1,3 +1,5 @@
+const Tag = require('./Tag');
+
 const types = {
   SCO : 'SCO',
   SUP: 'SUP',
@@ -23,6 +25,7 @@ class Organization {
     targetProfileShares = [],
     students = [],
     organizationInvitations = [],
+    tags = [],
     // references
   } = {}) {
     this.id = id;
@@ -41,6 +44,7 @@ class Organization {
     this.targetProfileShares = targetProfileShares;
     this.students = students;
     this.organizationInvitations = organizationInvitations;
+    this.tags = tags;
     // references
   }
 
@@ -57,7 +61,8 @@ class Organization {
   }
 
   get isAgriculture() {
-    return this.isSco && process.env['AGRICULTURE_ORGANIZATION_ID'] === this.id.toString();
+    const tagsName = this.tags.map((tag) => tag.name);
+    return this.isSco && tagsName.includes(Tag.AGRICULTURE);
   }
 
   get isPoleEmploi() {

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -10,5 +10,5 @@ class Tag {
     this.name = name;
   }
 }
-
+Tag.AGRICULTURE = 'AGRICULTURE';
 module.exports = Tag;

--- a/api/lib/domain/usecases/get-prescriber.js
+++ b/api/lib/domain/usecases/get-prescriber.js
@@ -1,3 +1,19 @@
-module.exports = function getPrescriber({ userId, prescriberRepository }) {
+const { UserNotMemberOfOrganizationError } = require('../errors');
+const _ = require('lodash');
+
+module.exports = async function getPrescriber({ userId, prescriberRepository, membershipRepository, userOrgaSettingsRepository }) {
+
+  const memberships = await membershipRepository.findByUserId({ userId });
+  if (_.isEmpty(memberships)) {
+    throw new UserNotMemberOfOrganizationError(`L’utilisateur ${userId} n’est membre d’aucune organisation.`);
+  }
+
+  const userOrgaSettings = await userOrgaSettingsRepository.findOneByUserId(userId);
+
+  if (_.isEmpty(userOrgaSettings)) {
+    const currentOrganization = memberships[0].organization;
+    await userOrgaSettingsRepository.create(userId, currentOrganization.id);
+  }
+
   return prescriberRepository.getPrescriber(userId);
 };

--- a/api/lib/infrastructure/data/organization.js
+++ b/api/lib/infrastructure/data/organization.js
@@ -1,6 +1,7 @@
 const Bookshelf = require('../bookshelf');
 
 require('./membership');
+require('./tag');
 require('./target-profile-share');
 
 const modelName = 'Organization';
@@ -19,6 +20,9 @@ module.exports = Bookshelf.model(modelName, {
     return this.hasMany('TargetProfileShare', 'organizationId');
   },
 
+  tags() {
+    return this.belongsToMany('Tag', 'organization-tags', 'organizationId',  'tagId');
+  },
 }, {
   modelName,
 });

--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -81,6 +81,13 @@ module.exports = {
       .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
   },
 
+  findByUserId({ userId }) {
+    return BookshelfMembership
+      .where({ userId, disabledAt: null })
+      .fetchAll({ withRelated: ['organization'] })
+      .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
+  },
+
   isMembershipExistingByOrganizationIdAndEmail(organizationId, email) {
     return BookshelfMembership
       .where({ 'memberships.organizationId': organizationId, 'users.email': email })

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -6,16 +6,16 @@ module.exports = {
     return new Serializer('prescriber', {
 
       transform: (record) => {
-        const recordWithoutClass = { ... record };
+        const recordWithoutClass = { ...record };
         recordWithoutClass.memberships.forEach((membership) => {
-          membership.organization = { 
-            ... membership.organization,
-            isAgriculture: membership.organization.isAgriculture,
-          };
+          membership.organization = { ...membership.organization };
         });
-        recordWithoutClass.userOrgaSettings.organization = {
-          ...recordWithoutClass.userOrgaSettings.currentOrganization,
-          isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization,
+        recordWithoutClass.userOrgaSettings = {
+          ...recordWithoutClass.userOrgaSettings,
+          organization: {
+            ...recordWithoutClass.userOrgaSettings.currentOrganization,
+            isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization.isAgriculture,
+          },
         };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
 
@@ -31,7 +31,7 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations', 'isAgriculture'],
+          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,
@@ -79,7 +79,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type'],
+          attributes: ['name', 'type', 'isAgriculture'],
         },
       },
     }).serialize(prescriber);

--- a/api/lib/infrastructure/utils/bookshelf-to-domain-converter.js
+++ b/api/lib/infrastructure/utils/bookshelf-to-domain-converter.js
@@ -35,7 +35,7 @@ function _buildDomainObject(BookshelfClass, bookshelfObjectJson) {
       );
     }
 
-    if ((relationshipType === 'hasMany') && _.isArray(bookshelfObjectJson[key])) {
+    if ((relationshipType === 'hasMany' || relationshipType === 'belongsToMany') && _.isArray(bookshelfObjectJson[key])) {
       return bookshelfObjectJson[key].map(
         (bookshelfObject) => _buildDomainObject(relationshipClass, bookshelfObject),
       );

--- a/api/scripts/create-or-update-sco-agri-organizations.js
+++ b/api/scripts/create-or-update-sco-agri-organizations.js
@@ -15,7 +15,7 @@ const organizationRepository = require('../lib/infrastructure/repositories/organ
 const tagRepository = require('../lib/infrastructure/repositories/tag-repository');
 const organizationTagRepository = require('../lib/infrastructure/repositories/organization-tag-repository');
 
-const TAG_NAME = 'AGRI';
+const TAG_NAME = 'AGRICULTURE';
 
 function checkData({ csvData }) {
   return csvData.map((data) => {
@@ -97,7 +97,7 @@ async function addTag(organizations) {
 }
 
 async function main() {
-  console.log('Starting creating or updating SCO AGRI organizations.');
+  console.log('Starting creating or updating SCO AGRICULTURE organizations.');
 
   try {
     const filePath = process.argv[2];
@@ -120,7 +120,7 @@ async function main() {
     const createOrUpdatedOrganizations = await createOrUpdateOrganizations({ organizationsByExternalId, checkedData });
     console.log('ok');
 
-    console.log('Adding AGRI tag...');
+    console.log('Adding AGRICULTURE tag...');
     await addTag(createOrUpdatedOrganizations);
     console.log('\nDone.');
 

--- a/api/tests/acceptance/application/membership-controller_test.js
+++ b/api/tests/acceptance/application/membership-controller_test.js
@@ -64,7 +64,6 @@ describe('Acceptance | Controller | membership-controller', () => {
         const expectedMembership = {
           data: {
             type: 'memberships',
-            id: '1',
             attributes: {
               'organization-role': 'ADMIN',
             },
@@ -84,7 +83,7 @@ describe('Acceptance | Controller | membership-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(201);
-        expect(_.omit(response.result, 'included')).to.deep.equal(expectedMembership);
+        expect(_.omit(response.result, ['included', 'data.id'])).to.deep.equal(expectedMembership);
       });
 
       context('When a membership is disabled', () => {

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -52,7 +52,6 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
             'is-managing-students': organization.isManagingStudents,
             'name': organization.name,
             'type': organization.type,
-            'is-agriculture': false,
           },
           relationships: {
             memberships: {
@@ -156,7 +155,7 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
 
     describe('Success case', () => {
 
-      it('should return found memberships with 200 HTTP status code', async () => {
+      it('should 200 HTTP status code', async () => {
         // given
         const expectedPrescriber = createExpectedPrescriber({ user, membership, userOrgaSettingsId, organization });
 

--- a/api/tests/integration/infrastructure/models/assessment_result_test.js
+++ b/api/tests/integration/infrastructure/models/assessment_result_test.js
@@ -2,9 +2,7 @@ const { sinon, knex } = require('../../../test-helper');
 const BookshelfAssessmentResults = require('../../../../lib/infrastructure/data/assessment-result');
 
 describe('Integration | Infrastructure | Models | BookshelfAssessmentResult', () => {
-
   describe('validation', () => {
-
     let rawData;
 
     beforeEach(() => {
@@ -16,21 +14,34 @@ describe('Integration | Infrastructure | Models | BookshelfAssessmentResult', ()
 
     afterEach(() => knex('assessment-results').delete());
 
-    describe('the status field', () => {
+    describe('the status field validated', () => {
+      it('should be saved', () => {
+        // given
+        rawData.status = 'validated';
+        const assessmentResult = new BookshelfAssessmentResults(rawData);
 
-      ['validated', 'rejected'].forEach((status) => {
-        it('should be saved when organisation type is ${organizationType}', () => {
-          // given
-          rawData.status = status;
-          const assessmentResult = new BookshelfAssessmentResults(rawData);
+        // when
+        const promise = assessmentResult.save();
 
-          // when
-          const promise = assessmentResult.save();
+        // then
+        return promise.catch((_) => {
+          sinon.assert.fail(new Error('Should not fail with validated type'));
+        });
+      });
+    });
 
-          // then
-          return promise.catch((_) => {
-            sinon.assert.fail(new Error(`Should not fail with ${status} type`));
-          });
+    describe('the status field rejected', () => {
+      it('should be saved', () => {
+        // given
+        rawData.status = 'rejected';
+        const assessmentResult = new BookshelfAssessmentResults(rawData);
+
+        // when
+        const promise = assessmentResult.save();
+
+        // then
+        return promise.catch((_) => {
+          sinon.assert.fail(new Error('Should not fail with rejected type'));
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -410,6 +410,65 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
     });
   });
 
+  describe('#findByUser', () => {
+
+    it('should retrieve membership with given userId', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const user1 = databaseBuilder.factory.buildUser();
+      const organizationRole1 = Membership.roles.ADMIN;
+      const user2 = databaseBuilder.factory.buildUser();
+      const organizationRole2 = Membership.roles.MEMBER;
+
+      databaseBuilder.factory.buildMembership({ organizationRole: organizationRole1, organizationId: organization.id, userId: user1.id });
+      const membership2 = databaseBuilder.factory.buildMembership({ organizationRole: organizationRole2, organizationId: organization.id, userId: user2.id });
+
+      await databaseBuilder.commit();
+
+      //when
+      const memberships = await membershipRepository.findByUserId({ userId: user2.id });
+
+      //then
+      expect(memberships).to.have.lengthOf(1);
+      expect(memberships[0]).to.be.instanceOf(Membership);
+      expect(memberships[0].id).to.equal(membership2.id);
+    });
+
+    it('should retrieve membership with its organization', async () => {
+      // given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+
+      databaseBuilder.factory.buildMembership({ organizationId, userId });
+
+      await databaseBuilder.commit();
+
+      //when
+      const memberships = await membershipRepository.findByUserId({ userId });
+
+      //then
+      expect(memberships).to.have.lengthOf(1);
+      const organization = memberships[0].organization;
+      expect(organization).to.be.instanceOf(Organization);
+    });
+
+    it('should retrieve only active membership', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+
+      databaseBuilder.factory.buildMembership({ userId, organizationId, disabledAt: new Date() });
+
+      await databaseBuilder.commit();
+
+      // when
+      const foundMemberships = await membershipRepository.findByUserId({ userId });
+
+      // then
+      expect(foundMemberships).to.have.lengthOf(0);
+    });
+  });
+
   describe('#isMembershipExistingByOrganizationIdAndEmail', () => {
 
     it('should return true when the membership exists by organizationId and email', async () => {

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -148,6 +148,7 @@ describe('Integration | Repository | Organization', function() {
           students: [],
           targetProfileShares: [],
           organizationInvitations: [],
+          tags: [],
         };
         await databaseBuilder.commit();
       });
@@ -207,7 +208,7 @@ describe('Integration | Repository | Organization', function() {
       });
     });
 
-    context('when organization have memberships', () => {
+    context('when organization has memberships', () => {
 
       it('should return a list of active members', async () => {
         // given

--- a/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/prescriber-repository_test.js
@@ -9,6 +9,7 @@ const Prescriber = require('../../../../lib/domain/read-models/Prescriber');
 const Membership = require('../../../../lib/domain/models/Membership');
 const UserOrgaSettings = require('../../../../lib/domain/models/UserOrgaSettings');
 const Organization = require('../../../../lib/domain/models/Organization');
+const Tag = require('../../../../lib/domain/models/Tag');
 
 describe('Integration | Infrastructure | Repository | Prescriber', () => {
 
@@ -155,6 +156,26 @@ describe('Integration | Infrastructure | Repository | Prescriber', () => {
 
         // then
         expect(foundPrescriber).to.be.an.instanceOf(Prescriber);
+      });
+
+      context('when current organization defined in user-orga-settings has tags', () => {
+
+        it('should return a list of tags', async () => {
+          // given
+          const tag1 = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
+          databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag1.id });
+          const tag2 = databaseBuilder.factory.buildTag({ name: 'OTHER' });
+          databaseBuilder.factory.buildOrganizationTag({ organizationId: organization.id, tagId: tag2.id });
+
+          await databaseBuilder.commit();
+
+          // when
+          const foundPrescriber = await prescriberRepository.getPrescriber(user.id);
+
+          // then
+          expect(foundPrescriber.userOrgaSettings.currentOrganization.tags.map((tag) => tag.name)).to.have.members(['OTHER', 'AGRICULTURE']);
+          expect(foundPrescriber.userOrgaSettings.currentOrganization.tags[0]).to.be.instanceOf(Tag);
+        });
       });
 
       context('when newYearSchoolingRegistrationsImportDate is defined in the env.', () => {

--- a/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-orga-settings-repository_test.js
@@ -13,7 +13,7 @@ describe('Integration | Repository | UserOrgaSettings', function() {
   const USER_PICKED_PROPERTIES = ['id', 'firstName', 'lastName', 'email', 'username', 'password', 'cgu',
     'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted'];
 
-  const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'email',
+  const ORGANIZATION_OMITTED_PROPERTIES = ['memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'email', 'tags',
     'createdAt', 'updatedAt'];
 
   let user;

--- a/api/tests/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
+++ b/api/tests/integration/infrastructure/utils/bookshelf-to-domain-converter_test.js
@@ -5,10 +5,12 @@ const User = require('../../../../lib/domain/models/User');
 const Membership = require('../../../../lib/domain/models/Membership');
 const TargetProfile = require('../../../../lib/domain/models/TargetProfile');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const Tag = require('../../../../lib/domain/models/Tag');
 
 const BookshelfUser = require('../../../../lib/infrastructure/data/user');
 const BookshelfCampaign = require('../../../../lib/infrastructure/data/campaign');
 const BookshelfCampaignParticipation = require('../../../../lib/infrastructure/data/campaign-participation');
+const BookshelfOrganization = require('../../../../lib/infrastructure/data/organization');
 
 describe('Integration | Infrastructure | Utils | Bookshelf to domain converter', function() {
 
@@ -88,6 +90,26 @@ describe('Integration | Infrastructure | Utils | Bookshelf to domain converter',
       // then
       expect(domainObject.targetProfile).to.be.instanceOf(TargetProfile);
     });
+
+    it('should support belongs-to-many relationships', async () => {
+      //given
+      const organizationId = databaseBuilder.factory.buildOrganization().id;
+      databaseBuilder.factory.buildOrganizationTag({ organizationId });
+      databaseBuilder.factory.buildOrganizationTag({ organizationId });
+      await databaseBuilder.commit();
+      const bookshelfObject = await BookshelfOrganization.where({ id: organizationId }).fetch({
+        withRelated: ['tags'],
+      });
+
+      // when
+      const domainObject = bookshelfToDomainConverter.buildDomainObject(BookshelfOrganization, bookshelfObject);
+
+      // then
+      expect(domainObject.tags).to.be.instanceOf(Array);
+      expect(domainObject.tags[0]).to.be.instanceOf(Tag);
+      expect(domainObject.tags.length).to.equal(2);
+    });
+
     it('should support domain object relationship’s name not matching the corresponding Bookshelf class name', async () => {
       // given
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/scripts/create-or-update-sco-agri-organizations_test.js
+++ b/api/tests/integration/scripts/create-or-update-sco-agri-organizations_test.js
@@ -153,7 +153,7 @@ describe('Integration | Scripts | create-or-update-sco-agri-organizations', () =
 
   describe('#addTag', () => {
 
-    context('When AGRI tag does not exist', () => {
+    context('When AGRICULTURE tag does not exist', () => {
 
       afterEach(() => {
         return knex('tags').delete();
@@ -169,16 +169,16 @@ describe('Integration | Scripts | create-or-update-sco-agri-organizations', () =
         // then
         const tagsInDB = await knex('tags').select();
         expect(tagsInDB.length).to.equal(1);
-        expect(tagsInDB[0].name).to.equal('AGRI');
+        expect(tagsInDB[0].name).to.equal('AGRICULTURE');
       });
     });
 
-    context('When AGRI tag already exists in DB', () => {
+    context('When AGRICULTURE tag already exists in DB', () => {
 
       let agriTag;
 
       beforeEach(async () => {
-        agriTag = databaseBuilder.factory.buildTag({ name: 'AGRI' });
+        agriTag = databaseBuilder.factory.buildTag({ name: 'AGRICULTURE' });
         await databaseBuilder.commit();
       });
 
@@ -186,9 +186,9 @@ describe('Integration | Scripts | create-or-update-sco-agri-organizations', () =
         return knex('organization-tags').delete();
       });
 
-      context('When organization does not have an AGRI tag', () => {
+      context('When organization does not have an AGRICULTURE tag', () => {
 
-        it('should add AGRI tag to the organization', async () => {
+        it('should add AGRICULTURE tag to the organization', async () => {
           // given
           const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO' });
           await databaseBuilder.commit();

--- a/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
+++ b/api/tests/integration/scripts/send-invitations-to-sco-organizations_test.js
@@ -15,7 +15,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       // given
       const externalId = '1234567A';
       const organization = databaseBuilder.factory.buildOrganization({ externalId });
-      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email']);
+      const expectedOrganization = _.omit(organization, ['createdAt', 'updatedAt', 'email', 'tags']);
 
       await databaseBuilder.commit();
 
@@ -23,7 +23,7 @@ describe('Integration | Scripts | send-invitations-to-sco-organizations.js', () 
       const result = await getOrganizationByExternalId(externalId);
 
       // then
-      expect(_.omit(result, ['email', 'memberships', 'organizationInvitations', 'students', 'targetProfileShares']))
+      expect(_.omit(result, ['email', 'memberships', 'organizationInvitations', 'students', 'targetProfileShares', 'tags']))
         .to.deep.equal(expectedOrganization);
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-organization.js
+++ b/api/tests/tooling/domain-builder/factory/build-organization.js
@@ -41,8 +41,9 @@ function buildOrganization(
     createdAt = new Date('2018-01-12T01:02:03Z'),
     memberships = [],
     targetProfileShares = [],
+    tags = [],
   } = {}) {
-  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, email, canCollectProfiles, createdAt, memberships, targetProfileShares });
+  return new Organization({ id, name, type, logoUrl, externalId, provinceCode, isManagingStudents, credit, email, canCollectProfiles, createdAt, memberships, targetProfileShares, tags });
 }
 
 buildOrganization.withMembers = function(

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder } = require('../../../test-helper');
 const Organization = require('../../../../lib/domain/models/Organization');
+const Tag = require('../../../../lib/domain/models/Tag');
 
 describe('Unit | Domain | Models | Organization', () => {
 
@@ -104,36 +105,38 @@ describe('Unit | Domain | Models | Organization', () => {
   });
 
   describe('get#isAgriculture', () => {
-    beforeEach(() => {
-      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
+
+    context('when organization is not SCO', ()  =>  {
+      it('should return false when the organization has the "AGRICULTURE" tag', () => {
+        // given
+        const tag = domainBuilder.buildTag({ name: Tag.AGRICULTURE });
+        const organization = domainBuilder.buildOrganization({ type: 'SUP', tags: [tag] });
+
+        // when / then
+        expect(organization.isAgriculture).is.false;
+      });
     });
 
-    afterEach(() => {
-      process.env['AGRICULTURE_ORGANIZATION_ID'] = null;
-    });
+    context('when organization is SCO', ()  =>  {
+      it('should return true when organization is of type SCO and has the "AGRICULTURE" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: Tag.AGRICULTURE });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
 
-    it('should return true when organization is of type SCO and id match Environnement variable AGRICULTURE_ORGANIZATION_ID', () => {
-      // given
-      const organization = domainBuilder.buildOrganization({ id: '1', type: 'SCO' });
+        // when / then
+        expect(organization.isAgriculture).is.true;
+      });
 
-      // when / then
-      expect(organization.isAgriculture).is.true;
-    });
+      it('should return false when when organization is of type SCO and has not the "AGRICULTURE" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: 'To infinity…and beyond!' });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
 
-    it('should return false when when organization is of type SCO and id doesnt match Environnement variable AGRICULTURE_ORGANIZATION_ID', () => {
-      // given
-      const organization = domainBuilder.buildOrganization({ id: '2', type: 'SCO' });
-
-      // when / then
-      expect(organization.isAgriculture).is.false;
-    });
-
-    it('should return false when when organization is not of type SCO', () => {
-      // given
-      const organization = domainBuilder.buildOrganization({ id: '1', type: 'SUP' });
-
-      // when / then
-      expect(organization.isAgriculture).is.false;
+        // when / then
+        expect(organization.isAgriculture).is.false;
+      });
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-prescriber_test.js
+++ b/api/tests/unit/domain/usecases/get-prescriber_test.js
@@ -1,25 +1,122 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const getPrescriber = require('../../../../lib/domain/usecases/get-prescriber');
+const { UserNotMemberOfOrganizationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-prescriber', () => {
 
+  const userId = 1;
+  const expectedResult = Symbol('prescriber');
   let prescriberRepository;
+  let membershipRepository;
+  let userOrgaSettingsRepository;
 
   beforeEach(() => {
     prescriberRepository = { getPrescriber: sinon.stub() };
+    membershipRepository = { findByUserId: sinon.stub() };
+    userOrgaSettingsRepository = { findOneByUserId: sinon.stub(), create: sinon.stub() };
   });
 
-  it('should get the prescriber', async () => {
-    // given
-    prescriberRepository.getPrescriber.withArgs(1).resolves({ id: 1 });
+  context('When user is not a member of any organization', () => {
+    it('should throw UserNotMemberOfOrganizationError', async () => {
+      // given
+      membershipRepository.findByUserId.withArgs({ userId }).resolves([]);
 
-    // when
-    const result = await getPrescriber({
-      userId: 1,
-      prescriberRepository,
+      // when
+      const error = await catchErr(getPrescriber)({
+        userId,
+        prescriberRepository,
+        membershipRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotMemberOfOrganizationError);
+      expect(error.message).to.equal('L’utilisateur 1 n’est membre d’aucune organisation.');
+    });
+  });
+
+  context('When user does not have userOrgaSettings yet', () => {
+    it('should create userOrgaSettings', async () => {
+      // given
+      const user = domainBuilder.buildUser({ id: userId });
+      const membership1 = domainBuilder.buildMembership({ user });
+      const membership2 = domainBuilder.buildMembership({ user });
+      membershipRepository.findByUserId.withArgs({ userId }).resolves([membership1, membership2]);
+      userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves(null);
+
+      // when
+      await getPrescriber({
+        userId,
+        prescriberRepository,
+        membershipRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(userOrgaSettingsRepository.create).to.have.been.calledWithExactly(userId, membership1.organization.id);
     });
 
-    // then
-    expect(result).to.deep.equal({ id: 1 });
+    it('should return prescriber', async () => {
+      // given
+      const user = domainBuilder.buildUser({ id: userId });
+      const membership = domainBuilder.buildMembership({ user });
+      membershipRepository.findByUserId.withArgs({ userId }).resolves([membership]);
+      userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves(null);
+      prescriberRepository.getPrescriber.withArgs(userId).resolves(expectedResult);
+
+      // when
+      const result = await getPrescriber({
+        userId,
+        prescriberRepository,
+        membershipRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  context('When user already has userOrgaSettings', () => {
+    it('should not create userOrgaSettings', async () => {
+      // given
+      const user = domainBuilder.buildUser({ id: userId });
+      const membership = domainBuilder.buildMembership({ user });
+      membershipRepository.findByUserId.withArgs({ userId }).resolves([membership]);
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings({ currentOrganization: membership.organisation, user: membership.user });
+      userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves(userOrgaSettings);
+
+      // when
+      await getPrescriber({
+        userId,
+        prescriberRepository,
+        membershipRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(userOrgaSettingsRepository.create).to.not.have.been.called;
+    });
+
+    it('should return prescriber', async () => {
+      // given
+      const user = domainBuilder.buildUser({ id: userId });
+      const membership = domainBuilder.buildMembership({ user });
+      membershipRepository.findByUserId.withArgs({ userId }).resolves([membership]);
+      const userOrgaSettings = domainBuilder.buildUserOrgaSettings({ currentOrganization: membership.organisation, user: membership.user });
+      userOrgaSettingsRepository.findOneByUserId.withArgs(userId).resolves(userOrgaSettings);
+      prescriberRepository.getPrescriber.withArgs(userId).resolves(expectedResult);
+
+      // when
+      const result = await getPrescriber({
+        userId,
+        prescriberRepository,
+        membershipRepository,
+        userOrgaSettingsRepository,
+      });
+
+      // then
+      expect(result).to.deep.equal(expectedResult);
+    });
   });
 });

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -49,7 +49,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
     });
   });
-    
+
   context('When user is not ADMIN in a SUP organization', () => {
     it('should throw an error', async () => {
       // given
@@ -64,10 +64,10 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
   });
 
   context('When user is ADMIN in a SCO-AGRICULTURE organization managing students', () => {
-    it('should return headers line', async () => {    
-      // given 
-      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
-      const organization = domainBuilder.buildOrganization({ id: '1', isManagingStudents: true, type: 'SCO' });
+    it('should return headers line', async () => {
+      // given
+      const tag = domainBuilder.buildTag({ name: 'AGRICULTURE' });
+      const organization = domainBuilder.buildOrganization({ id: '1', isManagingStudents: true, type: 'SCO', tags: [tag] });
       const membership = domainBuilder.buildMembership({ organizationRole: 'ADMIN', organization });
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
 
@@ -89,7 +89,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
         '"Statut*";' +
         '"Code MEF*";' +
         '"Division*"\n';
-        
+
       expect(result).to.deep.equal(csvExpected);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
C'est en utilisant une variable d'environnement qu'on définissait si une organisation avais le type "AGRICULTURE" et il ne pouvait y avoir qu'une seule organisation avec ce type.

## :robot: Solution
Utiliser les tags pour définir quelle organisation est de type. "AGRICULTURE"

## :rainbow: Remarques
RAS

## :100: Pour tester
Créer un tag avec un nom "AGRICULTURE"
Ajouter ce tag à une organisation SCO qui gère des élèves
Vérifier  que l'organisation peut importer. des élèves en utilisant le fichier CSV au format SIECLE


Attention. il faut changer le format du fichier
[data.txt](https://github.com/1024pix/pix/files/5392345/data.txt)
