### PR TITLE
[FEATURE]Ajout la classe dans l'export CSV de campagne de collecte de profil pour les organisation SCO (Pix-1548)

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
-const CampaignProfilCollectionExport  = require('../../infrastructure/serializers/csv/export-stream');
+const CampaignProfilCollectionExport  = require('../../infrastructure/serializers/csv/campaign-profile-collection-export');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   const user = await userRepository.getWithMemberships(userId);
@@ -41,7 +41,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   // after this function's returned promise resolves. If we await the map
   // function, node will keep all the data in memory until the end of the
   // complete operation.
-  campaignProfilCollectionExport(campaignParticipationResultDatas, placementProfileService).then(() => {
+  campaignProfilCollectionExport.export(campaignParticipationResultDatas, placementProfileService).then(() => {
     writableStream.end();
   }).catch((error) => {
     writableStream.emit('error', error);

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
 const moment = require('moment');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
-const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const ExportStream  = require('../../infrastructure/serializers/csv/export-stream');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,8 +1,5 @@
 const _ = require('lodash');
 const moment = require('moment');
-const bluebird = require('bluebird');
-
-const constants = require('../../infrastructure/constants');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const ExportStream  = require('../../infrastructure/serializers/csv/export-stream');
@@ -39,15 +36,8 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
     organizationRepository.get(campaign.organizationId),
     campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id, campaign.type),
   ]);
+
   const exportStream = new ExportStream(writableStream, organization, campaign, allPixCompetences);
-  const headers = exportStream._createHeaderOfCSV(allPixCompetences, campaign.idPixLabel, organization);
-
-  // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
-  // - https://en.wikipedia.org/wiki/Byte_order_mark
-  // - https://stackoverflow.com/a/38192870
-  const headerLine = '\uFEFF' + csvSerializer.serializeLine(headers.map((header) => header.title));
-
-  writableStream.write(headerLine);
 
   // No return/await here, we need the writing to continue in the background
   // after this function's returned promise resolves. If we await the map

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -53,23 +53,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   // after this function's returned promise resolves. If we await the map
   // function, node will keep all the data in memory until the end of the
   // complete operation.
-  const campaignParticipationResultDataChunks = _.chunk(campaignParticipationResultDatas, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
-  bluebird.map(campaignParticipationResultDataChunks, async (campaignParticipationResultDataChunk) => {
-    const userIdsAndDates = Object.fromEntries(campaignParticipationResultDataChunk.map((campaignParticipationResultData) => {
-      return [
-        campaignParticipationResultData.userId,
-        campaignParticipationResultData.sharedAt,
-      ];
-    }));
-
-    const placementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-      userIdsAndDates,
-      competences: allPixCompetences,
-      allowExcessPixAndLevels: false,
-    });
-
-    exportStream.export(campaignParticipationResultDataChunk,placementProfiles);
-  }, { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS }).then(() => {
+  exportStream.export(campaignParticipationResultDatas, placementProfileService).then(() => {
     writableStream.end();
   }).catch((error) => {
     writableStream.emit('error', error);

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -68,7 +68,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
       allowExcessPixAndLevels: false,
     });
 
-    exportStream.export(headers, campaignParticipationResultDataChunk,placementProfiles);
+    exportStream.export(campaignParticipationResultDataChunk,placementProfiles);
   }, { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS }).then(() => {
     writableStream.end();
   }).catch((error) => {

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -68,14 +68,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
       allowExcessPixAndLevels: false,
     });
 
-    let csvLines = '';
-    for (const placementProfile of placementProfiles) {
-      const campaignParticipationResultData = campaignParticipationResultDataChunk.find(({ userId }) =>  userId === placementProfile.userId);
-      const csvLine = exportStream.export(headers, campaignParticipationResultData,placementProfile);
-      csvLines = csvLines.concat(csvLine);
-    }
-
-    writableStream.write(csvLines);
+    exportStream.export(headers, campaignParticipationResultDataChunk,placementProfiles);
   }, { concurrency: constants.CONCURRENCY_HEAVY_OPERATIONS }).then(() => {
     writableStream.end();
   }).catch((error) => {

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
-const ExportStream  = require('../../infrastructure/serializers/csv/export-stream');
+const CampaignProfilCollectionExport  = require('../../infrastructure/serializers/csv/export-stream');
 
 async function _checkCreatorHasAccessToCampaignOrganization(userId, organizationId, userRepository) {
   const user = await userRepository.getWithMemberships(userId);
@@ -35,13 +35,13 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
     campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id, campaign.type),
   ]);
 
-  const exportStream = new ExportStream(writableStream, organization, campaign, allPixCompetences);
+  const campaignProfilCollectionExport = new CampaignProfilCollectionExport(writableStream, organization, campaign, allPixCompetences);
 
   // No return/await here, we need the writing to continue in the background
   // after this function's returned promise resolves. If we await the map
   // function, node will keep all the data in memory until the end of the
   // complete operation.
