### PR TITLE
[FEATURE] Ne plus afficher les checkpoints sur Pix-Concours (PIX-1515).

### DIFF
--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -108,6 +108,10 @@ export default class ResumeRoute extends Route {
   }
 
   _routeToResults(assessment) {
+    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+      return this.replaceWith('profile');
+    }
+
     if (assessment.isCertification) {
       return this.replaceWith('certifications.results', assessment.certificationNumber);
     }

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -23,6 +23,10 @@ export default class ResumeRoute extends Route {
     }
     const nextChallenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
 
+    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+      return this._resumeAssessmentWithoutCheckpoint(assessment, nextChallenge);
+    }
+
     if (assessment.hasCheckpoints) {
       return this._resumeAssessmentWithCheckpoint(assessment, nextChallenge);
     } else {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -51,6 +51,7 @@ module.exports = function(environment) {
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
+      IS_PIX_CONCOURS: process.env.IS_PIX_CONCOURS || false,
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {


### PR DESCRIPTION
## :unicorn: Problème
On ne veut plus afficher l'écran intermédiaire ni la page des résultats sur les parcours Pix Concours.

## :robot: Solution
On court-circuite certaines pages en fonction de la varenv `IS_PIX_CONCOURS`.

## :rainbow: Remarques
Les PR Pix Concours se basent depuis la branche `pix-1514-review-app-for-pix-concours` car on ne veut pas merger ces modifs. Le concours aura lieu 1 seul jour et sous la forme de POC, sur une RA. Tout sera supprimé ensuite. 

## :100: Pour tester
Aller sur la RA, lancer une compétence et vérifier que les pages checkpoint toutes les 5 questions ainsi que le dernier checkpoint ne s'affichent plus. 
