### PR TITLE
[BUGFIX] Empêcher la création de plusieurs assessments lorsqu'on retente une participation (PIX-1575)

### DIFF
--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -49,16 +49,16 @@ module.exports = {
     return null;
   },
 
-  async beginImprovement(request) {
+  async beginImprovement(request, h) {
     const userId = request.auth.credentials.userId;
     const campaignParticipationId = parseInt(request.params.id);
 
-    const campaignParticipation = await usecases.beginCampaignParticipationImprovement({
+    const { created } = await usecases.beginCampaignParticipationImprovement({
       campaignParticipationId,
       userId,
     });
-    return serializer.serialize(campaignParticipation);
 
+    return created ? h.response().created() : null;
   },
 
   async getAnalysis(request) {

--- a/api/lib/domain/read-models/CampaignAssessmentInfo.js
+++ b/api/lib/domain/read-models/CampaignAssessmentInfo.js
@@ -38,6 +38,10 @@ class CampaignAssessmentParticipation {
     return this.status !== CampaignAssessmentParticipation.statuses.NOT_STARTED;
   }
 
+  get hasOngoingImprovment() {
+    return this.isOngoing && this.isImproving;
+  }
+
   get isOngoing() {
     return this.status === CampaignAssessmentParticipation.statuses.ONGOING;
   }

--- a/api/lib/domain/read-models/CampaignAssessmentInfo.js
+++ b/api/lib/domain/read-models/CampaignAssessmentInfo.js
@@ -1,0 +1,56 @@
+const Assessment = require('../models/Assessment');
+
+const statuses = {
+  NOT_STARTED: 'not_started',
+  ONGOING: 'ongoing',
+  COMPLETED: 'completed',
+  SHARED: 'shared',
+};
+
+class CampaignAssessmentParticipation {
+
+  constructor({
+    campaignParticipationId,
+    userId,
+    campaignId,
+    assessmentId = null,
+    assessmentState,
+    isShared,
+    isImproving = false,
+  }) {
+    this.campaignParticipationId = campaignParticipationId;
+    this.userId = userId;
+    this.campaignId = campaignId;
+    this.assessmentId = assessmentId;
+    this.isImproving = isImproving;
+
+    this.status = this._getStatus(isShared, assessmentState);
+  }
+
+  _getStatus(isShared, assessmentState) {
+    if (isShared) return CampaignAssessmentParticipation.statuses.SHARED;
+    if (assessmentState === Assessment.states.COMPLETED) return CampaignAssessmentParticipation.statuses.COMPLETED;
+    if (assessmentState === Assessment.states.STARTED) return CampaignAssessmentParticipation.statuses.ONGOING;
+    return CampaignAssessmentParticipation.statuses.NOT_STARTED;
+  }
+
+  get hasStarted() {
+    return this.status !== CampaignAssessmentParticipation.statuses.NOT_STARTED;
+  }
+
+  get isOngoing() {
+    return this.status === CampaignAssessmentParticipation.statuses.ONGOING;
+  }
+
+  get isCompleted() {
+    return this.status === CampaignAssessmentParticipation.statuses.COMPLETED;
+  }
+
+  get isShared() {
+    return this.status === CampaignAssessmentParticipation.statuses.SHARED;
+  }
+}
+
+CampaignAssessmentParticipation.statuses = statuses;
+module.exports = CampaignAssessmentParticipation;
+

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -5,6 +5,7 @@ const dependencies = {
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
   badgeCriteriaService: require('../../domain/services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
+  campaignAssessmentInfoRepository: require('../../infrastructure/repositories/campaign-assessment-info-repository'),
   campaignAssessmentParticipationRepository: require('../../infrastructure/repositories/campaign-assessment-participation-repository'),
   campaignAssessmentParticipationResultRepository: require('../../infrastructure/repositories/campaign-assessment-participation-result-repository'),
   campaignAssessmentParticipationSummaryRepository: require('../../infrastructure/repositories/campaign-assessment-participation-summary-repository'),

--- a/api/lib/infrastructure/repositories/campaign-assessment-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-info-repository.js
@@ -1,0 +1,30 @@
+const { knex } = require('../bookshelf');
+const { NotFoundError } = require('../../../lib/domain/errors');
+const CampaignAssessmentInfo = require('../../../lib/domain/read-models/CampaignAssessmentInfo');
+
+module.exports = {
+  async getByCampaignParticipationId(campaignParticipationId) {
+    const result = await knex('campaign-participations')
+      .select([
+        'campaign-participations.id AS campaignParticipationId',
+        'campaign-participations.isShared AS isShared',
+        'campaign-participations.userId AS userId',
+        'campaign-participations.campaignId AS campaignId',
+        'assessments.id AS assessmentId',
+        'assessments.state AS assessmentState',
+        'assessments.isImproving AS isImproving',
+      ])
+      .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
+      .leftJoin('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
+      .where('campaign-participations.id', '=', campaignParticipationId)
+      .andWhere('campaigns.type', '=', 'ASSESSMENT')
+      .orderBy('assessments.createdAt', 'desc')
+      .first();
+
+    if (!result) {
+      throw new NotFoundError('Campaign Participation not found.');
+    }
+
+    return new CampaignAssessmentInfo(result);
+  },
+};

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -1,7 +1,6 @@
 const BookshelfCampaignParticipation = require('../data/campaign-participation');
 const CampaignParticipation = require('../../domain/models/CampaignParticipation');
 const Campaign = require('../../domain/models/Campaign');
-const Assessment = require('../../domain/models/Assessment');
 const Skill = require('../../domain/models/Skill');
 const User = require('../../domain/models/User');
 const { NotFoundError } = require('../../domain/errors');
@@ -144,19 +143,6 @@ module.exports = {
 
   countSharedParticipationOfCampaign(campaignId) {
     return this.count({ campaignId, isShared: true });
-  },
-
-  async isAssessmentCompleted(campaignParticipationId) {
-    const assessment = await knex('assessments')
-      .select('state')
-      .where({ campaignParticipationId })
-      .orderBy('assessments.createdAt', 'desc')
-      .first();
-
-    if (assessment) {
-      return assessment.state === Assessment.states.COMPLETED;
-    }
-    return false;
   },
 };
 

--- a/api/lib/infrastructure/serializers/jsonapi/image-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/image-serializer.js
@@ -1,0 +1,12 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(id, b64FormattedImage) {
+
+    return new Serializer('image', {
+      attributes: ['b64FormattedImage'],
+    }).serialize({ b64FormattedImage, id });
+  },
+
+};

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-info-repository_test.js
@@ -1,0 +1,97 @@
+const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+const campaignAssessmentInfoRepository = require('../../../../lib/infrastructure/repositories/campaign-assessment-info-repository');
+const CampaignAssessmentInfo = require('../../../../lib/domain/read-models/CampaignAssessmentInfo');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+
+describe('Integration | Infrastructure | Repositories | campaign-assessment-info-repository', () => {
+
+  describe('#getByCampaignParticipationId', () => {
+
+    it('should return the campaign assessment info by given campaignParticipationId', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+      const campaignParticipation = databaseBuilder.factory.buildCampaignParticipation({ isShared: false, campaignId });
+      const assessmentId = databaseBuilder.factory.buildAssessment({
+        campaignParticipationId: campaignParticipation.id,
+        state: Assessment.states.STARTED,
+        isImproving: true,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const actualCampaignAssessmentInfo = await campaignAssessmentInfoRepository.getByCampaignParticipationId(campaignParticipation.id);
+
+      // then
+      expect(actualCampaignAssessmentInfo).to.be.instanceOf(CampaignAssessmentInfo);
+      expect(actualCampaignAssessmentInfo.campaignParticipationId).to.equal(campaignParticipation.id);
+      expect(actualCampaignAssessmentInfo.userId).to.equal(campaignParticipation.userId);
+      expect(actualCampaignAssessmentInfo.campaignId).to.equal(campaignParticipation.campaignId);
+      expect(actualCampaignAssessmentInfo.assessmentId).to.equal(assessmentId);
+      expect(actualCampaignAssessmentInfo.status).to.equal(CampaignAssessmentInfo.statuses.ONGOING);
+      expect(actualCampaignAssessmentInfo.isImproving).to.equal(true);
+    });
+
+    it('should throw a NotFoundError if the participation does not exist', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION' }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ campaignId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const error = await catchErr(campaignAssessmentInfoRepository.getByCampaignParticipationId)(campaignParticipationId);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should throw a NotFoundError if the participation is from a campaign profiles_collection', async () => {
+      // when
+      const error = await catchErr(campaignAssessmentInfoRepository.getByCampaignParticipationId)(123);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+
+    it('should return info about the most recent assessment', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ isShared: false, campaignId }).id;
+      const mostRecentAssessmentId = databaseBuilder.factory.buildAssessment({
+        campaignParticipationId,
+        state: Assessment.states.COMPLETED,
+        isImproving: true,
+        createdAt: new Date('2020-01-01'),
+      }).id;
+      databaseBuilder.factory.buildAssessment({
+        campaignParticipationId,
+        state: Assessment.states.STARTED,
+        isImproving: false,
+        createdAt: new Date('2019-12-25'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const actualCampaignAssessmentInfo = await campaignAssessmentInfoRepository.getByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(actualCampaignAssessmentInfo.assessmentId).to.equal(mostRecentAssessmentId);
+      expect(actualCampaignAssessmentInfo.status).to.equal(CampaignAssessmentInfo.statuses.COMPLETED);
+      expect(actualCampaignAssessmentInfo.isImproving).to.equal(true);
+    });
+
+    it('should return a not started participation when no assessment found for participation', async () => {
+      // given
+      const campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT' }).id;
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({ isShared: false, campaignId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const actualCampaignAssessmentInfo = await campaignAssessmentInfoRepository.getByCampaignParticipationId(campaignParticipationId);
+
+      // then
+      expect(actualCampaignAssessmentInfo.assessmentId).to.be.null;
+      expect(actualCampaignAssessmentInfo.status).to.equal(CampaignAssessmentInfo.statuses.NOT_STARTED);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-repository_test.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const moment = require('moment');
 const { sinon, expect, knex, databaseBuilder } = require('../../../test-helper');
 const Campaign = require('../../../../lib/domain/models/Campaign');
-const Assessment = require('../../../../lib/domain/models/Assessment');
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
 const Skill = require('../../../../lib/domain/models/Skill');
 const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
@@ -513,56 +512,6 @@ describe('Integration | Repository | Campaign Participation', () => {
       const numberOfCampaignShared = await campaignParticipationRepository.countSharedParticipationOfCampaign(campaignId);
 
       expect(numberOfCampaignShared).to.equal(1);
-    });
-  });
-
-  describe('#isAssessmentCompleted', () => {
-
-    it('should return true when latest assessment is completed', async () => {
-      // given
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-      const otherCampaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-      // oldest assessment
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, state: Assessment.states.STARTED, createdAt: new Date('2019-01-04') });
-      // latest assessment
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, state: Assessment.states.COMPLETED, createdAt: new Date('2019-02-05') });
-      // noise
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId: otherCampaignParticipationId, state: Assessment.states.STARTED, createdAt: new Date('2019-04-05') });
-      await databaseBuilder.commit();
-
-      // when
-      const isAssessmentCompleted = await campaignParticipationRepository.isAssessmentCompleted(campaignParticipationId);
-
-      // then
-      expect(isAssessmentCompleted).to.be.true;
-    });
-
-    it('should return false when latest assessment is not completed', async () => {
-      // given
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-      // oldest assessment
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, state: Assessment.states.COMPLETED, createdAt: new Date('2019-01-04') });
-      // latest assessment
-      databaseBuilder.factory.buildAssessment({ campaignParticipationId, state: Assessment.states.STARTED, createdAt: new Date('2019-02-05') });
-      await databaseBuilder.commit();
-
-      // when
-      const isAssessmentCompleted = await campaignParticipationRepository.isAssessmentCompleted(campaignParticipationId);
-
-      // then
-      expect(isAssessmentCompleted).to.be.false;
-    });
-
-    it('should return false when campaignParticipation has no assessment', async () => {
-      // given
-      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
-      await databaseBuilder.commit();
-
-      // when
-      const isAssessmentCompleted = await campaignParticipationRepository.isAssessmentCompleted(campaignParticipationId);
-
-      // then
-      expect(isAssessmentCompleted).to.be.false;
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-assessment-info.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-assessment-info.js
@@ -1,0 +1,21 @@
+const CampaignAssessmentInfo = require('../../../../lib/domain/read-models/CampaignAssessmentInfo');
+
+module.exports = function buildCampaignAssessmentInfo(
+  {
+    campaignParticipationId = 123,
+    userId = 456,
+    campaignId = 789,
+    assessmentId = 159,
+    status = CampaignAssessmentInfo.statuses.ONGOING,
+    isImproving = false,
+  } = {}) {
+  const campaignAssessmentInfo = new CampaignAssessmentInfo({
+    campaignParticipationId,
+    userId,
+    campaignId,
+    assessmentId,
+    isImproving,
+  });
+  campaignAssessmentInfo.status = status;
+  return campaignAssessmentInfo;
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -10,6 +10,7 @@ module.exports = {
   buildBadgePartnerCompetence: require('./build-badge-partner-competence'),
   buildCampaign: require('./build-campaign'),
   buildCampaignAnalysis: require('./build-campaign-analysis'),
+  buildCampaignAssessmentInfo: require('./build-campaign-assessment-info'),
   buildCampaignCollectiveResult: require('./build-campaign-collective-result'),
   buildCampaignParticipation: require('./build-campaign-participation'),
   buildCampaignParticipationBadge: require('./build-campaign-participation-badge'),

--- a/api/tests/unit/domain/read-models/CampaignAssessmentInfo_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentInfo_test.js
@@ -109,4 +109,35 @@ describe('Unit | Domain | Models | CampaignAssessmentInfo', () => {
       expect(campaignAssessmentInfo.hasStarted).to.be.false;
     });
   });
+
+  describe('#hasOngoingImprovment', () => {
+
+    it('should return false when campaign assessment is neither ongoing nor is improving', () => {
+      let campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+        isShared: false,
+        isImproving: false,
+      });
+      expect(campaignAssessmentInfo.hasOngoingImprovment).to.be.true;
+
+      campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.COMPLETED,
+        isShared: false,
+        isImproving: true,
+      });
+      expect(campaignAssessmentInfo.hasOngoingImprovment).to.be.true;
+    });
+
+    it('should return true when campaign assessment is ongoing and is improving', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+        isShared: false,
+        isImproving: true,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.hasOngoingImprovment).to.be.true;
+    });
+  });
 });

--- a/api/tests/unit/domain/read-models/CampaignAssessmentInfo_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentInfo_test.js
@@ -1,0 +1,112 @@
+const { expect } = require('../../../test-helper');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+const CampaignAssessmentInfo = require('../../../../lib/domain/read-models/CampaignAssessmentInfo');
+
+describe('Unit | Domain | Models | CampaignAssessmentInfo', () => {
+
+  describe('#isOngoing', () => {
+
+    it('should return true when campaign assessment is on going', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isOngoing).to.be.true;
+    });
+
+    it('should return false when campaign assessment is not going', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.COMPLETED,
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isOngoing).to.be.false;
+    });
+  });
+
+  describe('#isCompleted', () => {
+
+    it('should return true when campaign assessment is completed', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.COMPLETED,
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isCompleted).to.be.true;
+    });
+
+    it('should return false when campaign assessment is not completed', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isCompleted).to.be.false;
+    });
+  });
+
+  describe('#isShared', () => {
+
+    it('should return true when campaign assessment is shared', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.COMPLETED,
+        isShared: true,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isShared).to.be.true;
+    });
+
+    it('should return false when campaign assessment is not shared', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.isShared).to.be.false;
+    });
+  });
+
+  describe('#hasStarted', () => {
+
+    it('should return true when campaign assessment has started', () => {
+      let campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.COMPLETED,
+      });
+      expect(campaignAssessmentInfo.hasStarted).to.be.true;
+
+      campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: Assessment.states.STARTED,
+      });
+      expect(campaignAssessmentInfo.hasStarted).to.be.true;
+
+      campaignAssessmentInfo = new CampaignAssessmentInfo({
+        isShared: true,
+      });
+      expect(campaignAssessmentInfo.hasStarted).to.be.true;
+    });
+
+    it('should return false when campaign assessment has not started', () => {
+      // given
+      const campaignAssessmentInfo = new CampaignAssessmentInfo({
+        assessmentState: 'anything else',
+        isShared: false,
+      });
+
+      // when / then
+      expect(campaignAssessmentInfo.hasStarted).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -1,16 +1,19 @@
 const { sinon, expect, domainBuilder, catchErr } = require('../../../test-helper');
-const { AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, ArchivedCampaignError } = require('../../../../lib/domain/errors');
+const { AlreadySharedCampaignParticipationError, AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, ArchivedCampaignError } = require('../../../../lib/domain/errors');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
+const CampaignAssessmentInfo = require('../../../../lib/domain/read-models/CampaignAssessmentInfo');
 const usecases = require('../../../../lib/domain/usecases');
 
 describe('Unit | UseCase | share-campaign-result2', () => {
   const campaignParticipationRepository = {
     get: sinon.stub(),
     share: sinon.stub(),
-    isAssessmentCompleted: sinon.stub(),
   };
   const campaignRepository = {
     get: sinon.stub(),
+  };
+  const campaignAssessmentInfoRepository = {
+    getByCampaignParticipationId: sinon.stub(),
   };
   const userId = 123;
   const campaignParticipationId = 456;
@@ -22,7 +25,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
     campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId: userId + 1 });
 
     // when
-    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
     // then
     expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
@@ -34,7 +37,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
     campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ id: campaignId, archivedAt: new Date('1990-11-04') }));
 
     // when
