### PR TITLE
[CLEANUP]  Refacto des vérifications concernant la pérennité des comptes dans les usecases (PIX-1499).

### DIFF
--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -49,8 +49,6 @@ async function findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser(
   organizationId,
   reconciliationInfo: { firstName, lastName, birthdate },
   schoolingRegistrationRepository,
-  userRepository,
-  obfuscationService,
 }) {
   const schoolingRegistrations = await schoolingRegistrationRepository.findByOrganizationIdAndBirthdate({ organizationId, birthdate });
 
@@ -62,10 +60,8 @@ async function findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser(
   if (!schoolingRegistrationId) {
     throw new NotFoundError('There were no schoolingRegistrations matching with names');
   }
-  const schoolingRegistration = _.find(schoolingRegistrations, { 'id': schoolingRegistrationId });
 
-  await checkIfStudentIsAlreadyReconciledOnTheSameOrganization(schoolingRegistration, userRepository, obfuscationService);
-  return schoolingRegistration;
+  return _.find(schoolingRegistrations, { 'id': schoolingRegistrationId });
 }
 
 async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSchoolingRegistration, userRepository, obfuscationService) {
@@ -200,5 +196,6 @@ module.exports = {
   findMatchingCandidateIdForGivenUser,
   findMatchingHigherSchoolingRegistrationIdForGivenOrganizationIdAndUser,
   findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser,
+  checkIfStudentIsAlreadyReconciledOnTheSameOrganization,
   checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations,
 };

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -64,24 +64,18 @@ async function findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser(
   return _.find(schoolingRegistrations, { 'id': schoolingRegistrationId });
 }
 
-async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSchoolingRegistration, userRepository, obfuscationService) {
-  if (!_.isNil(matchingSchoolingRegistration.userId))  {
-    const userId = matchingSchoolingRegistration.userId ;
-    const user = await userRepository.getUserAuthenticationMethods(userId);
-    const authenticationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
+async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(userId, userRepository, obfuscationService) {
+  const user = await userRepository.getUserAuthenticationMethods(userId);
+  const authenticationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-    const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
-    const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION[authenticationMethod.authenticatedBy];
-    const meta = {
-      shortCode: error.shortCode,
-      value: authenticationMethod.value,
-      userId: userId,
-    };
-    if (authenticationMethod.authenticatedBy === 'samlId') {
-      meta.schoolingRegistrationId = matchingSchoolingRegistration.id;
-    }
-    throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
-  }
+  const detail = 'Un compte existe déjà pour l‘élève dans le même établissement.';
+  const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_SAME_ORGANIZATION[authenticationMethod.authenticatedBy];
+  const meta = {
+    shortCode: error.shortCode,
+    value: authenticationMethod.value,
+    userId: userId,
+  };
+  throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
 }
 
 async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(userId, userRepository, obfuscationService) {

--- a/api/lib/domain/services/user-reconciliation-service.js
+++ b/api/lib/domain/services/user-reconciliation-service.js
@@ -88,21 +88,18 @@ async function checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchingSc
   }
 }
 
