### PR TITLE
[BUGFIX] Fix pour l'erreur lors de la liaison des target-profile à une organization (PIX-1478).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const { sendJsonApiError, PayloadTooLargeError } = require('../http-errors');
+const { sendJsonApiError, PayloadTooLargeError, NotFoundError } = require('../http-errors');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const organizationController = require('./organization-controller');
@@ -116,6 +116,18 @@ exports.register = async (server) => {
           assign: 'hasRolePixMaster',
         }],
         handler: organizationController.attachTargetProfiles,
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'target-profiles-to-attach': Joi.array().items(Joi.string().pattern(/^[0-9]+$/), Joi.number().integer()),
+              },
+            },
+          }).options({ allowUnknown: true }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new NotFoundError('L\'id d\'un des profils cible n\'est pas valide'), h);
+          },
+        },
         tags: ['api', 'organizations'],
       },
     },

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -91,7 +91,6 @@ module.exports = {
     const requestedOrganizationId = parseInt(request.params.id);
     const targetProfileIdsToAttach = request.payload.data.attributes['target-profiles-to-attach']
       .map((targetProfileToAttach) => parseInt(targetProfileToAttach));
-
     await usecases.attachTargetProfilesToOrganization({ organizationId: requestedOrganizationId, targetProfileIdsToAttach });
     return h.response().code(204);
   },

--- a/api/tests/integration/application/organizations/organization-controller_test.js
+++ b/api/tests/integration/application/organizations/organization-controller_test.js
@@ -312,9 +312,25 @@ describe('Integration | Application | Organizations | organization-controller', 
         it('should return a 403 HTTP response', async () => {
           // when
           const response = await httpTestServer.request('POST', '/api/organizations/1234/target-profiles', payload);
-
           // then
           expect(response.statusCode).to.equal(403);
+        });
+      });
+
+      context('when target-profile-id does not contain only numbers', () => {
+
+        beforeEach(() => {
+          securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+        });
+
+        it('should return a 404 HTTP response', async () => {
+          // when
+          payload.data.attributes['target-profiles-to-attach'] = ['sdqdqsd', 'qsqsdqd'];
+          const response = await httpTestServer.request('POST', '/api/organizations/1234/target-profiles', payload);
+
+          // then
+          expect(response.statusCode).to.equal(404);
+          expect(response.payload).to.have.string('L\'id d\'un des profils cible n\'est pas valide');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans pix admin, lorsqu'on souhaite rattacher plusieurs profils cible à une orga, on saisi l'ID du profil cible. Si ce n'est pas un ID valide, il y a une erreur sentry

## :robot: Solution
Ajouter une validation sur le payload de la requête

## :rainbow: Remarques
RAS

## :100: Pour tester
Essayer d'attacher un target profile à une organisation en utilisant un ID invalide (Avec autre chose que des nombres)