### PR TITLE
[FEATURE] Ajouter du markdown dans les descriptions de paliers et de badges (PIX-1619).

### DIFF
--- a/api/db/migrations/20201117143916_update-stages-message-column-string-to-text.js
+++ b/api/db/migrations/20201117143916_update-stages-message-column-string-to-text.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'stages';
+
+exports.up = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.text('message').alter();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('message').alter();
+  });
+};

--- a/api/db/migrations/20201117144053_update-badges-message-column-string-to-text.js
+++ b/api/db/migrations/20201117144053_update-badges-message-column-string-to-text.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'badges';
+
+exports.up = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.text('message').alter();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.alterTable(TABLE_NAME, function(table) {
+    table.string('message').alter();
+  });
+};

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -36,7 +36,7 @@
               {{this.reachedStage.title}}
             </div>
             <div class="stage-congrats__message">
-              {{this.reachedStage.message}}
+              <MarkdownToHtml @markdown={{this.reachedStage.message}} />
             </div>
           </div>
         {{else}}

--- a/mon-pix/app/templates/components/badge-acquired-card.hbs
+++ b/mon-pix/app/templates/components/badge-acquired-card.hbs
@@ -1,7 +1,7 @@
 <div class="badge-acquired-card">
   <div class="badge-acquired-card__text">
     <p class="badge-acquired-card-text__title">{{@title}}</p>
-    <p class="badge-acquired-card-text__message">{{@message}}</p>
+    <p class="badge-acquired-card-text__message"><MarkdownToHtml @markdown={{@message}} /></p>
   </div>
   <div class="badge-acquired-card__image"><img src="{{@imageUrl}}" alt="{{@altMessage}}" /></div>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
On veut rajouter des liens dans les descriptions de paliers et de badges.

## :robot: Solution
Permettre de les remplir en format markdown.

## :100: Pour tester
Modifier le champ `messages` de `stages` et `badges` par une valeur contenant du markdown et vérifier que tout s'affiche bien.
