### PR TITLE
[TECH] Rendre le rapport de CI plus lisible.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Lint and test scripts
           command: |
             npm ci
             npm run lint:scripts
@@ -102,6 +103,7 @@ jobs:
           paths:
             - ~/.npm
       - run:
+          name: Lint and test
           command: |
             npm run lint
             npm test
@@ -129,10 +131,14 @@ jobs:
           paths:
             - ~/.npm
       - run:
-          npm run lint:hbs
+          name: Lint templates
+          command: npm run lint:hbs
       - run:
-          npm run lint:scss
-      - run: |
+          name: Lint style sheets
+          command: npm run lint:scss
+      - run:
+         name: Test
+         command: |
           npx ember exam --split=$CIRCLE_NODE_TOTAL --partition=$((1 + CIRCLE_NODE_INDEX)) --reporter dot
 
   orga_build_and_test:
@@ -153,8 +159,12 @@ jobs:
           key: v7-orga-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
-      - run: npm run lint:ci
-      - run: npm test
+      - run:
+          name: Lint
+          command: npm run lint:ci
+      - run:
+          name: Test
+          command: npm test
 
   certif_build_and_test:
     docker:
@@ -174,7 +184,9 @@ jobs:
           key: v7-certif-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
-      - run: npm test
+      - run:
+          name: Test
+          command: npm test
 
   admin_build_and_test:
     docker:
@@ -194,7 +206,9 @@ jobs:
           key: v7-admin-npm-{{ checksum "cachekey" }}
           paths:
             - ~/.npm
-      - run: npm test
+      - run:
+          name: Test
+          command: npm test
 
   e2e_test:
     docker:
@@ -225,6 +239,7 @@ jobs:
           keys:
             - v7-api-npm-{{ checksum "~/pix/api/cachekey" }}
       - run:
+          name: Install Pix API
           working_directory: ~/pix/api
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
@@ -237,6 +252,7 @@ jobs:
           keys:
             - v7-mon-pix-npm-{{ checksum "~/pix/mon-pix/cachekey" }}
       - run:
+          name: Install Pix App
           environment:
             JOBS: 1
           working_directory: ~/pix/mon-pix
@@ -249,6 +265,7 @@ jobs:
           keys:
             - v7-orga-npm-{{ checksum "~/pix/orga/cachekey" }}
       - run:
+          name: Install Pix Orga
           environment:
             JOBS: 2
           working_directory: ~/pix/orga
@@ -257,50 +274,68 @@ jobs:
       - run:
           working_directory: ~/pix/certif
           command: cat package*.json > cachekey
+
       - restore_cache:
           keys:
             - v7-certif-npm-{{ checksum "~/pix/certif/cachekey" }}
+            -
       - run:
+          name: Install Pix Certif
           environment:
             JOBS: 2
           working_directory: ~/pix/certif
           command: npm ci
 
       - run:
+          name: Start Pix API
           working_directory: ~/pix/api
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           background: true
           command: npm start
 
-      - run: wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
+      - run:
+          name: Wait for Pix API to be up and running
+          command: wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
 
       - run:
+          name: Start Pix App
           working_directory: ~/pix/mon-pix
           environment:
             JOBS: 1
           background: true
           command: npm start
 
-      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4200
+      - run:
+          name: Wait for Pix App to be up and running
+          command: wget --retry-connrefused -T 60 -qO- http://localhost:4200
 
       - run:
+          name: Start orga
           working_directory: ~/pix/orga
           environment:
             JOBS: 2
           background: true
           command: npm start
-      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4201
 
       - run:
+          name: Wait for Pix Orga to be up and running
+          command: wget --retry-connrefused -T 60 -qO- http://localhost:4201
+
+      - run:
+          name: Start Pix Certif
           working_directory: ~/pix/certif
           environment:
             JOBS: 1
           background: true
           command: npm start
-      - run: wget --retry-connrefused -T 60 -qO- http://localhost:4203
 
       - run:
+          name: Wait for Pix Certif to be up and running
+          command: wget --retry-connrefused -T 60 -qO- http://localhost:4203
+
+      - run:
+          name: Test
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npm run cy:run:ci

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,11 @@
 # Contribuer à Pix
 
-Pour toute contribution, il est essentiel de respecter *a minima* les points suivants. Pour aller plus loin, vous pouvez parcourir les différents fichiers présentés dans le [README.md](./README.md)
+Pour toute contribution, il est essentiel de respecter *a minima* les points suivants. 
+Pour aller plus loin, vous pouvez parcourir les différents fichiers présentés dans le [README.md](./README.md)
+
+## Applications
+Le nom des applications respecte le modèle suivant <Pix [activity_shortname]>
+Ex : "Pix App", "Pix Admin", "Pix Orga", "Pix API", "Pix Certif"
 
 ## Branche `dev`
 


### PR DESCRIPTION
## :unicorn: Problème
Les commandes CLI CircleCI (balise `run`) sont nombreuses dans le job `e2etest` et contiennent des magic values comme les numéro de port (ici pour certif)
```
- run:  command: wget --retry-connrefused -T 60 -qO- http://localhost:4203
```
Cela est difficile d'accès pour un débutant (ou celui qui n'a pas modifié la CI depuis longtemps)
![image](https://user-images.githubusercontent.com/56302715/99359881-064d0c80-28b0-11eb-9c94-da4adba35279.png)

## :robot: Solution
Utiliser la propriété [`name`](https://circleci.com/docs/2.0/configuration-reference/#run) pour afficher l'intention plutot que l'implémentation

```
- run:
    name: Wait for certif to be up and running
    command: wget --retry-connrefused -T 60 -qO- http://localhost:4203
```

## :rainbow: Remarques
Cela m'a permis de me rendre compte que le job `checkout`ne faisait pas que du `checkout`


## :100: Pour tester
Consulter le CR de test
