### PR TITLE
[FEATURE] Inclure les résultats thématiques dans l'export des campagnes d'évaluation (PIX-1457).

### DIFF
--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -1,6 +1,7 @@
 const BASICS_BADGE_ID = 111;
 const TOOLS_BADGE_ID = 112;
 const MANIP_BADGE_ID = 113;
+const PRO_BASICS_BADGE_ID = 114;
 const TARGET_PROFILE_ID_FOR_BADGES = 984165;
 const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
 
@@ -8,6 +9,7 @@ function badgesBuilder({ databaseBuilder }) {
   _createBasicsBadge(databaseBuilder);
   _createToolsBadge(databaseBuilder);
   _createManipBadge(databaseBuilder);
+  _createProfessionalBasicsBadge(databaseBuilder);
 }
 
 function _createBasicsBadge(databaseBuilder) {
@@ -76,6 +78,20 @@ function _createManipBadge(databaseBuilder) {
   _associateBadgeCriteria(databaseBuilder, manipBadge);
 }
 
+function _createProfessionalBasicsBadge(databaseBuilder) {
+  const basicsBadge = databaseBuilder.factory.buildBadge({
+    id: PRO_BASICS_BADGE_ID,
+    altMessage: 'Vous avez validé les bases professionnelles.',
+    title: 'Bases professionnelles',
+    imageUrl: 'https://storage.gra.cloud.ovh.net/v1/AUTH_27c5a6d3d35841a5914c7fb9a8e96345/pix-images/badges/socle-de-base.svg',
+    key: 'Pro Basics',
+    message: 'Bravo ! Vous maîtrisez quelques bases  du numérique pour le monde professionnel !',
+    targetProfileId: 2,
+  });
+
+  _associateBadgeCriteria(databaseBuilder, basicsBadge);
+}
+
 function _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
   databaseBuilder.factory.buildBadgePartnerCompetence({
     name: 'Rechercher des informations sur internet',
@@ -125,4 +141,5 @@ module.exports = {
   BASICS_BADGE_ID,
   TOOLS_BADGE_ID,
   MANIP_BADGE_ID,
+  PRO_BASICS_BADGE_ID,
 };

--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -4,6 +4,7 @@ const {
   CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID,
   CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID,
 } = require('./certification/users');
+const { PRO_BASICS_BADGE_ID } = require('./badges-builder');
 
 module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
 
@@ -36,6 +37,7 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
     const participantExternalId = member.firstName.toLowerCase() + member.lastName.toLowerCase();
 
     const { id: campaignParticipationId } =  databaseBuilder.factory.buildCampaignParticipation({ campaignId: 1, userId, participantExternalId, isShared, sharedAt });
+    if (['Jaune', 'Antoine'].includes(member.firstName)) databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: PRO_BASICS_BADGE_ID });
 
     const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
       userId,

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -8,6 +8,7 @@ class TargetProfileWithLearningContent {
     tubes = [],
     competences = [],
     areas = [],
+    badges = [],
   } = {}) {
     this.id = id;
     this.name = name;
@@ -15,6 +16,7 @@ class TargetProfileWithLearningContent {
     this.tubes = tubes;
     this.competences = competences;
     this.areas = areas;
+    this.badges = badges;
   }
 
   get skillNames() {

--- a/api/lib/domain/services/campaign-csv-export-service.js
+++ b/api/lib/domain/services/campaign-csv-export-service.js
@@ -12,6 +12,7 @@ function createOneCsvLine({
   campaignParticipationInfo,
   targetProfile,
   participantKnowledgeElementsByCompetenceId,
+  acquiredBadges,
 }) {
   const line = new CampaignAssessmentCsvLine({
     organization,
@@ -19,6 +20,7 @@ function createOneCsvLine({
     campaignParticipationInfo,
     targetProfile,
     participantKnowledgeElementsByCompetenceId,
+    acquiredBadges,
     campaignParticipationService,
   });
 

--- a/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
@@ -18,9 +18,9 @@ module.exports = async function findPaginatedCampaignAssessmentParticipationSumm
 
   // get users badges for campaign
   const userIds = paginatedParticipations.campaignAssessmentParticipationSummaries.map((participation) => participation.userId);
-  const acquiredBadgeIdsByUsers = await badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers({ campaignId, userIds });
+  const acquiredBadgesByUsers = await badgeAcquisitionRepository.getCampaignAcquiredBadgesByUsers({ campaignId, userIds });
   paginatedParticipations.campaignAssessmentParticipationSummaries.forEach((participation) => {
-    const badges = acquiredBadgeIdsByUsers[participation.userId];
+    const badges = acquiredBadgesByUsers[participation.userId];
     participation.setBadges(badges);
   });
 

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -17,6 +17,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
     campaignParticipationInfoRepository,
     organizationRepository,
     knowledgeElementRepository,
+    badgeAcquisitionRepository,
     campaignCsvExportService,
   }) {
 
@@ -25,7 +26,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
   const [targetProfile, organization, campaignParticipationInfos] = await Promise.all([
-    targetProfileWithLearningContentRepository.get({ id: campaign.targetProfileId }),
+    targetProfileWithLearningContentRepository.getWithBadges({ id: campaign.targetProfileId }),
     organizationRepository.get(campaign.organizationId),
     campaignParticipationInfoRepository.findByCampaignId(campaign.id),
   ]);
@@ -107,6 +108,10 @@ function _createHeaderOfCSV(targetProfile, idPixLabel, organizationType, organiz
     'Date de début',
     'Partage (O/N)',
     'Date du partage',
+
+    ...(_.flatMap(targetProfile.badges, (badge) => [
+      `${badge} obtenu (O/N)`,
+    ])),
     '% maitrise de l\'ensemble des acquis du profil',
 
     ...(_.flatMap(targetProfile.competences, (competence) => [

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -28,22 +28,22 @@ module.exports = {
         qb.where('campaigns.id', '=', campaignId);
         qb.where('badge-acquisitions.userId', 'IN', userIds);
       })
-      .fetchAll({ 
+      .fetchAll({
         withRelated: ['badge'],
         require: false,
       });
 
     const badgeAcquisitions = results.map((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfBadgeAcquisition, result));
-    
-    const acquiredBadgeIdsByUsers = {};
+
+    const acquiredBadgesByUsers = {};
     for (const badgeAcquisition of badgeAcquisitions) {
       const { userId, badge } = badgeAcquisition;
-      if (acquiredBadgeIdsByUsers[userId]) {
-        acquiredBadgeIdsByUsers[userId].push(badge);
+      if (acquiredBadgesByUsers[userId]) {
+        acquiredBadgesByUsers[userId].push(badge);
       } else {
-        acquiredBadgeIdsByUsers[userId] = [badge];
+        acquiredBadgesByUsers[userId] = [badge];
       }
     }
-    return acquiredBadgeIdsByUsers;
+    return acquiredBadgesByUsers;
   },
 };

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -11,6 +11,7 @@ class CampaignAssessmentCsvLine {
     campaignParticipationInfo,
     targetProfile,
     participantKnowledgeElementsByCompetenceId,
+    acquiredBadges,
     campaignParticipationService,
   }) {
     this.organization = organization;
@@ -19,6 +20,7 @@ class CampaignAssessmentCsvLine {
     this.targetProfile = targetProfile;
     this.targetedKnowledgeElementsCount = _.sum(_.map(participantKnowledgeElementsByCompetenceId, (knowledgeElements) => knowledgeElements.length));
     this.targetedKnowledgeElementsByCompetence = participantKnowledgeElementsByCompetenceId;
+    this.acquiredBadges = acquiredBadges;
     this.campaignParticipationService = campaignParticipationService;
 
     // To have the good `this` in _getStatsForCompetence, it is necessary to bind it
@@ -40,7 +42,7 @@ class CampaignAssessmentCsvLine {
     ];
   }
 
-  _makeNotSharedStatsColumns(times) {
+  _makeEmptyColumns(times) {
     return _.times(times, () => EMPTY_CONTENT);
   }
 
@@ -73,6 +75,10 @@ class CampaignAssessmentCsvLine {
     });
   }
 
+  _makeBadgesColumns() {
+    return _.flatMap(this.targetProfile.badges, (badge) => _.includes(this.acquiredBadges, badge) ? 'Oui' : 'Non');
+  }
+
   _makeCommonColumns() {
     return [
       this.organization.name,
@@ -87,6 +93,7 @@ class CampaignAssessmentCsvLine {
       moment.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
       this.campaignParticipationInfo.isShared ? 'Oui' : 'Non',
       this.campaignParticipationInfo.isShared ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD') : EMPTY_CONTENT,
+      ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfile.badges.length)),
       this.campaignParticipationInfo.isShared ? this._percentageSkillsValidated() : EMPTY_CONTENT,
     ];
   }
@@ -101,9 +108,9 @@ class CampaignAssessmentCsvLine {
 
   _makeNotSharedColumns() {
     return [
-      ...this._makeNotSharedStatsColumns(this.targetProfile.competences.length * STATS_COLUMNS_COUNT),
-      ...this._makeNotSharedStatsColumns(this.targetProfile.areas.length * STATS_COLUMNS_COUNT),
-      ...this.organization.isSco ? [] : this._makeNotSharedStatsColumns(this.targetProfile.skills.length),
+      ...this._makeEmptyColumns(this.targetProfile.competences.length * STATS_COLUMNS_COUNT),
+      ...this._makeEmptyColumns(this.targetProfile.areas.length * STATS_COLUMNS_COUNT),
+      ...this.organization.isSco ? [] : this._makeEmptyColumns(this.targetProfile.skills.length),
     ];
   }
 

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -12,7 +12,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
     return cache.flushAll();
   });
 
-  describe('#get', () => {
+  describe('#getWithBadges', () => {
 
     it('should return target profile with learning content', async () => {
       // given
@@ -73,7 +73,52 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       await databaseBuilder.commit();
 
       // when
-      const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id });
+      const targetProfile = await targetProfileWithLearningContentRepository.getWithBadges({ id: targetProfileDB.id });
+
+      // then
+      expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
+      expect(targetProfile).to.deep.equal(expectedTargetProfile);
+    });
+
+    it('should return target profile with badges', async () => {
+      // given
+      const skill1_1_1_1 = domainBuilder.buildTargetedSkill({
+        id: 'recArea1_Competence1_Tube1_Skill1',
+        tubeId: 'recArea1_Competence1_Tube1',
+      });
+      const tube1_1_1 = domainBuilder.buildTargetedTube({
+        id: 'recArea1_Competence1_Tube1',
+        competenceId: 'recArea1_Competence1',
+        skills: [skill1_1_1_1],
+      });
+      const competence1_1 = domainBuilder.buildTargetedCompetence({
+        id: 'recArea1_Competence1',
+        areaId: 'recArea1',
+        tubes: [tube1_1_1],
+      });
+      const area1 = domainBuilder.buildTargetedArea({
+        id: 'recArea1',
+        competences: [competence1_1],
+      });
+      const targetProfileDB = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfileDB.id, skillId: 'recArea1_Competence1_Tube1_Skill1' });
+      const badge1 = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfileDB.id });
+      const badge2 = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfileDB.id });
+      const expectedTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        id: targetProfileDB.id,
+        name: targetProfileDB.name,
+        skills: [skill1_1_1_1],
+        tubes: [tube1_1_1],
+        competences: [competence1_1],
+        areas: [area1],
+        badges: [badge1.title, badge2.title],
+      });
+      const airtableObjects = airtableBuilder.factory.buildLearningContent.fromTargetProfileWithLearningContent({ targetProfile: expectedTargetProfile });
+      airtableBuilder.mockLists(airtableObjects);
+      await databaseBuilder.commit();
+
+      // when
+      const targetProfile = await targetProfileWithLearningContentRepository.getWithBadges({ id: targetProfileDB.id });
 
       // then
       expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
@@ -96,7 +141,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       await databaseBuilder.commit();
 
       // when
-      const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id, locale: ENGLISH_SPOKEN });
+      const targetProfile = await targetProfileWithLearningContentRepository.getWithBadges({ id: targetProfileDB.id, locale: ENGLISH_SPOKEN });
 
       // then
       expect(targetProfile).to.be.instanceOf(TargetProfileWithLearningContent);
