### PR TITLE
[TECH] Enrichir les test helpers de pix certif et async/await des tests d'API

### DIFF
--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -30,25 +30,21 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader() };
       });
 
-      it('should return 200 HTTP status', () => {
+      it('should return 200 HTTP status', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return a list of certificationCenter, with their name and id', () => {
+      it('should return a list of certificationCenter, with their name and id', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.result.data).to.have.lengthOf(5);
-          expect(_.keys(response.result.data[0].attributes)).to.have.members(['id', 'name', 'type', 'external-id', 'created-at']);
-        });
+        expect(response.result.data).to.have.lengthOf(5);
+        expect(_.keys(response.result.data[0].attributes)).to.have.members(['id', 'name', 'type', 'external-id', 'created-at']);
       });
     });
     context('when user is not PixMaster', () => {
@@ -56,26 +52,22 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
       });
 
-      it('should return 403 HTTP status code ', () => {
+      it('should return 403 HTTP status code ', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
-        });
+        expect(response.statusCode).to.equal(403);
       });
     });
 
     context('when user is not connected', () => {
-      it('should return 401 HTTP status code if user is not authenticated', () => {
+      it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
   });
@@ -106,25 +98,21 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader() };
       });
 
-      it('should return 200 HTTP status', () => {
+      it('should return 200 HTTP status', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return the certification center created', () => {
+      it('should return the certification center created', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.result.data.attributes.name).to.equal('Nouveau Centre de Certif');
-          expect(response.result.data.attributes.id).to.be.ok;
-        });
+        expect(response.result.data.attributes.name).to.equal('Nouveau Centre de Certif');
+        expect(response.result.data.attributes.id).to.be.ok;
       });
 
     });
@@ -134,26 +122,22 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
       });
 
-      it('should return 403 HTTP status code ', () => {
+      it('should return 403 HTTP status code ', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
-        });
+        expect(response.statusCode).to.equal(403);
       });
     });
 
     context('when user is not connected', () => {
-      it('should return 401 HTTP status code if user is not authenticated', () => {
+      it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
 
@@ -176,40 +160,34 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader() };
       });
 
-      it('should return 200 HTTP status', () => {
+      it('should return 200 HTTP status', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return the certification center asked', () => {
+      it('should return the certification center asked', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.result.data.id).to.equal(expectedCertificationCenter.id.toString());
-          expect(response.result.data.attributes.name).to.equal(expectedCertificationCenter.name);
-        });
+        expect(response.result.data.id).to.equal(expectedCertificationCenter.id.toString());
+        expect(response.result.data.attributes.name).to.equal(expectedCertificationCenter.name);
       });
 
-      it('should return notFoundError when the certificationCenter not exist', () => {
+      it('should return notFoundError when the certificationCenter not exist', async () => {
         // given
         options.url = '/api/certification-centers/112334';
 
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(404);
-          expect(response.result.errors[0].title).to.equal('Not Found');
-          expect(response.result.errors[0].detail).to.equal('Certification center with id: 112334 not found');
-        });
+        expect(response.statusCode).to.equal(404);
+        expect(response.result.errors[0].title).to.equal('Not Found');
+        expect(response.result.errors[0].detail).to.equal('Certification center with id: 112334 not found');
       });
 
     });
@@ -219,26 +197,22 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
       });
 
-      it('should return 403 HTTP status code ', () => {
+      it('should return 403 HTTP status code ', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
-        });
+        expect(response.statusCode).to.equal(403);
       });
     });
 
     context('when user is not connected', () => {
-      it('should return 401 HTTP status code if user is not authenticated', () => {
+      it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
   });
@@ -270,26 +244,22 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(user.id) };
       });
 
-      it('should return 200 HTTP status', () => {
+      it('should return 200 HTTP status', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
-        });
+        expect(response.statusCode).to.equal(200);
       });
 
-      it('should return the list of sessions', () => {
+      it('should return the list of sessions', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.result.data).to.have.lengthOf(expectedSessions.length);
-          expect(response.result.data.map((sessions) => sessions.id))
-            .to.have.members(expectedSessions.map((sessions) => sessions.id.toString()));
-        });
+        expect(response.result.data).to.have.lengthOf(expectedSessions.length);
+        expect(response.result.data.map((sessions) => sessions.id))
+          .to.have.members(expectedSessions.map((sessions) => sessions.id.toString()));
       });
 
     });
@@ -299,26 +269,22 @@ describe('Acceptance | API | Certification Center', () => {
         options.headers = { authorization: generateValidRequestAuthorizationHeader(otherUser.id) };
       });
 
