### PR TITLE
[FEATURE] Cacher les bannières de Pix Orga lorsque l'organisation est SCO AGRICULTURE (PIX-1492).

### DIFF
--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -6,7 +6,8 @@ export default class InformationBanner extends Component {
   @service currentUser;
   get displayNewYearSchoolingRegistrationsImportBanner() {
     return !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported &&
-      this.currentUser.isSCOManagingStudents;
+      this.currentUser.isSCOManagingStudents &&
+      !this.currentUser.isAgriculture;
   }
 
   get displayNewYearCampaignsBanner() {

--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -12,6 +12,8 @@ export default class InformationBanner extends Component {
 
   get displayNewYearCampaignsBanner() {
     const isBeforeBannerDeadLine = new Date() < new Date(bannerDeadLine);
-    return isBeforeBannerDeadLine && this.currentUser.isSCOManagingStudents;
+    return isBeforeBannerDeadLine &&
+      this.currentUser.isSCOManagingStudents &&
+      !this.currentUser.isAgriculture;
   }
 }

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -77,6 +77,26 @@ module('Integration | Component | information-banner', function(hooks) {
       });
 
     });
+
+    module('when prescriber’s organization is agriculture', function() {
+
+      test('should not display the banner regardless of whether students have been imported or not', async function(assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: false }
+          isSCOManagingStudents = true;
+          isAgriculture = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        await render(hbs`<InformationBanner/>`);
+
+        // then
+        assert.dom('.pix-banner').doesNotExist();
+      });
+
+    });
   });
 
   module('Campaign Banner', () => {

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -187,5 +187,34 @@ module('Integration | Component | information-banner', function(hooks) {
         assert.dom('.pix-banner').doesNotExist();
       });
     });
+
+    module('when prescriber’s organization is agriculture', function() {
+      const now = new Date('2019-01-01T05:06:07Z');
+      let clock;
+
+      hooks.beforeEach(() => {
+        clock = sinon.useFakeTimers(now);
+      });
+
+      hooks.afterEach(() => {
+        clock.restore();
+      });
+
+      test('should not show the campaign banner', async function(assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: true }
+          isSCOManagingStudents = true;
+          isAgriculture = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        await render(hbs`<InformationBanner/>`);
+
+        // then
+        assert.dom('.pix-banner').doesNotExist();
+      });
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les bannières SCO de Pix Orga, font mention d'importer les élèves avant une certaine date, et redirige vers une documentation non AGRICULTURE.

## :robot: Solution
Au moins pour la première année (question de timing), on n'affiche pas les bandeaux pour les organisations SCO AGRICULTURE.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix Orga avec sco.admin@example.net, et aller sur l'organisation "Lycée Agricole". Vérifier qu'il n'y a aucune bannière d'affichée.
