### PR TITLE
[FEATURE] Bloquer les boutons quand le temps est écoulé (PIX-1454).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -10,6 +10,7 @@ export default class ChallengeItemGeneric extends Component {
   @tracked isValidateButtonEnabled = true;
   @tracked isSkipButtonEnabled = true;
   @tracked hasUserConfirmedWarning = false;
+  @tracked isTimeoutChallenge = false;
   @tracked errorMessage = null;
   @tracked _elapsedTime = null;
 
@@ -66,6 +67,9 @@ export default class ChallengeItemGeneric extends Component {
       const timer = later(this, function() {
         const elapsedTime = this._elapsedTime;
         this._elapsedTime = elapsedTime + 1;
+        if ((this._elapsedTime - this.args.challenge.timer) >= 0) {
+          this.isTimeoutChallenge = true;
+        }
         this._tick();
       }, 1000);
 
@@ -77,7 +81,7 @@ export default class ChallengeItemGeneric extends Component {
   validateAnswer() {
     if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
 
-      if (this._hasError()) {
+      if (this._hasError()  && !this.isTimeoutChallenge) {
         const errorMessage = this._getErrorMessage();
         this.errorMessage = errorMessage;
         return;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -10,7 +10,7 @@ export default class ChallengeItemGeneric extends Component {
   @tracked isValidateButtonEnabled = true;
   @tracked isSkipButtonEnabled = true;
   @tracked hasUserConfirmedWarning = false;
-  @tracked isTimeoutChallenge = false;
+  @tracked hasChallengeTimedOut = false;
   @tracked errorMessage = null;
   @tracked _elapsedTime = null;
 
@@ -68,7 +68,7 @@ export default class ChallengeItemGeneric extends Component {
         const elapsedTime = this._elapsedTime;
         this._elapsedTime = elapsedTime + 1;
         if ((this._elapsedTime - this.args.challenge.timer) >= 0) {
-          this.isTimeoutChallenge = true;
+          this.hasChallengeTimedOut = true;
         } else {
           this._tick();
         }
@@ -82,7 +82,7 @@ export default class ChallengeItemGeneric extends Component {
   validateAnswer() {
     if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
 
-      if (this._hasError()  && !this.isTimeoutChallenge) {
+      if (this._hasError()  && !this.hasChallengeTimedOut) {
         const errorMessage = this._getErrorMessage();
         this.errorMessage = errorMessage;
         return;

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -69,8 +69,9 @@ export default class ChallengeItemGeneric extends Component {
         this._elapsedTime = elapsedTime + 1;
         if ((this._elapsedTime - this.args.challenge.timer) >= 0) {
           this.isTimeoutChallenge = true;
+        } else {
+          this._tick();
         }
-        this._tick();
       }, 1000);
 
       this._timer = timer;

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -149,6 +149,15 @@
   margin-right: 20px;
 }
 
+.challenge-actions__timed-out {
+  font-family: $font-roboto;
+  font-size: 1rem;
+  font-weight: 600;
+  color: $grey-70;
+  letter-spacing: 0.031rem;
+  margin-right: 20px;
+}
+
 .challenge-actions__action-continue {
   order: 1;
   width: 150px;

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -1,13 +1,29 @@
 <div class="rounded-panel__row challenge-actions">
   <h2 class="sr-only">{{t 'pages.challenge.parts.validation'}}</h2>
+
   {{#if @answer}}
-    <span class="challenge-actions__already-answered">{{t "pages.challenge.already-answered"}}</span>
+    <span class="challenge-actions__already-answered">
+      {{#if (eq @answer.result "timedout")}}
+        {{t "pages.challenge.timed.cannot-answer"}}
+      {{else}}
+        {{t "pages.challenge.already-answered"}}
+      {{/if}}
+    </span>
     <button class="button challenge-actions__action challenge-actions__action-continue"
             {{on 'click' (fn @resumeAssessment @assessment)}}
             type="button">
       <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}</span>
     </button>
-  {{else}}
+
+  {{else if @isTimeoutChallenge}}
+    <span class="challenge-actions__timed-out">{{t "pages.challenge.timed.cannot-answer"}}</span>
+    <button class="button challenge-actions__action challenge-actions__action-continue"
+      {{on 'click' @validateAnswer}}
+            type="button">
+      <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}</span>
+    </button>
+
+    {{else}}
     {{#if @isValidateButtonEnabled}}
       <button class="button challenge-actions__action challenge-actions__action-validate"
               {{on 'click' @validateAnswer}}

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -23,7 +23,7 @@
       <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}</span>
     </button>
 
-    {{else}}
+  {{else}}
     {{#if @isValidateButtonEnabled}}
       <button class="button challenge-actions__action challenge-actions__action-validate"
               {{on 'click' @validateAnswer}}

--- a/mon-pix/app/templates/components/challenge-actions.hbs
+++ b/mon-pix/app/templates/components/challenge-actions.hbs
@@ -15,7 +15,7 @@
       <span class="challenge-actions__action-continue-text">{{t "pages.challenge.actions.continue"}}</span>
     </button>
 
-  {{else if @isTimeoutChallenge}}
+  {{else if @hasChallengeTimedOut}}
     <span class="challenge-actions__timed-out">{{t "pages.challenge.timed.cannot-answer"}}</span>
     <button class="button challenge-actions__action challenge-actions__action-continue"
       {{on 'click' @validateAnswer}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -12,7 +12,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QcmProposals @answer={{@answer}}
@@ -26,7 +26,7 @@
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
-        {{#if this.isTimeoutChallenge}}
+        {{#if this.hasChallengeTimedOut}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
@@ -52,7 +52,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
-                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
+                          @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -12,7 +12,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QcmProposals @answer={{@answer}}
@@ -24,6 +24,11 @@
         {{#if @answer}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
+          </div>
+        {{/if}}
+        {{#if this.isTimeoutChallenge}}
+          <div class="challenge-response__locked-overlay">
+            <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
 
@@ -47,6 +52,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -13,7 +13,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QcuProposals @answer={{@answer}}
@@ -27,7 +27,7 @@
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
-        {{#if this.isTimeoutChallenge}}
+        {{#if this.hasChallengeTimedOut}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
@@ -53,7 +53,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
-                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
+                          @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -13,7 +13,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QcuProposals @answer={{@answer}}
@@ -25,6 +25,11 @@
         {{#if @answer}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
+          </div>
+        {{/if}}
+        {{#if this.isTimeoutChallenge}}
+          <div class="challenge-response__locked-overlay">
+            <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
 
@@ -48,6 +53,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -12,7 +12,7 @@
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       {{#if this.showProposal}}
-        <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+        <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
           <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
           <div class="challenge-proposals">
             <QrocProposal @answer={{@answer}}
@@ -26,6 +26,11 @@
           {{#if @answer}}
             <div class="challenge-response__locked-overlay">
               <FaIcon @icon='lock' class='challenge-response-locked__icon' />
+            </div>
+          {{/if}}
+          {{#if this.isTimeoutChallenge}}
+            <div class="challenge-response__locked-overlay">
+              <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
             </div>
           {{/if}}
 
@@ -50,6 +55,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -12,7 +12,7 @@
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       {{#if this.showProposal}}
-        <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
+        <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
           <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
           <div class="challenge-proposals">
             <QrocProposal @answer={{@answer}}
@@ -28,7 +28,7 @@
               <FaIcon @icon='lock' class='challenge-response-locked__icon' />
             </div>
           {{/if}}
-          {{#if this.isTimeoutChallenge}}
+          {{#if this.hasChallengeTimedOut}}
             <div class="challenge-response__locked-overlay">
               <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
             </div>
@@ -55,7 +55,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
-                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
+                          @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -12,7 +12,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QrocmProposal @answer={{@answer}}
@@ -25,6 +25,11 @@
         {{#if @answer}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
+          </div>
+        {{/if}}
+        {{#if this.isTimeoutChallenge}}
+          <div class="challenge-response__locked-overlay">
+            <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
 
@@ -48,6 +53,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
+                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -12,7 +12,7 @@
     <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
-      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.isTimeoutChallenge 'challenge-response--locked'}}">
+      <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
         <h2 class="sr-only">{{t 'pages.challenge.parts.answer-input'}}</h2>
         <div class="challenge-proposals">
           <QrocmProposal @answer={{@answer}}
@@ -27,7 +27,7 @@
             <FaIcon @icon='lock' class='challenge-response-locked__icon' />
           </div>
         {{/if}}
-        {{#if this.isTimeoutChallenge}}
+        {{#if this.hasChallengeTimedOut}}
           <div class="challenge-response__locked-overlay">
             <FaIcon @icon='hourglass-end' class='challenge-response-locked__icon' />
           </div>
@@ -53,7 +53,7 @@
                           @validateAnswer={{action "validateAnswer"}}
                           @skipChallenge={{action "skipChallenge"}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
-                          @isTimeoutChallenge={{this.isTimeoutChallenge}}
+                          @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>
       {{/if}}
     </form>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -16,6 +16,7 @@ module.exports = function() {
       'exclamation-triangle',
       'eye',
       'eye-slash',
+      'hourglass-end',
       'image',
       'info-circle',
       'lock',

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -90,7 +90,7 @@ describe('Integration | Component | challenge actions', function() {
     it('should only display "continue" button', async function() {
       // given
       this.set('isValidateButtonEnabled', true);
-      this.set('isTimeoutChallenge', true);
+      this.set('hasChallengeTimedOut', true);
       this.set('isSkipButtonEnabled', true);
       this.set('externalAction', () => {});
 
@@ -98,7 +98,7 @@ describe('Integration | Component | challenge actions', function() {
       await render(hbs`{{challenge-actions
         validateAnswer=(action externalAction)
         isValidateButtonEnabled=isValidateButtonEnabled
-        isTimeoutChallenge=isTimeoutChallenge
+        hasChallengeTimedOut=hasChallengeTimedOut
         isSkipButtonEnabled=isSkipButtonEnabled}}`);
 
       // then

--- a/mon-pix/tests/integration/components/challenge-actions-test.js
+++ b/mon-pix/tests/integration/components/challenge-actions-test.js
@@ -2,7 +2,7 @@ import RSVP from 'rsvp';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, find, render } from '@ember/test-helpers';
+import { click, find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 const VALIDATE_BUTTON = '.challenge-actions__action-validate';
@@ -83,5 +83,27 @@ describe('Integration | Component | challenge actions', function() {
       expect(find('.challenge-actions__action-skip__loader-bar')).to.exist;
     });
 
+  });
+
+  describe('Challenge has timed out', function() {
+
+    it('should only display "continue" button', async function() {
+      // given
+      this.set('isValidateButtonEnabled', true);
+      this.set('isTimeoutChallenge', true);
+      this.set('isSkipButtonEnabled', true);
+      this.set('externalAction', () => {});
+
+      // when
+      await render(hbs`{{challenge-actions
+        validateAnswer=(action externalAction)
+        isValidateButtonEnabled=isValidateButtonEnabled
+        isTimeoutChallenge=isTimeoutChallenge
+        isSkipButtonEnabled=isSkipButtonEnabled}}`);
+
+      // then
+      expect(findAll('.challenge-actions__action').length).to.equal(1);
+      expect(find('.challenge-actions__action-continue')).to.exist;
+    });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -373,6 +373,9 @@
                 "qroc": "To validate, please fill in the text field. Otherwise, click Skip.",
                 "qroc-auto-reply": "You did not answer correctly. Try again or skip to the next question.",
                 "qrocm": "To validate, please complete all answer fields. Otherwise, click Skip."
+            },
+            "timed" : {
+                "cannot-answer": ""
             }
         },
         "checkpoint": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -373,6 +373,9 @@
                 "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passez.",
                 "qroc-auto-reply": "L'épreuve n'est pas encore réussie. Vous aurez un message “Vous pouvez valider” quand vous aurez réussi. Essayez encore ou passez.",
                 "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
+            },
+            "timed" : {
+                "cannot-answer": "Le temps accordé est écoulé."
             }
         },
         "checkpoint": {


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs ne voient pas toujours que l'épreuve était en timeout

## :robot: Solution
Quand le temps imparti est écoulé : 
- On bloque la modification de la réponse
- On affiche seulement le bouton poursuivre

## :rainbow: Remarques

## :100: Pour tester
https://app-pr2034.review.pix.fr/challenges/receQkwO1dvjQc2S3/preview