### PR TITLE
[BUGFIX] Empêcher le job e2e de la CI de crasher par manque de mémoire (PIX-1551)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,8 @@ jobs:
           background: true
           command: npm start
 
+      - run: wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
+
       - run:
           working_directory: ~/pix/mon-pix
           environment:
@@ -276,12 +278,15 @@ jobs:
           background: true
           command: npm start
 
+      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4200
+
       - run:
           working_directory: ~/pix/orga
           environment:
             JOBS: 2
           background: true
           command: npm start
+      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4201
 
       - run:
           working_directory: ~/pix/certif
@@ -289,12 +294,9 @@ jobs:
             JOBS: 1
           background: true
           command: npm start
+      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4203
 
       - run:
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
-          command: |
-            wget --retry-connrefused -T 60 -qO- http://localhost:4200
-            wget --retry-connrefused -T 60 -qO- http://localhost:4201
-            wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
-            npm run cy:run:ci
+          command: npm run cy:run:ci


### PR DESCRIPTION
## :unicorn: Problème
La vision d'horreur de ces derniers jours :
![vision_horreur](https://user-images.githubusercontent.com/48727874/97851245-6743e480-1cf5-11eb-9761-b7a0c5846707.png)
et plus spécifiquement, aucune erreur "apparente" :
![crash-mem](https://user-images.githubusercontent.com/48727874/97851409-a2deae80-1cf5-11eb-9c05-c49361a13cad.png)
En fait, quand on regarde attentivement, on voit la mention d'une erreur 137...
https://support.circleci.com/hc/en-us/articles/115014359648-Exit-code-137-Out-of-memory

Ma théorie c'est que les lancements simultanés des applis testées en end-to-end, à savoir **api**, **orga**, **mon-pix** et **certif** provoquent ce dépassement mémoire.

## :robot: Solution
La solution présentée ici peut provoquer une petite rallonge de temps d'exécution de la CI, mais ça va éviter de la crasher en permanence.
Il s'agit simplement de lancer **séquentiellement** les applis.

## :rainbow: Remarques
Je pense qu'on aurait pu aussi s'en sortir en augmentant la taille du container docker vers un 8GB de RAM, mais c'est plus cher (après c'est acceptable je pense, il faut en discuter).

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
