### PR TITLE
[BUGFIX] Corriger l'erreur sur l'assessmentId lors de  la requête GET /api/campaign-participations (PIX-1472).

### DIFF
--- a/api/lib/application/campaignParticipations/index.js
+++ b/api/lib/application/campaignParticipations/index.js
@@ -1,5 +1,6 @@
 const Joi = require('@hapi/joi');
 const campaignParticipationController = require('./campaign-participation-controller');
+const { sendJsonApiError, NotFoundError } = require('../http-errors');
 
 exports.register = async function(server) {
   server.route([
@@ -8,6 +9,14 @@ exports.register = async function(server) {
       path: '/api/campaign-participations',
       config: {
         handler: campaignParticipationController.find,
+        validate: {
+          query: Joi.object({
+            'filter[assessmentId]': Joi.string().pattern(/^[0-9]+$/),
+          }).options({ allowUnknown: true }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new NotFoundError(), h);
+          },
+        },
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
           '- Récupération des campaign-participation par assessment',

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -193,6 +193,29 @@ describe('Acceptance | API | Campaign Participations', () => {
         });
       });
     });
+
+    context('when the assessmentId is not an integer', () => {
+
+      it('returns 404 when assessmentId is not an integer', async () => {
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organization = databaseBuilder.factory.buildOrganization();
+
+        databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
+        databaseBuilder.factory.buildCampaign({ organizationId: organization.id });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: '/api/campaign-participations?filter[assessmentId]=abcd',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(404);
+      });
+    });
   });
 
   describe('PATCH /api/campaign-participations/{id}', () => {

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -18,7 +18,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
       MEFCode: 'ABCDE',
       division: 'EDCBA',
     };
-
+    
     context('when all required fields are presents', () => {
       it('is valid', async () => {
         try {


### PR DESCRIPTION
## :unicorn: Problème
Problème : sur la page de fin de parcours, l'url a la forme : `/campagnes/AZERTY123/evaluation/resultats/10000000`, et les utilisateurs cherchent à changer le dernier chiffre, et mettent des lettres par exemple, ce qui donne un ID non valide en pase.

## :robot: Solution
définir le type des paramètres dans l'`index.js` de la route `GET /campaign-participations`

## :rainbow: Remarques
Je me demande si on aurais pas du renvoyer une erreur depuis le repository (EntityNotFound)

## :100: Pour tester
Faire la requête en passant un id  avec des lettres et vérifier qu'on a bien une erreur 400.