### PR TITLE
[BUGFIX] Rendre déterministes les tests e2e "... restreint en étant connecté via un organisme externe" (PIX-1607).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-assessment.feature
@@ -53,7 +53,6 @@ Fonctionnalité: Campagne d'évaluation
 
   Scénario: Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Et je vais sur la page d'accès à une campagne
     Lorsque je saisis "WINTER" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne

--- a/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/campaign-collect-profiles.feature
@@ -12,7 +12,7 @@ Fonctionnalité: Campagne de collecte de profils
     Lorsque je clique sur "Commencer"
     Alors je vois la page de "presentation" de la campagne
     Et la page "Presentation campagne collecte profils" est correctement affichée
-    Lorsque je clique sur "C’est parti !"
+    Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne
     Lorsque je clique sur "J'envoie mon profil"
     Alors je vois que j'ai partagé mon profil
@@ -21,7 +21,7 @@ Fonctionnalité: Campagne de collecte de profils
     Étant donné que je vais sur Pix
     Lorsque je vais sur la campagne "LION" avec l'identifiant "1er bataillon"
     Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "C’est parti !"
+    Lorsque je clique sur "C'est parti !"
     Et je clique sur "connectez-vous à votre compte"
     Et je me connecte avec le compte "daenerys.targaryen@pix.fr"
     Alors je vois la page d'"envoi-profil" de la campagne
@@ -41,21 +41,20 @@ Fonctionnalité: Campagne de collecte de profils
     Et je clique sur "C'est parti !"
     Et je clique sur le bouton "Associer"
     Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "C’est parti !"
+    Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne
     Lorsque je clique sur "J'envoie mon profil"
     Alors je vois que j'ai partagé mon profil
 
   Scénario: Je partage mon profil de manière restreinte en étant connecté via un organisme externe
     Étant donné que je me connecte à Pix via le GAR
-    Et je vais sur la page d'accès à une campagne
     Lorsque je saisis "WOLF" dans le champ "Ce code permet de démarrer un parcours"
     Et je clique sur "Commencer"
     Alors je vois la page de "rejoindre" de la campagne
     Lorsque je saisis la date de naissance 23-10-1986
     Et je clique sur "C'est parti !"
     Alors je vois la page de "presentation" de la campagne
-    Lorsque je clique sur "C’est parti !"
+    Lorsque je clique sur "C'est parti !"
     Alors je vois la page d'"envoi-profil" de la campagne
     Lorsque je clique sur "J'envoie mon profil"
     Alors je vois que j'ai partagé mon profil

--- a/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/resume-campaigns-with-type-profiles-collection-test.js
@@ -31,7 +31,7 @@ describe('Acceptance | Campaigns | Resume Campaigns with type Profiles Collecti
       // Reset state, invalidateSession() is not doing it...
       this.owner.lookup('route:campaigns.start-or-resume')._resetState();
       await visit(`/campagnes/${campaign.code}`);
-      await click(contains('C’est parti !'));
+      await click(contains('C\'est parti !'));
     });
 
     it('should propose to signup', function() {

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-profiles-collection-test.js
@@ -162,7 +162,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Profiles Collectio
           campaign = server.create('campaign', { type: PROFILES_COLLECTION });
           await visit(`/campagnes/${campaign.code}`);
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
-          expect(find('.campaign-landing-page__start-button').textContent.trim()).to.equal('C’est parti !');
+          expect(find('.campaign-landing-page__start-button').textContent.trim()).to.equal('C\'est parti !');
         });
       });
 

--- a/mon-pix/tests/helpers/campaign.js
+++ b/mon-pix/tests/helpers/campaign.js
@@ -25,7 +25,7 @@ export async function resumeCampaignOfTypeAssessmentByCode(campaignCode, hasExte
 
 export async function resumeCampaignOfTypeProfilesCollectionByCode(campaignCode, hasExternalParticipantId) {
   await visit(`/campagnes/${campaignCode}`);
-  await click(contains('C’est parti !'));
+  await click(contains('C\'est parti !'));
   if (hasExternalParticipantId) {
     await fillIn('#id-pix-label', 'monmail@truc.fr');
     await click(contains('Continuer'));

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -98,7 +98,7 @@
             },
             "profiles-collection": {
                 "title": "Envoyez votre profil",
-                "action": "C’est parti !",
+                "action": "C'est parti !",
                 "announcement": "Inscrivez-vous ou connectez-vous sur la plateforme Pix et envoyez votre profil à l'organisation destinataire.",
                 "legal": "Les informations relatives à votre profil PIX seront transmises à l'organisateur pour lui permettre de vous accompagner. Elle ne seront transmises qu'avec votre consentement."
             }


### PR DESCRIPTION
## :unicorn: Problème
Seuls 22% des tests CircleCI sortent en OK vendredi, dont les PR "Ready to merge"
2 tests end-to-end semblent être la cause :
* Campagne d'évaluation > Je rejoins un parcours prescrit restreint en étant connecté via un organisme externe
* Campagne de collecte de profils > Je partage mon profil de manière restreinte en étant connecté via un organisme externe

La page attendue n'est pas obtenue

## :robot: Solution
Corriger ce bug, en rendant ces tests déterministes.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Les tests e2e doivent être OK sur la CI à chacun d'au moins 3 lancements
`git commit --amend --no-edit && git push --force-with-lease`