### PR TITLE
[FEATURE] Pix Concours: cacher la notification de gain de niveau

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -4,6 +4,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 
+import ENV from 'mon-pix/config/environment';
+
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled'];
   @service intl;
@@ -11,6 +13,9 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
 
   get showLevelup() {
+    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+      return false;
+    }
     return this.model.assessment.showLevelup && this.newLevel;
   }
 


### PR DESCRIPTION
## :unicorn: Problème
Avec Pix Concours, l'utilisateur passe une série de questions prédéfinie sans checkpoint / page de résultat / notification de gain de niveau.

## :robot: Solution
- Cacher la notification de gain de niveau

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Définir la variable d'env FRONT: `IS_PIX_CONCOURS = true`
- vérifer que la notification de gain de niveau ne s'affiche pas lorsque l'utilisateur répond correctement aux questions
