### PR TITLE
[FEATURE] Ajouter le palier dans l'export des résultats d'un campagne d'évaluation (PIX-1458).

### DIFF
--- a/api/lib/domain/services/campaign-csv-export-service.js
+++ b/api/lib/domain/services/campaign-csv-export-service.js
@@ -13,12 +13,14 @@ function createOneCsvLine({
   targetProfile,
   participantKnowledgeElementsByCompetenceId,
   acquiredBadges,
+  stages,
 }) {
   const line = new CampaignAssessmentCsvLine({
     organization,
     campaign,
     campaignParticipationInfo,
     targetProfile,
+    stages,
     participantKnowledgeElementsByCompetenceId,
     acquiredBadges,
     campaignParticipationService,

--- a/api/lib/domain/usecases/get-campaign-report.js
+++ b/api/lib/domain/usecases/get-campaign-report.js
@@ -4,7 +4,7 @@ module.exports = async function getCampaignReport({ campaignId, campaignParticip
   const [participationsCount, sharedParticipationsCount, stages] = await Promise.all([
     campaignParticipationRepository.count({ campaignId }),
     campaignParticipationRepository.count({ campaignId, isShared: true }),
-    stageRepository.getByCampaignId(campaignId),
+    stageRepository.findByCampaignId(campaignId),
   ]);
 
   return new CampaignReport({ id: campaignId, participationsCount, sharedParticipationsCount, stages });

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -75,7 +75,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
         campaignParticipationInfo,
         targetProfile,
         participantKnowledgeElementsByCompetenceId,
-        stages,
+        stages: reachableStages,
         acquiredBadges,
       });
       csvLines = csvLines.concat(csvLine);

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -27,7 +27,7 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
   const targetProfile = await targetProfileWithLearningContentRepository.getWithBadges({ id: campaign.targetProfileId });
-  const  organization = await organizationRepository.get(campaign.organizationId);
+  const organization = await organizationRepository.get(campaign.organizationId);
   const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
   const stages = await stageRepository.findByCampaignId(campaign.id);
 

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -26,12 +26,10 @@ module.exports = async function startWritingCampaignAssessmentResultsToStream(
 
   await _checkCreatorHasAccessToCampaignOrganization(userId, campaign.organizationId, userRepository);
 
-  const [targetProfile, organization, campaignParticipationInfos, stages] = await Promise.all([
-    targetProfileWithLearningContentRepository.getWithBadges({ id: campaign.targetProfileId }),
-    organizationRepository.get(campaign.organizationId),
-    campaignParticipationInfoRepository.findByCampaignId(campaign.id),
-    stageRepository.findByCampaignId(campaign.id),
-  ]);
+  const targetProfile = await targetProfileWithLearningContentRepository.getWithBadges({ id: campaign.targetProfileId });
+  const  organization = await organizationRepository.get(campaign.organizationId);
+  const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
+  const stages = await stageRepository.findByCampaignId(campaign.id);
 
   // Create HEADER of CSV
   const reachableStages = stages.filter(({ threshold }) => threshold > 0);

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -2,11 +2,11 @@ const BookshelfStage = require('../../infrastructure/data/stage');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 
 module.exports = {
-  async getByCampaignId(campaignId) {
+  async findByCampaignId(campaignId) {
     const results = await BookshelfStage.query((qb) => {
       qb.join('campaigns', 'campaigns.targetProfileId', 'stages.targetProfileId');
       qb.where('campaigns.id', '=', campaignId);
-      qb.orderBy('stages.threshold', 'ASC');
+      qb.orderBy('stages.threshold');
     }).fetchAll({ require: false });
 
     return results.map((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfStage, result));

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -9,6 +9,6 @@ module.exports = {
       qb.orderBy('stages.threshold');
     }).fetchAll({ require: false });
 
-    return results.map((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfStage, result));
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfStage, results);
   },
 };

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -11,7 +11,7 @@ class CampaignAssessmentCsvLine {
     campaignParticipationInfo,
     targetProfile,
     participantKnowledgeElementsByCompetenceId,
-    stages,
+    stages = [],
     acquiredBadges,
     campaignParticipationService,
   }) {

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -96,7 +96,7 @@ class CampaignAssessmentCsvLine {
       this.campaignParticipationInfo.isShared ? 'Oui' : 'Non',
       this.campaignParticipationInfo.isShared ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD') : EMPTY_CONTENT,
       ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfile.badges.length)),
-      ...(this.stages[0] ? [this._reachedStage()] : []),
+      ...(this.stages[0] ? [this._getReachedStage()] : []),
       this.campaignParticipationInfo.isShared ? this._percentageSkillsValidated() : EMPTY_CONTENT,
     ];
   }
