### PR TITLE
[FEATURE] Ajouter une validation de l'INA dans l'import CSV pour les Organisations SCO AGRICULTURE important des apprentis (PIX-1665).

### DIFF
--- a/api/lib/domain/validators/schooling-registration-validator.js
+++ b/api/lib/domain/validators/schooling-registration-validator.js
@@ -5,6 +5,7 @@ const  SchoolingRegistration = require('../models/SchoolingRegistration');
 const { STUDENT , APPRENTICE } = SchoolingRegistration.STATUS;
 const validationConfiguration = { allowUnknown: true };
 const MAX_LENGTH = 255;
+const INA_PATTERN = /^[0-9]{10}[a-zA-Z]{1}$/;
 const CITY_CODE_LENGTH = 5;
 const PROVINCE_CODE_MIN_LENGTH = 2;
 const PROVINCE_CODE_MAX_LENGTH = 3;
@@ -17,7 +18,11 @@ const INSEE_REGEX = {
 };
 
 const validationSchema = Joi.object({
-  nationalIdentifier: Joi.string().max(MAX_LENGTH).required(),
+  nationalIdentifier: Joi.alternatives().conditional('status', {
+    is: APPRENTICE,
+    then: Joi.string().pattern(INA_PATTERN, { name: 'INA' }).required(),
+    otherwise: Joi.string().max(MAX_LENGTH).required(),
+  }),
   firstName: Joi.string().max(MAX_LENGTH).required(),
   middleName: Joi.string().max(MAX_LENGTH).optional(),
   thirdName: Joi.string().max(MAX_LENGTH).optional(),
@@ -83,6 +88,10 @@ module.exports = {
       if (type === 'any.only') {
         err.why = 'bad_values';
         err.valids = context.valids;
+      }
+      if (type === 'string.pattern.name') {
+        err.why = 'bad_pattern';
+        err.pattern = context.name;
       }
       err.key = context.key;
       throw err;

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -69,6 +69,10 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
   _handleError(err, index) {
     const column = this._columns.find((column) => column.name === err.key);
 
+    if (err.why === 'bad_pattern' && err.pattern === 'INA') {
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” (INA) doit être de 10 chiffres suivis d’une lettre.`);
+    }
+
     if (err.why === 'uniqueness') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” de cette ligne est présent plusieurs fois dans le fichier.`);
     }

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -800,7 +800,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
           const input = `${schoolingRegistrationCsvColumns}
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;ST;MEF1;Division 1;
-          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
           `;
           const buffer = iconv.encode(input, 'UTF-8');
 
@@ -823,7 +823,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           // then
           const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
           expect(schoolingRegistrations).to.have.lengthOf(2);
-          expect(_.map(schoolingRegistrations, 'nationalApprenticeId')).to.have.members([null, '456F']);
+          expect(_.map(schoolingRegistrations, 'nationalApprenticeId')).to.have.members([null, '0123456789F']);
         });
       });
 

