### PR TITLE
[FEATURE] Utiliser le tag "POLE EMPLOI" pour l'envoi des résultats à Pôle Emploi (PIX-1562).

### DIFF
--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -72,6 +72,7 @@ module.exports = function organizationsProBuilder({ databaseBuilder }) {
     provinceCode: null,
     email: null,
   });
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: 4, tagId: 4 });
 
   databaseBuilder.factory.buildMembership({
     userId: proUser1.id,

--- a/api/db/seeds/data/tags-builder.js
+++ b/api/db/seeds/data/tags-builder.js
@@ -2,4 +2,5 @@ module.exports = function tagsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildTag({ id: 1, name: 'AGRICULTURE' });
   databaseBuilder.factory.buildTag({ id: 2, name: 'PUBLIC' });
   databaseBuilder.factory.buildTag({ id: 3, name: 'PRIVE' });
+  databaseBuilder.factory.buildTag({ id: 4, name: 'POLE EMPLOI' });
 };

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -1,7 +1,7 @@
 const Tag = require('./Tag');
 
 const types = {
-  SCO : 'SCO',
+  SCO: 'SCO',
   SUP: 'SUP',
   PRO: 'PRO',
 };
@@ -66,7 +66,7 @@ class Organization {
   }
 
   get isPoleEmploi() {
-    return process.env['POLE_EMPLOI_ORGANIZATION_ID'] === this.id.toString();
+    return Boolean(this.tags.find((tag) => tag.name === Tag.POLE_EMPLOI));
   }
 }
 

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -61,8 +61,7 @@ class Organization {
   }
 
   get isAgriculture() {
-    const tagsName = this.tags.map((tag) => tag.name);
-    return this.isSco && tagsName.includes(Tag.AGRICULTURE);
+    return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AGRICULTURE));
   }
 
   get isPoleEmploi() {

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -11,4 +11,5 @@ class Tag {
   }
 }
 Tag.AGRICULTURE = 'AGRICULTURE';
+Tag.POLE_EMPLOI = 'POLE EMPLOI';
 module.exports = Tag;

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -141,29 +141,23 @@ describe('Unit | Domain | Models | Organization', () => {
   });
 
   describe('get#isPoleEmploi', () => {
-    beforeEach(() => {
-      process.env['POLE_EMPLOI_ORGANIZATION_ID'] = '1';
-    });
-
-    afterEach(() => {
-      process.env['POLE_EMPLOI_ORGANIZATION_ID'] = null;
-    });
-
-    it('should return true when organization id match Environnement variable POLE_EMPLOI_ORGANIZATION_ID', () => {
+    it('should return false when the organization has not the "POLE_EMPLOI" tag', () => {
       // given
-      const organization = domainBuilder.buildOrganization({ id: '1' });
-
-      // when / then
-      expect(organization.isPoleEmploi).is.true;
-    });
-
-    it('should return false when when organization id doesnt match Environnement variable POLE_EMPLOI_ORGANIZATION_ID', () => {
-      // given
-      const organization = domainBuilder.buildOrganization({ id: '2' });
+      const tag = domainBuilder.buildTag({ name: Tag.AGRICULTURE });
+      const organization = domainBuilder.buildOrganization({ tags: [tag] });
 
       // when / then
       expect(organization.isPoleEmploi).is.false;
     });
-  });
 
+    it('should return true when organization has the "POLE_EMPLOI" tag', () => {
+      // given
+      const tag1 = domainBuilder.buildTag({ name: Tag.POLE_EMPLOI });
+      const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+      const organization = domainBuilder.buildOrganization({ tags: [tag1, tag2] });
+
+      // when / then
+      expect(organization.isPoleEmploi).is.true;
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'à maintenant on identifiait une campagne pôle emploi par un ID d'organisation spécifiée pour chaque environnement. Cette utilisation est obsolète puisque les tags existent désormais.

## :robot: Solution
Migrer la logique d'ID d'organisation vers celle du taggage des organisations.

## :rainbow: Remarques
Penser à supprimer les variables d'environnement sur l'intégration et la recette notamment.

## :100: Pour tester
Participer en tant que userpix1@example.net à la campagne QWERTY789, et partager ses résultats. Regarder dans les logs que l'envoi s'est bien effectué.
