### PR TITLE
[FEATURE] Pouvoir télécharger le modèle csv en tant qu'organisation SCO-AGRICULTURE. (PIX-1357)

### DIFF
--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -1,43 +1,45 @@
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
+const SchoolingRegistrationParser = require('../../infrastructure/serializers/csv/schooling-registration-parser');
 
 module.exports = async function getSchoolingRegistrationsCsvTemplate({
   userId,
   organizationId,
   membershipRepository,
 }) {
+  let header = [];
   const [membership] = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
-  if (!_isAdminInSupOrganizationManagingStudents(membership)) {
+
+  if (!_isAdminOrganizationManagingStudent(membership)) {
     throw new UserNotAuthorizedToAccessEntity('User is not allowed to download csv template.');
   }
 
-  //Create HEADER of CSV
-  const headers = _createHeaderOfCSV();
+  const { isSup, isSco, isAgriculture } = membership.organization;
 
+  if (isSup) {
+    header = _getCsvColumns(HigherSchoolingRegistrationParser.COLUMNS);
+  } else if (isSco && isAgriculture) {
+    header = _getCsvColumns(SchoolingRegistrationParser.COLUMNS);
+  } else {
+    throw new UserNotAuthorizedToAccessEntity('User organization is not allowed to download csv template.');
+  }
+
+  //Create HEADER of CSV
+  return _createHeaderOfCSV(header);
+};
+
+function _getCsvColumns(columns) {
+  return columns.map((column) => column.label);
+}
+
+function _createHeaderOfCSV(header) {
   // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
   // - https://en.wikipedia.org/wiki/Byte_order_mark
   // - https://stackoverflow.com/a/38192870
-  return '\uFEFF' + csvSerializer.serializeLine(headers);
-};
-
-function _createHeaderOfCSV() {
-  return [
-    'Premier prénom',
-    'Deuxième prénom',
-    'Troisième prénom',
-    'Nom de famille',
-    'Nom d’usage',
-    'Date de naissance (jj/mm/aaaa)',
-    'Email',
-    'Numéro étudiant',
-    'Composante',
-    'Équipe pédagogique',
-    'Groupe',
-    'Diplôme',
-    'Régime',
-  ];
+  return '\uFEFF' + csvSerializer.serializeLine(header);
 }
 
-function _isAdminInSupOrganizationManagingStudents(membership) {
-  return membership && membership.isAdmin && membership.organization.isManagingStudents && membership.organization.isSup;
+function _isAdminOrganizationManagingStudent(membership) {
+  return membership && membership.isAdmin && membership.organization.isManagingStudents;
 }

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
@@ -9,14 +9,14 @@ const COLUMNS = [
   new CsvColumn({ name: 'thirdName', label:'Troisième prénom' }),
   new CsvColumn({ name: 'lastName', label:'Nom de famille', isRequired: true }),
   new CsvColumn({ name: 'preferredLastName', label:'Nom d’usage' }),
-  new CsvColumn({ name: 'studentNumber', label:'Numéro étudiant', isRequired: true, checkEncoding: true }),
+  new CsvColumn({ name: 'birthdate', label:'Date de naissance (jj/mm/aaaa)', isRequired: true, isDate: true }),
   new CsvColumn({ name: 'email', label:'Email' }),
-  new CsvColumn({ name: 'diploma', label:'Diplôme' }),
+  new CsvColumn({ name: 'studentNumber', label:'Numéro étudiant', isRequired: true, checkEncoding: true }),
   new CsvColumn({ name: 'department', label:'Composante' }),
   new CsvColumn({ name: 'educationalTeam', label:'Équipe pédagogique' }),
   new CsvColumn({ name: 'group', label:'Groupe' }),
+  new CsvColumn({ name: 'diploma', label:'Diplôme' }),
   new CsvColumn({ name: 'studyScheme', label:'Régime' }),
-  new CsvColumn({ name: 'birthdate', label:'Date de naissance (jj/mm/aaaa)', isRequired: true, isDate: true }),
 ];
 
 class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
@@ -36,6 +36,8 @@ class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
     super._handleError(...arguments);
   }
 }
+
+HigherSchoolingRegistrationParser.COLUMNS = COLUMNS;
 
 module.exports = HigherSchoolingRegistrationParser;
 

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -50,5 +50,7 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
   }
 }
 
+SchoolingRegistrationParser.COLUMNS = COLUMNS;
+
 module.exports = SchoolingRegistrationParser;
 

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -37,6 +37,90 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
     });
   });
 