--- a/api/tests/integration/scripts/prod/import-apprentices_test.js
+++ b/api/tests/integration/scripts/prod/import-apprentices_test.js
@@ -39,7 +39,7 @@ describe('Integration | Scripts | import-apprentices', () => {
           await databaseBuilder.commit();
 
           const registration1Attributes = {
-            nationalApprenticeId: '123F',
+            nationalApprenticeId: '9876543210F',
             firstName: 'Beatrix',
             middleName: 'The',
             thirdName: 'Bride',
@@ -56,7 +56,7 @@ describe('Integration | Scripts | import-apprentices', () => {
           };
 
           const registration2Attributes = {
-            nationalApprenticeId: '456F',
+            nationalApprenticeId: '0123456789F',
             firstName: 'O-Ren',
             lastName: 'Ishii',
             preferredLastName: 'Cottonmouth',
@@ -71,8 +71,8 @@ describe('Integration | Scripts | import-apprentices', () => {
           };
 
           const input = `${schoolingRegistrationCsvColumns}
-         123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
-           456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
+          9876543210F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;200;99100;AP;MEF1;Division 1;12345;
+          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;54321;
           `;
 
           const encodedInput = iconv.encode(input, 'utf8');

--- a/api/tests/unit/domain/usecases/import-schooling-registrations-from-siecle_test.js
+++ b/api/tests/unit/domain/usecases/import-schooling-registrations-from-siecle_test.js
@@ -87,7 +87,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
         format = 'csv';
         const input = `${schoolingRegistrationCsvColumns}
         123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
-        456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+        0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
         `;
         const path = __dirname + '/siecle.csv';
         payload = { path };
@@ -113,7 +113,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
         });
         const schoolingRegistration2 = new SchoolingRegistration({
           id: undefined,
-          nationalApprenticeId: '456F',
+          nationalApprenticeId: '0123456789F',
           firstName: 'O-Ren',
           lastName: 'Ishii',
           preferredLastName: 'Cottonmouth',

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -51,6 +51,56 @@ describe('Unit | Domain | Schooling Registration validator', () => {
       });
     });
 
+    context('nationalIdentifier', () => {
+      context('nationalIdentifier is a National Student Id', () => {
+        it('should be valid when National Student Id is not an apprentice', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: '1234', status: 'ST' });
+        
+          expect(error.key).to.be.undefined;
+        });
+      });
+
+      context('nationalIdentifier is a National Apprentice Id', () => {
+        it('should be valid when National Apprentice Id has the correct pattern', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: '0123456789A', status: 'AP' });
+        
+          expect(error.key).to.be.undefined;
+        });
+      
+        it('throw an error when National Apprentice Id has only numbers', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: '12345678900', status: 'AP' });
+  
+          expect(error.key).to.equal('nationalIdentifier');
+          expect(error.why).to.equal('bad_pattern');
+          expect(error.pattern).to.equal('INA');
+        });
+
+        it('throw an error when National Apprentice Id has only chars', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: 'ABCDEFGHIJH', status: 'AP' });
+  
+          expect(error.key).to.equal('nationalIdentifier');
+          expect(error.why).to.equal('bad_pattern');
+          expect(error.pattern).to.equal('INA');
+        });
+
+        it('throw an error when National Apprentice Id is too short', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: '1234', status: 'AP' });
+  
+          expect(error.key).to.equal('nationalIdentifier');
+          expect(error.why).to.equal('bad_pattern');
+          expect(error.pattern).to.equal('INA');
+        });
+
+        it('throw an error when National Apprentice Id is too long', async () => {
+          const error = await catchErr(checkValidation)({ ...validAttributes, nationalIdentifier: '12345678900A', status: 'AP' });
+  
+          expect(error.key).to.equal('nationalIdentifier');
+          expect(error.why).to.equal('bad_pattern');
+          expect(error.pattern).to.equal('INA');
+        });
+      });
+    });
+
     context('birthProvinceCode', () => {
       it('throw an error when birthProvinceCode has more than 3 characters', async () => {
         const error = await catchErr(checkValidation)({ ...validAttributes, birthProvinceCode: '1234' });
@@ -121,7 +171,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
 
       it('is valid when status is \'AP\'', async () => {
         try {
-          checkValidation({ ...validAttributes, status: 'AP' });
+          checkValidation({ ...validAttributes, nationalIdentifier: '0123456789F', status: 'AP' });
         } catch (e) {
           expect.fail('SchoolingRegistration is valid when status is \'AP\'');
         }

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -68,7 +68,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         it('returns schooling registrations for each line using the CSV column', () => {
           const input = `${schoolingRegistrationCsvColumns}
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
-          456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+          0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
           `;
           const organizationId = 789;
           const encodedInput = iconv.encode(input, 'utf8');
@@ -94,7 +94,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           });
   
           expect(registrations[1]).to.includes({
-            nationalStudentId: '456F',
+            nationalStudentId: '0123456789F',
             nationalApprenticeId: undefined,
             firstName: 'O-Ren',
             lastName: 'Ishii',
@@ -112,6 +112,20 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
       });
 
       context('when the data are not correct', () => {
+        it('should throw an EntityValidationError with malformated National Apprentice Id', async () => {
+          //given
+          const input = `${schoolingRegistrationCsvColumns}
+          123F;Beatrix;The;Bride;Kiddo;Black Mamba;aaaaa;97422;;200;99100;AP;MEF1;Division 1;
+          `;
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+
+          const error = await catchErr(parser.parse, parser)();
+          
+          //then
+          expect(error.message).to.contain('Ligne 2 : Le champ “Identifiant unique*” (INA) doit être de 10 chiffres suivis d’une lettre.');
+        });
+
         it('should throw an EntityValidationError with malformated birthDate', async () => {
           const wrongData = 'aaaa';
           //given
@@ -160,7 +174,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
         context('When the organization is Agriculture and file contain status AP', () => {
           it('should return schooling registration with nationalApprenticeId', () => {
             const input = `${schoolingRegistrationCsvColumns}
-            123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+            0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
             `;
             const organizationId = 789;
             const encodedInput = iconv.encode(input, 'utf8');
@@ -169,7 +183,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
             const { registrations } = parser.parse();
             expect(registrations[0]).to.includes({
               nationalStudentId: undefined,
-              nationalApprenticeId: '123F',
+              nationalApprenticeId: '0123456789F',
               status: 'AP',
             });
           });
@@ -198,8 +212,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
   
             it('should not return error given nationalIdentifier with different status', () => {
               const input = `${schoolingRegistrationCsvColumns}
-              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
-              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
               `;
               const organizationId = 789;
               const encodedInput = iconv.encode(input, 'utf8');
@@ -209,12 +223,12 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
               
               expect(registrations[0]).to.includes({
                 nationalStudentId: undefined,
-                nationalApprenticeId: '123F',
+                nationalApprenticeId: '0123456789F',
                 status: 'AP',
               });
     
               expect(registrations[1]).to.includes({
-                nationalStudentId: '123F',
+                nationalStudentId: '0123456789F',
                 nationalApprenticeId: undefined,
                 status: 'ST',
               });
@@ -222,8 +236,8 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
   
             it('should throw an CsvImportError, with same status', async () => {
               const input = `${schoolingRegistrationCsvColumns}
-              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
-              123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
+              0123456789F;Beatrix;The;Bride;Kiddo;Black Mamba;01/05/1986;97422;;200;99100;AP;MEF1;Division 1;
               `;
   
               const encodedInput = iconv.encode(input, 'utf8');


### PR DESCRIPTION
## :unicorn: Problème

En base, des imports ont eu lieu, et sur 50 élèves, seuls 5 avaient un INA correctement formaté : certains saisissent un identifiant "1234", d'autres la première lettre du prénom accolée au nom, d'autre une adresse email  et d'autres encore un INE.

## :robot: Solution

Formater l'INA de manière fixe :il est composé de 11 caractères, les 10 premiers sont des chiffres, le dernier est une lettre.

A l'import, si pas bon format : 

 "Ligne XXX: Le champ “Identifiant unique” (INA) doit être de 10 chiffres suivis d'une lettre."

## :rainbow: Remarques

n/a

## :100: Pour tester

Se connecter avec sco.admin@example.net => lycée agricole => élèves => import CSV
enregistrer ces fichiers au format csv

Message d'erreur:
```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
458F;Léa;;;Corse;Cottonmouth;01/01/1780;2A214;Corse;99;99100;AP;MEF1;Division 2
```

Passe correctement:
```
Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
4581234567F;Léa;;;Corse;Cottonmouth;01/01/1780;2A214;Corse;99;99100;AP;MEF1;Division 2
```