### PR TITLE
[FEATURE] Créer une catégorie "Autre" pour signalement quand on finalise une session (PIX-1470)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -137,6 +137,7 @@ module.exports = (function() {
     featureToggles: {
       certifPrescriptionSco: isFeatureEnabled(process.env.FT_CERTIF_PRESCRIPTION_SCO),
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
+      reportsCategorization: isFeatureEnabled(process.env.FT_REPORTS_CATEGORISATION),
     },
 
     infra: {
@@ -177,6 +178,7 @@ module.exports = (function() {
     config.features.garAccessV2 = false;
 
     config.featureToggles.certifPrescriptionSco = false;
+    config.featureToggles.reportsCategorization = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/tests/acceptance/application/feature-controller_tests.js
+++ b/api/tests/acceptance/application/feature-controller_tests.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           id: '0',
           attributes: {
             'certif-prescription-sco': false,
+            'reports-categorization': false,
             'is-pole-emploi-enabled': false,
           },
           type: 'feature-toggles',

--- a/certif/app/components/add-student-list.js
+++ b/certif/app/components/add-student-list.js
@@ -60,7 +60,7 @@ export default class AddStudentList extends Component {
     try {
       await this.args.session.save({ adapterOptions: { studentListToAdd, sessionId } });
       this.args.returnToSessionCandidates(sessionId);
-      this.notifications.success('Le(s) élève(s) ont bien été rajouté(s) à la session !');
+      this.notifications.success('Le(s) candidat(s) ont été ajouté(s) avec succès.');
     } catch (error) {
       this.notifications.error('Une erreur est survenue au moment d‘enregistrer les candidats... ');
     }

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -32,7 +32,7 @@
                 @maxlength={{@maxlength}}
                 {{on 'input' this.handleChange}}
                 />
-              <p>{{this.reportLength}} / 500</p>
+              <p class="content__report-type-details__char-count">{{this.reportLength}} / 500</p>
           </div>
         {{/if}}
       </div>

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -1,0 +1,46 @@
+<AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
+  <div class="examiner-report-modal">
+    <div class="pix-modal__close-link">
+      <a href="#" data-test-id="finalize-session-modal__close-cross" {{on "click" @closeModal}}>Fermer
+        <img src="/icons/icon-close-modal.svg" alt="Fermer la fenêtre de confirmation" width="24" height="24">
+      </a>
+    </div>
+
+    <PixBlock>
+      <div class="examiner-report-modal__title">
+        <h1>Signalement du candidat</h1>
+        <h3>{{@report.firstName}} {{@report.lastName}}</h3>
+      </div>
+
+      <div class="examiner-report-modal__content">
+        <input
+            id="report-of-type-other__radio-button"
+            type="radio"
+            name="other"
+            checked={{this.isReportOfTypeOtherChecked}}
+            {{on 'click' this.toggleShowReportOfTypeOther}} />
+        <label for="report-of-type-other__radio-button">Autre incident</label>
+        {{#if this.isReportOfTypeOtherChecked}}
+          <div class="content__report-type-details">
+            <label for="report-of-type-other__text-area">Détaillez l'incident</label>
+            <Textarea
+                id="report-of-type-other__text-area"
+                @class="session-finalization-reports-informations-step__textarea"
+                @value={{this.reportOfTypeOther}}
+                @maxlength={{@maxlength}}
+                {{on 'input' this.handleChange}}
+                />
+              <p>{{this.reportLength}} / 500</p>
+          </div>
+        {{/if}}
+      </div>
+
+      <div class="examiner-report-modal__actions">
+        <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
+          <button type="button" class="button--showed-as-link" {{on "click" @closeModal}}>Annuler</button>
+          <button type="button" class="button button--extra-thin" {{on "click" this.submitReport}}>Valider</button>
+        </div>
+      </div>
+    </PixBlock>
+  </div>
+</AppModal>

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -6,20 +6,22 @@
       </a>
     </div>
 
-    <PixBlock>
+    <div class="pix-modal__container pix-modal__container--white">
       <div class="examiner-report-modal__title">
         <h1>Signalement du candidat</h1>
         <h3>{{@report.firstName}} {{@report.lastName}}</h3>
       </div>
 
       <div class="examiner-report-modal__content">
-        <input
-            id="report-of-type-other__radio-button"
-            type="radio"
-            name="other"
-            checked={{this.isReportOfTypeOtherChecked}}
-            {{on 'click' this.toggleShowReportOfTypeOther}} />
-        <label for="report-of-type-other__radio-button">Autre incident</label>
+        <div class="content__report-type-button">
+          <input
+              id="report-of-type-other__radio-button"
+              type="radio"
+              name="other"
+              checked={{this.isReportOfTypeOtherChecked}}
+              {{on 'click' this.toggleShowReportOfTypeOther}} />
+          <label for="report-of-type-other__radio-button">Autre incident</label>
+        </div>
         {{#if this.isReportOfTypeOtherChecked}}
           <div class="content__report-type-details">
             <label for="report-of-type-other__text-area">Détaillez l'incident</label>
@@ -36,11 +38,9 @@
       </div>
 
       <div class="examiner-report-modal__actions">
-        <div class="pix-modal-footer pix-modal-footer--with-centered-buttons">
-          <button type="button" class="button--showed-as-link" {{on "click" @closeModal}}>Annuler</button>
-          <button type="button" class="button button--extra-thin" {{on "click" this.submitReport}}>Valider</button>
-        </div>
+        <button type="button" class="button--showed-as-link" {{on "click" @closeModal}}>Annuler</button>
+        <button type="button" class="button button--extra-thin" {{on "click" this.submitReport}}>Valider</button>
       </div>
-    </PixBlock>
+    </div>
   </div>
 </AppModal>

--- a/certif/app/components/examiner-report-modal.js
+++ b/certif/app/components/examiner-report-modal.js
@@ -1,0 +1,35 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class ExaminerReportModal extends Component {
+  @service store
+
+  reportOfTypeOther = this.args.report.examinerComment;
+
+  @tracked
+  isReportOfTypeOtherChecked = false
+
+  @tracked
+  reportLength = 0
+
+  @action
+  async toggleShowReportOfTypeOther() {
+    this.isReportOfTypeOtherChecked = !this.isReportOfTypeOtherChecked;
+    if (this.args.report.examinerComment) {
+      this.reportLength = this.args.report.examinerComment.length;
+    }
+  }
+
+  @action
+  submitReport() {
+    this.args.report.examinerComment = this.reportOfTypeOther;
+    this.args.closeModal();
+  }
+
+  @action
+  handleChange(e) {
+    this.reportLength = e.target.value.length;
+  }
+}

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -5,7 +5,7 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>N° de certification</th>
-        {{#if @isCategorizationOfReportsEnabled}}
+        {{#if @isReportsCategorizationFeatureToggleEnabled}}
           <th>Signalement</th>
         {{else}}
           <th>Signalement (à renseigner le cas échéant)</th>
@@ -26,8 +26,8 @@
           <td data-test-id="finalization-report-last-name_{{report.certificationCourseId}}">{{report.lastName}}</td>
           <td data-test-id="finalization-report-first-name_{{report.certificationCourseId}}">{{report.firstName}}</td>
           <td data-test-id="finalization-report-certification-number_{{report.certificationCourseId}}">{{report.certificationCourseId}}</td>
-          <td>
-            {{#if @isCategorizationOfReportsEnabled}}
+          <td data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}">
+            {{#if @isReportsCategorizationFeatureToggleEnabled}}
               <div class="finalization-report-examiner-comment">
                 {{#if report.examinerComment}}
                   <button type="button" class="button--showed-as-link add-button" {{on 'click' (fn this.openExaminerReportModal report)}}>
@@ -42,7 +42,6 @@
               </div>
             {{else}}
               <Textarea
-                data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}"
                 @class="session-finalization-reports-informations-step__textarea"
                 @value={{report.examinerComment}}
                 {{on 'input' (fn @updateCertificationReportExaminerComment report)}}

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -5,7 +5,11 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>N° de certification</th>
-        <th>Signalement (à renseigner le cas échéant)</th>
+        {{#if this.myFeatureToggle}}
+          <th>Signalement</th>
+        {{else}}
+          <th>Signalement (à renseigner le cas échéant)</th>
+        {{/if}}
         <th>
           <div class="session-finalization-reports-informations-step__row">
             <div class="session-finalization-reports-informations-step__checker" {{on 'click' (fn @toggleAllCertificationReportsHasSeenEndTestScreen this.hasCheckedSomething)}}>
@@ -23,13 +27,17 @@
           <td data-test-id="finalization-report-first-name_{{report.certificationCourseId}}">{{report.firstName}}</td>
           <td data-test-id="finalization-report-certification-number_{{report.certificationCourseId}}">{{report.certificationCourseId}}</td>
           <td>
-            <Textarea
-              data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}"
-              @class="session-finalization-reports-informations-step__textarea"
-              @value={{report.examinerComment}}
-              {{on 'input' (fn @updateCertificationReportExaminerComment report)}}
-              @maxlength={{@examinerCommentMaxLength}}
-            />
+            {{#if this.myFeatureToggle}}
+              <button type="button" class="button--showed-as-link" {{on 'click' (fn this.openExaminerReportModal report)}}>Signalement ?</button>
+            {{else}}
+              <Textarea
+                data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}"
+                @class="session-finalization-reports-informations-step__textarea"
+                @value={{report.examinerComment}}
+                {{on 'input' (fn @updateCertificationReportExaminerComment report)}}
+                @maxlength={{@examinerCommentMaxLength}}
+              />
+            {{/if}}
           </td>
           <td>
             <CertifCheckbox
@@ -42,4 +50,11 @@
       {{/each}}
     </tbody>
   </table>
+  {{#if this.showExaminerReportModal}}
+    <ExaminerReportModal
+      @closeModal={{this.closeExaminerReportModal}}
+      @report={{this.reportToEdit}}
+      @maxlength={{@examinerCommentMaxLength}}
+      />
+  {{/if}}
 </div>

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -5,7 +5,7 @@
         <th>Nom</th>
         <th>Prénom</th>
         <th>N° de certification</th>
-        {{#if this.myFeatureToggle}}
+        {{#if @isCategorizationOfReportsEnabled}}
           <th>Signalement</th>
         {{else}}
           <th>Signalement (à renseigner le cas échéant)</th>
@@ -27,7 +27,7 @@
           <td data-test-id="finalization-report-first-name_{{report.certificationCourseId}}">{{report.firstName}}</td>
           <td data-test-id="finalization-report-certification-number_{{report.certificationCourseId}}">{{report.certificationCourseId}}</td>
           <td>
-            {{#if this.myFeatureToggle}}
+            {{#if @isCategorizationOfReportsEnabled}}
               <button type="button" class="button--showed-as-link" {{on 'click' (fn this.openExaminerReportModal report)}}>Signalement ?</button>
               {{#if report.examinerComment}}
                 <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}"> 1 signalement </p>

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -29,6 +29,9 @@
           <td>
             {{#if this.myFeatureToggle}}
               <button type="button" class="button--showed-as-link" {{on 'click' (fn this.openExaminerReportModal report)}}>Signalement ?</button>
+              {{#if report.examinerComment}}
+                <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}"> 1 signalement </p>
+              {{/if}}
             {{else}}
               <Textarea
                 data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}"

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -28,10 +28,18 @@
           <td data-test-id="finalization-report-certification-number_{{report.certificationCourseId}}">{{report.certificationCourseId}}</td>
           <td>
             {{#if @isCategorizationOfReportsEnabled}}
-              <button type="button" class="button--showed-as-link" {{on 'click' (fn this.openExaminerReportModal report)}}>Signalement ?</button>
-              {{#if report.examinerComment}}
-                <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}"> 1 signalement </p>
-              {{/if}}
+              <div class="finalization-report-examiner-comment">
+                {{#if report.examinerComment}}
+                  <button type="button" class="button--showed-as-link add-button" {{on 'click' (fn this.openExaminerReportModal report)}}>
+                    Ajouter / modifier
+                  </button>
+                  <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}"> 1 signalement </p>
+                {{else}}
+                  <button type="button" class="button--showed-as-link add-button" {{on 'click' (fn this.openExaminerReportModal report)}}>
+                    Ajouter ?
+                  </button>
+                {{/if}}
+              </div>
             {{else}}
               <Textarea
                 data-test-id="finalization-report-examiner-comment_{{report.certificationCourseId}}"

--- a/certif/app/components/session-finalization-reports-informations-step.js
+++ b/certif/app/components/session-finalization-reports-informations-step.js
@@ -1,7 +1,17 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
 export default class SessionFinalizationReportsInformationsStep extends Component {
   textareaMaxLength = 500;
+  reportToEdit = null;
+
+  @tracked
+  showExaminerReportModal = false;
+
+  get myFeatureToggle() {
+    return true;
+  }
 
   get certifReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
@@ -19,6 +29,17 @@ export default class SessionFinalizationReportsInformationsStep extends Componen
 
   get headerCheckboxStatus() {
     return this.hasCheckedEverything ? 'checked' : this.hasCheckedSomething ? 'partial' : 'unchecked';
+  }
+
+  @action
+  async openExaminerReportModal(report) {
+    this.showExaminerReportModal = true;
+    this.reportToEdit = report;
+  }
+
+  @action
+  async closeExaminerReportModal() {
+    this.showExaminerReportModal = false;
   }
 
 }

--- a/certif/app/components/session-finalization-reports-informations-step.js
+++ b/certif/app/components/session-finalization-reports-informations-step.js
@@ -9,10 +9,6 @@ export default class SessionFinalizationReportsInformationsStep extends Componen
   @tracked
   showExaminerReportModal = false;
 
-  get myFeatureToggle() {
-    return true;
-  }
-
   get certifReportsAreNotEmpty() {
     return this.args.certificationReports.length !== 0;
   }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -11,7 +11,9 @@ export default class SessionsFinalizeController extends Controller {
 
   @service notifications;
 
-  @alias('model') session;
+  @alias('model.session') session;
+  @alias('model.isReportsCategorizationFeatureToggleEnabled') isReportsCategorizationFeatureToggleEnabled;
+
   examinerGlobalCommentMaxLength = 500;
   examinerCommentMaxLength = 500;
   @tracked isLoading = false;

--- a/certif/app/models/feature-toggle.js
+++ b/certif/app/models/feature-toggle.js
@@ -2,4 +2,5 @@ import Model, { attr } from '@ember-data/model';
 
 export default class FeatureToggle extends Model {
   @attr('boolean') certifPrescriptionSco;
+  @attr('boolean') reportsCategorization;
 }

--- a/certif/app/routes/authenticated/sessions/finalize.js
+++ b/certif/app/routes/authenticated/sessions/finalize.js
@@ -7,11 +7,14 @@ export default class SessionsFinalizeRoute extends Route {
   async model({ session_id }) {
     const session = await this.store.findRecord('session', session_id, { reload: true });
     await session.certificationReports;
-    return session;
+    const featureToggles = this.store.peekRecord('feature-toggle', 0);
+    const isReportsCategorizationFeatureToggleEnabled = featureToggles.reportsCategorization;
+
+    return { session, isReportsCategorizationFeatureToggleEnabled };
   }
 
   async afterModel(model, transition) {
-    if (model.isFinalized) {
+    if (model.session.isFinalized) {
       this.notifications.error('Cette session a déjà été finalisée.');
 
       transition.abort();

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -29,6 +29,7 @@
 @import "components/add-student-list";
 @import "components/certif-checkbox";
 @import "components/ember-cli-notifications-ie-fallback";
+@import "components/examiner-report-modal";
 @import "components/login-form";
 @import "components/finalize";
 @import "components/session-finalization-step-container";

--- a/certif/app/styles/components/examiner-report-modal.scss
+++ b/certif/app/styles/components/examiner-report-modal.scss
@@ -1,0 +1,83 @@
+.examiner-report-modal {
+
+  min-width: 480px;
+
+  &__title {
+    font-family: $open-sans;
+    padding: 12px 32px;
+    
+    h1 {
+      font-size: 1.25rem;
+      color: $grey-80;
+      margin: 0;
+      margin-bottom: 4px;
+    }
+
+    h3 {
+      font-size: 0.875rem;
+      color: $grey-50;
+      margin: 0;
+    }
+  }
+
+  &__content {
+    font-size: 0.875rem;
+    color: $grey-70;
+    border-top: 1px solid $grey-20;
+    border-bottom: 1px solid $grey-20;
+    padding: 22px 32px;
+    background-color: $grey-10;
+
+    .content__report-type-button {
+
+      display: flex;
+      align-items: center;
+
+      input[id="report-of-type-other__radio-button"] {
+        -ms-transform: scale(1.5); /* IE */
+        -moz-transform: scale(1.5); /* FF */
+        -webkit-transform: scale(1.5); /* Safari and Chrome */
+        -o-transform: scale(1.5); /* Opera */
+        transform: scale(1.5);
+        margin: 0;
+      }
+
+      label[for="report-of-type-other__radio-button"] {
+        margin-left: 16px;
+      }
+    }
+    
+
+    .content__report-type-details {
+      margin-top: 16px;
+      padding: 0 30px;
+
+      textarea {
+        box-sizing: border-box;
+        margin-top: 8px;
+        border: 1.2px solid $blue-zodia;
+        min-height: 82px;
+        padding: 8px 16px;
+      }
+    }
+  }
+
+  &__actions {
+    background-color: $grey-10;
+    padding: 16px 32px;
+    display: flex;
+    justify-content: flex-end;
+    border-radius: 0px 0px 5px 5px;
+
+    .button--showed-as-link {
+      font-family: $roboto;
+      text-decoration: none;
+      margin-right: 24px;
+      font-size: 0.875rem;
+
+      &:hover {
+        color: inherit;
+      }
+    }
+  }
+}

--- a/certif/app/styles/components/examiner-report-modal.scss
+++ b/certif/app/styles/components/examiner-report-modal.scss
@@ -1,6 +1,6 @@
 .examiner-report-modal {
 
-  min-width: 480px;
+  min-width: 496px;
 
   &__title {
     font-family: $open-sans;
@@ -34,11 +34,12 @@
       align-items: center;
 
       input[id="report-of-type-other__radio-button"] {
-        -ms-transform: scale(1.5); /* IE */
-        -moz-transform: scale(1.5); /* FF */
-        -webkit-transform: scale(1.5); /* Safari and Chrome */
-        -o-transform: scale(1.5); /* Opera */
-        transform: scale(1.5);
+        background-color: $communication-light;
+        -ms-transform: scale(1.2); /* IE */
+        -moz-transform: scale(1.2); /* FF */
+        -webkit-transform: scale(1.2); /* Safari and Chrome */
+        -o-transform: scale(1.2); /* Opera */
+        transform: scale(1.2);
         margin: 0;
       }
 
@@ -50,14 +51,28 @@
 
     .content__report-type-details {
       margin-top: 16px;
-      padding: 0 30px;
+      padding-left:   32px;
 
       textarea {
         box-sizing: border-box;
         margin-top: 8px;
         border: 1.2px solid $blue-zodia;
+        border-radius: 4px;
         min-height: 82px;
-        padding: 8px 16px;
+        padding: 8px;
+
+        &:focus {
+          outline: 2px solid $communication-dark;
+          -moz-outline-radius: 4px;
+          border: none;
+        }
+      }
+
+      &__char-count {
+        margin-top: 6px;
+        font-size: 12px;
+        display: flex;
+        flex-direction: row-reverse;
       }
     }
   }

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -29,6 +29,11 @@
 
   .finalization-report-examiner-comment {
     display: flex;
+
+    .add-button {
+      font-size: 13px;
+    }
   }
+
 
 }

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -26,4 +26,9 @@
   &__checker {
     margin-right: 16px;
   }
+
+  .finalization-report-examiner-comment {
+    display: flex;
+  }
+
 }

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -19,7 +19,7 @@ $pix-modal-border-radius: 5px;
 
     &--wide {
       @include device-is('desktop') {
-        width: 50vw;
+        width: max-content;
       }
     }
 

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -157,5 +157,5 @@ $pix-modal-border-radius: 5px;
 }
 
 .ember-modal-overlay.translucent {
-  background-color: rgba($grey-70, 0.95);
+  background-color: rgba($grey-70, 0.70);
 }

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -163,6 +163,16 @@ input[type=number] {
     text-decoration: none;
   }
 
+  &--showed-as-link {
+    text-decoration: underline;
+    border: none;
+    background: none;
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
   &--with-icon {
     display: flex;
     align-items: center;

--- a/certif/app/styles/globals/forms.scss
+++ b/certif/app/styles/globals/forms.scss
@@ -167,9 +167,13 @@ input[type=number] {
     text-decoration: underline;
     border: none;
     background: none;
+    font-family: $roboto;
+    font-size: 0.875rem;
+    color: $blue-zodia;
 
     &:hover {
       cursor: pointer;
+      color: $communication-dark;
     }
   }
 

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -14,6 +14,7 @@
       @iconAlt="">
     <SessionFinalizationReportsInformationsStep
         @certificationReports={{this.session.certificationReports}}
+        @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
         @updateCertificationReportExaminerComment={{this.updateCertificationReportExaminerComment}}
         @examinerCommentMaxLength={{this.examinerCommentMaxLength}}
         @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}

--- a/certif/mirage/factories/feature-toggle.js
+++ b/certif/mirage/factories/feature-toggle.js
@@ -3,4 +3,5 @@ import { Factory } from 'ember-cli-mirage';
 export default Factory.extend({
   id: 0,
   certifPrescriptionSco: false,
+  reportsCategorization: false,
 });

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -52,126 +52,163 @@ module('Acceptance | Session Finalization', function(hooks) {
       assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
     });
 
-    module('When user click on "Finaliser" button', function(hooks) {
+    module('When user click on "Finaliser" button', function() {
 
       let finalizeController;
 
-      hooks.beforeEach(function() {
-        finalizeController = this.owner.lookup('controller:authenticated.sessions.finalize');
-        return visit(`/sessions/${session.id}/finalisation`);
+      module('when reportsCategorization toggle is on', function() {
+        test('it should show "Ajouter ?" button', async function(assert) {
+          // given
+          const expectedText = 'Ajouter ?';
+          server.create('feature-toggle', { id: 0, reportsCategorization: true  });
+
+          // when
+          await visit(`/sessions/${session.id}/finalisation`);
+          // then
+          assert.dom('.button--showed-as-link').exists();
+          assert.dom('.button--showed-as-link').hasText(expectedText);
+        });
+
+        module('when there are examiner comment reports', function() {
+          test('it should show "Ajouter / modifier" button', async function(assert) {
+            // given
+            const expectedTextWithComment = 'Ajouter / modifier';
+            const expectedTextWithoutComment = 'Ajouter ?';
+            server.create('feature-toggle', { id: 0, reportsCategorization: true  });
+            const certificationReportsWithoutExaminerComment = server.create('certification-report', { examinerComment: null, certificationCourseId: 1 });
+            const certificationReportsWithExaminerComment = server.create('certification-report', { examinerComment: 'Coucou', certificationCourseId: 2 });
+            const certificationReports = [certificationReportsWithExaminerComment, certificationReportsWithoutExaminerComment];
+            session.update({ certificationReports });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+
+            // then
+            assert.dom('[data-test-id="finalization-report-examiner-comment_1"] .button--showed-as-link').hasText(expectedTextWithoutComment);
+            assert.dom('[data-test-id="finalization-report-examiner-comment_2"] .button--showed-as-link').hasText(expectedTextWithComment);
+          });
+        });
       });
 
-      test('it should allow the user to comment the session in textarea', async function(assert) {
-        // given
-        const expectedComment = 'You are a wizard Harry!';
-        const expectedIndicator = expectedComment.length + ' / 500';
+      module('when reportsCategorization toggle is off', function(hooks) {
 
-        // when
-        await fillIn('#examiner-global-comment', 'You are a wizard Harry!');
-
-        // then
-        assert.equal(finalizeController.model.examinerGlobalComment, expectedComment);
-        assert.dom('.session-finalization-examiner-global-comment-step__characters-information').exists();
-        assert.dom('.session-finalization-examiner-global-comment-step__characters-information').hasText(expectedIndicator);
-      });
-
-      test('it checks the hasSeenEndTestScreen checkbox', async function(assert) {
-        const certificationReport = await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
-
-        assert.equal(certificationReport.hasSeenEndTestScreen, true);
-      });
-
-      test('it checks all the checkboxes that can be checked using the check all options', async function(assert) {
-        const certificationReports = finalizeController.model.certificationReports.toArray();
-        const certificationReportA = certificationReports[0];
-        const certificationReportB = certificationReports[1];
-        await click('.session-finalization-reports-informations-step__checker');
-
-        assert.equal(certificationReportA.hasSeenEndTestScreen, true);
-        assert.equal(certificationReportB.hasSeenEndTestScreen, true);
-      });
-
-      test('it should open the confirm modal', async function(assert) {
-        // when
-        await click('[data-test-id="finalize__button"]');
-
-        // then
-        assert.equal(finalizeController.showConfirmModal, true);
-        assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
-      });
-
-      module('when confirm modal is open', function(hooks) {
         hooks.beforeEach(function() {
-          return click('[data-test-id="finalize__button"]');
+          finalizeController = this.owner.lookup('controller:authenticated.sessions.finalize');
+          return visit(`/sessions/${session.id}/finalisation`);
         });
 
-        test('it should close the modal on "fermer" cross click', async function(assert) {
+        test('it should allow the user to comment the session in textarea', async function(assert) {
+          // given
+          const expectedComment = 'You are a wizard Harry!';
+          const expectedIndicator = expectedComment.length + ' / 500';
+
           // when
-          await click('[data-test-id="finalize-session-modal__close-cross"]');
+          await fillIn('#examiner-global-comment', 'You are a wizard Harry!');
 
           // then
-          assert.equal(finalizeController.showConfirmModal, false);
+          assert.equal(finalizeController.session.examinerGlobalComment, expectedComment);
+          assert.dom('.session-finalization-examiner-global-comment-step__characters-information').exists();
+          assert.dom('.session-finalization-examiner-global-comment-step__characters-information').hasText(expectedIndicator);
+        });
+
+        test('it checks the hasSeenEndTestScreen checkbox', async function(assert) {
+          const certificationReport = await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
+
+          assert.equal(certificationReport.hasSeenEndTestScreen, true);
+        });
+
+        test('it checks all the checkboxes that can be checked using the check all options', async function(assert) {
+          const certificationReports = finalizeController.session.certificationReports.toArray();
+          const certificationReportA = certificationReports[0];
+          const certificationReportB = certificationReports[1];
+          await click('.session-finalization-reports-informations-step__checker');
+
+          assert.equal(certificationReportA.hasSeenEndTestScreen, true);
+          assert.equal(certificationReportB.hasSeenEndTestScreen, true);
+        });
+
+        test('it should open the confirm modal', async function(assert) {
+        // when
+          await click('[data-test-id="finalize__button"]');
+
+          // then
+          assert.equal(finalizeController.showConfirmModal, true);
           assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
         });
 
-        test('it should display the number of unchecked options (all)', async function(assert) {
-          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidat(s)');
+        module('when confirm modal is open', function(hooks) {
+          hooks.beforeEach(function() {
+            return click('[data-test-id="finalize__button"]');
+          });
+
+          test('it should close the modal on "fermer" cross click', async function(assert) {
+          // when
+            await click('[data-test-id="finalize-session-modal__close-cross"]');
+
+            // then
+            assert.equal(finalizeController.showConfirmModal, false);
+            assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
+          });
+
+          test('it should display the number of unchecked options (all)', async function(assert) {
+            assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 2 candidat(s)');
+          });
+
+          test('it should close the modal on cancel button click', async function(assert) {
+          // when
+            await click('[data-test-id="finalize-session-modal__cancel-button"]');
+
+            // then
+            assert.equal(finalizeController.showConfirmModal, false);
+            assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
+          });
+
+          test('it should close the modal on confirm button click', async function(assert) {
+          // when
+            await click('[data-test-id="finalize-session-modal__confirm-button"]');
+
+            // then
+            assert.equal(finalizeController.showConfirmModal, false);
+          });
+
+          test('it should redirect to session details page on confirm button click', async function(assert) {
+          // when
+            await click('[data-test-id="finalize-session-modal__confirm-button"]');
+
+            // then
+            assert.equal(currentURL(), `/sessions/${session.id}`);
+          });
+
+          test('it should show a success notification on session details page', async function(assert) {
+          // when
+            await click('[data-test-id="finalize-session-modal__confirm-button"]');
+
+            // then
+            assert.dom('[data-test-notification-message="success"]').exists();
+            assert.dom('[data-test-notification-message="success"]').hasText('Les informations de la session ont été transmises avec succès.');
+          });
+
         });
 
-        test('it should close the modal on cancel button click', async function(assert) {
-          // when
-          await click('[data-test-id="finalize-session-modal__cancel-button"]');
+        module('when confirm modal is open with one checked option', function(hooks) {
+          hooks.beforeEach(async function(assert) {
+            await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
+            return click('[data-test-id="finalize__button"]');
+          });
 
-          // then
-          assert.equal(finalizeController.showConfirmModal, false);
-          assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
-        });
-
-        test('it should close the modal on confirm button click', async function(assert) {
-          // when
-          await click('[data-test-id="finalize-session-modal__confirm-button"]');
-
-          // then
-          assert.equal(finalizeController.showConfirmModal, false);
-        });
-
-        test('it should redirect to session details page on confirm button click', async function(assert) {
-          // when
-          await click('[data-test-id="finalize-session-modal__confirm-button"]');
-
-          // then
-          assert.equal(currentURL(), `/sessions/${session.id}`);
-        });
-
-        test('it should show a success notification on session details page', async function(assert) {
-          // when
-          await click('[data-test-id="finalize-session-modal__confirm-button"]');
-
-          // then
-          assert.dom('[data-test-notification-message="success"]').exists();
-          assert.dom('[data-test-notification-message="success"]').hasText('Les informations de la session ont été transmises avec succès.');
+          test('it should display the number of unchecked options (one)', async function(assert) {
+            assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
+          });
         });
 
       });
-
-      module('when confirm modal is open with one checked option', function(hooks) {
-        hooks.beforeEach(async function(assert) {
-          await _checkFirstHasSeenEndTestScreenOption(finalizeController, assert);
-          return click('[data-test-id="finalize__button"]');
-        });
-
-        test('it should display the number of unchecked options (one)', async function(assert) {
-          assert.dom('.app-modal-body__contextual').hasText('La case "Écran de fin du test vu" n\'est pas cochée pour 1 candidat(s)');
-        });
-      });
-
     });
 
   });
 });
 
 async function _checkFirstHasSeenEndTestScreenOption(finalizeController, assert) {
-  const certificationReports = finalizeController.model.certificationReports.toArray();
+  const certificationReports = finalizeController.session.certificationReports.toArray();
   const certificationReport = certificationReports[0];
   const id = certificationReport.certificationCourseId;
   assert.equal(certificationReport.hasSeenEndTestScreen, false);

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -56,11 +56,11 @@ module('Acceptance | Session Finalization', function(hooks) {
 
       let finalizeController;
 
-      module('when reportsCategorization toggle is on', function() {
+      module('when categorizationOfReports toggle is on', function() {
         test('it should show "Ajouter ?" button', async function(assert) {
           // given
           const expectedText = 'Ajouter ?';
-          server.create('feature-toggle', { id: 0, reportsCategorization: true  });
+          server.create('feature-toggle', { id: 0, categorizationOfReports: true  });
 
           // when
           await visit(`/sessions/${session.id}/finalisation`);

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -56,17 +56,24 @@ module('Acceptance | Session Finalization', function(hooks) {
 
       let finalizeController;
 
-      module('when categorizationOfReports toggle is on', function() {
-        test('it should show "Ajouter ?" button', async function(assert) {
-          // given
-          const expectedText = 'Ajouter ?';
-          server.create('feature-toggle', { id: 0, categorizationOfReports: true  });
+      module('when reportsCategorization toggle is on', function() {
 
-          // when
-          await visit(`/sessions/${session.id}/finalisation`);
-          // then
-          assert.dom('.button--showed-as-link').exists();
-          assert.dom('.button--showed-as-link').hasText(expectedText);
+        module('when there is no examiner comment reports', function() {
+          test('it should show "Ajouter ?" button', async function(assert) {
+          // given
+            const expectedText = 'Ajouter ?';
+            server.create('feature-toggle', { id: 0, reportsCategorization: true  });
+            const certificationReportsWithoutExaminerComment = server.create('certification-report', { examinerComment: null, certificationCourseId: 1 });
+            const certificationReports = [certificationReportsWithoutExaminerComment];
+            session.update({ certificationReports });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+
+            // then
+            // assert.dom('.button--showed-as-link').hasText(expectedText);
+            assert.dom('[data-test-id="finalization-report-examiner-comment_1"] .button--showed-as-link').hasText(expectedText);
+          });
         });
 
         module('when there are examiner comment reports', function() {

--- a/certif/tests/integration/components/examiner-report-modal-test.js
+++ b/certif/tests/integration/components/examiner-report-modal-test.js
@@ -1,0 +1,108 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | examiner-report-modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const RADIO_BUTTON_SELECTOR = '#report-of-type-other__radio-button';
+  const LABEL_FOR_RADIO_BUTTON_SELECTOR = 'label[for="report-of-type-other__radio-button"]';
+  const TEXT_AREA_SELECTOR = '#report-of-type-other__text-area';
+  const REPORT_INPUT_LENGTH_INDICATOR = '.content__report-type-details p';
+
+  test('it show candidate informations in title', async function(assert) {
+    // given
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      examinerComment: null,
+      hasSeenEndTestScreen: false,
+    });
+    const closeExaminerReportModalStub = sinon.stub();
+    this.set('closeExaminerReportModal', closeExaminerReportModalStub);
+    this.set('reportToEdit', report);
+    this.set('maxlength', 500);
+
+    // when
+    await render(hbs`
+      <ExaminerReportModal
+        @closeModal={{this.closeExaminerReportModal}}
+        @report={{this.reportToEdit}}
+        @maxlength={{@examinerCommentMaxLength}}
+      />
+    `);
+
+    // then
+    const reportModalTitleSelector = '.examiner-report-modal__title h3';
+    assert.dom(reportModalTitleSelector).hasText('Lisa Monpud');
+  });
+
+  module('when radio button "Autre incident" is checked', function() {
+
+    test('it should show textearea for other type report', async function(assert) {
+      // given
+      const examinerComment = 'coucou';
+      const report = EmberObject.create({
+        certificationCourseId: 1,
+        firstName: 'Lisa',
+        lastName: 'Monpud',
+        examinerComment,
+        hasSeenEndTestScreen: false,
+      });
+      const closeExaminerReportModalStub = sinon.stub();
+      this.set('closeExaminerReportModal', closeExaminerReportModalStub);
+      this.set('reportToEdit', report);
+      this.set('maxlength', 500);
+      await render(hbs`
+        <ExaminerReportModal
+          @closeModal={{this.closeExaminerReportModal}}
+          @report={{this.reportToEdit}}
+          @maxlength={{@examinerCommentMaxLength}}
+        />
+      `);
+
+      // when
+      await click(RADIO_BUTTON_SELECTOR);
+
+      // then
+      assert.dom(TEXT_AREA_SELECTOR).exists();
+      assert.dom(REPORT_INPUT_LENGTH_INDICATOR).hasText(`${examinerComment.length} / 500`);
+    });
+  });
+
+  module('when radio button "Autre incident" is not checked', function() {
+
+    test('it should only show "Autre incident" label', async function(assert) {
+      // given
+      const report = EmberObject.create({
+        certificationCourseId: 1,
+        firstName: 'Lisa',
+        lastName: 'Monpud',
+        examinerComment: null,
+        hasSeenEndTestScreen: false,
+      });
+      const closeExaminerReportModalStub = sinon.stub();
+      this.set('closeExaminerReportModal', closeExaminerReportModalStub);
+      this.set('reportToEdit', report);
+      this.set('maxlength', 500);
+
+      // when
+      await render(hbs`
+        <ExaminerReportModal
+          @closeModal={{this.closeExaminerReportModal}}
+          @report={{this.reportToEdit}}
+          @maxlength={{@examinerCommentMaxLength}}
+        />
+      `);
+      
+      // then
+      assert.dom(TEXT_AREA_SELECTOR).doesNotExist();
+      assert.dom(LABEL_FOR_RADIO_BUTTON_SELECTOR).hasText('Autre incident');
+    });
+  });
+
+});

--- a/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
+++ b/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 
@@ -23,7 +23,7 @@ module('Integration | Component | session-finalization-reports-informations-step
       certificationCourseId: 3,
       firstName: 'Bob',
       lastName: 'Bober',
-      examinerComment: 'heeeeeyyy',
+      examinerComment: null,
       hasSeenEndTestScreen: true,
     }));
     this.set('certificationReports', [reportA, reportB]);
@@ -50,14 +50,10 @@ module('Integration | Component | session-finalization-reports-informations-step
     assert.dom(`[data-test-id="finalization-report-last-name_${reportB.certificationCourseId}"]`).hasText(reportB.lastName);
     assert.dom(`[data-test-id="finalization-report-first-name_${reportB.certificationCourseId}"]`).hasText(reportB.firstName);
     assert.dom(`[data-test-id="finalization-report-certification-number_${reportB.certificationCourseId}"]`).hasText(reportB.certificationCourseId.toString());
-    // assert.dom(`[data-test-id="finalization-report-examiner-comment_${reportA.certificationCourseId}"]`).hasText('zegzegzeg');
   });
 
-  test('it fills in the examinerComment', async function(assert) {
-    const examinerComment = 'This is an examiner comment !';
-    await fillIn(`[data-test-id="finalization-report-examiner-comment_${reportA.certificationCourseId}"]`, examinerComment);
-
-    assert.equal(reportA.examinerComment, examinerComment);
+  test('it shows "1 Signalement" only if there is an examinerComment', async function(assert) {
+    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportA.certificationCourseId}"]`).hasText('1 signalement');
+    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportB.certificationCourseId}"]`).doesNotExist();
   });
-
 });

--- a/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
+++ b/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
@@ -9,9 +9,10 @@ module('Integration | Component | session-finalization-reports-informations-step
   setupRenderingTest(hooks);
   let reportA;
   let reportB;
+  let store;
 
   hooks.beforeEach(async function() {
-    const store = this.owner.lookup('service:store');
+    store = this.owner.lookup('service:store');
     reportA = run(() => store.createRecord('certification-report', {
       certificationCourseId: 1234,
       firstName: 'Alice',
@@ -31,29 +32,56 @@ module('Integration | Component | session-finalization-reports-informations-step
     this.set('examinerCommentMaxLength', 500);
     this.set('toggleCertificationReportHasSeenEndTestScreen', sinon.stub().returns());
     this.set('toggleAllCertificationReportsHasSeenEndTestScreen', sinon.stub().returns());
-
-    await render(hbs`
-      <SessionFinalizationReportsInformationsStep
-        @certificationReports={{this.certificationReports}}
-        @updateCertificationReportExaminerComment={{this.updateCertificationReportExaminerComment}}
-        @examinerCommentMaxLength={{this.examinerCommentMaxLength}}
-        @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}
-        @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
-      />
-    `);
   });
 
-  test('it renders', function(assert) {
-    assert.dom(`[data-test-id="finalization-report-last-name_${reportA.certificationCourseId}"]`).hasText(reportA.lastName);
-    assert.dom(`[data-test-id="finalization-report-first-name_${reportA.certificationCourseId}"]`).hasText(reportA.firstName);
-    assert.dom(`[data-test-id="finalization-report-certification-number_${reportA.certificationCourseId}"]`).hasText(reportA.certificationCourseId.toString());
-    assert.dom(`[data-test-id="finalization-report-last-name_${reportB.certificationCourseId}"]`).hasText(reportB.lastName);
-    assert.dom(`[data-test-id="finalization-report-first-name_${reportB.certificationCourseId}"]`).hasText(reportB.firstName);
-    assert.dom(`[data-test-id="finalization-report-certification-number_${reportB.certificationCourseId}"]`).hasText(reportB.certificationCourseId.toString());
+  module('when feature categorizationOfReports is off', function() {
+
+    test('it renders', async function(assert) {
+      // given
+      this.set('isReportsCategorizationFeatureToggleEnabled', false);
+
+      // when
+      await render(hbs`
+        <SessionFinalizationReportsInformationsStep
+          @certificationReports={{this.certificationReports}}
+          @updateCertificationReportExaminerComment={{this.updateCertificationReportExaminerComment}}
+          @examinerCommentMaxLength={{this.examinerCommentMaxLength}}
+          @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+        />
+      `);
+
+      // then
+      assert.dom(`[data-test-id="finalization-report-last-name_${reportA.certificationCourseId}"]`).hasText(reportA.lastName);
+      assert.dom(`[data-test-id="finalization-report-first-name_${reportA.certificationCourseId}"]`).hasText(reportA.firstName);
+      assert.dom(`[data-test-id="finalization-report-certification-number_${reportA.certificationCourseId}"]`).hasText(reportA.certificationCourseId.toString());
+      assert.dom(`[data-test-id="finalization-report-last-name_${reportB.certificationCourseId}"]`).hasText(reportB.lastName);
+      assert.dom(`[data-test-id="finalization-report-first-name_${reportB.certificationCourseId}"]`).hasText(reportB.firstName);
+      assert.dom(`[data-test-id="finalization-report-certification-number_${reportB.certificationCourseId}"]`).hasText(reportB.certificationCourseId.toString());
+    });
   });
 
-  test('it shows "1 Signalement" only if there is an examinerComment', async function(assert) {
-    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportA.certificationCourseId}"]`).hasText('1 signalement');
-    assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportB.certificationCourseId}"]`).doesNotExist();
+  module('when feature categorizationOfReports is on', function() {
+
+    test('it shows "1 Signalement" only if there is an examinerComment', async function(assert) {
+      // given
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`
+        <SessionFinalizationReportsInformationsStep
+          @certificationReports={{this.certificationReports}}
+          @updateCertificationReportExaminerComment={{this.updateCertificationReportExaminerComment}}
+          @examinerCommentMaxLength={{this.examinerCommentMaxLength}}
+          @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+          @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+        />
+      `);
+      
+      // then
+      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportA.certificationCourseId}"]`).hasText('1 signalement');
+      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportB.certificationCourseId}"]`).doesNotExist();
+    });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -12,10 +12,10 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     test('it should count no unchecked box if no report', function(assert) {
       // given
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = ArrayProxy.create({
+      const session = ArrayProxy.create({
         certificationReports: [],
       });
-      controller.model = sessions;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
@@ -28,7 +28,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
       // given
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = ArrayProxy.create({
+      const session = ArrayProxy.create({
         certificationReports: [
           { hasSeenEndTestScreen: true },
           { hasSeenEndTestScreen: false },
@@ -37,7 +37,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
           { hasSeenEndTestScreen: true },
         ],
       });
-      controller.model = sessions;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
@@ -50,12 +50,12 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
       // given
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = ArrayProxy.create({
+      const session = ArrayProxy.create({
         certificationReports: [
           { hasSeenEndTestScreen: false },
         ],
       });
-      controller.model = sessions;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       const uncheckedHasSeenEndTestScreenCount = controller.uncheckedHasSeenEndTestScreenCount;
@@ -71,13 +71,13 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
       // given
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = ArrayProxy.create({
+      const session = ArrayProxy.create({
         certificationReports: [
           { hasSeenEndTestScreen: true },
           { hasSeenEndTestScreen: true },
         ],
       });
-      controller.model = sessions;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
@@ -90,13 +90,13 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
 
       // given
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-      const sessions = ArrayProxy.create({
+      const session = ArrayProxy.create({
         certificationReports: [
           { hasSeenEndTestScreen: false },
           { hasSeenEndTestScreen: true },
         ],
       });
-      controller.model = sessions;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       const hasUncheckedHasSeenEndTestScreen = controller.hasUncheckedHasSeenEndTestScreen;
@@ -113,7 +113,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       const initialValue = null;
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const session = { examinerGlobalComment: initialValue };
-      controller.model = session;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
       controller.examinerGlobalCommentMaxLength = 5;
 
       // when
@@ -129,7 +129,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       const newValue = 'hello';
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const session = { examinerGlobalComment: initialValue };
-      controller.model = session;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
@@ -144,7 +144,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
       const newValue = '  ';
       const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
       const session = { examinerGlobalComment: initialValue };
-      controller.model = session;
+      controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
       // when
       controller.send('updateExaminerGlobalComment', { target: { value: newValue } });
@@ -227,19 +227,19 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
         // given
         const someWereChecked = hasSeenEndTestScreen1 || hasSeenEndTestScreen2;
         const controller = this.owner.lookup('controller:' + FINALIZE_PATH);
-        const sessions = {
+        const session = {
           certificationReports: [
             { hasSeenEndTestScreen: hasSeenEndTestScreen1 },
             { hasSeenEndTestScreen: hasSeenEndTestScreen2 },
           ],
         };
-        controller.model = sessions;
+        controller.model = { session, isReportsCategorizationFeatureToggleEnabled: false };
 
         // when
         controller.send('toggleAllCertificationReportsHasSeenEndTestScreen', someWereChecked);
 
         // then
-        sessions.certificationReports.forEach((certif) => {
+        session.certificationReports.forEach((certif) => {
           assert.equal(certif.hasSeenEndTestScreen, expectedState);
         });
       }),


### PR DESCRIPTION
## :unicorn: Problème
Tout signalement ne nécessite pas une action du pôle certification. Le champ “signalement” sur la page de finalisation de session dans Pix certif étant une zone de saisie libre, il ne permet pas au pôle certif de facilement identifier le problème, et de savoir si celui-ci nécessite ou pas une action, ce qui entraîne une perte de temps pour le pôle certif. 

## :robot: Solution
Permettre aux référents de centre de certification de sélectionner une catégorie précise de signalement en cas de problème rencontré par un ou plusieurs candidats lors d’une session de certification.

- Sur la page de finalisation de session : 

dans la colonne “Signalement (à renseigner le cas échéant)”, remplacer la zone de saisie libre par un lien “Signalement” 

https://share.goabstract.com/e22f2a4b-fb4d-422b-a057-862d7b7eb5a3?collectionLayerId=186e7ada-1214-470a-a4e1-7339a911f9ee&mode=design

cliquer sur ce lien affiche une pop-up “Signalement du candidat” 

 https://share.goabstract.com/e22f2a4b-fb4d-422b-a057-862d7b7eb5a3?collectionLayerId=84d9a5bc-598a-45b8-9eb6-015060acae46&mode=design

dans un premier temps, uniquement avec l’option “Autre incident”

- bouton annuler : permet de retourner sur la page de finalisation de session

- bouton valider

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Activer le feature toggle sur l'API : `FT_REPORTS_CATEGORISATION=true npm start`
- Sur l'app certif se connecter et aller sur une session à finaliser
- Constater le nouvel affichage de la colonne "Signalement" : il n'y a plus de textarea mais un bouton "Ajouter ?"
- Cliquer sur "Ajouter ?" pour le premier candidat (par exemple)
- Constater qu'une modale s'affiche
- Cliquer sur la catégorie "Autre"
- Constater qu'un textarea s'affiche
- Le remplir d'un gentil mot doux et cliquer sur valider
- Constater que pour le premier candidat le texte "Ajouter ?" ne s'affiche plus et qu'il y a à la place "Ajouter / modifier 1 signalement"
- Cliquer sur "Ajouter / modifier" et reselectionner la catégorie "Autre"
- Constater que votre gentil mot doux est toujours là
Au rafraichissement de la page votre gentil mot doux devrait s'effacer et partir dans le vent.
Cependant si vous ne voulez pas le perdre vous pouvez finaliser la session et constater sur Pix Admin que pour cette certification votre commentaire est bien resté gravé dans le marbre.