### PR TITLE
[TECH] Déconnecter les utilisateurs connectés lors de la recréation de la BDD.

### DIFF
--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -12,6 +12,14 @@ url.pathname = '/postgres';
 
 const client = new PgClient(url.href);
 
+const disconnectAllSessionsButMineQuery =
+  `SELECT pg_terminate_backend(pg_stat_activity.pid)
+  FROM pg_stat_activity
+  WHERE pg_stat_activity.datname = '${DB_TO_DELETE_NAME}'
+  AND pid <> pg_backend_pid();`;
+
+(async () => { await client.query_and_log(disconnectAllSessionsButMineQuery); })();
+
 client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`)
   .then(() => {
     console.log('Database dropped');

--- a/api/scripts/database/drop-database.js
+++ b/api/scripts/database/drop-database.js
@@ -16,11 +16,11 @@ const disconnectAllSessionsButMineQuery =
   `SELECT pg_terminate_backend(pg_stat_activity.pid)
   FROM pg_stat_activity
   WHERE pg_stat_activity.datname = '${DB_TO_DELETE_NAME}'
-  AND pid <> pg_backend_pid();`;
+  AND pid <> pg_backend_pid()`;
 
-(async () => { await client.query_and_log(disconnectAllSessionsButMineQuery); })();
+const dropDatabaseQuery =  `DROP DATABASE ${DB_TO_DELETE_NAME}`;
 
-client.query_and_log(`DROP DATABASE ${DB_TO_DELETE_NAME};`)
+client.query_and_log(`${disconnectAllSessionsButMineQuery};${dropDatabaseQuery};`)
   .then(() => {
     console.log('Database dropped');
     client.end();


### PR DESCRIPTION
## :unicorn: Problème
En local ou en RA, quand le script `npm run db:reset` est lancé pour générer des JDD, le message suivant est parfois affiché

```
> pix-api@2.219.0 db:delete /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/api
> node scripts/database/drop-database
query: DROP DATABASE pix;
(node:15695) UnhandledPromiseRejectionWarning: error: database "pix" is being accessed by other users
```

## :robot: Solution
Les déconnecter avec `DROP DATABASE foo WITH (FORCE);`
https://www.postgresql.org/docs/13/sql-dropdatabase.html

## :rainbow: Remarques
A prioiri, il est possible de l'exécuter manuellement en production car on peut le faire en RA
Est-ce un risque mitigé ?

## :100: Pour tester
Etapes:
- se connecter avec un client BDD `psql postgres://postgres@localhost:5432/pix`
- lancer l'API `npm start`
- lancer les seeds `npm run db:seed`
- vérifier qu'on obtient `Ran 1 seed files`
