### PR TITLE
[FEATURE] Ajouter le type nombre au réponse QROC (PIX-1455).

### DIFF
--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -29,6 +29,17 @@
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
+      {{else if (eq @format 'nombre')}}
+        <input class="challenge-response__proposal"
+               type="number"
+               id="qroc_input"
+               {{on 'keydown' this.onInputChange}}
+               name={{block.input}}
+               placeholder={{block.placeholder}}
+               autocomplete="off"
+               value="{{this.userAnswer}}"
+               data-uid="qroc-proposal-uid"
+               disabled={{if @answer true}}>
       {{else}}
         <input class="challenge-response__proposal"
                size="{{get-qroc-input-size @format}}"

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -43,6 +43,21 @@ describe('Integration | Component | QROC proposal', function() {
     });
   });
 
+  describe('When format is a number', function() {
+
+    it('should display an input with number type', async function() {
+      // given
+      this.set('proposals', '${myInput}');
+      this.set('format', 'nombre');
+
+      // when
+      await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} />`);
+
+      // then
+      expect(find('.challenge-response__proposal').getAttribute('type')).to.equal('number');
+    });
+  });
+
   describe('When format is neither a paragraph nor a phrase', function() {
 
     [


### PR DESCRIPTION
## :unicorn: Problème
- Les questions QROC ne peuvent être que de format texte actuellement (avec des longueurs différentes). Des utilisateurs utilisent parfois mal ces champs.

## :robot: Solution
- Ajout du type "nombre" (`number`) pour forcer les nombre

## :100: Pour tester
Une question avec nombre : https://app-pr2029.review.pix.fr/challenges/recAsQI8VNgXcme11/preview
