### PR TITLE
[BUGFIX] Ajout d'une vérification sur l'id de certification sur Pix Admin (PIX-1652)

### DIFF
--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -1,5 +1,9 @@
+const Joi = require('@hapi/joi');
+
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');
+
+const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -24,6 +28,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/admin/certifications/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: idSpecification,
+          }),
+        },
         pre: [{
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',

--- a/api/tests/unit/application/certification-courses/index_test.js
+++ b/api/tests/unit/application/certification-courses/index_test.js
@@ -46,6 +46,30 @@ describe('Unit | Application | Certifications Course | Route', function() {
     });
   });
 
+  context('when certification ID params is not a number', () => {
+
+    it('should return 400', async () => {
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/certifications/1234*');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  context('when session ID params is out of range for database integer (> 2147483647)', () => {
+
+    it('should return 400', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/certifications/2147483648');
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+  //});
+
   describe('PATCH /api/certification-courses/id', () => {
 
     it('should exist', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui lorsque l'on fait une request GET /api/admin/certifications/1234*, l'api renvoie une erreur 500

Voir: https://sentry.io/organizations/pix/issues/2042256694/?project=1398749&referrer=slack

## :robot: Solution
Mettre en place une vérification Joi sur la route

AVANT

```
   method: 'GET',
      path: '/api/admin/certifications/{id}',
      config: {
        pre: [{
          method: securityPreHandlers.checkUserHasRolePixMaster,
          assign: 'hasRolePixMaster',
        }],
        handler: certificationCourseController.getResult,
        tags: ['api'],
      },`
```
APRES
```
   method: 'GET',
      path: '/api/admin/certifications/{id}',
      config: {
        validate: {
          params: Joi.object({
            id: idSpecification,
          }),
        },
        pre: [{
          method: securityPreHandlers.checkUserHasRolePixMaster,
          assign: 'hasRolePixMaster',
        }],
        handler: certificationCourseController.getResult,
        tags: ['api'],
      },
```
## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
