### PR TITLE
[FEATURE] Améliorations liste des candidats SCO (Pix-1532)

### DIFF
--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -1,0 +1,11 @@
+const { featureToggles } = require('../../config');
+const { NotFoundError } = require('../../application/http-errors');
+
+module.exports = {
+  async isCertifPrescriptionSCOEnabled() {
+    if (!featureToggles.certifPrescriptionSco) {
+      throw new NotFoundError('cette route est désactivée');
+    }
+    return true;
+  },
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -2,6 +2,7 @@ const Joi = require('@hapi/joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
+const featureToggles = require('../preHandlers/feature-toggles');
 const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async (server) => {
@@ -393,10 +394,16 @@ exports.register = async (server) => {
             id: idSpecification,
           }),
         },
-        pre: [{
-          method: sessionAuthorization.verify,
-          assign: 'authorizationCheck',
-        }],
+        pre: [
+          {
+            method: featureToggles.isCertifPrescriptionSCOEnabled,
+            assign: 'isCertifPrescriptionSCOEnabled',
+          },
+          {
+            method: sessionAuthorization.verify,
+            assign: 'authorizationCheck',
+          },
+        ],
         handler: sessionController.enrollStudentsToSession,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiésr**\n' +

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -1,6 +1,7 @@
 const { sinon, expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Membership = require('../../../../lib/domain/models/Membership');
+const config = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-controller-enroll-students-to-session', () => {
 
@@ -73,11 +74,13 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       let student;
 
       afterEach(() => {
+        config.featureToggles.certifPrescriptionSco = false;
         return knex('certification-candidates').delete();
-
       });
 
       beforeEach(async () => {
+        config.featureToggles.certifPrescriptionSco = true;
+
         const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
         sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
@@ -108,7 +111,6 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       });
 
       it('should respond with a 201', async () => {
-
         // when
         const response = await server.inject(options);
 

--- a/api/tests/unit/application/preHandlers/feature-toggles_test.js
+++ b/api/tests/unit/application/preHandlers/feature-toggles_test.js
@@ -1,0 +1,33 @@
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/application/http-errors');
+const featureTogglesPreHandler = require('../../../../lib/application/preHandlers/feature-toggles');
+const { featureToggles } = require('../../../../lib/config');
+
+describe('Unit | Pre-handler | Feature Toggles', () => {
+  describe('#isCertifPrescriptionSCOEnabled', () => {
+    beforeEach(() => {
+      sinon.stub(featureToggles, 'certifPrescriptionSco');
+    });
+    it('returns true whenever the certif prescription SCO toggle is enabled', async () => {
+      // given
+      featureToggles.certifPrescriptionSco = true;
+
+      // when
+      const isAccessGranted = await featureTogglesPreHandler.isCertifPrescriptionSCOEnabled();
+
+      // then
+      expect(isAccessGranted).to.be.true;
+    });
+
+    it('throws whenever the certif prescription SCO toggle is disabled', async () => {
+      // given
+      featureToggles.certifPrescriptionSco = false;
+
+      // when
+      const error = await catchErr(featureTogglesPreHandler.isCertifPrescriptionSCOEnabled)();
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+});

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -9,7 +9,7 @@ const firstOf20thCentury = -2206310961000;
 
 export default class CertificationCandidateInStagingItem extends Component {
 
-  isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   birthProvinceCodePattern = '^[0-9][A,a,B,b,0-9][0-9]?$'
 

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -61,7 +61,9 @@
               <th>Adresse e-mail du destinataire des résultats</th>
             {{/unless}}
           {{/if}}
-          <th>Adresse e-mail de convocation</th>
+            {{#unless this.isScoSession}}
+              <th>Adresse e-mail de convocation</th>
+            {{/unless}}
           {{#unless this.isScoSession}}
             <th>Identifiant externe</th>
           {{/unless}}
@@ -92,7 +94,9 @@
                 <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
               {{/unless}}
             {{/if}}
-            <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+              {{#unless this.isScoSession}}
+                <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+              {{/unless}}
             {{#unless this.isScoSession}}
               <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
             {{/unless}}

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -8,7 +8,7 @@ import toNumber from 'lodash/toNumber';
 import config from 'pix-certif/config/environment';
 
 export default class EnrolledCandidates extends Component {
-  isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @service store;
   @service notifications;

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 import config from 'pix-certif/config/environment';
 
 export default class ImportCandidates extends Component {
-  isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @service session;
   @service notifications;

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -5,7 +5,7 @@ import config from 'pix-certif/config/environment';
 
 export default class SessionsDetailsController extends Controller {
 
-  isResultRecipientEmailVisible = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -19,6 +19,12 @@ export default class CertificationCandidatesController extends Controller {
     });
   }
 
+  @computed('model.certificationCandidates.length')
+  get hasOneOrMoreCandidates() {
+    const certificationCandidatesCount = this.model.certificationCandidates.length;
+    return certificationCandidatesCount > 0;
+  }
+
   @action
   async reloadCertificationCandidateInController() {
     await this.reloadCertificationCandidate();

--- a/certif/app/styles/components/certif-checkbox.scss
+++ b/certif/app/styles/components/certif-checkbox.scss
@@ -16,6 +16,10 @@
     background-color: $grey-22;
   }
 
+  &--unchecked {
+    background-color: $white;
+  }
+
   &--partial:hover &__dash-icon {
     background-color: $grey-40;
   }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -1,5 +1,7 @@
 {{#if (and this.isUserFromSco this.isCertifPrescriptionScoEnabled)}}
-  <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>
+  {{#unless this.hasOneOrMoreCandidates}}
+    <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>
+  {{/unless}}
   {{#if this.hasOneOrMoreCandidates}}
   <EnrolledCandidates
         @isUserFromSco={{this.isUserFromSco}}

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -1,15 +1,23 @@
 {{#if (and this.isUserFromSco this.isCertifPrescriptionScoEnabled)}}
   <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>
+  {{#if this.hasOneOrMoreCandidates}}
+  <EnrolledCandidates
+        @isUserFromSco={{this.isUserFromSco}}
+        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+        @sessionId={{this.currentSession.id}}
+        @certificationCandidates={{this.certificationCandidates}}
+        @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
+  {{/if}}
 {{else}}
   <ImportCandidates
           @session={{this.currentSession}}
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @importAllowed={{this.importAllowed}}/>
-{{/if}}
 <EnrolledCandidates
         @isUserFromSco={{this.isUserFromSco}}
         @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
         @sessionId={{this.currentSession.id}}
         @certificationCandidates={{this.certificationCandidates}}
         @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
+{{/if}}

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -51,7 +51,7 @@ module.exports = function(environment) {
         NOT_FOUND: '404',
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
-      FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE: _isFeatureEnabled(process.env.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE),
+      FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS: _isFeatureEnabled(process.env.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS),
     },
 
     googleFonts: [

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -10,6 +10,7 @@ import {
 import { upload } from 'ember-file-upload/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import config from 'pix-certif/config/environment';
 
 module('Acceptance | Session Details Certification Candidates', function(hooks) {
   
@@ -26,6 +27,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
   hooks.afterEach(function() {
     const notificationMessagesService = this.owner.lookup('service:notifications');
     notificationMessagesService.clearAll();
+    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
   });
 
   module('When user is not logged in', function() {
@@ -174,6 +176,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
         module('when user is not SCO', function(hooks) {
 
           hooks.beforeEach(async function() {
+            server.create('feature-toggle', { id: 0, certifPrescriptionSco: false });
             await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
           });
 

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -91,16 +91,16 @@ module('Acceptance | Session Details', function(hooks) {
         assert.dom('.session-details-header-datetime__time .content-text').hasText('14:00');
       });
 
-      module('when FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE is on', function(hooks) {
+      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is on', function(hooks) {
 
-        const ft = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+        const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
         hooks.before(() => {
-          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = true;
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         });
 
         hooks.after(() => {
-          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = ft;
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
         });
 
         test('it should show download button when there is one or more candidate', async function(assert) {
@@ -127,16 +127,16 @@ module('Acceptance | Session Details', function(hooks) {
         });
       });
 
-      module('when FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE is off', function(hooks) {
+      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is off', function(hooks) {
 
-        const ft = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+        const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
         hooks.before(() => {
-          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = false;
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
         });
 
         hooks.after(() => {
-          config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = ft;
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
         });
 
         test('it should not show download button', async function(assert) {

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -24,14 +24,14 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   const EMAIL_SELECTOR = 'panel-candidate__email__';
   const EXTRA_TIME_SELECTOR = 'panel-candidate__extraTimePercentage__';
 
-  const ft = config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE;
+  const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   hooks.before(() => {
-    config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = true;
+    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
   });
 
   hooks.after(() => {
-    config.APP.FT_IS_RESULT_RECIPIENT_EMAIL_VISIBLE = ft;
+    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
   });
 
   test('it display candidates information', async function(assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
@@ -4,8 +4,31 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | authenticated/sessions/details/certification-candidates', function(hooks) {
   setupTest(hooks);
 
-  test('should create the controller', function(assert) {
-    const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
-    assert.ok(controller);
+  module('#computed hasOneOrMoreCandidates()', function() {
+    test('It should return true when has one or more candidates', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      controller.model = { certificationCandidates: ['certifCandidate1', 'certifCanddate2'] } ;
+
+      const shouldDisplayStudentList = controller.hasOneOrMoreCandidates;
+
+      // then
+      assert.equal(shouldDisplayStudentList, true);
+    });
+
+    test('It should return false when has no candidate', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');
+
+      // when
+      controller.model = { certificationCandidates: [] } ;
+
+      const shouldDisplayStudentList = controller.hasOneOrMoreCandidates;
+
+      // then
+      assert.equal(shouldDisplayStudentList, false);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Quelques améliorations à effectuer suite au ticket PIX-1376: ETQ Pix Certif user SCO, JV pouvoir visualiser la liste des élèves inscrit à une session de certification depuis l'onglet "Candidats"

## :robot: Solution

**_Dans l'ordre des commits_**

- Changer le background des checkbox non séléctionnées en blanc

- Masquer uniquement pour le SCO la colonne “Adresse e-mail de convocation”

- Ne pas afficher la liste des candidats lorsque aucun candidat n’a été ajouté

- Ne pas afficher la section “Ajouter des candidats” lorsque des candidats ont été ajoutés 

- Protéger la route API sur le feature toggle n'est pas activé


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