-async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService) {
-  if (_.get(student, 'account')) {
-    const userId = student.account.userId;
-    const user = await userRepository.getUserAuthenticationMethods(userId);
-    const authenticationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
+async function checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(userId, userRepository, obfuscationService) {
+  const user = await userRepository.getUserAuthenticationMethods(userId);
+  const authenticationMethod = obfuscationService.getUserAuthenticationMethodWithObfuscation(user);
 
-    const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
-    const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION[authenticationMethod.authenticatedBy];
-    const meta = {
-      shortCode: error.shortCode,
-      value: authenticationMethod.value,
-      userId: userId,
-    };
-    throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
-  }
+  const detail = 'Un compte existe déjà pour l‘élève dans un autre établissement.';
+  const error = STUDENT_RECONCILIATION_ERRORS.RECONCILIATION.IN_OTHER_ORGANIZATION[authenticationMethod.authenticatedBy];
+  const meta = {
+    shortCode: error.shortCode,
+    value: authenticationMethod.value,
+    userId: userId,
+  };
+  throw new SchoolingRegistrationAlreadyLinkedToUserError(detail, error.code, meta);
 }
 
 function _containsOneElement(arr) {
@@ -194,9 +191,7 @@ async function createUsernameByUser({ user: { firstName, lastName, birthdate }, 
   const firstPart = standardizeUser.firstName + '.' + standardizeUser.lastName;
   const secondPart = day + month;
 
-  const username = await generateUsernameUntilAvailable({ firstPart, secondPart, userRepository });
-
-  return username;
+  return await generateUsernameUntilAvailable({ firstPart, secondPart, userRepository });
 }
 
 module.exports = {

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -53,9 +53,9 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
       organizationId: campaign.organizationId,
       reconciliationInfo,
       schoolingRegistrationRepository,
-      userRepository,
-      obfuscationService,
     });
+
+    await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration, userRepository, obfuscationService);
 
     const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
     if (get(student, 'account')) {

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -1,6 +1,7 @@
 const { CampaignCodeError, ObjectValidationError } = require('../errors');
 const User = require('../models/User');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
+const get = require('lodash/get');
 
 module.exports = async function createUserAndReconcileToSchoolingRegistrationFromExternalUser({
   campaignCode,
@@ -57,7 +58,9 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
     });
 
     const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
-    await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
+    if (get(student, 'account')) {
+      await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student.account.userId, userRepository, obfuscationService);
+    }
 
     const user = await userRepository.getBySamlId(externalUser.samlId);
     if (user) {

--- a/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
+++ b/api/lib/domain/usecases/create-user-and-reconcile-to-schooling-registration-from-external-user.js
@@ -1,7 +1,6 @@
 const { CampaignCodeError, ObjectValidationError } = require('../errors');
 const User = require('../models/User');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
-const { get, isNil } = require('lodash');
 
 module.exports = async function createUserAndReconcileToSchoolingRegistrationFromExternalUser({
   campaignCode,
@@ -55,14 +54,7 @@ module.exports = async function createUserAndReconcileToSchoolingRegistrationFro
       schoolingRegistrationRepository,
     });
 
-    if (!isNil(matchedSchoolingRegistration.userId)) {
-      await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration.userId, userRepository, obfuscationService);
-    }
-
-    const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
-    if (get(student, 'account')) {
-      await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student.account.userId, userRepository, obfuscationService);
-    }
+    await userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount(matchedSchoolingRegistration, userRepository, obfuscationService, studentRepository);
 
     const user = await userRepository.getBySamlId(externalUser.samlId);
     if (user) {

--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -1,6 +1,5 @@
 const { CampaignCodeError, SchoolingRegistrationAlreadyLinkedToUserError } = require('../errors');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
-const { get, isNil } = require('lodash');
 
 module.exports = async function reconcileSchoolingRegistration({
   campaignCode,
@@ -24,14 +23,7 @@ module.exports = async function reconcileSchoolingRegistration({
     schoolingRegistrationRepository,
   });
 
-  if (!isNil(matchedSchoolingRegistration.userId)) {
-    await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration.userId, userRepository, obfuscationService);
-  }
-
-  const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
-  if (get(student, 'account')) {
-    await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student.account.userId, userRepository, obfuscationService);
-  }
+  await userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount(matchedSchoolingRegistration, userRepository, obfuscationService, studentRepository);
 
   await _checkIfAnotherStudentIsAlreadyReconciledWithTheSameOrganizationAndUser(reconciliationInfo.id, campaign.organizationId, schoolingRegistrationRepository);
 

--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -1,5 +1,6 @@
 const { CampaignCodeError, SchoolingRegistrationAlreadyLinkedToUserError } = require('../errors');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
+const get = require('lodash/get');
 
 module.exports = async function reconcileSchoolingRegistration({
   campaignCode,
@@ -26,7 +27,9 @@ module.exports = async function reconcileSchoolingRegistration({
   });
 
   const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
-  await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student, userRepository, obfuscationService);
+  if (get(student, 'account')) {
+    await userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations(student.account.userId, userRepository, obfuscationService);
+  }
 
   await _checkIfAnotherStudentIsAlreadyReconciledWithTheSameOrganizationAndUser(reconciliationInfo.id, campaign.organizationId, schoolingRegistrationRepository);
 

--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -22,9 +22,9 @@ module.exports = async function reconcileSchoolingRegistration({
     organizationId: campaign.organizationId,
     reconciliationInfo,
     schoolingRegistrationRepository,
-    userRepository,
-    obfuscationService,
   });
+
+  await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration, userRepository, obfuscationService);
 
   const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
   if (get(student, 'account')) {

--- a/api/lib/domain/usecases/reconcile-schooling-registration.js
+++ b/api/lib/domain/usecases/reconcile-schooling-registration.js
@@ -1,6 +1,6 @@
 const { CampaignCodeError, SchoolingRegistrationAlreadyLinkedToUserError } = require('../errors');
 const { STUDENT_RECONCILIATION_ERRORS } = require('../constants');
-const get = require('lodash/get');
+const { get, isNil } = require('lodash');
 
 module.exports = async function reconcileSchoolingRegistration({
   campaignCode,
@@ -24,7 +24,9 @@ module.exports = async function reconcileSchoolingRegistration({
     schoolingRegistrationRepository,
   });
 
-  await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration, userRepository, obfuscationService);
+  if (!isNil(matchedSchoolingRegistration.userId)) {
+    await userReconciliationService.checkIfStudentIsAlreadyReconciledOnTheSameOrganization(matchedSchoolingRegistration.userId, userRepository, obfuscationService);
+  }
 
   const student = await studentRepository.getReconciledStudentByNationalStudentId(matchedSchoolingRegistration.nationalStudentId);
   if (get(student, 'account')) {

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -148,7 +148,7 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
             code: 'ACCOUNT_WITH_GAR_ALREADY_EXIST_FOR_THE_SAME_ORGANIZATION',
             title: 'Conflict',
             detail: 'Un compte existe déjà pour l‘élève dans le même établissement.',
-            meta: { shortCode: 'R33', value: null, userId: userWithSamlOnly.id, schoolingRegistrationId: schoolingRegistration.id },
+            meta: { shortCode: 'R33', value: null, userId: userWithSamlOnly.id },
           };
 
           options.headers.authorization = generateValidRequestAuthorizationHeader(userWithSamlOnly.id);

--- a/api/tests/unit/domain/services/user-reconciliation-service_test.js
+++ b/api/tests/unit/domain/services/user-reconciliation-service_test.js
@@ -316,8 +316,6 @@ describe('Unit | Service | user-reconciliation-service', () => {
     let user;
     let organizationId;
     let schoolingRegistrationRepositoryStub;
-    let userRepositoryStub;
-    let obfuscationServiceStub;
 
     beforeEach(() => {
       organizationId = domainBuilder.buildOrganization().id;
@@ -360,39 +358,12 @@ describe('Unit | Service | user-reconciliation-service', () => {
           };
         });
 
-        context('When schoolingRegistration is already linked', () => {
-          beforeEach(() => {
-            schoolingRegistrations[0].userId = '123';
-            userRepositoryStub = {
-              getUserAuthenticationMethods: sinon.stub().resolves(),
-              updateUserAttributes: sinon.stub().resolves(),
-            };
-            obfuscationServiceStub = {
-              getUserAuthenticationMethodWithObfuscation: sinon.stub().returns({ authenticatedBy: 'email' }),
-            };
-          });
+        it('should return matched SchoolingRegistration', async () => {
+          // when
+          const result = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId, reconciliationInfo: user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
 
-          it('should throw OrganizationStudentAlreadyLinkedToUserError', async () => {
-            // given
-            schoolingRegistrationRepositoryStub.findByOrganizationIdAndBirthdate.resolves(schoolingRegistrations);
-            userRepositoryStub.getUserAuthenticationMethods.resolves({ email: 'email@example.net' });
-            // when
-            const result = await catchErr(userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser)({ organizationId, reconciliationInfo: user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub, userRepository: userRepositoryStub, obfuscationService: obfuscationServiceStub });
-
-            // then
-            expect(result).to.be.instanceOf(SchoolingRegistrationAlreadyLinkedToUserError);
-          });
-        });
-
-        context('When schoolingRegistration is not already linked', () => {
-
-          it('should return matched SchoolingRegistration', async () => {
-            // when
-            const result = await userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser({ organizationId, reconciliationInfo: user, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
-
-            // then
-            expect(result).to.equal(schoolingRegistrations[0]);
-          });
+          // then
+          expect(result).to.equal(schoolingRegistrations[0]);
         });
       });
     });

--- a/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
@@ -88,13 +88,10 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
 
     it('should return a SchoolingRegistrationAlreadyLinkedToUser error', async () => {
       // given
-      schoolingRegistration.userId = user.id;
-      schoolingRegistration.firstName = user.firstName;
-      schoolingRegistration.lastName = user.lastName;
       const exceptedErrorMessage = 'Un compte existe déjà pour l\'élève dans un autre établissement.';
       campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
-      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student());
+      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student({ account: {} }));
       userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations.throws(new SchoolingRegistrationAlreadyLinkedToUserError(exceptedErrorMessage));
 
       // when

--- a/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
@@ -38,6 +38,7 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
     };
     userReconciliationService = {
       findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser: sinon.stub(),
+      checkIfStudentIsAlreadyReconciledOnTheSameOrganization: sinon.stub(),
       checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations: sinon.stub(),
     };
     studentRepository = {

--- a/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-schooling-registration_test.js
@@ -1,7 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRegistration');
-const Student = require('../../../../lib/domain/models/Student');
 
 const { CampaignCodeError, NotFoundError, SchoolingRegistrationAlreadyLinkedToUserError } = require('../../../../lib/domain/errors');
 
@@ -11,7 +10,6 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
 
   let campaignRepository;
   let schoolingRegistrationRepository;
-  let studentRepository;
   let userReconciliationService;
 
   let schoolingRegistration;
@@ -38,11 +36,7 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
     };
     userReconciliationService = {
       findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser: sinon.stub(),
-      checkIfStudentIsAlreadyReconciledOnTheSameOrganization: sinon.stub(),
-      checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations: sinon.stub(),
-    };
-    studentRepository = {
-      getReconciledStudentByNationalStudentId: sinon.stub(),
+      checkIfStudentHasAnAlreadyReconciledAccount: sinon.stub(),
     };
   });
 
@@ -85,15 +79,13 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
     });
   });
 
