### PR TITLE
[TECH] Supprimer le mot déploiement du CR de CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ version: 2.0
 
 workflows:
   version: 2
-  build-test-and-deploy:
+  build-and-test:
     jobs:
       - checkout:
           filters:


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un nouveau arrive sur Pix, il se dit qu'on déploie vraiment beaucoup !
![image](https://user-images.githubusercontent.com/56302715/99637028-90c67500-2a44-11eb-8a91-08ed4b869b66.png)

## :robot: Solution
Supprimer `deploy`du nom du workflow de CI

```
workflows:
  version: 2
  build-test-and-deploy:
```

## :rainbow: Remarques
J'espère ne pas passer pour un psycho-rigide sur cette PR
Pour les curieux, le sha qui introduit le mot `deploy` est de @twickham en 2018 a7647958b71768f2c3c53509ca25370826f7b09c


## :100: Pour tester
Vérifier que la CI est exécutée sur cette PR
