### PR TITLE
[BUG] Rediriger vers la page '/' lors d'une déconnexion, sur Pix Admin/Certif/Orga (PIX-1493).

### DIFF
--- a/admin/app/services/url.js
+++ b/admin/app/services/url.js
@@ -1,16 +1,12 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
-import ENV from 'pix-admin/config/environment';
+import config from 'pix-admin/config/environment';
 
 export default class Url extends Service {
 
-  @service currentDomain;
-
-  definedHomeUrl = ENV.APP.HOME_URL;
+  definedHomeUrl = config.rootURL;
 
   get homeUrl() {
-    const homeUrl = `https://admin.pix.${this.currentDomain.getExtension()}`;
-    return this.definedHomeUrl || homeUrl;
+    return this.definedHomeUrl;
   }
 
 }

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -49,7 +49,6 @@ module.exports = function(environment) {
         FORBIDDEN: '403',
         NOT_FOUND: '404',
       },
-      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL,
@@ -89,7 +88,6 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -106,8 +104,6 @@ module.exports = function(environment) {
     ENV.locationType = 'none';
 
     ENV.APP.API_HOST = 'http://localhost:3000';
-
-    ENV.APP.HOME_URL = '/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/certif/app/services/url.js
+++ b/certif/app/services/url.js
@@ -1,16 +1,13 @@
 import Service from '@ember/service';
-import { inject as service } from '@ember/service';
-import ENV from 'pix-certif/config/environment';
+
+import config from 'pix-certif/config/environment';
 
 export default class Url extends Service {
 
-  @service currentDomain;
-
-  definedHomeUrl = ENV.APP.HOME_URL;
+  definedHomeUrl = config.rootURL;
 
   get homeUrl() {
-    const homeUrl = `https://certif.pix.${this.currentDomain.getExtension()}`;
-    return this.definedHomeUrl || homeUrl;
+    return this.definedHomeUrl;
   }
 
 }

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -50,7 +50,6 @@ module.exports = function(environment) {
         FORBIDDEN: '403',
         NOT_FOUND: '404',
       },
-      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE: _isFeatureEnabled(process.env.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE),
     },
@@ -83,7 +82,6 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -100,7 +98,6 @@ module.exports = function(environment) {
     ENV.locationType = 'none';
 
     ENV.APP.API_HOST = 'http://localhost:3000';
-    ENV.APP.HOME_URL = '/';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -1,22 +1,24 @@
-import Service from '@ember/service';
-import { inject as service } from '@ember/service';
+import Service, { inject as service } from '@ember/service';
+
 import ENV from 'pix-orga/config/environment';
 
 export default class Url extends Service {
+
   @service currentDomain;
+
   definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
   pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
-  definedHomeUrl = ENV.APP.HOME_URL;
+
+  definedHomeUrl = ENV.rootURL;
 
   get campaignsRootUrl() {
-    return this.definedCampaignsRootUrl ?
-      this.definedCampaignsRootUrl :
-      `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/campagnes/`;
+    return this.definedCampaignsRootUrl
+      ? this.definedCampaignsRootUrl
+      : `${this.pixAppUrlWithoutExtension}${this.currentDomain.getExtension()}/campagnes/`;
   }
 
   get homeUrl() {
-    const homeUrl = `https://orga.pix.${this.currentDomain.getExtension()}`;
-    return this.definedHomeUrl || homeUrl;
+    return this.definedHomeUrl;
   }
 
 }

--- a/orga/config/environment.js
+++ b/orga/config/environment.js
@@ -34,7 +34,6 @@ module.exports = function(environment) {
     APP: {
       API_HOST: process.env.API_HOST || '',
       CAMPAIGNS_ROOT_URL: process.env.CAMPAIGNS_ROOT_URL,
-      HOME_URL: process.env.HOME_URL,
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       PIX_APP_URL_WITHOUT_EXTENSION: process.env.PIX_APP_URL_WITHOUT_EXTENSION || 'https://app.pix.',
       IS_DISSOCIATE_BUTTON_ENABLED : _isFeatureEnabled(process.env.IS_DISSOCIATE_BUTTON_ENABLED),
@@ -79,7 +78,6 @@ module.exports = function(environment) {
 
   if (environment === 'development') {
     ENV.APP.CAMPAIGNS_ROOT_URL = 'http://localhost:4200/campagnes/';
-    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -102,8 +100,6 @@ module.exports = function(environment) {
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;
     ENV.APP.LOG_VIEW_LOOKUPS = false;
-
-    ENV.APP.HOME_URL = '/';
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;


### PR DESCRIPTION
## :unicorn: Problème
Sur les environnements Intégration et Recette, la déconnexion redirige vers l'environnement de production.

## :robot: Solution
* Utiliser la variable ENV.rootURL pour la redirection vers '/'.
* Première partie : Cibles Pix Admin, Certif et Orga

## :rainbow: Remarques
La mise à jour de Mon-Pix sera effectuée dans un second ticket.

## :100: Pour tester
Sur les environnements d'Intégration et de Recette, la déconnexion ne doit pas changer le Domain,
et la redirection doit se faire vers la page de connexion.