### PR TITLE
[BUGFIX] Utiliser replaceWith au lieu de transitionTo.

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -6,6 +6,7 @@ import Component from '@glimmer/component';
 
 export default class SkillReview extends Component {
   @service intl
+  @service router
 
   @tracked displayErrorMessage = false;
 
@@ -64,7 +65,7 @@ export default class SkillReview extends Component {
     const assessment = this.args.model.assessment;
     const campaignParticipation = this.args.model.campaignParticipation;
     await campaignParticipation.save({ adapterOptions: { beginImprovement: true } });
-    return this.transitionToRoute('campaigns.start-or-resume', assessment.codeCampaign);
+    return this.router.transitionTo('campaigns.start-or-resume', assessment.codeCampaign);
   }
 
 }

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -40,7 +40,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       model,
     });
 
-    component.transitionToRoute = sinon.stub();
+    component.router.transitionTo = sinon.stub();
   });
 
   describe('#shareCampaignParticipation', function() {
@@ -67,7 +67,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
       await component.actions.improvementCampaignParticipation.call(component);
 
       // then
-      sinon.assert.calledWith(component.transitionToRoute, 'campaigns.start-or-resume');
+      sinon.assert.calledWith(component.router.transitionTo, 'campaigns.start-or-resume');
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
On a laisser un transitionTo au lieu d'un replaceWith
Conséquence : Un bug si on veut retenter sa compétence

## :robot: Solution
Remettre un replaceWith

## :rainbow: Remarques
-

## :100: Pour tester

