### PR TITLE
[FEATURE] Permettre la selection d'élèves comme candidats d'une session (PIX-1374).

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -1,8 +1,15 @@
+{{#if @studentList}}
 <div class="table add-student-list">
   <table>
     <thead>
       <tr>
-        <th class="add-student-list__column-checkbox">▢</th>
+        <th>
+          <CertifCheckbox
+            class="add-student-list__checker"
+            @state={{headerCheckboxStatus}}
+            {{on 'click' toggleAllItems}}>
+          </CertifCheckbox>
+        </th>
         <th>Classe</th>
         <th>Nom</th>
         <th>Prénom</th>
@@ -12,7 +19,12 @@
     <tbody>
       {{#each @studentList as |student|}}
         <tr>
-          <td class="add-student-list__column-checkbox">▢</td>
+          <td class="add-student-list__column-checkbox">
+            <CertifCheckbox
+              @state={{if student.isSelected 'checked' 'unchecked'}}
+              {{on 'click' (fn toggleItem student)}}>
+            </CertifCheckbox>
+          </td>
           <td>{{student.division}}</td>
           <td>{{student.lastName}}</td>
           <td>{{student.firstName}}</td>
@@ -22,3 +34,4 @@
     </tbody>
   </table>
 </div>
+{{/if}}

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -1,0 +1,34 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class AddStudentList extends Component {
+
+  get headerCheckboxStatus() {
+    return this.hasCheckedEverything
+      ? 'checked'
+      : this.hasCheckedSomething ? 'partial' : 'unchecked';
+  }
+
+  get hasCheckedSomething() {
+    const hasOneOrMoreCheck = this.args.studentList.any((student) => student.isSelected);
+    return hasOneOrMoreCheck;
+  }
+
+  get hasCheckedEverything() {
+    const allCertifReportsAreCheck = this.args.studentList.every((student) => student.isSelected);
+    return allCertifReportsAreCheck;
+  }
+
+  @action
+  toggleItem(item) {
+    item.isSelected = !item.isSelected;
+  }
+
+  @action
+  toggleAllItems() {
+    const newState = !this.hasCheckedSomething;
+    this.args.studentList.forEach((student) => {
+      student.isSelected = newState;
+    });
+  }
+}

--- a/certif/app/components/certif-checkbox.hbs
+++ b/certif/app/components/certif-checkbox.hbs
@@ -1,0 +1,15 @@
+{{#if (eq @state 'checked')}}
+  <button type="button" class="checkbox checkbox--checked" ...attributes>
+    <img
+            src="/icons/icon-done.svg"
+            class="checkbox-step__done-icon"
+            alt="checkbox" >
+  </button>
+{{else if (eq @state 'partial')}}
+  <button type="button" class="checkbox checkbox--unchecked checkbox--partial" ...attributes>
+    <div class="checkbox-step__dash-icon"></div>
+  </button>
+{{else}}
+  <button type="button" class="checkbox checkbox--unchecked" ...attributes>
+  </button>
+{{/if}}

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -9,21 +9,7 @@
         <th>
           <div class="session-finalization-reports-informations-step__row">
             <div class="session-finalization-reports-informations-step__checker" {{on 'click' (fn @toggleAllCertificationReportsHasSeenEndTestScreen this.hasCheckedSomething)}}>
-              {{#if this.hasCheckedEverything}}
-                <div class="checkbox checkbox--checked">
-                  <img
-                    src="/icons/icon-done.svg"
-                    class="session-finalization-reports-informations-step__done-icon"
-                    alt="checkbox" >
-                </div>
-              {{else if this.hasCheckedSomething}}
-                <div class="checkbox checkbox--unchecked">
-                  <div class="session-finalization-reports-informations-step__dash-icon"></div>
-                </div>
-              {{else}}
-                <div class="checkbox checkbox--unchecked">
-                </div>
-              {{/if}}
+              <CertifCheckbox @state={{headerCheckboxStatus}}></CertifCheckbox>
             </div>
             Écran de fin du test vu
           </div>
@@ -46,22 +32,11 @@
             />
           </td>
           <td>
-            {{#if report.hasSeenEndTestScreen}}
-              <div
-                data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
-                class="checkbox checkbox--checked"
-                {{on 'click' (fn @toggleCertificationReportHasSeenEndTestScreen report)}}>
-                <img
-                  src="/icons/icon-done.svg"
-                  class="session-finalization-reports-informations-step__done-icon"
-                  alt="checkbox" >
-              </div>
-            {{else}}
-              <div
-                data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
-                class="checkbox checkbox--unchecked"
-                {{on 'click' (fn @toggleCertificationReportHasSeenEndTestScreen report)}}/>
-            {{/if}}
+            <CertifCheckbox
+                    data-test-id="finalization-report-has-seen-end-test-screen_{{report.certificationCourseId}}"
+                    @state={{if report.hasSeenEndTestScreen 'checked' 'unchecked'}}
+              {{on 'click' (fn @toggleCertificationReportHasSeenEndTestScreen report)}}>
+            </CertifCheckbox>
           </td>
         </tr>
       {{/each}}

--- a/certif/app/components/session-finalization-reports-informations-step.js
+++ b/certif/app/components/session-finalization-reports-informations-step.js
@@ -17,4 +17,8 @@ export default class SessionFinalizationReportsInformationsStep extends Componen
     return this.certifReportsAreNotEmpty && hasOneOrMoreCheck;
   }
 
+  get headerCheckboxStatus() {
+    return this.hasCheckedEverything ? 'checked' : this.hasCheckedSomething ? 'partial' : 'unchecked';
+  }
+
 }

--- a/certif/app/models/student.js
+++ b/certif/app/models/student.js
@@ -5,4 +5,5 @@ export default class StudentModel extends Model {
   @attr('string') lastName;
   @attr('date-only') birthdate;
   @attr('string') division;
+  @attr('boolean', { defaultValue: false }) isSelected;
 }

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -27,6 +27,7 @@
 @import "pages/authenticated/terms-of-service";
 
 @import "components/add-student-list";
+@import "components/certif-checkbox";
 @import "components/ember-cli-notifications-ie-fallback";
 @import "components/login-form";
 @import "components/finalize";

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -22,4 +22,8 @@
 
   &__column-checkbox { width: 30px; }
   &__column-birthdate { width: 60%; }
+
+  &__checker {
+    margin-right: 16px;
+  }
 }

--- a/certif/app/styles/components/certif-checkbox.scss
+++ b/certif/app/styles/components/certif-checkbox.scss
@@ -1,0 +1,23 @@
+.checkbox {
+
+  &__done-icon {
+    width: 10px;
+    height: 9px;
+  }
+
+  &__checker {
+    margin-right: 16px;
+  }
+
+  &-step__dash-icon {
+    width: 10px;
+    height: 4px;
+    border-radius: 1px;
+    background-color: $grey-22;
+  }
+
+  &:hover &__dash-icon{
+    background-color: $grey-40;
+  }
+
+}

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -23,24 +23,7 @@
     border-radius: 4px;
   }
 
-  &__done-icon {
-    width: 10px;
-    height: 9px;
-  }
-
   &__checker {
     margin-right: 16px;
   }
-
-  &__dash-icon {
-    width: 10px;
-    height: 4px;
-    border-radius: 1px;
-    background-color: $grey-22;
-  }
-
-  .checkbox:hover &__dash-icon{
-    background-color: $grey-40;
-  }
-
 }

--- a/certif/tests/integration/components/certif-checkbox-test.js
+++ b/certif/tests/integration/components/certif-checkbox-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import sinon from 'sinon';
+import { click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | certif-checkbox', function(hooks) {
+  setupRenderingTest(hooks);
+
+  [
+    { state: 'checked', classes: ['checkbox--checked'] },
+    { state: 'partial', classes: ['checkbox--unchecked', 'checkbox--partial'] },
+    { state: 'unchecked', classes: ['checkbox--unchecked'] },
+  ].forEach(({ state, classes }) =>
+    test(`it renders a checkbox in ${state} with the class '${classes.join(',')}'`, async function(assert) {
+      // given
+      const fakeFunc = sinon.spy();
+      this.set('fakeFunc', fakeFunc);
+      this.set('state', state);
+      await render(hbs`<CertifCheckbox @state={{state}} {{on 'click' (fn fakeFunc)}}></CertifCheckbox>`);
+
+      // when
+      await click('.checkbox');
+
+      // then
+      classes.forEach((cssClass) => assert.dom('.checkbox').hasClass(cssClass));
+      sinon.assert.calledOnce(fakeFunc);
+    }));
+
+});

--- a/certif/tests/unit/components/add-student-list-test.js
+++ b/certif/tests/unit/components/add-student-list-test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import ArrayProxy from '@ember/array/proxy';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
+
+module('Unit | Component | add-student-list', function(hooks) {
+  setupTest(hooks);
+
+  let component;
+
+  hooks.beforeEach(function() {
+    component = createGlimmerComponent('component:add-student-list');
+  });
+
+  module('#computed hasCheckedSomething', function() {
+
+    test('it should be false if has no checked student', function(assert) {
+      // given
+      const studentList = ArrayProxy.create({
+        content: [
+          { isSelected: false },
+          { isSelected: false },
+        ],
+      });
+      component.args.studentList = studentList;
+
+      // when
+      const hasCheckedSomething = component.hasCheckedSomething;
+
+      // then
+      assert.equal(hasCheckedSomething, false);
+    });
+
+    test('it should be true if at least one checked student', function(assert) {
+      // given
+      const studentList = ArrayProxy.create({
+        content: [
+          { isSelected: false },
+          { isSelected: true },
+        ],
+      });
+      component.args.studentList = studentList;
+
+      // when
+      const hasCheckedSomething = component.hasCheckedSomething;
+
+      // then
+      assert.equal(hasCheckedSomething, true);
+    });
+  });
+
+  module('#computed hasCheckedEverything', function() {
+
+    test('it should be false if they are not all checked', function(assert) {
+      // given
+      const studentList = ArrayProxy.create({
+        content: [
+          { isSelected: false },
+          { isSelected: true },
+        ],
+      });
+      component.args.studentList = studentList;
+
+      // when
+      const hasCheckedEverything = component.hasCheckedEverything;
+
+      // then
+      assert.equal(hasCheckedEverything, false);
+    });
+
+    test('it should be true if they are all checked', function(assert) {
+      // given
+      const studentList = ArrayProxy.create({
+        content: [
+          { isSelected: true },
+          { isSelected: true },
+        ],
+      });
+      component.args.studentList = studentList;
+
+      // when
+      const hasCheckedEverything = component.hasCheckedEverything;
+
+      // then
+      assert.equal(hasCheckedEverything, true);
+    });
+  });
+
+  module('#action toggleItem', function() {
+
+    test('it should toggle the isSelected attribute of the student', function(assert) {
+      // given
+      const initialValue = true;
+      const student = { isSelected: initialValue };
+
+      // when
+      component.toggleItem(student);
+
+      // then
+      assert.equal(student.isSelected, !initialValue);
+    });
+  });
+
+  module('#action toggleAllItems', function() {
+    [
+      { isSelected1: true, isSelected2: true, expectedState: false },
+      { isSelected1: true, isSelected2: false, expectedState: false },
+      { isSelected1: false, isSelected2: true, expectedState: false },
+      { isSelected1: false, isSelected2: false, expectedState: true },
+    ].forEach(({ isSelected1, isSelected2, expectedState }) =>
+      test('it should toggle the isSelected attribute of all the student depending on if some were checked', function(assert) {
+      // given
+        const studentList = ArrayProxy.create({
+          content: [
+            { isSelected: isSelected1 },
+            { isSelected: isSelected2 },
+          ],
+        });
+        component.args.studentList = studentList;
+
+        // when
+        component.toggleAllItems();
+
+        // then
+        component.args.studentList.content.forEach((student) => {
+          assert.equal(student.isSelected, expectedState);
+        });
+      }),
+    );
+  });
+});

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -217,26 +217,33 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
   module('#action toggleAllCertificationReportsHasSeenEndTestScreen', function() {
 
-    test('it should toggle the hasSeenEndTestScreen attribute of all the certifs in session to false depending on if some were checked', function(assert) {
-      // given
-      const someWereChecked = true;
-      const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = {
-        certificationReports: [
-          { hasSeenEndTestScreen: false },
-          { hasSeenEndTestScreen: true },
-        ],
-      };
-      controller.model = sessions;
+    [
+      { hasSeenEndTestScreen1: true, hasSeenEndTestScreen2: true, expectedState: false },
+      { hasSeenEndTestScreen1: true, hasSeenEndTestScreen2: false, expectedState: false },
+      { hasSeenEndTestScreen1: false, hasSeenEndTestScreen2: true, expectedState: false },
+      { hasSeenEndTestScreen1: false, hasSeenEndTestScreen2: false, expectedState: true },
+    ].forEach(({ hasSeenEndTestScreen1, hasSeenEndTestScreen2, expectedState }) =>
+      test('it should toggle the hasSeenEndTestScreen attribute of all certifs in session to false depending on if some were checked', function(assert) {
+        // given
+        const someWereChecked = hasSeenEndTestScreen1 || hasSeenEndTestScreen2;
+        const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
+        const sessions = {
+          certificationReports: [
+            { hasSeenEndTestScreen: hasSeenEndTestScreen1 },
+            { hasSeenEndTestScreen: hasSeenEndTestScreen2 },
+          ],
+        };
+        controller.model = sessions;
 
-      // when
-      controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
+        // when
+        controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
 
-      // then
-      sessions.certificationReports.forEach((certif) => {
-        assert.equal(certif.hasSeenEndTestScreen, !someWereChecked);
-      });
-    });
+        // then
+        sessions.certificationReports.forEach((certif) => {
+          assert.equal(certif.hasSeenEndTestScreen, expectedState);
+        });
+      }),
+    );
   });
 
   module('#action openModal', function() {

--- a/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/pix-certif/session.js
@@ -102,7 +102,7 @@ when('je retire un candidat de la liste', () => {
 
 when(`j'oublie de cocher une case d'Écran de fin de test vu`, () => {
   cy.get('table.session-finalization-reports-informations-step__table tbody tr').each(function ($element, index, collection) {
-    const checkBox = $element.find('td:nth-child(5) div');
+    const checkBox = $element.find('td:nth-child(5) button');
     if(index !== collection.length - 1 && checkBox.hasClass('checkbox--unchecked')) {
       cy.wrap(checkBox).click();
     } else if(index === collection.length - 1 && checkBox.hasClass('checkbox--checked')) {
@@ -113,7 +113,7 @@ when(`j'oublie de cocher une case d'Écran de fin de test vu`, () => {
 
 when(`je coche toutes les cases d'Écran de fin de test vu`, () => {
   cy.get('table.session-finalization-reports-informations-step__table tbody tr').each(function ($element) {
-    const checkBox = $element.find('td:nth-child(5) div');
+    const checkBox = $element.find('td:nth-child(5) button');
     if(checkBox.hasClass('checkbox--unchecked')) {
       cy.wrap(checkBox).click();
     }


### PR DESCRIPTION
## :unicorn: Problème
Nous avons dans la PR #1997, mis en place un nouveau tableau permettant d'afficher les élèves liés à ce centre de certification, seulement il n'est pas possible de choisir les candidats que l'on souhaite ajouter à la session. 

## :robot: Solution
Ajouter des checkboxes pour sélectionner les candidats. 
![studentSelection](https://user-images.githubusercontent.com/26384707/96469779-e33a2900-122d-11eb-9ad1-45dbe91b1782.gif)

Pour cela : 
- On a extrait un composant `certif-checkbox` de la finalisation de session
- On a ajouté dans le model `student` un attribut `isSelected` qui est par défaut à `false` : 
https://github.com/1024pix/pix/blob/a2785e50013196229311a5ff7da6a5501e57cf2a/certif/app/models/student.js#L8
- On a utilisé le composant dans notre composant `add-student-list` : 



## :rainbow: Remarques
Verifier que la finalisation de session (checkboxes) fonctionne toujours

## :100: Pour tester
Verifier que les checkboxes fonctionnent bien et que la checkbox d'entête gère 3 états:
- tout sélectionné (coche bleue)
- rien sélectionné (checkbox vide)
- une partie sélectionné (trait gris)
