### PR TITLE
[FEATURE] Ajouter à nouveau des étudiants pour une session de certification - PART 2 (PIX-1378)

### DIFF
--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -32,6 +32,7 @@ const certificationCandidateParticipationJoiSchema = Joi.object({
   extraTimePercentage: Joi.any().allow(null).optional(),
   sessionId: Joi.number().required(),
   userId: Joi.any().allow(null).optional(),
+  schoolingRegistrationId: Joi.any().allow(null).optional(),
 });
 
 class CertificationCandidate {
@@ -54,6 +55,7 @@ class CertificationCandidate {
       // references
       sessionId,
       userId,
+      schoolingRegistrationId = null,
     } = {}) {
     this.id = id;
     // attributes
@@ -71,6 +73,7 @@ class CertificationCandidate {
     // references
     this.sessionId = sessionId;
     this.userId = userId;
+    this.schoolingRegistrationId = schoolingRegistrationId;
   }
 
   validate(version = '1.3') {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-candidate-serializer.js
@@ -25,6 +25,7 @@ module.exports = {
         'externalId',
         'extraTimePercentage',
         'isLinked',
+        'schoolingRegistrationId',
       ],
     }).serialize(certificationCandidates);
   },

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -131,6 +131,7 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
                 'external-id': null,
                 'extra-time-percentage': null,
                 'result-recipient-email': null,
+                'schooling-registration-id': student.id,
               },
               'id': sinon.match.string,
               'type': 'certification-candidates',

--- a/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-certification-candidates_test.js
@@ -63,6 +63,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
           'external-id': certificationCandidateA.externalId,
           'extra-time-percentage': certificationCandidateA.extraTimePercentage,
           'is-linked': true,
+          'schooling-registration-id': null,
         };
         expectedCertificationCandidateBAttributes = {
           'first-name': certificationCandidateB.firstName,
@@ -76,6 +77,7 @@ describe('Acceptance | Controller | session-controller-get-certification-candida
           'external-id': certificationCandidateB.externalId,
           'extra-time-percentage': certificationCandidateB.extraTimePercentage,
           'is-linked': true,
+          'schooling-registration-id': null,
         };
         userId = databaseBuilder.factory.buildUser().id;
         databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });

--- a/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
+++ b/api/tests/acceptance/application/session/session-controller-post-certification-candidates_test.js
@@ -85,6 +85,7 @@ describe('Acceptance | Controller | session-controller-post-certification-candid
           'external-id': certificationCandidate.externalId,
           'extra-time-percentage': certificationCandidate.extraTimePercentage,
           'is-linked': false,
+          'schooling-registration-id': null,
         },
       };
 

--- a/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-candidate-repository_test.js
@@ -36,6 +36,7 @@ describe('Integration | Repository | CertificationCandidate', function() {
           externalId: 'ABCDEF123',
           birthdate: '1990-07-12',
           extraTimePercentage: '0.05',
+          schoolingRegistrationId: null,
         });
 
         delete certificationCandidate.id;

