### PR TITLE
[FEATURE] Supprimer la règle d'appartenance à Pix Orga pour ajouter des élèves à une session dans Pix Certif (PIX-1614)

### DIFF
--- a/api/db/seeds/data/certification/users.js
+++ b/api/db/seeds/data/certification/users.js
@@ -9,8 +9,6 @@ const CERTIF_REGULAR_USER2_ID = 107;
 const CERTIF_REGULAR_USER3_ID = 108;
 const CERTIF_REGULAR_USER4_ID = 109;
 const CERTIF_REGULAR_USER5_ID = 110;
-const Membership = require('../../../../lib/domain/models/Membership');
-const { MIDDLE_SCHOOL_ID } = require('../organizations-sco-builder');
 
 function certificationUsersBuilder({ databaseBuilder }) {
 
@@ -21,12 +19,6 @@ function certificationUsersBuilder({ databaseBuilder }) {
     email: 'certifsco@example.net',
     rawPassword: 'pix123',
     cgu: true,
-  });
-
-  databaseBuilder.factory.buildMembership({
-    userId: PIX_SCO_CERTIF_USER_ID,
-    organizationId: MIDDLE_SCHOOL_ID,
-    organizationRole: Membership.roles.ADMIN,
   });
 
   databaseBuilder.factory.buildUser.withUnencryptedPassword({

--- a/api/lib/domain/usecases/find-students-for-enrollement.js
+++ b/api/lib/domain/usecases/find-students-for-enrollement.js
@@ -1,19 +1,13 @@
-const { ForbiddenAccess } = require('../errors');
 const { NotFoundError } = require('../errors');
 const StudentForEnrollement = require('../read-models/StudentForEnrollement');
 
 module.exports = async function findStudentsForEnrollement({
-  userId,
   certificationCenterId,
   sessionId,
-  certificationCenterMembershipRepository,
   organizationRepository,
   schoolingRegistrationRepository,
   certificationCandidateRepository,
 }) {
-  const hasAccess = await certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter(userId, certificationCenterId);
-  if (!hasAccess) throw new ForbiddenAccess(`User ${userId} is not a member of certification center ${certificationCenterId}`);
-
   try {
     const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
     const students = await schoolingRegistrationRepository.findByOrganizationIdOrderByDivision({ organizationId });

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -279,50 +279,6 @@ describe('Acceptance | API | Certification Center', () => {
         expect(_.map(response.result.data, 'id')).to.deep.equal(['3', '2', '5', '4', '1']);
       });
 
-      context('when the certification center does not exist', () => {
-
-        it('should return Forbidden Access when the certificationCenter does not exist', async () => {
-          // given
-          const { user } = _buildUserWithCertificationCenterMemberShip(externalId);
-          databaseBuilder.factory.buildOrganization({ externalId });
-          const session = databaseBuilder.factory.buildSession();
-          await databaseBuilder.commit();
-
-          const notExistingCertificationCenter = { id: '10203' };
-          const request = _buildSchoolinRegistrationsWithConnectedUserRequest(user, notExistingCertificationCenter, session);
-
-          // when
-          const response = await server.inject(request);
-
-          // then
-          expect(response.statusCode).to.equal(403);
-          expect(response.result.errors[0].title).to.equal('Forbidden');
-          expect(response.result.errors[0].detail).to.equal(`User ${user.id} is not a member of certification center ${notExistingCertificationCenter.id}`);
-        });
-      });
-
-      context('when user is not a member of the certification center', () => {
-        let certificationCenterWhereUserDoesNotHaveAccess;
-
-        it('should return Forbidden Access when user are not register in the certificationCenter', async () => {
-          // given
-          const { user } = _buildUserWithCertificationCenterMemberShip(externalId);
-          databaseBuilder.factory.buildOrganization({ externalId });
-          certificationCenterWhereUserDoesNotHaveAccess = databaseBuilder.factory.buildCertificationCenter({ externalId });
-          const session = databaseBuilder.factory.buildSession({ certificationCenterId: certificationCenterWhereUserDoesNotHaveAccess.id });
-          await databaseBuilder.commit();
-
-          const request = _buildSchoolinRegistrationsWithConnectedUserRequest(user, certificationCenterWhereUserDoesNotHaveAccess, session);
-
-          // when
-          const response = await server.inject(request);
-
-          // then
-          expect(response.statusCode).to.equal(403);
-          expect(response.result.errors[0].title).to.equal('Forbidden');
-          expect(response.result.errors[0].detail).to.equal(`User ${user.id} is not a member of certification center ${certificationCenterWhereUserDoesNotHaveAccess.id}`);
-        });
-      });
     });
 
     context('when user is not connected', () => {

--- a/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
+++ b/api/tests/acceptance/application/session/session-controller-enroll-students_test.js
@@ -1,6 +1,5 @@
 const { sinon, expect, databaseBuilder, generateValidRequestAuthorizationHeader, knex } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const Membership = require('../../../../lib/domain/models/Membership');
 const config = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-controller-enroll-students-to-session', () => {
@@ -81,16 +80,14 @@ describe('Acceptance | Controller | session-controller-enroll-students-to-sessio
       beforeEach(async () => {
         config.featureToggles.certifPrescriptionSco = true;
 
-        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+        const { id: certificationCenterId, externalId } = databaseBuilder.factory.buildCertificationCenter();
+
         sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
-        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
-        const organizationId = databaseBuilder.factory.buildOrganization({ type: 'SCO' }).id;
-        databaseBuilder.factory.buildMembership({
-          organizationRole: Membership.roles.MEMBER,
-          organizationId,
-          userId,
-          disabledAt: null,
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({
+          type: 'SCO',
+          externalId,
         });
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId });
 
         student = databaseBuilder.factory.buildSchoolingRegistration({ organizationId });
 

--- a/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
+++ b/api/tests/unit/domain/usecases/enroll-students-to-session_test.js
@@ -16,7 +16,7 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
       const referentId = Symbol('a referent id');
 
       const studentIds = [1, 2, 3];
-      const { organizationForReferents, schoolingRegistrations } =
+      const { organizationForReferent, schoolingRegistrations } =
         _buildMatchingReferentOrganisationAndSchoolingRegistrations(studentIds);
 
       const expectedCertificationCandidates = schoolingRegistrations.map((sr) => {
@@ -32,12 +32,14 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
       const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
       const schoolingRegistrationRepository = { findByIds: sinon.stub() };
       schoolingRegistrationRepository.findByIds.withArgs({ ids: studentIds }).resolves(schoolingRegistrations);
-      const membershipRepository = { findByUserId: sinon.stub() };
-      membershipRepository.findByUserId.withArgs({ userId: referentId }).resolves(organizationForReferents);
       const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs(sessionId).resolves(session);
       const certificationCenterMembershipRepository = { findByUserId: sinon.stub() };
       certificationCenterMembershipRepository.findByUserId.withArgs(referentId).resolves(certificationCenterMemberships);
+      const organizationRepository = { getIdByCertificationCenterId: sinon.stub() };
+      organizationRepository.getIdByCertificationCenterId.withArgs(session.certificationCenterId).resolves(
+        organizationForReferent.id,
+      );
 
       // when
       await enrollStudentsToSession({
@@ -46,9 +48,9 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         referentId,
         scoCertificationCandidateRepository,
         certificationCenterMembershipRepository,
-        membershipRepository,
         schoolingRegistrationRepository,
         sessionRepository,
+        organizationRepository,
       });
 
       // then
@@ -63,17 +65,19 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
       const referentId = Symbol('an unauthorized referent id');
 
       const studentIds = [1, 2, 3];
-      const { organizationForReferents, schoolingRegistrations } =
+      const { organizationForReferent, schoolingRegistrations } =
         _buildNonMatchingReferentOrganisationAndSchoolingRegistrations(studentIds);
 
       const schoolingRegistrationRepository = { findByIds: sinon.stub() };
       schoolingRegistrationRepository.findByIds.withArgs({ ids: studentIds }).resolves(schoolingRegistrations);
-      const membershipRepository = { findByUserId: sinon.stub() };
-      membershipRepository.findByUserId.withArgs({ userId: referentId }).resolves(organizationForReferents);
       const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs(session.id).resolves(session);
       const certificationCenterMembershipRepository = { findByUserId: sinon.stub() };
       certificationCenterMembershipRepository.findByUserId.withArgs(referentId).resolves(certificationCenterMemberships);
+      const organizationRepository = { getIdByCertificationCenterId: sinon.stub() };
+      organizationRepository.getIdByCertificationCenterId.withArgs(session.certificationCenterId).resolves(
+        organizationForReferent.id,
+      );
 
       // when
       const error = await catchErr(enrollStudentsToSession)({
@@ -81,7 +85,7 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         studentIds,
         referentId,
         schoolingRegistrationRepository,
-        membershipRepository,
+        organizationRepository,
         sessionRepository,
         certificationCenterMembershipRepository,
       });
@@ -107,7 +111,7 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         studentIds,
         referentId,
         certificationCenterMembershipRepository,
-        membershipRepository: undefined,
+        organizationRepository: undefined,
         schoolingRegistrationRepository: undefined,
         sessionRepository,
       });
@@ -122,18 +126,20 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
       const sessionId = session.id;
       const studentIds = [];
       const referentId = Symbol('a referent id');
-      const { organizationForReferents, schoolingRegistrations } =
+      const { organizationForReferent, schoolingRegistrations } =
         _buildMatchingReferentOrganisationAndSchoolingRegistrations(studentIds);
 
       const scoCertificationCandidateRepository = new InMemorySCOCertificationCandidateRepository();
       const schoolingRegistrationRepository = { findByIds: sinon.stub() };
       schoolingRegistrationRepository.findByIds.withArgs({ ids: studentIds }).resolves(schoolingRegistrations);
-      const membershipRepository = { findByUserId: sinon.stub() };
-      membershipRepository.findByUserId.withArgs({ userId: referentId }).resolves(organizationForReferents);
       const sessionRepository = { get: sinon.stub() };
       sessionRepository.get.withArgs(sessionId).resolves(session);
       const certificationCenterMembershipRepository = { findByUserId: sinon.stub() };
       certificationCenterMembershipRepository.findByUserId.withArgs(referentId).resolves(certificationCenterMemberships);
+      const organizationRepository = { getIdByCertificationCenterId: sinon.stub() };
+      organizationRepository.getIdByCertificationCenterId.withArgs(session.certificationCenterId).resolves(
+        organizationForReferent.id,
+      );
 
       // when
       await enrollStudentsToSession({
@@ -142,7 +148,7 @@ describe('Unit | UseCase | enroll-students-to-session', () => {
         referentId,
         scoCertificationCandidateRepository,
         certificationCenterMembershipRepository,
-        membershipRepository,
+        organizationRepository,
         schoolingRegistrationRepository,
         sessionRepository,
       });
@@ -189,7 +195,7 @@ function _buildMatchingReferentOrganisationAndSchoolingRegistrations(studentIds)
     });
   });
 
-  return { organizationForReferents: [{ organization: organizationForReferent }], schoolingRegistrations };
+  return { organizationForReferent, schoolingRegistrations };
 }
 
 function _buildNonMatchingReferentOrganisationAndSchoolingRegistrations(studentIds) {
@@ -199,7 +205,7 @@ function _buildNonMatchingReferentOrganisationAndSchoolingRegistrations(studentI
   });
 
   const organizationForReferent = domainBuilder.buildOrganization();
-  return { organizationForReferents: [{ organization: organizationForReferent }], schoolingRegistrations };
+  return { organizationForReferent, schoolingRegistrations };
 }
 
 class InMemorySCOCertificationCandidateRepository {

--- a/api/tests/unit/domain/usecases/find-students-for-enrollement.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrollement.js
@@ -1,7 +1,6 @@
 const _ = require('lodash');
-const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
-const usecases = require('../../../../lib/domain/usecases');
-const { ForbiddenAccess, NotFoundError } = require('../../../../lib/domain/errors');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 const StudentForEnrollement = require('../../../../lib/domain/read-models/StudentForEnrollement');
 
 const findStudentsForEnrollement = require('../../../../lib/domain/usecases/find-students-for-enrollement');
@@ -19,10 +18,6 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
     findByOrganizationIdOrderByDivision: sinon.stub(),
   };
 
-  const certificationCenterMembershipRepository = {
-    doesUserHaveMembershipToCertificationCenter: sinon.stub(),
-  };
-
   const certificationCandidateRepository = {
     findBySessionId: sinon.stub(),
   };
@@ -34,9 +29,6 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
 
     organizationRepository.getIdByCertificationCenterId
       .withArgs(certificationCenter.id).resolves(organization.id);
-
-    certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter
-      .withArgs(userId, certificationCenter.id).resolves(true);
   });
 
   describe('when user has access to certification center', () => {
@@ -51,7 +43,6 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
           certificationCenterId,
           organizationRepository,
           schoolingRegistrationRepository,
-          certificationCenterMembershipRepository,
           certificationCandidateRepository,
         });
 
@@ -74,7 +65,6 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
         userId,
         certificationCenterId,
         sessionId,
-        certificationCenterMembershipRepository,
         organizationRepository,
         schoolingRegistrationRepository,
         certificationCandidateRepository,
@@ -82,8 +72,8 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
 
       // then
       const expectedEnrolledStudent = new StudentForEnrollement({ ...enrolledStudent, isEnrolled: true });
-      const exepectedEnrollableStudents = enrollableStudents.map((student) => new StudentForEnrollement({ ...student, isEnrolled: false }));
-      const expectedStudents = [ expectedEnrolledStudent, ...exepectedEnrollableStudents ];
+      const expectedEnrollableStudents = enrollableStudents.map((student) => new StudentForEnrollement({ ...student, isEnrolled: false }));
+      const expectedStudents = [ expectedEnrolledStudent, ...expectedEnrollableStudents ];
       expect(studentsFounds).to.be.deep.equal(expectedStudents);
     });
 
