### PR TITLE
[FEATURE] Mise en place du socle permettant le refacto des méthodes de connexion (PIX-1168).

### DIFF
--- a/api/db/migrations/20201028134814_create_table_authentication_methods.js
+++ b/api/db/migrations/20201028134814_create_table_authentication_methods.js
@@ -1,0 +1,22 @@
+const TABLE_NAME = 'authentication-methods';
+
+exports.up = async (knex) => {
+  await knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('id').primary();
+    t.integer('userId').references('users.id').index();
+    t.string('identityProvider').notNullable();
+    t.jsonb('authenticationComplement');
+    t.string('externalIdentifier');
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+    t.dateTime('updatedAt').notNullable().defaultTo(knex.fn.now());
+
+    t.unique(['identityProvider', 'externalIdentifier']);
+    t.unique(['identityProvider', 'userId']);
+  });
+
+  return knex.raw('ALTER TABLE "authentication-methods" ADD CONSTRAINT "authentication_methods_identityProvider_check" CHECK ( "identityProvider" IN (\'PIX\', \'GAR\', \'POLE_EMPLOI\') )');
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -1,0 +1,71 @@
+const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const { validateEntity } = require('../validators/entity-validator');
+
+const identityProviders = {
+  PIX : 'PIX',
+  GAR: 'GAR',
+  POLE_EMPLOI: 'POLE_EMPLOI',
+};
+
+class PasswordAuthenticationMethod {
+
+  constructor({
+    password,
+    shouldChangePassword,
+  } = {}) {
+    this.password = password;
+    this.shouldChangePassword = shouldChangePassword;
+
+    validateEntity(Joi.object({
+      password: Joi.string().required(),
+      shouldChangePassword: Joi.boolean().required(),
+    }), this);
+  }
+}
+
+const validationSchema = Joi.object({
+  id: Joi.number().optional(),
+  identityProvider: Joi.string().valid(...Object.values(identityProviders)).required(),
+  authenticationComplement: Joi.when('identityProvider', { is: identityProviders.PIX, then: Joi.object().instance(PasswordAuthenticationMethod).required(), otherwise: Joi.any().forbidden() }),
+  externalIdentifier: Joi.when('identityProvider', [
+    { is: identityProviders.GAR, then: Joi.string().required() },
+    { is: identityProviders.POLE_EMPLOI, then: Joi.string().required() },
+    { is: identityProviders.PIX, then: Joi.any().forbidden() },
+  ]),
+  userId: Joi.number().integer().required(),
+  createdAt: Joi.date().optional(),
+  updatedAt: Joi.date().optional(),
+});
+
+class AuthenticationMethod {
+
+  constructor({
+    id,
+    // attributes
+    identityProvider,
+    authenticationComplement,
+    externalIdentifier,
+    createdAt,
+    updatedAt,
+    // includes
+    // references
+    userId,
+  } = {}) {
+    this.id = id;
+    // attributes
+    this.identityProvider = identityProvider;
+    this.authenticationComplement = authenticationComplement;
+    this.externalIdentifier = externalIdentifier;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    // includes
+    // references
+    this.userId = userId;
+
+    validateEntity(validationSchema, this);
+  }
+}
+
+AuthenticationMethod.identityProviders = identityProviders;
+AuthenticationMethod.PasswordAuthenticationMethod = PasswordAuthenticationMethod;
+module.exports = AuthenticationMethod;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -1,6 +1,7 @@
 const dependencies = {
   answerRepository: require('../../infrastructure/repositories/answer-repository'),
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
+  authenticationMethodRepository: require('../../infrastructure/repositories/authentication-method-repository'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
   badgeCriteriaService: require('../../domain/services/badge-criteria-service'),

--- a/api/lib/infrastructure/data/authentication-method.js
+++ b/api/lib/infrastructure/data/authentication-method.js
@@ -1,0 +1,22 @@
+const Bookshelf = require('../bookshelf');
+// eslint-disable-next-line no-unused-vars
+const jsonColumns = require('bookshelf-json-columns');
+
+require('./user');
+
+const modelName = 'AuthenticationMethod';
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'authentication-methods',
+  hasTimestamps: ['createdAt', 'updatedAt'],
+  requireFetch: false,
+
+  user() {
+    return this.belongsTo('User');
+  },
+
+}, {
+  modelName,
+  jsonColumns: ['authenticationComplement'],
+});

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -1,0 +1,32 @@
+const BookshelfAuthenticationMethod = require('../../infrastructure/data/authentication-method');
+const bookshelfUtils = require('../utils/knex-utils');
+const AuthenticationMethod = require('../../domain/models/AuthenticationMethod');
+const DomainTransaction = require('../DomainTransaction');
+const { AlreadyExistingEntity } = require('../../domain/errors');
+
+function _toDomainEntity(bookshelfAuthenticationMethod) {
+  const attributes = bookshelfAuthenticationMethod.toJSON();
+  return new AuthenticationMethod({
+    id: attributes.id,
+    userId: attributes.userId,
+    identityProvider: attributes.identityProvider,
+    authenticationComplement: attributes.identityProvider === AuthenticationMethod.identityProviders.PIX ? new AuthenticationMethod.PasswordAuthenticationMethod(attributes.authenticationComplement) : undefined,
+    externalIdentifier: (attributes.identityProvider === AuthenticationMethod.identityProviders.GAR || attributes.identityProvider === AuthenticationMethod.identityProviders.POLE_EMPLOI) ? attributes.externalIdentifier : undefined,
+    createdAt: attributes.createdAt,
+    updatedAt: attributes.updatedAt,
+  });
+}
+module.exports = {
+
+  async create({ authenticationMethod, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    try {
+      const bookshelfAuthenticationMethod = await new BookshelfAuthenticationMethod(authenticationMethod)
+        .save(null, { transacting: domainTransaction.knexTransaction });
+      return _toDomainEntity(bookshelfAuthenticationMethod);
+    } catch (err) {
+      if (bookshelfUtils.isUniqConstraintViolated(err)) {
+        throw new AlreadyExistingEntity(`A snapshot already exists for the user ${authenticationMethod.userId} and the externalIdentifier ${authenticationMethod.externalIdentifier}.`);
+      }
+    }
+  },
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1554,6 +1554,11 @@
         "lodash": "^4.17.15"
       }
     },
