### PR TITLE
[FEATURE] Créer de la pagination sur l'ajout des élèves pour les établissements SCO (Pix-1588)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -37,7 +37,14 @@ module.exports = {
     const userId = parseInt(request.auth.credentials.userId);
     const certificationCenterId = parseInt(request.params.certificationCenterId);
     const sessionId = parseInt(request.params.sessionId);
-    const students = await usecases.findStudentsForEnrollement({ userId, certificationCenterId, sessionId });
-    return studentCertificationSerializer.serialize(students);
+    const { page } = queryParamsUtils.extractParameters(request.query);
+    const { data, pagination } = await usecases.findStudentsForEnrollement(
+      {
+        userId,
+        certificationCenterId,
+        sessionId,
+        page,
+      });
+    return studentCertificationSerializer.serialize(data, pagination);
   },
 };

--- a/api/lib/domain/usecases/find-students-for-enrollement.js
+++ b/api/lib/domain/usecases/find-students-for-enrollement.js
@@ -4,17 +4,25 @@ const StudentForEnrollement = require('../read-models/StudentForEnrollement');
 module.exports = async function findStudentsForEnrollement({
   certificationCenterId,
   sessionId,
+  page,
   organizationRepository,
   schoolingRegistrationRepository,
   certificationCandidateRepository,
 }) {
   try {
     const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
-    const students = await schoolingRegistrationRepository.findByOrganizationIdOrderByDivision({ organizationId });
+    const paginatedStudents = await schoolingRegistrationRepository.findByOrganizationIdOrderByDivision({ page, organizationId });
     const certificationCandidates = await certificationCandidateRepository.findBySessionId(sessionId);
-    return _buildStudentsForEnrollement({ students, certificationCandidates });
+    return {
+      data: _buildStudentsForEnrollement({ students: paginatedStudents.data, certificationCandidates }),
+      pagination: paginatedStudents.pagination,
+    };
   } catch (error) {
-    if (error instanceof NotFoundError) return [];
+    // This should not happen but still might (due to missing data in database)
+    // in that case, handle error gracefully.
+    // The error will be handled properly in the future.
+    if (error instanceof NotFoundError) return _emptyResponse(page);
+
     throw error;
   }
 };
@@ -23,4 +31,11 @@ function _buildStudentsForEnrollement({ students, certificationCandidates }) {
   return students.map((student) =>
     StudentForEnrollement.fromStudentsAndCertificationCandidates({ student, certificationCandidates }),
   );
+}
+
+function _emptyResponse(page) {
+  return {
+    data: [],
+    pagination: { page: page.number, pageSize: page.size, rowCount: 0, pageCount: 0 },
+  };
 }

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -57,20 +57,27 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations);
   },
 
-  _findByOrganizationId({ organizationId, orderByRaw }) {
+  findByOrganizationId({ organizationId }) {
     return BookshelfSchoolingRegistration
       .where({ organizationId })
-      .query((qb) => qb.orderByRaw(orderByRaw))
+      .query((qb) => qb.orderByRaw('LOWER("lastName") ASC, LOWER("firstName") ASC'))
       .fetchAll()
       .then((schoolingRegistrations) => bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations));
   },
 
