### PR TITLE
[FEATURE] Cacher le bas de la page présentation quand on démarre les campagnes Pix Concours (PIX-1563).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -13,7 +13,7 @@ export default class ChallengeController extends Controller {
   @tracked competenceLeveled = null;
 
   get showLevelup() {
-    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
       return false;
     }
     return this.model.assessment.showLevelup && this.newLevel;

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -1,7 +1,12 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
+import ENV from 'mon-pix/config/environment';
 
 export default class CampaignLandingPageController extends Controller {
+
+  get isNotPixConcours() {
+    return this.model.isTypeAssessment && ENV.APP.IS_PIX_CONCOURS === 'false';
+  }
 
   @action
   startCampaignParticipation() {

--- a/mon-pix/app/controllers/campaigns/campaign-landing-page.js
+++ b/mon-pix/app/controllers/campaigns/campaign-landing-page.js
@@ -4,8 +4,8 @@ import ENV from 'mon-pix/config/environment';
 
 export default class CampaignLandingPageController extends Controller {
 
-  get isNotPixConcours() {
-    return this.model.isTypeAssessment && ENV.APP.IS_PIX_CONCOURS === 'false';
+  get isNotPixContest() {
+    return this.model.isTypeAssessment && ENV.APP.IS_PIX_CONTEST === 'false';
   }
 
   @action

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -23,7 +23,7 @@ export default class ResumeRoute extends Route {
     }
     const nextChallenge = await this.store.queryRecord('challenge', { assessmentId: assessment.id });
 
-    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
       return this._resumeAssessmentWithoutCheckpoint(assessment, nextChallenge);
     }
 
@@ -108,7 +108,7 @@ export default class ResumeRoute extends Route {
   }
 
   _routeToResults(assessment) {
-    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
       return this.replaceWith('profile');
     }
 

--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -34,7 +34,7 @@ export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRo
   }
 
   _shouldShowTutorial(assessment) {
-    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
       return false;
     }
 

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -24,7 +24,7 @@
       />
     {{/if}}
 
-    {{#if @model.isTypeAssessment}}
+    {{#if this.isNotPixConcours}}
       <div class="rounded-panel campaign-landing-page__container__details">
         <div class="campaign-landing-page__details__text">
           <h2 class="campaign-landing-page__details__text title">

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -24,7 +24,7 @@
       />
     {{/if}}
 
-    {{#if this.isNotPixConcours}}
+    {{#if this.isNotPixContest}}
       <div class="rounded-panel campaign-landing-page__container__details">
         <div class="campaign-landing-page__details__text">
           <h2 class="campaign-landing-page__details__text title">

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -51,7 +51,7 @@ module.exports = function(environment) {
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
-      IS_PIX_CONCOURS: process.env.IS_PIX_CONCOURS || false,
+      IS_PIX_CONTEST: process.env.IS_PIX_CONTEST || false,
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {


### PR DESCRIPTION
## :unicorn: Problème
On ne veut pas voir les infos liées au déroulement des campagnes classiques quand on démarre un test Pix Concours.

## :robot: Solution
On n'affiche pas les blocs concernés.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lorsque l'on a la varible d'environnement `IS_PIX_CONCOURS=true` et que l'on commence une campagne, on veut juste voir cette partie de la landing page:
<img width="1132" alt="Screenshot 2020-11-04 at 11 45 46" src="https://user-images.githubusercontent.com/11294487/98102032-592bca80-1e93-11eb-9c67-fd1eb0f3c5bd.png">
 
