### PR TITLE
[BUGFIX] N'autoriser que les code INSEE pour les birthCountryCode et birthCityCode lors d'un import CSV (Pix-1623).

### DIFF
--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -67,8 +67,14 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
   }
 
   _handleError(err, index) {
+    const column = this._columns.find((column) => column.name === err.key);
+
     if (err.why === 'uniqueness') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Identifiant unique” de cette ligne est présent plusieurs fois dans le fichier.`);
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” de cette ligne est présent plusieurs fois dans le fichier.`);
+    }
+
+    if (err.why === 'not_valid_insee_code') {
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” n'est pas au format INSEE.`);
     }
    
     super._handleError(...arguments);

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -1,5 +1,5 @@
 const { expect, catchErr } = require('../../../test-helper');
-const { checkValidation } = require('../../../../lib/domain/validators/schooling-registration-validator');
+const { checkValidation, FRANCE_COUNTRY_CODE } = require('../../../../lib/domain/validators/schooling-registration-validator');
 
 describe('Unit | Domain | Schooling Registration validator', () => {
   context('#checkValidation', () => {
@@ -13,7 +13,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
       birthCity: 'city1',
       birthCityCode: 'city1',
       birthProvinceCode: '10',
-      birthCountryCode: '12345',
+      birthCountryCode: '99125',
       status: 'ST',
       MEFCode: 'ABCDE',
       division: 'EDCBA',
@@ -70,12 +70,36 @@ describe('Unit | Domain | Schooling Registration validator', () => {
     });
 
     context('birthCountryCode', () => {
+      context('is valid', () => {
+        it('respects INSEE Code, only number', async () => {
+          try {
+            checkValidation({ ...validAttributes, birthCountryCode: '99123' });
+          } catch (e) {
+            expect.fail('SchoolingRegistration is valid birthCountryCode respect INSEE code');
+          }  
+        });
+      });
+
       it('throw an error when birthCountryCode has not 5 characters', async () => {
         const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '123456' });
 
         expect(error.key).to.equal('birthCountryCode');
         expect(error.why).to.equal('length');
         expect(error.limit).to.equal(5);
+      });
+
+      it('throw an error when birthCountryCode not start with 99', async () => {
+        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '88123' });
+
+        expect(error.key).to.equal('birthCountryCode');
+        expect(error.why).to.equal('not_valid_insee_code');
+      });
+
+      it('throw an error when birthCountryCode contains letter', async () => {
+        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '2B122' });
+
+        expect(error.key).to.equal('birthCountryCode');
+        expect(error.why).to.equal('not_valid_insee_code');
       });
     });
 
@@ -142,10 +166,8 @@ describe('Unit | Domain | Schooling Registration validator', () => {
       });
 
       it('is valid when birthCity is undefined and birthCountry is France', async () => {
-        const franceCountryCode = '99100';
-
         try {
-          checkValidation({ ...validAttributes, birthCountryCode: franceCountryCode, birthCity: undefined });
+          checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '51430', birthCity: undefined });
         } catch (e) {
           expect.fail('SchoolingRegistration is valid when birthCity is undefined and birthCountry is France');
         }
@@ -153,30 +175,65 @@ describe('Unit | Domain | Schooling Registration validator', () => {
     });
 
     context('birthCityCode', () => {
-      it('throw an error when birthCityCode is not France and birthCity is undefined', async () => {
-        const franceCountryCode = '99100';
+      context('is valid', () => {
+        context('when birthCountryCode equal to France', () => {
 
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: franceCountryCode, birthCityCode: undefined });
+          it('respects INSEE Code, with one letter', async () => {
+            try {
+              checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '2B125' });
+            } catch (e) {
+              expect.fail('SchoolingRegistration is valid birthCityCode respect INSEE code, like Corsica');
+            }  
+          });
+    
+          it('respects INSEE Code, only number', async () => {
+            try {
+              checkValidation({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '13125' });
+            } catch (e) {
+              expect.fail('SchoolingRegistration is valid birthCityCode respect INSEE code, like Corsica');
+            }  
+          });    
+        });
 
-        expect(error.key).to.equal('birthCityCode');
-        expect(error.why).to.equal('required');
+        context('when birthCountryCode not equal to France', () => {
+          it('is valid with birthCityCode undefined', async () => {
+            try {
+              checkValidation({ ...validAttributes, birthCountryCode: '99125', birthCityCode: undefined });
+            } catch (e) {
+              expect.fail('SchoolingRegistration is valid when birthCity is undefined and birthCountry is not France');
+            }
+          });
+        });
       });
 
