### PR TITLE
[FEATURE] Autoriser l'import d'apprenti pour SCO Agriculture (Pix-1356) 

### DIFF
--- a/api/db/migrations/20201027144304_add_nationalApprenticeId_to_schooling-registrations.js
+++ b/api/db/migrations/20201027144304_add_nationalApprenticeId_to_schooling-registrations.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'schooling-registrations';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.string('nationalApprenticeId');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn('nationalApprenticeId');
+  });
+};

--- a/api/lib/domain/models/SchoolingRegistration.js
+++ b/api/lib/domain/models/SchoolingRegistration.js
@@ -1,3 +1,7 @@
+const STATUS = {
+  STUDENT : 'ST',
+  APPRENTICE : 'AP',
+};
 class SchoolingRegistration {
 
   constructor({
@@ -16,6 +20,7 @@ class SchoolingRegistration {
     MEFCode,
     status,
     nationalStudentId,
+    nationalApprenticeId,
     division,
     updatedAt,
     // references
@@ -37,6 +42,7 @@ class SchoolingRegistration {
     this.MEFCode = MEFCode;
     this.status = status;
     this.nationalStudentId = nationalStudentId;
+    this.nationalApprenticeId = nationalApprenticeId;
     this.division = division;
     this.updatedAt = updatedAt;
     // references
@@ -44,5 +50,7 @@ class SchoolingRegistration {
     this.organizationId = organizationId;
   }
 }
+
+SchoolingRegistration.STATUS = STATUS;
 
 module.exports = SchoolingRegistration;

--- a/api/lib/domain/validators/schooling-registration-validator.js
+++ b/api/lib/domain/validators/schooling-registration-validator.js
@@ -1,17 +1,18 @@
 const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
 const { EntityValidationError } = require('../errors');
+const  SchoolingRegistration = require('../models/SchoolingRegistration');
 
+const { STUDENT , APPRENTICE } = SchoolingRegistration.STATUS;
 const validationConfiguration = { allowUnknown: true };
 const MAX_LENGTH = 255;
 const CITY_CODE_LENGTH = 5;
 const PROVINCE_CODE_MIN_LENGTH = 2;
 const PROVINCE_CODE_MAX_LENGTH = 3;
 const COUNTRY_CODE_LENGTH = 5;
-const STATUSES = ['ST'];
 const FRANCE_COUNTRY_CODE = '99100';
 
 const validationSchema = Joi.object({
-  nationalStudentId: Joi.string().max(MAX_LENGTH).required(),
+  nationalIdentifier: Joi.string().max(MAX_LENGTH).required(),
   firstName: Joi.string().max(MAX_LENGTH).required(),
   middleName: Joi.string().max(MAX_LENGTH).optional(),
   thirdName: Joi.string().max(MAX_LENGTH).optional(),
@@ -30,7 +31,7 @@ const validationSchema = Joi.object({
   }),
   birthProvinceCode: Joi.string().min(PROVINCE_CODE_MIN_LENGTH).max(PROVINCE_CODE_MAX_LENGTH).required(),
   birthCountryCode: Joi.string().length(COUNTRY_CODE_LENGTH).required(),
-  status: Joi.string().valid(...STATUSES).required(),
+  status: Joi.string().valid(STUDENT,APPRENTICE).required(),
   MEFCode: Joi.string().max(MAX_LENGTH).required(),
   division: Joi.string().max(MAX_LENGTH).required(),
   organizationId: Joi.number().integer().required(),

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -91,7 +91,7 @@ module.exports = {
   async addOrUpdateOrganizationSchoolingRegistrations(schoolingRegistrationDatas, organizationId) {
 
     const nationalStudentIdsFromFile = schoolingRegistrationDatas.map((schoolingRegistrationData) => schoolingRegistrationData.nationalStudentId);
-    const students = await studentRepository.findReconciledStudentsByNationalStudentId(nationalStudentIdsFromFile);
+    const students = await studentRepository.findReconciledStudentsByNationalStudentId(_.compact(nationalStudentIdsFromFile));
 
     const schoolingRegistrationsFromFile = schoolingRegistrationDatas.map((schoolingRegistrationData) => new SchoolingRegistration({ ...schoolingRegistrationData, organizationId }));
     const currentSchoolingRegistrations = await this.findByOrganizationId({ organizationId });

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -4,7 +4,7 @@ const { checkValidation } = require('../../../domain/validators/schooling-regist
 const { CsvRegistrationParser, CsvColumn } = require('./csv-registration-parser');
 
 const COLUMNS = [
-  new CsvColumn({ name: 'nationalStudentId', label: 'Identifiant unique*', isRequired: true }),
+  new CsvColumn({ name: 'nationalIdentifier', label: 'Identifiant unique*', isRequired: true }),
   new CsvColumn({ name: 'firstName', label: 'Premier prénom*', isRequired: true, checkEncoding: true }),
   new CsvColumn({ name: 'middleName', label:'Deuxième prénom' }),
   new CsvColumn({ name: 'thirdName', label:'Troisième prénom' }),
@@ -33,10 +33,21 @@ class SchoolingRegistrationSet {
   }
 
   _transform(registrationAttributes)  {
-    const { birthCountryCode } = registrationAttributes;
+    let nationalStudentId;
+    let nationalApprenticeId;
+    const { birthCountryCode, nationalIdentifier, status } = registrationAttributes;
+
+    if (status === SchoolingRegistration.STATUS.STUDENT) {
+      nationalStudentId = nationalIdentifier;
+    } else if (status === SchoolingRegistration.STATUS.APPRENTICE) {
+      nationalApprenticeId = nationalIdentifier;
+    }
+
     return {
       ...registrationAttributes,
       birthCountryCode: birthCountryCode.slice(-3),
+      nationalApprenticeId,
+      nationalStudentId,
     };
   }
 }

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -5,7 +5,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
   context('#checkValidation', () => {
 
     const validAttributes = {
-      nationalStudentId: '12345',
+      nationalIdentifier: '12345',
       firstName: 'Ellen',
       lastName: 'Ripley',
       birthdate: '1979-05-25',
@@ -30,7 +30,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
     });
 
     context('required fields', () => {
-      ['firstName', 'lastName', 'birthdate', 'nationalStudentId', 'birthProvinceCode', 'birthProvinceCode', 'status', 'MEFCode', 'division', 'organizationId'].forEach((field) => {
+      ['firstName', 'lastName', 'birthdate', 'nationalIdentifier', 'birthProvinceCode', 'birthProvinceCode', 'status', 'MEFCode', 'division', 'organizationId'].forEach((field) => {
         it(`throw an error when ${field} is missing`, async () => {
           const error = await catchErr(checkValidation)({ ...validAttributes, [field]: undefined });
 
@@ -41,7 +41,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
     });
 
     context('fields with a a max length of 255 characters', () => {
-      ['firstName', 'middleName', 'thirdName', 'lastName', 'preferredLastName', 'nationalStudentId', 'birthCity', 'MEFCode', 'division'].forEach((field) => {
+      ['firstName', 'middleName', 'thirdName', 'lastName', 'preferredLastName', 'nationalIdentifier', 'birthCity', 'MEFCode', 'division'].forEach((field) => {
         it(`throw an error when ${field} has more than 255 characters`, async () => {
           const error = await catchErr(checkValidation)({ ...validAttributes, [field]: '1'.repeat(256) });
 
@@ -92,6 +92,14 @@ describe('Unit | Domain | Schooling Registration validator', () => {
           checkValidation({ ...validAttributes, status: 'ST' });
         } catch (e) {
           expect.fail('SchoolingRegistration is valid valid when status is \'ST\'');
+        }
+      });
+
+      it('is valid when status is \'AP\'', async () => {
+        try {
+          checkValidation({ ...validAttributes, status: 'AP' });
+        } catch (e) {
+          expect.fail('SchoolingRegistration is valid valid when status is \'AP\'');
         }
       });
     });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -41,6 +41,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         const { registrations } = parser.parse();
         expect(registrations[0]).to.includes({
           nationalStudentId: '123F',
+          nationalApprenticeId: undefined,
           firstName: 'Beatrix',
           middleName: 'The',
           thirdName: 'Bride',
@@ -57,6 +58,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         });
         expect(registrations[1]).to.includes({
           nationalStudentId: '456F',
+          nationalApprenticeId: undefined,
           firstName: 'O-Ren',
           lastName: 'Ishii',
           preferredLastName: 'Cottonmouth',
@@ -68,6 +70,24 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           MEFCode: 'MEF1',
           division: 'Division 2',
           organizationId,
+        });
+      });
+
+      context('When the file contains Apprentice (status AP)', () => {
+        it('should return schooling registration with nationalApprenticeId', () => {
+          const input = `Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+          `;
+          const organizationId = 789;
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+  
+          const { registrations } = parser.parse();
+          expect(registrations[0]).to.includes({
+            nationalStudentId: undefined,
+            nationalApprenticeId: '123F',
+            status: 'AP',
+          });
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
Permettre aux institutions SCO Agri d'ajouter des Apprenti. 
Nouvelle identification INA qui ne sont des INE .

## :robot: Solution
Nouveau champs en base pour les apprenti `nationalApprenticeId `peuplé seulement lorsque le status est `AP` .
Modifier les règles de parsing du CSV afin d'autoriser les status AP a être ajouté en base.

## :rainbow: Remarques
Dorénavant il y aura l'utilisation de deux colonnes pour les certifications nationalStudentId et nationalApprenticeId ? @estellelandry  si je ne dis pas de bêtise.

## :100: Pour tester
importer le contenu de ce CSV 

`Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d’usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2
28B;Minus;;;Cortex;Detroit;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 4
`
Orga :
sur un compte agri /  `sco.admin@example.net` / Lycée Agricole / Elèves / Importer .csv .

Vérifier qu'en base : 
* Minus Cortex a un `nationalApprenticeId` sans `nationalStudentId`
* Ishii O-Ren a un `nationalStudentId `sans `nationalApprenticeId`