### PR TITLE
[FEATURE] Ajout d'un message de redirection vers le support pour les téléchargement de fichiers (PIX-1451).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -10,7 +10,6 @@ export default class ChallengeStatement extends Component {
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
-  fileDownloadHelpCenterUrl= 'https://support.pix.fr/fr/support/solutions/articles/15000036390';
 
   constructor() {
     super(...arguments);
@@ -38,10 +37,6 @@ export default class ChallengeStatement extends Component {
 
   get id() {
     return 'challenge_statement_' + this.args.challenge.id;
-  }
-
-  get fileDownloadHelpCenterUrl() {
-    return this.fileDownloadHelpCenterUrl;
   }
 
   @action

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -10,6 +10,7 @@ export default class ChallengeStatement extends Component {
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
+  fileDownloadHelpCenterUrl= 'https://support.pix.fr/fr/support/solutions/articles/15000036390';
 
   constructor() {
     super(...arguments);
@@ -37,6 +38,10 @@ export default class ChallengeStatement extends Component {
 
   get id() {
     return 'challenge_statement_' + this.args.challenge.id;
+  }
+
+  get fileDownloadHelpCenterUrl() {
+    return this.fileDownloadHelpCenterUrl;
   }
 
   @action

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -160,6 +160,7 @@
 
 .challenge-statement__action {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
@@ -177,6 +178,27 @@
 .challenge-statement__action-link:hover,
 .challenge-statement__action-link:focus {
   color: $white;
+}
+
+.challenge-statement__action-help {
+  position: relative;
+  top: 16px;
+  font-size: 0.825rem;
+
+  &--link {
+    text-decoration: underline;
+    color: $blue;
+
+    &:active,
+    &:focus,
+    &:hover {
+      color: $blue-hover;
+    }
+
+    &:visited {
+      color: $blue;
+    }
+  }
 }
 
 .challenge-statement__action-label {

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -24,6 +24,7 @@
              download>
             <span class="challenge-statement__action-label">{{t 'pages.challenge.statement.file-download.actions.download'}}</span>
           </a>
+          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' url=this.fileDownloadHelpCenterUrl htmlSafe=true}}</p>
         </div>
       {{/if}}
 
@@ -65,6 +66,7 @@
              download>
             <span class="challenge-statement__action-label">{{t 'pages.challenge.statement.file-download.actions.download'}}</span>
           </a>
+          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' url=this.fileDownloadHelpCenterUrl htmlSafe=true}}</p>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -24,7 +24,7 @@
              download>
             <span class="challenge-statement__action-label">{{t 'pages.challenge.statement.file-download.actions.download'}}</span>
           </a>
-          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' url=this.fileDownloadHelpCenterUrl htmlSafe=true}}</p>
+          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' htmlSafe=true}}</p>
         </div>
       {{/if}}
 
@@ -66,7 +66,7 @@
              download>
             <span class="challenge-statement__action-label">{{t 'pages.challenge.statement.file-download.actions.download'}}</span>
           </a>
-          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' url=this.fileDownloadHelpCenterUrl htmlSafe=true}}</p>
+          <p class="challenge-statement__action-help">{{t 'pages.challenge.statement.file-download.help' htmlSafe=true}}</p>
         </div>
       {{/if}}
     </div>

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -343,6 +343,17 @@ describe('Integration | Component | ChallengeStatement', function() {
         expect(find('.challenge-statement__help-icon')).to.exist;
       });
 
+      it('should display instructions regarding downloading issues', async function() {
+        // given
+        addChallengeToContext(this, challenge);
+        addAssessmentToContext(this, { id: '267845' });
+
+        // when
+        await renderChallengeStatement();
+        // then
+        expect(find('.challenge-statement__action-help')).to.exist;
+      });
+
     });
 
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -364,7 +364,8 @@
                         "download": "Download"
                     },
                     "description": "Pix lets you choose which format of file to download. If you do not know which option to use, select the default option. This is the file format that is the most commonly used.",
-                    "file-type": "file .{fileExtension}"
+                    "file-type": "file .{fileExtension}",
+                    "help": ""
                 }
             },
             "skip-error-message": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -364,7 +364,8 @@
                         "download": "Télécharger"
                     },
                     "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
-                    "file-type": "fichier .{fileExtension}"
+                    "file-type": "fichier .{fileExtension}",
+                    "help": "Besoin d'aide pour '<'a href=\"{url}\" class=\"challenge-statement__action-help--link\" target=\"_blank\"'>'ouvrir, modifier ou retrouver ce fichier'</a>'."
                 }
             },
             "skip-error-message": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -365,7 +365,7 @@
                     },
                     "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
                     "file-type": "fichier .{fileExtension}",
-                    "help": "Besoin d'aide pour '<'a href=\"{url}\" class=\"challenge-statement__action-help--link\" target=\"_blank\"'>'ouvrir, modifier ou retrouver ce fichier'</a>'."
+                    "help": "Besoin d'aide pour '<'a href=\"https://support.pix.fr/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\"'>'ouvrir, modifier ou retrouver ce fichier'</a>'."
                 }
             },
             "skip-error-message": {


### PR DESCRIPTION
## :unicorn: Problème

Les utilisateurs peuvent rencontrer des difficultés lors du téléchargement de fichier(s) lors du passage des épreuves.

## :robot: Solution

Ajout d'un message en dessous du bouton de téléchargement des fichiers redirigeant vers le support.

## :rainbow: Remarques

- Une classe CSS a du être ajoutée au lien présent dans le fichier de traduction, sans quoi une erreur est remontée par le linter : [No-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity)
- L'URL du support a été ajoutée au composant mais peut être replacée (ex: environment.js) si nécessaire.

## :100: Pour tester

Réaliser une épreuve contenant un téléchargement de fichier. 
Ex : recC7E3nZmiFH0GHP
