### PR TITLE
[FEATURE] Modifier le message d'erreur des embed auto

### DIFF
--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -38,7 +38,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         // then
         expect(find('.alert')).to.exist;
-        expect(find('.alert').textContent.trim()).to.equal('L\'épreuve n\'est pas encore réussie. Vous aurez un message “Vous pouvez valider” quand vous aurez réussi. Essayez encore ou passez.');
+        expect(find('.alert').textContent.trim()).to.equal('“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.');
       });
 
       it('should go to the next challenge when user validates after finishing successfully the embed', async () => {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -372,7 +372,7 @@
                 "qcm": "Pour valider, sélectionnez au moins une réponse. Sinon, passez.",
                 "qcu": "Pour valider, sélectionnez une réponse. Sinon, passez.",
                 "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passez.",
-                "qroc-auto-reply": "L'épreuve n'est pas encore réussie. Vous aurez un message “Vous pouvez valider” quand vous aurez réussi. Essayez encore ou passez.",
+                "qroc-auto-reply": "“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.",
                 "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
             },
             "timed" : {


### PR DESCRIPTION
## :unicorn: Problème
Le message d'erreur lorsque l'utilisateur clique sur "Je passe" sans avoir fini l'épreuve d'embed auto n'est pas compris.

## :robot: Solution
Modifier le message d'erreur pour que l'utilisateur comprenne que l'épreuve n'est pas encore terminée.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Visualiser une épreuve avec embed auto (ex: challenge recQ9T7artY5x6naO)
