### PR TITLE
[BUGFIX] 2ème correction du payload d'envoi des résultats à Pôle Emploi (PIX-1622).

### DIFF
--- a/api/lib/domain/events/handle-campaign-participation-results-sending.js
+++ b/api/lib/domain/events/handle-campaign-participation-results-sending.js
@@ -42,7 +42,6 @@ class PoleEmploiPayload {
       dateDebut: campaign.createdAt,
       dateFin: campaign.archivedAt,
       type: PAYLOAD_CAMPAIGN_TYPE,
-      idCampagne: campaign.id,
       codeCampagne: campaign.code,
       urlCampagne: `${PAYLOAD_CAMPAIGN_URL}/${campaign.code}`,
       nomOrganisme: PAYLOAD_STRUCTURE_NAME,
@@ -59,7 +58,7 @@ class PoleEmploiPayload {
       dateDebut: participation.createdAt,
       dateProgression: participation.sharedAt,
       dateValidation: participation.sharedAt,
-      evaluationCible: participationResult.masteryPercentage,
+      evaluation: participationResult.masteryPercentage,
       uniteEvaluation: PAYLOAD_UNITS.PERCENTAGE,
       elementsEvalues: participationResult.competenceResults.map(this._buildElementEvalue),
     };
@@ -105,9 +104,9 @@ async function handleCampaignParticipationResultsSending({
 
   const campaign = await campaignRepository.get(campaignId);
   const organization = await organizationRepository.get(organizationId);
-  
+
   if (campaign.isAssessment() && organization.isPoleEmploi) {
-    
+
     const user = await userRepository.get(userId);
     const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
     const participation = await campaignParticipationRepository.get(campaignParticipationId);

--- a/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
+++ b/api/tests/unit/domain/events/handle-campaign-participation-results-sending_test.js
@@ -32,7 +32,6 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
       dateDebut: '2020-01-01T00:00:00.000Z',
       dateFin: '2020-02-01T00:00:00.000Z',
       type: 'EVALUATION',
-      idCampagne: 11223344,
       codeCampagne: 'CODEPE123',
       urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
       nomOrganisme: 'Pix',
@@ -50,7 +49,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
       dateDebut: '2020-01-02T00:00:00.000Z',
       dateProgression: '2020-01-03T00:00:00.000Z',
       dateValidation: '2020-01-03T00:00:00.000Z',
-      evaluationCible: 70,
+      evaluation: 70,
       uniteEvaluation: 'A',
       elementsEvalues: [
         {


### PR DESCRIPTION
## :unicorn: Problème
Les données envoyées à Pôle Emploi n'étaient pas tout à fait correctes. Il y a eu 2 évolutions :
- "evaluationCible" au lieu de "evaluation" ;
- "idCampagne" inutile.

## :robot: Solution
Corriger ces données.

## :rainbow: Remarques
NA

## :100: Pour tester
Pré-requis: Se connecter à scalingo et ouvrir la page des log de l'api pour la RA
https://my.osc-fr1.scalingo.com/apps/pix-api-review-pr2166/logs

Aller sur https://app-pr2166.review.pix.fr
Se connecter avec un utilisateur
Faire la campagne QWERTY789
Partager ses résultats
Voir dans les logs l'affichage des résultats d'évaluation au moment du partage