### PR TITLE
[BUGFIX] Afficher si possible le lieu de naissance sur l'attestation de certification Pix (PIX-1504).

### DIFF
--- a/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
+++ b/api/lib/infrastructure/utils/pdf/certification-attestation-pdf.js
@@ -28,7 +28,8 @@ function _drawScore(data, page, font, fontSize) {
 
 function _drawHeaderUserInfo(data, page, font, fontSize, rgb) {
   const fullName = `${startCase(data.firstName)} ${startCase(data.lastName)}`;
-  const birthInfo = formatDate(data.birthdate);
+  const birthplaceInfo = data.birthplace ? ` à ${data.birthplace}` : '';
+  const birthInfo = formatDate(data.birthdate) + birthplaceInfo;
   const certifCenter = data.certificationCenter;
   const certifDate = formatDate(data.deliveredAt);
   [


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur télécharge son attestation de certification pour le champ "Date et lieu de naissance" il ne voit que sa date de naissance. Le lieu n'est pas affiché alors que l'intitulé du champ semble dire le contraire.

## :robot: Solution
Rajouter dynamiquement l'information du lieu de naissance dans l'attestation de certification Pix.

## :rainbow: Remarques
Nous n'avons pas de test d'intégration ou acceptance vérifiant le contenu du fichier PDF car il semblerait que le fichier soit non déterministe.

## :100: Pour tester
- Se connecter sur mon-pix avec un compte ayant réussi une certification Pix `certif-success@example.net` 
- Aller dans l'onglet "Mes certifications" puis cliquer sur une certification obtenue. 
- Cliquer sur le bouton pour télécharger une attestation et vérifier que dans le premier encadré, où se trouve les informations générales sur le candidats, se trouve le lieu de naissance. 