### PR TITLE
[TECH] Mise en place d'une contrainte d'unicité pour s'assurer qu'un profil cible n'est rattaché qu'une seule fois à une organisation (PIX-491)

### DIFF
--- a/api/db/migrations/20201029134518_add-unique-constraint-organizationid-targetprofileid-on-target-profile-shares.js
+++ b/api/db/migrations/20201029134518_add-unique-constraint-organizationid-targetprofileid-on-target-profile-shares.js
@@ -1,0 +1,23 @@
+exports.up = async function(knex) {
+  await knex.with('all_target_profile_shares_ranked',
+    (qb) => {
+      qb.select([
+        'target-profile-shares.id',
+        knex.raw('ROW_NUMBER() OVER (PARTITION BY ??, ?? ORDER BY ??) AS rank', [
+          'target-profile-shares.organizationId',
+          'target-profile-shares.targetProfileId',
+          'target-profile-shares.createdAt',
+        ]),
+      ])
+        .from('target-profile-shares')
+        .join('organizations', 'organizations.id', 'target-profile-shares.organizationId');
+    })
+    .from('target-profile-shares')
+    .whereRaw('id = ANY((SELECT id FROM all_target_profile_shares_ranked WHERE rank > 1))')
+    .del();
+  return knex.schema.table('target-profile-shares', (table) => table.unique(['organizationId', 'targetProfileId']));
+};
+
+exports.down = async function(knex) {
+  return knex.schema.table('target-profile-shares', (table) => table.dropUnique(['organizationId', 'targetProfileId']));
+};


### PR DESCRIPTION
## :unicorn: Problème
A cause de bugs dans les scripts de rattachement ou de bugs manuels (car le rattachement est aussi encore et toujours manuel), la table `target-profile-shares` présente beaucoup de doublons sur le couple `organizationId/targetProfileId` (aujourd'hui en production environ 35 000 doublons :exploding_head: ).
Heureusement il n'y a pas d'impact sur la liste déroulante lors de la création d'un profil cible.

## :robot: Solution
Solution en deux temps :
- Supprimer tous les doublons
- Ajout de la contrainte unique sur `(organizationId, targetProfileId)`

Requête de suppression (on fait le choix de conserver le rattachement le plus ancien):
```sql
with "all_target_profile_shares_ranked" as (
  select 
    "target-profile-shares"."id", 
    ROW_NUMBER() OVER (PARTITION BY "target-profile-shares"."organizationId", "target-profile-shares"."targetProfileId" ORDER BY "target-profile-shares"."createdAt") AS rank 
  from "target-profile-shares" 
  inner join "organizations" on "organizations"."id" = "target-profile-shares"."organizationId"
) 
delete from "target-profile-shares" where id = ANY((SELECT id FROM all_target_profile_shares_ranked WHERE rank > 1))
```

## :rainbow: Remarques
Requête testée sur la BDD de réplication externe.

## :100: Pour tester

