### PR TITLE
Ajout de la classe dans l'export de csv de campagne d'évaluations pour les organisations SCO (PIX-1294).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -11,6 +11,7 @@ const validationSchema = Joi.object({
   isCompleted: Joi.boolean().required(),
   createdAt: Joi.date().required(),
   sharedAt: Joi.date().required().allow(null),
+  division: Joi.string().allow(null).optional(),
 });
 
 class CampaignParticipationInfo {
@@ -24,6 +25,7 @@ class CampaignParticipationInfo {
     isCompleted,
     createdAt,
     sharedAt,
+    division,
   } = {}) {
     this.participantFirstName = participantFirstName;
     this.participantLastName = participantLastName;
@@ -33,6 +35,7 @@ class CampaignParticipationInfo {
     this.isCompleted = isCompleted;
     this.createdAt = createdAt;
     this.sharedAt = sharedAt;
+    this.division = division;
 
     validateEntity(validationSchema, this);
   }

--- a/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-assessment-results-to-stream.js
@@ -111,6 +111,7 @@ function _createHeaderOfCSV(targetProfile, idPixLabel, organizationType, organiz
     'Nom du Profil Cible',
     'Nom du Participant',
     'Prénom du Participant',
+    ...((organizationType === 'SCO') ? ['Classe'] : []),
     ...((organizationType === 'SUP' && organizationIsManagingStudents) ? ['Numéro Étudiant'] : []),
 
     ...(idPixLabel ? [idPixLabel] : []),

--- a/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-info-repository.js
@@ -13,6 +13,7 @@ module.exports = {
           knex.raw('COALESCE ("schooling-registrations"."firstName", "users"."firstName") AS "firstName"'),
           knex.raw('COALESCE ("schooling-registrations"."lastName", "users"."lastName") AS "lastName"'),
           'schooling-registrations.studentNumber',
+          'schooling-registrations.division',
         ])
           .from('campaign-participations')
           .join('users', 'campaign-participations.userId', 'users.id')
@@ -45,5 +46,6 @@ function _rowToCampaignParticipationInfo(row) {
     isCompleted: row.state === Assessment.states.COMPLETED,
     createdAt: new Date(row.createdAt),
     sharedAt: row.sharedAt ? new Date(row.sharedAt) : null,
+    division: row.division,
   });
 }

--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -89,6 +89,7 @@ class CampaignAssessmentCsvLine {
       this.targetProfile.name,
       this.campaignParticipationInfo.participantLastName,
       this.campaignParticipationInfo.participantFirstName,
+      ...(this.organization.isSco ? [this.campaignParticipationInfo.division] : []),
       ...this._studentNumber,
       ...(this.campaign.idPixLabel ? [this.campaignParticipationInfo.participantExternalId] : []),
       this.campaignParticipationService.progress(this.campaignParticipationInfo.isCompleted, this.targetedKnowledgeElementsCount, this.targetProfile.skills.length),

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -61,6 +61,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
             participantFirstName: 'First',
             participantLastName: 'Last',
             studentNumber: null,
+            division: null,
           },
         ]);
         expect(campaignParticipationInfos[0].isShared).to.be.true;
@@ -122,6 +123,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
           participantFirstName: 'The',
           participantLastName: 'Narrator',
           studentNumber: null,
+          division: null,
         });
         expect(campaignParticipationInfosOrdered[0].isShared).to.equal(true);
 
@@ -134,6 +136,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
           participantFirstName: 'Tyler',
           participantLastName: 'Durden',
           studentNumber: null,
+          division: null,
         });
         expect(campaignParticipationInfosOrdered[1].isShared).to.equal(false);
       });
@@ -185,6 +188,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
           participantFirstName: 'The',
           participantLastName: 'Narrator',
           studentNumber: null,
+          division: null,
         }]);
       });
     });
@@ -230,6 +234,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
           organizationId: campaign.organizationId,
           userId,
           studentNumber: 'Pipon et Jambon',
+          division: '6eme',
         });
         databaseBuilder.factory.buildSchoolingRegistration({
           userId,
@@ -256,6 +261,15 @@ describe('Integration | Repository | Campaign Participation Info', () => {
         // then
         expect(campaignParticipationInfos[0].participantFirstName).to.equal(schoolingRegistration.firstName);
         expect(campaignParticipationInfos[0].participantLastName).to.equal(schoolingRegistration.lastName);
+      });
+
+      it('should return the division', async () => {
+
+        // when
+        const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
+
+        // then
+        expect(campaignParticipationInfos[0].division).to.equal(schoolingRegistration.division);
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation-info.js
@@ -9,6 +9,7 @@ function buildCampaignParticipationInfo({
   isCompleted = true,
   createdAt = new Date('2020-01-01'),
   sharedAt = new Date('2020-02-02'),
+  division,
 } = {}) {
   return new CampaignParticipationInfo({
     participantFirstName,
@@ -19,6 +20,7 @@ function buildCampaignParticipationInfo({
     isCompleted,
     createdAt,
     sharedAt,
+    division,
   });
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs SCO ne peuvent pas avoir les résultats par classe.

## :robot: Solution
Ajouter la classe du participant dans l'export des résultat de campagne pour les organizations SCO.

## :rainbow: Remarques
RAS

## :100: Pour tester
Télécharger les résultats d'une campagne d'évaluation  SCO et vérifier que la colonne  classe est présente