### PR TITLE
[FEATURE] Création du script d'ajout de tags aux organisations (PIX-1461).

### DIFF
--- a/api/db/seeds/data/tags-builder.js
+++ b/api/db/seeds/data/tags-builder.js
@@ -1,3 +1,5 @@
 module.exports = function tagsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildTag({ id: 1, name: 'AGRICULTURE' });
+  databaseBuilder.factory.buildTag({ id: 2, name: 'PUBLIC' });
+  databaseBuilder.factory.buildTag({ id: 3, name: 'PRIVE' });
 };

--- a/api/scripts/add-tags-to-organizations.js
+++ b/api/scripts/add-tags-to-organizations.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-console */
+// Usage: node add-tags-to-organizations.js path/file.csv
+// To use on file with columns |organizationId, tagName|
+
+'use strict';
+require('dotenv').config();
+const organizationTagRepository = require('../lib/infrastructure/repositories/organization-tag-repository');
+const tagRepository = require('../lib/infrastructure/repositories/tag-repository');
+const OrganizationTag = require('../lib/domain/models/OrganizationTag');
+const { parseCsv } = require('./helpers/csvHelpers');
+const uniq = require('lodash/uniq');
+
+function checkData({ csvData }) {
+  return csvData.map(([organizationId, tagName]) => {
+
+    if (!organizationId && !tagName) {
+      if (require.main === module) process.stdout.write('Found empty line in input file.');
+      return null;
+    }
+    if (!organizationId) {
+      if (require.main === module) process.stdout.write(`A line is missing an organizationId for tag ${tagName}`);
+      return null;
+    }
+    if (!tagName) {
+      if (require.main === module) process.stdout.write(`A line is missing a tag name for organization id ${organizationId}`);
+      return null;
+    }
+    return { organizationId, tagName };
+  }).filter((data) => !!data);
+}
+
+async function retrieveTagsByName({ checkedData }) {
+  const uniqTagNames = uniq(checkedData.map((data) => data.tagName));
+
+  const tagByNames = new Map();
+  for (let i = 0; i < uniqTagNames.length; i++) {
+    const name = uniqTagNames[i];
+    const tag = await tagRepository.findByName({ name });
+
+    if (tag === null) {
+      throw new Error(`The tag with name ${name} does not exist.`);
+    }
+    tagByNames.set(name, tag);
+  }
+  return tagByNames;
+}
+
+async function addTagsToOrganizations({ tagsByName, checkedData }) {
+  for (let i = 0; i < checkedData.length; i++) {
+    if (require.main === module) process.stdout.write(`\n${i + 1}/${checkedData.length} `);
+
+    const { organizationId, tagName } = checkedData[i];
+    const tagId = tagsByName.get(tagName).id;
+
+    const isExisting = await organizationTagRepository.isExistingByOrganizationIdAndTagId({ organizationId, tagId });
+
+    if (!isExisting) {
+      if (require.main === module) process.stdout.write(`Adding tag: ${tagName} to organization: ${organizationId} `);
+
+      const organizationTag = new OrganizationTag({ organizationId, tagId });
+      await organizationTagRepository.create(organizationTag);
+
+      if (require.main === module) process.stdout.write('===> ✔');
+    } else {
+      if (require.main === module) process.stdout.write(`Tag: ${tagName} already exists for organization: ${organizationId} `);
+    }
+  }
+}
+
+async function main() {
+  console.log('Starting script add-tags-to-organizations');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading and parsing csv data file... ');
+    const csvData = await parseCsv(filePath);
+    console.log('ok');
+
+    console.log('Checking data... ');
+    const checkedData = checkData({ csvData });
+    console.log('ok');
+
+    console.log('Retrieving tags by name... ');
+    const tagsByName = await retrieveTagsByName({ checkedData });
+    console.log('ok');
+
+    console.log('Adding tags to organizations…');
+    await addTagsToOrganizations({ tagsByName, checkedData });
+    console.log('\nDone.');
+
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+
+module.exports = {
+  addTagsToOrganizations,
+  retrieveTagsByName,
+  checkData,
+};

--- a/api/scripts/add-target-profile-shares-to-organizations.js
+++ b/api/scripts/add-target-profile-shares-to-organizations.js
@@ -55,7 +55,7 @@ async function main() {
     const filePath = process.argv[2];
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsv(filePath);
+    const csvData = await parseCsv(filePath);
     console.log('ok');
 
     console.log('Checking data... ');

--- a/api/scripts/create-or-update-sco-agri-organizations.js
+++ b/api/scripts/create-or-update-sco-agri-organizations.js
@@ -103,7 +103,7 @@ async function main() {
     const filePath = process.argv[2];
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsv(filePath);
+    const csvData = await parseCsv(filePath);
     console.log('ok');
 
     console.log('Checking data... ');

--- a/api/scripts/create-or-update-sco-organizations.js
+++ b/api/scripts/create-or-update-sco-organizations.js
@@ -125,7 +125,7 @@ async function main() {
     const filePath = process.argv[2];
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsv(filePath);
+    const csvData = await parseCsv(filePath);
     console.log('ok');
 
     console.log('Checking data... ');

--- a/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
+++ b/api/scripts/update-sco-organizations-with-is-managing-students-to-true.js
@@ -82,7 +82,7 @@ async function main() {
     const filePath = process.argv[2];
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsv(filePath);
+    const csvData = await parseCsv(filePath);
     console.log('ok');
 
     console.log('Checking data... ');

--- a/api/tests/integration/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/integration/scripts/add-tags-to-organizations_test.js
@@ -1,0 +1,124 @@
+const { expect, databaseBuilder, knex, catchErr } = require('../../test-helper');
+const { retrieveTagsByName, addTagsToOrganizations } = require('../../../scripts/add-tags-to-organizations');
+
+describe('Integration | Scripts | add-tags-to-organizations.js', () => {
+
+  let firstTag;
+  let secondTag;
+  let thirdTag;
+
+  beforeEach(() => {
+    firstTag = databaseBuilder.factory.buildTag({ name: 'tag1' });
+    secondTag = databaseBuilder.factory.buildTag({ name: 'tag2' });
+    thirdTag = databaseBuilder.factory.buildTag({ name: 'tag3' });
+
+    return databaseBuilder.commit();
+  });
+
+  describe('#retrieveTagsByName', () => {
+
+    it('should retrieve tags by tag name', async () => {
+      // given
+      const checkedData = [
+        { organizationId: 1,  tagName: firstTag.name },
+        { organizationId: 2,  tagName: secondTag.name },
+        { organizationId: 3,  tagName: firstTag.name },
+        { organizationId: 4,  tagName: thirdTag.name },
+        { organizationId: 5,  tagName: secondTag.name },
+      ];
+
+      // when
+      const tagsByName = await retrieveTagsByName({ checkedData });
+
+      // then
+      expect(tagsByName.size).to.equal(3);
+      expect(tagsByName.get(firstTag.name)).to.deep.equal(firstTag);
+      expect(tagsByName.get(secondTag.name)).to.deep.equal(secondTag);
+      expect(tagsByName.get(thirdTag.name)).to.deep.equal(thirdTag);
+    });
+
+    it('should throw an error if tag does not exist', async () => {
+      // given
+      const tagName = 'unknown_tag_name';
+      const checkedData = [
+        { organizationId: 1,  tagName },
+      ];
+
+      // when
+      const error = await catchErr(retrieveTagsByName)({ checkedData });
+
+      // then
+      expect(error.message).to.equal(`The tag with name ${tagName} does not exist.`);
+    });
+
+  });
+
+  describe('#addTagsToOrganizations', () => {
+
+    let firstOrganizationId;
+    let secondOrganizationId;
+    let thirdOrganizationId;
+
+    beforeEach(() => {
+      firstOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      secondOrganizationId = databaseBuilder.factory.buildOrganization().id;
+      thirdOrganizationId = databaseBuilder.factory.buildOrganization().id;
+
+      return databaseBuilder.commit();
+    });
+
+    afterEach(() => {
+      return knex('organization-tags').delete();
+    });
+
+    it('should add tags to organizations', async () => {
+      // given
+      const tagsByName = new Map([
+        [firstTag.name, firstTag],
+        [secondTag.name, secondTag],
+        [thirdTag.name, thirdTag],
+      ]);
+
+      const checkedData = [
+        { organizationId: firstOrganizationId,  tagName: firstTag.name },
+        { organizationId: secondOrganizationId,  tagName: secondTag.name },
+        { organizationId: thirdOrganizationId,  tagName: thirdTag.name },
+      ];
+
+      // when
+      await addTagsToOrganizations({ tagsByName, checkedData });
+
+      // then
+      const organizationTagsInDB = await knex('organization-tags');
+      expect(organizationTagsInDB.length).to.equal(3);
+      expect(await knex('organization-tags').where({ organizationId: firstOrganizationId, tagId: firstTag.id })).to.exist;
+      expect(await knex('organization-tags').where({ organizationId: secondOrganizationId, tagId: secondTag.id })).to.exist;
+      expect(await knex('organization-tags').where({ organizationId: thirdOrganizationId, tagId: thirdTag.id })).to.exist;
+    });
+
+    context('When tag already exists for an organization', () => {
+
+      beforeEach(() => {
+        databaseBuilder.factory.buildOrganizationTag({ organizationId: firstOrganizationId, tagId: firstTag.id });
+        return databaseBuilder.commit();
+      });
+
+      it('should not throw an error', async () => {
+        // given
+        const tagsByName = new Map([
+          [firstTag.name, firstTag],
+        ]);
+
+        const checkedData = [
+          { organizationId: firstOrganizationId,  tagName: firstTag.name },
+        ];
+
+        // when
+        await addTagsToOrganizations({ tagsByName, checkedData });
+
+        // then
+        expect(true).to.be.true;
+      });
+    });
+  });
+});

--- a/api/tests/unit/scripts/add-tags-to-organizations_test.js
+++ b/api/tests/unit/scripts/add-tags-to-organizations_test.js
@@ -1,0 +1,25 @@
+const { expect, sinon } = require('../../test-helper');
+const { addTagsToOrganizations } = require('../../../scripts/add-tags-to-organizations');
+const organizationTagRepository = require('../../../lib/infrastructure/repositories/organization-tag-repository');
+const Tag = require('../../../lib/domain/models/Tag');
+
+describe('Unit | Scripts | add-tags-to-organizations.js', () => {
+
+  context('When tag already exists for an organization', () => {
+
+    it('should not throw an error', async () => {
+      // given
+      const tagsByName = new Map([['tagName', new Tag({ name: 'tagName' })]]);
+      const checkedData = [{ organizationId: 1, tagName: 'tagName' }];
+
+      organizationTagRepository.create = sinon.stub();
+      organizationTagRepository.isExistingByOrganizationIdAndTagId = sinon.stub().resolves(true);
+
+      // when
+      await addTagsToOrganizations({ tagsByName, checkedData });
+
+      // then
+      expect(organizationTagRepository.create).to.not.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
On veut ajouter massivement des tags aux organisations.

## :robot: Solution
Création d'un script d'ajout de tags aux organisations.

## :rainbow: Remarques
D'anciens scripts ont été corrigés suite au passage en asynchrone de la fonction `parseCsv()`. 
Documentation du script: https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1946189854/2020-10-28+Ajout+de+tags+aux+organisations

## :100: Pour tester
- Dézipper le fichier:
[add-tags-to-organizations-test.zip](https://github.com/1024pix/pix/files/5459606/add-tags-to-organizations-test.zip)
- Exécuter la commande: `scalingo --region osc-fr1 -a pix-api-review-pr2079 run --file add-tags-to-organizations-test.csv node scripts/add-tags-to-organizations.js /tmp/uploads/add-tags-to-organizations-test.csv`
- Vérifier que les `organization-tags` ont bien été créés.