### PR TITLE
[CLEANUP] Déplacer la mise à jour du userOrgaSettings dans l'API (PIX-1498).

### DIFF
--- a/api/tests/integration/domain/usecases/get-prescriber_test.js
+++ b/api/tests/integration/domain/usecases/get-prescriber_test.js
@@ -1,0 +1,74 @@
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+
+const prescriberRepository = require('../../../../lib/infrastructure/repositories/prescriber-repository');
+const membershipRepository = require('../../../../lib/infrastructure/repositories/membership-repository');
+const userOrgaSettingsRepository = require('../../../../lib/infrastructure/repositories/user-orga-settings-repository');
+
+const getPrescriber = require('../../../../lib/domain/usecases/get-prescriber');
+
+describe('Integration | UseCases | get-prescriber', () => {
+
+  context('When prescriber does not have a userOrgaSettings', () => {
+
+    afterEach(() => {
+      return knex('user-orga-settings').delete();
+    });
+
+    it('should create it with the first membership\'s organization', async() => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const firstMembership = databaseBuilder.factory.buildMembership({ userId });
+      databaseBuilder.factory.buildMembership({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const prescriber = await getPrescriber({ userId, prescriberRepository, membershipRepository, userOrgaSettingsRepository });
+
+      // then
+      const userOrgaSettingsInDB = await knex('user-orga-settings').where({ userId, currentOrganizationId: firstMembership.organizationId }).select('*');
+      expect(userOrgaSettingsInDB).to.exist;
+      expect(prescriber.userOrgaSettings).to.exist;
+      expect(prescriber.userOrgaSettings.currentOrganization.id).to.equal(firstMembership.organizationId);
+    });
+  });
+
+  context('When prescriber has a userOrgaSettings', () => {
+
+    it('should return the prescriber\'s userOrgaSettings', async() => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const membership = databaseBuilder.factory.buildMembership({ userId });
+      const userOrgaSettings = databaseBuilder.factory.buildUserOrgaSettings({ userId, currentOrganizationId: membership.organizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const prescriber = await getPrescriber({ userId, prescriberRepository, membershipRepository, userOrgaSettingsRepository });
+
+      // then
+      expect(prescriber.userOrgaSettings).to.exist;
+      expect(prescriber.userOrgaSettings.id).to.equal(userOrgaSettings.id);
+    });
+
+    context('When the currentOrganization does not belong to prescriber\'s memberships anymore', () => {
+
+      it('should update the prescriber\'s userOrgaSettings with the organization of the first membership', async() => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const firstMembership = databaseBuilder.factory.buildMembership({ userId });
+        databaseBuilder.factory.buildMembership({ userId });
+        databaseBuilder.factory.buildUserOrgaSettings({ userId });
+        await databaseBuilder.commit();
+
+        // when
+        const prescriber = await getPrescriber({ userId, prescriberRepository, membershipRepository, userOrgaSettingsRepository });
+
+        // then
+        const userOrgaSettingsInDB = await knex('user-orga-settings').where({ userId, currentOrganizationId: firstMembership.organizationId }).select('*');
+        expect(userOrgaSettingsInDB).to.exist;
+        expect(prescriber.userOrgaSettings).to.exist;
+        expect(prescriber.userOrgaSettings.currentOrganization.id).to.equal(firstMembership.organizationId);
+      });
+    });
+  });
+
+});

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -75,9 +75,11 @@ module('Acceptance | join', function(hooks) {
         createPrescriberByUser(user);
 
         code = 'ABCDEFGH01';
-        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
         organizationInvitationId = server.create('organizationInvitation', {
-          organizationId, email: 'random@email.com', status: 'pending', code,
+          organizationId: user.userOrgaSettings.organization.id,
+          email: 'random@email.com',
+          status: 'pending',
+          code,
         }).id;
       });
 
@@ -126,9 +128,11 @@ module('Acceptance | join', function(hooks) {
         createPrescriberByUser(user);
 
         code = 'ABCDEFGH01';
-        const organizationId = server.create('organization', { name: 'College BRO & Evil Associates' }).id;
         organizationInvitationId = server.create('organizationInvitation', {
-          organizationId, email: 'random@email.com', status: 'pending', code,
+          organizationId: user.userOrgaSettings.organization.id,
+          email: 'random@email.com',
+          status: 'pending',
+          code,
         }).id;
       });
 

--- a/orga/tests/helpers/test-init.js
+++ b/orga/tests/helpers/test-init.js
@@ -33,21 +33,16 @@ export function createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServic
     userId: user.id,
   });
 
