### PR TITLE
[FEATURE] Ajout d'un bouton de finalisation de Pix-Concours (PIX-1596).

### DIFF
--- a/api/db/migrations/20201116150223_add-column-hasFinishedPixContest-to-user.js
+++ b/api/db/migrations/20201116150223_add-column-hasFinishedPixContest-to-user.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const NEW_COLUMN = 'finishedPixContestAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dateTime(NEW_COLUMN).nullable();
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(NEW_COLUMN);
+  });
+};

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -435,6 +435,28 @@ exports.register = async function(server) {
         tags: ['api', 'administration' , 'user'],
       },
     },
+    {
+      method: 'PATCH',
+      path: '/api/users/{id}/finish-pix-contest',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().positive().required(),
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser',
+        }],
+        handler: userController.finishPixContest,
+        notes : [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- L’id demandé doit correspondre à celui de l’utilisateur authentifié',
+          '- Permet à un utilisateur de cloturer sa session Pix-Concours',
+        ],
+        tags: ['api', 'user'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -203,4 +203,10 @@ module.exports = {
     return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
   },
 
+  async finishPixContest(request) {
+    const userId = parseInt(request.params.id);
+    const updatedUser = await usecases.finishPixContest({ userId });
+    return userSerializer.serialize(updatedUser);
+  },
+
 };

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -19,6 +19,7 @@ class User {
     hasSeenAssessmentInstructions,
     shouldChangePassword,
     mustValidateTermsOfService,
+    finishedPixContestAt,
     // includes
     memberships = [],
     certificationCenterMemberships = [],
@@ -44,6 +45,7 @@ class User {
     this.hasSeenAssessmentInstructions = hasSeenAssessmentInstructions;
     this.knowledgeElements = knowledgeElements;
     this.shouldChangePassword = shouldChangePassword;
+    this.finishedPixContestAt = finishedPixContestAt;
     // includes
     this.pixRoles = pixRoles;
     this.pixScore = pixScore;

--- a/api/lib/domain/usecases/finish-pix-contest.js
+++ b/api/lib/domain/usecases/finish-pix-contest.js
@@ -1,0 +1,4 @@
+module.exports = async function finishPixContest({ userId, userRepository }) {
+
+  return await userRepository.updateUserAttributes(userId, { finishedPixContestAt: new Date() });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -139,6 +139,7 @@ module.exports = injectDependencies({
   findTutorials: require('./find-tutorials'),
   findUserTutorials: require('./find-user-tutorials'),
   findPaginatedFilteredSchoolingRegistrations: require('./find-paginated-filtered-schooling-registrations'),
+  finishPixContest: require('./finish-pix-contest'),
   flagSessionResultsAsSentToPrescriber: require('./flag-session-results-as-sent-to-prescriber'),
   generateUsername: require('./generate-username'),
   generateUsernameWithTemporaryPassword: require('./generate-username-with-temporary-password'),
@@ -217,5 +218,4 @@ module.exports = injectDependencies({
   updateUserDetailsForAdministration: require('./update-user-details-for-administration'),
   updateUserPassword: require('./update-user-password'),
   updateUserSamlId: require('./update-user-samlId'),
-
 }, dependencies);

--- a/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-serializer.js
@@ -16,6 +16,7 @@ module.exports = {
         'memberships', 'certificationCenterMemberships',
         'pixScore', 'scorecards', 'profile',
         'campaignParticipations', 'hasSeenAssessmentInstructions', 'isCertifiable',
+        'finishedPixContestAt',
       ],
       memberships: {
         ref: 'id',

--- a/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-current-user_test.js
@@ -41,6 +41,7 @@ describe('Acceptance | Controller | users-controller-get-current-user', () => {
             'pix-orga-terms-of-service-accepted': user.pixOrgaTermsOfServiceAccepted,
             'pix-certif-terms-of-service-accepted': user.pixCertifTermsOfServiceAccepted,
             'has-seen-assessment-instructions': user.hasSeenAssessmentInstructions,
+            'finished-pix-contest-at': user.finishedPixContestAt,
           },
           relationships: {
             memberships: {

--- a/api/tests/tooling/database-builder/factory/build-user.js
+++ b/api/tests/tooling/database-builder/factory/build-user.js
@@ -25,6 +25,7 @@ const buildUser = function buildUser({
   hasSeenAssessmentInstructions = false,
   samlId,
   shouldChangePassword = false,
+  finishedPixContestAt = null,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -34,7 +35,7 @@ const buildUser = function buildUser({
 
   const values = {
     id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword, createdAt, updatedAt,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword, finishedPixContestAt, createdAt, updatedAt,
   };
 
   return databaseBuffer.pushInsertable({
@@ -58,13 +59,14 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   hasSeenAssessmentInstructions = false,
   samlId,
   shouldChangePassword = false,
+  finishedPixContestAt = null,
 }) {
 
   const password = encrypt.hashPasswordSync(rawPassword);
 
   const values = {
     id, firstName, lastName, email, username, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, samlId, shouldChangePassword, finishedPixContestAt,
   };
 
   return databaseBuffer.pushInsertable({
@@ -85,11 +87,12 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
   pixOrgaTermsOfServiceAccepted = false,
   pixCertifTermsOfServiceAccepted = false,
   hasSeenAssessmentInstructions = false,
+  finishedPixContestAt = null,
 } = {}) {
 
   const values = {
     id, firstName, lastName, email, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, finishedPixContestAt,
   };
 
   const user = databaseBuffer.pushInsertable({
@@ -116,11 +119,12 @@ buildUser.withMembership = function buildUserWithMemberships({
   hasSeenAssessmentInstructions = false,
   organizationRole = Membership.roles.ADMIN,
   organizationId = null,
+  finishedPixContestAt = null,
 } = {}) {
 
   const values = {
     id, firstName, lastName, email, password, cgu, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, finishedPixContestAt,
   };
 
   organizationId = _.isNil(organizationId) ? buildOrganization().id : organizationId;

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -17,6 +17,7 @@ module.exports = function buildUser(
     pixOrgaTermsOfServiceAccepted = false,
     pixCertifTermsOfServiceAccepted = false,
     hasSeenAssessmentInstructions = false,
+    finishedPixContestAt = new Date(),
     pixRoles = [buildPixRole()],
     memberships = [buildMembership()],
     certificationCenterMemberships = [buildCertificationCenterMembership()],
@@ -29,5 +30,6 @@ module.exports = function buildUser(
     pixOrgaTermsOfServiceAccepted, pixCertifTermsOfServiceAccepted,
     hasSeenAssessmentInstructions, shouldChangePassword,
     pixRoles, memberships, certificationCenterMemberships,
+    finishedPixContestAt,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-serializer_test.js
@@ -22,6 +22,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
         pixCertifTermsOfServiceAccepted: false,
         hasSeenAssessmentInstructions: false,
         password: 'Password123',
+        finishedPixContestAt: '2020-05-06T13:18:26.323Z',
       });
     });
 
@@ -44,6 +45,7 @@ describe('Unit | Serializer | JSONAPI | user-serializer', () => {
               'pix-orga-terms-of-service-accepted': userModelObject.pixOrgaTermsOfServiceAccepted,
               'pix-certif-terms-of-service-accepted': userModelObject.pixCertifTermsOfServiceAccepted,
               'has-seen-assessment-instructions': userModelObject.hasSeenAssessmentInstructions,
+              'finished-pix-contest-at': userModelObject.finishedPixContestAt,
             },
             relationships: {
               memberships: {

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -56,6 +56,11 @@ export default class User extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);
 
+    if (adapterOptions && adapterOptions.finishPixContest) {
+      delete adapterOptions.finishPixContest;
+      return url + '/finish-pix-contest';
+    }
+
     if (adapterOptions && adapterOptions.acceptPixTermsOfService) {
       delete adapterOptions.acceptPixTermsOfService;
       return url + '/pix-terms-of-service-acceptance';

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -8,6 +8,7 @@ export default class NavbarDesktopHeader extends Component {
   @service router;
   @service session;
   @service intl;
+  @service currentUser;
 
   @alias('session.isAuthenticated') isUserLogged;
 
@@ -24,5 +25,9 @@ export default class NavbarDesktopHeader extends Component {
 
   get _isExternalUser() {
     return this.session.get('data.externalUser');
+  }
+
+  get hasNotFinishedPixContest() {
+    return !this.currentUser.user.finishedPixContestAt;
   }
 }

--- a/mon-pix/app/components/profile-content.js
+++ b/mon-pix/app/components/profile-content.js
@@ -11,6 +11,10 @@ export default class ProfileContent extends Component {
     return ENV.APP.IS_PIX_CONTEST === 'true';
   }
 
+  get hasNotFinishedPixContest() {
+    return !this.currentUser.user.finishedPixContestAt;
+  }
+
   @action
   sendPixContestResults() {
     this.currentUser.user.save({ adapterOptions: { finishPixContest: true } });

--- a/mon-pix/app/components/profile-content.js
+++ b/mon-pix/app/components/profile-content.js
@@ -1,9 +1,18 @@
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class ProfileContent extends Component {
 
+  @service currentUser;
+
   get isPixContest() {
     return ENV.APP.IS_PIX_CONTEST === 'true';
+  }
+
+  @action
+  sendPixContestResults() {
+    this.currentUser.user.save({ adapterOptions: { finishPixContest: true } });
   }
 }

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -15,6 +15,7 @@ export default class User extends Model {
   @attr('boolean') mustValidateTermsOfService;
   @attr('boolean') hasSeenAssessmentInstructions;
   @attr('string') recaptchaToken;
+  @attr('date') finishedPixContestAt;
 
   // includes
   @belongsTo('is-certifiable') isCertifiable;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -164,6 +164,15 @@
   }
 }
 
+.rounded-panel-send-results {
+  display: flex;
+  justify-content: flex-end;
+
+  &__instructions {
+    margin-right: 8px;
+  }
+}
+
 .rounded-panel-rules {
   text-align: center;
   font-weight: $font-normal;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -173,6 +173,12 @@
   }
 }
 
+.rounded-panel-finished-pix-contest {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .rounded-panel-rules {
   text-align: center;
   font-weight: $font-normal;

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -37,6 +37,7 @@
     {{/unless}}
 
     {{#if isUserLogged}}
+      {{#if this.hasNotFinishedPixContest}}
       <ul class="navbar-desktop-header-container__campaign-menu">
         <li class="navbar-desktop-header-campaign-menu__item">
           <LinkTo @route="fill-in-campaign-code"
@@ -45,7 +46,7 @@
           </LinkTo>
         </li>
       </ul>
-
+      {{/if}}
     {{/if}}
 
     <!-- Links (right) -->

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -17,6 +17,12 @@
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link4' htmlSafe=true}}</p>
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link5' htmlSafe=true}}</p>
       </div>
+      <div class="rounded-panel-header-text__content rounded-panel-send-results">
+        <p class="rounded-panel-send-results__instructions">{{t 'pages.profile.pix-contest.send-results.instructions'}}</p>
+        <button type="button" class="button button--extra-thin" {{on 'click' this.sendPixContestResults}}>
+          {{t 'pages.profile.pix-contest.send-results.button'}}
+        </button>
+      </div>
     {{else}}
       <div class="rounded-panel-header-with-components">
         <div class="rounded-panel-header__left-wrapper">

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -4,6 +4,7 @@
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner profile__panel">
   <h1 class="sr-only">{{t 'pages.profile.accessibility.title'}}</h1>
     {{#if this.isPixContest}}
+      {{#if this.hasNotFinishedPixContest}}
       <div class="rounded-panel-header-with-components">
           <div class="rounded-panel-header-text__content rounded-panel-title rounded-panel-header-text__content--first-title">
             {{t 'pages.profile.pix-contest.title' }}
@@ -23,6 +24,11 @@
           {{t 'pages.profile.pix-contest.send-results.button'}}
         </button>
       </div>
+      {{else}}
+        <div class="rounded-panel-finished-pix-contest">
+          <p>{{t 'pages.profile.pix-contest.send-results.finished'}}</p>
+        </div>
+      {{/if}}
     {{else}}
       <div class="rounded-panel-header-with-components">
         <div class="rounded-panel-header__left-wrapper">

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -66,6 +66,11 @@ describe('Integration | Component | navbar-desktop-header', function() {
           },
         },
       }));
+      this.owner.register('service:currentUser', Service.extend({
+        user: {
+          finishedPixContestAt: null,
+        },
+      }));
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>}`);
     });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -650,7 +650,11 @@
                     "link4": "",
                     "link5": ""
                 },
-                "rules": ""
+                "rules": "",
+                "send-results": {
+                    "button": "",
+                    "instructions": ""
+                }
             },
             "resume-campaign-banner": {
                 "accessibility": {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -653,6 +653,7 @@
                 "rules": "",
                 "send-results": {
                     "button": "",
+                    "finished": "",
                     "instructions": ""
                 }
             },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -650,7 +650,11 @@
                     "link4": "'<a href=\"Quatrième lien\">'Nom du quatrième module'</a>'",
                     "link5": "'<a href=\"Cinquième lien\">'Nom du cinquième module'</a>'"
                 },
-                "rules": "Règles de l'épreuve"
+                "rules": "Règles de l'épreuve",
+                "send-results": {
+                    "button": "J'envoie ma copie",
+                    "instructions": "Instructions à modifier"
+                }
             },
             "resume-campaign-banner": {
                 "accessibility": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -653,6 +653,7 @@
                 "rules": "Règles de l'épreuve",
                 "send-results": {
                     "button": "J'envoie ma copie",
+                    "finished": "Votre copie a bien été transmise.",
                     "instructions": "Instructions à modifier"
                 }
             },


### PR DESCRIPTION
## :unicorn: Problème

Les utilisateurs doivent pouvoir signaler de la fin de leur épreuve et cela doit être vérifiable afin d'éviter toute triche ultérieure (ex: accès aux concours depuis l'extérieur)

## :robot: Solution

- Ajout d'un bouton en bas à droite "J'envoie ma copie"
- Au clic de ce bouton, les infos de la page /profil disparaissent et le message suivant apparait "Votre copie a bien été transmise" 
- Pouvoir mettre du texte à gauche du bouton pour expliquer à sa fonction/utilité.
- Retrait du bouton "J'ai un code" lorsque le test est terminé.

## :rainbow: Remarques

- Une colonne de fin d'examen a été ajoutée à l'utilisateur en DB (format `Date`) afin de vérifier de l'heure à laquelle l'utilisateur a cliqué sur le bouton implémenté.

## :100: Pour tester

Aller sur la RA
Cliquer sur "J'envoie ma copie"
Vérifier que la page fasse uniquement apparaitre "Votre copie a bien été transmise."
Vérifier que l'utilisateur ait sa colonne `finishedPixContestAt`avec l'heure de clic. (DB et EmberData)
