### PR TITLE
[FEATURE] Ajouter à nouveau des étudiants pour une session de certification - PART 1 (PIX-1378)

### DIFF
--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -6,8 +6,8 @@
         <th>
           <CertifCheckbox
             class="add-student-list__checker"
-            @state={{headerCheckboxStatus}}
-            {{on 'click' toggleAllItems}}>
+            @state={{this.headerCheckboxStatus}}
+            {{on 'click' this.toggleAllItems}}>
           </CertifCheckbox>
         </th>
         <th>Classe</th>
@@ -22,7 +22,7 @@
           <td class="add-student-list__column-checkbox">
             <CertifCheckbox
               @state={{if student.isSelected 'checked' 'unchecked'}}
-              {{on 'click' (fn toggleItem student)}}>
+              {{on 'click' (fn this.toggleItem student)}}>
             </CertifCheckbox>
           </td>
           <td>{{student.division}}</td>
@@ -36,8 +36,15 @@
 
   {{#if this.hasCheckedSomething}}
     <div class="add-student-list__bottom-action-bar">
+      <LinkTo 
+        @route="authenticated.sessions.details.certification-candidates" 
+        @model={{@session.id}}
+        class="add-student-list__cancel-button button button--link button--grey"
+        type="button">
+        Annuler
+      </LinkTo>
       <PixButton
-        @action={{action this.enrollStudents}}
+        {{on 'click' this.enrollStudents}}
         class="button button--link">Ajouter</PixButton>
     </div>
   {{/if}}

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -6,14 +6,18 @@
         <div class="panel-header__mandatory-warning">Les champs marqués de * sont obligatoires</div>
       {{/if}}
     </div>
-    {{#unless this.isScoSession}}
+    {{#if this.isScoSession}}
+      <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link enrolled-candidate__add-students">
+        Ajouter des candidats
+      </LinkTo>
+    {{else}}
       <div data-test-id="add-certification-candidate-staging__button" class="panel-header__action" {{on 'click' this.addCertificationCandidateInStaging}} >
         <div id="add-candidate" class="certification-candidates-add-button__text">
           Ajouter un candidat
         </div>
         <PixActionButton aria-describedby="add-candidate" @icon='plus'/>
       </div>
-    {{/unless}}
+    {{/if}}
   </div>
   <div class="table content-text content-text--small certification-candidates-table">
     {{#if (or @certificationCandidates this.candidatesInStaging)}}

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -29,7 +29,7 @@
 
   &__bottom-action-bar {
     display: flex;
-    justify-content: center;
+    justify-content: right;
     align-items: center;
     position: fixed;
     width: 100vw;
@@ -41,7 +41,11 @@
 
     .button {
       max-height: 44px;
-      width: 98px;
+      margin-left: 16px;
+    }
+
+    button {
+      margin-right: 35px;
     }
   }
 }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -16,10 +16,10 @@
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @importAllowed={{this.importAllowed}}/>
-<EnrolledCandidates
-        @isUserFromSco={{this.isUserFromSco}}
-        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
-        @sessionId={{this.currentSession.id}}
-        @certificationCandidates={{this.certificationCandidates}}
-        @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
+  <EnrolledCandidates
+          @isUserFromSco={{this.isUserFromSco}}
+          @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+          @sessionId={{this.currentSession.id}}
+          @certificationCandidates={{this.certificationCandidates}}
+          @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
 {{/if}}

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -109,6 +109,23 @@ module('Acceptance | Session Add Students', function(hooks) {
           assert.equal(checkboxChecked.length, 3);
         });
 
+        test('it should be possible to cancel enrolling students', async function(assert) {
+          // given
+          const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
+          const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
+          const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);
+          await click(firstCheckbox);
+          await click(secondCheckbox);
+          await click(thirdCheckbox);
+
+          // when
+          const cancelButtonSelector = '.add-student-list__cancel-button';
+          await click(cancelButtonSelector);
+
+          // then
+          assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
+        });
+
         module('when clicking on "Ajout"', function() {
           test('it redirect to previous page', async function(assert) {
             // given

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -111,12 +111,8 @@ module('Acceptance | Session Add Students', function(hooks) {
 
         test('it should be possible to cancel enrolling students', async function(assert) {
           // given
-          const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
-          const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
-          const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);
-          await click(firstCheckbox);
-          await click(secondCheckbox);
-          await click(thirdCheckbox);
+          const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
+          await click(checkbox);
 
           // when
           const cancelButtonSelector = '.add-student-list__cancel-button';
@@ -129,12 +125,8 @@ module('Acceptance | Session Add Students', function(hooks) {
         module('when clicking on "Ajout"', function() {
           test('it redirect to previous page', async function(assert) {
             // given
-            const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
-            const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
-            const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);
-            await click(firstCheckbox);
-            await click(secondCheckbox);
-            await click(thirdCheckbox);
+            const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
+            await click(checkbox);
 
             // when
             const addButton = document.querySelector('.add-student-list__bottom-action-bar button');

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -89,75 +89,69 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     assert.dom(`.${CERTIFICATION_CANDIDATES_TABLE_SELECTOR} tr:nth-child(3) .${CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR} button`).hasClass(DELETE_BUTTON_SELECTOR);
   });
 
-  [
-    { isSco: true, toggle: true, buttonVisible: false },
-    { isSco: true, toggle: false, buttonVisible: true },
-    { isSco: false, toggle: false, buttonVisible: true },
-    { isSco: false, toggle: true, buttonVisible: true },
-  ].forEach(({ isSco, toggle, buttonVisible }) =>
-    test(`it does ${buttonVisible ? '' : 'not '}display add single candidate button if user ${isSco ? '' : 'not '}sco and if feature toggle is ${toggle}`, async function(assert) {
-      const certificationCandidates = [];
+  module('add student(s) button', () => {
 
-      this.set('certificationCandidates', certificationCandidates);
-      this.set('isUserFromSco', isSco);
-      this.set('isCertifPrescriptionScoEnabled', toggle);
+    [
+      {
+        isSco: true,
+        toggle: true,
+        multipleButtonVisible: true,
+        it: 'it does display button to add multiple candidates if user is sco and feature toggle is on',
+      },
+      {
+        isSco: true,
+        toggle: false,
+        multipleButtonVisible: false,
+        it: 'it does not display button to add multiple candidates if user is sco and feature toggle is off',
+      },
+      {
+        isSco: false,
+        toggle: false,
+        multipleButtonVisible: false,
+        it: 'it does not display button to add multiple candidates if user is not sco and feature toggle is on',
+      },
+      {
+        isSco: false,
+        toggle: true,
+        multipleButtonVisible: false,
+        it: 'it does not display button to add multiple candidates if user is not sco and feature toggle is off',
+      },
+    ].forEach(({ isSco, toggle, multipleButtonVisible, it }) =>
+      test(it, async function(assert) {
+        const certificationCandidates = [];
 
-      await render(hbs`
-      <EnrolledCandidates
-        @sessionId="1"
-        @certificationCandidates={{this.certificationCandidates}}
-        @isUserFromSco={{this.isUserFromSco}}
-        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
-      >
-      </EnrolledCandidates>
-    `);
+        this.set('certificationCandidates', certificationCandidates);
+        this.set('isUserFromSco', isSco);
+        this.set('isCertifPrescriptionScoEnabled', toggle);
 
-      if (buttonVisible) {
-        assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
-      } else {
-        assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
-      }
-    }),
-  );
+        await render(hbs`
+        <EnrolledCandidates
+          @sessionId="1"
+          @certificationCandidates={{this.certificationCandidates}}
+          @isUserFromSco={{this.isUserFromSco}}
+          @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+        >
+        </EnrolledCandidates>
+        `);
 
-  [
-    { isSco: true, toggle: true, buttonVisible: true },
-    { isSco: true, toggle: false, buttonVisible: false },
-    { isSco: false, toggle: false, buttonVisible: false },
-    { isSco: false, toggle: true, buttonVisible: false },
-  ].forEach(({ isSco, toggle, buttonVisible }) =>
-    test(`it does ${buttonVisible ? '' : 'not '}display add multiple candidates button if user ${isSco ? '' : 'not '}sco and if feature toggle is ${toggle}`, async function(assert) {
-      const certificationCandidates = [];
-
-      this.set('certificationCandidates', certificationCandidates);
-      this.set('isUserFromSco', isSco);
-      this.set('isCertifPrescriptionScoEnabled', toggle);
-
-      await render(hbs`
-      <EnrolledCandidates
-        @sessionId="1"
-        @certificationCandidates={{this.certificationCandidates}}
-        @isUserFromSco={{this.isUserFromSco}}
-        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
-      >
-      </EnrolledCandidates>
-    `);
-
-      if (buttonVisible) {
-        assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
-      } else {
-        assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
-      }
-    }),
-  );
+        if (multipleButtonVisible) {
+          assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
+          assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
+        } else {
+          assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
+          assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
+        }
+      }),
+    );
+  });
 
   [
-    { isSco: true, toggle: true, shouldColumnsBeEmpty: true },
-    { isSco: true, toggle: false, shouldColumnsBeEmpty: false },
-    { isSco: false, toggle: false, shouldColumnsBeEmpty: false },
-    { isSco: false, toggle: true, shouldColumnsBeEmpty: false },
-  ].forEach(({ isSco, toggle, shouldColumnsBeEmpty }) =>
-    test(`it ${shouldColumnsBeEmpty ? 'does not' : 'does'} fill externalId and email columnss if user ${isSco ? 'is' : 'is not'} sco and if feature toggle is ${toggle}`, async function(assert) {
+    { isSco: true, toggle: true, shouldColumnsBeEmpty: true, it: 'it hides externalId and email columns if user is sco and feature toggle is on' },
+    { isSco: true, toggle: false, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is sco and feature toggle is off' },
+    { isSco: false, toggle: false, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is not sco and feature toggle is off' },
+    { isSco: false, toggle: true, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is not sco and feature toggle is on' },
+  ].forEach(({ isSco, toggle, shouldColumnsBeEmpty, it }) =>
+    test(it, async function(assert) {
       const candidate = _buildCertificationCandidate({});
       const certificationCandidates = [
         _buildCertificationCandidate({}),

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -12,7 +12,8 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   const CERTIFICATION_CANDIDATES_ACTION_DELETE_SELECTOR = 'certification-candidates-actions';
   const DELETE_BUTTON_SELECTOR = 'certification-candidates-actions__delete-button';
   const DELETE_BUTTON_DISABLED_SELECTOR = `${DELETE_BUTTON_SELECTOR}--disabled`;
-  const ADD_BUTTON_SELECTOR = 'certification-candidates-add-button__text';
+  const ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR = 'certification-candidates-add-button__text';
+  const ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR = 'enrolled-candidate__add-students';
   const EXTERNAL_ID_COLUMN_SELECTOR = 'panel-candidate__externalId__';
   const RESULT_RECIPIENT_EMAIL_COLUMN_SELECTOR = 'panel-candidate__result-recipient-email__';
   const BIRTHDATE_COLUMN_SELECTOR = 'panel-candidate__birthdate__';
@@ -94,7 +95,7 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     { isSco: false, toggle: false, buttonVisible: true },
     { isSco: false, toggle: true, buttonVisible: true },
   ].forEach(({ isSco, toggle, buttonVisible }) =>
-    test(`it does ${buttonVisible ? '' : 'not '}display candidates add button if user ${isSco ? '' : 'not '}sco and if feature toggle is ${toggle}`, async function(assert) {
+    test(`it does ${buttonVisible ? '' : 'not '}display add single candidate button if user ${isSco ? '' : 'not '}sco and if feature toggle is ${toggle}`, async function(assert) {
       const certificationCandidates = [];
 
       this.set('certificationCandidates', certificationCandidates);
@@ -112,9 +113,40 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     `);
 
       if (buttonVisible) {
-        assert.dom(`.${ADD_BUTTON_SELECTOR}`).isVisible();
+        assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
       } else {
-        assert.dom(`.${ADD_BUTTON_SELECTOR}`).isNotVisible();
+        assert.dom(`.${ADD_SINGLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
+      }
+    }),
+  );
+
+  [
+    { isSco: true, toggle: true, buttonVisible: true },
+    { isSco: true, toggle: false, buttonVisible: false },
+    { isSco: false, toggle: false, buttonVisible: false },
+    { isSco: false, toggle: true, buttonVisible: false },
+  ].forEach(({ isSco, toggle, buttonVisible }) =>
+    test(`it does ${buttonVisible ? '' : 'not '}display add multiple candidates button if user ${isSco ? '' : 'not '}sco and if feature toggle is ${toggle}`, async function(assert) {
+      const certificationCandidates = [];
+
+      this.set('certificationCandidates', certificationCandidates);
+      this.set('isUserFromSco', isSco);
+      this.set('isCertifPrescriptionScoEnabled', toggle);
+
+      await render(hbs`
+      <EnrolledCandidates
+        @sessionId="1"
+        @certificationCandidates={{this.certificationCandidates}}
+        @isUserFromSco={{this.isUserFromSco}}
+        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+      >
+      </EnrolledCandidates>
+    `);
+
+      if (buttonVisible) {
+        assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isVisible();
+      } else {
+        assert.dom(`.${ADD_MULTIPLE_CANDIDATE_BUTTON_SELECTOR}`).isNotVisible();
       }
     }),
   );


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il est possible pour un utilisateur venant du SCO d'ajouter des élèves à une session de certification si la session ne comporte pas déjà d'élève.
Une fois les premiers élèves rajouté, il n'est pas possible de rajouter à nouveau des élèves à cette session de certification.

## :robot: Solution
Permettre l'ajout d'étudiant à une session de certification SCO même lorsqu'on a déjà des candidats pour cette session.

## :rainbow: Remarques
Cette FEATURE est découpée en 2 partie.
Cette PR est la première partie, voir la partie `Pour tester` pour voir ce qu'elle contient.

## :100: Pour tester
- Se connecter dans Pix Certif avec un compte SCO 
- Aller dans l'onglet "Candidats" d'une session
- Ajouter des candidats si la session n'en comporte pas déjà
- Constater qu'un bouton "Ajouter des candidats" s'affiche dans le tableau listant les candidats de la session
![image](https://user-images.githubusercontent.com/38167520/97731628-ae538f00-1ad5-11eb-860a-c72b8eddbc3a.png)

- Cliquer dessus permet d'ajouter de nouveau des élèves.
- Constater qu'à la sélection d'au moins un élève, il y a un bouton "Annuler" dans la barre d'action en bas d'écran.
![image](https://user-images.githubusercontent.com/38167520/97731696-c1fef580-1ad5-11eb-80a2-4b23c2d4f6b3.png)