@@ -100,34 +90,12 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
           certificationCenterId,
           organizationRepository,
           schoolingRegistrationRepository,
-          certificationCenterMembershipRepository,
           certificationCandidateRepository,
         });
 
         // then
         expect(studentsFounds).to.be.deep.equal([]);
       });
-    });
-  });
-
-  describe('when user does not have access to certification center', () => {
-    it('should throw an access error', async () => {
-      // given
-      const wrongCertificationCenterId = 666;
-      certificationCenterMembershipRepository.doesUserHaveMembershipToCertificationCenter
-        .withArgs(userId, wrongCertificationCenterId).resolves(false);
-
-      // when
-      const error = await catchErr(usecases.findStudentsForEnrollement)({
-        userId,
-        certificationCenterId: wrongCertificationCenterId,
-        organizationRepository,
-        schoolingRegistrationRepository,
-        certificationCenterMembershipRepository,
-      });
-
-      // then
-      expect(error).to.be.instanceOf(ForbiddenAccess);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
En l'état, lors d'une inscription d'élève à une session de certification de type SCO, on vérifiait que le référent (utilisateur loggué) soit bien membre de la même organisation que les élèves qu'il inscrit. 
Or en situation réelle, le référent sera rattaché à un centre de certification mais ne sera pas directement rattaché à une organisation. Cette vérification aurait donc empêcher l'inscription.

## :robot: Solution
Remplacer la vérification du rattachement du référent à la même organisation que les élèves par la double vérification : 
- le référent appartient bien au centre de certification auquel appartient la session 
- ce centre de certification est bien rattaché à l'organisation (via `externalId`) à laquelle appartienne les élèves 

## :rainbow: Remarques
Le rattachement entre le centre de certification et une organisation via `l'externalId` n'est pas idéal (l'`externalId` est multi-usage et fait davantage office de metadata), il faudrait un champ dédié `organizationId` dans `certification-centers`. Cela sera fait ultérieurement.

## :100: Pour tester
Se connecter avec l'utilisateur `certifsco@example.net` et inscrire des élèves en tant que candidats de certification à une session SCO depuis Pix Certif (les seeds ne rattachent plus `certifsco@example.net` à une organisation)
