### PR TITLE
[FEATURE] Ajouter un tooltip lors du survol des badges dans les résultats participant d'une campagne (PIX-1459).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -46,7 +46,14 @@
             {{#if @campaign.targetProfile.hasBadges}}
               <td>
                 {{#each participation.badges as |badge|}}
-                  <img src={{badge.imageUrl}} alt={{badge.altMessage}} class="participant-list__badge" />
+                  <PixTooltip
+                    @text={{badge.title}}
+                    @position='bottom'
+                    @inline={{true}}
+                    class="participant-list__tooltip"
+                  >
+                    <img src={{badge.imageUrl}} alt={{badge.altMessage}} class="participant-list__badge" />
+                  </PixTooltip>
                 {{/each}}
               </td>
             {{/if}}

--- a/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/participants.scss
@@ -25,4 +25,9 @@
   &__badge {
     height: 40px;
   }
+
+  &__tooltip {
+    display: inline-block;
+  }
 }
+

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -226,13 +226,41 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       this.set('campaign', campaign);
       this.set('participations', participations);
       this.set('goToAssessmentPage', goTo);
-
       // when
       await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
 
       // then
       assert.contains('Résultats Thématiques');
       assert.dom('img[src="url-badge"]').exists();
+    });
+
+    test('it should display tooltip', async function(assert) {
+      // given
+      const badge = store.createRecord('badge', { id: 'b1', imageUrl: 'url-badge' });
+      const targetProfile = store.createRecord('targetProfile', {
+        id: 't1',
+        hasBadges: true,
+      });
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        targetProfile,
+      });
+
+      const participations = [{ firstName: 'John', lastName: 'Doe', badges: [badge] }];
+      participations.meta = { rowCount: 1 };
+
+      const goTo = function() {
+      };
+
+      this.set('campaign', campaign);
+      this.set('participations', participations);
+      this.set('goToAssessmentPage', goTo);
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
+      
+      // then
+      assert.dom('.pix-tooltip__content').exists();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
On souhaite afficher les noms des badges acquis dans les résultats d'une campagne.

## :robot: Solution
Ajout d'un tool -tip avec le nom du résultat thématique lorsque la souris survole l'icône du résultat thématique dans la liste des participants d'une campagnes.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à une organisation > Rejoindre une campagne > Réussir totalement ou en partie la campagne (pour avoir le plus de badge possible)
Survoler les badges.

<img width="493" alt="Capture d’écran 2020-10-23 à 11 25 50" src="https://user-images.githubusercontent.com/13931126/97004259-15ed6580-153d-11eb-97d8-abaccf65aeda.png">

