### PR TITLE
[TECH] Mise à jour des messages d'erreurs de réconciliation dans Mon-Pix (PIX-1426)

### DIFF
--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -3,22 +3,22 @@
         "bad-request-error": "Les données que vous avez soumises ne sont pas au bon format.",
         "internal-server-error": "Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.",
         "join-error": {
-            "r11": "Vous possédez déjà un compte Pix avec l’adresse e-mail '<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R11)",
-            "r12": "Vous possédez déjà un compte Pix utilisé avec l’identifiant '<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R12)",
-            "r13": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.",
-            "r31": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R31)",
-            "r32": "Vous possédez déjà un compte Pix utilisé avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code R32)",
+            "r11": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R11)",
+            "r12": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R12)",
+            "r13": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br><br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R13)",
+            "r31": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R31)",
+            "r32": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R32)",
             "r33": "Vous possédez déjà un compte Pix via l’ENT. Utilisez-le pour rejoindre le parcours.",
             "r70": "Une erreur est survenue. Déconnectez-vous et recommencez."
         },
         "login-unauthorized-error": "L'adresse e-mail ou l'identifiant et/ou le mot de passe saisis sont incorrects.",
         "register-error": {
-            "s51": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S51)",
-            "s52": "Vous possédez déjà un compte Pix avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S52)",
+            "s51": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R51)",
+            "s52": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R52)",
             "s53": "Vous possédez déjà un compte Pix via l’ENT.'<br>'Utilisez-le pour rejoindre le parcours.",
-            "s61": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S61)",
-            "s62": "Vous possédez déjà un compte Pix utilisé avec l’identifiant'<br>'{ value }.'<br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br>'(Code S62)",
-            "s63": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.'<br>'(Code S63)"
+            "s61": "Vous possédez déjà un compte Pix avec l’adresse e-mail'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R61)",
+            "s62": "Vous possédez déjà un compte Pix utilisé avec l’identifiant sous la forme prénom.nom suivi de 4 chiffres:'<br>'{ value }'<br><br>'Pour continuer, connectez-vous à ce compte ou demandez de l’aide à un enseignant.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R62)",
+            "s63": "Vous possédez déjà un compte Pix via l’ENT dans un autre établissement scolaire.'<br><br>'Pour continuer, contactez un enseignant qui pourra vous donner l’accès à ce compte à l’aide de Pix Orga.'<br><br>'(Pour l’enseignant : voir le ’Kit de dépannage’ dans Pix Orga &gt; Documentation - Code R63)"
         }
     },
     "application": {


### PR DESCRIPTION
## :unicorn: Problème
On souhaite ajouter des informations complémentaires dans les messages d'erreur (et d'information de connexion) présents dans la double mire lors de l'inscription et dans la réconciliation ( "R11", "R12", "R13", "R31", "R32", "S51", "S52", "S61", "S62", "S63").

Ces ajouts permettent de : 

1 - Préciser ce qu'est un identifiant car les élèves confondent avec adresse email.
2 - Indiquer aux enseignants où ils doivent se rendre pour aider l'élève.

## :robot: Solution
Ajouter l'information suivante pour le premier cas : "identifiant sous la forme prenom.nom suivi de 4 chiffres"

Ajouter pour le deuxième cas : "(Pour l'enseignant : voir le ‘Kit de dépannage’ dans Pix Orga > Documentation - Code XXX)"

## :rainbow: Remarques

## :100: Pour tester
Il y a plusieurs types de cas à tester ( 10 messages ont étés modifiés ).

Vous pouvez utiliser :  

- First Last (10/10/2010)
- Blue Ivy Carter (07/01/2012)
- User Gar (07/01/2002)

Ci-joint les screens des tests réalisés.
(Le premier montre la structure définitive du texte avec le saut de ligne entre les phrases, pas les suivants. )

<img width="301" alt="Capture d’écran 2020-11-10 à 15 02 25" src="https://user-images.githubusercontent.com/58915422/98686913-6e0fce80-2369-11eb-80a8-b7b03771f459.png">
<img width="338" alt="Capture d’écran 2020-11-10 à 13 12 50" src="https://user-images.githubusercontent.com/58915422/98688738-77019f80-236b-11eb-9139-4c8e3b6ff1ed.png">
<img width="340" alt="Capture d’écran 2020-11-10 à 12 51 58" src="https://user-images.githubusercontent.com/58915422/98689202-fabb8c00-236b-11eb-8a9f-950239f774ae.png">
<img width="352" alt="Capture d’écran 2020-11-10 à 13 19 22" src="https://user-images.githubusercontent.com/58915422/98689480-44a47200-236c-11eb-8f7b-fd67df2c6df1.png">




