### PR TITLE
[FEATURE] Mise à jour du message d'erreur lorsque le QROC contient un nombre. (PIX-1574)

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -25,7 +25,16 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _getErrorMessage() {
-    const errorMessage = this.args.challenge.autoReply ? 'pages.challenge.skip-error-message.qroc-auto-reply' : 'pages.challenge.skip-error-message.qroc';
+    let errorMessage;
+    if (this.args.challenge.autoReply) {
+      errorMessage = 'pages.challenge.skip-error-message.qroc-auto-reply';
+    }
+    else if (this.args.challenge.format === 'nombre') {
+      errorMessage = 'pages.challenge.skip-error-message.qroc-number';
+    }
+    else {
+      errorMessage = 'pages.challenge.skip-error-message.qroc';
+    }
     return this.intl.t(errorMessage);
   }
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -373,6 +373,7 @@
                 "qcu": "To validate, select an answer. Otherwise, click Skip.",
                 "qroc": "To validate, please fill in the text field. Otherwise, click Skip.",
                 "qroc-auto-reply": "You did not answer correctly. Try again or skip to the next question.",
+                "qroc-number": "",
                 "qrocm": "To validate, please complete all answer fields. Otherwise, click Skip."
             },
             "timed" : {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -373,6 +373,7 @@
                 "qcu": "Pour valider, sélectionnez une réponse. Sinon, passez.",
                 "qroc": "Pour valider, veuillez remplir le champ texte. Sinon, passez.",
                 "qroc-auto-reply": "“Vous pouvez valider” s‘affiche quand l‘épreuve est réussie. Essayez encore ou passez.",
+                "qroc-number": "Pour valider, veuillez saisir un nombre sinon passez.",
                 "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
             },
             "timed" : {


### PR DESCRIPTION
## :unicorn: Problème
Le message d'erreur qui s'affichait n'était pas le bon

## :robot: Solution
Ajouter une condition qui va afficher un message d'erreur différent lorsque le QROC contient un nombre

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Se rendre sur l'épreuve ayant pour id: rec7eEQN4Me8c9nm6
valider le champ vide et vérifier que le message d'erreur correspond à : "Pour valider, veuillez saisir un nombre sinon passez".
