### PR TITLE
[BUGFIX] Ajout d'une contrainte d'unicité sur le nationalStudentId et le nationalApprenticeId avant l'insertion en base (PIX-1581).

### DIFF
--- a/api/lib/domain/validators/schooling-registration-set-validator.js
+++ b/api/lib/domain/validators/schooling-registration-set-validator.js
@@ -1,0 +1,26 @@
+const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const { EntityValidationError } = require('../errors');
+
+const validationConfiguration = { allowUnknown: true };
+
+const validationSchema = Joi.array().unique((a, b) => {
+  return a.nationalStudentId === b.nationalStudentId && 
+  a.nationalApprenticeId === b.nationalApprenticeId; 
+});
+
+module.exports = {
+  checkValidationUnicity(schoolingRegistrationSet) {
+    const { error } = validationSchema.validate(
+      schoolingRegistrationSet.registrations,
+      validationConfiguration,
+    );
+
+    if (error) {
+      const err = EntityValidationError.fromJoiErrors(error.details);
+      err.key = 'nationalIdentifier';
+      err.why = 'uniqueness';
+      
+      throw err;
+    }
+  },
+};

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -68,7 +68,7 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
 
   _handleError(err, index) {
     if (err.why === 'uniqueness') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Identifiant unique” doit être unique au sein du fichier.`);
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Identifiant unique” ne doit pas contenir de doublon.`);
     }
    
     super._handleError(...arguments);

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -68,7 +68,7 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
 
   _handleError(err, index) {
     if (err.why === 'uniqueness') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Identifiant unique” ne doit pas contenir de doublon.`);
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Identifiant unique” de cette ligne est présent plusieurs fois dans le fichier.`);
     }
    
     super._handleError(...arguments);

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -873,7 +873,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
-          expect(response.result.errors[0].detail).to.contains('Le champ “Identifiant unique” ne doit pas contenir de doublon.');
+          expect(response.result.errors[0].detail).to.contains('Le champ “Identifiant unique” de cette ligne est présent plusieurs fois dans le fichier.');
         });
       });
     });

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -864,15 +864,16 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           options.payload = buffer;
         });
 
