### PR TITLE
[FEATURE] Pix Concours: Cacher le didacticiel (PIX-1516).

### DIFF
--- a/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/assessment/start-or-resume.js
@@ -2,6 +2,8 @@ import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 
+import ENV from 'mon-pix/config/environment';
+
 export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
   @service session;
@@ -32,6 +34,10 @@ export default class EvaluationStartOrResumeRoute extends Route.extend(SecuredRo
   }
 
   _shouldShowTutorial(assessment) {
+    if (ENV.APP.IS_PIX_CONCOURS === 'true') {
+      return false;
+    }
+
     return (
       !this.userHasJustConsultedTutorial
       && assessment.answers.length === 0


### PR DESCRIPTION
## :unicorn: Problème
Lors du Pix Concours, on souhaite cacher le didacticiel

## :robot: Solution
Ne pas afficher le didacticiel

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Avec la variable d'environnement front `IS_PIX_CONCOURS=true`, vérifier que le didacticiel ne s'affiche pas lorsque l'on commence une campagne.
