### PR TITLE
[TECH] Montée de version mineure de la BDD 12.3=>12.4.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:12.18.0
-      - image: postgres:12.3-alpine
+      - image: postgres:12.4-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -195,7 +195,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node12.18.0-chrome83-ff77
-      - image: postgres:12.3-alpine
+      - image: postgres:12.4-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12.3-alpine
+    image: postgres:12.4-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## :unicorn: Problème
Une nouvelle version de BDD est disponible sur Scalingo

## :robot: Solution
Configurer la BDD de CI + locale en 12.4

## :rainbow: Remarques
[Changelog](https://www.postgresql.org/docs/release/12.4/) => rien de notable IMHO

Penser à effectuer la montée de version manuelle des applications Scalingo Intégration/Recette après le merge
[=> voir Wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1549434939/Mises+jour+hors+npm)

## :100: Pour tester

Vérifier que la RA Scalingo est par défaut en 12.4
Vérifier que la suite de test passe en CI et en local
