### PR TITLE
[INFRA] Faire que le DatabaseBuilder lance une exception quand son commit échoue

### DIFF
--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -25,8 +25,10 @@ module.exports = class DatabaseBuilder {
     } catch (err) {
       console.error(`Erreur dans databaseBuilder.commit() : ${err}`);
       this._purgeDirtiness();
+      throw err;
+    } finally {
+      this.databaseBuffer.objectsToInsert = [];
     }
-    this.databaseBuffer.objectsToInsert = [];
   }
 
   async clean() {


### PR DESCRIPTION
## :unicorn: Problème

À l'occasion d'une erreur de test sur la CI, on s'est rendu compte que quand le DatabaseBuilder.commit() échoue, il se contente d'imprimer un log et ne lance pas d'exception. Ce qui fait que le test continue et échoue plus loin et donne un message d'erreur qui n'est pas celui du DatabaseBuilder.

Voir PR #2165, et un exemple d'échec avec mauvais message d'erreur ici :

- https://app.circleci.com/pipelines/github/1024pix/pix/17672/workflows/26b95133-9108-428e-a0dc-f85c20187a02/jobs/155188

## :robot: Solution

Ne plus supprimer l'erreur dans le DatabaseBuilder.commit()

## :100: Pour tester

Par exemple, casser une condition d'unicité dans un test d'intégration (insérer deux fois le même identifiant). Avant la correction, ça doit échouer trop loin, après la correction, ça doit échouer pile au moment du commit.