### PR TITLE
[FEATURE] Adapter l'algo des campagnes pour les tests Pix Concours (PIX-1573).

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -2,12 +2,14 @@
 const { AssessmentEndedError } = require('../errors');
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
+const getNextChallengeForDemo = require('./get-next-challenge-for-demo');
 
 module.exports = async function getNextChallengeForCampaignAssessment({
   knowledgeElementRepository,
   targetProfileRepository,
   challengeRepository,
   answerRepository,
+  courseRepository,
   improvementService,
   assessment,
   pickChallengeService,
@@ -19,6 +21,10 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   }
 
   const inputValues = await dataFetcher.fetchForCampaigns(...arguments);
+
+  if (process.env.IS_PIX_CONTEST === 'true') {
+    return getNextChallengeForDemo({ assessment, answerRepository, challengeRepository, courseRepository });
+  }
 
   const {
     possibleSkillsForNextChallenge,

--- a/api/lib/domain/usecases/get-next-challenge-for-demo.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-demo.js
@@ -9,7 +9,15 @@ module.exports = function getNextChallengeForDemo({
   courseRepository,
 }) {
 
-  const courseId = assessment.courseId;
+  let courseId;
+  let campaignId;
+
+  if (process.env.IS_PIX_CONTEST === 'true') {
+    campaignId = assessment.courseId;
+  }
+  else {
+    courseId = assessment.courseId;
+  }
 
   const logContext = {
     zone: 'usecase.getNextChallengeForDemo',
@@ -20,7 +28,9 @@ module.exports = function getNextChallengeForDemo({
   logger.trace(logContext, 'looking for next challenge in DEMO assessment');
 
   return Promise.all([
-    courseRepository.get(courseId),
+    process.env.IS_PIX_CONTEST === 'true' ?
+      courseRepository.getByCampaignId(campaignId)
+      : courseRepository.get(courseId),
     answerRepository.findByAssessment(assessment.id),
   ])
     .then(([course, answers]) => {

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -19,6 +19,17 @@ module.exports = async function startCampaignParticipation({ campaignParticipati
 };
 
 async function _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation) {
+  if (process.env.IS_PIX_CONTEST === 'true') {
+    const assessment = new Assessment({
+      userId,
+      state: Assessment.states.STARTED,
+      type: Assessment.types.CAMPAIGN,
+      courseId: createdCampaignParticipation.campaignId,
+      campaignParticipationId: createdCampaignParticipation.id,
+    });
+    return assessmentRepository.save({ assessment });
+  }
+
   const assessment = new Assessment({
     userId,
     state: Assessment.states.STARTED,

--- a/api/lib/infrastructure/datasources/airtable/course-datasource.js
+++ b/api/lib/infrastructure/datasources/airtable/course-datasource.js
@@ -14,6 +14,7 @@ module.exports = datasource.extend({
     'Competence (id persistant)',
     'Épreuves (id persistant)',
     'Image',
+    'Campagne ID',
   ],
 
   fromAirTableObject(airtableRecord) {
@@ -29,7 +30,13 @@ module.exports = datasource.extend({
       competences: airtableRecord.get('Competence (id persistant)'),
       challenges: _.reverse(airtableRecord.get('Épreuves (id persistant)')),
       imageUrl,
+      campaignId: airtableRecord.get('Campagne ID'),
     };
+  },
+
+  async getByCampaignId(campaignId) {
+    const courses = await this.list();
+    return courses.find((course) => course.campaignId === campaignId);
   },
 
 });

--- a/api/lib/infrastructure/repositories/course-repository.js
+++ b/api/lib/infrastructure/repositories/course-repository.js
@@ -11,6 +11,7 @@ function _toDomain(courseDataObject) {
     imageUrl: courseDataObject.imageUrl,
     challenges: courseDataObject.challenges,
     competences: courseDataObject.competences,
+    campaignId: courseDataObject.campaignId,
   });
 }
 
@@ -27,10 +28,27 @@ async function _get(id) {
   }
 }
 
+async function _getByCampaignId(campaignId) {
+  try {
+    const courseDataObject = await courseDatasource.getByCampaignId(campaignId);
+    return _toDomain(courseDataObject);
+  }
+  catch (error) {
+    if (error instanceof AirtableResourceNotFound) {
+      throw new NotFoundError();
+    }
+    throw error;
+  }
+}
+
 module.exports = {
 
   async get(id) {
     return _get(id);
+  },
+
+  async getByCampaignId(campaignId) {
+    return _getByCampaignId(campaignId);
   },
 
   async getCourseName(id) {

--- a/api/tests/unit/infrastructure/datasources/airtable/course-datasource_test.js
+++ b/api/tests/unit/infrastructure/datasources/airtable/course-datasource_test.js
@@ -29,6 +29,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
               'url': 'https://example.org/course.png',
             },
           ],
+          'Campagne ID': '10000003',
         },
       });
 
@@ -44,6 +45,7 @@ describe('Unit | Infrastructure | Datasource | Airtable | CourseDatasource', () 
         imageUrl: 'https://example.org/course.png',
 
         challenges: ['recChallenge2', 'recChallenge1'],
+        campaignId: '10000003',
       };
 
       expect(course).to.deep.equal(expectedCourse);


### PR DESCRIPTION
## :unicorn: Problème
Sur une campagne Pix Concours, les questions posées sont les mêmes pour tous les candidats, dans le même ordre.

## :robot: Solution
- L'algo de choix de questions pour la démo est réutilisé dans le cas de Pix Concours
- Une nouvelle colonne `Campagne ID` a été rajoutée dans le table `Tests` de Airtable pour pouvoir identifier à quelle campagne la série de questions appartient

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Utiliser la variable d'environnement `IS_PIX_CONTEST` dans le front et l'api pour activer le mode PIX CONCOURS.
- aller sur la campagne avec le code `CONCOURS`
- seulement trois épreuves sont possibles, dans l'ordre suivant: rec0gm0GFue3PQB3k, recLt9uwa2dR3IYpi, rectp52a41MGZ5WgG
- il possible de quitter la campagne, la même épreuve où le candidat s'est arrêté sera posée