+    "bookshelf-json-columns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bookshelf-json-columns/-/bookshelf-json-columns-3.0.0.tgz",
+      "integrity": "sha512-oLJ4P7DxgrERLjxCfQQxTa5KJ8CREr9aRXc7ejtomkl+DZvr5JD0OxQnvoGNA0/BBSEli5tbYtBVA5mSwjTYGw=="
+    },
     "bookshelf-validate": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/bookshelf-validate/-/bookshelf-validate-2.0.3.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -32,6 +32,7 @@
     "blipp": "^4.0.1",
     "bluebird": "^3.7.2",
     "bookshelf": "^1.2.0",
+    "bookshelf-json-columns": "^3.0.0",
     "bookshelf-validate": "^2.0.3",
     "boom": "^7.3.0",
     "bunyan": "^1.8.12",

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -1,0 +1,97 @@
+const { expect, databaseBuilder, knex, catchErr, domainBuilder } = require('../../../test-helper');
+const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const { AlreadyExistingEntity } = require('../../../../lib/domain/errors');
+
+describe('Integration | Repository | AuthenticationMethod', () => {
+
+  describe('#create', () => {
+
+    afterEach(() => {
+      return knex('authentication-methods').delete();
+    });
+
+    context('When creating a AuthenticationMethod containing an authentication complement', () => {
+
+      it('should return an AuthenticationMethod', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildPasswordAuthenticationMethod({
+          password: 'Password123',
+          shouldChangePassword: false,
+          userId,
+        });
+
+        // when
+        const savedAuthenticationMethod = await authenticationMethodRepository.create({ authenticationMethod });
+
+        expect(savedAuthenticationMethod).to.be.instanceOf(AuthenticationMethod);
+      });
+    });
+
+    context('When creating a AuthenticationMethod containing an external identifier', () => {
+
+      it('should return an AuthenticationMethod', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        await databaseBuilder.commit();
+
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod({
+          identityProvider: AuthenticationMethod.identityProviders.GAR,
+          externalIdentifier: 'externalIdentifier',
+          userId,
+        });
+
+        // when
+        const savedAuthenticationMethod = await authenticationMethodRepository.create({ authenticationMethod });
+
+        // then
+        expect(savedAuthenticationMethod).to.be.instanceOf(AuthenticationMethod);
+      });
+    });
+
+    context('When an AuthenticationMethod already exist for an identityProvider and an externalIdentifier', () => {
+
+      it('should throw an AlreadyExistingEntity', async () => {
+        // given
+        const identityProvider = AuthenticationMethod.identityProviders.GAR;
+        const externalIdentifier = 'alreadyExistingExternalIdentifier';
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildAuthenticationMethod({
+          identityProvider,
+          externalIdentifier,
+          userId: databaseBuilder.factory.buildUser().id,
+        });
+        await databaseBuilder.commit();
+
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod({ identityProvider, externalIdentifier, userId });
+
+        // when
+        const error = await catchErr(authenticationMethodRepository.create)({ authenticationMethod });
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntity);
+      });
+    });
+
+    context('When an AuthenticationMethod already exist for an identityProvider and a userId', () => {
+
+      it('should throw an AlreadyExistingEntity', async () => {
+        // given
+        const identityProvider = AuthenticationMethod.identityProviders.GAR;
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildAuthenticationMethod({ identityProvider, externalIdentifier: 'externalIdentifier1', userId });
+        await databaseBuilder.commit();
+
+        const authenticationMethod = domainBuilder.buildAuthenticationMethod({ identityProvider, externalIdentifier: 'externalIdentifier2', userId });
+
+        // when
+        const error = await catchErr(authenticationMethodRepository.create)({ authenticationMethod });
+
+        // then
+        expect(error).to.be.instanceOf(AlreadyExistingEntity);
+      });
+    });
+  });
+});

