### PR TITLE
[TECH] Faire en sorte que les tests de l'API retourne une erreur le cas écheant. 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -119,7 +119,7 @@
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
     "test": "cross-env NODE_ENV=test npm run db:prepare && npm run test:api",
-    "test:api": "cross-env status=0; npm run test:api:unit || cross-env status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || cross-env status=1 ; done ; exit $status",
+    "test:api": "status=0; npm run test:api:unit || status=1 ; for dir in $(find tests/* -maxdepth 0 -type d -not -path tests/unit) ; do npm run test:api:path -- $dir || status=1 ; done ; exit $status",
     "test:api:path": "cross-env NODE_ENV=test mocha --exit --recursive --reporter=dot",
     "test:api:unit": "cross-env TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit",
     "test:api:integration": "npm run test:api:path -- tests/integration",


### PR DESCRIPTION
## :unicorn: Problème
Depuis l'ajout de cross-env sur la PR #2041, la commande `npm test` ne tombe plus en erreur lorsque des tests ne passent pas. 

## :robot: Solution
Enlever les `cross-env` lorsqu'il ne s'agit pas de commande node ensuite. 

## :rainbow: Remarques
:warning: Ne fonctionne plus avec windows 

## :100: Pour tester
- Faire échouer un test et vérifier le status de la commande (`echo $?`) 
