### PR TITLE
[FEATURE] Afficher les résultats thématiques dans la liste des participants (PIX-1442)

### DIFF
--- a/api/lib/domain/models/BadgeAcquisition.js
+++ b/api/lib/domain/models/BadgeAcquisition.js
@@ -3,6 +3,7 @@ class BadgeAcquisition {
     id,
     // attributes
     // includes
+    badge,
     // references
     userId,
     badgeId,
@@ -10,6 +11,7 @@ class BadgeAcquisition {
     this.id = id;
     // attributes
     // includes
+    this.badge = badge;
     // references
     this.userId = userId;
     this.badgeId = badgeId;

--- a/api/lib/domain/models/TargetProfile.js
+++ b/api/lib/domain/models/TargetProfile.js
@@ -7,6 +7,7 @@ class TargetProfile {
     outdated,
     skills = [],
     stages,
+    badges,
     organizationId,
   } = {}) {
     this.id = id;
@@ -16,7 +17,12 @@ class TargetProfile {
     this.outdated = outdated;
     this.skills = skills;
     this.stages = stages;
+    this.badges = badges;
     this.organizationId = organizationId;
+  }
+
+  get hasBadges() {
+    return !!this.badges && this.badges.length > 0;
   }
 
   hasSkill(skillId) {

--- a/api/lib/domain/read-models/CampaignAssessmentParticipationSummary.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipationSummary.js
@@ -18,6 +18,7 @@ class CampaignAssessmentParticipationSummary {
     isShared,
     targetedSkillCount,
     validatedTargetedSkillCount,
+    badges = [],
   } = {}) {
     this.campaignParticipationId = campaignParticipationId;
     this.userId = userId;
@@ -29,6 +30,7 @@ class CampaignAssessmentParticipationSummary {
     this.targetedSkillCount = targetedSkillCount;
     this.validatedTargetedSkillCount = validatedTargetedSkillCount;
     this.masteryPercentage = this._computeMasteryPercentage(isShared);
+    this.badges = badges;
   }
 
   _computeMasteryPercentage(isShared) {
@@ -44,6 +46,10 @@ class CampaignAssessmentParticipationSummary {
     if (isShared) return CampaignAssessmentParticipationSummary.statuses.SHARED;
     if (state === Assessment.states.COMPLETED) return CampaignAssessmentParticipationSummary.statuses.COMPLETED;
     return CampaignAssessmentParticipationSummary.statuses.ONGOING;
+  }
+
+  setBadges(badges) {
+    this.badges = badges;
   }
 }
 

--- a/api/lib/infrastructure/data/target-profile.js
+++ b/api/lib/infrastructure/data/target-profile.js
@@ -16,8 +16,8 @@ module.exports = Bookshelf.model(modelName, {
     return this.hasMany('TargetProfileSkill', 'targetProfileId');
   },
 
-  badge() {
-    return this.belongsTo('Badge', 'targetProfileId');
+  badges() {
+    return this.hasMany('Badge', 'targetProfileId');
   },
 
   stages() {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-summary-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-summary-serializer.js
@@ -16,7 +16,13 @@ module.exports = {
         'participantExternalId',
         'status',
         'masteryPercentage',
+        'badges',
       ],
+      badges: {
+        ref: 'id',
+        included: true,
+        attributes: ['title', 'altMessage', 'imageUrl'],
+      },
       meta,
     }).serialize(campaignAssessmentParticipationSummaries);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-serializer.js
@@ -23,7 +23,7 @@ module.exports = {
       targetProfile: {
         ref: 'id',
         included: true,
-        attributes: ['name', 'imageUrl'],
+        attributes: ['name', 'imageUrl', 'hasBadges'],
       },
       campaignReport: {
         ref: 'id',

--- a/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-repository_test.js
@@ -488,11 +488,10 @@ describe('Integration | Repository | Campaign', () => {
     let campaign;
 
     beforeEach(() => {
-      const bookshelfCampaign = databaseBuilder.factory.buildCampaign({
-        id: 1,
-        name: 'My campaign',
-      });
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ id: 2 });
+      const bookshelfCampaign = databaseBuilder.factory.buildCampaign({ id: 1, name: 'My campaign', targetProfile });
       campaign = domainBuilder.buildCampaign(bookshelfCampaign);
+
       return databaseBuilder.commit();
     });
 
@@ -512,6 +511,26 @@ describe('Integration | Repository | Campaign', () => {
       const promise = campaignRepository.get(nonExistentId);
       // then
       return expect(promise).to.have.been.rejectedWith(NotFoundError);
+    });
+
+    describe('when target profile related is requested', () => {
+      it('should contain the target profile in the campaign', async () => {
+        // when
+        const result = await campaignRepository.get(campaign.id, { include: 'targetProfile' });
+
+        // then
+        expect(result.targetProfile.id).to.equal(campaign.targetProfile.id);
+      });
+    });
+
+    describe('when target profile and badges related is requested', () => {
+      it('should contain the target profile and badges in the campaign', async () => {
+        // when
+        const result = await campaignRepository.get(campaign.id, { include: ['targetProfile.badges'] });
+
+        // then
+        expect(result.targetProfile.badges).to.deep.equal([]);
+      });
     });
   });
 

--- a/api/tests/tooling/domain-builder/factory/build-target-profile.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile.js
@@ -11,6 +11,7 @@ module.exports = function buildTargetProfile({
   organizationId = faker.random.number(),
   outdated = false,
   stages = [],
+  badges,
 } = {}) {
   return new TargetProfile({
     id,
@@ -21,5 +22,6 @@ module.exports = function buildTargetProfile({
     organizationId,
     outdated,
     stages,
+    badges,
   });
 };

--- a/api/tests/unit/domain/models/TargetProfile_test.js
+++ b/api/tests/unit/domain/models/TargetProfile_test.js
@@ -2,6 +2,26 @@ const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | TargetProfile', () => {
 
+  describe('hasBadges', () => {
+
+    it('should return true when target profile has badges', () => {
+      // given
+      const badge = domainBuilder.buildBadge();
+      const targetProfile = domainBuilder.buildTargetProfile({ badges: [badge] });
+
+      // then
+      expect(targetProfile.hasBadges).to.be.true;
+    });
+
+    it('should return false when target profile doesn‘t have badges', () => {
+      // given
+      const targetProfile = domainBuilder.buildTargetProfile();
+
+      // then
+      expect(targetProfile.hasBadges).to.be.false;
+    });
+  });
+
   describe('hasSkill', () => {
 
     it('should return true when the skill is in target profile', () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-summary-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-summary-serializer_test.js
@@ -1,4 +1,4 @@
-const { expect } = require('../../../../test-helper');
+const { expect, domainBuilder } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-summary-serializer');
 
 describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-summary-serializer', function() {
@@ -23,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-summar
           participantExternalId: 'Thief',
           status: 'ONGOING',
           masteryPercentage: '99%',
+          badges: [domainBuilder.buildBadge({ id:1, title: 'b1', imageUrl: 'http://toto.svg', altMessage: 'alt' })],
         },
       ];
       const pagination = {
@@ -58,8 +59,27 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-summar
               status: 'ONGOING',
               'mastery-percentage': '99%',
             },
+            relationships: {
+              badges: {
+                data: [
+                  {
+                    id: '1',
+                    type: 'badges',
+                  },
+                ],
+              },
+            },
           },
         ],
+        included: [{
+          attributes: {
+            'image-url': 'http://toto.svg',
+            'title': 'b1',
+            'alt-message': 'alt',
+          },
+          id: '1',
+          type: 'badges',
+        }],
         meta: {
           page: {
             number: 1,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-serializer_test.js
@@ -13,6 +13,13 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
 
       it('should convert a Campaign model object into JSON API data', function() {
         // given
+        const targetProfile = domainBuilder.buildTargetProfile({ 
+          id: '123',
+          name: 'TargetProfile1',
+          imageUrl: 'http://url.fr',
+          badges: [domainBuilder.buildBadge({ id: 456, title: 'badge1', imageUrl: 'http://url.fr' })],
+        });
+
         const campaign = new Campaign({
           id: 5,
           name: 'My zuper campaign',
@@ -29,7 +36,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
           idPixLabel: 'company id',
           externalIdHelpImageUrl: 'some url',
           alternativeTextToExternalIdHelpImage: 'alternative text',
-          targetProfile: domainBuilder.buildTargetProfile({ id: '123', name: 'TargetProfile1', imageUrl: 'http://url.fr' }),
+          targetProfile,
           type: 'ASSESSMENT',
         });
 
@@ -89,6 +96,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               attributes: {
                 name: 'TargetProfile1',
                 'image-url': 'http://url.fr',
+                'has-badges': true,
               },
               id: '123',
               type: 'targetProfiles',
@@ -200,6 +208,7 @@ describe('Unit | Serializer | JSONAPI | campaign-serializer', function() {
               attributes: {
                 name: 'TargetProfile1',
                 'image-url': 'http://url.fr',
+                'has-badges': false,
               },
               id: '123',
               type: 'targetProfiles',

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -9,6 +9,9 @@
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}
           <th>Résultats</th>
+          {{#if @campaign.targetProfile.hasBadges}}
+            <th>Résultats Thématiques</th>
+          {{/if}}
         </tr>
       </thead>
 
@@ -40,6 +43,9 @@
                 {{/if}}
               {{/if}}
             </td>
+            {{#if @campaign.targetProfile.hasBadges}}
+              <td>Not implemented</td>
+            {{/if}}
           </tr>
         {{/each}}
         </tbody>

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -44,7 +44,11 @@
               {{/if}}
             </td>
             {{#if @campaign.targetProfile.hasBadges}}
-              <td>Not implemented</td>
+              <td>
+                {{#each participation.badges as |badge|}}
+                  <img src={{badge.imageUrl}} alt={{badge.altMessage}} class="participant-list__badge" />
+                {{/each}}
+              </td>
             {{/if}}
           </tr>
         {{/each}}

--- a/orga/app/models/badge.js
+++ b/orga/app/models/badge.js
@@ -4,4 +4,5 @@ const { Model, attr } = DS;
 export default class Badge extends Model {
   @attr('string') title;
   @attr('string') imageUrl;
+  @attr('string') altMessage;
 }

--- a/orga/app/models/badge.js
+++ b/orga/app/models/badge.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+const { Model, attr } = DS;
+
+export default class Badge extends Model {
+  @attr('string') title;
+  @attr('string') imageUrl;
+}

--- a/orga/app/models/campaign-assessment-participation-summary.js
+++ b/orga/app/models/campaign-assessment-participation-summary.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-const { Model, attr } = DS;
+const { Model, attr, hasMany } = DS;
 
 export const statuses = {
   SHARED: 'shared',
@@ -13,6 +13,8 @@ export default class CampaignAssessmentParticipationSummary extends Model {
   @attr() participantExternalId;
   @attr() status;
   @attr() masteryPercentage;
+
+  @hasMany('Badge') badges;
 
   get isShared() {
     return this.status === statuses.SHARED;

--- a/orga/app/models/target-profile.js
+++ b/orga/app/models/target-profile.js
@@ -3,4 +3,5 @@ const { Model, attr } = DS;
 
 export default class TargetProfile extends Model {
   @attr('string') name;
+  @attr('boolean') hasBadges;
 }

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class CampaignRoute extends Route {
 
   model(params) {
-    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile' })
+    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile,targetProfile.badges' })
       .catch((error) => {
         return this.send('error', error, this.replaceWith('not-found', params.campaign_id));
       });

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -1,22 +1,28 @@
-.participant-list__mastery-percentage {
-  color: $blue;
-  font-size: 1.25rem;
-  margin-left: 26px;
-}
+.participant-list {
+  &__mastery-percentage {
+    color: $blue;
+    font-size: 1.25rem;
+    margin-left: 26px;
+  }
 
-.participant-list__icon {
-  margin-right: 8px;
-  min-width: 15px;
-  display: inline-block;
-}
+  &__icon {
+    margin-right: 8px;
+    min-width: 15px;
+    display: inline-block;
+  }
 
-.participant-list__header {
-  display: flex;
-  align-items: center;
-  align-content: center;
-  height: 60px;
-  padding-left: 30px;
-  color: $grey-60;
-  font-family: $roboto;
-  font-size: 0.875rem;
+  &__header {
+    display: flex;
+    align-items: center;
+    align-content: center;
+    height: 60px;
+    padding-left: 30px;
+    color: $grey-60;
+    font-family: $roboto;
+    font-size: 0.875rem;
+  }
+
+  &__badge {
+    height: 40px;
+  }
 }

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -176,4 +176,63 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       assert.contains('En attente de participants');
     });
   });
+
+  module('when the campaign doesn‘t have badges', function() {
+    test('it should not display badge column', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+      });
+
+      const participations = [{ firstName: 'John', lastName: 'Doe' }];
+      participations.meta = { rowCount: 1 };
+
+      const goTo = function() {
+      };
+
+      this.set('campaign', campaign);
+      this.set('participations', participations);
+      this.set('goToAssessmentPage', goTo);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
+
+      // then
+      assert.notContains('Résultats Thématiques');
+    });
+  });
+
+  module('when the campaign has badges', function() {
+    test('it should display badge column', async function(assert) {
+      // given
+      const badge = store.createRecord('badge', { id: 'b1', imageUrl: 'url-badge' });
+      const targetProfile = store.createRecord('targetProfile', {
+        id: 't1',
+        hasBadges: true,
+      });
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        targetProfile,
+      });
+
+      const participations = [{ firstName: 'John', lastName: 'Doe', badges: [badge] }];
+      participations.meta = { rowCount: 1 };
+
+      const goTo = function() {
+      };
+
+      this.set('campaign', campaign);
+      this.set('participations', participations);
+      this.set('goToAssessmentPage', goTo);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
+
+      // then
+      assert.contains('Résultats Thématiques');
+      assert.dom('img[src="url-badge"]').exists();
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans pix-orga, actuellement, on ne voit pas les résultats thématiques (aka badges) acquis par les participants dans les campagnes d'évaluation.

## :robot: Solution

Permettre aux prescripteurs de consulter les résultats thématiques obtenus au sein de Pix Orga.
- Affichage d'une colonne "Résultat Thématique" dans la liste des participants. 
- Si il n’y a aucun résultat thématique défini pour ce profil cible alors ne pas afficher de colonne.

## :rainbow: Remarques
N/A

## :100: Pour tester
1. Se connecter à pix-orga avec le compte `pro.admin@example.net`
2. Aller sur la campagne "Pro - Campagne d’évaluation 5.1", onglet "Participants".
> Il n'y a pas la colonne des badges
2. Aller sur la campagne "Test badges", onglet "Participants".
> Il y a la colonne des badges avec les infos d'un participant