### PR TITLE
[FIX] Corrige le champs date de naissance lors de l'ajout manuel d'un candidat à une session de certification

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -25,12 +25,12 @@
     <div class="certification-candidates-input-wrapper">
       <OneWayDateMask
           required
-          pattern="[0-9]{2}/[0-9]{2}/[0-9]{4}"
           @placeholder='dd/mm/yyyy'
           @options={{hash inputFormat='dd/mm/yyyy' outputFormat='yyyy-mm-dd'}}
           @class="certification-candidates-input {{if this.birthdateFocused 'focused'}}"
+          id="certification-candidates-input-birthdate"
           {{on 'focus' this.focusBirthdate}}
-          @value={{undefined}}
+          @value={{this.maskedBirthdate}}
           @update={{this.updateCandidateDataBirthdate}}>
       </OneWayDateMask>
     </div>

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -26,6 +26,9 @@ export default class CertificationCandidateInStagingItem extends Component {
   birthCityFocused = false;
 
   @tracked
+  maskedBirthdate = undefined;
+
+  @tracked
   birthProvinceCodeFocused = false;
 
   @tracked
@@ -80,8 +83,9 @@ export default class CertificationCandidateInStagingItem extends Component {
   }
 
   @action
-  updateCandidateDataBirthdate(value) {
-    this.args.updateCandidateBirthdate(this.args.candidateData, value);
+  updateCandidateDataBirthdate(unmasked, masked) {
+    this.maskedBirthdate = masked;
+    this.args.updateCandidateBirthdate(this.args.candidateData, unmasked);
   }
 
   @action


### PR DESCRIPTION
## :unicorn: Problème
La saisie d'une date dans l'input est incorrect lorsque le jour commence par autre chose qu'un 0 (01/12/2020)

## :robot: Solution
Le plugin _ember-inputmask_ a changé son utilisation. Sa migration était incorrecte.

## :rainbow: Remarques
Probleme non reproductible avec des tests automatisés

## :100: Pour tester
Saisir une date (11/12/2020) constater, qu'elle s'affiche correctement