-      it('is valid when birthCityCode is undefined and birthCountry is not France', async () => {
-
-        try {
-          checkValidation({ ...validAttributes, birthCountryCode: '12345', birthCityCode: undefined });
-        } catch (e) {
-          expect.fail('SchoolingRegistration is valid when birthCity is undefined and birthCountry is not France');
-        }
-      });
-
-      it('throw an error when birthCityCode has not 5 characters', async () => {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCityCode: '1' });
-
-        expect(error.key).to.equal('birthCityCode');
-        expect(error.why).to.equal('length');
-        expect(error.limit).to.equal(5);
+      context('is invalid', () => {
+        context('when birthCountryCode is equal to France', () => {
+          it('throw an error with a birthCityCode of 5 characters', async () => {
+            const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '123456' });
+    
+            expect(error.key).to.equal('birthCityCode');
+            expect(error.why).to.equal('length');
+            expect(error.limit).to.equal(5);
+          });
+    
+          it('throws an error with a birthCityCode which has a letter not in second character', async () => {
+            const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: FRANCE_COUNTRY_CODE, birthCityCode: '21B22' });
+    
+            expect(error.key).to.equal('birthCityCode');
+            expect(error.why).to.equal('not_valid_insee_code');
+          });
+        });
+        
+        context('when birthCountryCode is not equal to France', () => {
+          it('throws an error with a birthCityCode of 256 characters', async () => {
+            const stringOf256Char = 'hZSJIp6WBhnZFxsnTxEQo1oSoWkRDSB8nQsbScrK9IfAmVGb1PFNdX333k6Tsn6YKHfebdRg2VryzQcY06GTm1sYIN9Y3B0uy1ZsZIFpZ3cQNLxnawaUfVQFylq1GFba9LNDowH7lISfn7HJbdf3hNawofdCbVNgRdw7ZAN8XdggDJUgyAs91GpQ6vCkrxa08AMYTI8QClkhUVazVGgwndtwN4EBG23K2AfayHKWVi6jSlPOgUrx4tgSAcxELxW2';
+            const error = await catchErr(checkValidation)({ ...validAttributes, birthCityCode: stringOf256Char });
+    
+            expect(error.key).to.equal('birthCityCode');
+            expect(error.why).to.equal('max_length');
+            expect(error.limit).to.equal(255);
+          });
+        });
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -113,9 +113,10 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
 
       context('when the data are not correct', () => {
         it('should throw an EntityValidationError with malformated birthDate', async () => {
+          const wrongData = 'aaaa';
           //given
           const input = `${schoolingRegistrationCsvColumns}
-          123F;Beatrix;The;Bride;Kiddo;Black Mamba;aaaaa;97422;;200;99100;ST;MEF1;Division 1;
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;${wrongData};97422;Shangai;200;99100;ST;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
           const parser = new SchoolingRegistrationParser(encodedInput, 123);
@@ -124,6 +125,36 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           
           //then
           expect(error).to.be.an.instanceOf(EntityValidationError);
+        });
+
+        it('should throw an EntityValidationError with malformated birthCountryCode', async () => {
+          //given
+          const wrongData = 'FRANC';
+          const input = `${schoolingRegistrationCsvColumns}
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;${wrongData};Shangai;200;;ST;MEF1;Division 1;
+          `;
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+
+          const error = await catchErr(parser.parse, parser)();
+          
+          //then
+          expect(error).to.be.an.instanceOf(CsvImportError);
+        });
+
+        it('should throw an EntityValidationError with malformated birthCityCode', async () => {
+          //given
+          const wrongData = 'A1234';
+          const input = `${schoolingRegistrationCsvColumns}
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;99100;France;200;${wrongData};ST;MEF1;Division 1;
+          `;
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+
+          const error = await catchErr(parser.parse, parser)();
+          
+          //then
+          expect(error).to.be.an.instanceOf(CsvImportError);
         });
 
         context('When the organization is Agriculture and file contain status AP', () => {


### PR DESCRIPTION
## :unicorn: Problème
Certains import des SCO Agri, ont des imports avec de mauvais code INSEE.

## :robot: Solution
Rajouter un paramètre de vérification du code INSEE afin qu'il soit valide.
## :rainbow: Remarques
> _RAS_

## :100: Pour tester
Se connecter avec `sco.admin@example.net` => lycée agricole => élèves => import CSV
enregistrer ces fichiers au format csv

**Code Pays :**
```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
456F;Juste;;;Leblanc;Cottonmouth;01/01/1780;51430;Shangai;99;FRANC;ST;MEF1;Division 2
```
KO

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
457F;Baby;;;Yoda;Cottonmouth;01/01/1780;51430;Shangai;99;A2222;ST;MEF1;Division 2
```
KO

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
457F;Import;;;Pays;Cottonmouth;01/01/1780;51430;Shangai;99;99200;ST;MEF1;Division 2
```
OK 

**CityCode FRANCE :**

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
458F;Léa;;;Corse;Cottonmouth;01/01/1780;A2214;Corse;99;99100;ST;MEF1;Division 2
```
KO

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
458F;Léa;;;Corse;Cottonmouth;01/01/1780;2A214;Corse;99;99100;ST;MEF1;Division 2
```
OK

```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
459F;Louise;;;Champagne;Cottonmouth;01/01/1780;51430;Shangai;99;99100;ST;MEF1;Division 2
```
OK