@@ -105,7 +150,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
 
     it('should throw a NotFoundError when targetProfile does not exists', async () => {
       // when
-      const error = await catchErr(targetProfileWithLearningContentRepository.get)({ id: 123 });
+      const error = await catchErr(targetProfileWithLearningContentRepository.getWithBadges)({ id: 123 });
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
+++ b/api/tests/tooling/domain-builder/factory/build-target-profile-with-learning-content.js
@@ -11,6 +11,7 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
   tubes = [],
   competences = [],
   areas = [],
+  badges = [],
 } = {}) {
   return new TargetProfileWithLearningContent({
     id,
@@ -19,12 +20,14 @@ const buildTargetProfileWithLearningContent = function buildTargetProfileWithLea
     tubes,
     competences,
     areas,
+    badges,
   });
 };
 
 buildTargetProfileWithLearningContent.withSimpleLearningContent = function withSimpleLearningContent({
   id = 123,
   name = 'Pour les champions du monde 1998 !! Merci Aimé',
+  badges = [],
 } = {}) {
   const skill = buildTargetedSkill({ id: 'skillId', tubeId: 'tubeId' });
   const tube = buildTargetedTube({ id: 'tubeId', competenceId: 'competenceId', skills: [skill] });
@@ -37,6 +40,7 @@ buildTargetProfileWithLearningContent.withSimpleLearningContent = function withS
     tubes: [tube],
     competences: [competence],
     areas: [area],
+    badges,
   });
 };
 

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -7,7 +7,7 @@ const campaignCsvExportService = require('../../../../lib/domain/services/campai
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', () => {
   const campaignRepository = { get: () => undefined };
   const userRepository = { getWithMemberships: () => undefined };
-  const targetProfileWithLearningContentRepository = { get: () => undefined };
+  const targetProfileWithLearningContentRepository = { getWithBadges: () => undefined };
   const organizationRepository = { get: () => undefined };
   const campaignParticipationInfoRepository = { findByCampaignId: () => undefined };
   const knowledgeElementRepository = { findTargetedGroupedByCompetencesForUsers: () => undefined };
@@ -25,7 +25,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     const campaign = domainBuilder.buildCampaign();
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(notAuthorizedUser.id).resolves(notAuthorizedUser);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').rejects();
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').rejects();
     sinon.stub(organizationRepository, 'get').rejects();
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').rejects();
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
@@ -70,7 +70,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
@@ -127,7 +127,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
@@ -169,7 +169,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     expect(csv).to.equal(csvExpected);
   });
 
