### PR TITLE
[FEATURE] Construction du payload PE au démarrage d'une campagne (PIX-1625)

### DIFF
--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -25,9 +25,11 @@ module.exports = {
   async save(request, h) {
     const userId = request.auth.credentials.userId;
     const campaignParticipation = await serializer.deserialize(request.payload);
-    const campaignParticipationDomain = await usecases.startCampaignParticipation({ campaignParticipation, userId });
+  
+    const event = await usecases.startCampaignParticipation({ campaignParticipation, userId });
+    await events.eventDispatcher.dispatch(event);
 
-    return h.response(serializer.serialize(campaignParticipationDomain)).created();
+    return h.response(serializer.serialize(event.campaignParticipation)).created();
   },
 
   async find(request) {

--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -26,10 +26,13 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     const campaignParticipation = await serializer.deserialize(request.payload);
   
-    const event = await usecases.startCampaignParticipation({ campaignParticipation, userId });
+    const { 
+      event,
+      campaignParticipation: campaignParticipationCreated,
+    } = await usecases.startCampaignParticipation({ campaignParticipation, userId });
     await events.eventDispatcher.dispatch(event);
 
-    return h.response(serializer.serialize(event.campaignParticipation)).created();
+    return h.response(serializer.serialize(campaignParticipationCreated)).created();
   },
 
   async find(request) {

--- a/api/lib/domain/events/CampaignParticipationResultsShared.js
+++ b/api/lib/domain/events/CampaignParticipationResultsShared.js
@@ -1,9 +1,6 @@
 class CampaignParticipationResultsShared {
-  constructor({ campaignId, campaignParticipationId, userId, organizationId } = {}) {
-    this.campaignId = campaignId;
+  constructor({ campaignParticipationId } = {}) {
     this.campaignParticipationId = campaignParticipationId;
-    this.userId = userId;
-    this.organizationId = organizationId;
   }
 }
 

--- a/api/lib/domain/events/CampaignParticipationStarted.js
+++ b/api/lib/domain/events/CampaignParticipationStarted.js
@@ -1,0 +1,7 @@
+class CampaignParticipationStarted {
+  constructor({ campaignParticipationId } = {}) {
+    this.campaignParticipationId = campaignParticipationId;
+  }
+}
+
+module.exports = CampaignParticipationStarted;

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -1,93 +1,8 @@
 const { checkEventType } = require('./check-event-type');
 const CampaignParticipationResultsShared = require('./CampaignParticipationResultsShared');
-const config = require('../../config');
+const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
 
 const eventType = CampaignParticipationResultsShared;
-
-const PAYLOAD_CAMPAIGN_TYPE = 'EVALUATION';
-const PAYLOAD_STRUCTURE_NAME = 'Pix';
-const PAYLOAD_STRUCTURE_TYPE = 'externe';
-const PAYLOAD_CAMPAIGN_URL = `${config.domain.pixApp}${config.domain.tldFr}/campagnes`;
-const PAYLOAD_TEST_STATE = { STARTED: 2, FINISHED: 3, SENT: 4 };
-const PAYLOAD_UNITS = { PERCENTAGE: 'A', SCORE: 'B' };
-const PAYLOAD_EVALUATION_CATEGORY = 'competence';
-const PAYLOAD_EVALUATION_TYPE = 'competence Pix';
-const PAYLOAD_PROGRESSION = { FINISHED: 100 };
-
-class PoleEmploiPayload {
-  constructor({ user, campaign, targetProfile, participation, participationResult }) {
-    this.individu = this._buildIndividu(user);
-    this.campagne = this._buildCampaign(campaign);
-    this.test = this._buildTest(targetProfile, participation, participationResult);
-  }
-
-  toString() {
-    return JSON.stringify({
-      campagne: this.campagne,
-      individu: this.individu,
-      test: this.test,
-    });
-  }
-
-  _buildIndividu(user) {
-    return {
-      nom: user.lastName,
-      prenom: user.firstName,
-    };
-  }
-
-  _buildCampaign(campaign) {
-    return {
-      nom: campaign.name,
-      dateDebut: campaign.createdAt,
-      dateFin: campaign.archivedAt,
-      type: PAYLOAD_CAMPAIGN_TYPE,
-      codeCampagne: campaign.code,
-      urlCampagne: `${PAYLOAD_CAMPAIGN_URL}/${campaign.code}`,
-      nomOrganisme: PAYLOAD_STRUCTURE_NAME,
-      typeOrganisme: PAYLOAD_STRUCTURE_TYPE,
-    };
-  }
-
-  _buildTest(targetProfile, participation, participationResult) {
-    return {
-      etat: PAYLOAD_TEST_STATE.SENT,
-      progression: PAYLOAD_PROGRESSION.FINISHED,
-      typeTest: this._getTypeTest(targetProfile.name),
-      referenceExterne: participation.id,
-      dateDebut: participation.createdAt,
-      dateProgression: participation.sharedAt,
-      dateValidation: participation.sharedAt,
-      evaluation: participationResult.masteryPercentage,
-      uniteEvaluation: PAYLOAD_UNITS.PERCENTAGE,
-      elementsEvalues: participationResult.competenceResults.map(this._buildElementEvalue),
-    };
-  }
-
-  _buildElementEvalue(competence) {
-    return {
-      libelle: competence.name,
-      categorie: PAYLOAD_EVALUATION_CATEGORY,
-      type: PAYLOAD_EVALUATION_TYPE,
-      domaineRattachement: competence.areaName,
-      nbSousElements: competence.totalSkillsCount,
-      evaluation: {
-        scoreObtenu: competence.masteryPercentage,
-        uniteScore: PAYLOAD_UNITS.PERCENTAGE,
-        nbSousElementValide: competence.validatedSkillsCount,
-      },
-    };
-  }
-
-  _getTypeTest(targetProfileName) {
-    if (targetProfileName.includes('Diagnostic initial')) {
-      return 'DI';
-    } else if (targetProfileName.includes('Parcours complet')) {
-      return 'PC';
-    }
-    return 'CP';
-  }
-}
 
 async function handlePoleEmploiParticipationShared({
   event,
@@ -112,7 +27,7 @@ async function handlePoleEmploiParticipationShared({
     const participation = await campaignParticipationRepository.get(campaignParticipationId);
     const participationResult = await campaignParticipationResultRepository.getByParticipationId(campaignParticipationId);
 
-    const payload = new PoleEmploiPayload({
+    const payload = PoleEmploiPayload.buildForParticipationShared({
       user,
       campaign,
       targetProfile,

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -15,16 +15,16 @@ async function handlePoleEmploiParticipationShared({
 }) {
   checkEventType(event, eventType);
 
-  const { organizationId, campaignId, userId, campaignParticipationId } = event;
+  const { campaignParticipationId } = event;
 
-  const campaign = await campaignRepository.get(campaignId);
-  const organization = await organizationRepository.get(organizationId);
+  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+  const campaign = await campaignRepository.get(participation.campaignId);
+  const organization = await organizationRepository.get(campaign.organizationId);
 
   if (campaign.isAssessment() && organization.isPoleEmploi) {
 
-    const user = await userRepository.get(userId);
+    const user = await userRepository.get(participation.userId);
     const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
-    const participation = await campaignParticipationRepository.get(campaignParticipationId);
     const participationResult = await campaignParticipationResultRepository.getByParticipationId(campaignParticipationId);
 
     const payload = PoleEmploiPayload.buildForParticipationShared({

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -89,7 +89,7 @@ class PoleEmploiPayload {
   }
 }
 
-async function handleCampaignParticipationResultsSending({
+async function handlePoleEmploiParticipationShared({
   event,
   campaignRepository,
   campaignParticipationRepository,
@@ -124,5 +124,5 @@ async function handleCampaignParticipationResultsSending({
   }
 }
 
-handleCampaignParticipationResultsSending.eventType = eventType;
-module.exports = handleCampaignParticipationResultsSending;
+handlePoleEmploiParticipationShared.eventType = eventType;
+module.exports = handlePoleEmploiParticipationShared;

--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -1,0 +1,40 @@
+const { checkEventType } = require('./check-event-type');
+const CampaignParticipationStarted = require('./CampaignParticipationStarted');
+const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
+
+const eventType = CampaignParticipationStarted;
+
+async function handlePoleEmploiParticipationStarted({
+  event,
+  campaignRepository,
+  campaignParticipationRepository,
+  organizationRepository,
+  targetProfileRepository,
+  userRepository,
+}) {
+  checkEventType(event, eventType);
+
+  const { campaignParticipationId } = event;
+
+  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+  const campaign = await campaignRepository.get(participation.campaignId);
+  const organization = await organizationRepository.get(campaign.organizationId);
+  
+  if (campaign.isAssessment() && organization.isPoleEmploi) {
+    
+    const user = await userRepository.get(participation.userId);
+    const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
+
+    const payload = PoleEmploiPayload.buildForParticipationStarted({
+      user,
+      campaign,
+      targetProfile,
+      participation,
+    });
+
+    console.log(payload.toString());
+  }
+}
+
+handlePoleEmploiParticipationStarted.eventType = eventType;
+module.exports = handlePoleEmploiParticipationStarted;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -31,6 +31,7 @@ dependencies.partnerCertificationRepository = partnerCertificationRepository;
 const handlersToBeInjected = {
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
+  handlePoleEmploiParticipationStarted: require('./handle-pole-emploi-participation-started'),
   handleCertificationScoring: require('./handle-certification-scoring'),
   handlePartnerCertifications: require('./handle-partner-certification'),
 };

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -30,7 +30,7 @@ dependencies.partnerCertificationRepository = partnerCertificationRepository;
 
 const handlersToBeInjected = {
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
-  handleCampaignParticipationResultsSending: require('./handle-campaign-participation-results-sending'),
+  handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
   handleCertificationScoring: require('./handle-certification-scoring'),
   handlePartnerCertifications: require('./handle-partner-certification'),
 };

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -27,9 +27,6 @@ module.exports = async function shareCampaignResult({
   await campaignParticipationRepository.share(campaignParticipation);
 
   return new CampaignParticipationResultsShared({
-    campaignId: campaign.id,
     campaignParticipationId: campaignParticipation.id,
-    userId,
-    organizationId: campaign.organizationId,
   });
 };

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -3,6 +3,7 @@ const _ = require('lodash');
 const Assessment = require('../models/Assessment');
 
 const { AlreadyExistingCampaignParticipationError, NotFoundError } = require('../../domain/errors');
+const CampaignParticipationStarted = require('../events/CampaignParticipationStarted');
 
 module.exports = async function startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository }) {
   const campaign = await campaignRepository.get(campaignParticipation.campaignId);
@@ -15,7 +16,8 @@ module.exports = async function startCampaignParticipation({ campaignParticipati
   if (campaign.isAssessment()) {
     await _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation);
   }
-  return createdCampaignParticipation;
+
+  return new CampaignParticipationStarted({ campaignParticipation: createdCampaignParticipation });
 };
 
 async function _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation) {

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -17,7 +17,10 @@ module.exports = async function startCampaignParticipation({ campaignParticipati
     await _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation);
   }
 
-  return new CampaignParticipationStarted({ campaignParticipation: createdCampaignParticipation });
+  return {
+    event: new CampaignParticipationStarted({ campaignParticipationId: createdCampaignParticipation.id }),
+    campaignParticipation: createdCampaignParticipation,
+  };
 };
 
 async function _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation) {

--- a/api/lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js
+++ b/api/lib/infrastructure/externals/pole-emploi/PoleEmploiPayload.js
@@ -1,0 +1,96 @@
+const config = require('../../../config');
+
+const CAMPAIGN_TYPE = 'EVALUATION';
+const STRUCTURE_NAME = 'Pix';
+const STRUCTURE_TYPE = 'externe';
+const CAMPAIGN_URL = `${config.domain.pixApp}${config.domain.tldFr}/campagnes`;
+const TEST_STATE = { STARTED: 2, FINISHED: 3, SHARED: 4 };
+const UNITS = { PERCENTAGE: 'A', SCORE: 'B' };
+const EVALUATION_CATEGORY = 'competence';
+const EVALUATION_TYPE = 'competence Pix';
+const PROGRESSION = { STARTED: 0, FINISHED: 100 };
+
+class PoleEmploiPayload {
+  constructor({ individu, campagne, test }) {
+    this.individu = individu;
+    this.campagne = campagne;
+    this.test = test;
+  }
+
+  static buildForParticipationShared({ user, campaign, targetProfile, participation, participationResult }) {
+    return new PoleEmploiPayload({ 
+      individu: _buildIndividu(user),
+      campagne: _buildCampaign(campaign),
+      test: _buildTest(TEST_STATE.SHARED, targetProfile, participation, participationResult),
+    });
+  }
+
+  toString() {
+    return JSON.stringify({
+      campagne: this.campagne,
+      individu: this.individu,
+      test: this.test,
+    });
+  }
+}
+
+function _buildIndividu(user) {
+  return {
+    nom: user.lastName,
+    prenom: user.firstName,
+  };
+}
+
+function _buildCampaign(campaign) {
+  return {
+    nom: campaign.name,
+    dateDebut: campaign.createdAt,
+    dateFin: campaign.archivedAt,
+    type: CAMPAIGN_TYPE,
+    codeCampagne: campaign.code,
+    urlCampagne: `${CAMPAIGN_URL}/${campaign.code}`,
+    nomOrganisme: STRUCTURE_NAME,
+    typeOrganisme: STRUCTURE_TYPE,
+  };
+}
+
+function _buildTest(etat, targetProfile, participation, participationResult) {
+  return {
+    etat,
+    progression: PROGRESSION.FINISHED,
+    typeTest: _getTypeTest(targetProfile.name),
+    referenceExterne: participation.id,
+    dateDebut: participation.createdAt,
+    dateProgression: participation.sharedAt,
+    dateValidation: participation.sharedAt,
+    evaluation: participationResult.masteryPercentage,
+    uniteEvaluation: UNITS.PERCENTAGE,
+    elementsEvalues: participationResult.competenceResults.map(_buildElementEvalue),
+  };
+}
+
+function _buildElementEvalue(competence) {
+  return {
+    libelle: competence.name,
+    categorie: EVALUATION_CATEGORY,
+    type: EVALUATION_TYPE,
+    domaineRattachement: competence.areaName,
+    nbSousElements: competence.totalSkillsCount,
+    evaluation: {
+      scoreObtenu: competence.masteryPercentage,
+      uniteScore: UNITS.PERCENTAGE,
+      nbSousElementValide: competence.validatedSkillsCount,
+    },
+  };
+}
+
+function _getTypeTest(targetProfileName) {
+  if (targetProfileName.includes('Diagnostic initial')) {
+    return 'DI';
+  } else if (targetProfileName.includes('Parcours complet')) {
+    return 'PC';
+  }
+  return 'CP';
+}
+
+module.exports = PoleEmploiPayload;

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -176,7 +176,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     it('should dispatch CampaignParticipationStartedEvent', async () => {
       // given
       const campaignParticipationStartedEvent = new CampaignParticipationStarted();
-      usecases.startCampaignParticipation.resolves(campaignParticipationStartedEvent);
+      usecases.startCampaignParticipation.resolves({ event: campaignParticipationStartedEvent });
 
       // when
       await campaignParticipationController.save(request, hFake);
@@ -188,7 +188,10 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     it('should return the serialized campaign participation when it has been successfully created', async () => {
       // given
       const campaignParticipation = domainBuilder.buildCampaignParticipation();
-      usecases.startCampaignParticipation.resolves(new CampaignParticipationStarted({ campaignParticipation }));
+      usecases.startCampaignParticipation.resolves({
+        event: new CampaignParticipationStarted({ campaignParticipationId: campaignParticipation.id }),
+        campaignParticipation,
+      });
 
       const serializedCampaignParticipation = { id: 88, assessmentId: 12 };
       serializer.serialize.returns(serializedCampaignParticipation);

--- a/api/tests/unit/domain/events/event-choregraphy-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-pole-emploi-participation-shared_test.js
@@ -2,8 +2,8 @@ const { expect } = require('../../../test-helper');
 const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 
-describe('Event Choregraphy | Campaign Participation Results Sending', function() {
-  it('Should trigger Campaign Participation Results Sending handler on CampaignParticipationResultsShared event', async () => {
+describe('Event Choregraphy | Pole Emploi Participation Shared', function() {
+  it('Should trigger Pole Emploi participation shared handler on CampaignParticipationResultsShared event', async () => {
     // given
     const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
     const event = new CampaignParticipationResultsShared();
@@ -13,6 +13,6 @@ describe('Event Choregraphy | Campaign Participation Results Sending', function(
     await eventDispatcher.dispatch(event, domainTransaction);
 
     // then
-    expect(handlerStubs.handleCampaignParticipationResultsSending).to.have.been.calledWith({ event, domainTransaction });
+    expect(handlerStubs.handlePoleEmploiParticipationShared).to.have.been.calledWith({ event, domainTransaction });
   });
 });

--- a/api/tests/unit/domain/events/event-choregraphy-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-pole-emploi-participation-started_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
+
+describe('Event Choregraphy | Pole Emploi Participation Started', function() {
+  it('Should trigger Pole Emploi participation started handler on CampaignParticipationStarted event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new CampaignParticipationStarted();
+    const domainTransaction = Symbol('a transaction');
+
+    // when
+    await eventDispatcher.dispatch(event, domainTransaction);
+
+    // then
+    expect(handlerStubs.handlePoleEmploiParticipationStarted).to.have.been.calledWith({ event, domainTransaction });
+  });
+});

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -103,19 +103,14 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
   });
 
   context('#handlePoleEmploiParticipationShared', () => {
-    const campaignParticipationId = Symbol('campaignParticipationId');
-    const campaignId = Symbol('campaignId');
+    const campaignParticipationId = 55667788;
+    const campaignId = 11223344;
     const userId = Symbol('userId');
     const organizationId = Symbol('organizationId');
 
     context('when campaign is of type ASSESSMENT and organization is Pole Emploi', () => {
       beforeEach(() => {
-        event = new CampaignParticipationResultsShared({
-          campaignId,
-          campaignParticipationId,
-          userId,
-          organizationId,
-        });
+        event = new CampaignParticipationResultsShared({ campaignParticipationId });
 
         organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: true });
         userRepositoryStub.withArgs(userId).resolves({ firstName: 'Jean', lastName: 'Bonneau' });
@@ -128,12 +123,15 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
             archivedAt: new Date('2020-02-01'),
             type: 'ASSESSMENT',
             targetProfileId: 'targetProfileId1',
+            organizationId,
           }),
         );
         targetProfileRepositoryStub.withArgs('targetProfileId1').resolves({ name: 'Diagnostic initial' });
         campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(
           domainBuilder.buildCampaignParticipation({
             id: 55667788,
+            campaignId,
+            userId,
             sharedAt: new Date('2020-01-03'),
             createdAt: new Date('2020-01-02'),
           }),
@@ -180,13 +178,17 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
 
     context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {
       beforeEach(() => {
-        event = new CampaignParticipationResultsShared({
-          campaignId,
-          campaignParticipationId,
-          userId,
-          organizationId,
-        });
-        campaignRepositoryStub.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT' }));
+        event = new CampaignParticipationResultsShared({ campaignParticipationId });
+        campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(
+          domainBuilder.buildCampaignParticipation({
+            id: 55667788,
+            campaignId,
+            userId,
+            sharedAt: new Date('2020-01-03'),
+            createdAt: new Date('2020-01-02'),
+          }),
+        );
+        campaignRepositoryStub.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT', organizationId }));
         organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: false });
         sinon.stub(console, 'log');
       });
@@ -205,17 +207,21 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
 
     context('when organization is Pole Emploi but campaign is of type PROFILES_COLLECTION', () => {
       beforeEach(() => {
-        event = new CampaignParticipationResultsShared({
-          campaignId,
-          campaignParticipationId,
-          userId,
-          organizationId,
-        });
-
+        event = new CampaignParticipationResultsShared({ campaignParticipationId });
+        
+        campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(
+          domainBuilder.buildCampaignParticipation({
+            id: 55667788,
+            campaignId,
+            userId,
+            sharedAt: new Date('2020-01-03'),
+            createdAt: new Date('2020-01-02'),
+          }),
+        );
         campaignRepositoryStub
           .withArgs(campaignId)
           .resolves(domainBuilder.buildCampaign({ type: 'PROFILES_COLLECTION' }));
-        organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: true });
+        organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: true, organizationId });
         sinon.stub(console, 'log');
       });
 

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -6,9 +6,9 @@ const campaignParticipationResultRepository = require('../../../../lib/infrastru
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
-const { handleCampaignParticipationResultsSending } = require('../../../../lib/domain/events')._forTestOnly.handlers;
+const { handlePoleEmploiParticipationShared } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
-describe('Unit | Domain | Events | handle-campaign-participation-results-sending', () => {
+describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () => {
   let event;
   let campaignRepositoryStub;
   let campaignParticipationRepositoryStub;
@@ -96,13 +96,13 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
     // given
     const event = 'not an event of the correct type';
     // when / then
-    const error = await catchErr(handleCampaignParticipationResultsSending)({ event, ...dependencies });
+    const error = await catchErr(handlePoleEmploiParticipationShared)({ event, ...dependencies });
 
     // then
     expect(error).not.to.be.null;
   });
 
-  context('#handleCampaignParticipationResultsSending', () => {
+  context('#handlePoleEmploiParticipationShared', () => {
     const campaignParticipationId = Symbol('campaignParticipationId');
     const campaignId = Symbol('campaignId');
     const userId = Symbol('userId');
@@ -166,7 +166,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
 
       it('it should console.log results', async () => {
         // when
-        await handleCampaignParticipationResultsSending({
+        await handlePoleEmploiParticipationShared({
           event,
           ...dependencies,
         });
@@ -193,7 +193,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
 
       it('it should not console.log results', async () => {
         // when
-        await handleCampaignParticipationResultsSending({
+        await handlePoleEmploiParticipationShared({
           event,
           ...dependencies,
         });
@@ -221,7 +221,7 @@ describe('Unit | Domain | Events | handle-campaign-participation-results-sending
 
       it('it should not console.log results', async () => {
         // when
-        await handleCampaignParticipationResultsSending({
+        await handlePoleEmploiParticipationShared({
           event,
           ...dependencies,
         });

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -1,0 +1,186 @@
+const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const targetProfileRepository = require('../../../../lib/infrastructure/repositories/target-profile-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
+const { handlePoleEmploiParticipationStarted } = require('../../../../lib/domain/events')._forTestOnly.handlers;
+
+describe('Unit | Domain | Events | handle-pole-emploi-participation-started', () => {
+  let event;
+  let campaignRepositoryStub;
+  let campaignParticipationRepositoryStub;
+  let organizationRepositoryStub;
+  let targetProfileRepositoryStub;
+  let userRepositoryStub;
+
+  const dependencies = {
+    campaignRepository,
+    campaignParticipationRepository,
+    organizationRepository,
+    targetProfileRepository,
+    userRepository,
+  };
+
+  const expectedResults = JSON.stringify({
+    campagne: {
+      nom: 'Campagne Pôle Emploi',
+      dateDebut: '2020-01-01T00:00:00.000Z',
+      dateFin: '2020-02-01T00:00:00.000Z',
+      type: 'EVALUATION',
+      codeCampagne: 'CODEPE123',
+      urlCampagne: 'https://app.pix.fr/campagnes/CODEPE123',
+      nomOrganisme: 'Pix',
+      typeOrganisme: 'externe',
+    },
+    individu: {
+      nom: 'Bonneau',
+      prenom: 'Jean',
+    },
+    test: {
+      etat: 2,
+      progression: 0,
+      typeTest: 'DI',
+      referenceExterne: 55667788,
+      dateDebut: '2020-01-02T00:00:00.000Z',
+      dateProgression: null,
+      dateValidation: null,
+      evaluation: null,
+      uniteEvaluation: 'A',
+      elementsEvalues: [],
+    },
+  });
+
+  beforeEach(() => {
+    campaignRepositoryStub = sinon.stub(campaignRepository, 'get');
+    campaignParticipationRepositoryStub = sinon.stub(campaignParticipationRepository, 'get');
+    organizationRepositoryStub = sinon.stub(organizationRepository, 'get');
+    targetProfileRepositoryStub = sinon.stub(targetProfileRepository, 'get');
+    userRepositoryStub = sinon.stub(userRepository, 'get');
+  });
+
+  it('fails when event is not of correct type', async () => {
+    // given
+    const event = 'not an event of the correct type';
+    // when / then
+    const error = await catchErr(handlePoleEmploiParticipationStarted)({ event, ...dependencies });
+
+    // then
+    expect(error).not.to.be.null;
+  });
+
+  context('#handlePoleEmploiParticipationStarted', () => {
+    const campaignParticipationId = 55667788;
+    const campaignId = Symbol('campaignId');
+    const userId = Symbol('userId');
+    const organizationId = Symbol('organizationId');
+
+    context('when campaign is of type ASSESSMENT and organization is Pole Emploi', () => {
+      beforeEach(() => {
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({
+          id: campaignParticipationId,
+          userId,
+          campaignId,
+          createdAt: new Date('2020-01-02'),
+        });
+
+        campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: true });
+        userRepositoryStub.withArgs(userId).resolves({ firstName: 'Jean', lastName: 'Bonneau' });
+        campaignRepositoryStub.withArgs(campaignId).resolves(
+          domainBuilder.buildCampaign({
+            id: campaignId,
+            name: 'Campagne Pôle Emploi',
+            code: 'CODEPE123',
+            createdAt: new Date('2020-01-01'),
+            archivedAt: new Date('2020-02-01'),
+            type: 'ASSESSMENT',
+            targetProfileId: 'targetProfileId1',
+            organizationId,
+          }),
+        );
+        targetProfileRepositoryStub.withArgs('targetProfileId1').resolves({ name: 'Diagnostic initial' });
+
+        event = new CampaignParticipationStarted({ campaignParticipationId });
+        
+        sinon.stub(console, 'log');
+      });
+
+      it('it should console.log results', async () => {
+        // when
+        await handlePoleEmploiParticipationStarted({
+          event,
+          ...dependencies,
+        });
+
+        // then
+        expect(console.log).to.have.been.calledOnce;
+        const results = console.log.firstCall.args[0];
+        expect(results).to.deep.equal(expectedResults);
+      });
+    });
+
+    context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {
+      beforeEach(() => {
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({
+          id: campaignParticipationId,
+          userId,
+          campaignId,
+          createdAt: new Date('2020-01-02'),
+        });
+        
+        campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignRepositoryStub.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT', organizationId }));
+        organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: false });
+        
+        event = new CampaignParticipationStarted({ campaignParticipationId });
+        
+        sinon.stub(console, 'log');
+      });
+
+      it('it should not console.log results', async () => {
+        // when
+        await handlePoleEmploiParticipationStarted({
+          event,
+          ...dependencies,
+        });
+
+        // then
+        sinon.assert.notCalled(console.log);
+      });
+    });
+
+    context('when organization is Pole Emploi but campaign is of type PROFILES_COLLECTION', () => {
+      beforeEach(() => {
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({
+          id: campaignParticipationId,
+          userId,
+          campaignId,
+          createdAt: new Date('2020-01-02'),
+        });
+        
+        campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignRepositoryStub
+          .withArgs(campaignId)
+          .resolves(domainBuilder.buildCampaign({ type: 'PROFILES_COLLECTION', organizationId }));
+        organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: true });
+
+        sinon.stub(console, 'log');
+
+        event = new CampaignParticipationStarted({ campaignParticipationId });
+      });
+
+      it('it should not console.log results', async () => {
+        // when
+        await handlePoleEmploiParticipationStarted({
+          event,
+          ...dependencies,
+        });
+
+        // then
+        sinon.assert.notCalled(console.log);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -3,7 +3,7 @@ const { AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, ArchivedCa
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const usecases = require('../../../../lib/domain/usecases');
 
-describe('Unit | UseCase | share-campaign-result2', () => {
+describe('Unit | UseCase | share-campaign-result', () => {
   const campaignParticipationRepository = {
     get: sinon.stub(),
     share: sinon.stub(),
@@ -79,12 +79,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
 
       // then
-      expect(actualEvent).to.deep.equal({
-        campaignId,
-        campaignParticipationId,
-        userId,
-        organizationId,
-      });
+      expect(actualEvent).to.deep.equal({ campaignParticipationId });
       expect(actualEvent).to.be.instanceOf(CampaignParticipationResultsShared);
     });
   });
@@ -113,12 +108,7 @@ describe('Unit | UseCase | share-campaign-result2', () => {
       const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
 
       // then
-      expect(actualEvent).to.deep.equal({
-        campaignId,
-        campaignParticipationId,
-        userId,
-        organizationId,
-      });
+      expect(actualEvent).to.deep.equal({ campaignParticipationId });
       expect(actualEvent).to.be.instanceOf(CampaignParticipationResultsShared);
     });
   });

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -111,12 +111,12 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     // given
     const assessmentId = 987654321;
     const campaignParticipation = domainBuilder.buildCampaignParticipation();
-    const campaignParticipationStartedEvent = new CampaignParticipationStarted({ campaignParticipation });
+    const campaignParticipationStartedEvent = new CampaignParticipationStarted({ campaignParticipationId: campaignParticipation.id });
     assessmentRepository.save.resolves({ id: assessmentId });
     campaignParticipationRepository.save.resolves(campaignParticipation);
 
     // when
-    const event = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const { event } = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
     expect(event).to.deep.equal(campaignParticipationStartedEvent);

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -3,6 +3,7 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const usecases = require('../../../../lib/domain/usecases');
 const { AlreadyExistingCampaignParticipationError, NotFoundError } = require('../../../../lib/domain/errors');
+const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
 
 describe('Unit | UseCase | start-campaign-participation', () => {
 
@@ -106,17 +107,18 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     });
   });
 
-  it('should return the saved campaign participation', async () => {
+  it('should return CampaignParticipationStarted event', async () => {
     // given
     const assessmentId = 987654321;
-    const createdCampaignParticipation = domainBuilder.buildCampaignParticipation();
+    const campaignParticipation = domainBuilder.buildCampaignParticipation();
+    const campaignParticipationStartedEvent = new CampaignParticipationStarted({ campaignParticipation });
     assessmentRepository.save.resolves({ id: assessmentId });
-    campaignParticipationRepository.save.resolves(createdCampaignParticipation);
+    campaignParticipationRepository.save.resolves(campaignParticipation);
 
     // when
-    const campaignParticipationReturned = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const event = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
 
     // then
-    expect(campaignParticipationReturned).to.deep.equal(createdCampaignParticipation);
+    expect(event).to.deep.equal(campaignParticipationStartedEvent);
   });
 });

--- a/api/tests/unit/infrastructure/externals/pole-emploi/PoleEmploiPayload_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/PoleEmploiPayload_test.js
@@ -1,0 +1,226 @@
+const PoleEmploiPayload = require('../../../../../lib/infrastructure/externals/pole-emploi/PoleEmploiPayload');
+const { expect, domainBuilder } = require('../../../../test-helper');
+
+describe('Unit | Infrastructure | Externals | Pole-Emploi | PoleEmploiPayload', () => {
+  let user;
+  let campaign;
+  let targetProfile;
+  let participation;
+
+  beforeEach(() => {
+    user = domainBuilder.buildUser();
+    targetProfile = domainBuilder.buildTargetProfile({ name: 'Diagnostic initial' });
+    campaign = domainBuilder.buildCampaign.ofTypeAssessment({ targetProfileId: targetProfile.id });
+    participation = domainBuilder.buildCampaignParticipation({ campaign, userId: user.id });
+  });
+
+  describe('buildForParticipationStarted', () => {
+  
+    it('should build individu payload for a campaign participation started', () => {
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.individu).to.deep.equal({
+        nom: user.lastName,
+        prenom: user.firstName,
+      });
+    });
+
+    it('should build campagne payload for a campaign participation started', () => {
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.campagne).to.deep.equal({
+        nom: campaign.name,
+        dateDebut: campaign.createdAt,
+        dateFin: campaign.archivedAt,
+        type: 'EVALUATION',
+        codeCampagne: campaign.code,
+        urlCampagne: `https://app.pix.fr/campagnes/${campaign.code}`,
+        nomOrganisme: 'Pix',
+        typeOrganisme: 'externe',
+      });
+    });
+
+    it('should build test payload for a campaign participation started', () => {
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.test).to.deep.equal({
+        etat: 2,
+        progression: 0,
+        typeTest: 'DI',
+        referenceExterne: participation.id,
+        dateDebut: participation.createdAt,
+        dateProgression: null,
+        dateValidation: null,
+        evaluation: null,
+        uniteEvaluation: 'A',
+        elementsEvalues: [],
+      });
+    });
+  });
+
+  describe('buildForParticipationShared', () => {
+  
+    it('should build individu payload for a campaign participation shared', () => {
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationShared({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+        participationResult: {},
+      });
+
+      // then
+      expect(payload.individu).to.deep.equal({
+        nom: user.lastName,
+        prenom: user.firstName,
+      });
+    });
+
+    it('should build campagne payload for a campaign participation shared', () => {
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationShared({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+        participationResult: {},
+      });
+
+      // then
+      expect(payload.campagne).to.deep.equal({
+        nom: campaign.name,
+        dateDebut: campaign.createdAt,
+        dateFin: campaign.archivedAt,
+        type: 'EVALUATION',
+        codeCampagne: campaign.code,
+        urlCampagne: `https://app.pix.fr/campagnes/${campaign.code}`,
+        nomOrganisme: 'Pix',
+        typeOrganisme: 'externe',
+      });
+    });
+
+    it('should build test payload for a campaign participation shared', () => {
+      // given
+      const participationResult = domainBuilder.buildCampaignParticipationResult({
+        totalSkillsCount: 10,
+        validatedSkillsCount: 7,
+        competenceResults: [
+          domainBuilder.buildCompetenceResult({
+            name: 'Gérer des données',
+            areaName: 'Information et données',
+            totalSkillsCount: 4,
+            testedSkillsCount: 2,
+            validatedSkillsCount: 2,
+          }),
+        ],
+      });
+
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationShared({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+        participationResult,
+      });
+
+      // then
+      expect(payload.test).to.deep.equal({
+        etat: 4,
+        progression: 100,
+        typeTest: 'DI',
+        referenceExterne: participation.id,
+        dateDebut: participation.createdAt,
+        dateProgression: participation.sharedAt,
+        dateValidation: participation.sharedAt,
+        evaluation: 70,
+        uniteEvaluation: 'A',
+        elementsEvalues: [{
+          libelle: 'Gérer des données',
+          categorie: 'competence',
+          type: 'competence Pix',
+          domaineRattachement: 'Information et données',
+          nbSousElements: 4,
+          evaluation: {
+            scoreObtenu: 50,
+            uniteScore: 'A',
+            nbSousElementValide: 2,
+          },
+        }],
+      });
+    });
+  });
+
+  describe('map different test types in the payload', () => {
+  
+    it('should map test type with target profile name "Diagnostic initial"', () => {
+      // given
+      targetProfile = domainBuilder.buildTargetProfile({ name: 'Diagnostic initial' });
+
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.test.typeTest).equal('DI');
+    });
+
+    it('should map test type with target profile name "Parcours complet"', () => {
+      // given
+      targetProfile = domainBuilder.buildTargetProfile({ name: 'Parcours complet' });
+
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.test.typeTest).equal('PC');
+    });
+
+    it('should map test type with other target profile names ', () => {
+      // given
+      targetProfile = domainBuilder.buildTargetProfile({ name: 'Other' });
+
+      // when
+      const payload = PoleEmploiPayload.buildForParticipationStarted({
+        user,
+        campaign,
+        participation,
+        targetProfile,
+      });
+
+      // then
+      expect(payload.test.typeTest).equal('CP');
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Il faut communiquer à pole emploi quand un demandeur d'emploi démarre un parcours.

## :robot: Solution

Déclencher un évènement au démarrage d'un parcours, afin d'envoyer les informations nécessaires à pôle emploi.
Dans un premier temps, nous affichons le payload à envoyer dans les logs, l'envoie sera réalisé dans une autre PR.

## :rainbow: Remarques

Schéma de la cinématique côté backend.
![image](https://user-images.githubusercontent.com/516360/99660851-3dafea80-2a63-11eb-9590-248e790d2965.png)

## :100: Pour tester

Pré-requis: Se connecter à scalingo et ouvrir la page des log de l'api pour la RA
https://my.osc-fr1.scalingo.com/apps/pix-api-review-pr2175/logs

1. Se connecter avec un utilisateur à Pix App: https://app-pr2175.review.pix.fr
2. Commencer la campagne avec le code QWERTY789

> Voir dans les logs le payload du démarrage de la campagne