### PR TITLE
[BUGFIX] Ne pas afficher la page de réconciliation si l'élève est déjà réconcilié (PIX-1064).

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -491,7 +491,7 @@ class ObjectValidationError extends DomainError {
 }
 
 class UserCouldNotBeReconciledError extends DomainError {
-  constructor(message = 'Cet utilisateur n\'a pas pu être rattaché à une organization.') {
+  constructor(message = 'Cet utilisateur n\'a pas pu être rattaché à une organisation.') {
     super(message);
   }
 }

--- a/api/tests/unit/domain/usecases/reconcile-user-to-organization_test.js
+++ b/api/tests/unit/domain/usecases/reconcile-user-to-organization_test.js
@@ -61,7 +61,7 @@ describe('Unit | UseCase | reconcile-user-to-organization', () => {
 
       // then
       expect(result).to.be.instanceof(UserCouldNotBeReconciledError);
-      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organization.');
+      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organisation.');
     });
   });
 
@@ -80,7 +80,7 @@ describe('Unit | UseCase | reconcile-user-to-organization', () => {
 
       // then
       expect(result).to.be.instanceof(UserCouldNotBeReconciledError);
-      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organization.');
+      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organisation.');
     });
   });
 
@@ -99,7 +99,7 @@ describe('Unit | UseCase | reconcile-user-to-organization', () => {
 
       // then
       expect(result).to.be.instanceof(UserCouldNotBeReconciledError);
-      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organization.');
+      expect(result.message).to.equal('Cet utilisateur n\'a pas pu être rattaché à une organisation.');
     });
   });
 

--- a/mon-pix/mirage/routes/schooling-registration-user-associations/index.js
+++ b/mon-pix/mirage/routes/schooling-registration-user-associations/index.js
@@ -26,7 +26,13 @@ export default function index(config) {
     const campaignCode = params.data.attributes['campaign-code'];
 
     const schoolingRegistration = schema.schoolingRegistrationUserAssociations.findBy({ campaignCode });
-    return schoolingRegistration ? schoolingRegistration : new Response(422);
+    return schoolingRegistration ? schoolingRegistration : new Response(422, {}, {
+      errors: [{
+        status: '422',
+        title: 'Unprocessable entity',
+        detail: 'Cet utilisateur n\'a pas pu être rattaché à une organisation.',
+      }],
+    });
   });
 
   config.put('/schooling-registration-user-associations/possibilities', () => {

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
@@ -11,7 +11,7 @@ const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_
 describe('Unit | Route | campaigns/restricted/join', function() {
   setupTest();
 
-  describe('#redirect', function() {
+  describe('#afterModel', function() {
 
     it('should redirect to campaigns.start-or-resume when an association already exists', async function() {
       // given
@@ -28,7 +28,7 @@ describe('Unit | Route | campaigns/restricted/join', function() {
       const transition = { to: { queryParams: {} } };
 
       // when
-      await route.redirect(campaign, transition);
+      await route.afterModel(campaign, transition);
 
       // then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un élève est déjà réconcilié ou que la réconciliation automatique a fonctionné, on aperçoit, pendant un cours un instant la page de réconciliation avant d'être redirigé sur la page de présentation du parcours.  

## :robot: Solution
Utiliser le hook `afterModel` plutôt que `redirect`.

## :rainbow: Remarques
En plus de cette modification, un `try/catch` a été ajouté autour de la requête de réconciliation automatique afin d'éviter l'erreur `Transition was aborted`.

Concernant le changement du `redirect` en `afterModel`, il semble que le template s'affiche s'il n'y a pas eu d'erreurs durant les hooks `beforeModel`, `model` et `afterModel`. J'ai tenté de vérifier cette affirmation en regardant le code ou les tests d'Ember JS mais sans succès.

## :100: Pour tester
Vérifier les comportements suivant:
- Élève déjà réconcilié:
    - Rejoindre la campagnes BADGES123.
    - Se connecter avec l'utilisateur blueivy.carter@example.net/pix123.
    - Résultat attendu: La page de réconciliation n'est pas affichée et on arrive sur la page de présentation du parcours.
- Élève non réconcilié mais la réconciliation automatique fonctionne:
    - Rejoindre la campagnes BADGES456.
    - Se connecter avec l'utilisateur george.decambridge2207/pix123.
    - Résultat attendu: La page de réconciliation n'est pas affichée et on arrive sur la page de présentation du parcours.
    - Exécuter la requête `update "schooling-registrations" set "userId" = null where id = 100026;` pour supprimer la réconciliation.
- Élève non réconcilié et réconciliation automatique échoue:
    - Rejoindre la campagnes BADGES123.
    - Se connecter avec l'utilisateur userpix1@example.net/pix123.
    - Résultat attendu: La page de réconciliation est affichée et l'erreur `Transition was aborted` n'apparaît plus dans la console.