### PR TITLE
[TECH] Préconiser l'utilisation d'un serveur http léger dans les tests.

### DIFF
--- a/api/tests/.eslintrc.yaml
+++ b/api/tests/.eslintrc.yaml
@@ -1,2 +1,4 @@
+extends: '../.eslintrc.yaml'
+
 env:
   mocha: true

--- a/api/tests/integration/.eslintrc.yaml
+++ b/api/tests/integration/.eslintrc.yaml
@@ -1,0 +1,6 @@
+extends: '../.eslintrc.yaml'
+
+rules:
+  no-restricted-modules:
+    -  error
+    -  paths: ['@hapi/hapi']


### PR DESCRIPTION
## :unicorn: Problème
Le serveur http [HapiJS](https://hapi.dev/tutorials/gettingstarted/?lang=en_US) offre l'intégralité des fonctionnalités de production, mais prend de la place en mémoire et du temps à démarrer. 

Pour les tests utilisant le serveur http, un [helper plus léger ](api/tests/tooling/server/http-test-server.js) a été développé, qui enregistre notamment moins de plugin (ex: logging).

[Une PR récente](https://github.com/1024pix/pix/pull/2017) a remplacé l'intégralité des serveur http dans les test par cette version légère, mais il est toujours possible d'utiliser par inadvertance la version complète.

## :robot: Solution
Ajouter un nudge sous la forme d'une règle Eslint qui déconseille l'usage du serveur dans les tests d'intégration

## :rainbow: Remarques
Si le besoin est justifié, il est possible de désactiver lé règle localement grâce à la syntaxe suivante

```
// eslint-disable-next-line no-restricted-modules
const Hapi = require('@hapi/hapi');
```

## :100: Pour tester

### Local

Sur un fichier
```
npx eslint ./tests/integration/application/use-an-actual-http-server_test.js                                                                1 ↵
/pix/api/tests/integration/application/use-an-actual-http-server_test.js
  2:14  error  '@hapi/hapi' module is restricted from being used  no-restricted-modules
```

Sur l'ensemble des fichiers
`npm run lint`

### CI
Vérifier que la CI sort en erreur suite à l'utilisation d'un serveur http complet dans un commit coupable dédié
`[REMOVE-BEFORE-MERGE] Add actual http server in test `

Conforme, voir [ build en erreur ](https://app.circleci.com/pipelines/github/1024pix/pix/16635/workflows/8a5e22d1-2853-433a-9470-b8438d2e63ea/jobs/148740)

