### PR TITLE
[FEATURE] Correction de l'affichage Pix-Concours (PIX-1635).

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -26,8 +26,4 @@ export default class NavbarDesktopHeader extends Component {
   get _isExternalUser() {
     return this.session.get('data.externalUser');
   }
-
-  get hasNotFinishedPixContest() {
-    return !this.currentUser.user.finishedPixContestAt;
-  }
 }

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -37,7 +37,7 @@
     {{/unless}}
 
     {{#if isUserLogged}}
-      {{#if this.hasNotFinishedPixContest}}
+      {{#unless @isPixContest}}
       <ul class="navbar-desktop-header-container__campaign-menu">
         <li class="navbar-desktop-header-campaign-menu__item">
           <LinkTo @route="fill-in-campaign-code"
@@ -46,7 +46,7 @@
           </LinkTo>
         </li>
       </ul>
-      {{/if}}
+      {{/unless}}
     {{/if}}
 
     <!-- Links (right) -->

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -10,7 +10,7 @@
             {{t 'pages.profile.pix-contest.title' }}
           </div>
       </div>
-      <p class="rounded-panel-header-text__content rounded-panel-rules">{{t 'pages.profile.pix-contest.rules'}}</p>
+      <p class="rounded-panel-header-text__content rounded-panel-rules">{{t 'pages.profile.pix-contest.rules' htmlSafe=true}}</p>
       <div class="rounded-panel-header-text__content rounded-panel-links">
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link1' htmlSafe=true}}</p>
         {{t 'pages.profile.pix-contest.descriptions.description1'}}

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -13,10 +13,15 @@
       <p class="rounded-panel-header-text__content rounded-panel-rules">{{t 'pages.profile.pix-contest.rules'}}</p>
       <div class="rounded-panel-header-text__content rounded-panel-links">
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link1' htmlSafe=true}}</p>
+        {{t 'pages.profile.pix-contest.descriptions.description1'}}
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link2' htmlSafe=true}}</p>
+        {{t 'pages.profile.pix-contest.descriptions.description2'}}
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link3' htmlSafe=true}}</p>
+        {{t 'pages.profile.pix-contest.descriptions.description3'}}
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link4' htmlSafe=true}}</p>
+        {{t 'pages.profile.pix-contest.descriptions.description4'}}
         <p class="rounded-panel-links__link">{{t 'pages.profile.pix-contest.links.link5' htmlSafe=true}}</p>
+        {{t 'pages.profile.pix-contest.descriptions.description5'}}
       </div>
       <div class="rounded-panel-header-text__content rounded-panel-send-results">
         <p class="rounded-panel-send-results__instructions">{{t 'pages.profile.pix-contest.send-results.instructions'}}</p>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -643,6 +643,13 @@
             "first-title": "You have 16 skills to test. '<br>'Get your thinking hat on and off we go!",
             "pix-contest": {
                 "title": "",
+                "descriptions": {
+                    "description1": "",
+                    "description2": "",
+                    "description3": "",
+                    "description4": "",
+                    "description5": ""
+                },
                 "links": {
                     "link1": "",
                     "link2": "",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -76,8 +76,15 @@
                 "title": "Begin your personalised test",
                 "action": "Begin",
                 "announcement": "Start your personalised test.'<br>' Sign up or log in to the Pix platform and start your test.",
+                "certify": {
+                    "title": "Prepare a certification recognised throughout Europe and in the business world",
+                    "description": "The Pix Certification enables you to highlight your digital skills to employers."
+                },
                 "details": "During this personalised test, you will be able to:",
-                "legal": "Information about your progress will be sent to the organiser so they can provide support. Your test results will only be shared with your permission.",
+                "develop": {
+                    "title": "See your results as you go along and view tips to improve.",
+                    "description": "Every 5 questions, you will be able to see your results and watch tutorials to help you improve your skills."
+                },
                 "evaluate": {
                     "title": "Assess your digital skills with fun tests on different subjects, such as:",
                     "complement": "The Pix public service for the assessment and certification of digital skills enables assessment of your level in 5 major skill areas covering current uses of digital technology.",
@@ -87,14 +94,7 @@
                         "label": "Find out more."
                     }
                 },
-                "certify": {
-                    "title": "Prepare a certification recognised throughout Europe and in the business world",
-                    "description": "The Pix Certification enables you to highlight your digital skills to employers."
-                },
-                "develop": {
-                    "title": "See your results as you go along and view tips to improve.",
-                    "description": "Every 5 questions, you will be able to see your results and watch tutorials to help you improve your skills."
-                }
+                "legal": "Information about your progress will be sent to the organiser so they can provide support. Your test results will only be shared with your permission."
             },
             "profiles-collection": {
                 "title": "Submit your profile",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -809,7 +809,7 @@
             "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
             "pix-contest": {
                 "link": "Cliquez ici pour être redirigé sur la page d'accueil",
-                "title": "Bravo, vous avez terminé ce module!"
+                "title": "Vous avez terminé ce module!"
             },
             "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
             "send-status": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -643,6 +643,13 @@
             "first-title": "Vous avez 16 compétences à tester. '<br>'On se concentre et c'est partix&nbsp;!",
             "pix-contest": {
                 "title": "Bienvenue dans cette session Pix-concours.",
+                "descriptions": {
+                    "description1": "Texte à modifier 1",
+                    "description2": "Texte à modifier 2",
+                    "description3": "Texte à modifier 3",
+                    "description4": "Texte à modifier 4",
+                    "description5": "Texte à modifier 5"
+                },
                 "links": {
                     "link1": "'<a href=\"/campagnes/CAMPTEST\">'Module 1'</a>'",
                     "link2": "'<a href=\"Second lien\">'Nom du second module'</a>'",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -75,9 +75,9 @@
             "assessment": {
                 "title": "Commencez votre parcours",
                 "action": "Je commence",
-                "announcement": "Démarrez votre parcours d'évaluation personnalisé.'<br>' Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
+                "announcement": "",
                 "details": "Durant ce parcours, vous aurez l’opportunité de :",
-                "legal": "Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre de vous accompagner. Les résultats des tests ne seront transmis qu’avec votre consentement.",
+                "legal": "",
                 "evaluate": {
                     "title": "Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :",
                     "complement": "Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -661,7 +661,7 @@
                 "send-results": {
                     "button": "J'envoie ma copie",
                     "finished": "Votre copie a bien été transmise.",
-                    "instructions": "Instructions à modifier"
+                    "instructions": "Tout envoi de copie est définitif."
                 }
             },
             "resume-campaign-banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -644,20 +644,20 @@
             "pix-contest": {
                 "title": "Bienvenue dans cette session Pix-concours.",
                 "descriptions": {
-                    "description1": "Texte à modifier 1",
-                    "description2": "Texte à modifier 2",
-                    "description3": "Texte à modifier 3",
-                    "description4": "Texte à modifier 4",
-                    "description5": "Texte à modifier 5"
+                    "description1": "Nombre de questions posées : xxx / Temps approximatif pour passer le module : xxx minutes",
+                    "description2": "Nombre de questions posées : xxx / Temps approximatif pour passer le module : xxx minutes",
+                    "description3": "Nombre de questions posées : xxx / Temps approximatif pour passer le module : xxx minutes",
+                    "description4": "Nombre de questions posées : xxx / Temps approximatif pour passer le module : xxx minutes",
+                    "description5": "Nombre de questions posées : xxx / Temps approximatif pour passer le module : xxx minutes"
                 },
                 "links": {
-                    "link1": "'<a href=\"/campagnes/CAMPTEST\">'Module 1'</a>'",
-                    "link2": "'<a href=\"Second lien\">'Nom du second module'</a>'",
-                    "link3": "'<a href=\"Troisième lien\">'Nom du troisième module'</a>'",
-                    "link4": "'<a href=\"Quatrième lien\">'Nom du quatrième module'</a>'",
-                    "link5": "'<a href=\"Cinquième lien\">'Nom du cinquième module'</a>'"
+                    "link1": "'<a href=\"/campagnes/CAMPTEST\">'Module Développer des documents textuels'</a>'",
+                    "link2": "'<a href=\"Second lien\">'Module Mener une recherche et une veille d’information'</a>'",
+                    "link3": "'<a href=\"Troisième lien\">'Module Gérer des données'</a>'",
+                    "link4": "'<a href=\"Quatrième lien\">'Module Traiter des données'</a>'",
+                    "link5": "'<a href=\"Cinquième lien\">'Module Interagir/partager des données'</a>'"
                 },
-                "rules": "Règles de l'épreuve",
+                "rules": "Rappel :'<br>'- Vous pouvez passer les modules dans l’ordre que vous voulez '<br>'- Vous pouvez arrêter et reprendre votre module '<br>'- Une fois la question validée, il n’est pas possible de modifier votre réponse",
                 "send-results": {
                     "button": "J'envoie ma copie",
                     "finished": "Votre copie a bien été transmise.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -76,8 +76,15 @@
                 "title": "Commencez votre parcours",
                 "action": "Je commence",
                 "announcement": "",
+                "certify": {
+                    "title": "Préparer une certification reconnue par l’État et le monde professionnel",
+                    "description": "La certification Pix permet de valoriser ses compétences numériques auprès des employeurs."
+                },
                 "details": "Durant ce parcours, vous aurez l’opportunité de :",
-                "legal": "",
+                "develop": {
+                    "title": "Découvrir vos résultats au fil du test et consulter des indices pour progresser.",
+                    "description": "Après 5 épreuves, vous pouvez visualiser vos réponses et suivre des tutos pour développer vos compétences."
+                },
                 "evaluate": {
                     "title": "Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :",
                     "complement": "Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.",
@@ -87,14 +94,7 @@
                         "label": "En savoir plus."
                     }
                 },
-                "develop": {
-                    "title": "Découvrir vos résultats au fil du test et consulter des indices pour progresser.",
-                    "description": "Après 5 épreuves, vous pouvez visualiser vos réponses et suivre des tutos pour développer vos compétences."
-                },
-                "certify": {
-                    "title": "Préparer une certification reconnue par l’État et le monde professionnel",
-                    "description": "La certification Pix permet de valoriser ses compétences numériques auprès des employeurs."
-                }
+                "legal": ""
             },
             "profiles-collection": {
                 "title": "Envoyez votre profil",


### PR DESCRIPTION
## :unicorn: Problème

Plusieurs éléments à retirer / modifier / ajouter dans Pix-Concours

## :robot: Solution

- Retirer le "Bravo" dans le message à la fin d'un parcours
- Ajouter des entrées dans le fichier de trad pour saisir du contenu entre chacun des modules dans la liste page profil
- Retirer le bouton "j'ai un code" du header
- Retirer le texte surligné en jaune dans la page “Début de parcours” avec le CTA “Commencez”
- Update du texte de la homepage

## :100: Pour tester

Naviguer dans Pix-Concours