-  it('should contains Numéro Étudiant header when orga is SUP and managing students', async () => {
+  it('should contains studentNumber header when organization is SUP and managing students', async () => {
     // given
     const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ isManagingStudents: true, type: 'SUP' });
     const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
@@ -177,7 +177,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
@@ -233,7 +233,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(admin.id).resolves(admin);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([participantInfo]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').resolves({
       [participantInfo.userId] : {
@@ -310,7 +310,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -3,9 +3,10 @@ const CampaignAssessmentCsvLine = require('../../../../lib/infrastructure/utils/
 const campaignParticipationService = require('../../../../lib/domain/services/campaign-participation-service');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 
-function _computeExpectedColumns(campaign, organization) {
+function _computeExpectedColumnsIndex(campaign, organization, badges) {
   const studentNumberPresenceModifier = (organization.type === 'SUP' && organization.isManagingStudents) ? 1 : 0;
   const externalIdPresenceModifier = campaign.idPixLabel ? 1 : 0;
+  const badgePresenceModifier = badges.length;
 
   return {
     ORGANIZATION_NAME: 0,
@@ -20,8 +21,9 @@ function _computeExpectedColumns(campaign, organization) {
     PARTICIPATION_CREATED_AT: 7 + studentNumberPresenceModifier + externalIdPresenceModifier,
     PARTICIPATION_IS_SHARED: 8 + studentNumberPresenceModifier + externalIdPresenceModifier,
     PARTICIPATION_SHARED_AT: 9 + studentNumberPresenceModifier + externalIdPresenceModifier,
-    PARTICIPATION_PERCENTAGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier,
-    DETAILS_START: 11 + studentNumberPresenceModifier + externalIdPresenceModifier,
+    BADGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier,
+    PARTICIPATION_PERCENTAGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier,
+    DETAILS_START: 11 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier,
   };
 }
 
@@ -50,7 +52,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
       const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
       // then
-      const cols = _computeExpectedColumns(campaign, organization);
+      const cols = _computeExpectedColumnsIndex(campaign, organization, []);
       expect(csvLine[cols.ORGANIZATION_NAME], 'organization name').to.equal(organization.name);
       expect(csvLine[cols.CAMPAIGN_ID], 'campaign id').to.equal(campaign.id);
       expect(csvLine[cols.CAMPAIGN_NAME], 'campaign name').to.equal(campaign.name);
@@ -83,7 +85,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumns(campaign, organization);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
         expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
       });
     });
@@ -111,7 +113,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumns(campaign, organization);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
         expect(csvLine[cols.EXTERNAL_ID], 'external id').to.equal(campaignParticipationInfo.participantExternalId);
       });
 
@@ -138,7 +140,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumns(campaign, organization);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
         expect(csvLine[cols.EXTERNAL_ID], 'external id').to.equal(campaignParticipationInfo.participantExternalId);
         expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
       });
