### PR TITLE
[FEATURE] Page d'accueil de Pix-concours (PIX-1556)

### DIFF
--- a/mon-pix/app/components/footer.js
+++ b/mon-pix/app/components/footer.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
+import ENV from 'mon-pix/config/environment';
 
 export default class Footer extends Component {
   @service url;
@@ -14,5 +15,9 @@ export default class Footer extends Component {
   get currentYear() {
     this.date = new Date();
     return this.date.getFullYear().toString();
+  }
+
+  get isPixContest() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
   }
 }

--- a/mon-pix/app/components/navbar-header.js
+++ b/mon-pix/app/components/navbar-header.js
@@ -1,10 +1,15 @@
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import ENV from 'mon-pix/config/environment';
 
 export default class NavbarHeader extends Component {
   @service url;
 
   get isFrenchDomainExtension() {
     return this.url.isFrenchDomainExtension;
+  }
+
+  get isPixContest() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
   }
 }

--- a/mon-pix/app/components/profile-content.js
+++ b/mon-pix/app/components/profile-content.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+import ENV from 'mon-pix/config/environment';
+
+export default class ProfileContent extends Component {
+
+  get isPixContest() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
+  }
+}

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -15,6 +15,25 @@
   }
 }
 
+.footer-pix-contest {
+  display: flex;
+  margin-top: auto;
+
+  &__container {
+    display: flex;
+    flex-direction: column;
+    margin: 0 auto;
+    max-width: 980px;
+    padding: 18px 16px;
+    width: 100%;
+
+    @include device-is('desktop') {
+      flex-direction: row;
+      padding: 18px 0 48px;
+    }
+  }
+}
+
 .footer-container {
 
   &__content {

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -22,6 +22,9 @@
 
   &__campaign-menu {
     padding-left: 0;
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
   }
 }
 

--- a/mon-pix/app/styles/components/_navbar-mobile-header.scss
+++ b/mon-pix/app/styles/components/_navbar-mobile-header.scss
@@ -42,6 +42,8 @@
 /* Pour faire en sorte que les pages gardent le gris car sinon c'est blanc */
 .ember-burger-menu > .bm-outlet > .bm-content {
   background-color: transparent;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Pour permettre à `resume-campaign-banner.hbs` de rester sticky sur les moteurs Chrome */

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -149,3 +149,28 @@
     font-variant-caps: all-small-caps;
   }
 }
+
+.rounded-panel-links {
+  text-align: center;
+  font-weight: $font-light;
+
+  @include device-is('tablet') {
+    display: block;
+    text-align: left;
+  }
+
+  &__link {
+    margin-bottom: 24px;
+  }
+}
+
+.rounded-panel-rules {
+  text-align: center;
+  font-weight: $font-normal;
+  font-size: 1rem;
+
+  @include device-is('tablet') {
+    display: block;
+    text-align: left;
+  }
+}

--- a/mon-pix/app/templates/components/footer.hbs
+++ b/mon-pix/app/templates/components/footer.hbs
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class={{if this.isPixContest "footer-pix-contest" "footer"}}>
   <div class="footer__container">
     <div class="footer-container__logos">
       <PixLogo/>

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -20,16 +20,18 @@
               {{t 'navigation.main.profile'}}
             </LinkTo>
           </li>
