### PR TITLE
[FIX] Correction de l'ordre des colonnes badges et paliers dans l'export CSV (PIX-1587)

### DIFF
--- a/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
+++ b/api/lib/infrastructure/utils/CampaignAssessmentCsvLine.js
@@ -96,8 +96,8 @@ class CampaignAssessmentCsvLine {
       moment.utc(this.campaignParticipationInfo.createdAt).format('YYYY-MM-DD'),
       this.campaignParticipationInfo.isShared ? 'Oui' : 'Non',
       this.campaignParticipationInfo.isShared ? moment.utc(this.campaignParticipationInfo.sharedAt).format('YYYY-MM-DD') : EMPTY_CONTENT,
-      ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfile.badges.length)),
       ...(this.stages[0] ? [this._getReachedStage()] : []),
+      ...(this.campaignParticipationInfo.isShared ? this._makeBadgesColumns() : this._makeEmptyColumns(this.targetProfile.badges.length)),
       this.campaignParticipationInfo.isShared ? this._percentageSkillsValidated() : EMPTY_CONTENT,
     ];
   }

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -11,6 +11,7 @@ const organizationRepository = require('../../../../lib/infrastructure/repositor
 const targetProfileWithLearningContentRepository = require('../../../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const stageRepository = require('../../../../lib/infrastructure/repositories/stage-repository');
+const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repositories/badge-acquisition-repository');
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
@@ -99,6 +100,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         type: Assessment.types.CAMPAIGN,
       });
       databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 1 });
+      databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
       await databaseBuilder.commit();
 
       const domainTargetProfile = domainBuilder.buildTargetProfileWithLearningContent({
@@ -135,6 +137,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         '"Oui";' +
         '2019-03-01;' +
         '1;' +
+        '"Non";' +
         '0,67;' +
         '0,67;' +
         '3;' +
@@ -158,6 +161,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-
         campaignParticipationInfoRepository,
         knowledgeElementRepository,
         stageRepository,
+        badgeAcquisitionRepository,
         campaignCsvExportService,
       });
 


### PR DESCRIPTION
## :unicorn: Problème

Lors de l'export CSV de campagne d'évaluation, le contenu des colonnes de badges et de résultats thématique sont inversées par rapport à l'entête des colonnes.

## :robot: Solution

Mettre les données des badges et résultats thématiques dans les bonnes colonnes.

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se rendre ici : https://orga-pr2140.review.pix.fr/campagnes/10000000/evaluations
2. Se connecter avec sup.admin@example.net
3. Exporter le CSV
> Voir que les headers des colonnes Résultats thématiques et Paliers correspondent aux bonnes données.