+  context('When user is ADMIN in a SUP organization not managing students', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: false, type: 'SUP' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+    
+  context('When user is not ADMIN in a SUP organization', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: false, organization: { isManagingStudents: true, type: 'SUP' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('When user is ADMIN in a SCO-AGRICULTURE organization managing students', () => {
+    it('should return headers line', async () => {    
+      // given 
+      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
+      const organization = domainBuilder.buildOrganization({ id: '1', isManagingStudents: true, type: 'SCO' });
+      const membership = domainBuilder.buildMembership({ organizationRole: 'ADMIN', organization });
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
+
+      // when
+      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository });
+
+      // then
+      const csvExpected = '\uFEFF"Identifiant unique*";' +
+        '"Premier prénom*";' +
+        '"Deuxième prénom";' +
+        '"Troisième prénom";' +
+        '"Nom de famille*";' +
+        '"Nom d’usage";' +
+        '"Date de naissance (jj/mm/aaaa)*";' +
+        '"Code commune naissance**";' +
+        '"Libellé commune naissance**";' +
+        '"Code département naissance*";' +
+        '"Code pays naissance*";' +
+        '"Statut*";' +
+        '"Code MEF*";' +
+        '"Division*"\n';
+        
+      expect(result).to.deep.equal(csvExpected);
+    });
+  });
+
+  context('When user is ADMIN in a SCO-AGRICULTURE organization not managing students', () => {
+    it('should throw an error', async () => {
+      // given
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: false, type: 'SCO' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
+  context('When user is not ADMIN in a SCO-AGRICULTURE organization', () => {
+    it('should throw an error', async () => {
+      // given
+      process.env['AGRICULTURE_ORGANIZATION_ID'] = '1';
+      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: false, organization: { id: '1', isManagingStudents: true, type: 'SCO' } }]);
+
+      // when
+      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
+
+      // then
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+
   context('When user is not a member of the organization', () => {
     it('should throw an error', async () => {
       // given
@@ -50,20 +134,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
     });
   });
 
-  context('When user is member of a SUP organization managing students but not ADMIN', () => {
-    it('should throw an error', async () => {
-      // given
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: false, organization: { isManagingStudents: true, type: 'SUP' } }]);
-
-      // when
-      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
-    });
-  });
-
-  context('When user is ADMIN in an organization managing students but not a SUP one', () => {
+  context('When user is ADMIN in a SCO organization', () => {
     it('should throw an error', async () => {
       // given
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: true, type: 'SCO' } }]);
@@ -76,16 +147,5 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
     });
   });
 
-  context('When user is ADMIN in an SUP organization but it does not manage students', () => {
-    it('should throw an error', async () => {
-      // given
-      sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([{ isAdmin: true, organization: { isManagingStudents: false, type: 'SUP' } }]);
-
-      // when
-      const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
-
-      // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
-    });
-  });
 });
+

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -2,6 +2,12 @@
   <div class="page__title page-title">Élèves</div>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
+      {{#if this.currentUser.isAgriculture}}
+        <a class="button button--link button--no-color"
+          href="{{this.urlToDownloadCsvTemplate}}" target="_blank" rel="noopener noreferrer" download>
+          Télécharger le modèle
+        </a>
+      {{/if}}
       <FileUpload @name="file-upload" @for="students-file-upload" @accept={{this.acceptedFileType}} @multiple={{false}} @onfileadd={{@importStudents}}>
         <span class="button" role="button" tabindex="0">Importer ({{this.acceptedFileType}})</span>
       </FileUpload>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -7,6 +7,7 @@ import ENV from 'pix-orga/config/environment';
 export default class ListItems extends Component {
 
   @service currentUser;
+  @service session;
   @service store;
   @service router;
   @service notifications;
@@ -21,6 +22,10 @@ export default class ListItems extends Component {
       return '.csv';
     }
     return '.xml';
+  }
+
+  get urlToDownloadCsvTemplate() {
+    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
   }
 
   @action

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -291,6 +291,10 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           assert.contains('Importer (.xml)');
         });
 
+        test('it should not display download template csv file button', async function(assert) {
+          assert.notContains('Télécharger le modèle');
+        });
+
         test('it should display the dissociate action', async function(assert) {
           // when
           await click('[aria-label="Afficher les actions"]');
@@ -305,6 +309,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           class CurrentUserStub extends Service {
             isAdminInOrganization = true;
             isAgriculture = true;
+            organization = {};
           }
           this.set('importStudentsSpy', () => {});
           this.owner.register('service:current-user', CurrentUserStub);
@@ -313,6 +318,11 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
         test('it should display import CSV file button', async function(assert) {
           assert.contains('Importer (.csv)');
+        });
+
+        test('it should display download template csv button', async function(assert) {
+          // then
+          assert.contains('Télécharger le modèle');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Aucun bouton n'est disponible pour pouvoir télécharger le modèle CSV pour une organisation de type SCO-AGRICULTURE.

## :robot: Solution
Mise à disposition du bouton "Télécharger le modèle" pour les prescripteur ADMIN des organisation SCO AGRI (même UI que pour le SUP) avec téléchargement de template. 

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur une organisation SCO-AGRICULTURE > élèves > télécharger le modèle.