--- a/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-candidate.js
@@ -23,6 +23,7 @@ module.exports = function buildCertificationCandidate(
     // references
     sessionId = faker.random.number(),
     userId = faker.random.number(),
+    schoolingRegistrationId,
   } = {}) {
 
   const certificationCandidate = new CertificationCandidate({
@@ -42,6 +43,7 @@ module.exports = function buildCertificationCandidate(
     hasSeendEndTestScreen,
     createdAt,
     userId,
+    schoolingRegistrationId,
   });
 
   return certificationCandidate;

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-candidate-serializer_test.js
@@ -6,39 +6,43 @@ const _ = require('lodash');
 describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', function() {
 
   let certificationCandidate;
-  let jsonApiData;
 
   beforeEach(() => {
-    certificationCandidate = domainBuilder.buildCertificationCandidate();
-    jsonApiData = {
-      data: {
-        type: 'certification-candidates',
-        id: certificationCandidate.id.toString(),
-        attributes: {
-          'first-name': certificationCandidate.firstName,
-          'last-name': certificationCandidate.lastName,
-          'birth-city': certificationCandidate.birthCity,
-          'birth-province-code': certificationCandidate.birthProvinceCode,
-          'birth-country': certificationCandidate.birthCountry,
-          'email': certificationCandidate.email,
-          'result-recipient-email': certificationCandidate.resultRecipientEmail,
-          'birthdate': certificationCandidate.birthdate,
-          'external-id': certificationCandidate.externalId,
-          'extra-time-percentage': certificationCandidate.extraTimePercentage,
-          'is-linked': !_.isNil(certificationCandidate.userId),
-        },
-      },
-    };
+    certificationCandidate = domainBuilder.buildCertificationCandidate({
+      schoolingRegistrationId: 1,
+    });
   });
 
   describe('#serialize()', () => {
 
     it('should convert a CertificationCandidate model object into JSON API data', function() {
+      // given
+      const expectedJsonApiData = {
+        data: {
+          type: 'certification-candidates',
+          id: certificationCandidate.id.toString(),
+          attributes: {
+            'first-name': certificationCandidate.firstName,
+            'last-name': certificationCandidate.lastName,
+            'birth-city': certificationCandidate.birthCity,
+            'birth-province-code': certificationCandidate.birthProvinceCode,
+            'birth-country': certificationCandidate.birthCountry,
+            'email': certificationCandidate.email,
+            'result-recipient-email': certificationCandidate.resultRecipientEmail,
+            'birthdate': certificationCandidate.birthdate,
+            'external-id': certificationCandidate.externalId,
+            'extra-time-percentage': certificationCandidate.extraTimePercentage,
+            'is-linked': !_.isNil(certificationCandidate.userId),
+            'schooling-registration-id': certificationCandidate.schoolingRegistrationId,
+          },
+        },
+      };
+
       // when
       const jsonApi = serializer.serialize(certificationCandidate);
 
       // then
-      expect(jsonApi).to.deep.equal(jsonApiData);
+      expect(jsonApi).to.deep.equal(expectedJsonApiData);
     });
 
   });
@@ -46,6 +50,28 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
   describe('#deserialize()', () => {
 
     it('should convert JSON API data into a CertificationCandidate model object', async function() {
+      // given
+      const jsonApiData = {
+        data: {
+          type: 'certification-candidates',
+          id: certificationCandidate.id.toString(),
+          attributes: {
+            'first-name': certificationCandidate.firstName,
+            'last-name': certificationCandidate.lastName,
+            'birth-city': certificationCandidate.birthCity,
+            'birth-province-code': certificationCandidate.birthProvinceCode,
+            'birth-country': certificationCandidate.birthCountry,
+            'email': certificationCandidate.email,
+            'result-recipient-email': certificationCandidate.resultRecipientEmail,
+            'birthdate': certificationCandidate.birthdate,
+            'external-id': certificationCandidate.externalId,
+            'extra-time-percentage': certificationCandidate.extraTimePercentage,
+            'is-linked': !_.isNil(certificationCandidate.userId),
+            'schooling-registration-id': certificationCandidate.schoolingRegistrationId,
+          },
+        },
+      };
+
       // when
       const deserializedCertificationCandidate = await serializer.deserialize(jsonApiData);
 
@@ -61,6 +87,7 @@ describe('Unit | Serializer | JSONAPI | certification-candidate-serializer', fun
       expect(deserializedCertificationCandidate.externalId).to.equal(certificationCandidate.externalId);
       expect(deserializedCertificationCandidate.email).to.equal(certificationCandidate.email);
       expect(deserializedCertificationCandidate.resultRecipientEmail).to.equal(certificationCandidate.resultRecipientEmail);
+      expect(deserializedCertificationCandidate.schoolingRegistrationId).to.equal(certificationCandidate.schoolingRegistrationId);
     });
 
   });

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -53,9 +53,10 @@
           type="button">
           Annuler
         </LinkTo>
-        <PixButton
-          {{on 'click' this.enrollStudents}}
-          class="bottom-action-bar__actions--add-button button button--link">Ajouter</PixButton>
+        <PixButton {{on 'click' this.enrollStudents}}
+          class="bottom-action-bar__actions--add-button button button--link {{if this.hasCheckedSomething "" "button--disabled"}}">
+          Ajouter
+        </PixButton>
       </div>
 
     </div>

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -36,16 +36,28 @@
 
   {{#if this.hasCheckedSomething}}
     <div class="add-student-list__bottom-action-bar">
-      <LinkTo 
-        @route="authenticated.sessions.details.certification-candidates" 
-        @model={{@session.id}}
-        class="add-student-list__cancel-button button button--link button--grey"
-        type="button">
-        Annuler
-      </LinkTo>
-      <PixButton
-        {{on 'click' this.enrollStudents}}
-        class="button button--link">Ajouter</PixButton>
+
+      <div class="bottom-action-bar__informations">
+        <p class="bottom-action-bar__informations--candidates-selected">Aucun élève sélectionnés</p>
+        <span class="bottom-action-bar__seperator"></span>
+        <p class="bottom-action-bar__informations--candidates-already-added">
+          {{this.numberOfStudentsAlreadyCandidate}} candidats déjà ajoutés à la session
+        </p>
+      </div>
+
+      <div class="bottom-action-bar__actions">
+        <LinkTo
+          @route="authenticated.sessions.details.certification-candidates"
+          @model={{@session.id}}
+          class="bottom-action-bar__actions--cancel-button button button--link button--grey"
+          type="button">
+          Annuler
+        </LinkTo>
+        <PixButton
+          {{on 'click' this.enrollStudents}}
+          class="bottom-action-bar__actions--add-button button button--link">Ajouter</PixButton>
+      </div>
+
     </div>
   {{/if}}
 </div>

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -34,14 +34,14 @@
     </tbody>
   </table>
 
-  {{#if this.hasCheckedSomething}}
+  {{#if this.showStickyBar}}
     <div class="add-student-list__bottom-action-bar">
 
       <div class="bottom-action-bar__informations">
-        <p class="bottom-action-bar__informations--candidates-selected">Aucun élève sélectionnés</p>
+        <p class="bottom-action-bar__informations--candidates-selected">{{this.studentsSelectedInformation}}</p>
         <span class="bottom-action-bar__seperator"></span>
         <p class="bottom-action-bar__informations--candidates-already-added">
-          {{this.numberOfStudentsAlreadyCandidate}} candidats déjà ajoutés à la session
+          {{this.numberOfStudentsAlreadyCandidate}} candidat(s) déjà ajouté(s) à la session
         </p>
       </div>
 

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -38,7 +38,13 @@
     <div class="add-student-list__bottom-action-bar">
 
       <div class="bottom-action-bar__informations">
-        <p class="bottom-action-bar__informations--candidates-selected">{{this.studentsSelectedInformation}}</p>
+        <p class="bottom-action-bar__informations--candidates-selected">
+          {{#if this.numberOfStudentsSelected}}
+            {{this.numberOfStudentsSelected}} candidat(s) sélectionné(s)
+          {{else}}
+            Aucun candidat sélectionné
+          {{/if}}
+        </p>
         <span class="bottom-action-bar__seperator"></span>
         <p class="bottom-action-bar__informations--candidates-already-added">
           {{this.numberOfStudentsAlreadyCandidate}} candidat(s) déjà ajouté(s) à la session

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -26,6 +26,19 @@ export default class AddStudentList extends Component {
     return this.args.certificationCandidates ? this.args.certificationCandidates.length : 0;
   }
 
+  get showStickyBar() {
+    const thereIsAlreadySomeCandidates = this.numberOfStudentsAlreadyCandidate > 0;
+    return this.hasCheckedSomething || thereIsAlreadySomeCandidates;
+  }
+
+  get studentsSelectedInformation() {
+    const countStudents = (count, student) => student.isSelected ? count + 1 : count;
+    const numberOfStudentsSelected = this.args.studentList.reduce(countStudents, 0);
+    return numberOfStudentsSelected > 0
+      ? `${numberOfStudentsSelected} candidat(s) sélectionné(s)`
+      : 'Aucun candidat sélectionné';
+  }
+
   @action
   toggleItem(item) {
     item.isSelected = !item.isSelected;

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -22,6 +22,10 @@ export default class AddStudentList extends Component {
     return allCertifReportsAreCheck;
   }
 
+  get numberOfStudentsAlreadyCandidate() {
+    return this.args.certificationCandidates ? this.args.certificationCandidates.length : 0;
+  }
+
   @action
   toggleItem(item) {
     item.isSelected = !item.isSelected;

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -31,12 +31,9 @@ export default class AddStudentList extends Component {
     return this.hasCheckedSomething || thereIsAlreadySomeCandidates;
   }
 
-  get studentsSelectedInformation() {
-    const countStudents = (count, student) => student.isSelected ? count + 1 : count;
-    const numberOfStudentsSelected = this.args.studentList.reduce(countStudents, 0);
-    return numberOfStudentsSelected > 0
-      ? `${numberOfStudentsSelected} candidat(s) sélectionné(s)`
-      : 'Aucun candidat sélectionné';
+  get numberOfStudentsSelected() {
+    const selectedStudents = this.args.studentList.filter((student) => student.isSelected);
+    return selectedStudents.length;
   }
 
   @action

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -7,7 +7,10 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     const students = await this.store.findAll('student',
       { adapterOptions : { certificationCenterId } },
     );
-    return { session, students };
+    const certificationCandidates = await this.store.query('certification-candidate', {
+      sessionId: params.session_id,
+    });
+    return { session, students, certificationCandidates };
   }
 
   setupController(controller, model) {

--- a/certif/app/styles/components/add-student-list.scss
+++ b/certif/app/styles/components/add-student-list.scss
@@ -29,7 +29,7 @@
 
   &__bottom-action-bar {
     display: flex;
-    justify-content: right;
+    justify-content: space-between;
     align-items: center;
     position: fixed;
     width: 100vw;
@@ -38,14 +38,40 @@
     bottom: 0;
     box-shadow: -2px 2px 9px 0 rgba(0, 0, 0, 0.22);
     background-color: $white;
+    color: $blue-zodia;
+    font-family: $roboto;
 
-    .button {
-      max-height: 44px;
-      margin-left: 16px;
+    .bottom-action-bar__informations {
+      margin-left: calc(250px + 35px);
+      display: flex;
+      align-items: baseline;
+
+      &--candidates-selected {
+        font-size: 1.125rem;
+      }
+      &--candidates-already-added {
+        font-size: 0.875rem;
+      }
+
+      .bottom-action-bar__seperator {
+        margin: 0 16px;
+        align-self: center;
+        background: $grey-25;
+        height: 30px;
+        width: 1px;
+      }
     }
 
-    button {
-      margin-right: 35px;
+    .bottom-action-bar__actions {
+      .button {
+        max-height: 44px;
+        margin-left: 16px;
+      }
+
+      &--add-button {
+        margin-right: 35px;
+      }
     }
   }
+
 }

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -7,5 +7,9 @@
 
   <h1 class="add-student__title">Ajouter des candidats</h1>
 
-  <AddStudentList @studentList={{@model.students}} @session={{@model.session}} @returnToSessionCandidates={{this.returnToSessionCandidates}} />
+  <AddStudentList
+    @certificationCandidates={{@model.certificationCandidates}}
+    @studentList={{@model.students}}
+    @session={{@model.session}}
+    @returnToSessionCandidates={{this.returnToSessionCandidates}} />
 </div>

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -115,7 +115,7 @@ module('Acceptance | Session Add Students', function(hooks) {
           await click(checkbox);
 
           // when
-          const cancelButtonSelector = '.add-student-list__cancel-button';
+          const cancelButtonSelector = '.bottom-action-bar__actions--cancel-button';
           await click(cancelButtonSelector);
 
           // then

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -210,12 +210,10 @@ module('Integration | Component | add-student-list', function(hooks) {
       });
 
       module('when there is already enrolled students (certification candidates), the sticky bar is shown', () => {
-        module('when there is no additional selected student', () => {
-          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
-            // given
-            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
-            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
+        module('when there is no additional selected student', function(hooks) {
 
+          hooks.beforeEach(async function() {
+            // given
             const birthdate = new Date('2018-01-12T09:29:16Z');
             const studentList = [
               _buildUnselectedStudent('Marie', 'Dupont', '3E', birthdate),
@@ -234,19 +232,27 @@ module('Integration | Component | add-student-list', function(hooks) {
               @returnToSessionCandidates={{this.returnToSessionCandidates}}
               @certificationCandidates={{this.certificationCandidates}}>
             </AddStudentList>`);
+          });
 
+          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
             // then
+            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
+            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
             assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('Aucun candidat sélectionné');
           });
+
+          test('it should disable the "Ajouter" button', async function(assert) {
+            // then
+            const addButtonDisabled = '.bottom-action-bar__actions--add-button.button--disabled';
+            assert.dom(addButtonDisabled).exists();
+          });
         });
 
-        module('when there is additional selected student', () => {
-          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
-            // given
-            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
-            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
+        module('when there is additional selected student', function(hooks) {
 
+          hooks.beforeEach(async function() {
+            // given
             const birthdate = new Date('2018-01-12T09:29:16Z');
             const studentList = [
               _buildSelectedStudent('Marie', 'Dupont', '3E', birthdate),
@@ -265,10 +271,22 @@ module('Integration | Component | add-student-list', function(hooks) {
               @returnToSessionCandidates={{this.returnToSessionCandidates}}
               @certificationCandidates={{this.certificationCandidates}}>
             </AddStudentList>`);
+          });
 
+          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
             // then
+            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
+            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
             assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
             assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
+          });
+
+          test('it should show "Ajouter" button', async function(assert) {
+            // then
+            const addButtonDisabled = '.bottom-action-bar__actions--add-button.button--disabled';
+            const addButton = '.bottom-action-bar__actions--add-button';
+            assert.dom(addButtonDisabled).doesNotExist();
+            assert.dom(addButton).exists();
           });
         });
       });

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -148,6 +148,131 @@ module('Integration | Component | add-student-list', function(hooks) {
         assert.equal(this.candidatesWasSaved, true);
       });
     });
+
+    module('sticky bar', () => {
+      module('when there is no enrolled students (certification candidates)', () => {
+        module('when there is no selected student', () => {
+          test('should not show the sticky bar', async function(assert) {
+            //given
+            const birthdate = new Date('2018-01-12T09:29:16Z');
+            const studentList = [
+              _buildUnselectedStudent('Marie', 'Dupont', '3E', birthdate),
+              _buildUnselectedStudent('Tom', 'Dupont', '4G', birthdate),
+            ];
+            this.set('studentList', studentList);
+            this.set('certificationCandidates', []);
+            this.set('session', _buildSession());
+            this.set('returnToSessionCandidates', () => {});
+
+            // when
+            await render(hbs`<AddStudentList
+              @studentList={{this.studentList}}
+              @certificationCandidates={{this.certificationCandidates}}
+              @session={{this.session}}
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}>
+            </AddStudentList>`);
+
+            // then
+            assert.dom('.add-student-list__bottom-action-bar').doesNotExist();
+          });
+        });
+
+        module('when there are 2 selected students', () => {
+          test('it should show "Aucun candidat sélectionné | 2 candidats déjà ajoutés à la session"', async function(assert) {
+            // given
+            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
+            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
+            const birthdate = new Date('2018-01-12T09:29:16Z');
+            const studentList = [
+              _buildUnselectedStudent('Marie', 'Dupont', '3E', birthdate),
+              _buildSelectedStudent('Tom', 'Dupont', '4G', birthdate),
+              _buildSelectedStudent('Paul', 'Dupont', '4G', birthdate),
+            ];
+            const certificationCandidates = [];
+            this.set('studentList', studentList);
+            this.set('certificationCandidates', certificationCandidates);
+            this.set('session', _buildSession());
+            this.set('returnToSessionCandidates', () => {});
+
+            // when
+            await render(hbs`<AddStudentList
+              @studentList={{this.studentList}}
+              @session={{this.session}}
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @certificationCandidates={{this.certificationCandidates}}>
+            </AddStudentList>`);
+
+            // then
+            assert.dom(candidatesEnrolledSelector).includesText('0 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
+          });
+        });
+      });
+
+      module('when there is already enrolled students (certification candidates), the sticky bar is shown', () => {
+        module('when there is no additional selected student', () => {
+          test('it should show "Aucun candidat sélectionné | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
+            // given
+            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
+            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
+
+            const birthdate = new Date('2018-01-12T09:29:16Z');
+            const studentList = [
+              _buildUnselectedStudent('Marie', 'Dupont', '3E', birthdate),
+              _buildUnselectedStudent('Tom', 'Dupont', '4G', birthdate),
+            ];
+            const certificationCandidates = [ _buildCertificationCandidate(), _buildCertificationCandidate() ];
+            this.set('studentList', studentList);
+            this.set('certificationCandidates', certificationCandidates);
+            this.set('session', _buildSession());
+            this.set('returnToSessionCandidates', () => {});
+
+            // when
+            await render(hbs`<AddStudentList
+              @studentList={{this.studentList}}
+              @session={{this.session}}
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @certificationCandidates={{this.certificationCandidates}}>
+            </AddStudentList>`);
+
+            // then
+            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesSelectedSelector).includesText('Aucun candidat sélectionné');
+          });
+        });
+
+        module('when there is additional selected student', () => {
+          test('it should show "2 candidat(s) sélectionné(s) | 2 candidat(s) déjà ajouté(s) à la session"', async function(assert) {
+            // given
+            const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
+            const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
+
+            const birthdate = new Date('2018-01-12T09:29:16Z');
+            const studentList = [
+              _buildSelectedStudent('Marie', 'Dupont', '3E', birthdate),
+              _buildSelectedStudent('Tom', 'Dupont', '4G', birthdate),
+            ];
+            const certificationCandidates = [ _buildCertificationCandidate(), _buildCertificationCandidate() ];
+            this.set('studentList', studentList);
+            this.set('certificationCandidates', certificationCandidates);
+            this.set('session', _buildSession());
+            this.set('returnToSessionCandidates', () => {});
+
+            // when
+            await render(hbs`<AddStudentList
+              @studentList={{this.studentList}}
+              @session={{this.session}}
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @certificationCandidates={{this.certificationCandidates}}>
+            </AddStudentList>`);
+
+            // then
+            assert.dom(candidatesEnrolledSelector).includesText('2 candidat(s) déjà ajouté(s) à la session');
+            assert.dom(candidatesSelectedSelector).includesText('2 candidat(s) sélectionné(s)');
+          });
+        });
+      });
+    });
   });
 
   function _buildUnselectedStudent(firstName = 'firstName', lastName = 'lastName', division = 'division', birthdate = 'birthdate') {
@@ -159,6 +284,34 @@ module('Integration | Component | add-student-list', function(hooks) {
   function _buildSelectedStudent(firstName = 'firstName', lastName = 'lastName', division = 'division', birthdate = 'birthdate') {
     return EmberObject.create({
       firstName, lastName, division, birthdate, isSelected: true,
+    });
+  }
+
+  function _buildCertificationCandidate(
+    firstName = 'firstName',
+    lastName = 'lastName',
+    birthdate = 'birthdate',
+    birthCity = 'birthCity',
+    birthProvinceCode = 'birthProvinceCode',
+    birthCountry = 'birthCountry',
+    isLinked = false,
+  ) {
+    return EmberObject.create({
+      firstName, lastName, birthdate, birthCity, birthProvinceCode, birthCountry, isLinked,
+    });
+  }
+
+  function _buildSession(
+    address = '13 rue des petits champs',
+    accessCode = 'ABCDE',
+    status = 'started',
+    save = () => {},
+  ) {
+    return EmberObject.create({
+      address,
+      accessCode,
+      status,
+      save,
     });
   }
 });

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 module('Integration | Component | add-student-list', function(hooks) {
   setupRenderingTest(hooks);
@@ -323,7 +324,7 @@ module('Integration | Component | add-student-list', function(hooks) {
     address = '13 rue des petits champs',
     accessCode = 'ABCDE',
     status = 'started',
-    save = () => {},
+    save = sinon.stub(),
   ) {
     return EmberObject.create({
       address,

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -11,9 +11,11 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
     const session = Symbol('Ma super session 1');
     const certificationCenterId = Symbol('certificationCenterId');
     const students = Symbol('students');
+    const certificationCandidates = Symbol('certificationCandidates');
     const expectedModel = {
       session,
       students,
+      certificationCandidates,
     };
 
     hooks.beforeEach(function() {
@@ -27,6 +29,7 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       route.store.findRecord = findRecordStub;
       route.modelFor = sinon.stub().returns({ id: certificationCenterId });
       route.store.findAll = sinon.stub().resolves(students);
+      route.store.query = sinon.stub().resolves(certificationCandidates);
 
       // when
       const actualModel = await route.model({ session_id });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il est possible pour un utilisateur venant du SCO d'ajouter des élèves à une session de certification si la session ne comporte pas déjà d'élève.
Une fois les premiers élèves rajouté, il n'est pas possible de rajouter à nouveau des élèves à cette session de certification.

## :robot: Solution
Après avoir ajouté quelques étudiants en tant que candidat à une session de certification, ajouter de nouveau des candidats. 
Voir de nouvelles informations sur la page d'ajout de candidats : 
- afficher le bandeau sticky si on a déjà des élèves-candidats
- le nombre de candidats déjà ajoutés à la session est indiqué dans le bandeau “sticky”
- différents états pour le bouton "Ajouter" :
    - est désactivé quand aucun élève supplémentaire a été sélectionné
    - devient actif quand au moins un élève supplémentaire a été sélectionné

## :rainbow: Remarques
Cette FEATURE est découpée en 2 partie. Voir [la partie 1 ici](https://github.com/1024pix/pix/pull/2086).
Cette PR est la deuxième partie, voir la partie `Pour tester` pour voir ce qu'elle contient en détail.

Maquette : https://app.abstract.com/share/7aaf62f5-4754-4cbd-8bf1-ad44b41e29fd?collectionLayerId=60965a30-24a0-4c93-ab7b-c495f0a0c75a&mode=design

## :100: Pour tester
- Se connecter à Pix certif avec un membre du sco `certifsco@example.net`
--- 

- Aller sur une session sans candidat
- Cliquer sur Ajouter des candidats
- Constater qu'il n'y a pas de menu en bas
- Sélectionner un élève
- Constater que le menu en bas s'affiche avec les informations suivantes : `Aucun candidat sélectionné | 0 candidat(s) déjà ajouté(s) à la session`

----

- Aller sur une session avec X candidats déjà inscrits
- Cliquer sur Ajouter des candidats
- Constater que le menu en bas s'affiche avec les informations suivantes : `Aucun candidat sélectionné | X candidat(s) déjà ajouté(s) à la session`
- Constater que le bouton "Ajouter" n'est pas activé (grisé et non cliquable)
- Sélectionner 2 élèves
- Constater que le menu en bas s'affiche avec : `2 candidat(s) sélectionné(s) | X candidat(s) déjà ajouté(s) à la session`
- Constater que le bouton "Ajouter" est activé et cliquable

