### PR TITLE
[ORGA] Ajout d'un tooltip pour l'import des orga SCO Agri (PIX-1565)

### DIFF
--- a/orga/app/components/organization-credit-info.hbs
+++ b/orga/app/components/organization-credit-info.hbs
@@ -5,7 +5,7 @@
 		@text={{this.tooltipContent}}
 		@position='bottom'
 		@inline={{false}}
-		@class="organization-credit-info__tooltip">
+		@class="pix-orga-tooltip">
 			<FaIcon @icon="info-circle" class="info-icon"/>
 	</PixTooltip>
 </div>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -3,6 +3,15 @@
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
       {{#if this.currentUser.isAgriculture}}
+        <PixTooltip
+          @text={{this.textTooltipForAgri}}
+          @position='bottom'
+          @class="pix-orga-tooltip list-students-page__tooltip">
+            <span class="list-students-page__tooltip-title">
+              <span>En savoir plus</span>
+              <FaIcon @icon="info-circle" class="info-icon"/>
+            </span>
+        </PixTooltip>
         <a class="button button--link button--no-color"
           href="{{this.urlToDownloadCsvTemplate}}" target="_blank" rel="noopener noreferrer" download>
           Télécharger le modèle

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-orga/config/environment';
+import { htmlSafe } from '@ember/string';
 
 export default class ListItems extends Component {
 
@@ -26,6 +27,10 @@ export default class ListItems extends Component {
 
   get urlToDownloadCsvTemplate() {
     return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
+  }
+
+  get textTooltipForAgri() {
+    return htmlSafe('Quelques informations concernant l’import :<ul><li>Pour vos élèves : utiliser l’export FREGATA vers Pix et cliquer sur le bouton importer.</li><li>Pour vos apprentis : Pix importe tous les apprentis fin novembre au sein de votre espace Pix Orga. Les ajouts ponctuels d’apprentis se feront à partir de décembre, pour cela consulter la documentation Pix Orga et utiliser le modèle fourni.</li></ul>');
   }
 
   @action

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -16,6 +16,7 @@
 @import "globals/tables";
 @import "globals/texts";
 @import "globals/titles";
+@import "globals/tooltip";
 @import "components/login-form";
 @import "components/campaign-list";
 @import "components/circle-chart";

--- a/orga/app/styles/components/organization-credit-info.scss
+++ b/orga/app/styles/components/organization-credit-info.scss
@@ -13,38 +13,4 @@
 		color: $grey-40;
 		margin: 0 8px;
 	}
-
-	&__tooltip .pix-tooltip__content {
-		width: 382px;
-		padding: 16px;
-		font-size: 0.875rem;
-		background-color: white;
-		border: 1px solid $grey-40;
-		border-radius: 4px;
-		box-shadow: -2px 4px 4px 2px rgba($black, 0.1);
-	}
-
-	&__tooltip .pix-tooltip__content--bottom::before {
-		top: -5px;
-		left: calc(95% - 4px);
-		border-color: $grey-40 transparent transparent $grey-40;
-		transform: rotate(45deg);
-	}
-
-	&__tooltip .pix-tooltip__content::before {
-		content: "";
-		position: absolute;
-		border-width: 1px;
-		border-style: solid;
-		height: 8px;
-		width: 8px;
-		background-color: white;
-	}
-
-	&__tooltip .pix-tooltip__content--bottom {
-		top: calc(100% + 20px);
-		left: 50%;
-		transform: translate(-95%);
-		padding: 23px 16px;
-	}
 }

--- a/orga/app/styles/globals/tooltip.scss
+++ b/orga/app/styles/globals/tooltip.scss
@@ -1,0 +1,36 @@
+.pix-orga-tooltip {
+  .pix-tooltip__content {
+    width: 382px;
+    padding: 16px;
+    font-size: 0.875rem;
+    background-color: white;
+    color: $grey-60;
+    border: 1px solid $grey-40;
+    border-radius: 4px;
+    box-shadow: -2px 4px 4px 2px rgba($black, 0.1);
+  }
+
+  .pix-tooltip__content--bottom::before {
+    top: -5px;
+    left: calc(95% - 4px);
+    border-color: $grey-40 transparent transparent $grey-40;
+    transform: rotate(45deg);
+  }
+
+  .pix-tooltip__content::before {
+    content: "";
+    position: absolute;
+    border-width: 1px;
+    border-style: solid;
+    height: 8px;
+    width: 8px;
+    background-color: white;
+  }
+
+  .pix-tooltip__content--bottom {
+    top: calc(100% + 20px);
+    left: 50%;
+    transform: translate(-95%);
+    padding: 23px 16px;
+  }
+}

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -8,15 +8,40 @@ $margin-right: 32px;
 
   &__header {
     display: flex;
+    align-items: baseline;
+    justify-content: space-between;
     margin: 1em;
   }
 
-  &__import-students-button {
-    margin-top: 20px;
-    margin-left: auto;
+  &__tooltip {
+    display: inline-block;
+    color: $grey-40;
 
-    & :last-child {
-      margin-left: 10px;
+    .pix-tooltip ul {
+      margin-block-start: 1em;
+      margin-block-end: 1em;
+      padding-inline-start: 40px;
+    }
+
+    .pix-tooltip li {
+      list-style: disc;
+      padding: initial;
+    }
+  }
+
+  &__tooltip-title {
+    font-size: 0.75rem;
+    svg {
+      margin-left: 4px;
+    }
+  }
+
+  &__import-students-button {
+    > * {
+      margin-right: 10px;
+    }
+    > *:last-child {
+      margin-right: 0px;
     }
   }
 

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -295,6 +295,10 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           assert.notContains('Télécharger le modèle');
         });
 
+        test('it should not display the tooltip for agriculture organization', async function(assert) {
+          assert.notContains('En savoir plus');
+        });
+
         test('it should display the dissociate action', async function(assert) {
           // when
           await click('[aria-label="Afficher les actions"]');
@@ -323,6 +327,10 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
         test('it should display download template csv button', async function(assert) {
           // then
           assert.contains('Télécharger le modèle');
+        });
+
+        test('it should not display the tooltip', async function(assert) {
+          assert.contains('En savoir plus');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème

Actuellement aucun élément d'explication n'est présent dans l'utilisation du template de l'import.
Nous souhaitons rajouter une documentation pour les orga de type SCO Tag AGRI

## :robot: Solution

Ajouter une tooltip à côté des boutons d'import pour les orga de type SCO AGRI 

![image](https://user-images.githubusercontent.com/516360/98544522-6e8a6580-2294-11eb-9e0a-28e61ce50046.png)

## :100: Pour tester

Se connecter sur orga avec sco.admin@example.net, sélection l'organisation Lycée agricole
Dans l'onglet élève, voir le label "En savoir plus" et une tooltip apparaît au survol.