### PR TITLE
[TECH] Créer un script permettant d'ajouter un nombre important d'élèves (PIX-1572)

### DIFF
--- a/api/scripts/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/add-many-students-to-sco-certification-center.js
@@ -6,7 +6,7 @@ const { SchoolingRegistrationsCouldNotBeSavedError } = require('../lib/domain/er
 const { knex } = require('../lib/infrastructure/bookshelf');
 const DomainTransaction = require('../lib/infrastructure/DomainTransaction');
 
-function buildSchoolingRegistration() {
+function _buildSchoolingRegistration() {
   return new SchoolingRegistration({
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
@@ -17,7 +17,7 @@ function buildSchoolingRegistration() {
 }
 
 async function addManyStudentsToScoCertificationCenter(numberOfStudents) {
-  const manyStudents = times(numberOfStudents, () => buildSchoolingRegistration());
+  const manyStudents = times(numberOfStudents, _buildSchoolingRegistration);
   try {
     await knex
       .batchInsert('schooling-registrations', manyStudents)
@@ -32,13 +32,9 @@ async function main() {
 
   const numberOfStudents = process.argv[2];
 
-  try {
-    await addManyStudentsToScoCertificationCenter(numberOfStudents);
-    console.log('\nDone.');
-  } catch (error) {
-    console.error('\n', error);
-    process.exit(1);
-  }
+  await addManyStudentsToScoCertificationCenter(numberOfStudents);
+
+  console.log('\nDone.');
 }
 
 if (require.main === module) {

--- a/api/scripts/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/add-many-students-to-sco-certification-center.js
@@ -1,0 +1,56 @@
+const { MIDDLE_SCHOOL_ID } = require('../db/seeds/data/organizations-sco-builder');
+const times = require('lodash/times');
+const faker = require('faker');
+const SchoolingRegistration = require('../lib/domain/models/SchoolingRegistration');
+const { SchoolingRegistrationsCouldNotBeSavedError } = require('../lib/domain/errors');
+const { knex } = require('../lib/infrastructure/bookshelf');
+const DomainTransaction = require('../lib/infrastructure/DomainTransaction');
+
+function buildSchoolingRegistration() {
+  return new SchoolingRegistration({
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    birthdate: faker.date.past(),
+    division: faker.lorem.word(),
+    organizationId: MIDDLE_SCHOOL_ID,
+  });
+}
+
+async function addManyStudentsToScoCertificationCenter(numberOfStudents) {
+  const manyStudents = times(numberOfStudents, () => buildSchoolingRegistration());
+  try {
+    await knex
+      .batchInsert('schooling-registrations', manyStudents)
+      .transacting(DomainTransaction.emptyTransaction().knexTransaction);
+  } catch (err) {
+    throw new SchoolingRegistrationsCouldNotBeSavedError();
+  }
+}
+
+async function main() {
+  console.log('Starting adding SCO students to certification center.');
+
+  const numberOfStudents = process.argv[2];
+
+  try {
+    await addManyStudentsToScoCertificationCenter(numberOfStudents);
+    console.log('\nDone.');
+  } catch (error) {
+    console.error('\n', error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+
+module.exports = {
+  addManyStudentsToScoCertificationCenter,
+};

--- a/api/tests/acceptance/scripts/add-many-tudents-to-sco-certification-center_test.js
+++ b/api/tests/acceptance/scripts/add-many-tudents-to-sco-certification-center_test.js
@@ -1,0 +1,46 @@
+const { expect } = require('../../test-helper');
+const { MIDDLE_SCHOOL_ID } = require('../../../db/seeds/data/organizations-sco-builder');
+
+const { knex } = require('../../../lib/infrastructure/bookshelf')
+const BookshelfSchoolingRegistration = require('../../../lib/infrastructure/data/schooling-registration');
+const { databaseBuilder } = require('../../test-helper');
+
+const { addManyStudentsToScoCertificationCenter } = require('../../../scripts/add-many-students-to-sco-certification-center');
+
+describe('Acceptance | Scripts | add-many-students-to-sco-certification-centers.js', () => {
+
+  describe('#addManyStudentsToScoCertificationCenter', () => {
+
+    const getNumberOfSchoolingRegistrations = () => {
+      return BookshelfSchoolingRegistration.count()
+        .then((number) => parseInt(number, 10));
+    };
+
+    afterEach(() => {
+      return knex('schooling-registrations').delete();
+    });
+
+    it('should insert 2 sco certification centers', async () => {
+      // given
+      const numberOfSchoolingRegistrationToCreate = 3;
+      databaseBuilder.factory.buildOrganization({
+        id: MIDDLE_SCHOOL_ID,
+        type: 'SCO',
+        name: 'Collège The Night Watch',
+        isManagingStudents: true,
+        canCollectProfiles: true,
+        email: 'sco.generic.account@example.net',
+        externalId: 123,
+        provinceCode: '12',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await addManyStudentsToScoCertificationCenter(numberOfSchoolingRegistrationToCreate);
+      const numberAfter = await getNumberOfSchoolingRegistrations();
+
+      // then
+      expect(numberAfter).to.equal(numberOfSchoolingRegistrationToCreate);
+    });
+  });
+});

--- a/api/tests/acceptance/scripts/add-many-tudents-to-sco-certification-center_test.js
+++ b/api/tests/acceptance/scripts/add-many-tudents-to-sco-certification-center_test.js
@@ -1,7 +1,7 @@
 const { expect } = require('../../test-helper');
 const { MIDDLE_SCHOOL_ID } = require('../../../db/seeds/data/organizations-sco-builder');
 
-const { knex } = require('../../../lib/infrastructure/bookshelf')
+const { knex } = require('../../../lib/infrastructure/bookshelf');
 const BookshelfSchoolingRegistration = require('../../../lib/infrastructure/data/schooling-registration');
 const { databaseBuilder } = require('../../test-helper');
 
@@ -10,11 +10,6 @@ const { addManyStudentsToScoCertificationCenter } = require('../../../scripts/ad
 describe('Acceptance | Scripts | add-many-students-to-sco-certification-centers.js', () => {
 
   describe('#addManyStudentsToScoCertificationCenter', () => {
-
-    const getNumberOfSchoolingRegistrations = () => {
-      return BookshelfSchoolingRegistration.count()
-        .then((number) => parseInt(number, 10));
-    };
 
     afterEach(() => {
       return knex('schooling-registrations').delete();
@@ -37,10 +32,15 @@ describe('Acceptance | Scripts | add-many-students-to-sco-certification-centers.
 
       // when
       await addManyStudentsToScoCertificationCenter(numberOfSchoolingRegistrationToCreate);
-      const numberAfter = await getNumberOfSchoolingRegistrations();
+      const numberAfter = await _getNumberOfSchoolingRegistrations();
 
       // then
       expect(numberAfter).to.equal(numberOfSchoolingRegistrationToCreate);
     });
   });
 });
+
+function _getNumberOfSchoolingRegistrations() {
+  return BookshelfSchoolingRegistration.count()
+    .then((number) => parseInt(number, 10));
+}


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix “Prescription de certif SCO”, la liste de tous les élèves d’un établissement importée dans Pix Orga s’affiche dans Pix certif pour un utilisateur SCO souhaitant ajouter des candidats à une session de certification.

Certains établissements peuvent avoir jusqu'à 3640, actuellement, (voir plus) élèves dans leur établissement, se pose alors des questions quant aux perfs sur l’affichage de la liste des élèves dans Pix Certif.

Avec la requête suivante : 
```sql
select count(*) from "schooling-registrations"
group by "organizationId"
ORDER BY count(*) DESC;
```
On peut voir qu'il y a au moins 10 établissements à plus de 3000 élèves. Et des centaines d'établissement à plus de 1000 élèves.

## :robot: Solution
Créer des seeds avec un nombre important d'élèves (5000 ?) afin de vérifier l’impact sur les perfs, et de constater si le besoin de paginer cette liste est urgent (et donc intègre la V0) ou pas (et donc peut intégrer une version future de cet épix).

## :rainbow: Remarques

**Pour 50 élèves:**

![image](https://user-images.githubusercontent.com/37305474/98650929-dfd02400-2339-11eb-8e6b-1badfb0eb67a.png)

**Pour 200 élèves:**

![image](https://user-images.githubusercontent.com/37305474/98569247-5aedf780-22b2-11eb-9171-e1b0d56d4c2c.png)

**Pour 1000 élèves:**

![image](https://user-images.githubusercontent.com/37305474/98569056-14000200-22b2-11eb-83f4-76ee34ae7a96.png)

**Pour 4000 élèves:** 

![image](https://user-images.githubusercontent.com/37305474/98568406-5bd25980-22b1-11eb-9f4b-2fd89035a0cf.png)


**Pour 8000 élèves:**

![image](https://user-images.githubusercontent.com/37305474/98568806-cbe0df80-22b1-11eb-8d01-203edf77e2cc.png)



## :100: Pour tester
- Se placer dans api et lancer: 

```node scripts/add-many-students-to-sco-certification-center.js {nombre d'élève}```