### PR TITLE
[TECH] Limiter le temps d'attente au démarrage des tests E2E sur la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,8 +219,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
     parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e
-    environment:
-      INTERVAL_CHECK_APPLICATION_IS_UP_SECOND: 10
     steps:
       - attach_workspace:
           at: ~/pix
@@ -298,7 +296,7 @@ jobs:
 
       - run:
           name: Wait for Pix API to be up and running
-          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:3000/api
+          command: wget --retry-connrefused -T $E2E_INTERVAL_TO_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:3000/api
 
       - run:
           name: Start Pix App
@@ -310,7 +308,7 @@ jobs:
 
       - run:
           name: Wait for Pix App to be up and running
-          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4200
+          command: wget --retry-connrefused -T $E2E_INTERVAL_TO_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4200
 
       - run:
           name: Start orga
@@ -322,7 +320,7 @@ jobs:
 
       - run:
           name: Wait for Pix Orga to be up and running
-          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4201
+          command: wget --retry-connrefused -T $E2E_INTERVAL_TO_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4201
 
       - run:
           name: Start Pix Certif
@@ -334,7 +332,7 @@ jobs:
 
       - run:
           name: Wait for Pix Certif to be up and running
-          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4203
+          command: wget --retry-connrefused -T $E2E_INTERVAL_TO_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4203
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
     parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e
     environment:
-      INTERVAL_CHECK_APPLICATION_IS_UP_SECOND: 60
+      INTERVAL_CHECK_APPLICATION_IS_UP_SECOND: 10
     steps:
       - attach_workspace:
           at: ~/pix
@@ -296,11 +296,9 @@ jobs:
           background: true
           command: npm start
 
-      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:3000/api
-
       - run:
           name: Wait for Pix API to be up and running
-          command: wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
+          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:3000/api
 
       - run:
           name: Start Pix App
@@ -310,11 +308,9 @@ jobs:
           background: true
           command: npm start
 
-      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4200
-
       - run:
           name: Wait for Pix App to be up and running
-          command: wget --retry-connrefused -T 60 -qO- http://localhost:4200
+          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4200
 
       - run:
           name: Start orga
@@ -323,11 +319,10 @@ jobs:
             JOBS: 2
           background: true
           command: npm start
-      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4201
 
       - run:
           name: Wait for Pix Orga to be up and running
-          command: wget --retry-connrefused -T 60 -qO- http://localhost:4201
+          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4201
 
       - run:
           name: Start Pix Certif
@@ -336,11 +331,10 @@ jobs:
             JOBS: 1
           background: true
           command: npm start
-      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4203
 
       - run:
           name: Wait for Pix Certif to be up and running
-          command: wget --retry-connrefused -T 60 -qO- http://localhost:4203
+          command: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4203
 
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,8 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
     parallelism: 5
     working_directory: ~/pix/high-level-tests/e2e
+    environment:
+      INTERVAL_CHECK_APPLICATION_IS_UP_SECOND: 60
     steps:
       - attach_workspace:
           at: ~/pix
@@ -294,6 +296,8 @@ jobs:
           background: true
           command: npm start
 
+      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:3000/api
+
       - run:
           name: Wait for Pix API to be up and running
           command: wget --retry-connrefused -T 60 -qO- http://localhost:3000/api
@@ -306,6 +310,8 @@ jobs:
           background: true
           command: npm start
 
+      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4200
+
       - run:
           name: Wait for Pix App to be up and running
           command: wget --retry-connrefused -T 60 -qO- http://localhost:4200
@@ -317,6 +323,7 @@ jobs:
             JOBS: 2
           background: true
           command: npm start
+      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4201
 
       - run:
           name: Wait for Pix Orga to be up and running
@@ -329,6 +336,7 @@ jobs:
             JOBS: 1
           background: true
           command: npm start
+      - run: wget --retry-connrefused -T $INTERVAL_CHECK_APPLICATION_IS_UP_SECOND -qO- http://localhost:4203
 
       - run:
           name: Wait for Pix Certif to be up and running


### PR DESCRIPTION
## :unicorn: Problème
Pour démarrer les 4 applications avant de lancer les tests E2E, on scrute le ports avec wget
` run: wget --retry-connrefused -T 60 -qO- http://localhost:4200`

Le délai de ré-essai `-T` est de 60 secondes. Dans le pire des scénarios, si chacune des 4 applications est disponible à une seconde d'intervalle, on attend 4 minutes (sur un temps d'exécution hors attente de 15 minutes). 

Or la charge nécessaire pour scruter est minime.

## :robot: Solution
Passer le délai à 10 secondes

## :rainbow: Remarques
Une petite BSR en passant en utilisant les variables d'environnement de CircleCI, pour pouvoir changer cet intervalle sans changer le code

## :100: Pour tester
Lancer la CI et monitorer le job `e2e_test` => [exemple](https://app.circleci.com/pipelines/github/1024pix/pix/17607/workflows/7e660e5f-db81-4fa3-b3e8-c214a67ea9ea/jobs/154759)
