### PR TITLE
[TRANSLATION] Corriger le html dans les fichiers de traduction

### DIFF
--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -738,47 +738,6 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       // then
       expect(component.displayInformationModal).to.be.false;
     });
-
-    describe('Errors', function() {
-      beforeEach(function() {
-        component.firstName = 'pix';
-        component.lastName = 'aile';
-        component.dayOfBirth = '10';
-        component.monthOfBirth = '10';
-        component.yearOfBirth = '1010';
-      });
-
-      it('should display a not found error', async function() {
-        // given
-        onSubmitToReconcileStub.rejects({ errors: [{ status: '404' }] });
-
-        // when
-        await component.actions.submit.call(component, eventStub);
-
-        // then
-        sinon.assert.calledOnce(record.unloadRecord);
-        expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br><br> Vous êtes un enseignant ? <br> L‘accès à un parcours n‘est pas disponible pour le moment.');
-      });
-
-      describe('When student is already reconciled', () => {
-
-        it('should open information modal and set reconciliationError', async function() {
-          // given
-          const error = { status: '409', meta: { userId: 1 } };
-
-          onSubmitToReconcileStub.rejects({ errors: [error] });
-
-          // when
-          await component.actions.submit.call(component, eventStub);
-
-          // then
-          sinon.assert.calledOnce(record.unloadRecord);
-          expect(component.displayInformationModal).to.be.true;
-          expect(component.reconciliationError).to.equal(error);
-          expect(component.isLoading).to.be.false;
-          sinon.assert.calledWith(sessionStub.set, 'data.expectedUserId', error.meta.userId);
-        });
-      });
-    });
+    
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -562,13 +562,14 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       it('should display a not found error', async function() {
         // given
         onSubmitToReconcileStub.rejects({ errors: [{ status: '404' }] });
+        const expectedErrorMessage = this.intl.t('pages.join.sco.error-not-found');
 
         // when
         await component.actions.submit.call(component, eventStub);
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        expect(component.errorMessage.string.length).to.be.greaterThan(0);
+        expect(component.errorMessage.string).to.equal(expectedErrorMessage);
       });
 
       describe('When student is already reconciled', () => {
@@ -738,6 +739,6 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       // then
       expect(component.displayInformationModal).to.be.false;
     });
-    
+
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -550,6 +550,15 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         component.yearOfBirth = '1010';
       });
 
+      it('should display no error', async function() {
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.calledOnce(record.unloadRecord);
+        expect(component.errorMessage).to.be.null;
+      });
+
       it('should display a not found error', async function() {
         // given
         onSubmitToReconcileStub.rejects({ errors: [{ status: '404' }] });
@@ -559,7 +568,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/><br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
+        expect(component.errorMessage.string.length).to.be.greaterThan(0);
       });
 
       describe('When student is already reconciled', () => {
@@ -748,7 +757,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
         // then
         sinon.assert.calledOnce(record.unloadRecord);
-        expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br/> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br/><br/> Vous êtes un enseignant ? <br/> L‘accès à un parcours n‘est pas disponible pour le moment.');
+        expect(component.errorMessage.string).to.equal('Vous êtes un élève ? <br> Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.<br><br> Vous êtes un enseignant ? <br> L‘accès à un parcours n‘est pas disponible pour le moment.');
       });
 
       describe('When student is already reconciled', () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -4,21 +4,21 @@
         "internal-server-error": "An error occurred, our teams are working on finding a solution. Please try again later.",
         "join-error": {
             "r11": "{ value }",
-            "r12": "You already have a Pix account under the username '<br />'{ value }.'<br />'To continue, log in with this account or ask for help from a teacher.'<br />'(Code R12)",
-            "r13": "You already have a Pix account through your virtual learning environment (\"ENT\") in another school '<br /> 'To continue, contact a teacher who can give you access to this account using Pix Orga.",
+            "r12": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code R12)",
+            "r13": "You already have a Pix account through your virtual learning environment (\"ENT\") in another school '<br> 'To continue, contact a teacher who can give you access to this account using Pix Orga.",
             "r31": "{ value }",
-            "r32": "You already have a Pix account under the username '<br />'{ value }.'<br />'To continue, log in with this account or ask for help from a teacher.'<br />'(Code R32)",
+            "r32": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code R32)",
             "r33": "You already have a Pix account through your virtual learning environment (\"ENT\"). Log in with this account to take your personalised test.",
             "r70": "An error occurred. Please log out and try again."
         },
         "login-unauthorized-error": "There was an error in the email address or username/password entered.",
         "register-error": {
             "s51": "{ value }",
-            "s52": "You already have a Pix account under the username '<br />'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br />'(Code S52)",
+            "s52": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code S52)",
             "s53": "You already have a Pix account through your virtual learning environment (\"ENT\"). Log in with this account to take your personalised test.",
             "s61": "{ value }",
