### PR TITLE
[FEATURE] Vérifier l'accès à la session de certification des élèves (PIX-1540)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -220,6 +220,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.SchoolingRegistrationAlreadyLinkedToUserError) {
     return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }
+  if (error instanceof DomainErrors.MatchingReconciledStudentNotFoundError) {
+    return new HttpErrors.BadRequestError(error.message, error.code);
+  }
   if (error instanceof DomainErrors.UserNotAuthorizedToUpdatePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -83,10 +83,11 @@ class ImproveCompetenceEvaluationForbiddenError extends BaseHttpError {
 }
 
 class BadRequestError extends BaseHttpError {
-  constructor(message) {
+  constructor(message, code) {
     super(message);
     this.title = 'Bad Request';
     this.status = 400;
+    this.code = code;
   }
 }
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -175,8 +175,8 @@ module.exports = {
       userId, sessionId, firstName, lastName, birthdate,
     });
 
-    const serialized = await certificationCandidateSerializer.serialize(event.certificationCandidate);
-
+    const certificationCandidate = await usecases.getCertificationCandidate({ userId, sessionId });
+    const serialized = await certificationCandidateSerializer.serialize(certificationCandidate);
     return (event instanceof UserLinkedEvent) ? h.response(serialized).created() : serialized;
   },
 

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -14,6 +14,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const { getCertificationResultsCsv } = require('../../infrastructure/utils/csv/certification-results');
 const trim = require('lodash/trim');
