### PR TITLE
[BUGFIX] Page blanche en fin de campagne (PIX-1272).

### DIFF
--- a/mon-pix/app/app.js
+++ b/mon-pix/app/app.js
@@ -7,6 +7,7 @@ import { InitSentryForEmber } from '@sentry/ember';
 import '@formatjs/intl-pluralrules/polyfill';
 import '@formatjs/intl-pluralrules/locale-data/en';
 import '@formatjs/intl-pluralrules/locale-data/fr';
+import '@formatjs/intl-getcanonicallocales/polyfill';
 
 if (config.sentry.enabled) {
   InitSentryForEmber();

--- a/mon-pix/app/app.js
+++ b/mon-pix/app/app.js
@@ -4,6 +4,10 @@ import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 import { InitSentryForEmber } from '@sentry/ember';
 
+import '@formatjs/intl-pluralrules/polyfill';
+import '@formatjs/intl-pluralrules/locale-data/en';
+import '@formatjs/intl-pluralrules/locale-data/fr';
+
 if (config.sentry.enabled) {
   InitSentryForEmber();
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13157,6 +13157,24 @@
         }
       }
     },
+    "@formatjs/intl-getcanonicallocales": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.4.6.tgz",
+      "integrity": "sha512-V54a+Ks02vke2CSmuGJ4GCvrdWfN105GSH7oZRoW5QSiwuac+fmxb5Qpu4002HetuRu0rrRTm+NMUTfZ1VB2xw==",
+      "dev": true,
+      "requires": {
+        "cldr-core": "36.0.0",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "@formatjs/intl-numberformat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.0.2.tgz",

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -13140,6 +13140,23 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
+    "@formatjs/ecma402-abstract": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.2.5.tgz",
+      "integrity": "sha512-k0fqS3LBNOHueAoMdgig8Ni6TchsH+zbzWBzX2gTFm50X9mxHwnuXdCk0XLlCIbvgVVlzcO254Men/mHAheMbg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "@formatjs/intl-numberformat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-numberformat/-/intl-numberformat-5.0.2.tgz",
@@ -13147,6 +13164,24 @@
       "dev": true,
       "requires": {
         "@formatjs/intl-utils": "^3.6.0"
+      }
+    },
+    "@formatjs/intl-pluralrules": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-3.4.10.tgz",
+      "integrity": "sha512-KcZZv38bu0pho9+9pMUOsCAi9/Kayh4+V5QZ/I9ps5OFSQlQaFMP5sX/zHBp41SsT6HxTfrPw5CHWpGrS75NQQ==",
+      "dev": true,
+      "requires": {
+        "@formatjs/ecma402-abstract": "^1.2.5",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
       }
     },
     "@formatjs/intl-utils": {

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,6 +40,7 @@
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^1.1.0",
     "@ember/render-modifiers": "^1.0.2",
+    "@formatjs/intl-getcanonicallocales": "^1.4.6",
     "@formatjs/intl-pluralrules": "^3.4.10",
     "@fortawesome/ember-fontawesome": "^0.2.2",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -40,6 +40,7 @@
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^1.1.0",
     "@ember/render-modifiers": "^1.0.2",
+    "@formatjs/intl-pluralrules": "^3.4.10",
     "@fortawesome/ember-fontawesome": "^0.2.2",
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-regular-svg-icons": "^5.14.0",


### PR DESCRIPTION
## :unicorn: Problème
Nous recevons des tickets de support signalant une disparition des compétences ainsi que l'apparition d'une page blanche en lieu et place de la page de résultats de fin de campagne.

## :robot: Solution
Ce problème semble être lié à l'utilisation de navigateurs ne supportant pas l'objet `Intl.PluralRules` ([documentation MDN](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Intl/PluralRules))
Pour palier à ce problème, nous passons par l'ajout du polyfill `@formatjs/intl-pluralrules`

## :rainbow: Remarques

Sur la documentation du package [Ember-intl](https://ember-intl.github.io/ember-intl/versions/master/docs/runtime-requirements), nous remarquons l'existence de divers autres polyfills.

L'un deux, `Intl.getCanonicalLocales` est nécessaire lors de l'import de `Intl.PluralRules`.

## :100: Pour tester

Terminer une campagne sur la RA via les navigateurs ne supportant pas l'objet `Intl.PluralRules`  (voir doc MDN ci-dessus) et utiliser Lambda-Test pour accéder aux navigateurs en question) et vérifier que la page blanche reportée par les utilisateurs est remplacée par les résultats de fin d'épreuve.