-          <li class="navbar-desktop-header-menu__item">
-            <LinkTo @route="certifications" class="navbar-desktop-header-menu__link">
-              {{t 'navigation.main.start-certification'}}
-            </LinkTo>
-          </li>
-          <li class="navbar-desktop-header-menu__item">
-            <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-desktop-header-menu__link">
-              {{t 'navigation.main.help'}}
-            </a>
-          </li>
+          {{#unless @isPixContest}}
+            <li class="navbar-desktop-header-menu__item">
+              <LinkTo @route="certifications" class="navbar-desktop-header-menu__link">
+                {{t 'navigation.main.start-certification'}}
+              </LinkTo>
+            </li>
+            <li class="navbar-desktop-header-menu__item">
+              <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-desktop-header-menu__link">
+                {{t 'navigation.main.help'}}
+              </a>
+            </li>
+          {{/unless}}
         </ul>
       {{/if}}
     {{/unless}}
@@ -47,12 +49,14 @@
     {{/if}}
 
     <!-- Links (right) -->
-    <div class="navbar-desktop-header-right">
-      <NavbarDesktopMenu @menu={{this.menu}} />
+    {{#unless @isPixContest}}
+      <div class="navbar-desktop-header-right">
+        <NavbarDesktopMenu @menu={{this.menu}} />
 
-      {{#if this.isUserLogged}}
-        <UserLoggedMenu />
-      {{/if}}
-    </div>
+        {{#if this.isUserLogged}}
+          <UserLoggedMenu />
+        {{/if}}
+      </div>
+    {{/unless}}
   </div>
 </div>

--- a/mon-pix/app/templates/components/navbar-header.hbs
+++ b/mon-pix/app/templates/components/navbar-header.hbs
@@ -3,7 +3,7 @@
     <ResumeCampaignBanner  @campaignParticipations={{@campaignParticipations}}/>
   {{/if}}
   {{#if (media 'isDesktop')}}
-    <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}}/>
+    <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} @isPixContest={{this.isPixContest}}/>
   {{else}}
     <NavbarMobileHeader @burger={{@burger}} @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}} />
   {{/if}}

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -3,25 +3,41 @@
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner profile__panel">
   <h1 class="sr-only">{{t 'pages.profile.accessibility.title'}}</h1>
-    <div class="rounded-panel-header-with-components">
-      <div class="rounded-panel-header__left-wrapper">
-        <div class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
-        {{t 'pages.profile.first-title' htmlSafe=true}}
+    {{#if this.isPixContest}}
+      <div class="rounded-panel-header-with-components">
+          <div class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
+            {{t 'pages.profile.pix-contest.title' }}
+          </div>
+      </div>
+      <p class="rounded-panel-header-text__content rounded-panel-rules">{{t 'pages.profile.pix-contest.rules'}}</p>
+      <div class="rounded-panel-header-text__content rounded-panel-links">
+        <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link1' htmlSafe=true}}</p>
+        <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link2' htmlSafe=true}}</p>
+        <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link3' htmlSafe=true}}</p>
+        <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link4' htmlSafe=true}}</p>
+        <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link5' htmlSafe=true}}</p>
+      </div>
+    {{else}}
+      <div class="rounded-panel-header-with-components">
+        <div class="rounded-panel-header__left-wrapper">
+          <div class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
+          {{t 'pages.profile.first-title' htmlSafe=true}}
+          </div>
+        </div>
+        <div class="rounded-panel-header__right-wrapper">
+          <h2 class="sr-only">{{t 'pages.profile.accessibility.user-score'}}</h2>
+          <HexagonScore @pixScore={{@model.profile.pixScore}} />
         </div>
       </div>
-      <div class="rounded-panel-header__right-wrapper">
-        <h2 class="sr-only">{{t 'pages.profile.accessibility.user-score'}}</h2>
-        <HexagonScore @pixScore={{@model.profile.pixScore}} />
-      </div>
-    </div>
 
-    {{#if @model.profile.scorecards}}
-      <ProfileScorecards @interactive={{true}} @areasCode={{@model.profile.areasCode}} @scorecards={{@model.profile.scorecards}}/>
-    {{else}}
-      <p class="app-loader__image">
-        <img src="/images/interwind.gif" alt="" role="presentation" />
-        <br>{{t 'common.loading.default'}}
-      </p>
-   {{/if}}
+      {{#if @model.profile.scorecards}}
+        <ProfileScorecards @interactive={{true}} @areasCode={{@model.profile.areasCode}} @scorecards={{@model.profile.scorecards}}/>
+      {{else}}
+        <p class="app-loader__image">
+          <img src="/images/interwind.gif" alt="" role="presentation" />
+          <br>{{t 'common.loading.default'}}
+        </p>
+     {{/if}}
+    {{/if}}
   </div>
 </div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -640,6 +640,17 @@
                 "details": "details"
             },
             "first-title": "You have 16 skills to test. '<br>'Get your thinking hat on and off we go!",
+            "pix-contest": {
+                "title": "",
+                "links": {
+                    "link1": "",
+                    "link2": "",
+                    "link3": "",
+                    "link4": "",
+                    "link5": ""
+                },
+                "rules": ""
+            },
             "resume-campaign-banner": {
                 "accessibility": {
                     "resume": "Resume your personalised test",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -640,6 +640,17 @@
                 "details": "détails"
             },
             "first-title": "Vous avez 16 compétences à tester. '<br>'On se concentre et c'est partix&nbsp;!",
+            "pix-contest": {
+                "title": "Bienvenue dans cette session Pix-concours.",
+                "links": {
+                    "link1": "'<a href=\"Premier lien\">'Nom du premier module'</a>'",
+                    "link2": "'<a href=\"Second lien\">'Nom du second module'</a>'",
+                    "link3": "'<a href=\"Troisième lien\">'Nom du troisième module'</a>'",
+                    "link4": "'<a href=\"Quatrième lien\">'Nom du quatrième module'</a>'",
+                    "link5": "'<a href=\"Cinquième lien\">'Nom du cinquième module'</a>'"
+                },
+                "rules": "Règles de l'épreuve"
+            },
             "resume-campaign-banner": {
                 "accessibility": {
                     "resume": "Continuer votre parcours",


### PR DESCRIPTION
## :unicorn: Problème

La page de profil doit être modifiée dans le cadre de Pix-Concours.

Il faut ainsi : 
- Garder le fonctionnement du bandeau jaune reprendre ou finaliser
- Garder le logo pix et la Marianne
- Ne garder que l’entrée de menu “Profil”
- Retirer dropdown avec son prénom
- Retirer score pix
- Retirer les cartes

Et pouvoir pour l'examen :
- Avoir un texte d’introduction
- 5 liens vers les campagnes

## :robot: Solution

Rendu conditionnel à partir de la variable d'environnement `IS_PIX_CONTEST` et modification du style.
Le classe racine du footer a été dupliquée et modifiée afin d'empêcher un échec de test e2e.

## :rainbow: Remarques

Le format mobile n'est pas modifié, l'épreuve se déroulant sur ordinateur.

## :100: Pour tester

Aller sur la page d'accueil de Pix-App
(La variable d'environnement `IS_PIX_CONTEST` a été ajoutée à la RA)
