### PR TITLE
[FEATURE] Modifier les instructions d'aide pour les téléchargements de fichiers (PIX-1591).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -198,6 +198,14 @@
     &:visited {
       color: $blue;
     }
+
+    &::after {
+      @include external-link;
+
+      position: relative;
+      top: 4px;
+      left: 2px;
+    }
   }
 }
 

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -365,7 +365,7 @@
                     },
                     "description": "Pix vous laisse le choix du format de fichier à télécharger. Si vous ne savez pas quelle option retenir, conservez le choix par défaut. Il correspond au format de fichier pris en charge par le plus grand nombre de logiciels.",
                     "file-type": "fichier .{fileExtension}",
-                    "help": "Besoin d'aide pour '<'a href=\"https://support.pix.fr/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\"'>'ouvrir, modifier ou retrouver ce fichier'</a>'."
+                    "help": "Besoin d'aide pour '<'a href=\"https://support.pix.fr/fr/support/solutions/articles/15000036390\" class=\"challenge-statement__action-help--link\" target=\"_blank\"'>'ouvrir, modifier ou retrouver ce fichier'</a>' ?"
                 }
             },
             "skip-error-message": {


### PR DESCRIPTION
## :unicorn: Problème

Les instructions d'aide au téléchargement n'indiquent pas que le lien associé s'ouvre dans un nouvel onglet

## :robot: Solution

- Ajout d'un point d'interrogation pour bien préciser à l'utilisateur qu'il s'agit simplement d'une question
- Ajout d'une icône d'ouverture de lien externe au clic sur le texte.

## :100: Pour tester

Réaliser une épreuve avec téléchargement de fichier et constater les changements effectués (ex: recV0JVQJU9xTn5Pn)
