### PR TITLE
[FEATURE] Pix concours : amélioration et gestion du bandeau.

### DIFF
--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -16,15 +16,16 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   tryImproving,
   locale,
 }) {
+
+  if (process.env.IS_PIX_CONTEST === 'true') {
+    return getNextChallengeForDemo({ assessment, answerRepository, challengeRepository, courseRepository });
+  }
+
   if (tryImproving) {
     assessment.isImproving = true;
   }
 
   const inputValues = await dataFetcher.fetchForCampaigns(...arguments);
-
-  if (process.env.IS_PIX_CONTEST === 'true') {
-    return getNextChallengeForDemo({ assessment, answerRepository, challengeRepository, courseRepository });
-  }
 
   const {
     possibleSkillsForNextChallenge,

--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -1,5 +1,6 @@
 import _maxBy from 'lodash/maxBy';
 import Component from '@glimmer/component';
+import ENV from 'mon-pix/config/environment';
 
 export default class ResumeCampaignBanner extends Component {
 
@@ -9,6 +10,11 @@ export default class ResumeCampaignBanner extends Component {
 
   get lastUnsharedCampaignParticipation() {
     return _maxBy(this.unsharedCampaignParticipations, 'createdAt');
+  }
+
+  get showResumeBar() {
+    return ENV.APP.IS_PIX_CONTEST !== 'true' ||
+      (ENV.APP.IS_PIX_CONTEST === 'true' && !this.campaignParticipationState.assessment.get('isCompleted'));
   }
 
   get campaignParticipationState() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -26,6 +26,9 @@ export default class ChallengeController extends Controller {
   get pageTitle() {
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
+      return this.intl.t('pages.challenge.title-pix-contest', { stepNumber });
+    }
 
     return this.intl.t('pages.challenge.title', { stepNumber, totalChallengeNumber });
   }

--- a/mon-pix/app/templates/components/resume-campaign-banner.hbs
+++ b/mon-pix/app/templates/components/resume-campaign-banner.hbs
@@ -1,15 +1,17 @@
-<div class="resume-campaign-banner">
-{{#if campaignParticipationState}}
-  <div class="resume-campaign-banner__container">
-    {{#if campaignParticipationState.isTypeAssessment}}
-      <ResumeCampaignBannerAssessment
-        @isCompleted={{campaignParticipationState.assessment.isCompleted}}
-        @title={{campaignParticipationState.title}}
-        @code={{campaignParticipationState.code}}
-      />
-    {{else}}
-      <ResumeCampaignBannerCollectProfile @code={{campaignParticipationState.code}} />
-    {{/if}}
+{{#if showResumeBar}}
+  <div class="resume-campaign-banner">
+  {{#if campaignParticipationState}}
+    <div class="resume-campaign-banner__container">
+      {{#if campaignParticipationState.isTypeAssessment}}
+        <ResumeCampaignBannerAssessment
+          @isCompleted={{campaignParticipationState.assessment.isCompleted}}
+          @title={{campaignParticipationState.title}}
+          @code={{campaignParticipationState.code}}
+        />
+      {{else}}
+        <ResumeCampaignBannerCollectProfile @code={{campaignParticipationState.code}} />
+      {{/if}}
+    </div>
+  {{/if}}
   </div>
 {{/if}}
-</div>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -236,6 +236,7 @@
         },
         "challenge": {
             "title": "Question {stepNumber} of {totalChallengeNumber}",
+            "title-pix-contest": "Question {stepNumber}",
             "actions": {
                 "continue": "Continue",
                 "validate": "Validate",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -236,6 +236,7 @@
         },
         "challenge": {
             "title": "Épreuve {stepNumber} sur {totalChallengeNumber}",
+            "title-pix-contest": "Épreuve {stepNumber}",
             "actions": {
                 "continue": "Poursuivre",
                 "validate": "Je valide",
@@ -643,7 +644,7 @@
             "pix-contest": {
                 "title": "Bienvenue dans cette session Pix-concours.",
                 "links": {
-                    "link1": "'<a href=\"Premier lien\">'Nom du premier module'</a>'",
+                    "link1": "'<a href=\"/campagnes/CAMPTEST\">'Module 1'</a>'",
                     "link2": "'<a href=\"Second lien\">'Nom du second module'</a>'",
                     "link3": "'<a href=\"Troisième lien\">'Nom du troisième module'</a>'",
                     "link4": "'<a href=\"Quatrième lien\">'Nom du quatrième module'</a>'",


### PR DESCRIPTION
## :unicorn: Problème
- Titre des épreuves qui affichait 1/5
- L'affichage du bandeau pour partager sa campagne

## :robot: Solution
- Utiliser la variable IS_PIX_CONTEST
- Avancer le moment où on switch sur le getNextChallengeDemo pour éviter des appels intuiles

## :rainbow: Remarques

## :100: Pour tester
- Ajouter IS_PIX_CONTEST=true sur la RA
- Ajouter une campagne
- Voir les titres et les bandeaux de reprise