-            "s62": "You already have a Pix account under the username '<br />'{ value }.'<br />'To continue, log in with this account or ask for help from a teacher.'<br />'(Code S62)",
-            "s63": "You already have a Pix account through your virtual learning environment (\"ENT\") in another school '<br /> 'To continue, contact a teacher who can give you access to this account using Pix Orga.'<br />'(Code S63)"
+            "s62": "You already have a Pix account under the username '<br>'{ value }.'<br>'To continue, log in with this account or ask for help from a teacher.'<br>'(Code S62)",
+            "s63": "You already have a Pix account through your virtual learning environment (\"ENT\") in another school '<br> 'To continue, contact a teacher who can give you access to this account using Pix Orga.'<br>'(Code S63)"
         }
     },
     "application": {
@@ -75,7 +75,7 @@
             "assessment": {
                 "title": "Begin your personalised test",
                 "action": "Begin",
-                "announcement": "Start your personalised test.<br /> Sign up or log in to the Pix platform and start your test.",
+                "announcement": "Start your personalised test.'<br>' Sign up or log in to the Pix platform and start your test.",
                 "details": "During this personalised test, you will be able to:",
                 "legal": "Information about your progress will be sent to the organiser so they can provide support. Your test results will only be shared with your permission.",
                 "evaluate": {
@@ -506,7 +506,7 @@
             "first-title": "{ organizationName }",
             "sco": {
                 "continue-with-pix": "Continue with my Pix account",
-                "error-not-found": "If you're a pupil '<br />' Check your information (first name, last name and date of birth) or contact a teacher.'<br /><br />' If you're a teacher '<br />' Access to this personalised test is not available at the moment.",
+                "error-not-found": "If you're a pupil '<br>' Check your information (first name, last name and date of birth) or contact a teacher.'<br><br>' If you're a teacher '<br>' Access to this personalised test is not available at the moment.",
                 "login-information-title": "Pix account information",
                 "login-information-message": "The Pix account  '<b>'{ connectionMethod }'</b>' will be linked with the pupil:  '<b>'{ firstName }  { lastName }'</b>'.'<b>'If this is you, click on \"Link\". Otherwise, log out.",
                 "associate": "Link"
@@ -600,7 +600,7 @@
         },
         "not-connected": {
             "title": "Logged out",
-            "message": "You've been logged out.'<br />'Thanks! See you soon"
+            "message": "You've been logged out.'<br>'Thanks! See you soon"
         },
         "password-reset-demand": {
             "title": "Forgotten your password?",
@@ -699,7 +699,7 @@
                 "send": "Submit my profile",
                 "shared": "Thank you, your profile has been submitted!"
             },
-            "instructions": "You are about to submit the score and skill levels shown on your Pix profile. <br/> Any changes in your profile after this submission will not be shared. <br/> Remember to check your profile before submitting it!"
+            "instructions": "You are about to submit the score and skill levels shown on your Pix profile. '<br>' Any changes in your profile after this submission will not be shared. '<br>' Remember to check your profile before submitting it!"
         },
         "sign-in": {
             "title": "Log in",
@@ -763,7 +763,7 @@
         },
         "skill-review": {
             "title": "Result",
-            "abstract": "You have mastered '<strong>'{percentage}%'</strong>'<br/> of the skills tested.",
+            "abstract": "You have mastered '<strong>'{percentage}%'</strong><br>' of the skills tested.",
             "abstract-title": "Your result for this personalised test",
             "actions": {
                 "continue": "Continue my Pix experience",
@@ -771,7 +771,7 @@
                 "try-again": "Try again"
             },
             "already-shared": "Thank you, your results have been submitted!",
-            "archived": "This personalised test has been archived by the organiser.<br/> It is no longer to possible to submit results, but they have been taken into account for your personalised test.",
+            "archived": "This personalised test has been archived by the organiser.'<br>' It is no longer to possible to submit results, but they have been taken into account for your personalised test.",
             "badges-title": "Your thematic results",
             "details": {
                 "header-skill": "Skills tested",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -75,7 +75,7 @@
             "assessment": {
                 "title": "Commencez votre parcours",
                 "action": "Je commence",
-                "announcement": "Démarrez votre parcours d'évaluation personnalisé.<br /> Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
+                "announcement": "Démarrez votre parcours d'évaluation personnalisé.'<br>' Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
                 "details": "Durant ce parcours, vous aurez l’opportunité de :",
                 "legal": "Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre de vous accompagner. Les résultats des tests ne seront transmis qu’avec votre consentement.",
                 "evaluate": {
@@ -506,7 +506,7 @@
             "first-title": "Rejoignez l'organisation { organizationName }",
             "sco": {
                 "continue-with-pix": "Continuer avec mon compte Pix",
-                "error-not-found": "Vous êtes un élève ? '<br/>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br/><br/>' Vous êtes un enseignant ? '<br/>' L‘accès à un parcours n‘est pas disponible pour le moment.",
+                "error-not-found": "Vous êtes un élève ? '<br>' Vérifiez vos informations (prénom, nom et date de naissance) ou contactez un enseignant.'<br><br>' Vous êtes un enseignant ? '<br>' L‘accès à un parcours n‘est pas disponible pour le moment.",
                 "login-information-title": "Information de connexion",
                 "login-information-message": "Le compte Pix '<b>'{ connectionMethod }'</b>' va être associé à l'élève: '<b>'{ firstName } { lastName }'</b>'.'<br><br>'S’il s’agit bien de vous, cliquez sur \"Associer\", sinon déconnectez-vous.",
                 "associate": "Associer"
@@ -699,7 +699,7 @@
                 "send": "J'envoie mon profil",
                 "shared": "Merci, votre profil a bien été envoyé !"
             },
-            "instructions": "Vous allez transmettre le score et les niveaux de compétence présents sur votre profil Pix. <br/> Toute évolution de votre profil après cet envoi ne sera pas transmise. <br/> Pensez à le vérifier avant de l'envoyer !"
+            "instructions": "Vous allez transmettre le score et les niveaux de compétence présents sur votre profil Pix. '<br>' Toute évolution de votre profil après cet envoi ne sera pas transmise. '<br>' Pensez à le vérifier avant de l'envoyer !"
         },
         "sign-in": {
             "title": "Connexion",
@@ -763,7 +763,7 @@
         },
         "skill-review": {
             "title": "Résultat",
-            "abstract": "Vous maîtrisez '<strong>'{percentage}%'</strong>'<br/> des compétences testées.",
+            "abstract": "Vous maîtrisez '<strong>'{percentage}%'</strong><br>' des compétences testées.",
             "abstract-title": "Votre résultat pour ce parcours",
             "actions": {
                 "continue": "Continuez votre expérience Pix",
@@ -771,7 +771,7 @@
                 "try-again": "Je retente"
             },
             "already-shared": "Merci, vos résultats ont bien été envoyés !",
-            "archived": "Ce parcours a été archivé par l'organisateur.<br/> L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.",
+            "archived": "Ce parcours a été archivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.",
             "badges-title": "Vos résultats thématiques",
             "details": {
                 "header-skill": "Compétences testées",


### PR DESCRIPTION
## :unicorn: Problème
- les tags HTML `br` ne sont pas autofermantes
- dans certains cas, l'utilisation de `br` n'est pas nécessaire car cela force un retour à la ligne pour afficher seulement un mot.

## :robot: Solution
- les balises HTML `br` ne peuvent pas être autofermantes dans les fichiers de trauduction de notre appli, car dans les tests on fait la comparaison avec du innerHtml (qui contient `<br>`) et la valeur de la clé de traduction (qui contiendrait `<br />`)
- dans le cas où `br` n'est pas nécessaire, utiliser `b`

## :rainbow: Remarques
La branche part de `translation-from-po-editor-2020-20-16`.
Elle sera rebasée sur `dev` avant le merge.

**Problème**: Côté fichier de traduction, on utilise `<br />`. En inspectant le DOM, on se rend compte que `<br />` a été converti simplement en `<br>`  (sans balise autofermante). D'où les tests qui cassent actuellement.

## :100: Pour tester
Lancer app.pix en EN et voir les traductions
