### PR TITLE
[TECH] Retirer les imports globaux de lodash

### DIFF
--- a/admin/.eslintrc.js
+++ b/admin/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
   },
   rules: {
     'ember/no-mixins': 'off',
+    'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
   },
   overrides: [
     // node files

--- a/admin/app/components/login-form.js
+++ b/admin/app/components/login-form.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'pix-admin/config/environment';
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 export default class LoginForm extends Component {
 
@@ -28,7 +28,7 @@ export default class LoginForm extends Component {
 
   _manageErrorsApi(response = {}) {
 
-    const nbErrors = _.get(response, 'responseJSON.errors.length', 0);
+    const nbErrors = get(response, 'responseJSON.errors.length', 0);
     if (nbErrors > 0) {
       const firstError = response.responseJSON.errors[0];
       const messageError = this._showErrorMessages(firstError.status, firstError.detail);

--- a/admin/app/controllers/authenticated/certifications.js
+++ b/admin/app/controllers/authenticated/certifications.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
+import trim from 'lodash/trim';
 
 export default class CertificationsController extends Controller {
   @service router;
@@ -12,7 +12,7 @@ export default class CertificationsController extends Controller {
   @action
   loadCertification(event) {
     event.preventDefault();
-    const certifId = _.trim(this.inputId);
+    const certifId = trim(this.inputId);
     const routeName = 'authenticated.certifications.certification';
     this.router.transitionTo(routeName, certifId);
   }

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -4,9 +4,10 @@ import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { schedule } from '@ember/runloop';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
+import find from 'lodash/find';
+
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
 
 export default class CertificationInformationsController extends Controller {
 
@@ -200,7 +201,7 @@ export default class CertificationInformationsController extends Controller {
 
   _updatePropForCompetence(competenceCode, value, propName, linkedPropName) {
     const competences = this._copyCompetences();
-    const competence = _.find(competences, { competence_code: competenceCode });
+    const competence = find(competences, { competence_code: competenceCode });
     if (competence) {
       if (value.trim().length === 0) {
         if (competence[linkedPropName]) {

--- a/admin/app/controllers/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/controllers/authenticated/organizations/get/target-profiles.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import uniq  from 'lodash/uniq';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -34,6 +34,6 @@ export default class GetTargetProfilesController extends Controller {
 
   _getUniqueTargetProfiles() {
     const targetProfileIds = this.targetProfilesToAttach.split(',').map((targetProfileId) => targetProfileId.trim());
-    return _.uniq(targetProfileIds);
+    return uniq(targetProfileIds);
   }
 }

--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
-import _ from 'lodash';
+import map from 'lodash/map';
 import config from 'pix-admin/config/environment';
 import { statusToDisplayName, FINALIZED } from 'pix-admin/models/session';
 
@@ -25,7 +25,7 @@ export default class SessionListController extends Controller {
 
   sessionStatusAndLabels = [
     { status: null, label: 'Tous' },
-    ...(_.map(statusToDisplayName, (label, status) => ({ status, label }))),
+    ...(map(statusToDisplayName, (label, status) => ({ status, label }))),
   ];
 
   certificationCenterTypeAndLabels = [

--- a/admin/app/controllers/authenticated/sessions/session.js
+++ b/admin/app/controllers/authenticated/sessions/session.js
@@ -2,7 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
+import trim from 'lodash/trim';
 
 export default class SessionController extends Controller {
   @service router;
@@ -12,7 +12,7 @@ export default class SessionController extends Controller {
   @action
   loadSession(event) {
     event.preventDefault();
-    const sessionId = _.trim(this.inputId);
+    const sessionId = trim(this.inputId);
     const routeName = this.router.currentRouteName;
     this.router.transitionTo(routeName, sessionId);
   }

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import some from 'lodash/some';
 
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -14,7 +14,7 @@ export default class ListController extends Controller {
 
   @computed('model.juryCertificationSummaries.@each.status')
   get canPublish() {
-    return !(_.some(
+    return !(some(
       this.model.juryCertificationSummaries.toArray(),
       (certif) => ['error', 'started'].includes(certif.status),
     ));

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,10 +1,13 @@
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
+import sumBy from 'lodash/sumBy';
+import some from 'lodash/some';
+import trim from 'lodash/trim';
 
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 
 function _getNumberOf(juryCertificationSummaries, booleanFct) {
-  return _.sumBy(
+  return sumBy(
     juryCertificationSummaries.toArray(),
     (juryCertificationSummary) => Number(booleanFct(juryCertificationSummary)),
   );
@@ -50,12 +53,12 @@ export default class Session extends Model {
 
   @computed('examinerGlobalComment')
   get hasExaminerGlobalComment() {
-    return !_.isEmpty(_.trim(this.examinerGlobalComment));
+    return !isEmpty(trim(this.examinerGlobalComment));
   }
 
   @computed('juryCertificationSummaries.@each.isPublished')
   get isPublished() {
-    return _.some(
+    return some(
       this.juryCertificationSummaries.toArray(),
       (juryCertificationSummary) => juryCertificationSummary.isPublished,
     );

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { FINALIZED } from 'pix-admin/models/session';
-import { trim } from 'lodash';
+import trim from 'lodash/trim';
 
 export default Route.extend(AuthenticatedRouteMixin, {
   queryParams: {

--- a/admin/app/routes/authenticated/target-profiles/list.js
+++ b/admin/app/routes/authenticated/target-profiles/list.js
@@ -1,7 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
-import { isEmpty } from 'lodash';
+import isEmpty  from 'lodash/isEmpty';
 
 export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
   @service notifications;

--- a/admin/app/services/current-user.js
+++ b/admin/app/services/current-user.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import get from 'lodash/get';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -12,7 +12,7 @@ export default class CurrentUserService extends Service {
       try {
         this.user = await this.store.queryRecord('user', { me: true });
       } catch (error) {
-        if (_.get(error, 'errors[0].code') === 401) {
+        if (get(error, 'errors[0].code') === 401) {
           return this.session.invalidate();
         }
       }

--- a/admin/app/services/error-notifier.js
+++ b/admin/app/services/error-notifier.js
@@ -1,4 +1,6 @@
-import { every, isEmpty } from 'lodash';
+import every from 'lodash/every';
+import isEmpty from 'lodash/isEmpty';
+
 import { inject as service } from '@ember/service';
 import Service from '@ember/service';
 

--- a/admin/app/services/session-info-service.js
+++ b/admin/app/services/session-info-service.js
@@ -1,5 +1,7 @@
 import json2csv from 'json2csv';
-import _ from 'lodash';
+import concat from 'lodash/concat';
+import isEmpty from 'lodash/isEmpty';
+
 import moment from 'moment';
 
 import Service, { inject as service } from '@ember/service';
@@ -89,12 +91,12 @@ export default class SessionInfoServiceService extends Service {
 
 function _filterCertificationsEligibleForJury(certifications) {
   return certifications.filter((certification) => {
-    return (certification.status !== 'validated') || (!_.isEmpty(certification.examinerComment)) || !certification.hasSeenEndTestScreen;
+    return (certification.status !== 'validated') || (!isEmpty(certification.examinerComment)) || !certification.hasSeenEndTestScreen;
   });
 }
 
 function _buildJuryFileHeaders() {
-  return _.concat(
+  return concat(
     [
       'ID de session',
       'ID de certification',

--- a/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
+++ b/admin/mirage/handlers/find-paginated-and-filtered-sessions.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import filter from 'lodash/filter';
+import slice from 'lodash/slice';
+
 import { Response } from 'ember-cli-mirage';
 
 export function findPaginatedAndFilteredSessions(schema, request) {
@@ -70,28 +72,28 @@ function _areFiltersValid({ idFilter }) {
 function _applyFilters(sessions, { idFilter, certificationCenterNameFilter, statusFilter, resultsSentToPrescriberAtFilter }) {
   let filteredSessions = sessions;
   if (idFilter) {
-    filteredSessions = _.filter(filteredSessions, (session) => {
+    filteredSessions = filter(filteredSessions, (session) => {
       return session.id === idFilter;
     });
   }
   if (certificationCenterNameFilter) {
     const filterName = certificationCenterNameFilter.toLowerCase();
-    filteredSessions = _.filter(filteredSessions, (session) => {
+    filteredSessions = filter(filteredSessions, (session) => {
       const currentName = session.certificationCenterName.toLowerCase();
       return currentName.search(filterName) !== -1;
     });
   }
   if (statusFilter) {
-    filteredSessions = _.filter(filteredSessions, { status: statusFilter });
+    filteredSessions = filter(filteredSessions, { status: statusFilter });
   }
   if (resultsSentToPrescriberAtFilter) {
     if (resultsSentToPrescriberAtFilter === 'true') {
-      filteredSessions = _.filter(filteredSessions, (session) => {
+      filteredSessions = filter(filteredSessions, (session) => {
         return Boolean(session.resultsSentToPrescriberAt);
       });
     }
     if (resultsSentToPrescriberAtFilter === 'false') {
-      filteredSessions = _.filter(filteredSessions, (session) => {
+      filteredSessions = filter(filteredSessions, (session) => {
         return !(session.resultsSentToPrescriberAt);
       });
     }
@@ -104,5 +106,5 @@ function _applyPagination(sessions, { page, pageSize }) {
   const start = (page - 1) * pageSize;
   const end = start + pageSize;
 
-  return _.slice(sessions, start, end);
+  return slice(sessions, start, end);
 }

--- a/admin/mirage/handlers/organizations.js
+++ b/admin/mirage/handlers/organizations.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import get from 'lodash/get';
+import slice from 'lodash/slice';
 
 export function findPaginatedOrganizationMemberships(schema, request) {
   const organizationId = request.params.id;
@@ -21,8 +22,8 @@ export function findPaginatedOrganizationMemberships(schema, request) {
 
 function _getPaginationFromQueryParams(queryParams) {
   return {
-    pageSize: parseInt(_.get(queryParams, 'page[size]',  10)),
-    page: parseInt(_.get(queryParams, 'page[number]',  1)),
+    pageSize: parseInt(get(queryParams, 'page[size]',  10)),
+    page: parseInt(get(queryParams, 'page[number]',  1)),
   };
 }
 
@@ -30,5 +31,5 @@ function _applyPagination(summaries, { page, pageSize }) {
   const start = (page - 1) * pageSize;
   const end = start + pageSize;
 
-  return _.slice(summaries, start, end);
+  return slice(summaries, start, end);
 }

--- a/certif/.eslintrc.js
+++ b/certif/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
     browser: true,
   },
   rules: {
+    'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
   },
   overrides: [
     // node files

--- a/certif/app/components/login-form.js
+++ b/certif/app/components/login-form.js
@@ -3,7 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-certif/config/environment';
-import _ from 'lodash';
+import get from 'lodash/get';
 
 export default class LoginForm extends Component {
 
@@ -40,7 +40,7 @@ export default class LoginForm extends Component {
 
   _manageErrorsApi(response = {}) {
 
-    const nbErrors = _.get(response, 'responseJSON.errors.length', 0);
+    const nbErrors = get(response, 'responseJSON.errors.length', 0);
 
     if (nbErrors > 0) {
       const firstError = response.responseJSON.errors[0];

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -4,7 +4,10 @@ import { htmlSafe } from '@ember/template';
 import EmberObject, { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
-import _ from 'lodash';
+import every from 'lodash/every';
+import toNumber from 'lodash/toNumber';
+import get from 'lodash/get';
+
 import config from 'pix-certif/config/environment';
 
 export default class CertificationCandidatesController extends Controller {
@@ -21,9 +24,9 @@ export default class CertificationCandidatesController extends Controller {
 
   @tracked candidatesInStaging = [];
 
-  @computed('certificationCandidates.{[],@each.isLinked}')
+  @computed('certificationCandidates', 'certificationCandidates.@each.isLinked')
   get importAllowed() {
-    return _.every(this.certificationCandidates.toArray(), (certificationCandidate) => {
+    return every(this.certificationCandidates.toArray(), (certificationCandidate) => {
       return !certificationCandidate.isLinked;
     });
   }
@@ -38,7 +41,7 @@ export default class CertificationCandidatesController extends Controller {
 
   _fromPercentageStringToDecimal(value) {
     return value ?
-      _.toNumber(value) / 100 : value;
+      toNumber(value) / 100 : value;
   }
 
   _hasDuplicate({ currentLastName, currentFirstName, currentBirthdate }) {
@@ -113,7 +116,7 @@ export default class CertificationCandidatesController extends Controller {
       this.notifications.success('Le candidat a été ajouté avec succès.');
     } catch (err) {
       let errorText = 'Une erreur s\'est produite lors de l\'ajout du candidat.';
-      if (_.get(err, 'errors[0].status') === '409' || err === 'Duplicate') {
+      if (get(err, 'errors[0].status') === '409' || err === 'Duplicate') {
         errorText = 'Ce candidat est déjà dans la liste, vous ne pouvez pas l\'ajouter à nouveau.';
       }
       this.notifications.error(errorText);
@@ -134,7 +137,7 @@ export default class CertificationCandidatesController extends Controller {
       this.notifications.success('Le candidat a été supprimé avec succès.');
     } catch (err) {
       let errorText = 'Une erreur s\'est produite lors de la suppression du candidat';
-      if (_.get(err, 'errors[0].code') === 403) {
+      if (get(err, 'errors[0].code') === 403) {
         errorText = 'Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.';
       }
       this.notifications.error(errorText);

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -1,10 +1,11 @@
-import _ from 'lodash';
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
-import { sumBy } from 'lodash';
+import sumBy from 'lodash/sumBy';
+import isEmpty from 'lodash/isEmpty';
+import trim from 'lodash/trim';
 
 export default class SessionsFinalizeController extends Controller {
 
@@ -93,6 +94,6 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   _convertStringToNullIfEmpty(str) {
-    return _.isEmpty(_.trim(str)) ? null : str;
+    return isEmpty(trim(str)) ? null : str;
   }
 }

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -1,7 +1,7 @@
-import _ from 'lodash';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { computed } from '@ember/object';
+import get from 'lodash/get';
 
 export default class CurrentUserService extends Service {
   @service session;
@@ -25,7 +25,7 @@ export default class CurrentUserService extends Service {
         this.user = user;
         this.certificationCenter = certificationCenter;
       } catch (error) {
-        if (_.get(error, 'errors[0].code') === 401) {
+        if (get(error, 'errors[0].code') === 401) {
           return this.session.invalidate();
         }
       }

--- a/mon-pix/.eslintrc.js
+++ b/mon-pix/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     browser: true,
   },
   rules: {
+    'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
     'ember/avoid-leaking-state-in-ember-objects': 'off',
     'ember/no-get': ['error'],
     'ember/no-empty-attrs': 'error',

--- a/orga/.eslintrc.js
+++ b/orga/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     browser: true,
   },
   rules: {
-    'no-restricted-imports': [2, { 'paths': ['lodash'] }],
+    'no-restricted-imports': ['error', { 'paths': ['lodash'] }],
   },
   overrides: [
     // node files


### PR DESCRIPTION
## :unicorn: Problème
Certaines app front utilisent encore les imports globaux de lodash, ce qui n'est pas homogène et allourdi les bundles.

## :robot: Solution
- Ajouter la règle de lint mise en place dans orga (#1831) dans les eslintrc
`'no-restricted-imports': ['error', { 'paths': ['lodash'] }]`
- Importer seulement les méthodes utilisées
```
// avant
import _ from 'lodash'

// après
import get from 'lodash/get'
```


## :rainbow: Remarques
Exemple de gain de taille côté Admin

DEV
 - dist/assets/vendor-6fdb829b70747ebf7bf90f3a17652356.js: 3.36 MB (902.55 KB gzipped)

BRANCHE
 - dist/assets/vendor-1f1c1fed51ead4dc0447f764777ec92b.js: 3.32 MB (887.12 KB gzipped)

TOTAL
 - 0.4Mb de gain en gzipped

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
