### PR TITLE
[FEATURE] Modification du message lors du timeout d'une épreuve

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -376,7 +376,7 @@
                 "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
             },
             "timed" : {
-                "cannot-answer": "Le temps accordé est écoulé."
+                "cannot-answer": "Le temps imparti est écoulé."
             }
         },
         "checkpoint": {


### PR DESCRIPTION
## :unicorn: Problème
Le message affiché lors du timeout d'une épreuve n'était pas suffisamment clair.

## :robot: Solution
Modifier le message qui apparaît lorsque le temps accordé à une épreuve est écoulé.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Visualiser une épreuve timée (ex: recWKzE8cRHRkb44F)
