### PR TITLE
[FEATURE] Changement du wording de la banière SCO (remplacement Toussaint par Noël) (PIX-1528).

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -18,7 +18,7 @@
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner>
-    <strong>Parcours de rentrée 2020</strong> : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint. Plus d’info
+    <strong>Parcours de rentrée 2020</strong> : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant les vacances de Noël. Plus d’info
     <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" class="link link-dark" target="_blank" rel="noopener noreferrer">
       collège
       <FaIcon @icon="external-link-alt" />

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -155,7 +155,7 @@ module('Integration | Component | information-banner', function(hooks) {
           // then
           assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
           assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
-          assert.dom('.pix-banner').includesText('Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant la Toussaint. Plus d’info collège et lycée (GT et Pro)');
+          assert.dom('.pix-banner').includesText('Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant les vacances de Noël. Plus d’info collège et lycée (GT et Pro)');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
La team métier SCO a décidé de changer la deadline de fin des parcours de rentrée, au lieu de la Toussaint la deadline est reportée aux vacances de Noël.

## :robot: Solution
Changement du wording dans la bannière SCO

## :rainbow: Remarques
/

## :100: Pour tester
Se connecter sur une organisation SCO (non agriculture) qui aurait déjà importé des élèves cette année scolaire, avec le compte suivant : sco.admin@example.net
Constater que la date de la bannière a bien été changé. 
