### PR TITLE
[BUGFIX] Gestion de la contrainte d'unicité sur le partage de profils cible en amont afin de ne pas remonter un erreur de BDD (PIX-1608).

### DIFF
--- a/admin/app/controllers/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/controllers/authenticated/organizations/get/target-profiles.js
@@ -26,9 +26,11 @@ export default class GetTargetProfilesController extends Controller {
     if (!errors) {
       return this.notifications.error('Une erreur est survenue.');
     }
-    const error404 = errors.find(({ status }) => status === '404');
-    if (error404) {
-      this.notifications.error(error404.detail);
+
+    const error = errors.find(({ status }) => ['404', '409'].includes(status));
+
+    if (error) {
+      this.notifications.error(error.detail);
     }
   }
 

--- a/api/lib/domain/usecases/attach-organizations-to-target-profile.js
+++ b/api/lib/domain/usecases/attach-organizations-to-target-profile.js
@@ -1,4 +1,4 @@
-module.exports = async function attachTargetProfilesToOrganization({
+module.exports = async function attachOrganizationsToTargetProfile({
   targetProfileId,
   organizationIds,
   targetProfileRepository,

--- a/api/lib/domain/usecases/attach-target-profiles-to-organization.js
+++ b/api/lib/domain/usecases/attach-target-profiles-to-organization.js
@@ -1,15 +1,18 @@
 const _ = require('lodash');
+const { ConflictError } = require('../../application/http-errors');
 const { NotFoundError } = require('../errors');
 
 module.exports = async function attachTargetProfilesToOrganization({
   organizationId,
   targetProfileIdsToAttach,
+  organizationRepository,
   targetProfileRepository,
   targetProfileShareRepository,
 }) {
   const uniqueTargetProfileIdsToAttach = _.uniq(targetProfileIdsToAttach);
 
   const foundTargetProfiles = await targetProfileRepository.findByIds(uniqueTargetProfileIdsToAttach);
+  const organization = await organizationRepository.get(organizationId);
 
   if (foundTargetProfiles.length !== uniqueTargetProfileIdsToAttach.length) {
     const foundTargetProfileIds = _.map(foundTargetProfiles, 'id');
@@ -17,5 +20,12 @@ module.exports = async function attachTargetProfilesToOrganization({
     throw new NotFoundError(`Le profil cible ${targetProfileIdNotExisting} n'existe pas.`);
   }
 
-  return targetProfileShareRepository.addTargetProfilesToOrganization({ organizationId, targetProfileIdList: uniqueTargetProfileIdsToAttach });
+  const targetProfileIdOfOrganization = _.map(organization.targetProfileShares,'targetProfileId');
+  const targetProfileShareToAttach = _.difference(uniqueTargetProfileIdsToAttach, targetProfileIdOfOrganization);
+
+  if (targetProfileShareToAttach.length === 0) {
+    throw new ConflictError('Profil(s) cible(s) déjà rattaché.');
+  }
+
+  return targetProfileShareRepository.addTargetProfilesToOrganization({ organizationId, targetProfileIdList: targetProfileShareToAttach });
 };

--- a/api/lib/infrastructure/repositories/target-profile-share-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-share-repository.js
@@ -1,7 +1,6 @@
 const Bookshelf = require('../bookshelf');
 
 module.exports = {
-
   addTargetProfilesToOrganization({ organizationId, targetProfileIdList }) {
     const targetProfileShareToAdd = targetProfileIdList.map((targetProfileId) => {
       return { organizationId, targetProfileId };

--- a/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
@@ -33,7 +33,7 @@ describe('Integration | Repository | Target-profile-share', () => {
       // then
       const targetProfileShares = await knex('target-profile-shares').where({ organizationId });
       expect(targetProfileShares).to.have.lengthOf(3);
-      expect(_.map(targetProfileShares, 'targetProfileId')).to.have.members([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
+      expect(_.map(targetProfileShares, 'targetProfileId')).exactlyContain([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
     });
 
     it('should not erase old target profil share', async function() {
@@ -48,7 +48,7 @@ describe('Integration | Repository | Target-profile-share', () => {
       // then
       const targetProfileShares = await knex('target-profile-shares').where({ organizationId });
       expect(targetProfileShares).to.have.lengthOf(3);
-      expect(_.map(targetProfileShares, 'targetProfileId')).to.have.members([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
+      expect(_.map(targetProfileShares, 'targetProfileId')).exactlyContain([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/attach-target-profiles-to-organization_test.js
+++ b/api/tests/unit/domain/usecases/attach-target-profiles-to-organization_test.js
@@ -2,9 +2,11 @@ const { expect, sinon, catchErr } = require('../../../test-helper');
 const { NotFoundError } = require('../../../../lib/domain/errors');
 
 const attachTargetProfilesToOrganization = require('../../../../lib/domain/usecases/attach-target-profiles-to-organization');
+const { ConflictError } = require('../../../../lib/application/http-errors');
 
 describe('Unit | UseCase | attach-target-profiles-to-organization', () => {
 
+  let organizationRepository;
   let targetProfileShareRepository;
   let targetProfileRepository;
   let targetProfileIdsToAttach;
@@ -12,6 +14,9 @@ describe('Unit | UseCase | attach-target-profiles-to-organization', () => {
   const expectedResult = Symbol('success');
 
   beforeEach(() => {
+    organizationRepository = { 
+      get: sinon.stub(), 
+    };
     targetProfileRepository = {
       findByIds: sinon.stub(),
     };
@@ -24,10 +29,28 @@ describe('Unit | UseCase | attach-target-profiles-to-organization', () => {
     // given
     targetProfileIdsToAttach = [1];
     targetProfileRepository.findByIds.withArgs(targetProfileIdsToAttach).resolves([{ id: 1 }]);
+    organizationRepository.get.withArgs(organizationId).resolves({ targetProfileShares : [] });
+    
     targetProfileShareRepository.addTargetProfilesToOrganization.withArgs({ organizationId, targetProfileIdList: targetProfileIdsToAttach }).resolves(expectedResult);
 
     // when
-    const result = await attachTargetProfilesToOrganization({ targetProfileShareRepository, targetProfileRepository, organizationId, targetProfileIdsToAttach });
+    const result = await attachTargetProfilesToOrganization({ targetProfileShareRepository, targetProfileRepository, organizationRepository, organizationId, targetProfileIdsToAttach });
+
+    // then
+    expect(result).to.equal(expectedResult);
+  });
+
+  it('should call repository with organizationId and targetProfileIdsToAttach even one target profile already linked', async () => {
+    // given
+    targetProfileIdsToAttach = [1, 2];
+    targetProfileRepository.findByIds.withArgs(targetProfileIdsToAttach).resolves([{ id: 1 }, { id: 2 }]);
+
+    organizationRepository.get.withArgs(organizationId).resolves({ targetProfileShares: [{ targetProfileId:1 }] });
+    
+    targetProfileShareRepository.addTargetProfilesToOrganization.withArgs({ organizationId, targetProfileIdList: [2] }).resolves(expectedResult);
+
+    // when
+    const result = await attachTargetProfilesToOrganization({ targetProfileShareRepository, targetProfileRepository, organizationRepository, organizationId, targetProfileIdsToAttach });
 
     // then
     expect(result).to.equal(expectedResult);
@@ -38,10 +61,12 @@ describe('Unit | UseCase | attach-target-profiles-to-organization', () => {
     targetProfileIdsToAttach = [1, 2, 2];
     const cleanedTargetProfileIdsToAttach = [1, 2];
     targetProfileRepository.findByIds.withArgs(cleanedTargetProfileIdsToAttach).resolves([{ id: 1 }, { id: 2 }]);
+    organizationRepository.get.withArgs(organizationId).resolves({ targetProfileShares : [] });
+
     targetProfileShareRepository.addTargetProfilesToOrganization.withArgs({ organizationId, targetProfileIdList: cleanedTargetProfileIdsToAttach }).resolves(expectedResult);
 
     // when
-    const result = await attachTargetProfilesToOrganization({ targetProfileShareRepository, targetProfileRepository, organizationId, targetProfileIdsToAttach });
+    const result = await attachTargetProfilesToOrganization({ targetProfileShareRepository, targetProfileRepository, organizationRepository, organizationId, targetProfileIdsToAttach });
 
     // then
     expect(result).to.equal(expectedResult);
@@ -51,12 +76,28 @@ describe('Unit | UseCase | attach-target-profiles-to-organization', () => {
     // given
     targetProfileIdsToAttach = [1, 2];
     targetProfileRepository.findByIds.withArgs(targetProfileIdsToAttach).resolves([{ id: 2 }]);
+    organizationRepository.get.withArgs(organizationId).resolves({ targetProfileShares : [] });
 
     // when
-    const error = await catchErr(attachTargetProfilesToOrganization)({ targetProfileShareRepository, targetProfileRepository, organizationId, targetProfileIdsToAttach });
+    const error = await catchErr(attachTargetProfilesToOrganization)({ targetProfileShareRepository, targetProfileRepository, organizationRepository, organizationId, targetProfileIdsToAttach });
 
     // then
     expect(error).to.be.instanceOf(NotFoundError);
     expect(error.message).to.equal('Le profil cible 1 n\'existe pas.');
+  });
+
+  it('should throw a NotFoundError when a target profile already attached to organization', async () => {
+    // given
+    targetProfileIdsToAttach = [1];
+    targetProfileRepository.findByIds.withArgs(targetProfileIdsToAttach).resolves([{ id: 1 }]);
+
+    organizationRepository.get.withArgs(organizationId).resolves({ targetProfileShares: [{ targetProfileId:1 }] });
+
+    // when
+    const error = await catchErr(attachTargetProfilesToOrganization)({ targetProfileShareRepository, targetProfileRepository, organizationRepository, organizationId, targetProfileIdsToAttach });
+
+    // then
+    expect(error).to.be.instanceOf(ConflictError);
+    expect(error.message).to.equal('Profil(s) cible(s) déjà rattaché.');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
des erreurs sentry sont remonté depuis un ajout de contrainte d'unicité

## :robot: Solution
retiré les target profile existant sur l'organisation et n'ajouter que celle manquante.
remonté un message d'erreur si tout les targets profils sont déjà sur l'organisation

## :rainbow: Remarques
Comme c'était sur PixAdmin, je me suis dit que plutôt de levé l'erreur sur un target existant. autant le retiré avant l'insertion.

## :100: Pour tester
Aller sur pix Admin et tenter de rajouter des target profil existant . 