### PR TITLE
[TECH] Récupérer le référentiel de contenu depuis l'API LCMS.

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -42,11 +42,6 @@ module.exports = (function() {
       options: {},
     },
 
-    airtable: {
-      apiKey: process.env.CYPRESS_AIRTABLE_API_KEY || process.env.AIRTABLE_API_KEY,
-      base: process.env.CYPRESS_AIRTABLE_BASE || process.env.AIRTABLE_BASE,
-    },
-
     domain: {
       tldFr: process.env.TLD_FR || '.fr',
       tldOrg: process.env.TLD_ORG || '.org',
@@ -56,8 +51,8 @@ module.exports = (function() {
     },
 
     lcms: {
-      url: process.env.LCMS_API_URL,
-      apiKey: process.env.LCMS_API_KEY,
+      url: process.env.CYPRESS_LCMS_API_URL || process.env.LCMS_API_URL,
+      apiKey: process.env.CYPRESS_LCMS_API_KEY || process.env.LCMS_API_KEY,
     },
 
     logging: {

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -55,6 +55,11 @@ module.exports = (function() {
       pixOrga: process.env.DOMAIN_PIX_ORGA || 'https://orga.pix',
     },
 
+    lcms: {
+      url: process.env.LCMS_API_URL,
+      apiKey: process.env.LCMS_API_KEY,
+    },
+
     logging: {
       enabled: isFeatureEnabled(process.env.LOG_ENABLED),
       colorEnabled: (process.env.NODE_ENV === 'development'),
@@ -156,8 +161,8 @@ module.exports = (function() {
   if (process.env.NODE_ENV === 'test') {
     config.port = 0;
 
-    config.airtable.apiKey = 'test-api-key';
-    config.airtable.base = 'test-base';
+    config.lcms.apiKey = 'test-api-key';
+    config.lcms.url = 'https://lcms-test.pix.fr/api';
 
     config.domain.tldFr = '.fr';
     config.domain.tldOrg = '.org';

--- a/api/lib/infrastructure/airtable.js
+++ b/api/lib/infrastructure/airtable.js
@@ -1,10 +1,10 @@
 const Airtable = require('airtable');
-const airtableSettings = require('../config').airtable;
+const lcmsSettings = require('../config').lcms;
 const logger = require('./logger');
 const _ = require('lodash');
 
 function _airtableClient() {
-  return new Airtable({ apiKey: airtableSettings.apiKey }).base(airtableSettings.base);
+  return new Airtable({ endpointUrl: lcmsSettings.url, apiKey: lcmsSettings.apiKey }).base('content');
 }
 
 async function getRecord(tableName, recordId) {

--- a/api/sample.env
+++ b/api/sample.env
@@ -225,7 +225,7 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # presence: required
 # type: String
 # default: none
-LCMS_API_KEY=
+LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 
 # Learning content API URL.
 #
@@ -235,7 +235,7 @@ LCMS_API_KEY=
 # presence: required
 # type: String
 # default: none
-LCMS_API_URL=https://lcms-minimal.pix.fr/api
+LCMS_API_URL=https://lcms.minimal.pix.fr/api
 
 # =======
 # LOGGING

--- a/api/sample.env
+++ b/api/sample.env
@@ -217,8 +217,7 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # LEARNING CONTENT
 # ================
 
-# API key provided in your Airtable personal account used for fetching learning
-# content.
+# API key provided by learning content management system.
 #
 # If not present and if the Redis cache were not enabled/preloaded, the
 # application will crash during data fetching.
@@ -226,10 +225,9 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # presence: required
 # type: String
 # default: none
-AIRTABLE_API_KEY=keyblo10ZCvCqBAJg
+LCMS_API_KEY=
 
-# API token provided in your Airtable database configuration used for fetching
-# learning content.
+# Learning content API URL.
 #
 # If not present and if the Redis cache were not enabled/preloaded, the
 # application will crash during data fetching.
@@ -237,7 +235,7 @@ AIRTABLE_API_KEY=keyblo10ZCvCqBAJg
 # presence: required
 # type: String
 # default: none
-AIRTABLE_BASE=app3fvsqhtHJntXaC
+LCMS_API_URL=https://lcms-minimal.pix.fr/api
 
 # =======
 # LOGGING

--- a/api/tests/acceptance/application/course-controller_test.js
+++ b/api/tests/acceptance/application/course-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, nock, generateValidRequestAuthorizationHeader } = require('../../test-helper');
+const { expect, nock, generateValidRequestAuthorizationHeader, airtableBuilder } = require('../../test-helper');
 const createServer = require('../../../server');
 const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
 
@@ -14,50 +14,39 @@ describe('Acceptance | API | Courses', () => {
   describe('GET /api/courses/:course_id', () => {
 
     before(() => {
-      nock.cleanAll();
+      const course = airtableBuilder.factory.buildCourse({
+        'id': 'rec_course_id',
+        'nom': 'A la recherche de l\'information #01',
+        'description': 'Mener une recherche et une veille d\'information',
+        'image': [{
+          'id': 'attmP7vjRHdp5UcQA',
+          'url': 'https://dl.airtable.com/x5gtLtMTpyJBg9dJov82_keyboard-824317_960_720.jpg',
+          'filename': 'keyboard-824317_960_720.jpg',
+          'type': 'image/jpeg',
+        }],
+        'epreuves': [
+          'k_challenge_id',
+        ],
+        'preview': 'http://development.pix.fr/courses/rec_course_id/preview',
+        'NbDEpreuves': 10,
+        'acquis': '#ordonnancement,#source,#rechercheInfo,#moteur,#wikipedia,#syntaxe,#sponsor,#rechercheInfo,#cult1.1,#rechercheInfo',
+        'createdTime': '2016-08-09T15:17:53.000Z',
+      });
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Tests')
-        .query(true)
-        .times(3)
-        .reply(200, {
-          records: [{
-            id: 'rec_course_id',
-            fields: {
-              'id persistant': 'rec_course_id',
-              'Nom': 'A la recherche de l\'information #01',
-              'Description': 'Mener une recherche et une veille d\'information',
-              'Image': [{
-                'id': 'attmP7vjRHdp5UcQA',
-                'url': 'https://dl.airtable.com/x5gtLtMTpyJBg9dJov82_keyboard-824317_960_720.jpg',
-                'filename': 'keyboard-824317_960_720.jpg',
-                'type': 'image/jpeg',
-              }],
-              'Durée': 13,
-              'Épreuves.v2': [
-                'k_challenge_id',
-              ],
-              'Ordre affichage': 2,
-              'Preview': 'http://development.pix.fr/courses/rec_course_id/preview',
-              'Nb d\'épreuves': 10,
-              'Acquis': '#ordonnancement,#source,#rechercheInfo,#moteur,#wikipedia,#syntaxe,#sponsor,#rechercheInfo,#cult1.1,#rechercheInfo',
-            },
-            createdTime: '2016-08-09T15:17:53.000Z',
-          }],
-        });
+      airtableBuilder
+        .mockList({ tableName: 'Tests' })
+        .returns([course])
+        .activate();
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Epreuves')
-        .query(true)
-        .times(3)
-        .reply(200, {
-          records: [{
-            id: 'k_challenge_id',
-            fields: {
-              'id persistant': 'k_challenge_id',
-            },
-          }],
-        });
+      const challenge = airtableBuilder.factory.buildChallenge({
+        'id': 'k_challenge_id',
+      });
+
+      airtableBuilder
+        .mockList({ tableName: 'Epreuves' })
+        .returns([challenge])
+        .activate();
+
     });
 
     after(() => {

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, generateValidRequestAuthorizationHeader, nock, databaseBuilder } = require('../../test-helper');
+const { expect, generateValidRequestAuthorizationHeader, nock, databaseBuilder, airtableBuilder } = require('../../test-helper');
 const createServer = require('../../../server');
 
 describe('Acceptance | API | Progressions', () => {
@@ -15,18 +15,20 @@ describe('Acceptance | API | Progressions', () => {
     let userId;
 
     beforeEach(async () => {
-      nock.cleanAll();
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Epreuves')
-        .query(true)
-        .times(3)
-        .reply(200, {});
+      const challenge = airtableBuilder.factory.buildChallenge({});
 
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Acquis')
-        .query(true)
-        .reply(200, {});
+      airtableBuilder
+        .mockList({ tableName: 'Epreuves' })
+        .returns([challenge])
+        .activate();
+
+      const skill = airtableBuilder.factory.buildSkill({});
+  
+      airtableBuilder
+        .mockList({ tableName: 'Acquis' })
+        .returns([skill])
+        .activate();
 
       userId = databaseBuilder.factory.buildUser({}).id;
       const targetProfileId = databaseBuilder.factory.buildTargetProfile().id;

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -1,4 +1,4 @@
-const { expect, generateValidRequestAuthorizationHeader, nock, databaseBuilder } = require('../../test-helper');
+const { expect, generateValidRequestAuthorizationHeader, nock, databaseBuilder, airtableBuilder } = require('../../test-helper');
 const createServer = require('../../../server');
 const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
 
@@ -19,11 +19,13 @@ describe('Acceptance | Controller | target-profile-controller', () => {
     let targetProfileId;
 
     beforeEach(async () => {
-      nock.cleanAll();
-      nock('https://api.airtable.com')
-        .get('/v0/test-base/Acquis')
-        .query(true)
-        .reply(200, {});
+      const skill = airtableBuilder.factory.buildSkill({});
+  
+      airtableBuilder
+        .mockList({ tableName: 'Acquis' })
+        .returns([skill])
+        .activate();
+
       targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
       user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
 

--- a/api/tests/tooling/airtable-builder/airtable-builder.js
+++ b/api/tests/tooling/airtable-builder/airtable-builder.js
@@ -3,7 +3,7 @@ const AirtableMockRoute = require('./airtable-mock-route');
 
 module.exports = class AirtableBuilder {
   constructor({ nock }) {
-    this.nockScope = nock('https://api.airtable.com').persist();
+    this.nockScope = nock('https://lcms-test.pix.fr/api').persist();
     this.nock = nock;
     this.factory = factory;
     this.ROUTE_TYPE = AirtableMockRoute.ROUTE_TYPE;

--- a/api/tests/tooling/airtable-builder/airtable-mock-route.js
+++ b/api/tests/tooling/airtable-builder/airtable-mock-route.js
@@ -47,7 +47,7 @@ AirtableMockRoute.ROUTE_TYPE = ROUTE_TYPE;
 module.exports = AirtableMockRoute;
 
 function generateUrlForRouteType({ routeType, tableName, returnBody }) {
-  const url = `/v0/test-base/${tableName}`;
+  const url = `/v0/content/${tableName}`;
   const returnBodyId = returnBody && returnBody.fields && returnBody.fields['id persistant'];
 
   if (!returnBodyId && routeType === ROUTE_TYPE.GET) {


### PR DESCRIPTION
## :unicorn: Problème
Le référentiel de contenu est récupérer directement depuis l'API airtable.

## :robot: Solution
Modifier le endpoint du client airtable pour utiliser l'API LCMS.

## :rainbow: Remarques
On a du ajouter un préfixe de version dans l'URL de l'API LCMS.

ceci est une solution temporaire en attendant de créer une route unique pour récupérer le référentiel.

Il faut provisionner les variables d'environnement LCMS_API_KEY et LCMS_API_URL

## :100: Pour tester
Se connecter a la review app et vérifier que les données du référentiel s'affichent correctement.