+const { UserLinkedEvent } = require('../../domain/usecases/link-user-to-session-certification-candidate');
 
 module.exports = {
 
@@ -170,13 +171,13 @@ module.exports = {
     const lastName = trim(request.payload.data.attributes['last-name']);
     const birthdate = request.payload.data.attributes['birthdate'];
 
-    const { linkCreated, certificationCandidate } = await usecases.linkUserToSessionCertificationCandidate({
+    const event = await usecases.linkUserToSessionCertificationCandidate({
       userId, sessionId, firstName, lastName, birthdate,
     });
 
-    const serialized = await certificationCandidateSerializer.serialize(certificationCandidate);
+    const serialized = await certificationCandidateSerializer.serialize(event.certificationCandidate);
 
-    return linkCreated ? h.response(serialized).created() : serialized;
+    return (event instanceof UserLinkedEvent) ? h.response(serialized).created() : serialized;
   },
 
   async finalize(request) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -13,6 +13,7 @@ const jurySessionRepository = require('../../infrastructure/repositories/jury-se
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const { getCertificationResultsCsv } = require('../../infrastructure/utils/csv/certification-results');
+const trim = require('lodash/trim');
 
 module.exports = {
 
@@ -165,8 +166,8 @@ module.exports = {
   async createCandidateParticipation(request, h) {
     const userId = request.auth.credentials.userId;
     const sessionId = request.params.id;
-    const firstName = request.payload.data.attributes['first-name'];
-    const lastName = request.payload.data.attributes['last-name'];
+    const firstName = trim(request.payload.data.attributes['first-name']);
+    const lastName = trim(request.payload.data.attributes['last-name']);
     const birthdate = request.payload.data.attributes['birthdate'];
 
     const { linkCreated, certificationCandidate } = await usecases.linkUserToSessionCertificationCandidate({

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -14,7 +14,7 @@ const queryParamsUtils = require('../../infrastructure/utils/query-params-utils'
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
 const { getCertificationResultsCsv } = require('../../infrastructure/utils/csv/certification-results');
 const trim = require('lodash/trim');
-const { UserLinkedEvent } = require('../../domain/usecases/link-user-to-session-certification-candidate');
+const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
 
 module.exports = {
 
@@ -177,7 +177,7 @@ module.exports = {
 
     const certificationCandidate = await usecases.getCertificationCandidate({ userId, sessionId });
     const serialized = await certificationCandidateSerializer.serialize(certificationCandidate);
-    return (event instanceof UserLinkedEvent) ? h.response(serialized).created() : serialized;
+    return (event instanceof UserLinkedToCertificationCandidate) ? h.response(serialized).created() : serialized;
   },
 
   async finalize(request) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -254,8 +254,9 @@ class CertificationCandidateByPersonalInfoNotFoundError extends DomainError {
 }
 
 class MatchingReconciledStudentNotFoundError extends DomainError {
-  constructor(message = 'Aucun candidat de certification SCO n\'a été trouvé avec ces informations.') {
+  constructor(message = 'Le candidat de certification ne correspond pas à l\'étudiant trouvé avec ces informations.') {
     super(message);
+    this.code = 'MATCHING_RECONCILED_STUDENT_NOT_FOUND';
   }
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -246,8 +246,15 @@ class CertificationCandidateAlreadyLinkedToUserError extends DomainError {
     super(message);
   }
 }
+
 class CertificationCandidateByPersonalInfoNotFoundError extends DomainError {
   constructor(message = 'Aucun candidat de certification n\'a été trouvé avec ces informations.') {
+    super(message);
+  }
+}
+
+class MatchingReconciledStudentNotFoundError extends DomainError {
+  constructor(message = 'Aucun candidat de certification SCO n\'a été trouvé avec ces informations.') {
     super(message);
   }
 }
@@ -645,6 +652,7 @@ module.exports = {
   CertificationCandidateForbiddenDeletionError,
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
+  MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   CertificationCandidateCreationOrUpdateError,
   CertificationCandidateDeletionError,

--- a/api/lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js
+++ b/api/lib/domain/events/UserAlreadyLinkedToCertificationCandidate.js
@@ -1,0 +1,2 @@
+module.exports = class UserAlreadyLinkedToCertificationCandidate {
+};

--- a/api/lib/domain/events/UserLinkedToCertificationCandidate.js
+++ b/api/lib/domain/events/UserLinkedToCertificationCandidate.js
@@ -1,0 +1,2 @@
+module.exports = class UserLinkedToCertificationCandidate {
+};

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,4 +1,5 @@
-const _ = require('lodash');
+const isNil = require('lodash/isNil');
+const endsWith = require('lodash/endsWith');
 const Joi = require('@hapi/joi')
   .extend(require('@hapi/joi-date'));
 const {
@@ -72,7 +73,7 @@ class CertificationCandidate {
     this.resultRecipientEmail = resultRecipientEmail;
     this.externalId = externalId;
     this.birthdate = birthdate;
-    this.extraTimePercentage = !_.isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
+    this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.createdAt = createdAt;
     // references
     this.sessionId = sessionId;
@@ -103,11 +104,19 @@ class CertificationCandidate {
   validateParticipation() {
     const { error } = certificationCandidateParticipationJoiSchema.validate(this);
     if (error) {
-      if (_.endsWith(error.details[0].type, 'required')) {
+      if (endsWith(error.details[0].type, 'required')) {
         throw new CertificationCandidatePersonalInfoFieldMissingError();
       }
       throw new CertificationCandidatePersonalInfoWrongFormat();
     }
+  }
+
+  isLinkedToAUser() {
+    return !isNil(this.userId);
+  }
+
+  isLinkedToUserId(userId) {
+    return this.userId === userId;
   }
 }
 

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,7 +1,11 @@
 const _ = require('lodash');
 const Joi = require('@hapi/joi')
   .extend(require('@hapi/joi-date'));
-const { InvalidCertificationCandidate } = require('../errors');
+const {
+  InvalidCertificationCandidate,
+  CertificationCandidatePersonalInfoFieldMissingError,
+  CertificationCandidatePersonalInfoWrongFormat,
+} = require('../errors');
 
 const certificationCandidateValidationJoiSchema_v1_3 = Joi.object({
   firstName: Joi.string().required().empty(null),
@@ -99,7 +103,10 @@ class CertificationCandidate {
   validateParticipation() {
     const { error } = certificationCandidateParticipationJoiSchema.validate(this);
     if (error) {
-      throw error;
+      if (_.endsWith(error.details[0].type, 'required')) {
+        throw new CertificationCandidatePersonalInfoFieldMissingError();
+      }
+      throw new CertificationCandidatePersonalInfoWrongFormat();
     }
   }
 }

--- a/api/lib/domain/usecases/get-certification-candidate.js
+++ b/api/lib/domain/usecases/get-certification-candidate.js
@@ -1,0 +1,9 @@
+async function getCertificationCandidate({
+  userId,
+  sessionId,
+  certificationCandidateRepository,
+}) {
+  return certificationCandidateRepository.getBySessionIdAndUserId({ userId, sessionId });
+}
+
+module.exports = getCertificationCandidate;

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -157,6 +157,7 @@ module.exports = injectDependencies({
   getCampaignProfile: require('./get-campaign-profile'),
   getCampaignReport: require('./get-campaign-report'),
   getCertificationAttestation: require('./certificate/get-certification-attestation'),
+  getCertificationCandidate: require('./get-certification-candidate'),
   getCertificationCenter: require('./get-certification-center'),
   getCertificationCourse: require('./get-certification-course'),
   getCorrectionForAnswer: require('./get-correction-for-answer'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -193,7 +193,7 @@ module.exports = injectDependencies({
   importHigherSchoolingRegistrations: require('./import-higher-schooling-registrations'),
   importSchoolingRegistrationsFromSIECLEFormat: require('./import-schooling-registrations-from-siecle'),
   improveCompetenceEvaluation: require('./improve-competence-evaluation'),
-  linkUserToSessionCertificationCandidate: require('./link-user-to-session-certification-candidate'),
+  linkUserToSessionCertificationCandidate: require('./link-user-to-session-certification-candidate').linkUserToSessionCertificationCandidate,
   reconcileHigherSchoolingRegistration: require('./reconcile-higher-schooling-registration'),
   reconcileSchoolingRegistration: require('./reconcile-schooling-registration'),
   reconcileUserToOrganization: require('./reconcile-user-to-organization'),

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -7,6 +7,8 @@ const {
   CertificationCandidateByPersonalInfoTooManyMatchesError,
   UserAlreadyLinkedToCandidateInSessionError,
 } = require('../errors');
+const UserLinkedToCertificationCandidate = require('../events/UserLinkedToCertificationCandidate');
+const UserAlreadyLinkedToCertificationCandidate = require('../events/UserAlreadyLinkedToCertificationCandidate');
 
 async function linkUserToSessionCertificationCandidate({
   userId,
@@ -48,11 +50,11 @@ async function linkUserToSessionCertificationCandidate({
       certificationCandidate,
       certificationCandidateRepository,
     });
-    return new UserLinkedEvent();
+    return new UserLinkedToCertificationCandidate();
   }
 
   if (certificationCandidate.isLinkedToUserId(userId)) {
-    return new UserAlreadyLinkedEvent();
+    return new UserAlreadyLinkedToCertificationCandidate();
   } else {
     throw new CertificationCandidateAlreadyLinkedToUserError();
   }
@@ -101,12 +103,6 @@ async function _linkUserToCandidate({
   return certificationCandidate;
 }
 
-class UserLinkedEvent {
-}
-
-class UserAlreadyLinkedEvent {
-}
-
 async function _checkCandidateMatchTheReconciledStudent({ userId, certificationCandidate, schoolingRegistrationRepository }) {
   const isSchoolingRegistrationIdLinkedToUserAndSCOOrganization = await schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
     userId,
@@ -119,6 +115,4 @@ async function _checkCandidateMatchTheReconciledStudent({ userId, certificationC
 
 module.exports = {
   linkUserToSessionCertificationCandidate,
-  UserAlreadyLinkedEvent,
-  UserLinkedEvent,
 };

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -108,11 +108,11 @@ class UserAlreadyLinkedEvent {
 }
 
 async function _checkCandidateMatchTheReconciledStudent({ userId, certificationCandidate, schoolingRegistrationRepository }) {
-  const students = await schoolingRegistrationRepository.findByUserIdAndSchoolingRegistrationIdAndSCOOrganization({
+  const isSchoolingRegistrationIdLinkedToUserAndSCOOrganization = await schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
     userId,
     schoolingRegistrationId: certificationCandidate.schoolingRegistrationId,
   });
-  if (_.isEmpty(students)) {
+  if (!isSchoolingRegistrationIdLinkedToUserAndSCOOrganization) {
     throw new MatchingReconciledStudentNotFoundError();
   }
 }

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -17,14 +17,8 @@ module.exports = async function linkUserToSessionCertificationCandidate({
   birthdate,
   certificationCandidateRepository,
 }) {
-  const trimmedFirstName = firstName
-    ? firstName.trim()
-    : firstName;
-  const trimmedLastName = lastName
-    ? lastName.trim()
-    : lastName;
   const participatingCertificationCandidate = new CertificationCandidate({
-    firstName: trimmedFirstName, lastName: trimmedLastName, birthdate, sessionId });
+    firstName, lastName, birthdate, sessionId });
 
   try {
     participatingCertificationCandidate.validateParticipation();

--- a/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
+++ b/api/lib/domain/usecases/link-user-to-session-certification-candidate.js
@@ -14,7 +14,13 @@ async function linkUserToSessionCertificationCandidate({
   lastName,
   birthdate,
   certificationCandidateRepository,
+  sessionRepository,
 }) {
+  const isSco = await sessionRepository.isSco(sessionId);
+  if (isSco) {
+    throw Error('sco!');
+  }
+
   const participatingCertificationCandidate = new CertificationCandidate({
     firstName,
     lastName,

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -79,6 +79,17 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations);
   },
 
+  // FIXME find or get => on a uniquement besoin du nationalStudentId
+  async findByUserIdAndSchoolingRegistrationIdAndSCOOrganization({ userId, schoolingRegistrationId }) {
+    const schoolingRegistrations = await BookshelfSchoolingRegistration
+      .query((qb) => qb.join('organizations', 'schooling-registrations.organizationId', 'organizations.id'))
+      .where({ userId, type: 'SCO', 'schooling-registrations.id': schoolingRegistrationId })
+      //FIXME do not fetch everything
+      .fetchAll();
+
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations);
+  },
+
   async findByUserIdAndSCOOrganization({ userId }) {
     const schoolingRegistrations = await BookshelfSchoolingRegistration
       .query((qb) => qb.join('organizations', 'schooling-registrations.organizationId', 'organizations.id'))

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -130,4 +130,13 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, publishedSession);
   },
 
+  async isSco(sessionId) {
+    const session = await BookshelfSession
+      .where({ 'sessions.id': sessionId, 'certification-centers.type': 'SCO' })
+      .query((qb) => {
+        qb.innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId');
+      })
+      .fetch({ columns: 'sessions.id' });
+    return Boolean(session);
+  },
 };

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -311,8 +311,8 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
-  describe('#findByUserIdAndSchoolingRegistrationIdAndSCOOrganization', () => {
-    it('should return the schoolingRegistration that matches an id and matches also a given user id and a SCO organization', async () => {
+  describe('#isSchoolingRegistrationIdLinkedToUserAndSCOOrganization', () => {
+    it('should return true when a schoolingRegistration matches an id and matches also a given user id and a SCO organization', async () => {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const otherUserId = databaseBuilder.factory.buildUser().id;
@@ -326,14 +326,24 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
       await databaseBuilder.commit();
 
       // when
-      const schoolingRegistrations = await schoolingRegistrationRepository.findByUserIdAndSchoolingRegistrationIdAndSCOOrganization({
+      const isLinked = await schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
         userId,
         schoolingRegistrationId : matchingSchoolingRegistrationId,
       });
 
       // then
-      expect(schoolingRegistrations).to.have.a.lengthOf(1);
-      expect(schoolingRegistrations[0].id).to.equal(matchingSchoolingRegistrationId);
+      expect(isLinked).to.be.true;
+    });
+
+    it('should return false when no schoolingRegistration matches an id and matches also a given user id and a SCO organization', async () => {
+      // when
+      const isLinked = await schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
+        userId: 42,
+        schoolingRegistrationId : 42,
+      });
+
+      // then
+      expect(isLinked).to.be.false;
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/schooling-registration-repository_test.js
@@ -311,6 +311,32 @@ describe('Integration | Infrastructure | Repository | schooling-registration-rep
     });
   });
 
+  describe('#findByUserIdAndSchoolingRegistrationIdAndSCOOrganization', () => {
+    it('should return the schoolingRegistration that matches an id and matches also a given user id and a SCO organization', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const otherUserId = databaseBuilder.factory.buildUser().id;
+      const firstScoOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const secondScoOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
+      const supOrganizationId = databaseBuilder.factory.buildOrganization({ type: 'SUP' }).id;
+      const matchingSchoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({ userId, organizationId: firstScoOrganizationId }).id;
+      databaseBuilder.factory.buildSchoolingRegistration({ userId, organizationId: secondScoOrganizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({ userId: otherUserId, organizationId: secondScoOrganizationId });
+      databaseBuilder.factory.buildSchoolingRegistration({ userId, organizationId: supOrganizationId });
+      await databaseBuilder.commit();
+
+      // when
+      const schoolingRegistrations = await schoolingRegistrationRepository.findByUserIdAndSchoolingRegistrationIdAndSCOOrganization({
+        userId,
+        schoolingRegistrationId : matchingSchoolingRegistrationId,
+      });
+
+      // then
+      expect(schoolingRegistrations).to.have.a.lengthOf(1);
+      expect(schoolingRegistrations[0].id).to.equal(matchingSchoolingRegistrationId);
+    });
+  });
+
   describe('#addOrUpdateOrganizationSchoolingRegistrations', () => {
 
     context('when there are only schoolingRegistrations to create', () => {

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -452,4 +452,39 @@ describe('Integration | Repository | Session', function() {
     });
   });
 
+  describe('#isSco', () => {
+    it('should be true when the certification center is of type SCO', async () => {
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        type: 'SCO',
+      });
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenterId: certificationCenter.id,
+      });
+
+      await databaseBuilder.commit();
+
+      const result = await sessionRepository.isSco(session.id);
+
+      expect(result).to.be.true;
+    });
+
+    it('should be false when the certification center is not of type SCO', async () => {
+      // given
+      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
+        type: 'PRO',
+      });
+      const session = databaseBuilder.factory.buildSession({
+        certificationCenterId: certificationCenter.id,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const result = await sessionRepository.isSco(session.id);
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
 });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -15,28 +15,8 @@ const requestResponseUtils = require('../../../../lib/infrastructure/utils/reque
 const sessionValidator = require('../../../../lib/domain/validators/session-validator');
 const juryCertificationSummaryRepository = require('../../../../lib/infrastructure/repositories/jury-certification-summary-repository');
 const jurySessionRepository = require('../../../../lib/infrastructure/repositories/jury-session-repository');
-const { UserAlreadyLinkedEvent, UserLinkedEvent } = require('../../../../lib/domain/usecases/link-user-to-session-certification-candidate');
-
-function buildRequest(sessionId, userId, firstName, lastName, birthdate) {
-  return {
-    params: { id: sessionId },
-    auth: {
-      credentials: {
-        userId,
-      },
-    },
-    payload: {
-      data: {
-        attributes: {
-          'first-name': firstName,
-          'last-name': lastName,
-          'birthdate': birthdate,
-        },
-        type: 'certification-candidates',
-      },
-    },
-  };
-}
+const UserAlreadyLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate');
+const UserLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserLinkedToCertificationCandidate');
 
 describe('Unit | Controller | sessionController', () => {
 
@@ -535,7 +515,7 @@ describe('Unit | Controller | sessionController', () => {
       firstName = 'firstName     ';
       lastName = 'lastName    ';
       sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
-        .withArgs({ userId, sessionId, firstName: 'firstName', lastName: 'lastName', birthdate }).resolves(new UserAlreadyLinkedEvent());
+        .withArgs({ userId, sessionId, firstName: 'firstName', lastName: 'lastName', birthdate }).resolves(new UserAlreadyLinkedToCertificationCandidate());
       sinon.stub(usecases, 'getCertificationCandidate')
         .withArgs({ userId, sessionId })
         .resolves(linkedCertificationCandidate);
@@ -553,7 +533,7 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, firstName, lastName, birthdate })
-          .resolves(new UserAlreadyLinkedEvent());
+          .resolves(new UserAlreadyLinkedToCertificationCandidate());
         sinon.stub(usecases, 'getCertificationCandidate')
           .withArgs({ userId, sessionId })
           .resolves(linkedCertificationCandidate);
@@ -576,7 +556,7 @@ describe('Unit | Controller | sessionController', () => {
       beforeEach(() => {
         sinon.stub(usecases, 'linkUserToSessionCertificationCandidate')
           .withArgs({ userId, sessionId, firstName, lastName, birthdate })
-          .resolves(new UserLinkedEvent());
+          .resolves(new UserLinkedToCertificationCandidate());
         sinon.stub(usecases, 'getCertificationCandidate')
           .withArgs({ userId, sessionId })
           .resolves(linkedCertificationCandidate);
@@ -826,3 +806,24 @@ describe('Unit | Controller | sessionController', () => {
 
   });
 });
+
+function buildRequest(sessionId, userId, firstName, lastName, birthdate) {
+  return {
+    params: { id: sessionId },
+    auth: {
+      credentials: {
+        userId,
+      },
+    },
+    payload: {
+      data: {
+        attributes: {
+          'first-name': firstName,
+          'last-name': lastName,
+          'birthdate': birthdate,
+        },
+        type: 'certification-candidates',
+      },
+    },
+  };
+}

--- a/api/tests/unit/domain/models/CertificationCandidate_test.js
+++ b/api/tests/unit/domain/models/CertificationCandidate_test.js
@@ -1,7 +1,10 @@
 const { expect, domainBuilder, catchErr } = require('../../../test-helper');
 const CertificationCandidate = require('../../../../lib/domain/models/CertificationCandidate');
-const { InvalidCertificationCandidate } = require('../../../../lib/domain/errors');
-const { ValidationError } = require('@hapi/joi');
+const {
+  InvalidCertificationCandidate,
+  CertificationCandidatePersonalInfoFieldMissingError,
+  CertificationCandidatePersonalInfoWrongFormat,
+} = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | Certification Candidate', () => {
 
@@ -211,7 +214,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoFieldMissingError);
       }
     });
 
@@ -224,7 +227,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 
@@ -238,7 +241,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoFieldMissingError);
       }
     });
 
@@ -251,7 +254,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 
@@ -265,7 +268,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoFieldMissingError);
       }
     });
 
@@ -278,7 +281,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 
@@ -291,7 +294,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 
@@ -304,7 +307,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 
@@ -318,7 +321,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoFieldMissingError);
       }
     });
 
@@ -331,7 +334,7 @@ describe('Unit | Domain | Models | Certification Candidate', () => {
         certificationCandidate.validateParticipation();
         expect.fail('Expected error to have been thrown');
       } catch (err) { // then
-        expect(err).to.be.instanceOf(ValidationError);
+        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
       }
     });
 

--- a/api/tests/unit/domain/usecases/get-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-candidate_test.js
@@ -1,0 +1,24 @@
+const { expect, sinon } = require('../../../test-helper');
+const getCertificationCandidate = require('../../../../lib/domain/usecases/get-certification-candidate');
+
+describe('Unit | Domain | Use Cases | get-certification-candidate', () => {
+
+  it('should get the certification candidate', async () => {
+    // given
+    const userId = Symbol('userId');
+    const sessionId = Symbol('sessionId');
+    const expectedCertificationCandidate = Symbol('certifCandidate');
+    const certificationCandidateRepository = {
+      getBySessionIdAndUserId: sinon.stub(),
+    };
+    certificationCandidateRepository.getBySessionIdAndUserId
+      .withArgs({ userId, sessionId })
+      .resolves(expectedCertificationCandidate);
+
+    // when
+    const certificationCandidate = await getCertificationCandidate({ userId, sessionId, certificationCandidateRepository });
+
+    // then
+    expect(certificationCandidate).to.equal(expectedCertificationCandidate);
+  });
+});

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -406,7 +406,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
             .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
 
-          const scoCertificationCandidateRepository = _buildFakeSCOCertificationCandidateRepository();
           // when
           const event = await linkUserToSessionCertificationCandidate({
             sessionId,
@@ -416,7 +415,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             birthdate,
             certificationCandidateRepository,
             schoolingRegistrationRepository,
-            scoCertificationCandidateRepository,
             sessionRepository,
           });
 
@@ -458,8 +456,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
             .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
 
-          const scoCertificationCandidateRepository = _buildFakeSCOCertificationCandidateRepository();
-
           // when
           const error = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
@@ -470,7 +466,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             certificationCandidateRepository,
             schoolingRegistrationRepository,
             sessionRepository,
-            scoCertificationCandidateRepository,
           });
 
           // then
@@ -523,12 +518,5 @@ function _buildFakeCertificationCandidateRepository() {
       this.linkToUser.withArgs(args).resolves(resolves);
       return this;
     },
-  };
-}
-
-function _buildFakeSCOCertificationCandidateRepository() {
-  const linkToUser = sinon.stub();
-  return {
-    linkToUser,
   };
 }

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -11,7 +11,7 @@ const {
   UserAlreadyLinkedToCandidateInSessionError,
 } = require('../../../../lib/domain/errors');
 
-describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
+describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
   const sessionId = 'sessionId';
   const userId = 'userId';
   let firstName;
@@ -250,26 +250,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candid
         });
 
         it('should create a link and return the linked certification candidate', async () => {
-          // when
-          const result = await usecases.linkUserToSessionCertificationCandidate({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-          });
-
-          // then
-          expect(result.linkCreated).to.be.true;
-          sinon.assert.calledWith(certificationCandidateRepository.linkToUser, { id: certificationCandidate.id, userId });
-        });
-
-        it('should trim spaces in first and last name when searching for a candidate', async () => {
-          // given
-          firstName = ` \t${firstName} \t`;
-          lastName = `  \t${lastName} \t`;
-
           // when
           const result = await usecases.linkUserToSessionCertificationCandidate({
             sessionId,

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -31,6 +31,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       it('should throw a CertificationCandidatePersonalInfoFieldMissingError', async () => {
         // given
         firstName = undefined;
+        const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
 
         // when
         const err = await catchErr(linkUserToSessionCertificationCandidate)({
@@ -40,6 +41,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
+          sessionRepository,
         });
 
         // then
@@ -52,6 +54,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       it('should throw a CertificationCandidatePersonalInfoWrongFormat', async () => {
         // given
         birthdate = 'invalid format';
+        const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
 
         // when
         const err = await catchErr(linkUserToSessionCertificationCandidate)({
@@ -61,6 +64,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
+          sessionRepository,
         });
 
         // then
@@ -82,6 +86,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       });
 
       it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async () => {
+        // given
+        const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
         // when
         const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
@@ -90,6 +97,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
+          sessionRepository,
         });
 
         // then
@@ -111,6 +119,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       });
 
       it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async () => {
+        // given
+        const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
         // when
         const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
@@ -119,6 +130,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
+          sessionRepository,
         });
 
         // then
@@ -147,6 +159,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should not create a link and return the matching certification candidate', async () => {
+          // given
+          const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
           // when
           const result = await linkUserToSessionCertificationCandidate({
             sessionId,
@@ -155,6 +170,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
+            sessionRepository,
           });
 
           // then
@@ -179,6 +195,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should throw a CertificationCandidateAlreadyLinkedToUserError', async () => {
+          // given
+          const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
+          // when
           const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
@@ -186,6 +206,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
+            sessionRepository,
           });
 
           // then
@@ -214,6 +235,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should throw a UserAlreadyLinkedToCandidateInSessionError', async () => {
+          // given
+          const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
+          // when
           const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
@@ -221,6 +246,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
+            sessionRepository,
           });
 
           // then
@@ -250,6 +276,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should create a link and return the linked certification candidate', async () => {
+          // given
+          const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: false });
+
           // when
           const result = await linkUserToSessionCertificationCandidate({
             sessionId,
@@ -258,6 +287,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
+            sessionRepository,
           });
 
           // then
@@ -267,4 +297,40 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       });
     });
   });
+
+  context('when the session is of type SCO', () => {
+    it('throws an exception (temporary for building test)', async () => {
+      // given
+      const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
+      sinon.stub(certificationCandidateRepository,
+        'findBySessionIdAndPersonalInfo')
+        .withArgs({
+          sessionId,
+          firstName: firstName,
+          lastName: lastName,
+          birthdate: birthdate,
+        }).resolves([certificationCandidate]);
+
+      const sessionRepository = _buildFakeSessionRepository({ sessionId, isSco: true });
+
+      // when
+      const err = await catchErr(linkUserToSessionCertificationCandidate)({
+        sessionId,
+        userId,
+        firstName,
+        lastName,
+        birthdate,
+        certificationCandidateRepository,
+        sessionRepository,
+      });
+
+      expect(err).to.be.instanceOf(Error);
+    });
+  });
 });
+
+function _buildFakeSessionRepository({ sessionId, isSco }) {
+  const isScoStub = sinon.stub();
+  isScoStub.withArgs(sessionId).resolves(isSco);
+  return { isSco: isScoStub };
+}

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -9,7 +9,8 @@ const {
   CertificationCandidatePersonalInfoWrongFormat,
   UserAlreadyLinkedToCandidateInSessionError,
 } = require('../../../../lib/domain/errors');
-const { UserLinkedEvent, UserAlreadyLinkedEvent } = require('../../../../lib/domain/usecases/link-user-to-session-certification-candidate');
+const UserLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserLinkedToCertificationCandidate');
+const UserAlreadyLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserAlreadyLinkedToCertificationCandidate');
 
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
   const sessionId = 42;
@@ -178,7 +179,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
           // then
           expect(result).to.deep.equal(
-            new UserAlreadyLinkedEvent(certificationCandidate),
+            new UserAlreadyLinkedToCertificationCandidate(),
           );
         });
       });
