### PR TITLE
[FEATURE] Ajout du prénom et nom du user connecté sur la page saisie code parcours (PIX-1415).

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -7,10 +7,29 @@ export default class FillInCampaignCodeController extends Controller {
 
   @service store;
   @service intl;
+  @service session;
+  @service currentUser;
 
   campaignCode = null;
 
   @tracked errorMessage = null;
+
+  get isUserAuthenticated() {
+    return this.session.isAuthenticated;
+  }
+
+  get firstTitle() {
+    return this.isUserAuthenticated
+      ? this.intl.t('pages.fill-in-campaign-code.first-title-connected', { firstName: this.currentUser.user.firstName })
+      : this.intl.t('pages.fill-in-campaign-code.first-title-not-connected');
+  }
+
+  get warningMessage() {
+    return this.intl.t('pages.fill-in-campaign-code.warning-message', {
+      firstName: this.currentUser.user.firstName,
+      lastName: this.currentUser.user.lastName,
+    });
+  }
 
   @action
   async startCampaign() {
@@ -53,5 +72,10 @@ export default class FillInCampaignCodeController extends Controller {
   @action
   clearErrorMessage() {
     this.errorMessage = null;
+  }
+
+  @action
+  disconnect() {
+    this.session.invalidate();
   }
 }

--- a/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
+++ b/mon-pix/app/styles/pages/_fill-in-campaign-code.scss
@@ -56,4 +56,11 @@
     padding: 16px 10px;
     text-align: center;
   }
+
+  &__warning {
+    color: $grey-90;
+    font-size: 0.875rem;
+    text-align: center;
+    margin-top: 10px;
+  }
 }

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -9,7 +9,7 @@
       <main
         class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
         <h1 class="fill-in-campaign-code__title rounded-panel-title">
-          {{t 'pages.fill-in-campaign-code.first-title'}}
+          {{this.firstTitle}}
         </h1>
 
         <label for="campaign-code"
@@ -41,6 +41,12 @@
             </button>
           </div>
         </form>
+
+        {{#if this.isUserAuthenticated}}
+          <div class="fill-in-campaign-code__warning">
+            <span>{{this.warningMessage}}</span>&nbsp;<span class="link" {{action this.disconnect}}>{{t 'pages.fill-in-campaign-code.warning-message-logout'}}</span>
+          </div>
+        {{/if}}
       </main>
     </div>
 

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
@@ -2,19 +2,27 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import setupIntl from '../../helpers/setup-intl';
 
 describe('Unit | Controller | Fill in Campaign Code', function() {
 
   setupIntlRenderingTest();
+  setupIntl();
 
   let controller;
   let storeStub;
+  let sessionStub;
+  let currentUserStub;
 
   beforeEach(function() {
     controller = this.owner.lookup('controller:fill-in-campaign-code');
     storeStub = { query: sinon.stub() };
     controller.transitionToRoute = sinon.stub();
+    sessionStub = { invalidate: sinon.stub() };
+    currentUserStub = { user: { firstName: 'John', lastname: 'Doe' } };
     controller.set('store', storeStub);
+    controller.set('session', sessionStub);
+    controller.set('currentUser', currentUserStub);
     controller.set('errorMessage', null);
     controller.set('campaignCode', null);
   });
@@ -71,4 +79,61 @@ describe('Unit | Controller | Fill in Campaign Code', function() {
     });
   });
 
+  describe('get firstTitle', () => {
+
+    context('When user is not authenticated', () => {
+
+      it('should return the not connected first title', () => {
+        // given
+        sessionStub.isAuthenticated = false;
+        const expectedFirstTitle = controller.intl.t('pages.fill-in-campaign-code.first-title-not-connected');
+
+        // when
+        const firstTitle = controller.firstTitle;
+
+        // then
+        expect(firstTitle).to.equal(expectedFirstTitle);
+      });
+    });
+
+    context('When user is authenticated', () => {
+
+      it('should return the connected first title with user firstName', () => {
+        // given
+        sessionStub.isAuthenticated = true;
+        const expectedFirstTitle = controller.intl.t('pages.fill-in-campaign-code.first-title-connected', { firstName: currentUserStub.user.firstName });
+
+        // when
+        const firstTitle = controller.firstTitle;
+
+        // then
+        expect(firstTitle).to.equal(expectedFirstTitle);
+      });
+    });
+  });
+
+  describe('get isUserAuthenticated', () => {
+
+    it('should return session.isAuthenticated', () => {
+      // given
+      sessionStub.isAuthenticated = true;
+
+      // when
+      const isUserAuthenticated = controller.isUserAuthenticated;
+
+      // then
+      expect(isUserAuthenticated).to.equal(sessionStub.isAuthenticated);
+    });
+  });
+
+  describe('#disconnect', () => {
+
+    it('should invalidate the session', () => {
+      // when
+      controller.disconnect();
+
+      // then
+      sinon.assert.calledOnce(sessionStub.invalidate);
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -876,14 +876,17 @@
         },
         "fill-in-campaign-code": {
             "title": "I have a code",
-            "first-title": "Enter your code",
+            "first-title-not-connected": "Enter your code",
+            "first-title-connected": "{ firstName }, enter your code",
             "description": "This code can be used to start a personalised test'<br>'or to submit your profile to an organisation",
             "errors": {
                 "forbidden": "Oops! We can’t find you. Check your details to continue or contact the organiser.",
                 "missing-code": "Please enter a code.",
                 "not-found": "Your code is incorrect. Please check it or contact the organiser."
             },
-            "start": "Start"
+            "start": "Start",
+            "warning-message": "If you are not { firstName } { lastName },",
+            "warning-message-logout": "please log out"
         },
         "fill-in-certificate-verification-code": {
             "title": "Verify the authenticity of a Pix Certificate",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -876,14 +876,17 @@
         },
         "fill-in-campaign-code": {
             "title": "J'ai un code",
-            "first-title": "Saisissez votre code",
+            "first-title-not-connected": "Saisissez votre code",
+            "first-title-connected": "{ firstName }, saisissez votre code",
             "description": "Ce code permet de démarrer un parcours'<br>'ou d’envoyer votre profil à une organisation",
             "errors": {
                 "forbidden": "Oups ! nous ne parvenons pas à vous trouver. Vérifiez vos informations afin de continuer ou prévenez l’organisateur.",
                 "missing-code": "Veuillez saisir un code.",
                 "not-found": "Votre code est erroné, veuillez vérifier ou contacter l’organisateur."
             },
-            "start": "Commencer"
+            "start": "Commencer",
+            "warning-message": "Vous n'êtes pas { firstName } { lastName } ?",
+            "warning-message-logout": "Se déconnecter"
         },
         "fill-in-certificate-verification-code": {
             "title": "Vérifier un certificat Pix",


### PR DESCRIPTION
## :unicorn: Problème
Il arrive parfois que les élèves se réconcilient avec le mauvais compte si le précédent utilisateur ne s'est pas déconnecté.

## :robot: Solution
Ajouter le nom et prénom de l'utilisateur connecté dans la page de saisie d'un code parcours ainsi que la possibilité de se déconnecter.

## :100: Pour tester
Rejoindre la page /campagnes:
- En mode non connecté, vérifier que rien n'a changé.
- En mode connecté, le prénom de l'utilisateur doit apparaître dans le titre et un rappel doit être présent en bas de page, avec un lien pour se déconnecter.  