@@ -148,7 +148,7 @@ class CampaignAssessmentCsvLine {
     return _.round(this._countValidatedKnowledgeElements() / this.targetProfile.skills.length, 2);
   }
 
-  _reachedStage() {
+  _getReachedStage() {
     if (!this.campaignParticipationInfo.isShared) {
       return EMPTY_CONTENT;
     }

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -155,7 +155,7 @@ class CampaignAssessmentCsvLine {
 
     const percentageSkillsValidated = this._percentageSkillsValidated() * 100;
 
-    return this.stages.filter((stage) => stage.threshold > 0 && percentageSkillsValidated >= stage.threshold).length;
+    return this.stages.filter((stage) => percentageSkillsValidated >= stage.threshold).length;
   }
 
   get _studentNumber() {

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -11,6 +11,7 @@ class CampaignAssessmentCsvLine {
     campaignParticipationInfo,
     targetProfile,
     participantKnowledgeElementsByCompetenceId,
+    stages,
     acquiredBadges,
     campaignParticipationService,
   }) {
@@ -18,6 +19,7 @@ class CampaignAssessmentCsvLine {
     this.campaign = campaign;
     this.campaignParticipationInfo = campaignParticipationInfo;
     this.targetProfile = targetProfile;
+    this.stages = stages;
     this.targetedKnowledgeElementsCount = _.sum(_.map(participantKnowledgeElementsByCompetenceId, (knowledgeElements) => knowledgeElements.length));
     this.targetedKnowledgeElementsByCompetence = participantKnowledgeElementsByCompetenceId;
     this.acquiredBadges = acquiredBadges;
@@ -94,6 +96,7 @@ class CampaignAssessmentCsvLine {
       this.campaignParticipationInfo.isShared ? 'Oui' : 'Non',
       this.campaignParticipationInfo.isShared ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD') : EMPTY_CONTENT,
       ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfile.badges.length)),
+      ...(this.stages[0] ? [this._reachedStage()] : []),
       this.campaignParticipationInfo.isShared ? this._percentageSkillsValidated() : EMPTY_CONTENT,
     ];
   }
@@ -143,6 +146,16 @@ class CampaignAssessmentCsvLine {
 
   _percentageSkillsValidated() {
     return _.round(this._countValidatedKnowledgeElements() / this.targetProfile.skills.length, 2);
+  }
+
+  _reachedStage() {
+    if (!this.campaignParticipationInfo.isShared) {
+      return EMPTY_CONTENT;
+    }
+
+    const percentageSkillsValidated = this._percentageSkillsValidated() * 100;
+
+    return this.stages.filter((stage) => stage.threshold > 0 && percentageSkillsValidated >= stage.threshold).length;
   }
 
   get _studentNumber() {

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -10,6 +10,7 @@ const knowledgeElementRepository = require('../../../../lib/infrastructure/repos
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const targetProfileWithLearningContentRepository = require('../../../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const stageRepository = require('../../../../lib/infrastructure/repositories/stage-repository');
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
@@ -97,6 +98,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         state: Assessment.states.COMPLETED,
         type: Assessment.types.CAMPAIGN,
       });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 1 });
       await databaseBuilder.commit();
 
       const domainTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
@@ -132,6 +134,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         '2019-02-25;' +
         '"Oui";' +
         '2019-03-01;' +
+        '1;' +
         '0,67;' +
         '0,67;' +
         '3;' +
@@ -154,6 +157,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         organizationRepository,
         campaignParticipationInfoRepository,
         knowledgeElementRepository,
+        stageRepository,
         campaignCsvExportService,
       });
 

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -3,21 +3,21 @@ const stageRepository = require('../../../../lib/infrastructure/repositories/sta
 
 describe('Integration | Repository | StageRepository', () => {
 
-  describe('#getByCampaignId', () => {
+  describe('#findByCampaignId', () => {
     it('should retrieve stage given campaignId', async () => {
       // given
       const tagetProfile = databaseBuilder.factory.buildTargetProfile();
       const campaign = databaseBuilder.factory.buildCampaign();
 
-      databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold : 55 });
       databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold : 24 });
+      databaseBuilder.factory.buildStage({ targetProfileId: campaign.targetProfileId, threshold : 55 });
 
       databaseBuilder.factory.buildStage({ targetProfileId: tagetProfile.id });
-      
+
       await databaseBuilder.commit();
 
       // when
-      const stages = await stageRepository.getByCampaignId(campaign.id);
+      const stages = await stageRepository.findByCampaignId(campaign.id);
 
       // then
       expect(stages.length).to.equal(2);

--- a/api/tests/tooling/domain-builder/factory/build-stage.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage.js
@@ -1,0 +1,17 @@
+const faker = require('faker');
+const Stage = require('../../../../lib/domain/models/Stage');
+
+module.exports = function buildStage({
+  id = faker.random.uuid(),
+  title = faker.company.catchPhrase(),
+  message = faker.company.catchPhrase(),
+  threshold = 1,
+} = {}) {
+
+  return new Stage({
+    id,
+    title,
+    message,
+    threshold,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -55,6 +55,7 @@ module.exports = {
   buildSkillAirtableDataObject: require('./build-skill-airtable-data-object'),
   buildSkillCollection: require('./build-skill-collection'),
   buildSolution: require('./build-solution'),
+  buildStage: require('./build-stage'),
   buildTag: require('./build-tag'),
   buildTargetedArea: require('./build-targeted-area'),
   buildTargetedCompetence: require('./build-targeted-competence'),

--- a/api/tests/unit/domain/usecases/get-campaign-report_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-report_test.js
@@ -13,14 +13,14 @@ describe('Unit | UseCase | get-campaign-report', () => {
 
   beforeEach(() => {
     campaignParticipationRepository = { count: sinon.stub() };
-    stageRepository = { getByCampaignId: sinon.stub() };
+    stageRepository = { findByCampaignId: sinon.stub() };
   });
 
   it('should get the campaignReport', async () => {
     // given
     campaignParticipationRepository.count.withArgs({ campaignId }).resolves(7);
     campaignParticipationRepository.count.withArgs({ campaignId, isShared: true }).resolves(4);
-    stageRepository.getByCampaignId.withArgs(campaignId).resolves(stagesList);
+    stageRepository.findByCampaignId.withArgs(campaignId).resolves(stagesList);
 
     // when
     const campaignReport = await getCampaignReport({ campaignId, campaignParticipationRepository, stageRepository });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -12,6 +12,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   const campaignParticipationInfoRepository = { findByCampaignId: () => undefined };
   const knowledgeElementRepository = { findTargetedGroupedByCompetencesForUsers: () => undefined };
   const badgeAcquisitionRepository = { getCampaignAcquiredBadgesByUsers: () => undefined };
+  const stageRepository = { findByCampaignId: () => undefined };
   let writableStream;
   let csvPromise;
 
@@ -30,6 +31,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(organizationRepository, 'get').rejects();
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').rejects();
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
 
     // when
     const err = await catchErr(startWritingCampaignAssessmentResultsToStream)({
@@ -42,6 +44,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
 
@@ -74,6 +77,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -111,6 +115,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
     const csv = await csvPromise;
@@ -131,6 +136,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -162,6 +168,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
     const csv = await csvPromise;
@@ -181,6 +188,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -212,6 +220,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
     const csv = await csvPromise;
@@ -231,6 +240,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -263,6 +273,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
     const csv = await csvPromise;
@@ -297,6 +308,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(badgeAcquisitionRepository, 'getCampaignAcquiredBadgesByUsers').resolves({
       [participantInfo.userId]: [badge],
     });
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvHeaderExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -347,6 +359,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       badgeAcquisitionRepository,
       campaignCsvExportService,
     });
@@ -373,6 +386,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves([]);
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -402,6 +416,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       organizationRepository,
       campaignParticipationInfoRepository,
       knowledgeElementRepository,
+      stageRepository,
       campaignCsvExportService,
     });
     const csv = await csvPromise;
@@ -410,6 +425,61 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     expect(csv).to.equal(csvExpected);
   });
 
+  it('should display stages', async () => {
+    // given
+    const { user, campaign, organization } = _buildOrganizationAndUserWithMembershipAndCampaign({ type: 'SCO' });
+    const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
+    const stages = [
+      domainBuilder.buildStage({ threshold: 0 }),
+      domainBuilder.buildStage({ threshold: 10 }),
+      domainBuilder.buildStage({ threshold: 50 }),
+    ];
+    campaign.targetProfileId = targetProfile.id;
+    sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
+    sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
+    sinon.stub(organizationRepository, 'get').withArgs(campaign.organizationId).resolves(organization);
+    sinon.stub(targetProfileWithLearningContentRepository, 'getWithBadges').withArgs({ id: campaign.targetProfileId }).resolves(targetProfile);
+    sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
+    sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+    sinon.stub(stageRepository, 'findByCampaignId').resolves(stages);
+    const csvExpected = '\uFEFF"Nom de l\'organisation";' +
+      '"ID Campagne";' +
+      '"Nom de la campagne";' +
+      '"Nom du Profil Cible";' +
+      '"Nom du Participant";' +
+      '"Prénom du Participant";' +
+      '"% de progression";' +
+      '"Date de début";' +
+      '"Partage (O/N)";' +
+      '"Date du partage";' +
+      '"Palier obtenu (/2)";' +
+      '"% maitrise de l\'ensemble des acquis du profil";' +
+      `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
+      `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
+      `"Acquis maitrisés dans la compétence ${targetProfile.competences[0].name}";` +
+      `"% de maitrise des acquis du domaine ${targetProfile.areas[0].title}";` +
+      `"Nombre d'acquis du profil cible du domaine ${targetProfile.areas[0].title}";` +
+      `"Acquis maitrisés du domaine ${targetProfile.areas[0].title}"\n`;
+
+    // when
+    startWritingCampaignAssessmentResultsToStream({
+      userId: user.id,
+      campaignId: campaign.id,
+      writableStream,
+      campaignRepository,
+      userRepository,
+      targetProfileWithLearningContentRepository,
+      organizationRepository,
+      campaignParticipationInfoRepository,
+      knowledgeElementRepository,
+      stageRepository,
+      campaignCsvExportService,
+    });
+    const csv = await csvPromise;
+
+    // then
+    expect(csv).to.equal(csvExpected);
+  });
 });
 
 function _buildOrganizationAndUserWithMembershipAndCampaign({ idPixLabel = null, type = 'SCO', isManagingStudents = false } = {}) {

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -720,69 +720,6 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
 
     context('when there are stages', () => {
       context('when participation is shared', () => {
-        context('when the stage with 0 as threshold have been reached', () => {
-          it('tells 0 stage reached', () => {
-            // given
-            const organization = domainBuilder.buildOrganization();
-            const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
-            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
-            const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
-            const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
-            const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
-            const tube = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1, skill2,  skill3], competenceId: 'recCompetence1' });
-            const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube], areaId: 'recArea1' });
-            const area = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence] });
-            const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
-              skills: [skill1, skill2, skill3],
-              tubes: [tube],
-              competences: [competence],
-              areas: [area],
-            });
-            const stages = [
-              domainBuilder.buildStage({ threshold: 0 }),
-              domainBuilder.buildStage({ threshold: 60 }),
-            ];
-            const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
-              status: KnowledgeElement.StatusType.VALIDATED,
-              earnedPix: 3,
-              skillId: skill1.id,
-              competenceId: competence.id,
-            });
-            const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
-              status: KnowledgeElement.StatusType.INVALIDATED,
-              earnedPix: 2,
-              skillId: skill2.id,
-              competenceId: competence.id,
-            });
-            const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
-              status: KnowledgeElement.StatusType.INVALIDATED,
-              earnedPix: 4,
-              skillId: skill3.id,
-              competenceId: competence.id,
-            });
-            const participantKnowledgeElementsByCompetenceId = {
-              'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
-            };
-            const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
-              organization,
-              campaign,
-              campaignParticipationInfo,
-              targetProfile,
-              stages,
-              participantKnowledgeElementsByCompetenceId,
-              campaignParticipationService,
-            });
-
-            // when
-            const csvLine = campaignAssessmentCsvLine.toCsvLine();
-
-            // then
-            const cols = _computeExpectedColumnsIndex(campaign, organization,  [],  stages);
-            // First competence
-            expect(csvLine[cols.STAGE_REACHED]).to.equal(0);
-          });
-        });
-
         context('when some stages have been reached', () => {
           it('tells highest stage reached', () => {
             // given

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -3,10 +3,11 @@ const CampaignAssessmentCsvLine = require('../../../../lib/infrastructure/utils/
 const campaignParticipationService = require('../../../../lib/domain/services/campaign-participation-service');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 
-function _computeExpectedColumnsIndex(campaign, organization, badges) {
+function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
   const studentNumberPresenceModifier = (organization.type === 'SUP' && organization.isManagingStudents) ? 1 : 0;
   const externalIdPresenceModifier = campaign.idPixLabel ? 1 : 0;
   const badgePresenceModifier = badges.length;
+  const stagesPresenceModifier = stages[0] ? 1 : 0;
 
   return {
     ORGANIZATION_NAME: 0,
@@ -22,8 +23,9 @@ function _computeExpectedColumnsIndex(campaign, organization, badges) {
     PARTICIPATION_IS_SHARED: 8 + studentNumberPresenceModifier + externalIdPresenceModifier,
     PARTICIPATION_SHARED_AT: 9 + studentNumberPresenceModifier + externalIdPresenceModifier,
     BADGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier,
-    PARTICIPATION_PERCENTAGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier,
-    DETAILS_START: 11 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier,
+    STAGE_REACHED: 10 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier,
+    PARTICIPATION_PERCENTAGE: 10 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier + stagesPresenceModifier,
+    DETAILS_START: 11 + studentNumberPresenceModifier + externalIdPresenceModifier + badgePresenceModifier + stagesPresenceModifier,
   };
 }
 
@@ -42,6 +44,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         campaign,
         campaignParticipationInfo,
         targetProfile,
+        stages: [],
         participantKnowledgeElementsByCompetenceId: {
           [targetProfile.competences[0].id]: [],
         },
@@ -52,7 +55,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
       const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
       // then
-      const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+      const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
       expect(csvLine[cols.ORGANIZATION_NAME], 'organization name').to.equal(organization.name);
       expect(csvLine[cols.CAMPAIGN_ID], 'campaign id').to.equal(campaign.id);
       expect(csvLine[cols.CAMPAIGN_NAME], 'campaign name').to.equal(campaign.name);
@@ -75,6 +78,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           campaign,
           campaignParticipationInfo,
           targetProfile,
+          stages: [],
           participantKnowledgeElementsByCompetenceId: {
             [targetProfile.competences[0].id]: [],
           },
@@ -85,7 +89,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
         expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
       });
     });
@@ -103,6 +107,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           campaign,
           campaignParticipationInfo,
           targetProfile,
+          stages: [],
           participantKnowledgeElementsByCompetenceId: {
             [targetProfile.competences[0].id]: [],
           },
@@ -113,7 +118,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
         expect(csvLine[cols.EXTERNAL_ID], 'external id').to.equal(campaignParticipationInfo.participantExternalId);
       });
 
