### PR TITLE
[FEATURE] Autoriser l'import XML SIECLE seulement pour les organisations ayant un UAI concordant (PIX-1293).

### DIFF
--- a/api/lib/domain/services/schooling-registrations-xml-service.js
+++ b/api/lib/domain/services/schooling-registrations-xml-service.js
@@ -14,10 +14,12 @@ function extractSchoolingRegistrationsInformationFromSIECLE(buffer) {
     return [];
   }
 
+  const UAIFromSIECLE = _getEitherElementValueOrNull(parsedXmlDom, 'UAJ');
+
   const xmlSchoolingRegistrationsStructures = Array.from(parsedXmlDom.getElementsByTagName('STRUCTURES_ELEVE'));
   const xmlSchoolingRegistrations = Array.from(parsedXmlDom.getElementsByTagName('ELEVE'));
 
-  return xmlSchoolingRegistrations
+  const resultFromExtraction = xmlSchoolingRegistrations
     .filter((xmlSchoolingRegistration) => _filterLeftSchoolingRegistrations(xmlSchoolingRegistration, xmlSchoolingRegistrationsStructures))
     .filter((xmlSchoolingRegistration) => _filterNotYetArrivedSchoolingRegistrations(xmlSchoolingRegistration))
     .map((xmlSchoolingRegistration) => {
@@ -41,6 +43,8 @@ function extractSchoolingRegistrationsInformationFromSIECLE(buffer) {
         division: _findSchoolingRegistrationDivision(schoolingRegistrationStructuresContainer),
       };
     });
+
+  return { UAIFromSIECLE, resultFromExtraction };
 }
 
 function _buildXmlDomFromBuffer(xmlBuffer) {

--- a/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
+++ b/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
@@ -2,25 +2,30 @@ const { FileValidationError, SameNationalStudentIdInOrganizationError, SameNatio
 const _ = require('lodash');
 const SchoolingRegistrationParser = require('../../infrastructure/serializers/csv/schooling-registration-parser');
 
-module.exports = async function importSchoolingRegistrationsFromSIECLE({ organizationId, buffer, format, schoolingRegistrationsXmlService, schoolingRegistrationRepository }) {
+module.exports = async function importSchoolingRegistrationsFromSIECLE({ organizationId, buffer, format, organizationRepository, schoolingRegistrationsXmlService, schoolingRegistrationRepository }) {
 
-  let schoolingRegistrationDatas = [];
+  let schoolingRegistrationData = [];
 
   if (format === 'xml') {
-    schoolingRegistrationDatas = schoolingRegistrationsXmlService.extractSchoolingRegistrationsInformationFromSIECLE(buffer);
+    const { UAIFromSIECLE, resultFromExtraction } = schoolingRegistrationsXmlService.extractSchoolingRegistrationsInformationFromSIECLE(buffer);
+    const organization = await organizationRepository.get(organizationId);
+    if (UAIFromSIECLE !== organization.externalId) {
+      throw new FileValidationError('Aucun étudiant n’a été importé. L’import n’est pas possible car l’UAI du fichier SIECLE ne correspond pas à celui de votre établissement. En cas de difficulté, contactez support.pix.fr.');
+    }
+    schoolingRegistrationData = resultFromExtraction;
   } else if (format === 'csv') {
     const csvSiecleParser = new SchoolingRegistrationParser(buffer, organizationId);
-    schoolingRegistrationDatas = csvSiecleParser.parse().registrations;
+    schoolingRegistrationData = csvSiecleParser.parse().registrations;
   } else {
     throw new FileValidationError('Format de fichier non valide.');
   }
 
-  if (_.isEmpty(schoolingRegistrationDatas)) {
-    throw new FileValidationError('Aucune inscription d\'élève n\'a pu être importée depuis ce fichier.Vérifiez que le fichier est conforme.');
+  if (_.isEmpty(schoolingRegistrationData)) {
+    throw new FileValidationError('Aucune inscription d’élève n’a pu être importée depuis ce fichier. Vérifiez que le fichier est conforme.');
   }
 
   try {
-    await schoolingRegistrationRepository.addOrUpdateOrganizationSchoolingRegistrations(schoolingRegistrationDatas, organizationId);
+    await schoolingRegistrationRepository.addOrUpdateOrganizationSchoolingRegistrations(schoolingRegistrationData, organizationId);
   } catch (err) {
     if (err instanceof SameNationalStudentIdInOrganizationError) {
       throw new SameNationalStudentIdInFileError(err.nationalStudentId);

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -19,12 +19,13 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
   describe('POST /api/organizations/{id}/schooling-registrations/import-siecle', () => {
 
+    const externalId = 'UAI123ABC';
     let organizationId;
     let options;
 
     beforeEach(async () => {
       const connectedUser = databaseBuilder.factory.buildUser();
-      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true }).id;
+      organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId }).id;
       databaseBuilder.factory.buildMembership({
         organizationId,
         userId: connectedUser.id,
@@ -52,6 +53,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const buffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   '<ELEVE ELEVE_ID="0001">' +
@@ -142,6 +146,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const malformedStudentsBuffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+            '<PARAMETRES>' +
+            '<UAJ>UAI123ABC</UAJ>' +
+            '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   wellFormattedStudent +
@@ -246,6 +253,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const buffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   '<ELEVE ELEVE_ID="0001">' +
@@ -318,6 +328,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const bufferWithMalformedStudent = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+            '<PARAMETRES>' +
+            '<UAJ>UAI123ABC</UAJ>' +
+            '</PARAMETRES>' +
             '<DONNEES>' +
             '<ELEVES>' +
             schoolingRegistration1 +
@@ -393,6 +406,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const bufferWithMalformedStudent = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   schoolingRegistrationThatCantBeUpdatedBecauseBirthdateIsMissing +
@@ -505,6 +521,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const buffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   schoolingRegistrationThatCouldBeCreated +
@@ -612,6 +631,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const buffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   schoolingRegistrationThatCantBeCreatedBecauseBirthdateIsMissing +
@@ -671,6 +693,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const malformedStudentsBuffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
               '<DONNEES>' +
                 '<ELEVES>' +
                   '<ELEVE ELEVE_ID="0001">' +
@@ -710,6 +735,9 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const malformedBuffer = iconv.encode(
             '<?xml version="1.0" encoding="ISO-8859-15"?>' +
             '<BEE_ELEVES VERSION="2.1">' +
+              '<PARAMETRES>' +
+              '<UAJ>UAI123ABC</UAJ>' +
+              '</PARAMETRES>' +
             '</BEE_ELEVES>', 'ISO-8859-15');
           options.payload = malformedBuffer;
         });
@@ -722,7 +750,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(422);
-          expect(response.result.errors[0].detail).to.equal('Aucune inscription d\'élève n\'a pu être importée depuis ce fichier.Vérifiez que le fichier est conforme.');
+          expect(response.result.errors[0].detail).to.equal('Aucune inscription d’élève n’a pu être importée depuis ce fichier. Vérifiez que le fichier est conforme.');
         });
       });
     });
@@ -809,12 +837,15 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
         });
       });
     });
