### PR TITLE
[BUGFIX] Retirer les mots Parcours de l'application (PIX-1577)

### DIFF
--- a/mon-pix/tests/acceptance/checkpoint-test.js
+++ b/mon-pix/tests/acceptance/checkpoint-test.js
@@ -37,7 +37,7 @@ describe('Acceptance | Checkpoint', () => {
       expect(find('.checkpoint-progression-gauge-wrapper')).to.exist;
       expect(find('.assessment-results__list')).to.exist;
       expect(findAll('.result-item')).to.have.lengthOf(NB_ANSWERS);
-      expect(find('.checkpoint__continue').textContent).to.contain('Continuer mon parcours');
+      expect(find('.checkpoint__continue').textContent).to.contain('Continuer');
       expect(find('.checkpoint-no-answer')).to.not.exist;
     });
   });

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
@@ -21,7 +21,7 @@ describe('Unit | Controller | Assessments | Checkpoint', function() {
       controller.set('finalCheckpoint', false);
 
       // then
-      expect(controller.nextPageButtonText).to.equal('Continuer mon parcours');
+      expect(controller.nextPageButtonText).to.equal('Continuer');
     });
 
     it('should propose to see the results of the assessment if it is the final checkpoint', function() {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -381,12 +381,12 @@
         },
         "checkpoint": {
             "title": {
-                "assessment-progress": "Avancement du parcours",
+                "assessment-progress": "Avancement",
                 "end-of-assessment": "Fin de votre évaluation"
             },
             "actions": {
                 "next-page": {
-                    "continue": "Continuer mon parcours",
+                    "continue": "Continuer",
                     "results": "Voir mes résultats"
                 }
             },
@@ -399,7 +399,7 @@
             },
             "completion-percentage": {
                 "label": "'<p class=\"sr-only\">'Vous avez effectué '</p>'{completionPercentage}%'<p class=\"sr-only\">' de votre parcours.'</p>'",
-                "caption": "avancement du parcours"
+                "caption": "avancement"
             }
         },
         "comparison-window": {


### PR DESCRIPTION
## :unicorn: Problème
Le mot "parcours" est utilisé en interne, il faut donc le retirer

## :robot: Solution
Retirer le mot 'parcours' sur la page checkpoint

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Lancer une évaluation et vérifier que le mot parcours n'apparait plus aux endroits ou il était