-        it('should not import any schoolingRegistration and return a 422', async () => {
+        it('should not import any schoolingRegistration and return a 412', async () => {
           // when
           const response = await server.inject(options);
 
           // then
           const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
+          
           expect(schoolingRegistrations).to.have.lengthOf(0);
-          expect(response.statusCode).to.equal(422);
-          expect(response.result.errors[0].detail).to.equal('L’INE 123F est présent plusieurs fois dans le fichier. La base SIECLE doit être corrigée pour supprimer les doublons. Réimportez ensuite le nouveau fichier.');
+          expect(response.statusCode).to.equal(412);
+          expect(response.result.errors[0].detail).to.contains('Le champ “Identifiant unique” ne doit pas contenir de doublon.');
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -7,6 +7,38 @@ const schoolingRegistrationCsvColumns = SchoolingRegistrationParser.COLUMNS.map(
 
 describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
   context('when the header is correctly formed', () => {
+    context('when the header is not correctly formed', () => {
+      const organizationId = 123;
+  
+      const fieldList = ['Identifiant unique*', 'Nom de famille*', 'Date de naissance (jj/mm/aaaa)*', 'Code département naissance*', 'Code pays naissance*', 'Statut*', 'Code MEF*', 'Division*'];
+      fieldList.forEach((field) => {
+        context(`when the ${field} column is missing`, () => {
+          it('should throw an CsvImportError', async () => {
+            let input = schoolingRegistrationCsvColumns.replace(`${field}`,  '');
+            input = input.replace(';;',  ';');
+            const encodedInput = iconv.encode(input, 'utf8');
+            const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+  
+            const error = await catchErr(parser.parse, parser)();
+  
+            expect(error.message).to.contain(`La colonne "${field}" est obligatoire.`);
+          });
+        });
+      });
+  
+      context('when the Premier prénom* column is missing', () => {
+        it('should throw an CsvImportError', async () => {
+          const input = schoolingRegistrationCsvColumns.replace('Premier prénom*;',  '');
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+  
+          const error = await catchErr(parser.parse, parser)();
+  
+          expect(error.message).to.contain('Encodage du fichier non supporté.');
+        });
+      });
+    });
+    
     context('when there is no line', () => {
       it('returns no registrations', () => {
         const input = schoolingRegistrationCsvColumns;
@@ -18,101 +50,63 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         expect(registrations).to.be.empty;
       });
     });
+
     context('when there are lines', () => {
-      it('returns a schooling registration for each line', () => {
-        const input = `${schoolingRegistrationCsvColumns}
-        123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-        456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
-        `;
-        const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new SchoolingRegistrationParser(encodedInput, 456);
-
-        const { registrations } = parser.parse();
-        expect(registrations).to.have.lengthOf(2);
-      });
-
-      it('returns schooling registrations for each line using the CSV column', () => {
-        const input = `${schoolingRegistrationCsvColumns}
-        123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
-        456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
-        `;
-        const organizationId = 789;
-        const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
-
-        const { registrations } = parser.parse();
-        expect(registrations[0]).to.includes({
-          nationalStudentId: '123F',
-          nationalApprenticeId: undefined,
-          firstName: 'Beatrix',
-          middleName: 'The',
-          thirdName: 'Bride',
-          lastName: 'Kiddo',
-          preferredLastName: 'Black Mamba',
-          birthdate: '1970-01-01',
-          birthCityCode: '97422',
-          birthProvinceCode: '974',
-          birthCountryCode: '100',
-          status: 'ST',
-          MEFCode: 'MEF1',
-          division: 'Division 1',
-          organizationId,
-        });
-        expect(registrations[1]).to.includes({
-          nationalStudentId: '456F',
-          nationalApprenticeId: undefined,
-          firstName: 'O-Ren',
-          lastName: 'Ishii',
-          preferredLastName: 'Cottonmouth',
-          birthdate: '1980-01-01',
-          birthCity: 'Shangai',
-          birthProvinceCode: '99',
-          birthCountryCode: '132',
-          status: 'ST',
-          MEFCode: 'MEF1',
-          division: 'Division 2',
-          organizationId,
-        });
-      });
-
-      context('When the organization hasApprentice and file contain status AP', () => {
-        it('should return schooling registration with nationalApprenticeId', () => {
+      context('when the data are correct', () => {
+        it('returns a schooling registration for each line', () => {
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
+          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
           `;
-          const organizationId = 789;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId, true);
+          const parser = new SchoolingRegistrationParser(encodedInput, 456);
   
           const { registrations } = parser.parse();
-          expect(registrations[0]).to.includes({
-            nationalStudentId: undefined,
-            nationalApprenticeId: '123F',
-            status: 'AP',
-          });
+          expect(registrations).to.have.lengthOf(2);
         });
-
-        it('should not return error given nationalIdentifier with different status', () => {
+  
+        it('returns schooling registrations for each line using the CSV column', () => {
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
           `;
           const organizationId = 789;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId, true);
+          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
   
           const { registrations } = parser.parse();
-          
           expect(registrations[0]).to.includes({
-            nationalStudentId: undefined,
-            nationalApprenticeId: '123F',
-            status: 'AP',
-          });
-
-          expect(registrations[1]).to.includes({
             nationalStudentId: '123F',
             nationalApprenticeId: undefined,
+            firstName: 'Beatrix',
+            middleName: 'The',
+            thirdName: 'Bride',
+            lastName: 'Kiddo',
+            preferredLastName: 'Black Mamba',
+            birthdate: '1970-01-01',
+            birthCityCode: '97422',
+            birthProvinceCode: '974',
+            birthCountryCode: '100',
             status: 'ST',
+            MEFCode: 'MEF1',
+            division: 'Division 1',
+            organizationId,
+          });
+  
+          expect(registrations[1]).to.includes({
+            nationalStudentId: '456F',
+            nationalApprenticeId: undefined,
+            firstName: 'O-Ren',
+            lastName: 'Ishii',
+            preferredLastName: 'Cottonmouth',
+            birthdate: '1980-01-01',
+            birthCity: 'Shangai',
+            birthProvinceCode: '99',
+            birthCountryCode: '132',
+            status: 'AP',
+            MEFCode: 'MEF1',
+            division: 'Division 2',
+            organizationId,
           });
         });
       });
@@ -132,88 +126,86 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           expect(error).to.be.an.instanceOf(EntityValidationError);
         });
 
-        context('when organization is SCO and CSV has duplicates on national identifier' , () => {
-          it('should throw an CsvImportError', async () => {
+        context('When the organization is Agriculture and file contain status AP', () => {
+          it('should return schooling registration with nationalApprenticeId', () => {
             const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
             `;
-
+            const organizationId = 789;
             const encodedInput = iconv.encode(input, 'utf8');
-            const parser = new SchoolingRegistrationParser(encodedInput, 123);
-  
-            const error = await catchErr(parser.parse, parser)();
-            
-            //then
-            expect(error).to.be.an.instanceOf(CsvImportError);
+            const parser = new SchoolingRegistrationParser(encodedInput, organizationId, true);
+    
+            const { registrations } = parser.parse();
+            expect(registrations[0]).to.includes({
+              nationalStudentId: undefined,
+              nationalApprenticeId: '123F',
+              status: 'AP',
+            });
           });
         });
 
-        context('when organization is SCO Agriculture and CSV has duplicates on national identifier' , () => {
-          it('should throw an CsvImportError, with all status AP', async () => {
-            const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
-            `;
-
-            const encodedInput = iconv.encode(input, 'utf8');
-            const parser = new SchoolingRegistrationParser(encodedInput, 123, true);
+        context('When csv has duplicates on national identifier', () => {
+          context('when organization is SCO' , () => {
+            it('should throw an CsvImportError even with different status', async () => {
+              const input = `${schoolingRegistrationCsvColumns}
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              `;
   
-            const error = await catchErr(parser.parse, parser)();
-            
-            //then
-            expect(error).to.be.an.instanceOf(CsvImportError);
+              const encodedInput = iconv.encode(input, 'utf8');
+              const parser = new SchoolingRegistrationParser(encodedInput, 123);
+    
+              const error = await catchErr(parser.parse, parser)();
+              
+              //then
+              expect(error).to.be.an.instanceOf(CsvImportError);
+            });
           });
-
-          it('should throw an CsvImportError, with all status ST', async () => {
-            const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;ST;MEF1;Division 1;
-            `;
-
-            const encodedInput = iconv.encode(input, 'utf8');
-            const parser = new SchoolingRegistrationParser(encodedInput, 123, true);
+          
+          context('when organization is SCO Agriculture' , () => {
+            const isAgriculture = true;
   
-            const error = await catchErr(parser.parse, parser)();
-            
-            //then
-            expect(error).to.be.an.instanceOf(CsvImportError);
-          });
+            it('should not return error given nationalIdentifier with different status', () => {
+              const input = `${schoolingRegistrationCsvColumns}
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+              `;
+              const organizationId = 789;
+              const encodedInput = iconv.encode(input, 'utf8');
+              const parser = new SchoolingRegistrationParser(encodedInput, organizationId, isAgriculture);
+      
+              const { registrations } = parser.parse();
+              
+              expect(registrations[0]).to.includes({
+                nationalStudentId: undefined,
+                nationalApprenticeId: '123F',
+                status: 'AP',
+              });
+    
+              expect(registrations[1]).to.includes({
+                nationalStudentId: '123F',
+                nationalApprenticeId: undefined,
+                status: 'ST',
+              });
+            });
+  
+            it('should throw an CsvImportError, with same status', async () => {
+              const input = `${schoolingRegistrationCsvColumns}
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              `;
+  
+              const encodedInput = iconv.encode(input, 'utf8');
+              const parser = new SchoolingRegistrationParser(encodedInput, 123, isAgriculture);
+    
+              const error = await catchErr(parser.parse, parser)();
+              
+              //then
+              expect(error).to.be.an.instanceOf(CsvImportError);
+            });
+          });  
         });
       });
     });
-  });
-
-  context('when the header is not correctly formed', () => {
-    const organizationId = 123;
-
-    const fieldList = ['Identifiant unique*', 'Nom de famille*', 'Date de naissance (jj/mm/aaaa)*', 'Code département naissance*', 'Code pays naissance*', 'Statut*', 'Code MEF*', 'Division*'];
-    fieldList.forEach((field) => {
-      context(`when the ${field} column is missing`, () => {
-        it('should throw an CsvImportError', async () => {
-          let input = schoolingRegistrationCsvColumns.replace(`${field}`,  '');
-          input = input.replace(';;',  ';');
-          const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
-
-          const error = await catchErr(parser.parse, parser)();
-
-          expect(error.message).to.contain(`La colonne "${field}" est obligatoire.`);
-        });
-      });
-    });
-
-    context('when the Premier prénom* column is missing', () => {
-      it('should throw an CsvImportError', async () => {
-        const input = schoolingRegistrationCsvColumns.replace('Premier prénom*;',  '');
-        const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
-
-        const error = await catchErr(parser.parse, parser)();
-
-        expect(error.message).to.contain('Encodage du fichier non supporté.');
-      });
-    });
-
   });
 });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -92,7 +92,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           });
         });
 
-        it('should return not return error given nationalIdentifier with different status', () => {
+        it('should not return error given nationalIdentifier with different status', () => {
           const input = `${schoolingRegistrationCsvColumns}
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
@@ -118,8 +118,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
       });
 
       context('when the data are not correct', () => {
-        it('should throw an EntityValidationError', async () => {
-          //given wrong birthDate
+        it('should throw an EntityValidationError with malformated birthDate', async () => {
+          //given
           const input = `${schoolingRegistrationCsvColumns}
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;aaaaa;97422;;200;99100;ST;MEF1;Division 1;
           `;


### PR DESCRIPTION
## :unicorn: Problème
La vérification de l'unicité sur le fichier csv se faisait au moment de l'insertion en base. lors d'un update avec un doublon de nationalIdentifier. 

ces doublons passait comme un double update de l'utilisateur si ce nationalIdentifier était déjà présent en base. 

## :robot: Solution
Rajouter un contôle d'unicité lors du parse du CSV. pour le nationalStudentId et la nationalApprenticeId.

## :rainbow: Remarques
Ces deux identifiants n'étant pas corrélé. nous supposons qu'il est possible d'avoir un nationalStudentId et un nationalApprenticeId identique dans le même fichiers seulement pour les SCO Agri. Le status de l'élève le fera passer en AP ou ST et ne rentrera pas en conflit en base. 

## :100: Pour tester
Tout est içi https://1024pix.atlassian.net/browse/PIX-1581