-  context('When student is already reconciled in others organizations', () => {
+  context('When student has already a reconciled account', () => {
 
     it('should return a SchoolingRegistrationAlreadyLinkedToUser error', async () => {
       // given
-      const exceptedErrorMessage = 'Un compte existe déjà pour l\'élève dans un autre établissement.';
       campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
-      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student({ account: {} }));
-      userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations.throws(new SchoolingRegistrationAlreadyLinkedToUserError(exceptedErrorMessage));
+      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.throws(new SchoolingRegistrationAlreadyLinkedToUserError());
 
       // when
       const result = await catchErr(usecases.reconcileSchoolingRegistration)({
@@ -101,12 +93,10 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
         campaignCode,
         campaignRepository,
         userReconciliationService,
-        studentRepository,
       });
 
       // then
       expect(result).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
-      expect(result.message).to.equal(exceptedErrorMessage);
     });
   });
 
@@ -120,11 +110,10 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
 
       const alreadyReconciledSchoolingRegistrationWithAnotherStudent = domainBuilder.buildSchoolingRegistration({ organizationId, userId: user.id });
 
-      const exceptedErrorMEssage = 'Un autre étudiant est déjà réconcilié dans la même organisation et avec le même compte utilisateur';
+      const exceptedErrorMessage = 'Un autre étudiant est déjà réconcilié dans la même organisation et avec le même compte utilisateur';
       campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
-      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student());
-      userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations.resolves();
+      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
       schoolingRegistrationRepository.findOneByUserIdAndOrganizationId.withArgs({
         userId: user.id,
         organizationId,
@@ -136,13 +125,12 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
         campaignCode,
         campaignRepository,
         userReconciliationService,
-        studentRepository,
         schoolingRegistrationRepository,
       });
 
       // then
       expect(result).to.be.instanceof(SchoolingRegistrationAlreadyLinkedToUserError);