-    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
     // then
     expect(error).to.be.instanceOf(ArchivedCampaignError);
@@ -45,24 +48,43 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       // given
       campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId, campaignId });
       campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(false);
+      campaignAssessmentInfoRepository.getByCampaignParticipationId
+        .withArgs(campaignParticipationId)
+        .resolves(domainBuilder.buildCampaignAssessmentInfo({ campaignParticipationId, status: CampaignAssessmentInfo.statuses.ONGOING }));
 
       // when
-      const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
       // then
       expect(error).to.be.instanceOf(AssessmentNotCompletedError);
     });
 
-    it('should share successfully the participation when latest assessment is completed', async () => {
+    it('should throw a AlreadySharedCampaignParticipationError error when the participation is already shared', async () => {
+      // given
+      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId, campaignId });
+      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null }));
+      campaignAssessmentInfoRepository.getByCampaignParticipationId
+        .withArgs(campaignParticipationId)
+        .resolves(domainBuilder.buildCampaignAssessmentInfo({ campaignParticipationId, status: CampaignAssessmentInfo.statuses.SHARED }));
+
+      // when
+      const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
+
+      // then
+      expect(error).to.be.instanceOf(AlreadySharedCampaignParticipationError);
+    });
+
+    it('should share successfully the participation when assessment is completed', async () => {
       // given
       const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
       campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
       campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(true);
+      campaignAssessmentInfoRepository.getByCampaignParticipationId
+        .withArgs(campaignParticipationId)
+        .resolves(domainBuilder.buildCampaignAssessmentInfo({ campaignParticipationId, status: CampaignAssessmentInfo.statuses.COMPLETED }));
 
       // when
-      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
       // then
       expect(campaignParticipationRepository.share).to.have.been.calledWith(campaignParticipation);
@@ -73,10 +95,12 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
       campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
       campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null, organizationId }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(true);
+      campaignAssessmentInfoRepository.getByCampaignParticipationId
+        .withArgs(campaignParticipationId)
+        .resolves(domainBuilder.buildCampaignAssessmentInfo({ campaignParticipationId, status: CampaignAssessmentInfo.statuses.COMPLETED }));
 
       // when
-      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
       // then
       expect(actualEvent).to.deep.equal({
@@ -98,7 +122,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeProfilesCollection({ id: campaignId, archivedAt: null }));
 
       // when
-      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
       // then
       expect(campaignParticipationRepository.share).to.have.been.calledWith(campaignParticipation);
@@ -111,7 +135,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeProfilesCollection({ id: campaignId, archivedAt: null, organizationId }));
 
       // when
-      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository, campaignAssessmentInfoRepository });
 
       // then
       expect(actualEvent).to.deep.equal({

--- a/mon-pix/app/models/image.js
+++ b/mon-pix/app/models/image.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ImageModel extends Model {
+  @attr() b64FormattedImage;
+}

--- a/mon-pix/tests/unit/models/image-test.js
+++ b/mon-pix/tests/unit/models/image-test.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Model | image', function() {
+  setupTest();
+
+  // Replace this with your real tests.
+  it('exists', function() {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('image', {});
+    expect(model).to.be.ok;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Reproduire le bug en local :
- Clean sa BDD et lancer mon-pix + api
- Se connecter avec certif1@example.net
- Commencer la compétence 5.1 en autonomie "Résoudre les problèmes techniques" et répondre très rarement juste (une seule fois c'est bien) et aller jusqu'au bout de la compétence (vous pouvez passer)
- Participer à la campagne AZERTY123 et se rendre sur la page de partage de résultats sans partager
- Ouvrir la console du développeur, et sur la page de résultats faire plusieurs fois : appuyer sur je retente, faire "précédent" sur le navigateur...

On voit que plusieurs assessments différents sont créés.
![multiple_creations](https://user-images.githubusercontent.com/48727874/98344669-daaa6680-2013-11eb-9a6c-dafef75031e9.png)

## :robot: Solution
- Ne pas créer de nouvel assessment si un est déjà en cours
- S'assurer que dans tout le flow prescription côté APP (et côté pixOrga) on se base sur l'assessment le plus récent

## :rainbow: Remarques

## :100: Pour tester
Essayer de reproduire le bug ;)
