### PR TITLE
[FEATURE] Ne pas afficher le lieu de naissance sur le certificat si il n'est pas disponible (PIX-1531).

### DIFF
--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -13,7 +13,11 @@
 
       <p>{{@certification.fullName}}</p>
       <p>
-        {{t "pages.certificate.candidate-birth-complete" birthdate=birthdate birthplace=@certification.birthplace}}
+        {{#if @certification.birthplace}}
+          {{t "pages.certificate.candidate-birth-complete" birthdate=birthdate birthplace=@certification.birthplace}}
+        {{else}}
+          {{t "pages.certificate.candidate-birth" birthdate=birthdate}}
+        {{/if}}
       </p>
 
       {{#if @certification.certificationCenter}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -106,6 +106,7 @@
         "certificate": {
             "title": "Pix Certificate",
             "back-link": "Return to my certificates",
+            "candidate-birth": "Born on {birthdate}",
             "candidate-birth-complete": "Born on {birthdate} in {birthplace}",
             "certification-center": "Certification centre:",
             "attestation": "Download my certificate of achievement",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -106,6 +106,7 @@
         "certificate": {
             "title": "Certificat Pix",
             "back-link": "Retour à mes certifications",
+            "candidate-birth": "Born on {birthdate}",
             "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
             "certification-center": "Centre de certification :",
             "attestation": "Télécharger mon attestation",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -106,7 +106,7 @@
         "certificate": {
             "title": "Certificat Pix",
             "back-link": "Retour à mes certifications",
-            "candidate-birth": "Born on {birthdate}",
+            "candidate-birth": "Né(e) le {birthdate}",
             "candidate-birth-complete": "Né(e) le {birthdate} à {birthplace}",
             "certification-center": "Centre de certification :",
             "attestation": "Télécharger mon attestation",


### PR DESCRIPTION
## :unicorn: Problème
La date et le lieu de naissance sont affichés sur le certificat Pix, au format "Né(e) le {{birthdate}} à {{birthplace}}". Néanmoins, il arrive que le lieu de naissance ne soit pas disponible pour certains candidats. Dans ce cas aujourd'hui, le "à" est affiché sans lieu de naissance ce qui n'est pas correct.

## :robot: Solution
Ne pas afficher le "à" sur le certificat si le lieu de naissance du candidat n'est pas renseigné.

## :100: Pour tester
- ouvrir le certificat Pix d'un candidat ayant un lieu de naissance : la date et le lieu de naissance doivent être affichés correctement
- ouvrir le certificat Pix d'un candidat sans lieu de naissance : seule la date de naissance du candidat doit être affichée