@@ -130,6 +135,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           competences: [],
           campaignParticipationInfo,
           targetProfile,
+          stages: [],
           participantKnowledgeElementsByCompetenceId: {
             [targetProfile.competences[0].id]: [],
           },
@@ -140,7 +146,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
         expect(csvLine[cols.EXTERNAL_ID], 'external id').to.equal(campaignParticipationInfo.participantExternalId);
         expect(csvLine[cols.STUDENT_NUMBER_COL], 'student number').to.equal(campaignParticipationInfo.studentNumber);
       });
@@ -158,6 +164,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           campaign,
           campaignParticipationInfo,
           targetProfile,
+          stages: [],
           participantKnowledgeElementsByCompetenceId: {
             [targetProfile.competences[0].id]: [],
           },
@@ -168,7 +175,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
         const EMPTY_CONTENT = 'NA';
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Non');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal(EMPTY_CONTENT);
@@ -194,6 +201,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           campaign,
           campaignParticipationInfo,
           targetProfile,
+          stages: [],
           participantKnowledgeElementsByCompetenceId: {
             [targetProfile.competences[0].id]: [knowledgeElement],
           },
@@ -204,7 +212,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
         const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
         // then
-        const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+        const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
         expect(csvLine[cols.PARTICIPATION_IS_SHARED], 'is shared').to.equal('Oui');
         expect(csvLine[cols.PARTICIPATION_SHARED_AT], 'shared at').to.equal('2020-01-01');
         expect(csvLine[cols.PARTICIPATION_PERCENTAGE], 'participation percentage').to.equal(1);