@@ -287,7 +288,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           });
 
           // then
-          expect(result).to.deep.equal(new UserLinkedEvent(certificationCandidate));
+          expect(result).to.deep.equal(new UserAlreadyLinkedToCertificationCandidate());
           sinon.assert.calledWith(certificationCandidateRepository.linkToUser, {
             id: certificationCandidate.id,
             userId,
@@ -424,7 +425,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             id: certificationCandidate.id,
             userId,
           });
-          expect(event).to.be.instanceOf(UserLinkedEvent);
+          expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
         });
       });
 

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -1,5 +1,4 @@
 const { catchErr, expect, sinon } = require('../../../test-helper');
-const CertificationCandidate = require('../../../../lib/domain/models/CertificationCandidate');
 const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
 const usecases = require('../../../../lib/domain/usecases');
 const {
@@ -12,7 +11,7 @@ const {
 } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
-  const sessionId = 'sessionId';
+  const sessionId = 42;
   const userId = 'userId';
   let firstName;
   let lastName;
@@ -22,7 +21,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
     firstName = 'Charlie';
     lastName = 'Bideau';
     birthdate = '2010-10-10';
-    sinon.stub(CertificationCandidate.prototype, 'validateParticipation');
   });
 
   context('when there is a problem with the personal info', () => {
@@ -31,7 +29,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidatePersonalInfoFieldMissingError', async () => {
         // given
-        CertificationCandidate.prototype.validateParticipation.throws({ details: { type: 'any.required' } });
+        firstName = undefined;
 
         // when
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
@@ -52,7 +50,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidatePersonalInfoWrongFormat', async () => {
         // given
-        CertificationCandidate.prototype.validateParticipation.throws({ details: { type: 'any.format' } });
+        birthdate = 'invalid format';
 
         // when
         const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -350,9 +350,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             resolves: [certificationCandidate] });
 
         const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-          .withFindByUserIdAndSchoolingRegistrationIdAndSCOOrganization({
+          .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
             args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
-            resolves: [],
+            resolves: false,
           });
 
         // when