--- a/api/tests/tooling/database-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/database-builder/factory/build-authentication-method.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-sync */
+const databaseBuffer = require('../database-buffer');
+const buildUser = require('./build-user');
+const encrypt = require('../../../../lib/domain/services/encryption-service');
+const isUndefined = require('lodash/isUndefined');
+const faker = require('faker');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+
+const buildAuthenticationMethod = function({
+  id,
+  identityProvider = AuthenticationMethod.identityProviders.GAR,
+  externalIdentifier = faker.random.word(),
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  const values = {
+    id,
+    identityProvider,
+    externalIdentifier,
+    authenticationComplement: undefined,
+    userId,
+    createdAt,
+    updatedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'authentication-methods',
+    values,
+  });
+};
+
+buildAuthenticationMethod.buildPasswordAuthenticationMethod = function({
+  id,
+  password,
+  shouldChangePassword = false,
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  password = isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  const values = {
+    id,
+    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    authenticationComplement: new AuthenticationMethod.PasswordAuthenticationMethod({ password, shouldChangePassword }),
+    externalIdentifier: undefined,
+    userId,
+    createdAt,
+    updatedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'authentication-methods',
+    values,
+  });
+};
+
+module.exports = buildAuthenticationMethod;

--- a/api/tests/tooling/database-builder/factory/index.js
+++ b/api/tests/tooling/database-builder/factory/index.js
@@ -4,6 +4,7 @@ module.exports = {
   buildAssessment: require('./build-assessment'),
   buildAssessmentFromParticipation: require('./build-assessment-from-participation'),
   buildAssessmentResult: require('./build-assessment-result'),
+  buildAuthenticationMethod: require('./build-authentication-method'),
   buildBadge: require('./build-badge'),
   buildBadgeAcquisition: require('./build-badge-acquisition'),
   buildBadgeCriterion: require('./build-badge-criterion'),

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -1,0 +1,53 @@
+/* eslint-disable no-sync */
+const buildUser = require('./build-user');
+const encrypt = require('../../../../lib/domain/services/encryption-service');
+const isUndefined = require('lodash/isUndefined');
+const faker = require('faker');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+
+const buildAuthenticationMethod = function({
+  id,
+  identityProvider = AuthenticationMethod.identityProviders.GAR,
+  externalIdentifier = faker.random.uuid(),
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  return new AuthenticationMethod({
+    id,
+    identityProvider,
+    externalIdentifier,
+    authenticationComplement: undefined,
+    userId,
+    createdAt,
+    updatedAt,
+  });
+};
+
+buildAuthenticationMethod.buildPasswordAuthenticationMethod = function({
+  id,
+  password,
+  shouldChangePassword = false,
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  password = isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  return new AuthenticationMethod({
+    id,
+    identityProvider: AuthenticationMethod.identityProviders.PIX,
+    authenticationComplement: new AuthenticationMethod.PasswordAuthenticationMethod({ password, shouldChangePassword }),
+    externalIdentifier: undefined,
+    userId,
+    createdAt,
+    updatedAt,
+  });
+};
+
+module.exports = buildAuthenticationMethod;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -4,6 +4,7 @@ module.exports = {
   buildAreaAirtableDataObject: require('./build-area-airtable-data-object'),
   buildAssessment: require('./build-assessment'),
   buildAssessmentResult: require('./build-assessment-result'),
+  buildAuthenticationMethod: require('./build-authentication-method'),
   buildBadge: require('./build-badge'),
   buildBadgeAcquisition: require('./build-badge-acquisition'),
   buildBadgeCriterion: require('./build-badge-criterion'),

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -1,0 +1,83 @@
+const { expect } = require('../../../test-helper');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+const { ObjectValidationError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Models | AuthenticationMethod', () => {
+
+  describe('constructor', () => {
+
+    it('should successfully instantiate object when identityProvider is GAR and externalIdentifier is defined', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: 'externalIdentifier', userId: 1 }))
+        .not.to.throw(ObjectValidationError);
+    });
+
+    it('should successfully instantiate object when identityProvider is POLE_EMPLOI and externalIdentifier is defined', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI, externalIdentifier: 'externalIdentifier', userId: 1 }))
+        .not.to.throw(ObjectValidationError);
+    });
+
+    it('should throw an ObjectValidationError when identityProvider is not valid', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: 'not_valid', externalIdentifier: 'externalIdentifier', userId: 1 }))
+        .to.throw(ObjectValidationError);
+      expect(() => new AuthenticationMethod({ identityProvider: undefined, externalIdentifier: 'externalIdentifier', userId: 1 }))
+        .to.throw(ObjectValidationError);
+    });
+
+    it('should throw an ObjectValidationError when externalIdentifier is not defined for identityProvider GAR or POLE_EMPLOI', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: undefined, userId: 1 }))
+        .to.throw(ObjectValidationError);
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI, externalIdentifier: undefined, userId: 1 }))
+        .to.throw(ObjectValidationError);
+    });
+
+    it('should throw an ObjectValidationError when authenticationComplement is not defined for identityProvider PIX', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.PIX, authenticationComplement: undefined, userId: 1 }))
+        .to.throw(ObjectValidationError);
+    });
+
+    it('should throw an ObjectValidationError when userId is not valid', () => {
+      // when
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: 'externalIdentifier', userId: 'not_valid' }))
+        .to.throw(ObjectValidationError);
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: 'externalIdentifier', userId: undefined }))
+        .to.throw(ObjectValidationError);
+    });
+
+    context('PasswordAuthenticationMethod', () => {
+
+      let validArguments;
+      beforeEach(() => {
+        validArguments = {
+          password: 'Password123',
+          shouldChangePassword: false,
+        };
+      });
+
+      it('should successfully instantiate object when passing all valid arguments', () => {
+        // when
+        expect(() => new AuthenticationMethod.PasswordAuthenticationMethod(validArguments)).not.to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when password is not valid', () => {
+        // when
+        expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, password: 1234 }))
+          .to.throw(ObjectValidationError);
+        expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, password: undefined }))
+          .to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when shouldChangePassword is not valid', () => {
+        // when
+        expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, shouldChangePassword: 'not_valid' }))
+          .to.throw(ObjectValidationError);
+        expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, shouldChangePassword: undefined }))
+          .to.throw(ObjectValidationError);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les différentes méthodes permettant à un utilisateur de se connecter à Pix grossissent: mot de passe, depuis un ENT via le GAR, via un compte pôle emploi. Actuellement, pour déterminer les accès possibles d'un utilisateur, nous ajoutons des colonnes dans la table `users`. Cependant, cette façon de faire commence à devenir problématique et le sera d'autant plus à mesure que nous allons nous interfacer avec d'autres partenaires.   

## :robot: Solution
Création d'une table `authentication-methods` dont la colonne portant l'information de connexion sera au format JSONB afin de permettre une gestion plus souple des spécificités de ces différentes méthodes de connexion.

## :rainbow: Remarques
- Le langage Javascript étant faiblement typé, j'ai pris le parti d'ajouter une validation JOI lors de l'instanciation de l'objet `AuthenticationMethod` afin de:
    - Vérifier la cohérence entre la valeur de l'attribut `externalIdentifier` et celui de l'attribut `authenticationComplement`.
   - Garantir le format de l'objet contenu dans l'attribut `authenticationComplement` afin de ne pas insérer n'importe quoi en base.
- Le plugin Bookshlef `bookshelf-json-columns``a été ajouté afin de faciliter l'utilisation d'une colonne de type JSONB.
- Un test de création a été créé afin de valider la possibilité d'insérer du JSON dans une colonne JSONB.
- Un paramètre `domainTransation` a été ajouté à la méthode de repository `authenticationMéthodRepository.create()` dans le but de rendre transactionnel la création d'un utilisateur et la création de sa méthode de connexion. Un exemple d'utilisation de l'objet `DomainTransation` depuis un usecase peut être trouvé dans le usecase `importHigherSchoolingRegistration`.