### PR TITLE
[BUGFIX] S'assurer de faire les vérifications d'assessment sur celui le plus récent d'une participation lors du partage des résultats (PIX-1571)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -55,7 +55,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.ImproveCompetenceEvaluationForbiddenError) {
     return new HttpErrors.ImproveCompetenceEvaluationForbiddenError(error.message);
   }
-  if (error instanceof DomainErrors.CampaignAlreadyArchivedError) {
+  if (error instanceof DomainErrors.ArchivedCampaignError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
   if (error instanceof DomainErrors.AlreadyRatedAssessmentError) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -548,7 +548,7 @@ class UserAlreadyLinkedToCandidateInSessionError extends DomainError {
   }
 }
 
-class CampaignAlreadyArchivedError extends DomainError {
+class ArchivedCampaignError extends DomainError {
   constructor(message = 'Cette campagne est déjà archivée.') {
     super(message);
   }
@@ -639,7 +639,7 @@ module.exports = {
   AssessmentEndedError,
   AssessmentNotCompletedError,
   AssessmentResultNotCreatedError,
-  CampaignAlreadyArchivedError,
+  ArchivedCampaignError,
   CampaignCodeError,
   CertificateVerificationCodeGenerationTooManyTrials,
   CertificationCandidateForbiddenDeletionError,

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -64,6 +64,10 @@ class Campaign {
   isProfilesCollection() {
     return this.type === types.PROFILES_COLLECTION;
   }
+
+  isArchived() {
+    return Boolean(this.archivedAt);
+  }
 }
 
 Campaign.types = types;

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -1,47 +1,25 @@
 const { UserNotAuthorizedToAccessEntity, AssessmentNotCompletedError, CampaignAlreadyArchivedError } = require('../errors');
 const CampaignParticipationResultsShared = require('../events/CampaignParticipationResultsShared');
-const smartRandom = require('../services/smart-random/smart-random');
-const dataFetcher = require('../services/smart-random/data-fetcher');
 
 module.exports = async function shareCampaignResult({
   userId,
   campaignParticipationId,
-  assessmentRepository,
-  answerRepository,
   campaignParticipationRepository,
-  challengeRepository,
-  knowledgeElementRepository,
-  targetProfileRepository,
-  improvementService,
   campaignRepository,
 }) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
-  const campaign = await campaignRepository.get(campaignParticipation.campaignId);
+  if (campaignParticipation.userId !== userId) {
+    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this campaign participation');
+  }
 
-  const isCampaignArchived = Boolean(campaign.archivedAt);
-  if (isCampaignArchived) {
+  const campaign = await campaignRepository.get(campaignParticipation.campaignId);
+  if (campaign.isArchived()) {
     throw new CampaignAlreadyArchivedError();
   }
 
   if (campaign.isAssessment()) {
-    const assessment = await assessmentRepository.getByCampaignParticipationId(campaignParticipation.id);
-
-    if (assessment.userId !== userId) {
-      throw new UserNotAuthorizedToAccessEntity('User does not have an access to this campaign participation');
-    }
-
-    const getNextChallengeData = await dataFetcher.fetchForCampaigns({
-      assessment,
-      answerRepository,
-      targetProfileRepository,
-      challengeRepository,
-      knowledgeElementRepository,
-      improvementService,
-    });
-
-    const { hasAssessmentEnded } = smartRandom.getPossibleSkillsForNextChallenge(getNextChallengeData);
-
-    if (!hasAssessmentEnded) {
+    const isLatestAssessmentCompleted = await campaignParticipationRepository.isAssessmentCompleted(campaignParticipationId);
+    if (!isLatestAssessmentCompleted) {
       throw new AssessmentNotCompletedError();
     }
   }

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity, AssessmentNotCompletedError, CampaignAlreadyArchivedError } = require('../errors');
+const { UserNotAuthorizedToAccessEntity, AssessmentNotCompletedError, ArchivedCampaignError } = require('../errors');
 const CampaignParticipationResultsShared = require('../events/CampaignParticipationResultsShared');
 
 module.exports = async function shareCampaignResult({
@@ -14,7 +14,7 @@ module.exports = async function shareCampaignResult({
 
   const campaign = await campaignRepository.get(campaignParticipation.campaignId);
   if (campaign.isArchived()) {
-    throw new CampaignAlreadyArchivedError();
+    throw new ArchivedCampaignError('Cannot share results on an archived campaign.');
   }
 
   if (campaign.isAssessment()) {

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -1,6 +1,7 @@
 const BookshelfCampaignParticipation = require('../data/campaign-participation');
 const CampaignParticipation = require('../../domain/models/CampaignParticipation');
 const Campaign = require('../../domain/models/Campaign');
+const Assessment = require('../../domain/models/Assessment');
 const Skill = require('../../domain/models/Skill');
 const User = require('../../domain/models/User');
 const { NotFoundError } = require('../../domain/errors');
@@ -143,6 +144,19 @@ module.exports = {
 
   countSharedParticipationOfCampaign(campaignId) {
     return this.count({ campaignId, isShared: true });
+  },
+
+  async isAssessmentCompleted(campaignParticipationId) {
+    const assessment = await knex('assessments')
+      .select('state')
+      .where({ campaignParticipationId })
+      .orderBy('assessments.createdAt', 'desc')
+      .first();
+
+    if (assessment) {
+      return assessment.state === Assessment.states.COMPLETED;
+    }
+    return false;
   },
 };
 

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const createServer = require('../../../server');
 const Assessment = require('../../../lib/domain/models/Assessment');
 const cache = require('../../../lib/infrastructure/caches/learning-content-cache');
@@ -296,36 +295,22 @@ describe('Acceptance | API | Campaign Participations', () => {
       return cache.flushAll();
     });
 
-    context('when there is no remaining challenges', () => {
-      beforeEach(async () => {
-        const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
-
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb1Id });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb2Id });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb3Id });
-
-        campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+    context('when assessment is completed', () => {
+      beforeEach(() => {
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           id: campaignParticipationId,
+          userId: user.id,
           isShared: false,
           sharedAt: null,
-          campaignId: campaign.id,
         });
         assessment = databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation.id,
           userId: user.id,
           type: Assessment.types.CAMPAIGN,
+          state: Assessment.states.COMPLETED,
         });
 
-        _([
-          { skillId: skillWeb1Id, status: 'validated' },
-          { skillId: skillWeb2Id, status: 'validated' },
-          { skillId: skillWeb3Id, status: 'validated' },
-        ]).each((ke, id) => {
-          databaseBuilder.factory.buildKnowledgeElement({ ...ke, id, userId: user.id, assessmentId: assessment.id });
-        });
-
-        await databaseBuilder.commit();
+        return databaseBuilder.commit();
       });
 
       it('should allow the user to share his campaign participation', async () => {
@@ -338,28 +323,22 @@ describe('Acceptance | API | Campaign Participations', () => {
       });
     });
 
-    context('when there is some remaining challenges', () => {
-      beforeEach(async () => {
-        const { id: targetProfileId } = databaseBuilder.factory.buildTargetProfile();
-
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb1Id });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb2Id });
-        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: skillWeb3Id });
-
-        campaign = databaseBuilder.factory.buildCampaign({ targetProfileId });
+    context('when assessment is not completed', () => {
+      beforeEach(() => {
         campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({
           id: campaignParticipationId,
+          userId: user.id,
           isShared: false,
           sharedAt: null,
-          campaignId: campaign.id,
         });
         assessment = databaseBuilder.factory.buildAssessment({
           campaignParticipationId: campaignParticipation.id,
           userId: user.id,
           type: Assessment.types.CAMPAIGN,
+          state: Assessment.states.STARTED,
         });
 
-        await databaseBuilder.commit();
+        return databaseBuilder.commit();
       });
 
       it('should disallow the user to share his campaign participation', async () => {

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -55,8 +55,8 @@ describe('Unit | Domain | Errors', () => {
     expect(errors.UserAlreadyLinkedToCandidateInSessionError).to.exist;
   });
 
-  it('should export a CampaignAlreadyArchivedError',() => {
-    expect(errors.CampaignAlreadyArchivedError).to.exist;
+  it('should export a ArchivedCampaignError',() => {
+    expect(errors.ArchivedCampaignError).to.exist;
   });
 
   it('should export a UserNotAuthorizedToUpdatePasswordError', () => {

--- a/api/tests/unit/domain/models/Campaign_test.js
+++ b/api/tests/unit/domain/models/Campaign_test.js
@@ -1,0 +1,61 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Campaign', () => {
+
+  describe('isAssessment', () => {
+
+    it('should return true when campaign is of type assessment', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign.ofTypeAssessment();
+
+      // when / then
+      expect(campaign.isAssessment()).to.be.true;
+    });
+
+    it('should return false when campaign is not of type assessment', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection();
+
+      // when / then
+      expect(campaign.isAssessment()).to.be.false;
+    });
+  });
+
+  describe('isProfilesCollection', () => {
+
+    it('should return true when campaign is of type profiles collection', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection();
+
+      // when / then
+      expect(campaign.isProfilesCollection()).to.be.true;
+    });
+
+    it('should return false when campaign is not of type profiles collection', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign.ofTypeAssessment();
+
+      // when / then
+      expect(campaign.isProfilesCollection()).to.be.false;
+    });
+  });
+
+  describe('isArchived', () => {
+
+    it('should return true when campaign is archived', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign({ archivedAt: new Date('1990-01-04') });
+
+      // when / then
+      expect(campaign.isArchived()).to.be.true;
+    });
+
+    it('should return false when campaign is not of type profiles collection', () => {
+      // given
+      const campaign = domainBuilder.buildCampaign({ archivedAt: null });
+
+      // when / then
+      expect(campaign.isArchived()).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -1,5 +1,5 @@
 const { sinon, expect, domainBuilder, catchErr } = require('../../../test-helper');
-const { AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, CampaignAlreadyArchivedError } = require('../../../../lib/domain/errors');
+const { AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, ArchivedCampaignError } = require('../../../../lib/domain/errors');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const usecases = require('../../../../lib/domain/usecases');
 
@@ -28,7 +28,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
     expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
   });
 
-  it('should throw a CampaignAlreadyArchivedError error when campaign is archived', async () => {
+  it('should throw a ArchivedCampaignError error when campaign is archived', async () => {
     // given
     campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId, campaignId });
     campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ id: campaignId, archivedAt: new Date('1990-11-04') }));
@@ -37,7 +37,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
     const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
 
     // then
-    expect(error).to.be.instanceOf(CampaignAlreadyArchivedError);
+    expect(error).to.be.instanceOf(ArchivedCampaignError);
   });
 
   context('when the campaign is of type assessment', () => {


### PR DESCRIPTION
## :unicorn: Problème
Un participation à une campagne peut être liée à plusieurs assessments pour diverses raisons normales ou pas (lors d'un **retenter**, lors de ralentissements serveur, etc...).
De fait, lorsqu'on fait des raisonnements sur une participation, il faut toujours se baser sur l'assessment le plus récent.
Ce n'était pas le cas dans le usecase de partage des résultats d'une campagne.

## :robot: Solution
S'assurer que l'assessment qu'on vérifie lors du partage des résultats est toujours le plus récent.

- Ecriture de test unitaire sur le modèle Campaign
- Simplification des vérifications autour de l'assessment, on se contente de vérifier seulement l'état de l'assessment
- Réécriture du test unitaire du usecase

## :rainbow: Remarques

## :100: Pour tester
:grimacing: 