@@ -403,7 +403,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             });
 
           const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-            .withFindByUserIdAndSchoolingRegistrationIdAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: [schoolingRegistration] });
+            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
 
           const scoCertificationCandidateRepository = _buildFakeSCOCertificationCandidateRepository();
           // when
@@ -455,7 +455,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             }, resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }) });
 
           const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-            .withFindByUserIdAndSchoolingRegistrationIdAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: [schoolingRegistration] });
+            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args:{ userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
 
           const scoCertificationCandidateRepository = _buildFakeSCOCertificationCandidateRepository();
 
@@ -492,11 +492,11 @@ function _buildFakeSessionRepository() {
 }
 
 function _buildFakeSchoolingRegistrationRepository() {
-  const findByUserIdAndSchoolingRegistrationIdAndSCOOrganization = sinon.stub();
+  const isSchoolingRegistrationIdLinkedToUserAndSCOOrganization = sinon.stub();
   return {
-    findByUserIdAndSchoolingRegistrationIdAndSCOOrganization,
-    withFindByUserIdAndSchoolingRegistrationIdAndSCOOrganization({ args, resolves }) {
-      this.findByUserIdAndSchoolingRegistrationIdAndSCOOrganization.withArgs(args).resolves(resolves);
+    isSchoolingRegistrationIdLinkedToUserAndSCOOrganization,
+    withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args, resolves }) {
+      this.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization.withArgs(args).resolves(resolves);
       return this;
     },
   };

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -1,6 +1,6 @@
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const certificationCandidateRepository = require('../../../../lib/infrastructure/repositories/certification-candidate-repository');
-const usecases = require('../../../../lib/domain/usecases');
+const { linkUserToSessionCertificationCandidate } = require('../../../../lib/domain/usecases/link-user-to-session-certification-candidate');
 const {
   CertificationCandidateAlreadyLinkedToUserError,
   CertificationCandidateByPersonalInfoNotFoundError,
@@ -33,7 +33,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         firstName = undefined;
 
         // when
-        const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
           firstName,
@@ -54,7 +54,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         birthdate = 'invalid format';
 
         // when
-        const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
           firstName,
@@ -83,7 +83,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async () => {
         // when
-        const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
           firstName,
@@ -112,7 +112,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async () => {
         // when
-        const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+        const err = await catchErr(linkUserToSessionCertificationCandidate)({
           sessionId,
           userId,
           firstName,
@@ -148,7 +148,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should not create a link and return the matching certification candidate', async () => {
           // when
-          const result = await usecases.linkUserToSessionCertificationCandidate({
+          const result = await linkUserToSessionCertificationCandidate({
             sessionId,
             userId,
             firstName,
@@ -179,7 +179,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should throw a CertificationCandidateAlreadyLinkedToUserError', async () => {
-          const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+          const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
             firstName,
@@ -214,7 +214,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         });
 
         it('should throw a UserAlreadyLinkedToCandidateInSessionError', async () => {
-          const err = await catchErr(usecases.linkUserToSessionCertificationCandidate)({
+          const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
             userId,
             firstName,
@@ -251,7 +251,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should create a link and return the linked certification candidate', async () => {
           // when
-          const result = await usecases.linkUserToSessionCertificationCandidate({
+          const result = await linkUserToSessionCertificationCandidate({
             sessionId,
             userId,
             firstName,

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -6,12 +6,17 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import _get from 'lodash/get';
 import classic from 'ember-classic-decorator';
 
 function _pad(num, size) {
   let s = num + '';
   while (s.length < size) s = '0' + s;
   return s;
+}
+
+function _isMatchingReconciledStudentNotFoundError(err) {
+  return _get(err, 'errors[0].code') === 'MATCHING_RECONCILED_STUDENT_NOT_FOUND';
 }
 
 @classic
@@ -82,7 +87,12 @@ export default class CertificationJoiner extends Component {
         currentCandidate.deleteRecord();
       }
       this.isLoading = false;
-      this.errorMessage = 'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.';
+
+      if (_isMatchingReconciledStudentNotFoundError(err)) {
+        this.errorMessage = 'Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.';
+      } else {
+        this.errorMessage = 'Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.';
+      }
     }
   }
 

--- a/mon-pix/tests/unit/components/certification-joiner-test.js
+++ b/mon-pix/tests/unit/components/certification-joiner-test.js
@@ -17,8 +17,8 @@ describe('Unit | Component | certification-joiner', function() {
     });
   });
 
-  describe('#joinCertificationSession', function() {
-    it('should trim spaces in first name and last name', async function() {
+  describe('#attemptNext', function() {
+    it('should create certificate candidate with trimmed first and last name', async function() {
       // given
       const component = this.owner.lookup('component:certification-joiner');
 
@@ -28,9 +28,10 @@ describe('Unit | Component | certification-joiner', function() {
       component.store = { createRecord: createRecordMock };
       component.firstName = ' Michel ';
       component.lastName = ' de Montaigne ';
+      component.stepsData = {};
 
       // when
-      await component.joinCertificationSession();
+      await component.attemptNext();
 
       // then
       sinon.assert.calledWithMatch(createRecordMock, 'certification-candidate', {
@@ -39,6 +40,80 @@ describe('Unit | Component | certification-joiner', function() {
         firstName: 'Michel',
         lastName: 'de Montaigne',
       });
+      expect(component.errorMessage).to.be.null;
+    });
+
+    it('should display an error message on student mismatch error', async function() {
+      // given
+      const sessionId = Symbol('session');
+      const component = this.owner.lookup('component:certification-joiner');
+
+      const saveStub = sinon.stub();
+      saveStub
+        .withArgs({ adapterOptions: { joinSession: true, sessionId } })
+        .throws(
+          {
+            errors: [
+              {
+                detail: 'Some message',
+                code: 'MATCHING_RECONCILED_STUDENT_NOT_FOUND',
+              },
+            ],
+          });
+      //
+      const createRecordMock = sinon.mock();
+      createRecordMock.returns({ save: saveStub });
+
+      component.store = { createRecord: createRecordMock };
+      component.firstName = ' Michel ';
+      component.lastName = ' de Montaigne ';
+      component.sessionId = sessionId;
+      component.stepsData = {};
+
+      // when
+      await component.attemptNext();
+
+      // then
+      sinon.assert.calledWithMatch(createRecordMock, 'certification-candidate', {
+        sessionId: sinon.match.any,
+        birthdate: sinon.match.any,
+        firstName: 'Michel',
+        lastName: 'de Montaigne',
+      });
+      expect(component.errorMessage).to.equal('Oups ! Il semble que vous n’utilisiez pas le bon compte Pix pour rejoindre cette session de certification.\nPour continuer, connectez-vous au bon compte Pix ou demandez de l’aide au surveillant.');
+    });
+
+    it('should display an error message on student is not found', async function() {
+      // given
+      const sessionId = Symbol('session');
+      const component = this.owner.lookup('component:certification-joiner');
+
+      const saveStub = sinon.stub();
+      saveStub
+        .withArgs({ adapterOptions: { joinSession: true, sessionId } })
+        .throws({ errors: [ { detail: 'blublabli' }] });
+      //
+      const createRecordMock = sinon.mock();
+      createRecordMock.returns({ save: saveStub });
+
+      component.store = { createRecord: createRecordMock };
+      component.firstName = ' Michel ';
+      component.lastName = ' de Montaigne ';
+      component.sessionId = sessionId;
+      component.stepsData = {};
+
+      // when
+      await component.attemptNext();
+
+      // then
+      sinon.assert.calledWithMatch(createRecordMock, 'certification-candidate', {
+        sessionId: sinon.match.any,
+        birthdate: sinon.match.any,
+        firstName: 'Michel',
+        lastName: 'de Montaigne',
+      });
+      expect(component.errorMessage).to.equal('Oups ! Nous ne parvenons pas à vous trouver.\nVérifiez vos informations afin de continuer ou prévenez le surveillant.');
     });
   });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
On veut s'assurer qu'un élève qui entre dans une session SCO utilise bien le compte PIX avec lequel il a été réconcilié.

## :robot: Solution
Faire le lien entre le `user` la `schooling-registration` et le `certification-candidate` au moment de l'entrée dans une session de certification SCO.
- Si la `schooling-registration` liée au `user` est aussi liée au `certification-candidate` trouvé par nom/prénom/date de naissance, permettre l'accès
- Sinon, afficher un message d'erreur indiquant à l'utilisateur qu'il est connecté au mauvais compte PIX.  

## :rainbow: Remarques
RAS

## :100: Pour tester
### Nouveau comportement 
- Inscrire deux élèves (certifiables) à une session de certification SCO via l'outil d'inscription dédié au SCO dans Pix-Certif (se connecter avec `certifsco@example.net` et activer le toggle `FT_CERTIF_PRESCRIPTION_SCO`).
Se connecter dans Mon-Pix avec l'élève 1, entrer les données (nom/prénom/ddn) de l'élève 2. On doit voir apparaitre un message indiquant ne pas être connecter avec le bon compte. Entrer ensuite les données correctes de l'élève 1 (nom/prénom/ddn), on doit pouvoir accéder à la session.

### Tests de non-regression 
- Entrer des données invalides (num de session/nom/prenom/ddn). On doit voir apparaître un message générique indiquant qu'on a pas été trouvé.
- Pouvoir accéder à une session non-SCO en entrant session/nom/prenom/ddn