### PR TITLE
[FEATURE] Réduire la taille du champ réponse lorsque la réponse attendue est un nombre (PIX-1590).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-response.scss
+++ b/mon-pix/app/styles/components/_challenge-response.scss
@@ -29,6 +29,10 @@
     display: flex;
     width: 100%;
   }
+
+  &--number {
+    width: 100px;
+  }
 }
 
 .challenge-response__proposal-label {

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -30,7 +30,7 @@
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
       {{else if (eq @format 'nombre')}}
-        <input class="challenge-response__proposal"
+        <input class="challenge-response__proposal challenge-response__proposal--number"
                type="number"
                id="qroc_input"
                {{on 'keydown' this.onInputChange}}


### PR DESCRIPTION
## :unicorn: Problème
Lorsque la réponse est un nombre, le champs de réponse est trop large et cela peut induire le candidat en confusion.

## :robot: Solution
Réduire la taille du champs input lorsque le format du challenge est `nombre`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur l'épreuve rec7eEQN4Me8c9nm6, vérifier que le champs input est plus petit que les autres champs QROC.
