### PR TITLE
[TECH] Corriger l'url de connexion à lcms dans sample.env

### DIFF
--- a/api/sample.env
+++ b/api/sample.env
@@ -235,7 +235,7 @@ LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
 # presence: required
 # type: String
 # default: none
-LCMS_API_URL=https://lcms.minimal.pix.fr/api
+LCMS_API_URL=https://lcms.minimal.pix.fr/api/airtable
 
 # =======
 # LOGGING


### PR DESCRIPTION
## :unicorn: Problème
L'url de connexion à LCMS dans le template sample.env n'est pas correcte car il manque le suffixe `/airtable`.
Cela peut induire à des oublis de suffixer par `/airtable` lorsque l'on cherche à modifier l'url LCMS.

## :robot: Solution
Ajouter `/airtable` à l'url lcms.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