-      it('should return 403 HTTP status code ', () => {
+      it('should return 403 HTTP status code ', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(403);
-        });
+        expect(response.statusCode).to.equal(403);
       });
     });
 
     context('when user is not connected', () => {
-      it('should return 401 HTTP status code if user is not authenticated', () => {
+      it('should return 401 HTTP status code if user is not authenticated', async () => {
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
   });

--- a/certif/tests/acceptance/authentication-test.js
+++ b/certif/tests/acceptance/authentication-test.js
@@ -6,7 +6,7 @@ import {
   invalidateSession,
 } from 'ember-simple-auth/test-support';
 import {
-  createUserWithMembership,
+  createUserWithMembershipAndTermsOfServiceNotAccepted,
   createUserWithMembershipAndTermsOfServiceAccepted,
   authenticateSession,
 } from '../helpers/test-init';
@@ -39,7 +39,7 @@ module('Acceptance | authentication', function(hooks) {
 
     hooks.beforeEach(async () => {
       await invalidateSession();
-      user = createUserWithMembership();
+      user = createUserWithMembershipAndTermsOfServiceNotAccepted();
     });
 
     test('it should redirect user to the terms-of-service page', async function(assert) {

--- a/certif/tests/acceptance/session-candidates-test.js
+++ b/certif/tests/acceptance/session-candidates-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { createUserWithMembershipAndTermsOfServiceAccepted, authenticateSession } from '../helpers/test-init';
+import { createUserAndMembershipAndTermsOfServiceAccepted, authenticateSession } from '../helpers/test-init';
 import { upload } from 'ember-file-upload/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -13,6 +13,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
   let user;
   let session;
+  let certificationCenter;
 
   const validLastName = 'MonNom';
   const validFirstName = 'MonPrenom';
@@ -22,9 +23,7 @@ module('Acceptance | Session Candidates', function(hooks) {
   const validBirthdate = '01021990';
 
   hooks.beforeEach(function() {
-    user = createUserWithMembershipAndTermsOfServiceAccepted();
-    const certificationCenterId = user.certificationCenterMemberships.models[0].certificationCenterId;
-    session = server.create('session', { certificationCenterId });
+    createSession();
   });
 
   hooks.afterEach(function() {
@@ -98,7 +97,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
           test('it should leave the line up for modification', async function(assert) {
             this.server.post('/sessions/:id/certification-candidates', () => ({
-              errors: [ 'Invalid data' ],
+              errors: ['Invalid data'],
             }), 400);
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
@@ -111,7 +110,7 @@ module('Acceptance | Session Candidates', function(hooks) {
 
           test('it should display notification error', async function(assert) {
             this.server.post('/sessions/:id/certification-candidates', () => ({
-              errors: [ 'Invalid data' ],
+              errors: ['Invalid data'],
             }), 400);
             // when
             await click('[data-test-id="add-certification-candidate-staging__button"]');
@@ -188,7 +187,6 @@ module('Acceptance | Session Candidates', function(hooks) {
             // then
             assert.dom(`[data-test-id="panel-candidate__lastName__${notLinkedCertificationCandidate.id}"]`).doesNotExist();
           });
-
         });
       });
 
@@ -250,4 +248,9 @@ module('Acceptance | Session Candidates', function(hooks) {
     await fillIn(`[data-test-id="panel-candidate__${code}__add-staging"] > div > input`, value);
   }
 
+  function createSession() {
+    ({ user, certificationCenter } = createUserAndMembershipAndTermsOfServiceAccepted());
+    session = server.create('session', { certificationCenterId: certificationCenter.id });
+  }
 });
+

--- a/certif/tests/acceptance/terms-of-service-test.js
+++ b/certif/tests/acceptance/terms-of-service-test.js
@@ -3,7 +3,7 @@ import { click, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentSession } from 'ember-simple-auth/test-support';
 import {
-  createUserWithMembership,
+  createUserWithMembershipAndTermsOfServiceNotAccepted,
   createUserWithMembershipAndTermsOfServiceAccepted,
   authenticateSession,
 } from '../helpers/test-init';
@@ -28,7 +28,7 @@ module('Acceptance | terms-of-service', function(hooks) {
   module('When user is authenticated and has not yet accepted terms of service', function(hooks) {
 
     hooks.beforeEach(async () => {
-      user = createUserWithMembership();
+      user = createUserWithMembershipAndTermsOfServiceNotAccepted();
 
       await authenticateSession(user.id);
     });

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -1,15 +1,16 @@
 import { authenticateSession as emberAuthenticateSession } from 'ember-simple-auth/test-support';
 
-export function createUserWithMembership() {
+export function createUserAndMembership(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix') {
   const user = server.create('user', {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
-    'pixCertifTermsOfServiceAccepted': false,
+    pixCertifTermsOfServiceAccepted,
   });
 
   const certificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification du pix',
+    name: certificationCenterName,
+    type: certificationCenterType,
   });
 
   const certificationCenterMembership = server.create('certificationCenterMembership', {
@@ -20,53 +21,23 @@ export function createUserWithMembership() {
   user.certificationCenterMemberships = [certificationCenterMembership];
   user.save();
 
-  return user;
+  return { user, certificationCenter };
 }
 
 export function createScoUserWithMembershipAndTermsOfServiceAccepted() {
-  const user = server.create('user', {
-    firstName: 'Harry',
-    lastName: 'SCO-ver',
-    email: 'harry@scover.com',
-    'pixCertifTermsOfServiceAccepted': true,
-  });
-
-  const certificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification SCO du pix',
-    type: 'SCO',
-  });
-
-  const certificationCenterMembership = server.create('certificationCenterMembership', {
-    certificationCenter,
-    user,
-  });
-
-  user.certificationCenterMemberships = [certificationCenterMembership];
-  user.save();
-
-  return user;
+  return createUserWithMembershipAndTermsOfServiceAccepted('SCO' , 'Centre de certification SCO du pix');
 }
 
-export function createUserWithMembershipAndTermsOfServiceAccepted() {
-  const user = server.create('user', {
-    firstName: 'Harry',
-    lastName: 'Cover',
-    email: 'harry@cover.com',
-    'pixCertifTermsOfServiceAccepted': true,
-  });
+export function createUserAndMembershipAndTermsOfServiceAccepted(certificationCenterType = undefined, certificationCenterName = 'Centre de certification du pix') {
+  return createUserAndMembership(true, certificationCenterType , certificationCenterName);
+}
 
-  const certificationCenter = server.create('certificationCenter', {
-    name: 'Centre de certification du pix',
-  });
-
-  const certificationCenterMembership = server.create('certificationCenterMembership', {
-    certificationCenter,
-    user,
-  });
-
-  user.certificationCenterMemberships = [certificationCenterMembership];
-  user.save();
-
+export function createUserWithMembershipAndTermsOfServiceAccepted(certificationCenterType = undefined, certificationCenterName = 'Centre de certification du pix') {
+  const { user } = createUserAndMembership(true, certificationCenterType , certificationCenterName);
+  return user;
+}
+export function createUserWithMembershipAndTermsOfServiceNotAccepted() {
+  const { user } = createUserAndMembership(false);
   return user;
 }
 

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -122,7 +122,7 @@ module('Acceptance | authentication', function(hooks) {
       assert.equal(currentURL(), '/campagnes');
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
     });
-    
+
     test('it should show user name', async function(assert) {
       // given
       server.create('campaign');
@@ -161,9 +161,9 @@ module('Acceptance | authentication', function(hooks) {
         // then
         assert.dom('.organization-credit-info').doesNotExist();
       });
-      
+
     });
-    
+
     module('When prescriber has already accepted terms of service', function(hooks) {
 
       hooks.beforeEach(async () => {
@@ -241,11 +241,11 @@ module('Acceptance | authentication', function(hooks) {
         assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
         assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
       });
-      
+
       module('When the organization has credits and prescriber is ADMIN', function(hooks) {
         hooks.beforeEach(async () => {
           const user = createPrescriberForOrganization({ firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' }, { name: 'BRO & Evil Associates', credit: 10000 }, 'ADMIN');
-  
+
           await authenticateSession({
             user_id: user.id,
             access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
@@ -260,9 +260,9 @@ module('Acceptance | authentication', function(hooks) {
           // then
           assert.dom('.organization-credit-info').exists();
         });
-        
+
       });
-      
+
       module('When prescriber belongs to an organization that is managing students', function(hooks) {
 
         hooks.beforeEach(async () => {
@@ -340,7 +340,7 @@ module('Acceptance | authentication', function(hooks) {
       module('When the organization has credits and prescriber is MEMBER', function(hooks) {
         hooks.beforeEach(async () => {
           const user = createPrescriberForOrganization({ firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' }, { name: 'BRO & Evil Associates', credit: 10000 }, 'MEMBER');
-  
+
           await authenticateSession({
             user_id: user.id,
             access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
@@ -355,9 +355,9 @@ module('Acceptance | authentication', function(hooks) {
           // then
           assert.dom('.organization-credit-info').doesNotExist();
         });
-        
+
       });
-      
+
       module('When user belongs to an organization that is managing students', function(hooks) {
 
         hooks.beforeEach(async () => {
@@ -384,7 +384,7 @@ module('Acceptance | authentication', function(hooks) {
         });
       });
     });
-    
+
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
Cette PR permet : 
- d'utiliser des async / await plutôt que des promises dans certains tests API
- de retourner un centre de certif lorsqu'on créé un user dans les tests de Pix Certif

## :rainbow: Remarques
Ces BSR ont été fait dans le cadre de la FEATURE https://github.com/1024pix/pix/pull/1997 . Cependant ils ont été séparé pour simplier sa review.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
