### PR TITLE
[FEATURE] Ajouter une page de fin aux campagnes de Pix Concours (PIX-1541).

### DIFF
--- a/mon-pix/app/controllers/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/controllers/campaigns/assessment/skill-review.js
@@ -2,6 +2,8 @@ import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
+import ENV from 'mon-pix/config/environment';
+
 export default class SkillReviewController extends Controller {
   @tracked displayLoadingButton = false;
   @tracked displayErrorMessage = false;
@@ -40,6 +42,10 @@ export default class SkillReviewController extends Controller {
 
   get stageCount() {
     return this.model.campaignParticipation.campaignParticipationResult.get('stageCount');
+  }
+
+  get isPixContest() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
   }
 
   @action

--- a/mon-pix/app/routes/assessments/resume.js
+++ b/mon-pix/app/routes/assessments/resume.js
@@ -108,10 +108,6 @@ export default class ResumeRoute extends Route {
   }
 
   _routeToResults(assessment) {
-    if (ENV.APP.IS_PIX_CONTEST === 'true') {
-      return this.replaceWith('profile');
-    }
-
     if (assessment.isCertification) {
       return this.replaceWith('certifications.results', assessment.certificationNumber);
     }

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -1,5 +1,12 @@
 .skill-review {
 
+  &__pix-contest {
+
+    h1 {
+      margin-bottom: 16px;
+    }
+  }
+
   &__banner {
     width: 100%;
     margin-bottom: 30px;

--- a/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/skill-review.hbs
@@ -7,112 +7,122 @@
   </div>
 
   <PixBlock @shadow="heavy" class="skill-review__result-container">
-    {{#if this.model.campaignParticipation.campaign.isArchived}}
 
-      <div class="skill-review__campaign-archived">
-        <img class="skill-review__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg" alt="" role="none">
-        <p class="skill-review__campaign-archived-text">
-          {{t 'pages.skill-review.archived' htmlSafe=true}}
-        </p>
-        <LinkTo @route="index" class="skill-review-share__back-to-home link">
-          {{t 'pages.skill-review.actions.continue'}}
+    {{#if this.isPixContest}}
+      <div class="skill-review__pix-contest">
+        <h1>{{t 'pages.skill-review.pix-contest.title'}}</h1>
+        <LinkTo @route="profile">
+          {{t 'pages.skill-review.pix-contest.link'}}
         </LinkTo>
       </div>
-
     {{else}}
-      <div class="skill-review__result-and-action">
-        <h2 class="sr-only">{{t 'pages.skill-review.abstract-title'}}</h2>
-        {{#if this.showStages}}
-          <ReachedStage
-            @stageCount={{this.stageCount}}
-            @starCount={{this.reachedStage.starCount}}
-            @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
-            @imageUrl={{model.campaignParticipation.campaign.targetProfile.imageUrl}}
-          />
+      {{#if this.model.campaignParticipation.campaign.isArchived}}
+
+        <div class="skill-review__campaign-archived">
+          <img class="skill-review__campaign-archived-image " src="{{this.rootURL}}/images/bees/fat-bee.svg" alt="" role="none">
+          <p class="skill-review__campaign-archived-text">
+            {{t 'pages.skill-review.archived' htmlSafe=true}}
+          </p>
+          <LinkTo @route="index" class="skill-review-share__back-to-home link">
+            {{t 'pages.skill-review.actions.continue'}}
+          </LinkTo>
+        </div>
+
+      {{else}}
+        <div class="skill-review__result-and-action">
+          <h2 class="sr-only">{{t 'pages.skill-review.abstract-title'}}</h2>
+          {{#if this.showStages}}
+            <ReachedStage
+              @stageCount={{this.stageCount}}
+              @starCount={{this.reachedStage.starCount}}
+              @percentage={{model.campaignParticipation.campaignParticipationResult.masteryPercentage}}
+              @imageUrl={{model.campaignParticipation.campaign.targetProfile.imageUrl}}
+            />
+          {{/if}}
+
+            <div class="skill-review__share">
+
+              {{#if this.showStages}}
+                <div class="skill-review-share__stage-congrats">
+                  <div class="stage-congrats__title">
+                    {{this.reachedStage.title}}
+                  </div>
+                  <div class="stage-congrats__message">
+                    {{this.reachedStage.message}}
+                  </div>
+                </div>
+              {{else}}
+                <p class="rounded-panel-title skill-review-result__abstract">
+                  {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
+                </p>
+              {{/if}}
+              <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
+
+              <div class="skill-review-result__share-container {{if this.showStages "skill-review-result__share-container--left"}}">
+                <CampaignShareButton
+                  @isShared={{this.model.campaignParticipation.isShared}}
+                  @displayErrorMessage={{this.displayErrorMessage}}
+                  @displayLoadingButton={{this.displayLoadingButton}}
+                  @shareCampaignParticipation={{this.shareCampaignParticipation}}
+                />
+              </div>
+          </div>
+        </div>
+
+        {{#if this.showBadges}}
+          {{#unless this.hideBadgesTitle}}
+            <h2 class="skill-review-result__badge-subtitle">
+              {{t 'pages.skill-review.badges-title'}}
+            </h2>
+          {{/unless}}
+          <div class="badge-acquired-container">
+            {{#each this.acquiredBadges as |badge|}}
+              <BadgeAcquiredCard
+                @title={{badge.title}}
+                @message={{badge.message}}
+                @imageUrl={{badge.imageUrl}}
+                @altMessage={{badge.altMessage}}
+              />
+            {{/each}}
+          </div>
+          <div class="skill-review-result__dash-line"></div>
         {{/if}}
 
-          <div class="skill-review__share">
+        {{#if this.displayImprovementButton}}
+          <SkillReviewTryAgain
+            @campaignParticipation={{this.model.campaignParticipation}}
+            @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
+        {{/if}}
+      {{/if}}
 
-            {{#if this.showStages}}
-              <div class="skill-review-share__stage-congrats">
-                <div class="stage-congrats__title">
-                  {{this.reachedStage.title}}
-                </div>
-                <div class="stage-congrats__message">
-                  {{this.reachedStage.message}}
-                </div>
-              </div>
-            {{else}}
-              <p class="rounded-panel-title skill-review-result__abstract">
-                {{t 'pages.skill-review.abstract' percentage=this.model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
-              </p>
-            {{/if}}
-            <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
+      <div class="skill-review-result__dash-line"></div>
 
-            <div class="skill-review-result__share-container {{if this.showStages "skill-review-result__share-container--left"}}">
-              <CampaignShareButton
-                @isShared={{this.model.campaignParticipation.isShared}}
-                @displayErrorMessage={{this.displayErrorMessage}}
-                @displayLoadingButton={{this.displayLoadingButton}}
-                @shareCampaignParticipation={{this.shareCampaignParticipation}}
-              />
-            </div>
-        </div>
-      </div>
-
-      {{#if this.showBadges}}
-        {{#unless this.hideBadgesTitle}}
-          <h2 class="skill-review-result__badge-subtitle">
-            {{t 'pages.skill-review.badges-title'}}
+      <main>
+       <div class="skill-review-result__table-header">
+          <h2 class="skill-review-result__subtitle">
+            {{t 'pages.skill-review.details.title'}}
           </h2>
-        {{/unless}}
-        <div class="badge-acquired-container">
-          {{#each this.acquiredBadges as |badge|}}
-            <BadgeAcquiredCard
-              @title={{badge.title}}
-              @message={{badge.message}}
-              @imageUrl={{badge.imageUrl}}
-              @altMessage={{badge.altMessage}}
-            />
-          {{/each}}
+          <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
+            <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
+              {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
+            </span>
+          </CircleChart>
         </div>
-        <div class="skill-review-result__dash-line"></div>
-      {{/if}}
 
-      {{#if this.displayImprovementButton}}
-        <SkillReviewTryAgain
-          @campaignParticipation={{this.model.campaignParticipation}}
-          @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
-      {{/if}}
+       <CampaignSkillReviewCompetenceResult
+         @showCleaCompetences={{this.showCleaCompetences}}
+         @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
+         @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}}
+       />
+      </main>
+
+      <div class="skill-review-result__information">
+        <FaIcon @icon='info-circle' class='skill-review-information__info-icon' aria-hidden="true"/>
+        <div class="skill-review-information__text">
+          {{t 'pages.skill-review.information'}}
+        </div>
+      </div>
     {{/if}}
-
-    <div class="skill-review-result__dash-line"></div>
-
-    <main>
-     <div class="skill-review-result__table-header">
-        <h2 class="skill-review-result__subtitle">
-          {{t 'pages.skill-review.details.title'}}
-        </h2>
-        <CircleChart @value={{this.model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
-          <span aria-label="{{t "pages.skill-review.details.result"}}" class="skill-review-table-header__circle-chart-value">
-            {{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}%
-          </span>
-        </CircleChart>
-      </div>
-
-     <CampaignSkillReviewCompetenceResult
-       @showCleaCompetences={{this.showCleaCompetences}}
-       @competenceResults={{this.model.campaignParticipation.campaignParticipationResult.competenceResults}}
-       @partnerCompetenceResults={{this.model.campaignParticipation.campaignParticipationResult.cleaBadge.partnerCompetenceResults}}
-     />
-    </main>
-
-    <div class="skill-review-result__information">
-      <FaIcon @icon='info-circle' class='skill-review-information__info-icon' aria-hidden="true"/>
-      <div class="skill-review-information__text">
-        {{t 'pages.skill-review.information'}}
-      </div>
-    </div>
 
   </PixBlock>
 </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -790,6 +790,10 @@
             },
             "information": "If you have already completed personalised tests on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",
             "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
+            "pix-contest": {
+                "link": "",
+                "title": ""
+            },
             "send-results": "Don't forget to submit your results.",
             "send-status": {
                 "in-progress": "Results are being shared..."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -790,6 +790,10 @@
             },
             "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
             "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
+            "pix-contest": {
+                "link": "Cliquez ici pour être redirigé sur la page d'accueil",
+                "title": "Bravo, vous avez terminé ce module!"
+            },
             "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
             "send-status": {
                 "in-progress": "Envoi en cours"


### PR DESCRIPTION
## :unicorn: Problème
A la fin d'une des campagnes de Pix Concours, on souhaite visualiser une page de fin contenant un lien vers la page d'accueil de pix concours qui contient les 5 liens de compagnes.

## :robot: Solution
Implémenter cette page de résultats. La page d'accueil de Pix Concours sera la page de profil.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Avec la variable d'environnement `IS_PIX_CONTEST`, vérifier qu'une page de résultatt s'ffiche bien en fin de campagne.
