### PR TITLE
[BUGFIX] Le téléchargement du template CSV SCO agri ne fonctionne pas

### DIFF
--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -77,7 +77,7 @@ module.exports = {
   findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization = false }) {
     return BookshelfMembership
       .where({ userId, organizationId, disabledAt: null })
-      .fetchAll({ withRelated: includeOrganization ? ['organization'] : [] })
+      .fetchAll({ withRelated: includeOrganization ? ['organization', 'organization.tags'] : [] })
       .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
   },
 

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -385,6 +385,23 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
         // then
         expect(foundMemberships).to.have.lengthOf(0);
       });
+
+      it('should retrieve membership and organization with tags', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        databaseBuilder.factory.buildOrganizationTag({ organizationId }).id;
+        databaseBuilder.factory.buildMembership({ userId, organizationId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const foundMemberships = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
+
+        // then
+        expect(foundMemberships[0].organization.id).to.equal(organizationId);
+        expect(foundMemberships[0].organization.tags).to.have.lengthOf(1);
+      });
     });
 
     context('When organization is required', () => {


### PR DESCRIPTION
## :unicorn: Problème

Quand on télécharge le template CSV des orga SCO Agri, on obtient un JSON alors que l'on devrait avoir le template de CSV

## :robot: Solution

Faire en sorte de télécharger le bon template pour les orga SCO Agri.

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter avec le compte sco.admin@example.net sur pix-orga
2. Sélectionner l'orga "Lycée agricole"
3. Se rendre sur la page élèves et télécharger le modèle CSV
> Vous devriez avoir le modèle en téléchargement