### PR TITLE
[TECH] Ajouter un script de création en masse des apprentis (Pix-1353).

### DIFF
--- a/api/scripts/prod/import-apprentices.js
+++ b/api/scripts/prod/import-apprentices.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-sync */
+// Usage: node import-apprentices path/file.csv
+
+const { CsvColumn } = require('../../lib/infrastructure/serializers/csv/csv-registration-parser');
+const SchoolingRegistrationParser = require('../../lib/infrastructure/serializers/csv/schooling-registration-parser');
+const fs = require('fs');
+const { knex } = require('../../db/knex-database-connection');
+
+const column = new CsvColumn({ name: 'uai', label:'UAI*', isRequired: true });
+
+class CsvApprenticesParser extends SchoolingRegistrationParser {
+  constructor(input, oranizationByUAI) {
+    super(input, null);
+    this.organizationByUai = oranizationByUAI;
+    this._columns.push(column);
+  }
+
+  _lineToRegistrationAttributes(line) {
+    const registrationAttributes = {};
+
+    this._columns.forEach((column) => {
+      const value = line[column.label];
+      if (column.isDate) {
+        registrationAttributes[column.name] = this._buildDateAttribute(value);
+      } else if (column.name === 'uai') {
+        registrationAttributes.organizationId = this.organizationByUai[value];
+      } else {
+        registrationAttributes[column.name] = value;
+      }
+    });
+
+    return registrationAttributes;
+  }
+}
+
+async function findOrganizationByUai() {
+  const organizations = await knex.select(['id as organizationId', 'externalId']).from('organizations').where({ type: 'SCO' });
+  const organizationByUai = {};
+
+  organizations.forEach(({ organizationId, externalId }) => organizationByUai[externalId] = organizationId);
+
+  return organizationByUai;
+}
+
+async function importApprentices(filePath, fileSystem) {
+  const input = fileSystem.readFileSync(filePath);
+  const organizationByUai = await findOrganizationByUai();
+
+  const csvApprenticesParser = new  CsvApprenticesParser(input, organizationByUai);
+  const schoolingRegistrationSet = csvApprenticesParser.parse();
+  await knex.batchInsert('schooling-registrations', schoolingRegistrationSet.registrations);
+}
+
+async function main() {
+  return importApprentices(process.argv[2], fs);
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+
+module.exports = importApprentices;

--- a/api/tests/integration/scripts/prod/import-apprentices_test.js
+++ b/api/tests/integration/scripts/prod/import-apprentices_test.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-sync */
+const { expect, databaseBuilder, catchErr, knex, sinon } = require('../../../test-helper');
+const importApprentices = require('../../../../scripts/prod/import-apprentices');
+const iconv = require('iconv-lite');
+const { CsvImportError } = require('../../../../lib/domain/errors');
+
+describe('Integration | Scripts | import-apprentices', () => {
+  const fileSystem = {
+    readFileSync: sinon.stub(),
+  };
+
+  describe('#importApprentices', () => {
+
+    afterEach(async () => {
+      await knex('schooling-registrations').delete();
+    });
+
+    context('when the header is correctly formed', () => {
+      context('when there is no line', () => {
+        it('create no registrations',  async () => {
+          const input = 'Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*;UAI*';
+          const encodedInput = iconv.encode(input, 'utf8');
+          fileSystem.readFileSync.withArgs('tmp.csv').returns(encodedInput);
+
+          await importApprentices('tmp.csv', fileSystem);
+          const registrations = await knex.select('*').from('schooling-registrations');
+          expect(registrations).to.be.empty;
+        });
+      });
+
+      context('when there are lines', () => {
+        it('create registrations for the correct organization', async () => {
+          const organization1 = databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: '12345' });
+          const organization2 = databaseBuilder.factory.buildOrganization({ type: 'SCO', externalId: '54321' });
+          await databaseBuilder.commit();
+
+          const registration1Attributes = {
+            nationalApprenticeId: '123F',
+            firstName: 'Beatrix',
+            middleName: 'The',
+            thirdName: 'Bride',
+            lastName: 'Kiddo',
+            preferredLastName: 'Black Mamba',
+            birthdate: '1970-01-01',
+            birthCityCode: '97422',
+            birthProvinceCode: '200',
+            birthCountryCode: '100',
+            status: 'AP',
+            MEFCode: 'MEF1',
+            division: 'Division 1',
+            organizationId: organization1.id,
+          };
+
+          const registration2Attributes = {
+            nationalApprenticeId: '456F',
+            firstName: 'O-Ren',
+            lastName: 'Ishii',
+            preferredLastName: 'Cottonmouth',
+            birthdate: '1980-01-01',
+            birthCity: 'Shangai',
+            birthProvinceCode: '99',
+            birthCountryCode: '132',
+            status: 'AP',
+            MEFCode: 'MEF1',
+            division: 'Division 2',
+            organizationId: organization2.id,
+          };
+
+          const input = `Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*;UAI*
+         123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
+           456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
+          `;
+
+          const encodedInput = iconv.encode(input, 'utf8');
+
+          fileSystem.readFileSync.withArgs('tmp.csv').returns(encodedInput);
+
+          await importApprentices('tmp.csv', fileSystem);
+          const [registration1, registration2 ] = await knex.select('*').from('schooling-registrations').orderBy('organizationId');
+          expect(registration1).to.include(registration1Attributes);
+          expect(registration2).to.include(registration2Attributes);
+        });
+
+        context('when there is an error', () => {
+          it('throws a CsvImportError', async  () => {
+            const header = 'Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*;UAI*';
+            const lineWithoutUniqueIdentifier = ';Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;';
+            const input =
+            `${header}
+            ${lineWithoutUniqueIdentifier}`;
+
+            const encodedInput = iconv.encode(input, 'utf8');
+            fileSystem.readFileSync.withArgs('tmp.csv').returns(encodedInput);
+
+            const err = await catchErr(importApprentices)('tmp.csv', fileSystem);
+            expect(err).to.be.an.instanceOf(CsvImportError);
+          });
+        });
+      });
+    });
+    context('when the header is not correctly formed', () => {
+      const requiredColumns = [
+        'Identifiant unique*',
+        'Premier prénom*',
+        'Deuxième prénom',
+        'Troisième prénom',
+        'Nom de famille*',
+        'Nom d’usage',
+        'Date de naissance (jj/mm/aaaa)*',
+        'Code commune naissance**',
+        'Libellé commune naissance**',
+        'Code département naissance*',
+        'Code pays naissance*',
+        'Statut*',
+        'Code MEF*',
+        'Division*',
+        'UAI*',
+      ];
+
+      requiredColumns.forEach((missingColumn) =>  {
+        it('throws a CsvImportError', async  () => {
+          const input = requiredColumns.filter((column)  => column != missingColumn).join(';');
+
+          const encodedInput = iconv.encode(input, 'utf8');
+          fileSystem.readFileSync.withArgs('tmp.csv').returns(encodedInput);
+
+          const err = await catchErr(importApprentices)('tmp.csv', fileSystem);
+          expect(err).to.be.an.instanceOf(CsvImportError);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les organisations SCO/AGRI. on des élèves avec le statut d'apprentis.
Depuis la rentrées les apprentis. ne sont pas importer dans Pix Orga.


## :robot: Solution
Créer un script pour importer les apprentis.



## :rainbow: Remarques
Le CSV aura ces colonnes.


```js
        'Identifiant unique*',
        'Premier prénom*',
        'Deuxième prénom',
        'Troisième prénom',
        'Nom de famille*',
        'Nom d’usage',
        'Date de naissance (jj/mm/aaaa)*',
        'Code commune naissance**',
        'Libellé commune naissance**',
        'Code département naissance*',
        'Code pays naissance*',
        'Statut*',
        'Code MEF*',
        'Division*',
        'UAI*',
```
## :100: Pour tester
Lancer le script en local avec le  fichier (attention il faut changer l'extension) et vérifier que chaque élève est bien associé à la organisation avec la bonne UAI.

[agri.txt](https://github.com/1024pix/pix/files/5452181/agri.txt)