-  exportStream.export(campaignParticipationResultDatas, placementProfileService).then(() => {
+  campaignProfilCollectionExport(campaignParticipationResultDatas, placementProfileService).then(() => {
     writableStream.end();
   }).catch((error) => {
     writableStream.emit('error', error);

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const moment = require('moment');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../errors');
 const ExportStream  = require('../../infrastructure/serializers/csv/export-stream');

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -71,17 +71,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
     let csvLines = '';
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDataChunk.find(({ userId }) =>  userId === placementProfile.userId);
-      const csvLine = exportStream._createOneLineOfCSV({
-        headers,
-        organization,
-        campaign,
-        campaignParticipationResultData,
-        placementProfile,
-
-        participantFirstName: campaignParticipationResultData.participantFirstName,
-        participantLastName: campaignParticipationResultData.participantLastName,
-        studentNumber: campaignParticipationResultData.studentNumber,
-      });
+      const csvLine = exportStream.export(headers, campaignParticipationResultData,placementProfile);
       csvLines = csvLines.concat(csvLine);
     }
 

--- a/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
@@ -1,0 +1,96 @@
+const csvSerializer = require('../../serializers/csv/csv-serializer');
+const moment = require('moment');
+
+const EMPTY_ARRAY = [];
+const NOT_SHARED = 'NA';
+
+class CampaignProfileCollectionResultLine {
+
+  constructor(campaign, organization, campaignParticipationResult, competences, placementProfile) {
+    this.organization = organization;
+    this.campaign = campaign;
+    this.campaignParticipationResult = campaignParticipationResult;
+    this.competences = competences;
+    this.placementProfile = placementProfile;
+  }
+
+  toCsvLine()  {
+    const line =  [
+      this.organization.name,
+      this.campaign.id,
+      this.campaign.name,
+      this.campaignParticipationResult.participantLastName,
+      this.campaignParticipationResult.participantFirstName,
+      ...(this._getDivisionColumn()),
+      ...(this._getStudentNumberColumn()),
+      ...(this._getIdPixLabelColumn()),
+      this._yesOrNo(this.campaignParticipationResult.isShared),
+      this._getSharedAtColumn(),
+      this._getTotalEarnedPixColumn(),
+      this._getIsCertifiableColumn(),
+      this._getCompetencesCountColumn(),
+      ...this._competenceColumns(),
+    ];
+
+    return csvSerializer.serializeLine(line);
+  }
+
+  _getDivisionColumn() {
+    return this.organization.isSco ? [this.campaignParticipationResult.division] : EMPTY_ARRAY;
+  }
+
+  _getCompetencesCountColumn() {
+    return this.campaignParticipationResult.isShared ? this.placementProfile.getCertifiableCompetencesCount() : NOT_SHARED;
+  }
+
+  _getIsCertifiableColumn() {
+    return this.campaignParticipationResult.isShared ? this._yesOrNo(this.placementProfile.isCertifiable()) : NOT_SHARED;
+  }
+
+  _getIdPixLabelColumn() {
+    return this.campaign.idPixLabel ? [this.campaignParticipationResult.participantExternalId] : EMPTY_ARRAY;
+  }
+
+  _getStudentNumberColumn() {
+    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+
+    return displayStudentNumber ? [this.campaignParticipationResult.studentNumber] : EMPTY_ARRAY;
+  }
+
+  _getSharedAtColumn() {
+    return this.campaignParticipationResult.isShared ? moment.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD') : NOT_SHARED;
+  }
+
+  _getTotalEarnedPixColumn() {
+    let totalEarnedPix = NOT_SHARED;
+    if (this.campaignParticipationResult.isShared)  {
+      totalEarnedPix = 0;
+      this.placementProfile.userCompetences.forEach(({ pixScore }) => {
+        totalEarnedPix += pixScore;
+      });
+    }
+
+    return totalEarnedPix;
+  }
+
+  _yesOrNo(value) {
+    return value ? 'Oui' : 'Non';
+  }
+
+  _competenceColumns() {
+    const columns = [];
+    this.competences.forEach((competence) => {
+      const { estimatedLevel, pixScore } = this.placementProfile.userCompetences.find(({ id }) => id === competence.id);
+
+      if (this.campaignParticipationResult.isShared) {
+        columns.push(estimatedLevel, pixScore);
+      } else {
+        columns.push(NOT_SHARED, NOT_SHARED);
+      }
+    });
+
+    return columns;
+  }
+}
+
+module.exports = CampaignProfileCollectionResultLine;

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -55,6 +55,7 @@ module.exports = {
         qb.select([
           'campaign-participations.*',
           'schooling-registrations.studentNumber',
+          'schooling-registrations.division',
           knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
           knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
         ])
@@ -212,5 +213,6 @@ function _rowToResult(row) {
     studentNumber: row.studentNumber,
     participantFirstName: row.firstName,
     participantLastName: row.lastName,
+    division: row.division,
   };
 }

--- a/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
@@ -6,7 +6,7 @@ const constants = require('../../constants');
 const EMPTY_ARRAY = [];
 const NOT_SHARED = 'NA';
 
-class ExportStream {
+class CampaignProfileCollectionExport {
 
   constructor(outputStream, organization, campaign, competences) {
     this.stream = outputStream;
@@ -165,4 +165,4 @@ class ExportStream {
   }
 }
 
-module.exports = ExportStream;
+module.exports = CampaignProfileCollectionExport;

--- a/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
@@ -1,10 +1,8 @@
 const _ = require('lodash');
-const moment = require('moment');
 const bluebird = require('bluebird');
 const csvSerializer = require('./csv-serializer');
 const constants = require('../../constants');
-const EMPTY_ARRAY = [];
-const NOT_SHARED = 'NA';
+const CampaignProfileCollectionResultLine = require('../../exports/campaigns/campaign-profile-collection-result-line');
 
 class CampaignProfileCollectionExport {
 
@@ -73,88 +71,11 @@ class CampaignProfileCollectionExport {
     let csvLines = '';
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) => userId === placementProfile.userId);
-      const csvLine = this._buildLine({ campaignParticipationResultData, placementProfile });
-      csvLines = csvLines.concat(csvLine);
+
+      const line = new CampaignProfileCollectionResultLine(this.campaign, this.organization, campaignParticipationResultData, this.competences, placementProfile);
+      csvLines = csvLines.concat(line.toCsvLine());
     }
     return csvLines;
-  }
-
-  _buildLine({ campaignParticipationResultData, placementProfile }) {
-    const line =  [
-      this.organization.name,
-      this.campaign.id,
-      this.campaign.name,
-      campaignParticipationResultData.participantLastName,
-      campaignParticipationResultData.participantFirstName,
-      ...(this._getDivisionColumn(campaignParticipationResultData)),
-      ...(this._getStudentNumberColumn(campaignParticipationResultData)),
-      ...(this._getIdPixLabelColumn(campaignParticipationResultData)),
-      this._yesOrNo(campaignParticipationResultData.isShared),
-      this._getSharedAtColumn(campaignParticipationResultData),
-      this._getTotalEarnedPixColumn(placementProfile.userCompetences, campaignParticipationResultData.isShared),
-      this._getIsCertifiableColumn(placementProfile, campaignParticipationResultData.isShared),
-      this._getCompetencesCountColumn(placementProfile, campaignParticipationResultData.isShared),
-      ...this._competenceColumns(this.competences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
-    ];
-
-    return csvSerializer.serializeLine(line);
-  }
-
-  _getDivisionColumn(campaignParticipationResultData) {
-    return this.organization.isSco ? [campaignParticipationResultData.division] : EMPTY_ARRAY;
-  }
-
-  _getCompetencesCountColumn(placementProfile, isShared) {
-    return isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED;
-  }
-
-  _getIsCertifiableColumn(placementProfile, isShared) {
-    return isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED;
-  }
-
-  _getIdPixLabelColumn(campaignParticipationResultData) {
-    return this.idPixLabel ? [campaignParticipationResultData.participantExternalId] : EMPTY_ARRAY;
-  }
-
-  _getStudentNumberColumn(campaignParticipationResultData) {
-    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
-
-    return displayStudentNumber ? [campaignParticipationResultData.studentNumber] : EMPTY_ARRAY;
-  }
-
-  _getSharedAtColumn(campaignParticipationResultData) {
-    return campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED;
-  }
-
-  _getTotalEarnedPixColumn(userCompetences, isShared) {
-    let totalEarnedPix = NOT_SHARED;
-    if (isShared)  {
-      totalEarnedPix = 0;
-      userCompetences.forEach(({ pixScore }) => {
-        totalEarnedPix += pixScore;
-      });
-    }
-
-    return totalEarnedPix;
-  }
-
-  _yesOrNo(value) {
-    return value ? 'Oui' : 'Non';
-  }
-
-  _competenceColumns(competencesList, userCompetences, isShared) {
-    const columns = [];
-    competencesList.forEach((competence) => {
-      const { estimatedLevel, pixScore } = userCompetences.find(({ id }) => id === competence.id);
-
-      if (isShared) {
-        columns.push(estimatedLevel, pixScore);
-      } else {
-        columns.push(NOT_SHARED, NOT_SHARED);
-      }
-    });
-
-    return columns;
   }
 
   _competenceColumnHeaders(competencesList) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -132,7 +132,6 @@ class ExportStream {
     return csvSerializer.serializeLine(line);
   }
 
-
   _yesOrNo(value) {
     return value ? 'Oui' : 'Non';
   }

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -97,11 +97,15 @@ class ExportStream {
       this._getSharedAtColumn(campaignParticipationResultData),
       this._getTotalEarnedPixColumn(placementProfile.userCompetences, campaignParticipationResultData.isShared),
       this._getIsCertifiableColumn(placementProfile, campaignParticipationResultData.isShared),
-      campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED,
+      this._getCompetencesCountColumn(placementProfile, campaignParticipationResultData.isShared),
       ...this._competenceColumns(this.competences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _getCompetencesCountColumn(placementProfile, isShared) {
+    return isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED;
   }
 
   _getIsCertifiableColumn(placementProfile, isShared) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -40,8 +40,8 @@ class ExportStream {
       'Nom de la campagne',
       'Nom du Participant',
       'Prénom du Participant',
-      ...(displayStudentNumber ? ['Numéro Étudiant'] : []),
-      ...(this.idPixLabel ? [ this.idPixLabel] : []),
+      displayStudentNumber && 'Numéro Étudiant',
+      this.idPixLabel,
       'Envoi (O/N)',
       'Date de l\'envoi',
       'Nombre de pix total',
@@ -53,7 +53,7 @@ class ExportStream {
       ])),
     ];
 
-    return '\uFEFF' + csvSerializer.serializeLine(header);
+    return '\uFEFF' + csvSerializer.serializeLine(_.compact(header));
   }
 
   async _getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -78,6 +78,23 @@ class ExportStream {
     return placementProfiles;
   }
 
+  _buildLines(placementProfiles, campaignParticipationResultDatas) {
+    let csvLines = '';
+    for (const placementProfile of placementProfiles) {
+      const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) => userId === placementProfile.userId);
+      const csvLine = this._createOneLineOfCSV({
+        campaignParticipationResultData,
+        placementProfile,
+
+        participantFirstName: campaignParticipationResultData.participantFirstName,
+        participantLastName: campaignParticipationResultData.participantLastName,
+        studentNumber: campaignParticipationResultData.studentNumber,
+      });
+      csvLines = csvLines.concat(csvLine);
+    }
+    return csvLines;
+  }
+
   _createOneLineOfCSV({
     campaignParticipationResultData,
     placementProfile,

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -96,12 +96,16 @@ class ExportStream {
       this._yesOrNo(campaignParticipationResultData.isShared),
       this._getSharedAtColumn(campaignParticipationResultData),
       this._getTotalEarnedPixColumn(placementProfile.userCompetences, campaignParticipationResultData.isShared),
-      campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED,
+      this._getIsCertifiableColumn(placementProfile, campaignParticipationResultData.isShared),
       campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED,
       ...this._competenceColumns(this.competences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _getIsCertifiableColumn(placementProfile, isShared) {
+    return isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED;
   }
 
   _getIdPixLabelColumn(campaignParticipationResultData) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -93,9 +93,7 @@ class ExportStream {
       campaignParticipationResultData.participantLastName,
       campaignParticipationResultData.participantFirstName,
       ...(this._getStudentNumberColumn(campaignParticipationResultData)),
-
-      ...(this.idPixLabel ? [ campaignParticipationResultData.participantExternalId] : EMPTY_ARRAY),
-
+      ...(this._getIdPixLabelColumn(campaignParticipationResultData)),
       this._yesOrNo(campaignParticipationResultData.isShared),
       campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED,
       campaignParticipationResultData.isShared ? totalEarnedPix : NOT_SHARED,
@@ -105,6 +103,10 @@ class ExportStream {
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _getIdPixLabelColumn(campaignParticipationResultData) {
+    return this.idPixLabel ? [campaignParticipationResultData.participantExternalId] : EMPTY_ARRAY;
   }
 
   _getStudentNumberColumn(campaignParticipationResultData) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -100,11 +100,7 @@ class ExportStream {
     placementProfile,
   }) {
     const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
-    let totalEarnedPix = 0;
-    placementProfile.userCompetences.forEach(({ pixScore }) => {
-      totalEarnedPix += pixScore;
-    });
-
+    const totalEarnedPix = this._computeTotalEarnPix(placementProfile.userCompetences);
     const line =  [
       this.organization.name,
       this.campaign.id,
@@ -130,6 +126,15 @@ class ExportStream {
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _computeTotalEarnPix(userCompetences) {
+    let totalEarnedPix = 0;
+    userCompetences.forEach(({ pixScore }) => {
+      totalEarnedPix += pixScore;
+    });
+
+    return totalEarnedPix;
   }
 
   _yesOrNo(value) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -20,8 +20,7 @@ class ExportStream {
     // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
     // - https://en.wikipedia.org/wiki/Byte_order_mark
     // - https://stackoverflow.com/a/38192870
-    const headerLine = '\uFEFF' + csvSerializer.serializeLine(this._buildHeader());
-    this.stream.write(headerLine);
+    this.stream.write(this._buildHeader());
 
     const campaignParticipationResultDataChunks = _.chunk(campaignParticipationResultDatas, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
 
@@ -40,6 +39,30 @@ class ExportStream {
 
       this.stream.write(csvLines);
     });
+  }
+
+  _buildHeader() {
+    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+    const header = [
+      'Nom de l\'organisation',
+      'ID Campagne',
+      'Nom de la campagne',
+      'Nom du Participant',
+      'Prénom du Participant',
+      ...(displayStudentNumber ? ['Numéro Étudiant'] : []),
+      ...(this.idPixLabel ? [ this.idPixLabel] : []),
+      'Envoi (O/N)',
+      'Date de l\'envoi',
+      'Nombre de pix total',
+      'Certifiable (O/N)',
+      'Nombre de compétences certifiables',
+      ...(_.flatMap(this.allPixCompetences, (competence) => [
+        `Niveau pour la compétence ${competence.name}`,
+        `Nombre de pix pour la compétence ${competence.name}`,
+      ])),
+    ];
+
+    return '\uFEFF' + csvSerializer.serializeLine(header);
   }
 
   async getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {
@@ -92,27 +115,6 @@ class ExportStream {
     return csvSerializer.serializeLine(line);
   }
 
-  _buildHeader() {
-    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
-    return [
-      'Nom de l\'organisation',
-      'ID Campagne',
-      'Nom de la campagne',
-      'Nom du Participant',
-      'Prénom du Participant',
-      ...(displayStudentNumber ? ['Numéro Étudiant'] : []),
-      ...(this.idPixLabel ? [ this.idPixLabel] : []),
-      'Envoi (O/N)',
-      'Date de l\'envoi',
-      'Nombre de pix total',
-      'Certifiable (O/N)',
-      'Nombre de compétences certifiables',
-      ...(_.flatMap(this.allPixCompetences, (competence) => [
-        `Niveau pour la compétence ${competence.name}`,
-        `Nombre de pix pour la compétence ${competence.name}`,
-      ])),
-    ];
-  }
 
   _yesOrNo(value) {
     return value ? 'Oui' : 'Non';

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -85,7 +85,6 @@ class ExportStream {
   }
 
   _buildLine({ campaignParticipationResultData, placementProfile }) {
-    const totalEarnedPix = this._computeTotalEarnPix(placementProfile.userCompetences);
     const line =  [
       this.organization.name,
       this.campaign.id,
@@ -96,7 +95,7 @@ class ExportStream {
       ...(this._getIdPixLabelColumn(campaignParticipationResultData)),
       this._yesOrNo(campaignParticipationResultData.isShared),
       this._getSharedAtColumn(campaignParticipationResultData),
-      campaignParticipationResultData.isShared ? totalEarnedPix : NOT_SHARED,
+      this._getTotalEarnedPixColumn(placementProfile.userCompetences, campaignParticipationResultData.isShared),
       campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED,
       campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED,
       ...this._competenceColumns(this.competences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
@@ -119,11 +118,14 @@ class ExportStream {
     return campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED;
   }
 
-  _computeTotalEarnPix(userCompetences) {
-    let totalEarnedPix = 0;
-    userCompetences.forEach(({ pixScore }) => {
-      totalEarnedPix += pixScore;
-    });
+  _getTotalEarnedPixColumn(userCompetences, isShared) {
+    let totalEarnedPix = NOT_SHARED;
+    if (isShared)  {
+      totalEarnedPix = 0;
+      userCompetences.forEach(({ pixScore }) => {
+        totalEarnedPix += pixScore;
+      });
+    }
 
     return totalEarnedPix;
   }

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -35,12 +35,14 @@ class ExportStream {
 
   _buildHeader() {
     const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+    const displayDivision = this.organization.isSco;
     const header = [
       'Nom de l\'organisation',
       'ID Campagne',
       'Nom de la campagne',
       'Nom du Participant',
       'Prénom du Participant',
+      displayDivision && 'Classe',
       displayStudentNumber && 'Numéro Étudiant',
       this.idPixLabel,
       'Envoi (O/N)',
@@ -84,6 +86,7 @@ class ExportStream {
       this.campaign.name,
       campaignParticipationResultData.participantLastName,
       campaignParticipationResultData.participantFirstName,
+      ...(this._getDivisionColumn(campaignParticipationResultData)),
       ...(this._getStudentNumberColumn(campaignParticipationResultData)),
       ...(this._getIdPixLabelColumn(campaignParticipationResultData)),
       this._yesOrNo(campaignParticipationResultData.isShared),
@@ -95,6 +98,10 @@ class ExportStream {
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _getDivisionColumn(campaignParticipationResultData) {
+    return this.organization.isSco ? [campaignParticipationResultData.division] : EMPTY_ARRAY;
   }
 
   _getCompetencesCountColumn(placementProfile, isShared) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -95,7 +95,7 @@ class ExportStream {
       ...(this._getStudentNumberColumn(campaignParticipationResultData)),
       ...(this._getIdPixLabelColumn(campaignParticipationResultData)),
       this._yesOrNo(campaignParticipationResultData.isShared),
-      campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED,
+      this._getSharedAtColumn(campaignParticipationResultData),
       campaignParticipationResultData.isShared ? totalEarnedPix : NOT_SHARED,
       campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED,
       campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED,
@@ -113,6 +113,10 @@ class ExportStream {
     const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
 
     return displayStudentNumber ? [campaignParticipationResultData.studentNumber] : EMPTY_ARRAY;
+  }
+
+  _getSharedAtColumn(campaignParticipationResultData) {
+    return campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED;
   }
 
   _computeTotalEarnPix(userCompetences) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -71,14 +71,7 @@ class ExportStream {
     let csvLines = '';
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) => userId === placementProfile.userId);
-      const csvLine = this._buildLine({
-        campaignParticipationResultData,
-        placementProfile,
-
-        participantFirstName: campaignParticipationResultData.participantFirstName,
-        participantLastName: campaignParticipationResultData.participantLastName,
-        studentNumber: campaignParticipationResultData.studentNumber,
-      });
+      const csvLine = this._buildLine({ campaignParticipationResultData, placementProfile });
       csvLines = csvLines.concat(csvLine);
     }
     return csvLines;

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -116,13 +116,7 @@ class ExportStream {
       campaignParticipationResultData.isShared ? totalEarnedPix : 'NA',
       campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : 'NA',
       campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : 'NA',
-      ...(_.flatMap(this.allPixCompetences, (competence) => {
-        if (campaignParticipationResultData.isShared) {
-          const userCompetence = placementProfile.userCompetences.find(({ id }) => id === competence.id);
-          return [ userCompetence.estimatedLevel, userCompetence.pixScore];
-        }
-        return ['NA', 'NA'];
-      })),
+      ...this._competenceColumns(this.allPixCompetences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
     ];
 
     return csvSerializer.serializeLine(line);
@@ -139,6 +133,21 @@ class ExportStream {
 
   _yesOrNo(value) {
     return value ? 'Oui' : 'Non';
+  }
+
+  _competenceColumns(competencesList, userCompetences, isShared) {
+    const columns = [];
+    competencesList.forEach((competence) => {
+      const { estimatedLevel, pixScore } = userCompetences.find(({ id }) => id === competence.id);
+
+      if (isShared) {
+        columns.push(estimatedLevel, pixScore);
+      } else {
+        columns.push('NA', 'NA');
+      }
+    });
+
+    return columns;
   }
 }
 

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -4,6 +4,7 @@ const bluebird = require('bluebird');
 const csvSerializer = require('./csv-serializer');
 const constants = require('../../constants');
 const EMPTY_ARRAY = [];
+const NOT_SHARED = 'NA';
 
 class ExportStream {
 
@@ -97,10 +98,10 @@ class ExportStream {
       ...(this.idPixLabel ? [ campaignParticipationResultData.participantExternalId] : EMPTY_ARRAY),
 
       this._yesOrNo(campaignParticipationResultData.isShared),
-      campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : 'NA',
-      campaignParticipationResultData.isShared ? totalEarnedPix : 'NA',
-      campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : 'NA',
-      campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : 'NA',
+      campaignParticipationResultData.isShared ? moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD') : NOT_SHARED,
+      campaignParticipationResultData.isShared ? totalEarnedPix : NOT_SHARED,
+      campaignParticipationResultData.isShared ? this._yesOrNo(placementProfile.isCertifiable()) : NOT_SHARED,
+      campaignParticipationResultData.isShared ? placementProfile.getCertifiableCompetencesCount() : NOT_SHARED,
       ...this._competenceColumns(this.competences, placementProfile.userCompetences, campaignParticipationResultData.isShared),
     ];
 
@@ -128,7 +129,7 @@ class ExportStream {
       if (isShared) {
         columns.push(estimatedLevel, pixScore);
       } else {
-        columns.push('NA', 'NA');
+        columns.push(NOT_SHARED, NOT_SHARED);
       }
     });
 

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -47,10 +47,7 @@ class ExportStream {
       'Nombre de pix total',
       'Certifiable (O/N)',
       'Nombre de compétences certifiables',
-      ...(_.flatMap(this.competences, (competence) => [
-        `Niveau pour la compétence ${competence.name}`,
-        `Nombre de pix pour la compétence ${competence.name}`,
-      ])),
+      ...(this._competenceColumnHeaders(this.competences)),
     ];
 
     return '\uFEFF' + csvSerializer.serializeLine(_.compact(header));
@@ -136,6 +133,13 @@ class ExportStream {
     });
 
     return columns;
+  }
+
+  _competenceColumnHeaders(competencesList) {
+    return _.flatMap(competencesList, (competence) => [
+      `Niveau pour la compétence ${competence.name}`,
+      `Nombre de pix pour la compétence ${competence.name}`,
+    ]);
   }
 }
 

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -12,14 +12,15 @@ class ExportStream {
     this.campaign = campaign;
     this.idPixLabel = campaign.idPixLabel;
     this.allPixCompetences = allPixCompetences;
+    this.headers = this._createHeaderOfCSV();
   }
 
-  export(headers, campaignParticipationResultDatas, placementProfiles) {
+  export(campaignParticipationResultDatas, placementProfiles) {
     let csvLines = '';
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) =>  userId === placementProfile.userId);
       const csvLine = this._createOneLineOfCSV({
-        headers,
+        headers: this.headers,
         organization: this.organization,
         campaign: this.campaign,
         campaignParticipationResultData,

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -85,7 +85,6 @@ class ExportStream {
   }
 
   _buildLine({ campaignParticipationResultData, placementProfile }) {
-    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
     const totalEarnedPix = this._computeTotalEarnPix(placementProfile.userCompetences);
     const line =  [
       this.organization.name,
@@ -93,7 +92,7 @@ class ExportStream {
       this.campaign.name,
       campaignParticipationResultData.participantLastName,
       campaignParticipationResultData.participantFirstName,
-      ...(displayStudentNumber ? [campaignParticipationResultData.studentNumber] : EMPTY_ARRAY),
+      ...(this._getStudentNumberColumn(campaignParticipationResultData)),
 
       ...(this.idPixLabel ? [ campaignParticipationResultData.participantExternalId] : EMPTY_ARRAY),
 
@@ -106,6 +105,12 @@ class ExportStream {
     ];
 
     return csvSerializer.serializeLine(line);
+  }
+
+  _getStudentNumberColumn(campaignParticipationResultData) {
+    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+
+    return displayStudentNumber ? [campaignParticipationResultData.studentNumber] : EMPTY_ARRAY;
   }
 
   _computeTotalEarnPix(userCompetences) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -43,8 +43,6 @@ class ExportStream {
       for (const placementProfile of placementProfiles) {
         const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) =>  userId === placementProfile.userId);
         const csvLine = this._createOneLineOfCSV({
-          organization: this.organization,
-          campaign: this.campaign,
           campaignParticipationResultData,
           placementProfile,
         });
@@ -56,8 +54,6 @@ class ExportStream {
   }
 
   _createOneLineOfCSV({
-    organization,
-    campaign,
     campaignParticipationResultData,
     placementProfile,
   }) {

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -14,20 +14,25 @@ class ExportStream {
     this.allPixCompetences = allPixCompetences;
   }
 
-  export(headers, campaignParticipationResultData, placementProfile) {
-    const csvLine = this._createOneLineOfCSV({
-      headers,
-      organization: this.organization,
-      campaign: this.campaign,
-      campaignParticipationResultData,
-      placementProfile,
+  export(headers, campaignParticipationResultDatas, placementProfiles) {
+    let csvLines = '';
+    for (const placementProfile of placementProfiles) {
+      const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) =>  userId === placementProfile.userId);
+      const csvLine = this._createOneLineOfCSV({
+        headers,
+        organization: this.organization,
+        campaign: this.campaign,
+        campaignParticipationResultData,
+        placementProfile,
 
-      participantFirstName: campaignParticipationResultData.participantFirstName,
-      participantLastName: campaignParticipationResultData.participantLastName,
-      studentNumber: campaignParticipationResultData.studentNumber,
-    });
+        participantFirstName: campaignParticipationResultData.participantFirstName,
+        participantLastName: campaignParticipationResultData.participantLastName,
+        studentNumber: campaignParticipationResultData.studentNumber,
+      });
+      csvLines = csvLines.concat(csvLine);
+    }
 
-    return csvLine;
+    this.stream.write(csvLines);
   }
 
   _getCommonColumns({

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -16,7 +16,6 @@ class ExportStream {
   }
 
   export(campaignParticipationResultDatas, placementProfileService) {
-    const headers = this._createHeaderOfCSV();
 
     // WHY: add \uFEFF the UTF-8 BOM at the start of the text, see:
     // - https://en.wikipedia.org/wiki/Byte_order_mark

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -1,0 +1,150 @@
+const _ = require('lodash');
+const moment = require('moment');
+const bluebird = require('bluebird');
+const csvSerializer = require('./csv-serializer');
+const constants = require('../../constants');
+
+class ExportStream {
+
+  constructor(outputStream, organization, campaign, allPixCompetences) {
+    this.stream = outputStream;
+    this.organization = organization;
+    this.campaign = campaign;
+    this.idPixLabel = campaign.idPixLabel;
+    this.allPixCompetences = allPixCompetences;
+  }
+
+  export(headers, campaignParticipationResultData, placementProfile) {
+    const csvLine = this._createOneLineOfCSV({
+      headers,
+      organization: this.organization,
+      campaign: this.campaign,
+      campaignParticipationResultData,
+      placementProfile,
+
+      participantFirstName: campaignParticipationResultData.participantFirstName,
+      participantLastName: campaignParticipationResultData.participantLastName,
+      studentNumber: campaignParticipationResultData.studentNumber,
+    });
+
+    return csvLine;
+  }
+
+  _getCommonColumns({
+    organization,
+    campaign,
+    campaignParticipationResultData,
+    participantFirstName,
+    participantLastName,
+    studentNumber,
+  }) {
+    const EMPTY_LINE = '';
+    const displayStudentNumber = studentNumber && organization.isSup && organization.isManagingStudents;
+    return {
+      organizationName: organization.name,
+      campaignId: campaign.id,
+      campaignName: campaign.name,
+      participantLastName,
+      participantFirstName,
+      studentNumber: displayStudentNumber ? studentNumber : EMPTY_LINE,
+      isShared: campaignParticipationResultData.isShared ? 'Oui' : 'Non',
+      ...(campaign.idPixLabel ? { participantExternalId: campaignParticipationResultData.participantExternalId } : {}),
+    };
+  }
+
+  _getSharedColumns({
+    campaignParticipationResultData,
+    placementProfile,
+  }) {
+    const competenceStats = _.map(placementProfile.userCompetences, (userCompetence) => {
+
+      return {
+        id: userCompetence.id,
+        earnedPix: userCompetence.pixScore,
+        level: userCompetence.estimatedLevel,
+      };
+    });
+
+    const lineMap = {
+      sharedAt: moment.utc(campaignParticipationResultData.sharedAt).format('YYYY-MM-DD'),
+      totalEarnedPix: _.sumBy(competenceStats, 'earnedPix'),
+      isCertifiable: placementProfile.isCertifiable() ? 'Oui' : 'Non',
+      certifiableCompetencesCount: placementProfile.getCertifiableCompetencesCount(),
+    };
+
+    let totalEarnedPix = 0;
+    placementProfile.userCompetences.forEach(({ id, pixScore, estimatedLevel }) => {
+      lineMap[`competence_${id}_level`] = estimatedLevel;
+      lineMap[`competence_${id}_earnedPix`] = pixScore;
+      totalEarnedPix += pixScore;
+    });
+
+    lineMap['totalEarnedPix'] = totalEarnedPix;
+
+    return lineMap;
+  }
+
+  _createOneLineOfCSV({
+    headers,
+    organization,
+    campaign,
+    campaignParticipationResultData,
+    placementProfile,
+    participantFirstName,
+    participantLastName,
+    studentNumber,
+  }) {
+    const lineMap = this._getCommonColumns({
+      organization,
+      campaign,
+      campaignParticipationResultData,
+
+      participantFirstName,
+      participantLastName,
+      studentNumber,
+    });
+
+    if (campaignParticipationResultData.isShared) {
+      _.assign(lineMap, this._getSharedColumns({
+        campaignParticipationResultData,
+        placementProfile,
+      }));
+    }
+
+    const lineArray = headers.map(({ property }) => {
+      return property in lineMap ? lineMap[property] : 'NA';
+    });
+
+    return csvSerializer.serializeLine(lineArray);
+  }
+
+  _createHeaderOfCSV() {
+    const EMPTY_ARRAY = [];
+    const displayStudentNumber = this.organization.isSup && this.organization.isManagingStudents;
+    return [
+      { title: 'Nom de l\'organisation', property: 'organizationName' },
+      { title: 'ID Campagne', property: 'campaignId' },
+      { title: 'Nom de la campagne', property: 'campaignName' },
+      { title: 'Nom du Participant', property: 'participantLastName' },
+      { title: 'Prénom du Participant', property: 'participantFirstName' },
+
+      ...(displayStudentNumber ? [{ title: 'Numéro Étudiant', property: 'studentNumber' }] : EMPTY_ARRAY),
+
+      ...(this.idPixLabel ? [ { title: this.idPixLabel, property: 'participantExternalId' } ] : EMPTY_ARRAY),
+
+      { title: 'Envoi (O/N)', property: 'isShared' },
+      { title: 'Date de l\'envoi', property: 'sharedAt' },
+      { title: 'Nombre de pix total', property: 'totalEarnedPix' },
+      { title: 'Certifiable (O/N)', property: 'isCertifiable' },
+      { title: 'Nombre de compétences certifiables', property: 'certifiableCompetencesCount' },
+
+      ...(_.flatMap(this.allPixCompetences, (competence) => [
+        { title: `Niveau pour la compétence ${competence.name}`, property: `competence_${competence.id}_level` },
+        { title: `Nombre de pix pour la compétence ${competence.name}`, property: `competence_${competence.id}_earnedPix` },
+      ])),
+    ];
+  }
+
+}
+
+module.exports = ExportStream;

--- a/api/lib/infrastructure/serializers/csv/export-stream.js
+++ b/api/lib/infrastructure/serializers/csv/export-stream.js
@@ -25,17 +25,8 @@ class ExportStream {
     const campaignParticipationResultDataChunks = _.chunk(campaignParticipationResultDatas, constants.CHUNK_SIZE_CAMPAIGN_RESULT_PROCESSING);
 
     return bluebird.map(campaignParticipationResultDataChunks, async (campaignParticipationResultDataChunk) => {
-      const placementProfiles = await this.getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService);
-
-      let csvLines = '';
-      for (const placementProfile of placementProfiles) {
-        const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) =>  userId === placementProfile.userId);
-        const csvLine = this._createOneLineOfCSV({
-          campaignParticipationResultData,
-          placementProfile,
-        });
-        csvLines = csvLines.concat(csvLine);
-      }
+      const placementProfiles = await this._getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService);
+      const csvLines = this._buildLines(placementProfiles, campaignParticipationResultDatas);
 
       this.stream.write(csvLines);
     });
@@ -65,7 +56,7 @@ class ExportStream {
     return '\uFEFF' + csvSerializer.serializeLine(header);
   }
 
-  async getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {
+  async _getUsersPlacementProfiles(campaignParticipationResultDataChunk, placementProfileService) {
     const userIdsAndDates = {};
     campaignParticipationResultDataChunk.forEach(({ userId, sharedAt }) => userIdsAndDates[userId] = sharedAt);
 

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -11,7 +11,7 @@ const organizationRepository = require('../../../../lib/infrastructure/repositor
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
 
-describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', () => {
+describe.only('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', () => {
 
   describe('#startWritingCampaignProfilesCollectionResultsToStream', () => {
 
@@ -34,9 +34,9 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
       const skillUrl1 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl1', nom: '@url1', ['compétenceViaTube']: ['recCompetence2'] });
       const skillUrl8 = airtableBuilder.factory.buildSkill({ id: 'recSkillUrl8', nom: '@url8', ['compétenceViaTube']: ['recCompetence2'] });
       const skills = [skillWeb1, skillWeb2, skillWeb3, skillUrl1, skillUrl8];
-  
+
       participant = databaseBuilder.factory.buildUser();
-      
+
       databaseBuilder.factory.buildKnowledgeElement({
         status: 'validated',
         pixScore: 2,
@@ -89,9 +89,9 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         userId: participant.id,
         createdAt,
       });
-    
+
       await databaseBuilder.commit();
-  
+
       const competence1 = airtableBuilder.factory.buildCompetence({
         id: 'recCompetence1',
         titre: 'Competence1',
@@ -99,7 +99,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         domaineIds: ['recArea1'],
         acquisViaTubes: [skillWeb1, skillWeb2, skillWeb3].map((skill) => skill.id),
       });
-  
+
       const competence2 = airtableBuilder.factory.buildCompetence({
         id: 'recCompetence2',
         titre: 'Competence2',
@@ -107,14 +107,14 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
         domaineIds: ['recArea3'],
         acquisViaTubes: [skillUrl1.id, skillUrl8.id],
       });
-  
+
       const area1 = airtableBuilder.factory.buildArea({ id: 'recArea1', code: '1', titre: 'Domain 1' });
       const area3 = airtableBuilder.factory.buildArea({ id: 'recArea3', code: '3', title: 'Domain 3' });
-  
+
       airtableBuilder.mockList({ tableName: 'Competences' }).returns([competence1, competence2]).activate();
       airtableBuilder.mockList({ tableName: 'Acquis' }).returns(skills).activate();
       airtableBuilder.mockList({ tableName: 'Domaines' }).returns([area1, area3]).activate();
-  
+
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
     });
@@ -141,7 +141,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           type: 'PROFILES_COLLECTION',
           title: null,
         });
-    
+
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
           sharedAt: new Date('2019-03-01T23:04:05Z'),
@@ -172,7 +172,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           '12;' +
           '5;' +
           '40';
-  
+
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
           userId: user.id,
@@ -185,11 +185,11 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           campaignParticipationRepository,
           placementProfileService,
         });
-  
+
         const csv = await csvPromise;
         const csvLines = csv.split('\n');
         const csvFirstLineCells = csvLines[0].split(';');
-  
+
         // then
         expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
         expect(csvLines[1]).to.equal(expectedCsvSecondLine);
@@ -197,7 +197,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
     });
 
     context('When the organization is SUP and isManagingStudent', () => {
-      
+
       beforeEach(async () => {
         organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
         databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
@@ -213,7 +213,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           type: 'PROFILES_COLLECTION',
           title: null,
         });
-    
+
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           createdAt,
           sharedAt: new Date('2019-03-01T23:04:05Z'),
@@ -225,7 +225,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
 
         await databaseBuilder.commit();
       });
-  
+
       it('should return the complete line with student number', async () => {
         // given
         const expectedCsvFirstCell = '\uFEFF"Nom de l\'organisation"';
@@ -245,7 +245,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           '12;' +
           '5;' +
           '40';
-  
+
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
           userId: user.id,
@@ -258,11 +258,11 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-
           campaignParticipationRepository,
           placementProfileService,
         });
-  
+
         const csv = await csvPromise;
         const csvLines = csv.split('\n');
         const csvFirstLineCells = csvLines[0].split(';');
-  
+
         // then
         expect(csvFirstLineCells[0]).to.equal(expectedCsvFirstCell);
         expect(csvLines[1]).to.equal(expectedCsvSecondLine);

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -249,7 +249,7 @@ describe('Integration | Repository | Campaign Participation', () => {
 
     context('when the participant is linked to a schooling registration', () => {
       beforeEach(async () => {
-        databaseBuilder.factory.buildSchoolingRegistration({ firstName: 'Hubert', lastName: 'Parterre', userId, organizationId: campaign1.organizationId });
+        databaseBuilder.factory.buildSchoolingRegistration({ firstName: 'Hubert', lastName: 'Parterre', userId, organizationId: campaign1.organizationId, division: '6emeD' });
         await databaseBuilder.commit();
       });
 
@@ -262,10 +262,11 @@ describe('Integration | Repository | Campaign Participation', () => {
 
         // then
         const attributes = participationResultDatas.map((participationResultData) =>
-          _.pick(participationResultData, ['participantFirstName', 'participantLastName']));
+          _.pick(participationResultData, ['participantFirstName', 'participantLastName', 'division']));
         expect(attributes).to.deep.equal([{
           participantFirstName: 'Hubert',
           participantLastName: 'Parterre',
+          division: '6emeD',
         }]);
       });
     });

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -4,7 +4,7 @@ const { expect, sinon, domainBuilder, streamToPromise } = require('../../../test
 const startWritingCampaignProfilesCollectionResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream');
 const PlacementProfile = require('../../../../lib/domain/models/PlacementProfile');
 
-describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
+describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
 
   const user = domainBuilder.buildUser({ firstName: '@Jean', lastName: '=Bono' });
   const organization = user.memberships[0].organization;
@@ -80,6 +80,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
           '"Nom de la campagne";' +
           '"Nom du Participant";' +
           '"Prénom du Participant";' +
+          '"Classe";' +
           '"Envoi (O/N)";' +
           '"Date de l\'envoi";' +
           '"Nombre de pix total";' +
@@ -126,6 +127,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             userId: 123,
             participantFirstName: user.firstName,
             participantLastName: user.lastName,
+            division: '6emeA',
           };
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
 
@@ -134,6 +136,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             `"'${campaign.name}";` +
             `"'${user.lastName}";` +
             `"'${user.firstName}";` +
+            `"${campaignParticipationResultData.division}";` +
             '"Oui";' +
             '2019-03-01;' +
             '13;' +
@@ -178,6 +181,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             userId: 123,
             participantFirstName: user.firstName,
             participantLastName: user.lastName,
+            division: '5emeB',
           };
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
 
@@ -186,6 +190,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             `"'${campaign.name}";` +
             `"'${user.lastName}";` +
             `"'${user.firstName}";` +
+            `"${campaignParticipationResultData.division}";` +
             '"Oui";' +
             '2019-03-01;' +
             '13;' +
@@ -231,6 +236,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             userId: 123,
             participantFirstName: user.firstName,
             participantLastName: user.lastName,
+            division: '4emeC',
           };
 
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
@@ -241,6 +247,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
             `"'${campaign.name}";` +
             `"'${user.lastName}";` +
             `"'${user.firstName}";` +
+            `"${campaignParticipationResultData.division}";` +
             '"Non";' +
             '"NA";' +
             '"NA";' +
@@ -549,6 +556,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
           '"Nom de la campagne";' +
           '"Nom du Participant";' +
           '"Prénom du Participant";' +
+          '"Classe";' +
           '"Mail Pro";' +
           '"Envoi (O/N)";' +
           '"Date de l\'envoi";' +
@@ -592,6 +600,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
           userId: 123,
           participantFirstName: user.firstName,
           participantLastName: user.lastName,
+          division: '3emeD',
         };
 
         findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
@@ -602,6 +611,7 @@ describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-coll
           `"'${campaign.name}";` +
           `"'${user.lastName}";` +
           `"'${user.firstName}";` +
+          `"${campaignParticipationResultData.division}";` +
           `"'${campaignParticipationResultData.participantExternalId}";` +
           '"Non";' +
           '"NA";' +

--- a/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -4,7 +4,7 @@ const { expect, sinon, domainBuilder, streamToPromise } = require('../../../test
 const startWritingCampaignProfilesCollectionResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream');
 const PlacementProfile = require('../../../../lib/domain/models/PlacementProfile');
 
-describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
+describe.only('Unit | Domain | Use Cases | start-writing-campaign-profiles-collection-results-to-stream', () => {
 
   const user = domainBuilder.buildUser({ firstName: '@Jean', lastName: '=Bono' });
   const organization = user.memberships[0].organization;
@@ -90,7 +90,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
           '"Niveau pour la compétence Competence2";' +
           '"Nombre de pix pour la compétence Competence2"\n';
         findProfilesCollectionResultDataByCampaignIdStub.resolves([]);
-  
+
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
           userId: user.id,
@@ -103,20 +103,20 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
           campaignParticipationRepository,
           placementProfileService,
         });
-  
+
         const csv = await csvPromise;
-  
+
         // then
         expect(csv).to.equal(expectedHeader);
       });
-  
+
       context('when isShared is true', () => {
-  
+
         it('should return the complete line with 1 certifiable competence', async () => {
           // given
           sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(false);
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(1);
-  
+
           const campaignParticipationResultData = {
             id: 1,
             isShared: true,
@@ -128,7 +128,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantLastName: user.lastName,
           };
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine = `"${organization.name}";` +
             `${campaign.id};` +
             `"'${campaign.name}";` +
@@ -143,7 +143,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '9;' +
             '0;' +
             '4';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -156,19 +156,19 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
-  
+
         it('should return the complete line with 5 certifiable competence', async () => {
           // given
           sinon.stub(PlacementProfile.prototype, 'isCertifiable').returns(true);
           sinon.stub(PlacementProfile.prototype, 'getCertifiableCompetencesCount').returns(5);
-  
+
           const campaignParticipationResultData = {
             id: 1,
             isShared: true,
@@ -180,7 +180,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantLastName: user.lastName,
           };
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine = `"${organization.name}";` +
             `${campaign.id};` +
             `"'${campaign.name}";` +
@@ -195,7 +195,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '9;' +
             '0;' +
             '4';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -208,17 +208,17 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
       });
-  
+
       context('when isShared is false', () => {
-  
+
         it('should return the beginning of the line with user information for her participation', async () => {
           // given
           const campaignParticipationResultData = {
@@ -232,9 +232,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantFirstName: user.firstName,
             participantLastName: user.lastName,
           };
-  
+
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine =
             `"${organization.name}";` +
             `${campaign.id};` +
@@ -250,7 +250,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '"NA";' +
             '"NA";' +
             '"NA"';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -263,16 +263,16 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
       });
     });
-    
+
     context('When organization is SUP and isManagingStudent', () => {
       beforeEach(() => {
         organization.type = 'SUP';
@@ -297,7 +297,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
           '"Nombre de pix pour la compétence Competence1";' +
           '"Niveau pour la compétence Competence2";' +
           '"Nombre de pix pour la compétence Competence2"';
-  
+
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
           userId: user.id,
@@ -310,14 +310,14 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
           campaignParticipationRepository,
           placementProfileService,
         });
-  
+
         const csv = await csvPromise;
         const csvLines = csv.split('\n');
-  
+
         // then
         expect(csvLines[0]).to.equal(expectedHeader);
       });
-  
+
       context ('when the participant does not have a student number', () => {
         it('should return the csv without student number information', async () => {
           // given
@@ -332,9 +332,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantLastName: user.lastName,
             studentNumber: '',
           };
-  
+
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine =
             `"${organization.name}";` +
             `${campaign.id};` +
@@ -351,7 +351,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '"NA";' +
             '"NA";' +
             '"NA"';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -364,15 +364,15 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
       });
-  
+
       context ('when the participant have a student number', () => {
         it('should return the csv with student number information', async () => {
           // given
@@ -387,9 +387,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantLastName: user.lastName,
             studentNumber: '12345A',
           };
-  
+
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine =
             `"${organization.name}";` +
             `${campaign.id};` +
@@ -406,7 +406,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '"NA";' +
             '"NA";' +
             '"NA"';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -419,10 +419,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
@@ -435,7 +435,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
         organization.isManagingStudents = false;
         sinon.stub(organizationRepository, 'get').resolves(organization);
       });
-  
+
       it('should return the header in CSV without Student Number', async () => {
         // given
         const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
@@ -452,7 +452,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '"Nombre de pix pour la compétence Competence1";' +
             '"Niveau pour la compétence Competence2";' +
             '"Nombre de pix pour la compétence Competence2"';
-    
+
         // when
         startWritingCampaignProfilesCollectionResultsToStream({
           userId: user.id,
@@ -465,10 +465,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
           campaignParticipationRepository,
           placementProfileService,
         });
-    
+
         const csv = await csvPromise;
         const csvLines = csv.split('\n');
-    
+
         // then
         expect(csvLines[0]).to.equal(expectedHeader);
       });
@@ -487,9 +487,9 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             participantLastName: user.lastName,
             studentNumber: '12345A',
           };
-  
+
           findProfilesCollectionResultDataByCampaignIdStub.resolves([campaignParticipationResultData]);
-  
+
           const csvSecondLine =
             `"${organization.name}";` +
             `${campaign.id};` +
@@ -505,7 +505,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             '"NA";' +
             '"NA";' +
             '"NA"';
-  
+
           // when
           startWritingCampaignProfilesCollectionResultsToStream({
             userId: user.id,
@@ -518,16 +518,16 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-profiles-collectio
             campaignParticipationRepository,
             placementProfileService,
           });
-  
+
           const csv = await csvPromise;
           const csvLines = csv.split('\n');
-  
+
           // then
           expect(csvLines[1]).to.equal(csvSecondLine);
         });
       });
     });
-    
+
     context('When campaign has an idPixLabel', () => {
       beforeEach(() => {
         organization.type = 'SCO';


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs SCO ne peuvent pas avoir les résultats par classe.

## :robot: Solution
Ajouter la classe dans l'export des résultat des campagnes de collecte de profils.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à Pix Orga avec sco.admin@example.net
Télécharger les résultats de la campagne du type collecte de profils.
Vérifier que la colonne division est bien présente et remplie 