@@ -271,6 +279,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
           });
@@ -279,7 +288,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
@@ -371,6 +380,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
           });
@@ -379,7 +389,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal('NA');
@@ -473,6 +483,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
           });
@@ -481,7 +492,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal(0.5);
@@ -567,6 +578,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
           });
@@ -575,7 +587,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, []);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], []);
           let currentColumn = cols.DETAILS_START;
           // First competence
           expect(csvLine[currentColumn++], '% maitrise de la competence').to.equal('NA');
@@ -617,6 +629,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId: {
               [targetProfile.competences[0].id]: [],
             },
@@ -628,7 +641,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge],  []);
           const EMPTY_CONTENT = 'NA';
           expect(csvLine[cols.BADGE], 'badge').to.equal(EMPTY_CONTENT);
         });
@@ -653,6 +666,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId: {
               [targetProfile.competences[0].id]: [knowledgeElement],
             },
@@ -664,7 +678,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge], []);
           expect(csvLine[cols.BADGE], 'badge').to.equal('Oui');
         });
 
@@ -686,6 +700,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             campaign,
             campaignParticipationInfo,
             targetProfile,
+            stages: [],
             participantKnowledgeElementsByCompetenceId: {
               [targetProfile.competences[0].id]: [knowledgeElement],
             },