-  findByOrganizationId({ organizationId }) {
-    return this._findByOrganizationId({ organizationId, orderByRaw: 'LOWER("lastName") ASC, LOWER("firstName") ASC' });
-  },
+  async findByOrganizationIdOrderByDivision({ organizationId, page }) {
+    const { models, pagination } = await BookshelfSchoolingRegistration
+      .where({ organizationId })
+      .query((qb) => qb.orderByRaw('LOWER("division") ASC, LOWER("lastName") ASC, LOWER("firstName") ASC'))
+      .fetchPage({
+        page: page.number,
+        pageSize: page.size,
+      });
 
-  findByOrganizationIdOrderByDivision({ organizationId }) {
-    return this._findByOrganizationId({ organizationId, orderByRaw: 'LOWER("division") ASC, LOWER("lastName") ASC, LOWER("firstName") ASC' });
+    return {
+      data: bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, models),
+      pagination,
+    };
   },
 
   async findByUserId({ userId }) {

--- a/api/lib/infrastructure/serializers/jsonapi/student-certification-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/student-certification-serializer.js
@@ -1,7 +1,7 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(students) {
+  serialize(students, pagination) {
     return new Serializer('students', {
       attributes: [
         'lastName',
@@ -10,6 +10,7 @@ module.exports = {
         'division',
         'isEnrolled',
       ],
+      meta: pagination,
     }).serialize(students);
   },
 };

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -225,14 +225,14 @@ describe('Acceptance | API | Certification Center', () => {
     function _buildSchoolinRegistrationsWithConnectedUserRequest(user, certificationCenter, session) {
       return {
         method: 'GET',
-        url: '/api/certification-centers/' + certificationCenter.id + '/sessions/' + session.id + '/students',
+        url: '/api/certification-centers/' + certificationCenter.id + '/sessions/' + session.id + '/students?page[size]=10&page[number]=1',
         headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
       };
     }
     function _buildSchoolinRegistrationsNotConnectedUserRequest(certificationCenter, session) {
       return {
         method: 'GET',
-        url: '/api/certification-centers/' + certificationCenter.id + '/sessions/' + session.id + '/students',
+        url: '/api/certification-centers/' + certificationCenter.id + '/sessions/' + session.id + '/students?page[size]=10&page[number]=1',
       };
     }
 

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -19,28 +19,37 @@ describe('Unit | Controller | certifications-center-controller', () => {
           certificationCenterId: '99',
           sessionId: '88',
         },
+        query: { 'page[size]': 10, 'page[number]': 1 },
       };
-      const expectedSerializedStudents = { data: [{
-        'attributes': {
-          'birthdate': student.birthdate,
-          'division': student.division,
-          'first-name': student.firstName,
-          'last-name': student.lastName,
-        },
-        'id': student.id + '',
-        'type': 'students',
-      }] };
 
       sinon
         .stub(usecases, 'findStudentsForEnrollement')
-        .withArgs({ userId: 111, certificationCenterId: 99, sessionId: 88 })
-        .resolves([student]);
+        .withArgs({ userId: 111, certificationCenterId: 99, sessionId: 88, page: { size: 10, number: 1 } })
+        .resolves({
+          data: [student],
+          pagination: { page: 1, pageSize: 10, rowCount: 1, pageCount: 1 },
+        });
 
       // when
       const response = await certificationCenterController.getStudents(request, hFake);
 
       // then
-      expect(response).to.deep.equal(expectedSerializedStudents);
+      expect(response).to.deep.equal(
+        {
+          data: [{
+            'attributes': {
+              'birthdate': student.birthdate,
+              'division': student.division,
+              'first-name': student.firstName,
+              'last-name': student.lastName,
+            },
+            'id': `${student.id}`,
+            'type': 'students',
+
+          }],
+          meta: { page: 1, pageSize: 10, rowCount: 1, pageCount: 1 },
+        },
+      );
     });
   });
 

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -1,0 +1,47 @@
+const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
+
+const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | Controller | certifications-center-controller', () => {
+
+  describe('#getStudents', () => {
+
+    it('should return a paginated serialized list of students', async () => {
+      // given
+      const student = domainBuilder.buildSchoolingRegistration();
+
+      const request = {
+        auth: {
+          credentials: { userId: '111' },
+        },
+        params: {
+          certificationCenterId: '99',
+          sessionId: '88',
+        },
+      };
+      const expectedSerializedStudents = { data: [{
+        'attributes': {
+          'birthdate': student.birthdate,
+          'division': student.division,
+          'first-name': student.firstName,
+          'last-name': student.lastName,
+        },
+        'id': student.id + '',
+        'type': 'students',
+      }] };
+
+      sinon
+        .stub(usecases, 'findStudentsForEnrollement')
+        .withArgs({ userId: 111, certificationCenterId: 99, sessionId: 88 })
+        .resolves([student]);
+
+      // when
+      const response = await certificationCenterController.getStudents(request, hFake);
+
+      // then
+      expect(response).to.deep.equal(expectedSerializedStudents);
+    });
+  });
+
+});

