### PR TITLE
[TECH] Mettre à jour le lien Pix cloud vers les documents de Pix Orga. 

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/new.hbs
+++ b/orga/app/components/routes/authenticated/campaign/new.hbs
@@ -62,7 +62,7 @@
         <p class="form__comment" id="campaign-target-profile-comment-label">
           Si vous souhaitez avoir plus d'information, consultez
           <a class="link"
-             href="https://cloud.pix.fr/s/zK7xHArNzGWaYP7"
+             href="https://cloud.pix.fr/s/3joGMGYWSpmHg5w"
              target="_blank"
              rel="noopener noreferrer"> la documentation correspondante</a>.
         </p>

--- a/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
@@ -154,7 +154,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.dom('a[href="https://cloud.pix.fr/s/zK7xHArNzGWaYP7"]').exists();
+      assert.dom('a[href="https://cloud.pix.fr/s/3joGMGYWSpmHg5w"]').exists();
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
L'url de Pix cloud qui contient les documents a changé.

## :robot: Solution
Mettre le nouveau lien Pix Cloud.

## :rainbow: Remarques
RAS

## :100: Pour tester
Tester le lien lors de la création de campagne.