@@ -697,8 +712,263 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           const csvLine = campaignAssessmentCsvLine.toCsvLine();
 
           // then
-          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge]);
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [badge],  []);
           expect(csvLine[cols.BADGE], 'badge').to.equal('Non');
+        });
+      });
+    });
+
+    context('when there are stages', () => {
+      context('when participation is shared', () => {
+        context('when the stage with 0 as threshold have been reached', () => {
+          it('tells 0 stage reached', () => {
+            // given
+            const organization = domainBuilder.buildOrganization();
+            const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+            const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+            const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+            const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
+            const tube = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1, skill2,  skill3], competenceId: 'recCompetence1' });
+            const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube], areaId: 'recArea1' });
+            const area = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence] });
+            const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+              skills: [skill1, skill2, skill3],
+              tubes: [tube],
+              competences: [competence],
+              areas: [area],
+            });
+            const stages = [
+              domainBuilder.buildStage({ threshold: 0 }),
+              domainBuilder.buildStage({ threshold: 60 }),
+            ];
+            const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 3,
+              skillId: skill1.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.INVALIDATED,
+              earnedPix: 2,
+              skillId: skill2.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.INVALIDATED,
+              earnedPix: 4,
+              skillId: skill3.id,
+              competenceId: competence.id,
+            });
+            const participantKnowledgeElementsByCompetenceId = {
+              'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
+            };
+            const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+              organization,
+              campaign,
+              campaignParticipationInfo,
+              targetProfile,
+              stages,
+              participantKnowledgeElementsByCompetenceId,
+              campaignParticipationService,
+            });
+
+            // when
+            const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+            // then
+            const cols = _computeExpectedColumnsIndex(campaign, organization,  [],  stages);
+            // First competence
+            expect(csvLine[cols.STAGE_REACHED]).to.equal(0);
+          });
+        });
+
+        context('when some stages have been reached', () => {
+          it('tells highest stage reached', () => {
+            // given
+            const organization = domainBuilder.buildOrganization();
+            const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+            const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+            const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+            const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
+            const tube = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1, skill2,  skill3], competenceId: 'recCompetence1' });
+            const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube], areaId: 'recArea1' });
+            const area = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence] });
+            const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+              skills: [skill1, skill2, skill3],
+              tubes: [tube],
+              competences: [competence],
+              areas: [area],
+            });
+            const stages = [
+              domainBuilder.buildStage({ threshold: 33 }),
+              domainBuilder.buildStage({ threshold: 66 }),
+              domainBuilder.buildStage({ threshold: 99 }),
+            ];
+            const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 3,
+              skillId: skill1.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 2,
+              skillId: skill2.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.INVALIDATED,
+              earnedPix: 4,
+              skillId: skill3.id,
+              competenceId: competence.id,
+            });
+            const participantKnowledgeElementsByCompetenceId = {
+              'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
+            };
+            const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+              organization,
+              campaign,
+              campaignParticipationInfo,
+              targetProfile,
+              stages,
+              participantKnowledgeElementsByCompetenceId,
+              campaignParticipationService,
+            });
+
+            // when
+            const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+            // then
+            const cols = _computeExpectedColumnsIndex(campaign, organization,  [],  stages);
+            expect(csvLine[cols.STAGE_REACHED]).to.equal(2);
+          });
+        });
+
+        context('when all stages have been reached', () => {
+          it('tells that last stage has been reached', () => {
+            // given
+            const organization = domainBuilder.buildOrganization();
+            const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+            const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: new Date('2020-01-01') });
+            const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+            const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+            const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
+            const tube = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1, skill2,  skill3], competenceId: 'recCompetence1' });
+            const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube], areaId: 'recArea1' });
+            const area = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence] });
+            const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+              skills: [skill1, skill2, skill3],
+              tubes: [tube],
+              competences: [competence],
+              areas: [area],
+            });
+            const stages = [
+              domainBuilder.buildStage({ threshold: 33 }),
+              domainBuilder.buildStage({ threshold: 66 }),
+              domainBuilder.buildStage({ threshold: 99 }),
+            ];
+            const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 3,
+              skillId: skill1.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 2,
+              skillId: skill2.id,
+              competenceId: competence.id,
+            });
+            const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
+              status: KnowledgeElement.StatusType.VALIDATED,
+              earnedPix: 4,
+              skillId: skill3.id,
+              competenceId: competence.id,
+            });
+            const participantKnowledgeElementsByCompetenceId = {
+              'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
+            };
+            const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+              organization,
+              campaign,
+              campaignParticipationInfo,
+              targetProfile,
+              stages,
+              participantKnowledgeElementsByCompetenceId,
+              campaignParticipationService,
+            });
+
+            // when
+            const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+            // then
+            const cols = _computeExpectedColumnsIndex(campaign, organization,  [],  stages);
+            expect(csvLine[cols.STAGE_REACHED]).to.equal(3);
+          });
+        });
+      });
+
+      context('when participation is not shared', () => {
+        it('gives NA as stage reached', () => {
+          // given
+          const organization = domainBuilder.buildOrganization();
+          const campaign = domainBuilder.buildCampaign({ idPixLabel: null });
+          const campaignParticipationInfo = domainBuilder.buildCampaignParticipationInfo({ sharedAt: null });
+          const skill1 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_1', tubeId: 'recTube1' });
+          const skill2 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_2', tubeId: 'recTube1' });
+          const skill3 = domainBuilder.buildTargetedSkill({ id: 'recSkill1_3', tubeId: 'recTube1' });
+          const tube = domainBuilder.buildTargetedTube({ id: 'recTube1', skills: [skill1, skill2,  skill3], competenceId: 'recCompetence1' });
+          const competence = domainBuilder.buildTargetedCompetence({ id: 'recCompetence1', tubes: [tube], areaId: 'recArea1' });
+          const area = domainBuilder.buildTargetedArea({ id: 'recArea1', competences: [competence] });
+          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+            skills: [skill1, skill2, skill3],
+            tubes: [tube],
+            competences: [competence],
+            areas: [area],
+          });
+          const stages = [
+            domainBuilder.buildStage({ threshold: 30 }),
+            domainBuilder.buildStage({ threshold: 60 }),
+          ];
+          const knowledgeElement1 = domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 3,
+            skillId: skill1.id,
+            competenceId: competence.id,
+          });
+          const knowledgeElement2 = domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.VALIDATED,
+            earnedPix: 2,
+            skillId: skill2.id,
+            competenceId: competence.id,
+          });
+          const knowledgeElement3 = domainBuilder.buildKnowledgeElement({
+            status: KnowledgeElement.StatusType.INVALIDATED,
+            earnedPix: 4,
+            skillId: skill3.id,
+            competenceId: competence.id,
+          });
+          const participantKnowledgeElementsByCompetenceId = {
+            'recCompetence1': [knowledgeElement1, knowledgeElement2, knowledgeElement3],
+          };
+          const campaignAssessmentCsvLine = new CampaignAssessmentCsvLine({
+            organization,
+            campaign,
+            campaignParticipationInfo,
+            targetProfile,
+            stages,
+            participantKnowledgeElementsByCompetenceId,
+            campaignParticipationService,
+          });
+
+          // when
+          const csvLine = campaignAssessmentCsvLine.toCsvLine();
+
+          // then
+          const cols = _computeExpectedColumnsIndex(campaign, organization, [], stages);
+          expect(csvLine[cols.STAGE_REACHED]).to.equal('NA');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs n'ont pas l'information sur le palier atteint par un participant pendant une  campagne dans l'export des résultat.


## :robot: Solution
Affichage de la colonne Paliers dans le csv d'export des résultats d'une campagne d'évaluation.

Nom de la colonne : "Palier obtenu (/nbr_paliers_max)"  (par exemple “Palier obtenu (/5)” )
Résultat de la colonne : le nombre de palier (1, 2, 3 etc.)

Position : entre la colonne de "date de partage" ou “Résultat thématique obtenu” et le "% maitrise de l'ensemble des acquis" 

## :rainbow: Remarques
RAS

## :100: Pour tester
Télécharger l'export des résultats de la campagne `Campagne d’évaluation 5.1` (pro.admin@example.net)
Vérifier la présence de la colonne, que les participants ayant partagé leur résultat ai bien le numéro du palier atteint.
Vérifier que dans les résultats d'une campagne sans palier que  la colonne est absente.