### PR TITLE
[FEATURE] Retirer la barre de progression durant les épreuves Pix-Concours (PIX-1582).

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -19,6 +19,10 @@ export default class ChallengeController extends Controller {
     return this.model.assessment.showLevelup && this.newLevel;
   }
 
+  get hideProgressBar() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
+  }
+
   get pageTitle() {
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -11,7 +11,9 @@
   </div>
 
   <div class="assessment-challenge__content rounded-panel--over-background-banner">
-    <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
+    {{#unless this.hideProgressBar}}
+      <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
+    {{/unless}}
     <main>
       {{component (get-challenge-component-class @model.challenge)
                 challenge=@model.challenge


### PR DESCRIPTION
## :unicorn: Problème

La barre de progression doit être retirée lors des épreuves de Pix-Concours

## :robot: Solution

Condition de rendu de la barre à l'aide de la variable d'environnement `IS_PIX_CONTEST`

## :100: Pour tester

Réaliser une campagne ou n'importe quelle autre épreuve avec la variable d'environnement `IS_PIX_CONTEST` égale à `true`