-  
+
     context('Resource access management', () => {
       beforeEach(() => {
         const buffer = iconv.encode(
           '<?xml version="1.0" encoding="ISO-8859-15"?>' +
           '<BEE_ELEVES VERSION="2.1">' +
+            '<PARAMETRES>' +
+            '<UAJ>UAI123ABC</UAJ>' +
+            '</PARAMETRES>' +
           '</BEE_ELEVES>', 'ISO-8859-15');
         options.payload = buffer;
       });

--- a/api/tests/integration/domain/services/schooling-registrations-xml-service_test.js
+++ b/api/tests/integration/domain/services/schooling-registrations-xml-service_test.js
@@ -6,12 +6,16 @@ const iconv = require('iconv-lite');
 describe('Integration | Services | schooling-registrations-xml-service', () => {
 
   describe('extractSchoolingRegistrationsInformationFromSIECLE', () => {
+    const UAIFromSIECLE = '123ABC';
 
     it('should parse in schoolingRegistrations informations', function() {
       // given
       const buffer = iconv.encode(
         '<?xml version="1.0" encoding="ISO-8859-15"?>' +
         '<BEE_ELEVES VERSION="2.1">' +
+        '<PARAMETRES>' +
+        '<UAJ>123ABC</UAJ>' +
+        '</PARAMETRES>' +
         '<DONNEES>' +
         '<ELEVES>' +
         '<ELEVE ELEVE_ID="0001">' +
@@ -99,7 +103,7 @@ describe('Integration | Services | schooling-registrations-xml-service', () => {
       const result = schoolingRegistrationsXmlService.extractSchoolingRegistrationsInformationFromSIECLE(buffer);
 
       //then
-      expect(result).to.deep.equal(expectedSchoolingRegistrations);
+      expect(result).to.deep.equal({ UAIFromSIECLE, resultFromExtraction: expectedSchoolingRegistrations });
     });
 
     it('should not parse schoolingRegistrations who are no longer in the school', function() {
@@ -107,6 +111,9 @@ describe('Integration | Services | schooling-registrations-xml-service', () => {
       const buffer = iconv.encode(
         '<?xml version="1.0" encoding="ISO-8859-15"?>' +
         '<BEE_ELEVES VERSION="2.1">' +
+        '<PARAMETRES>' +
+        '<UAJ>123ABC</UAJ>' +
+        '</PARAMETRES>' +
         '<DONNEES>' +
         '<ELEVES>' +
         '<ELEVE ELEVE_ID="0001">' +
@@ -206,7 +213,7 @@ describe('Integration | Services | schooling-registrations-xml-service', () => {
       const result = schoolingRegistrationsXmlService.extractSchoolingRegistrationsInformationFromSIECLE(buffer);
 
       //then
-      expect(result).to.deep.equal(expectedSchoolingRegistrations);
+      expect(result).to.deep.equal({ UAIFromSIECLE, resultFromExtraction: expectedSchoolingRegistrations });
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Certaines organisations sont des cités scolaires (collège et lycée, ou collège et lycée professionnel, etc), et ont donc plusieurs espace Orga dans Pix Orga.
Or ils ne font pas attention, et importent parfois les élèves dans la mauvaise organisation...

## :robot: Solution
Vérifier que l'import se fait bien dans la bonne organisation à l'aide du champ `UAJ` du fichier (qui en fait est la même chose que l'`UAI`) et le comparer à l'information stockée en base en temps qu'`externalId` dans la table `Organization`.

## :rainbow: Remarques
Ce champ dans SIECLE devient donc Obligatoire.

## :100: Pour tester
Importer un fichier SIECLE sans UAI, vérifier la levée de l'erreur.
Importer un fichier SIECLE avec le mauvais UAI, vérifier la levée de l'erreur.