-  const prescriber = server.create('prescriber', {
+  const userOrgaSettings = server.create('user-orga-setting', { user, organization });
+
+  return server.create('prescriber', {
     id: user.id,
     firstName,
     lastName,
     pixOrgaTermsOfServiceAccepted,
     memberships: [membership],
+    userOrgaSettings: userOrgaSettings,
   });
-
-  if (pixOrgaTermsOfServiceAccepted) {
-    prescriber.userOrgaSettings = server.create('user-orga-setting', { user, organization });
-  } else {
-    server.create('user-orga-setting', {});
-  }
-
-  return prescriber;
 }
 
 function _addUserToOrganization(user, { externalId, canCollectProfiles } = {}) {
@@ -143,7 +138,7 @@ export function createPrescriberForOrganization(userAttributes = {}, organizatio
     userId: user.id,
     organizationRole,
   });
-  
+
   user.memberships = [membership];
   user.userOrgaSettings = server.create('user-orga-setting', { organization, user });
 

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -3,7 +3,6 @@ import { setupTest } from 'ember-qunit';
 import { reject, resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
-import sinon from 'sinon';
 
 module('Unit | Service | current-user', function(hooks) {
 
@@ -240,82 +239,6 @@ module('Unit | Service | current-user', function(hooks) {
 
         // then
         assert.equal(currentUserService.organization.id, organization2.id);
-      });
-    });
-
-    module('when user has no userOrgaSettings', function(hooks) {
-
-      let firstOrganization;
-
-      hooks.beforeEach(function() {
-        const user = Object.create({ id: 1 });
-        firstOrganization = Object.create({ id: 9 });
-        const secondOrganization = Object.create({ id: 10 });
-        const membership1 = Object.create({ user, organization: firstOrganization });
-        const membership2 = Object.create({ user, organization: secondOrganization });
-        connectedUser.memberships = [membership1, membership2];
-
-        storeStub.createRecord = sinon.stub().returns({
-          save: sinon.stub(),
-        });
-      });
-
-      test('should create it', async function(assert) {
-        // given
-        const createRecordSpy = sinon.spy();
-        storeStub.createRecord = createRecordSpy;
-
-        // when
-        await currentUserService.load();
-
-        // then
-        assert.equal(createRecordSpy.callCount, 1);
-        assert.ok(createRecordSpy.calledWith('user-orga-setting', { organization: firstOrganization }));
-      });
-
-      test('should set the first membership\'s organization as current organization', async function(assert) {
-        // when
-        await currentUserService.load();
-
-        // then
-        assert.equal(currentUserService.organization, firstOrganization);
-      });
-    });
-
-    module('when organization in userOrgaSettings doesn\'t match with memberships', function(hooks) {
-
-      let saveStub;
-      let firstOrganization;
-
-      hooks.beforeEach(function() {
-        firstOrganization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
-        const secondOrganization = Object.create({ id: 10, type: 'SCO', isManagingStudents: false, isSco: true });
-        const notMatchingOrganization = Object.create({ id: 11, type: 'SCO', isManagingStudents: false, isSco: true });
-
-        const membership1 = Object.create({ organization: firstOrganization, organizationRole: 'ADMIN', isAdmin: true });
-        const membership2 = Object.create({ organization: secondOrganization, organizationRole: 'ADMIN', isAdmin: true });
-        connectedUser.memberships = [membership1, membership2];
-
-        saveStub = sinon.stub();
-
-        connectedUser.userOrgaSettings = Object.create({ organization: notMatchingOrganization, save: saveStub });
-      });
-
-      test('should update the organization of the userOrgaSettings', async function(assert) {
-        // when
-        await currentUserService.load();
-
-        // then
-        assert.equal(saveStub.callCount, 1);
-      });
-
-      test('should set the membership\'s organization as current organization', async function(assert) {
-        // when
-        await currentUserService.load();
-
-        // then
-        assert.equal(currentUserService.organization, firstOrganization);
-        assert.equal(currentUserService.organization, firstOrganization);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Il arrive parfois qu'un des `memberships` d'un utilisateur soit supprimé en base de données alors que l'utilisateur est connecté à PIx Orga sur l'organisation dont il ne doit plus avoir l'accès. Dans ce cas, l'organisation courante, stockée dans le  userOrgaSettings de l'utilisateur, pointe toujours sur l'ancienne organisation. Pour palier à ce problème, nous mettons à jour l'organisation courante du `userOrgaSettings` avec l'organisation de son premier `membership` lors de sa connexion ou du rafraîchissement de la page. Ce traitement est effectué par le front alors qu'il devrait être effectué par l'API lors de la récupération du prescriber.    

## :robot: Solution
Ajouter dans l'API, lors de la récupération du prescriber, une vérification de la valeur de l'organisation courante et une mise à jour du `userOrgaSettings` si cette dernière n'est pas correcte.

## :rainbow: Remarques
La création du `userOrgaSettings` lorsqu'il n'existe pas a été déplacé dans l'API par la team-prescription. Je me suis donc permis de supprimer le code qui permettait de le faire côté front

## :100: Pour tester
Se connecter à Pix Orga avec un utilisateur dont l'organisation courante du `userOrgaSettings` ne fait pas partie des organisations contenues dans ces `memberships` et vérifier qu'il n'y a pas d'erreur. Ce test peut aussi être effectué avec un utilisateur déjà connecté, dont on modifierait la valeur de l'organisation courante en base de donnée, lors du rafraîchissement de la page.