@@ -166,7 +168,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumns(campaign, organization);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
         const EMPTY_CONTENT = 'NA';
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Non');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(EMPTY_CONTENT);
@@ -202,7 +204,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumns(campaign, organization);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Oui');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal('2020-01-01');
         expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(1);
@@ -277,7 +279,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumns(campaign, organization);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
@@ -377,7 +379,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumns(campaign, organization);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal('NA');
@@ -479,7 +481,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumns(campaign, organization);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
@@ -573,7 +575,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumns(campaign, organization);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal('NA');
@@ -597,6 +599,106 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal('NA');
 
           expect(csvLine).to.have.lengthOf(currentColumn);
+        });
+      });
+    });
+
+    context('when campaign has bagdes', () => {
+      context('when participation is not shared', () => {
+        it('should not show badges acquired or not', () => {
+          // given
+          const organization = domainBuilder.buildOrganization();
+          const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: null });
+          const badge = 'badge title';
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({ badges: [badge] });
+          const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            participantKnowledgeElementsByCompetenceId: {
+              [targetProfile.competences[0].id]: [],
+            },
+            acquiredBadges: [badge],
+            campaignParticipationService,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          // then
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          const EMPTY_CONTENT = 'NA';
+          expect(csvLine[cols.BADGE], 'badge').to.equal(EMPTY_CONTENT);
+        });
+      });
+
+      context('when participation is shared', () => {
+        it('should show badges acquired', () => {
+          // given
+          const organization = domainBuilder.buildOrganization();
+          const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+          const badge = 'badge title';
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({ badges: [badge] });
+          const knowledgeElement = domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 3,
+            skillId: targetProfile.skills[0].id,
+            competenceId: targetProfile.competences[0].id,
+          });
+          const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            participantKnowledgeElementsByCompetenceId: {
+              [targetProfile.competences[0].id]: [knowledgeElement],
+            },
+            acquiredBadges: [badge],
+            campaignParticipationService,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          // then
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          expect(csvLine[cols.BADGE], 'badge').to.equal('Oui');
+        });
+
+        it('should show badges not acquired', () => {
+          // given
+          const organization = domainBuilder.buildOrganization();
+          const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+          const badge = 'badge title';
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({ badges: [badge] });
+          const knowledgeElement = domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 3,
+            skillId: targetProfile.skills[0].id,
+            competenceId: targetProfile.competences[0].id,
+          });
+          const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            participantKnowledgeElementsByCompetenceId: {
+              [targetProfile.competences[0].id]: [knowledgeElement],
+            },
+            acquiredBadges: [],
+            campaignParticipationService,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          // then
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          expect(csvLine[cols.BADGE], 'badge').to.equal('Non');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les résultats thématiques apparaissent dans Pix Orga dans la liste des participants, mais pas dans l'export pour une campagne d'évaluation.

## :robot: Solution
Ajouter les résultats thématiques, une colonne par résultat, et afficher :
- Oui si obtenu ;
- Non si non obtenu ;
- NA si les résultats ne sont pas encore partagés.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix Orga avec pro.admin@example.net, choisir la campagne d'évaluation qui a des participants (code AZERT123) et télécharger les résultats. 
Vérifier que les colonnes apparaissent bien sous la forme "<Titre du badge> obtenu (O/N)" pour le header, et Oui/Non/NA pour les lignes.
