### PR TITLE
[TECH] Correcteur d'erreur d'orthographe sur le terme targetprofile dans le code (PIX-1525)

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
@@ -74,16 +74,16 @@ function _campaignParticipationByParticipantSortedByDate(qb, campaignId) {
 }
 
 async function _buildCampaignAssessmentParticipationSummaries(results, targetedSkillIds) {
-  const _getValidatedSkillCountInTargetProfil = await _makeMemoizedGetValidatedSkillCountInTargetProfil(results, targetedSkillIds);
+  const _getValidatedSkillCountInTargetProfile = await _makeMemoizedGetValidatedSkillCountInTargetProfile(results, targetedSkillIds);
 
   return results.map((result) => new CampaignAssessmentParticipationSummary({
     ...result,
     targetedSkillCount: targetedSkillIds.length,
-    validatedTargetedSkillCount: _getValidatedSkillCountInTargetProfil(result.userId),
+    validatedTargetedSkillCount: _getValidatedSkillCountInTargetProfile(result.userId),
   }));
 }
 
-async function _makeMemoizedGetValidatedSkillCountInTargetProfil(results, targetedSkillIds) {
+async function _makeMemoizedGetValidatedSkillCountInTargetProfile(results, targetedSkillIds) {
   const sharedResults = results
     .filter((result) => result.isShared);
 


### PR DESCRIPTION
## :unicorn: Problème
Erreur d'orthographe pour le terme TargetProfile (qui était écris sans e)

## :robot: Solution
Ajouter des  ("oeufs"  🥚) e 

## :rainbow: Remarques
/

## :100: Pour tester
Non regression