--- a/certif/app/adapters/student.js
+++ b/certif/app/adapters/student.js
@@ -2,13 +2,13 @@ import ApplicationAdapter from './application';
 
 export default class StudentAdapter extends ApplicationAdapter {
 
-  urlForFindAll(modelName, snapshot) {
-    const certificationCenterId = snapshot.adapterOptions && snapshot.adapterOptions.certificationCenterId;
-    const sessionId = snapshot.adapterOptions && snapshot.adapterOptions.sessionId;
-
-    if (certificationCenterId && sessionId) {
+  urlForQuery(query) {
+    const { sessionId, certificationCenterId } = query.filter;
+    if (sessionId && certificationCenterId) {
+      delete query.filter.sessionId;
+      delete query.filter.certificationCenterId;
       return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/sessions/${sessionId}/students`;
     }
-    return super.urlForFindAll(...arguments);
-  }
+    return super.urlForQuery(...arguments);
+  } 
 }

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -76,7 +76,7 @@
           Annuler
         </LinkTo>
         <PixButton {{on 'click' this.enrollStudents}}
-          class="bottom-action-bar__actions--add-button button button--link {{if this.hasCheckedSomething "" "button--disabled"}}">
+          class="bottom-action-bar__actions--add-button button button--link {{if this.shouldEnableAddButton "" "button--disabled"}}">
           Ajouter
         </PixButton>
       </div>

--- a/certif/app/components/add-student-list.hbs
+++ b/certif/app/components/add-student-list.hbs
@@ -48,6 +48,8 @@
     </tbody>
   </table>
 
+  <PaginationControl @pagination={{@studentList.meta}}/>
+
   {{#if this.showStickyBar}}
     <div class="add-student-list__bottom-action-bar">
 

--- a/certif/app/components/pagination-control.hbs
+++ b/certif/app/components/pagination-control.hbs
@@ -7,7 +7,7 @@
         <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>
         <option value="100" selected="{{if (eq this.pageSize 100) true}}">100</option>
       </select>
-      <FaIcon class='page-size__choice--icon' @icon='sort'></FaIcon>
+      <FaIcon class="page-size__choice--icon" @icon="sort" aria-label="Nombre d'étudiants par page"/>
     </div>
   </div>
   <div class="page-navigation">
@@ -19,7 +19,7 @@
         @replace={{true}}
         class="icon-button icon-button--link"
       >
-        <FaIcon @icon='arrow-left'></FaIcon>
+        <FaIcon @icon="arrow-left" aria-label="Page précédente"/>
       </LinkTo>
     </div>
     <div>
@@ -34,7 +34,7 @@
         @replace={{true}}
         class="icon-button icon-button--link"
       >
-        <FaIcon @icon='arrow-right'></FaIcon>
+        <FaIcon @icon="arrow-right" aria-label="Page suivante"/>
       </LinkTo>
     </div>
   </div>

--- a/certif/app/components/pagination-control.hbs
+++ b/certif/app/components/pagination-control.hbs
@@ -3,10 +3,9 @@
     <div class="page-size__label">Voir</div>
     <div class="page-size__choice">
       <select class="content-text content-text--small" {{on "change" this.changePageSize}}>
-        <option value="1" selected="{{if (eq this.pageSize 1) true}}">1</option>
-        <option value="2" selected="{{if (eq this.pageSize 2) true}}">2</option>
-        <option value="5" selected="{{if (eq this.pageSize 5) true}}">5</option>
-        <option value="10" selected="{{if (eq this.pageSize 10) true}}">10</option>
+        <option value="25" selected="{{if (eq this.pageSize 25) true}}">25</option>
+        <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>
+        <option value="100" selected="{{if (eq this.pageSize 100) true}}">100</option>
       </select>
       <FaIcon class='page-size__choice--icon' @icon='sort'></FaIcon>
     </div>

--- a/certif/app/components/pagination-control.hbs
+++ b/certif/app/components/pagination-control.hbs
@@ -1,0 +1,42 @@
+<div class="pagination-control content-text content-text--small">
+  <div class="page-size">
+    <div class="page-size__label">Voir</div>
+    <div class="page-size__choice">
+      <select class="content-text content-text--small" {{on "change" this.changePageSize}}>
+        <option value="1" selected="{{if (eq this.pageSize 1) true}}">1</option>
+        <option value="2" selected="{{if (eq this.pageSize 2) true}}">2</option>
+        <option value="5" selected="{{if (eq this.pageSize 5) true}}">5</option>
+        <option value="10" selected="{{if (eq this.pageSize 10) true}}">10</option>
+      </select>
+      <FaIcon class='page-size__choice--icon' @icon='sort'></FaIcon>
+    </div>
+  </div>
+  <div class="page-navigation">
+    <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq this.currentPage 1) "page-navigation__arrow--disabled"}}">
+      <LinkTo
+        aria-label="Aller à la page précédente"
+        @query={{hash pageNumber=this.previousPage}}
+        @disabledWhen={{eq this.currentPage 1}}
+        @replace={{true}}
+        class="icon-button icon-button--link"
+      >
+        <FaIcon @icon='arrow-left'></FaIcon>
+      </LinkTo>
+    </div>
+    <div>
+      Page {{this.currentPage}} / {{this.pageCount}}
+    </div>
+
+    <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq this.currentPage this.pageCount) "page-navigation__arrow--disabled"}}">
+      <LinkTo
+        aria-label="Aller à la page suivante"
+        @query={{hash pageNumber=this.nextPage}}
+        @disabledWhen={{eq this.currentPage this.pageCount}}
+        @replace={{true}}
+        class="icon-button icon-button--link"
+      >
+        <FaIcon @icon='arrow-right'></FaIcon>
+      </LinkTo>
+    </div>
+  </div>
+</div>

--- a/certif/app/components/pagination-control.js
+++ b/certif/app/components/pagination-control.js
@@ -1,0 +1,33 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class PaginationControl extends Component {
+
+  @service router;
+
+  get currentPage() {
+    return this.args.pagination ? this.args.pagination.page : 1;
+  }
+
+  get pageCount() {
+    return this.args.pagination ? this.args.pagination.pageCount : 0;
+  }
+
+  get pageSize() {
+    return this.args.pagination ? this.args.pagination.pageSize : 10;
+  }
+
+  get nextPage() {
+    return Math.min(this.currentPage + 1, this.pageCount);
+  }
+
+  get previousPage() {
+    return Math.max(this.currentPage - 1, 1);
+  }
+
+  @action
+  changePageSize(event) {
+    this.router.replaceWith({ queryParams: { pageSize: event.target.value, pageNumber: 1 } });
+  }
+}

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -39,9 +39,10 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     );
   }
 
-  // TODO : reset page courante + taille de page
   resetController(controller, isExiting) {
     if (isExiting) {
+      controller.set('pageSize', undefined);
+      controller.set('pageNumber', undefined);
       const allStudentsInStore = this.store.peekAll('student');
       allStudentsInStore.forEach((student) => {
         student.isSelected = false;

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -11,6 +11,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     const session = await this.store.findRecord('session', params.session_id);
     const { id: certificationCenterId } = this.modelFor('authenticated');
 
+    const certificationCandidates = await this.store.query('certification-candidate', { sessionId:params.session_id });
     const DEFAULT_PAGE_SIZE = 50;
     const FIRST_PAGE_NUMBER = 1;
     const students = await this.store.query('student',
@@ -26,7 +27,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
       },
     );
 
-    return { session, students };
+    return { session, students, numberOfEnrolledStudents: certificationCandidates.length };
   }
 
   setupController(controller, model) {
@@ -38,6 +39,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     );
   }
 
+  // TODO : reset page courante + taille de page
   resetController(controller, isExiting) {
     if (isExiting) {
       const allStudentsInStore = this.store.peekAll('student');

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -1,12 +1,27 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
+  queryParams = {
+    pageNumber: { refreshModel: true },
+    pageSize: { refreshModel: true },
+  };
+
   async model(params) {
     const session = await this.store.findRecord('session', params.session_id);
     const { id: certificationCenterId } = this.modelFor('authenticated');
 
-    const students = await this.store.findAll('student',
-      { adapterOptions : { certificationCenterId, sessionId: session.id } },
+    const students = await this.store.query('student',
+      {
+        page: {
+          number: params.pageNumber,
+          size: params.pageSize,
+        },
+        filter : {
+          certificationCenterId,
+          sessionId: session.id,
+        } ,
+      },
     );
 
     return { session, students };
@@ -28,5 +43,10 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
         student.isSelected = false;
       });
     }
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -11,11 +11,13 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
     const session = await this.store.findRecord('session', params.session_id);
     const { id: certificationCenterId } = this.modelFor('authenticated');
 
+    const DEFAULT_PAGE_SIZE = 50;
+    const FIRST_PAGE_NUMBER = 1;
     const students = await this.store.query('student',
       {
         page: {
-          number: params.pageNumber,
-          size: params.pageSize,
+          number: params.pageNumber || FIRST_PAGE_NUMBER,
+          size: params.pageSize || DEFAULT_PAGE_SIZE,
         },
         filter : {
           certificationCenterId,

--- a/certif/app/styles/app.scss
+++ b/certif/app/styles/app.scss
@@ -36,6 +36,7 @@
 @import "components/session-finalization-reports-informations-step";
 @import "components/session-finalization-formbuilder-link-step";
 @import "components/session-finalization-examiner-global-comment-step";
+@import "components/pagination-control.scss";
 
 body, html{
   margin: 0;

--- a/certif/app/styles/components/pagination-control.scss
+++ b/certif/app/styles/components/pagination-control.scss
@@ -1,0 +1,69 @@
+.pagination-control {
+    display: flex;
+    justify-content: space-between;
+    margin: 16px 0;
+    font-weight: 500;
+  }
+
+  .page-size {
+    display: flex;
+    align-items: center;
+
+    &__label {
+      margin-right: 16px;
+    }
+
+    &__choice {
+      position: relative;
+      display: flex;
+      align-items: center;
+      color: $grey-70;
+
+      select {
+        height: 35px;
+        width: 70px;
+        background-color: $grey-20;
+        border: none;
+        border-radius: 5px;
+        padding-left: 8px;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+      }
+
+      select::-ms-expand {
+        display: none;
+      }
+
+      &--icon {
+        right: 8px;
+        position: absolute;
+        pointer-events: none;
+        top: calc(50% - 6px);
+      }
+    }
+  }
+
+  .page-navigation {
+    display: flex;
+    align-items: center;
+
+    &__arrow {
+      &--disabled .icon-button{
+        color: $grey-22;
+        cursor: default;
+
+        &.icon-button:hover, &.icon-button:active {
+          background-color: transparent;
+        }
+      }
+
+      &--previous {
+        margin-right: 8px;
+      }
+
+      &--next {
+        margin-left: 8px;
+      }
+    }
+  }

--- a/certif/app/styles/components/pagination-control.scss
+++ b/certif/app/styles/components/pagination-control.scss
@@ -1,7 +1,7 @@
 .pagination-control {
     display: flex;
     justify-content: space-between;
-    margin: 16px 0;
+    padding: 8px 28px;
     font-weight: 500;
   }
 

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,5 +1,5 @@
 .add-student {
-
+margin-bottom: 68px;
   &__return-to span {
     color: $blue-zodia;
   }

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -10,5 +10,6 @@
   <AddStudentList
     @studentList={{@model.students}}
     @session={{@model.session}}
+    @numberOfEnrolledStudents={{@model.numberOfEnrolledStudents}}
     @returnToSessionCandidates={{this.returnToSessionCandidates}} />
 </div>

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -1,5 +1,6 @@
 import Response from 'ember-cli-mirage/response';
 import { upload } from 'ember-file-upload/mirage';
+import { findPaginatedStudents } from './handlers/find-paginated-students';
 
 function parseQueryString(queryString) {
   const result = Object.create(null);
@@ -21,9 +22,7 @@ export default function() {
     return schema.sessions.where({ certificationCenterId });
   });
 
-  this.get('/certification-centers/:certificationCenterId/sessions/:sessionId/students', (schema) => {
-    return schema.students.all();
-  });
+  this.get('/certification-centers/:certificationCenterId/sessions/:sessionId/students', findPaginatedStudents);
 
   this.post('/revoke', () => {});
 

--- a/certif/mirage/handlers/find-paginated-students.js
+++ b/certif/mirage/handlers/find-paginated-students.js
@@ -1,0 +1,20 @@
+import { getPaginationFromQueryParams, applyPagination } from './pagination-utils';
+
+export function findPaginatedStudents(schema, request) {
+  const queryParams = request.queryParams;
+  const students = schema.students.all();
+
+  const rowCount = students.length;
+
+  const pagination = getPaginationFromQueryParams(queryParams);
+  const paginatedStudents = applyPagination(students.models, pagination);
+
+  const json = this.serialize({ modelName: 'student', models: paginatedStudents }, 'student');
+  json.meta = {
+    page: pagination.page,
+    pageSize: pagination.pageSize,
+    rowCount,
+    pageCount: Math.ceil(rowCount / pagination.pageSize),
+  };
+  return json;
+}

--- a/certif/mirage/handlers/pagination-utils.js
+++ b/certif/mirage/handlers/pagination-utils.js
@@ -1,0 +1,15 @@
+import slice from 'lodash/slice';
+
+export function getPaginationFromQueryParams(queryParams) {
+  return {
+    pageSize: parseInt(queryParams['page[size]'] ||  10),
+    page: parseInt(queryParams['page[number]'] || 1),
+  };
+}
+
+export function applyPagination(data, { page, pageSize }) {
+  const start = (page - 1) * pageSize;
+  const end = start + pageSize;
+
+  return slice(data, start, end);
+}

--- a/certif/mirage/serializers/student.js
+++ b/certif/mirage/serializers/student.js
@@ -1,0 +1,4 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+});

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -76,18 +76,17 @@ module('Acceptance | Session Add Students', function(hooks) {
 
       const rowSelector = '.add-student-list table tbody tr';
 
-      module('when there are no enrolled students', function(hooks) {
+      module('when there are no enrolled students', function() {
+        const DEFAULT_PAGE_SIZE = 10;
 
-        hooks.beforeEach(async () => {
+        test('it should show first page of students (with default size)', async function(assert) {
           // given
-          server.createList('student', 10, { isSelected: false, isEnrolled: false });
+          server.createList('student', DEFAULT_PAGE_SIZE + 2, { isSelected: false, isEnrolled: false });
           await visit(`/sessions/${session.id}/ajout-eleves`);
-        });
 
-        test('it should show all students', async function(assert) {
           // then
           const allRow = document.querySelectorAll(rowSelector);
-          assert.equal(allRow.length, 10);
+          assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
         });
 
         module('when selecting some students', function() {
@@ -96,6 +95,10 @@ module('Acceptance | Session Add Students', function(hooks) {
           const checkboxCheckedSelector = `${checkboxSelector}.checkbox--checked`;
 
           test('it should be possible to select 3 students', async function(assert) {
+            // given
+            server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
+            await visit(`/sessions/${session.id}/ajout-eleves`);
+
             // when
             const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
             const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
@@ -106,12 +109,16 @@ module('Acceptance | Session Add Students', function(hooks) {
 
             // then
             const allRow = document.querySelectorAll(rowSelector);
-            assert.equal(allRow.length, 10);
+            assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
             const checkboxChecked = document.querySelectorAll(checkboxCheckedSelector);
             assert.equal(checkboxChecked.length, 3);
           });
 
           test('it should be possible to cancel enrolling students', async function(assert) {
+            // given
+            server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
+            await visit(`/sessions/${session.id}/ajout-eleves`);
+
             // given
             const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
             await click(checkbox);
@@ -127,6 +134,8 @@ module('Acceptance | Session Add Students', function(hooks) {
           module('when clicking on "Ajout"', function() {
             test('it redirect to previous page', async function(assert) {
               // given
+              server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
+              await visit(`/sessions/${session.id}/ajout-eleves`);
               const checkbox = document.querySelector(rowSelector + ' ' + checkboxSelector);
               await click(checkbox);
 
@@ -140,6 +149,8 @@ module('Acceptance | Session Add Students', function(hooks) {
 
             test('it should add students as certification candidates', async function(assert) {
               // given
+              server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
+              await visit(`/sessions/${session.id}/ajout-eleves`);
               const firstCheckbox = document.querySelector(rowSelector + ':nth-child(1) ' + checkboxSelector);
               const secondCheckbox = document.querySelector(rowSelector + ':nth-child(2) ' + checkboxSelector);
               const thirdCheckbox = document.querySelector(rowSelector + ':nth-child(3) ' + checkboxSelector);

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -77,7 +77,7 @@ module('Acceptance | Session Add Students', function(hooks) {
       const rowSelector = '.add-student-list table tbody tr';
 
       module('when there are no enrolled students', function() {
-        const DEFAULT_PAGE_SIZE = 10;
+        const DEFAULT_PAGE_SIZE = 50;
 
         test('it should show first page of students (with default size)', async function(assert) {
           // given

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -8,6 +8,11 @@ import EmberObject from '@ember/object';
 module('Integration | Component | add-student-list', function(hooks) {
   setupRenderingTest(hooks);
 
+  let store;
+  hooks.beforeEach(function() {
+    store = this.owner.lookup('service:store');
+  });
+
   module('when there is no student', () => {
     test('it shows an empty table', async function(assert) {
       // when
@@ -125,6 +130,8 @@ module('Integration | Component | add-student-list', function(hooks) {
           _buildSelectedStudent('Marie', 'Dupont', '3E', birthdate),
           _buildSelectedStudent('Tom', 'Dupont', '4G', birthdate),
         ];
+
+        sinon.stub(store, 'peekAll').withArgs('student').returns(studentList);
         const save = sinon.spy();
         this.set('students', studentList);
         this.set('session', EmberObject.create({
@@ -181,7 +188,7 @@ module('Integration | Component | add-student-list', function(hooks) {
         });
 
         module('when there are 2 selected students', () => {
-          test('it should show "Aucun candidat sélectionné | 2 candidats déjà ajoutés à la session"', async function(assert) {
+          test('it should show "2 candidat(s) sélectionné(s) | 0 candidat déjà ajoutés à la session"', async function(assert) {
             // given
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';
             const candidatesSelectedSelector = '.bottom-action-bar__informations--candidates-selected';
@@ -191,15 +198,18 @@ module('Integration | Component | add-student-list', function(hooks) {
               _buildSelectedStudent('Tom', 'Dupont', '4G', birthdate),
               _buildSelectedStudent('Paul', 'Dupont', '4G', birthdate),
             ];
+            sinon.stub(store, 'peekAll').withArgs('student').returns(studentList);
             this.set('studentList', studentList);
             this.set('session', _buildSession());
             this.set('returnToSessionCandidates', () => {});
+            this.set('numberOfEnrolledStudents', 0);
 
             // when
             await render(hbs`<AddStudentList
               @studentList={{this.studentList}}
               @session={{this.session}}
-              @returnToSessionCandidates={{this.returnToSessionCandidates}}>
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @numberOfEnrolledStudents={{this.numberOfEnrolledStudents}}>
             </AddStudentList>`);
 
             // then
@@ -219,15 +229,18 @@ module('Integration | Component | add-student-list', function(hooks) {
               _buildUnselectedStudent('Marie', 'Dupont', '3E', birthdate, true),
               _buildUnselectedStudent('Tom', 'Dupont', '4G', birthdate, true),
             ];
+            sinon.stub(store, 'peekAll').withArgs('student').returns(studentList);
             this.set('studentList', studentList);
             this.set('session', _buildSession());
             this.set('returnToSessionCandidates', () => {});
+            this.set('numberOfEnrolledStudents', 2);
 
             // when
             await render(hbs`<AddStudentList
               @studentList={{this.studentList}}
               @session={{this.session}}
-              @returnToSessionCandidates={{this.returnToSessionCandidates}}>
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @numberOfEnrolledStudents={{this.numberOfEnrolledStudents}}>
             </AddStudentList>`);
           });
 
@@ -257,15 +270,18 @@ module('Integration | Component | add-student-list', function(hooks) {
               _buildSelectedStudent('TomTom', 'Dupont', '4G', birthdate),
               _buildSelectedStudent('Marie-Jo', 'Dudu', '4G', birthdate),
             ];
+            sinon.stub(store, 'peekAll').withArgs('student').returns(studentList);
             this.set('studentList', studentList);
             this.set('session', _buildSession());
             this.set('returnToSessionCandidates', () => {});
+            this.set('numberOfEnrolledStudents', 2);
 
             // when
             await render(hbs`<AddStudentList
               @studentList={{this.studentList}}
               @session={{this.session}}
-              @returnToSessionCandidates={{this.returnToSessionCandidates}}>
+              @returnToSessionCandidates={{this.returnToSessionCandidates}}
+              @numberOfEnrolledStudents={{this.numberOfEnrolledStudents}}>
             </AddStudentList>`);
           });
 

--- a/certif/tests/integration/components/pagination-control-test.js
+++ b/certif/tests/integration/components/pagination-control-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+function getMetaForPage(pageNumber) {
+  const rowCount = 50;
+  const pageSize = 25;
+  return {
+    page: pageNumber,
+    pageSize,
+    rowCount,
+    pageCount: Math.ceil(rowCount / pageSize),
+  };
+}
+
+module('Integration | Component | pagination-control', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should disable previous button when user is on first page', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(1));
+
+    // when
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // then
+    assert.dom('.page-navigation__arrow--previous').hasClass('page-navigation__arrow--disabled');
+    assert.dom('.page-navigation__arrow--previous .icon-button').hasClass('disabled');
+  });
+
+  test('it should disable next button when user is on last page', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(2));
+
+    // when
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // then
+    assert.dom('.page-navigation__arrow--next').hasClass('page-navigation__arrow--disabled');
+    assert.dom('.page-navigation__arrow--next .icon-button').hasClass('disabled');
+  });
+
+  test('it should enable previous button when user is on second page', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(2));
+
+    // when
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // then
+    assert.dom('.page-navigation__arrow--previous').hasNoClass('page-navigation__arrow--disabled');
+    assert.dom('.page-navigation__arrow--previous .icon-button').hasNoClass('disabled');
+  });
+
+});

--- a/certif/tests/unit/adapters/student-test.js
+++ b/certif/tests/unit/adapters/student-test.js
@@ -19,10 +19,19 @@ module('Unit | Adapter | student', function(hooks) {
       // given
       const certificationCenterId = 1;
       const sessionId = 3;
-      const adapterOptions = { certificationCenterId, sessionId };
+      const query = { 
+        page: {
+          number: 1,
+          size: 1,
+        },
+        filter : {
+          certificationCenterId, 
+          sessionId, 
+        } ,
+      };
 
       // when
-      const url = await adapter.urlForFindAll(undefined, { adapterOptions });
+      const url = await adapter.urlForQuery(query);
 
       // then
       assert.equal(url.endsWith(`certification-centers/${certificationCenterId}/sessions/${sessionId}/students`), true);

--- a/certif/tests/unit/components/add-student-list-test.js
+++ b/certif/tests/unit/components/add-student-list-test.js
@@ -9,9 +9,11 @@ module('Unit | Component | add-student-list', function(hooks) {
   setupTest(hooks);
 
   let component;
+  let store;
 
   hooks.beforeEach(function() {
     component = createGlimmerComponent('component:add-student-list');
+    store = this.owner.lookup('service:store');
   });
 
   module('#computed hasCheckedSomething', function() {
@@ -112,6 +114,7 @@ module('Unit | Component | add-student-list', function(hooks) {
       component.args.studentList = [...unselectedStudents, ...selectedStudents];
       component.args.session = { id: sessionId, save: sinon.stub().resolves() };
       component.args.returnToSessionCandidates = sinon.spy();
+      sinon.stub(store, 'peekAll').withArgs('student').returns(selectedStudents);
 
       // when
       await component.enrollStudents();

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -10,10 +10,20 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
     const session_id = 1;
     const session = { id: session_id };
     const certificationCenterId = Symbol('certificationCenterId');
-    const studentEnriched = [{ id: '1', firstName: 'Tom', lastName: 'Dupont', isEnrolled: true }];
+
+    const paginatedStudents =  {
+      data: [{ id: '1', firstName: 'Tom', lastName: 'Dupont', isEnrolled: true }],
+      meta: {
+        page: 1,
+        pageCount: 1,
+        pageSize: 10,
+        rowCount: 5,
+      },
+    };
+
     const expectedModel = {
       session,
-      students: studentEnriched,
+      students: paginatedStudents,
     };
 
     hooks.beforeEach(function() {
@@ -26,14 +36,24 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       findRecordStub.withArgs('session', session_id).resolves(session);
       route.store.findRecord = findRecordStub;
       route.modelFor = sinon.stub().returns({ id: certificationCenterId });
-      route.store.findAll = sinon.stub().resolves(studentEnriched);
+      route.store.query = sinon.stub().resolves(paginatedStudents);
 
       // when
-      const actualModel = await route.model({ session_id });
+      const actualModel = await route.model({ session_id, pageNumber: 1, pageSize: 1  });
 
       // then
       sinon.assert.calledWith(route.modelFor, 'authenticated');
-      sinon.assert.calledWith(route.store.findAll, 'student', { adapterOptions : { certificationCenterId, sessionId: session.id } });
+      sinon.assert.calledWith(route.store.query, 'student', { 
+        filter: {
+          certificationCenterId, 
+          sessionId: session.id, 
+        },
+        page: {
+          size: 1,
+          number:1,
+        }, 
+      },
+      );
       assert.deepEqual(actualModel, expectedModel);
     });
   });

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -22,6 +22,7 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
     };
 
     const expectedModel = {
+      numberOfEnrolledStudents: 1,
       session,
       students: paginatedStudents,
     };
@@ -36,22 +37,24 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       findRecordStub.withArgs('session', session_id).resolves(session);
       route.store.findRecord = findRecordStub;
       route.modelFor = sinon.stub().returns({ id: certificationCenterId });
-      route.store.query = sinon.stub().resolves(paginatedStudents);
+      route.store.query = sinon.stub();
+      route.store.query.onCall(0).resolves([Symbol('a candidate')]);
+      route.store.query.onCall(1).resolves(paginatedStudents);
 
       // when
       const actualModel = await route.model({ session_id, pageNumber: 1, pageSize: 1  });
 
       // then
       sinon.assert.calledWith(route.modelFor, 'authenticated');
-      sinon.assert.calledWith(route.store.query, 'student', { 
+      sinon.assert.calledWith(route.store.query, 'student', {
         filter: {
-          certificationCenterId, 
-          sessionId: session.id, 
+          certificationCenterId,
+          sessionId: session.id,
         },
         page: {
           size: 1,
           number:1,
-        }, 
+        },
       },
       );
       assert.deepEqual(actualModel, expectedModel);


### PR DESCRIPTION
## :unicorn: Problème
Suite à #2133 il a été constaté que des listes importantes d'élèves entraîneraient un temps de chargement beaucoup trop long.

## :robot: Solution
Afin de limiter les temps de chargements trop important, il a été décidé d'ajouter une pagination lors du processus d'ajout d'élève à une session de certification sco.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

- Activer les toggle FT_REPORTS_CATEGORISATION=true && FT_CERTIF_PRESCRIPTION_SCO=true sur api
- Se connecter sur pix certif
- Ajouter des nouveaux élèves à une session de certification
- Constater qu'il est possible de paginer la liste d'élèves proposée
