### PR TITLE
[TECH] Comparer les temps de réponse entre le mode buffer et le mode file lors de l'import du fichier SIECLE

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -173,7 +173,7 @@ exports.register = async (server) => {
           }),
         },
         payload: {
-          maxBytes: 1048576 * 10, // 10MB
+          maxBytes: 1048576 * 20, // 10MB
           parse: 'gunzip',
         },
         handler: organizationController.importSchoolingRegistrationsFromSIECLE,


### PR DESCRIPTION
## :unicorn: Problème
L'optimisation de l'import de fichier SIECLE est en production. L'objectif de la réduction du pic de mémoire est atteint 💯 
Après avoir upload pas mal de fichier volumineux en production ( entre 18 et 19h30 ) la consommation mémoire en production reste constante.

![image](https://user-images.githubusercontent.com/10045497/99239901-fecc2b80-27fb-11eb-81a3-b907346e6acb.png)

Suite à des tests manuels, on a pu remarqué que le temps de réponse varie selon la débit d'upload de la connexion utilisateur.

Pour le cas d'un fichier SIECLE en erreur, la réponse est quasi instantané pour une connexion avec un débit d'upload de 50Mb.
Le temps de réponse augmente avec un débit d'upload de 0,6 Mb/s .

Le but de cette PR est de vérifier si ce débit d'upload impact les deux modes de hapi ( buffer et en mode file ) et trouver des pistes pour réduire le temps de réponse.

## :robot: Solution

Résultat des tests: On constate que les temps de réponses de l'upload du fichier avec le mode buffer est aussi dépendant du débit d'upload de l'utilisateur connecté.

Pour un fichier de 5,5 Mb qui est censé sortir en erreur, le traitement du parsing du fichier a mis 1,3min. Si ce dernier est supérieur au temps du timeout client positionné par les routers Scalingo 60s, une erreur d'import est affichée à l'utilisateur alors que la requête continue de s'éxecuter. 

Un aperçu datadog qui montre ces timeouts en WARNING alors qu'ils devraient être mappé en ERROR.
Un fix a été fait coté datadog pour y remédier.

![image](https://user-images.githubusercontent.com/10045497/99365505-ad817200-28b7-11eb-81b3-7b9a37391a66.png)

Il est donc important de streamer la réponse pour que le navigator ne ferme pas la connexion.
Des pistes aussi sur la compression du fichier en .zip permet aussi de réduire ce temps de réponse.

## :rainbow: Remarques

Ci-dessous quelques métrics en production:

En regardant un peu les temps de réponses avant l'optimisation, on constate qu'il existe des fichiers qui ont pris 5,7min.
![image](https://user-images.githubusercontent.com/10045497/99240223-7a2ddd00-27fc-11eb-9c5c-c2ad10408046.png)

Après l'optimisation et dans l'environnement de production:
Pour un fichier de 10,7Mb le traitement en production a pris **2,3 minutes** avec une mémoire constante et un débit d'upload de **0,675Mb**.

L'idée de cette PR est de comparer les temps de réponse avec un débit d'upload qui s'approche du débit des enseignants et de pouvoir déterminer quelle est le temps raisonnable pour l'import des gros fichiers SIECLE tout en gardant une mémoire constante et en évitant les timeouts coté client.

## :100: Pour tester
RAS