-      expect(result.message).to.equal(exceptedErrorMEssage);
+      expect(result.message).to.equal(exceptedErrorMessage);
     });
 
   });
@@ -157,8 +145,7 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
       schoolingRegistration.lastName = user.lastName;
       campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
-      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student());
-      userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations.resolves();
+      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
       schoolingRegistrationRepository.reconcileUserToSchoolingRegistration.withArgs({
         userId: user.id,
         schoolingRegistrationId,
@@ -171,7 +158,6 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
         campaignCode,
         campaignRepository,
         userReconciliationService,
-        studentRepository,
         schoolingRegistrationRepository,
       });
 
@@ -191,8 +177,7 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
       schoolingRegistration.lastName = user.lastName;
       campaignRepository.getByCode.withArgs(campaignCode).resolves({ organizationId });
       userReconciliationService.findMatchingSchoolingRegistrationIdForGivenOrganizationIdAndUser.resolves(schoolingRegistration);
-      studentRepository.getReconciledStudentByNationalStudentId.resolves(new Student());
-      userReconciliationService.checkIfStudentHasAlreadyAccountsReconciledInOtherOrganizations.resolves();
+      userReconciliationService.checkIfStudentHasAnAlreadyReconciledAccount.resolves();
 
       // when
       const result = await usecases.reconcileSchoolingRegistration({
@@ -201,7 +186,6 @@ describe('Unit | UseCase | reconcile-schooling-registration', () => {
         campaignCode,
         campaignRepository,
         userReconciliationService,
-        studentRepository,
         schoolingRegistrationRepository,
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Les fonctions permettant de déterminer si un utilisateur possédait déjà un compte réconcilié dans l'établissement actuel ou dans un autre établissement devenait difficilement lisibles, ce qui rend certains développements actuels plus douloureux.

## :robot: Solution
Refactorer le service user-reconciliaton-service.js.

## :rainbow: Remarques
Il est conseillé d'effectuer la revue commit par commit afin de bien comprendre les étapes qui ont conduit à la version finale.  

## :100: Pour tester

- Formulaire de réconcilication
   - Se connecter
   - Rejoindre la campagne BADGES123
   - Remplir le formulaire de réconciliation avec les informations George/De Cambridge/22-07-2013
   - Vérifier que la modal de connexion s'affiche bien avec le message R32

- Accès de puis le GAR
   - Aller sur [Pix IDP](https://test-idp.integration.pix.fr/) 
   - Se connecter avec l'élève Lyanna Mormont
   - Accéder à la campagne BADGES123
   - Rentrer la date de naissance 07-01-2002
   - Vérifier que la modal de connexion s'affiche bien avec le message R31 