### PR TITLE
[FEATURE] Prise en compte des 0 après virgules et points dans QROC (PIX-1592).

### DIFF
--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -18,7 +18,7 @@ class Examiner {
     // references
   }
 
-  evaluate(answer) {
+  evaluate({ answer, challengeFormat }) {
 
     const correctedAnswer = new Answer(answer);
 
@@ -29,7 +29,7 @@ class Examiner {
       return correctedAnswer;
     }
 
-    const answerValidation = this.validator.assess(answer);
+    const answerValidation = this.validator.assess({ answer, challengeFormat });
     correctedAnswer.result = answerValidation.result;
     correctedAnswer.resultDetails = answerValidation.resultDetails;
 

--- a/api/lib/domain/models/ValidatorQCM.js
+++ b/api/lib/domain/models/ValidatorQCM.js
@@ -19,7 +19,7 @@ class ValidatorQCM extends Validator {
     // references
   }
 
-  assess(answer) {
+  assess({ answer }) {
     const result = solutionServiceQCM.match(answer.value, this.solution.value);
 
     return new Validation({

--- a/api/lib/domain/models/ValidatorQCU.js
+++ b/api/lib/domain/models/ValidatorQCU.js
@@ -19,7 +19,7 @@ class ValidatorQCU extends Validator {
     // references
   }
 
-  assess(answer) {
+  assess({ answer }) {
     const result = solutionServiceQCU.match(answer.value, this.solution.value);
 
     return new Validation({

--- a/api/lib/domain/models/ValidatorQROC.js
+++ b/api/lib/domain/models/ValidatorQROC.js
@@ -19,8 +19,8 @@ class ValidatorQROC extends Validator {
     // references
   }
 
-  assess(answer) {
-    const result = solutionServiceQROC.match(answer.value, this.solution.value, this.solution.deactivations);
+  assess({ answer, challengeFormat }) {
+    const result = solutionServiceQROC.match({ answer: answer.value, solution: this.solution.value, deactivations: this.solution.deactivations, challengeFormat });
 
     return new Validation({
       result,

--- a/api/lib/domain/models/ValidatorQROCMDep.js
+++ b/api/lib/domain/models/ValidatorQROCMDep.js
@@ -19,7 +19,7 @@ class ValidatorQROCMDep extends Validator {
     // references
   }
 
-  assess(answer) {
+  assess({ answer }) {
     const result = solutionServiceQROCMDep.match(
       answer.value,
       this.solution.value,

--- a/api/lib/domain/models/ValidatorQROCMInd.js
+++ b/api/lib/domain/models/ValidatorQROCMInd.js
@@ -19,7 +19,7 @@ class ValidatorQROCMInd extends Validator {
     // references
   }
 
-  assess(answer) {
+  assess({ answer }) {
     const resultObject = solutionServiceQROCMInd.match(answer.value, this.solution.value, this.solution.enabledTreatments);
 
     return new Validation({

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -1,6 +1,6 @@
 const utils = require('./solution-service-utils');
 const deactivationsService = require('../../../lib/domain/services/deactivations-service');
-const { isNumeric, splitIntoWordsAndRemoveBackspaces } = require('../../../lib/infrastructure/utils/string-utils');
+const { isNumeric, splitIntoWordsAndRemoveBackspaces, cleanStringAndParseFloat } = require('../../../lib/infrastructure/utils/string-utils');
 const { includes, isEmpty, isString, map } = require('lodash');
 const {
   normalizeAndRemoveAccents,
@@ -32,7 +32,7 @@ module.exports = {
 };
 
 function _getAnswerStatusFromNumberMatching(answer, solution) {
-  if (parseFloat(answer) === parseFloat(solution)) {
+  if (cleanStringAndParseFloat(answer) === cleanStringAndParseFloat(solution)) {
     return AnswerStatus.OK;
   }
   return AnswerStatus.KO;

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -10,6 +10,8 @@ const {
 
 const AnswerStatus = require('../models/AnswerStatus');
 
+const LEVENSHTEIN_DISTANCE_MAX_RATE = 0.25;
+
 module.exports = {
 
   match(answer, solution, deactivations) {
@@ -79,51 +81,44 @@ function _applyTreatmentsToSolutions(solution, deactivations) {
 function _getAnswerStatusAccordingToLevenshteinDistance(validations, deactivations) {
 
   if (deactivationsService.isDefault(deactivations)) {
-    if (validations.t1t2t3Ratio <= 0.25) {
+    if (validations.t1t2t3Ratio <= LEVENSHTEIN_DISTANCE_MAX_RATE) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT1(deactivations)) {
-    if (validations.t2t3Ratio <= 0.25) {
+    if (validations.t2t3Ratio <= LEVENSHTEIN_DISTANCE_MAX_RATE) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT2(deactivations)) {
-    if (validations.t1t3Ratio <= 0.25) {
+    if (validations.t1t3Ratio <= LEVENSHTEIN_DISTANCE_MAX_RATE) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT3(deactivations)) {
     if (includes(validations.adminAnswers, validations.t1t2)) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT1T2(deactivations)) {
-    if (validations.t3Ratio <= 0.25) {
+    if (validations.t3Ratio <= LEVENSHTEIN_DISTANCE_MAX_RATE) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT1T3(deactivations)) {
     if (includes(validations.adminAnswers, validations.t2)) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT2T3(deactivations)) {
     if (includes(validations.adminAnswers, validations.t1)) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
   else if (deactivationsService.hasT1T2T3(deactivations)) {
     if (includes(validations.adminAnswers, validations.userAnswer)) {
       return AnswerStatus.OK;
     }
-    return AnswerStatus.KO;
   }
+  return AnswerStatus.KO;
 }

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -1,6 +1,6 @@
 const utils = require('./solution-service-utils');
 const deactivationsService = require('../../../lib/domain/services/deactivations-service');
-const isNumeric = require('../../../lib/infrastructure/utils/string-utils');
+const { isNumeric, splitIntoWordsAndRemoveBackspaces } = require('../../../lib/infrastructure/utils/string-utils');
 const _ = require('../../infrastructure/utils/lodash-utils');
 const {
   normalizeAndRemoveAccents,
@@ -40,15 +40,8 @@ function _getAnswerStatusFromStringMatching(answer, solution, deactivations) {
   return _getAnswerStatusAccordingToLevenshteinDistance(validations, deactivations);
 }
 
-function _applyPreTreatmentsToSolutions(solution) {
-  return _.chain(solution)
-    .split('\n')
-    .reject(_.isEmpty)
-    .value();
-}
-
 function _applyTreatmentsToSolutions(solution, deactivations) {
-  const pretreatedSolutions = _applyPreTreatmentsToSolutions(solution);
+  const pretreatedSolutions = splitIntoWordsAndRemoveBackspaces(solution);
   return _.map(pretreatedSolutions, (pretreatedSolution) => {
 
     if (deactivationsService.isDefault(deactivations)) {

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -1,7 +1,11 @@
 const utils = require('./solution-service-utils');
 const deactivationsService = require('./deactivations-service');
 const _ = require('../../infrastructure/utils/lodash-utils');
-const { normalizeAndRemoveAccents: t1, removeSpecialCharacters: t2, applyPreTreatments } = require('./validation-treatments');
+const {
+  normalizeAndRemoveAccents,
+  removeSpecialCharacters,
+  applyPreTreatments,
+} = require('./validation-treatments');
 
 const AnswerStatus = require('../models/AnswerStatus');
 
@@ -39,25 +43,27 @@ function _applyTreatmentsToSolutions(solution, deactivations) {
   return _.map(pretreatedSolutions, (pretreatedSolution) => {
 
     if (deactivationsService.isDefault(deactivations)) {
-      return t2(t1(pretreatedSolution));
+      const normalizedWithoutAccentsSolution = normalizeAndRemoveAccents(pretreatedSolution);
+      return removeSpecialCharacters(normalizedWithoutAccentsSolution);
     }
     else if (deactivationsService.hasOnlyT1(deactivations)) {
-      return t2(pretreatedSolution);
+      return removeSpecialCharacters(pretreatedSolution);
     }
     else if (deactivationsService.hasOnlyT2(deactivations)) {
-      return t1(pretreatedSolution);
+      return normalizeAndRemoveAccents(pretreatedSolution);
     }
     else if (deactivationsService.hasOnlyT3(deactivations)) {
-      return t2(t1(pretreatedSolution));
+      const normalizedWithoutAccentsSolution = normalizeAndRemoveAccents(pretreatedSolution);
+      return removeSpecialCharacters(normalizedWithoutAccentsSolution);
     }
     else if (deactivationsService.hasOnlyT1T2(deactivations)) {
       return pretreatedSolution;
     }
     else if (deactivationsService.hasOnlyT1T3(deactivations)) {
-      return t2(pretreatedSolution);
+      return removeSpecialCharacters(pretreatedSolution);
     }
     else if (deactivationsService.hasOnlyT2T3(deactivations)) {
-      return t1(pretreatedSolution);
+      return normalizeAndRemoveAccents(pretreatedSolution);
     }
     else if (deactivationsService.hasT1T2T3(deactivations)) {
       return pretreatedSolution;

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -1,5 +1,6 @@
 const utils = require('./solution-service-utils');
-const deactivationsService = require('./deactivations-service');
+const deactivationsService = require('../../../lib/domain/services/deactivations-service');
+const isNumeric = require('../../../lib/infrastructure/utils/string-utils');
 const _ = require('../../infrastructure/utils/lodash-utils');
 const {
   normalizeAndRemoveAccents,
@@ -15,16 +16,24 @@ module.exports = {
 
     const isIncorrectAnswerFormat = !_.isString(answer);
     const isIncorrectSolutionFormat = !_.isString(solution) || _.isEmpty(solution);
+
     if (isIncorrectAnswerFormat || isIncorrectSolutionFormat) {
       return AnswerStatus.KO;
     }
-    const answerStatus = _verifyStringMatching(answer, solution, deactivations);
 
-    return answerStatus;
+    if (isNumeric(answer.value) && isNumeric(solution)) {
+      return _getAnswerStatusFromNumberMatching(answer, solution);
+    }
+
+    return _getAnswerStatusFromStringMatching(answer, solution, deactivations);
   },
 };
 
-function _verifyStringMatching(answer, solution, deactivations) {
+function _getAnswerStatusFromNumberMatching(answer, solution) {
+  return AnswerStatus.KO;
+}
+
+function _getAnswerStatusFromStringMatching(answer, solution, deactivations) {
   const treatedAnswer = applyPreTreatments(answer);
   const treatedSolutions = _applyTreatmentsToSolutions(solution, deactivations);
   const validations = utils.treatmentT1T2T3(treatedAnswer, treatedSolutions);

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -21,7 +21,7 @@ module.exports = {
       return AnswerStatus.KO;
     }
 
-    if (isNumeric(answer.value) && isNumeric(solution)) {
+    if (isNumeric(answer) && isNumeric(solution)) {
       return _getAnswerStatusFromNumberMatching(answer, solution);
     }
 
@@ -30,6 +30,9 @@ module.exports = {
 };
 
 function _getAnswerStatusFromNumberMatching(answer, solution) {
+  if (parseFloat(answer) === parseFloat(solution)) {
+    return AnswerStatus.OK;
+  }
   return AnswerStatus.KO;
 }
 

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -1,7 +1,7 @@
 const utils = require('./solution-service-utils');
 const deactivationsService = require('../../../lib/domain/services/deactivations-service');
 const { isNumeric, splitIntoWordsAndRemoveBackspaces } = require('../../../lib/infrastructure/utils/string-utils');
-const _ = require('../../infrastructure/utils/lodash-utils');
+const { includes, isEmpty, isString, map } = require('lodash');
 const {
   normalizeAndRemoveAccents,
   removeSpecialCharacters,
@@ -14,8 +14,8 @@ module.exports = {
 
   match(answer, solution, deactivations) {
 
-    const isIncorrectAnswerFormat = !_.isString(answer);
-    const isIncorrectSolutionFormat = !_.isString(solution) || _.isEmpty(solution);
+    const isIncorrectAnswerFormat = !isString(answer);
+    const isIncorrectSolutionFormat = !isString(solution) || isEmpty(solution);
 
     if (isIncorrectAnswerFormat || isIncorrectSolutionFormat) {
       return AnswerStatus.KO;
@@ -42,7 +42,7 @@ function _getAnswerStatusFromStringMatching(answer, solution, deactivations) {
 
 function _applyTreatmentsToSolutions(solution, deactivations) {
   const pretreatedSolutions = splitIntoWordsAndRemoveBackspaces(solution);
-  return _.map(pretreatedSolutions, (pretreatedSolution) => {
+  return map(pretreatedSolutions, (pretreatedSolution) => {
 
     if (deactivationsService.isDefault(deactivations)) {
       const normalizedWithoutAccentsSolution = normalizeAndRemoveAccents(pretreatedSolution);
@@ -94,7 +94,7 @@ function _getAnswerStatusAccordingToLevenshteinDistance(validations, deactivatio
     return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT3(deactivations)) {
-    if (_.includes(validations.adminAnswers, validations.t1t2)) {
+    if (includes(validations.adminAnswers, validations.t1t2)) {
       return AnswerStatus.OK;
     }
     return AnswerStatus.KO;
@@ -106,19 +106,19 @@ function _getAnswerStatusAccordingToLevenshteinDistance(validations, deactivatio
     return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT1T3(deactivations)) {
-    if (_.includes(validations.adminAnswers, validations.t2)) {
+    if (includes(validations.adminAnswers, validations.t2)) {
       return AnswerStatus.OK;
     }
     return AnswerStatus.KO;
   }
   else if (deactivationsService.hasOnlyT2T3(deactivations)) {
-    if (_.includes(validations.adminAnswers, validations.t1)) {
+    if (includes(validations.adminAnswers, validations.t1)) {
       return AnswerStatus.OK;
     }
     return AnswerStatus.KO;
   }
   else if (deactivationsService.hasT1T2T3(deactivations)) {
-    if (_.includes(validations.adminAnswers, validations.userAnswer)) {
+    if (includes(validations.adminAnswers, validations.userAnswer)) {
       return AnswerStatus.OK;
     }
     return AnswerStatus.KO;

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -11,10 +11,11 @@ const {
 const AnswerStatus = require('../models/AnswerStatus');
 
 const LEVENSHTEIN_DISTANCE_MAX_RATE = 0.25;
+const CHALLENGE_NUMBER_FORMAT = 'nombre';
 
 module.exports = {
 
-  match(answer, solution, deactivations) {
+  match({ answer, challengeFormat, solution, deactivations }) {
 
     const isIncorrectAnswerFormat = !isString(answer);
     const isIncorrectSolutionFormat = !isString(solution) || isEmpty(solution);
@@ -28,7 +29,7 @@ module.exports = {
       return isNumeric(solution);
     });
 
-    if (isNumeric(answer) && areAllNumericSolutions) {
+    if (isNumeric(answer) && areAllNumericSolutions && challengeFormat === CHALLENGE_NUMBER_FORMAT) {
       return _getAnswerStatusFromNumberMatching(answer, solutions);
     }
 

--- a/api/lib/domain/services/solution-service-qroc.js
+++ b/api/lib/domain/services/solution-service-qroc.js
@@ -29,15 +29,19 @@ module.exports = {
     });
 
     if (isNumeric(answer) && areAllNumericSolutions) {
-      return _getAnswerStatusFromNumberMatching(answer, solution);
+      return _getAnswerStatusFromNumberMatching(answer, solutions);
     }
 
     return _getAnswerStatusFromStringMatching(answer, solutions, deactivations);
   },
 };
 
-function _getAnswerStatusFromNumberMatching(answer, solution) {
-  if (cleanStringAndParseFloat(answer) === cleanStringAndParseFloat(solution)) {
+function _getAnswerStatusFromNumberMatching(answer, solutions) {
+  const treatedSolutions = solutions.map((solution) => cleanStringAndParseFloat(solution));
+  const treatedAnswer = cleanStringAndParseFloat(answer);
+  const indexOfSolution = treatedSolutions.indexOf(treatedAnswer);
+  const isAnswerMatchingSolution = indexOfSolution !== -1;
+  if (isAnswerMatchingSolution) {
     return AnswerStatus.OK;
   }
   return AnswerStatus.KO;

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -87,7 +87,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
 
 function _evaluateAnswer(challenge, answer) {
   const examiner = new Examiner({ validator: challenge.validator });
-  return examiner.evaluate(answer);
+  return examiner.evaluate({ answer, challengeFormat: challenge.format });
 }
 
 async function _getKnowledgeElements({ assessment, answer, challenge, skillRepository, targetProfileRepository, knowledgeElementRepository }) {

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -1,0 +1,12 @@
+function isNumeric(string) {
+  if (typeof string != 'string') {
+    return false;
+  }
+  const stringWithoutComma = string.replace(',', '.').trim();
+  const stringWithoutCommaAndSpace = stringWithoutComma.replace(' ', '');
+  return !isNaN(stringWithoutCommaAndSpace) && !isNaN(parseFloat(stringWithoutCommaAndSpace));
+}
+
+module.exports = {
+  isNumeric,
+};

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -9,6 +9,11 @@ function isNumeric(string) {
   return !isNaN(stringWithoutCommaAndSpace) && !isNaN(parseFloat(stringWithoutCommaAndSpace));
 }
 
+function cleanStringAndParseFloat(string) {
+  const stringWithoutSpace = string.replace(' ', '');
+  return parseFloat(stringWithoutSpace.replace(',', '.'));
+}
+
 function splitIntoWordsAndRemoveBackspaces(string) {
   return _.chain(string)
     .split('\n')
@@ -19,4 +24,5 @@ function splitIntoWordsAndRemoveBackspaces(string) {
 module.exports = {
   isNumeric,
   splitIntoWordsAndRemoveBackspaces,
+  cleanStringAndParseFloat,
 };

--- a/api/lib/infrastructure/utils/string-utils.js
+++ b/api/lib/infrastructure/utils/string-utils.js
@@ -1,3 +1,5 @@
+const _ = require('../../infrastructure/utils/lodash-utils');
+
 function isNumeric(string) {
   if (typeof string != 'string') {
     return false;
@@ -7,6 +9,14 @@ function isNumeric(string) {
   return !isNaN(stringWithoutCommaAndSpace) && !isNaN(parseFloat(stringWithoutCommaAndSpace));
 }
 
+function splitIntoWordsAndRemoveBackspaces(string) {
+  return _.chain(string)
+    .split('\n')
+    .reject(_.isEmpty)
+    .value();
+}
+
 module.exports = {
   isNumeric,
+  splitIntoWordsAndRemoveBackspaces,
 };

--- a/api/tests/unit/domain/models/Examiner_test.js
+++ b/api/tests/unit/domain/models/Examiner_test.js
@@ -6,6 +6,7 @@ const { expect, domainBuilder, sinon } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | Examiner', () => {
 
+  const challengeFormat = 'nombre';
   const validator = {
     assess: () => undefined,
   };
@@ -28,7 +29,7 @@ describe('Unit | Domain | Models | Examiner', () => {
         examiner = new Examiner({ validator });
 
         // when
-        correctedAnswer = examiner.evaluate(uncorrectedAnswer);
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat  });
       });
 
       it('should return an answer with skipped as result and null as resultDetails', () => {
@@ -61,7 +62,7 @@ describe('Unit | Domain | Models | Examiner', () => {
         examiner = new Examiner({ validator });
 
         // when
-        correctedAnswer = examiner.evaluate(uncorrectedAnswer);
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat });
       });
 
       it('should return an answer with TIMEOUT as result, and the correct resultDetails', () => {
@@ -75,7 +76,7 @@ describe('Unit | Domain | Models | Examiner', () => {
       });
       it('should call validator.assess with answer to assess validity of answer', () => {
         // then
-        expect(validator.assess).to.have.been.calledWithExactly(uncorrectedAnswer);
+        expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
       });
     });
 
@@ -94,7 +95,7 @@ describe('Unit | Domain | Models | Examiner', () => {
         examiner = new Examiner({ validator });
 
         // when
-        correctedAnswer = examiner.evaluate(uncorrectedAnswer);
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat });
       });
 
       it('should return an answer with TIMEOUT as result, and the correct resultDetails', () => {
@@ -106,9 +107,10 @@ describe('Unit | Domain | Models | Examiner', () => {
         expect(correctedAnswer).to.be.an.instanceOf(Answer);
         expect(correctedAnswer).to.deep.equal(expectedAnswer);
       });
+
       it('should call validator.assess with answer to assess validity of answer', () => {
         // then
-        expect(validator.assess).to.have.been.calledWithExactly(uncorrectedAnswer);
+        expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
       });
     });
 
@@ -127,7 +129,7 @@ describe('Unit | Domain | Models | Examiner', () => {
         examiner = new Examiner({ validator });
 
         // when
-        correctedAnswer = examiner.evaluate(uncorrectedAnswer);
+        correctedAnswer = examiner.evaluate({ answer: uncorrectedAnswer, challengeFormat });
       });
 
       it('should return an answer with the validator‘s result and resultDetails', () => {
@@ -141,7 +143,7 @@ describe('Unit | Domain | Models | Examiner', () => {
       });
       it('should call validator.assess with answer to assess validity of answer', () => {
         // then
-        expect(validator.assess).to.have.been.calledWithExactly(uncorrectedAnswer);
+        expect(validator.assess).to.have.been.calledWithExactly({ answer: uncorrectedAnswer, challengeFormat });
       });
     });
   });

--- a/api/tests/unit/domain/models/ValidatorQCM_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCM_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | ValidatorQCM', () => {
       validator = new ValidatorQCM({ solution: solution });
 
       // when
-      validation = validator.assess(uncorrectedAnswer);
+      validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
     it('should call solutionServiceQCU', () => {

--- a/api/tests/unit/domain/models/ValidatorQCU_test.js
+++ b/api/tests/unit/domain/models/ValidatorQCU_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | ValidatorQCU', () => {
       validator = new ValidatorQCU({ solution: solution });
 
       // when
-      validation = validator.assess(uncorrectedAnswer);
+      validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
     it('should call solutionServiceQCU', () => {

--- a/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMDep_test.js
@@ -35,7 +35,7 @@ describe('Unit | Domain | Models | ValidatorQROCMDep', () => {
       validator = new ValidatorQROCMDep({ solution: solution });
 
       // when
-      validation = validator.assess(uncorrectedAnswer);
+      validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
     it('should call solutionServiceQROCMDep', () => {

--- a/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROCMInd_test.js
@@ -28,7 +28,7 @@ describe('Unit | Domain | Models | ValidatorQROCMInd', () => {
       validator = new ValidatorQROCMInd({ solution: solution });
 
       // when
-      validation = validator.assess(uncorrectedAnswer);
+      validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
     it('should call solutionServiceQROCMInd', () => {

--- a/api/tests/unit/domain/models/ValidatorQROC_test.js
+++ b/api/tests/unit/domain/models/ValidatorQROC_test.js
@@ -18,6 +18,7 @@ describe('Unit | Domain | Models | ValidatorQROC', () => {
     let validation;
     let validator;
     let solution;
+    let challengeFormat;
 
     beforeEach(() => {
       // given
@@ -28,13 +29,17 @@ describe('Unit | Domain | Models | ValidatorQROC', () => {
       validator = new ValidatorQROC({ solution: solution });
 
       // when
-      validation = validator.assess(uncorrectedAnswer);
+      validation = validator.assess({ answer: uncorrectedAnswer });
     });
 
     it('should call solutionServiceQROC', () => {
       // then
-      expect(solutionServiceQroc.match).to.have.been.calledWith(
-        uncorrectedAnswer.value, solution.value, solution.deactivations);
+      expect(solutionServiceQroc.match).to.have.been.calledWith({
+        answer: uncorrectedAnswer.value,
+        solution: solution.value,
+        deactivations: solution.deactivations,
+        challengeFormat,
+      });
     });
     it('should return a validation object with the returned status', () => {
       const expectedValidation = domainBuilder.buildValidation({

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -8,18 +8,39 @@ const ANSWER_OK = AnswerStatus.OK;
 
 describe('Unit | Service | SolutionServiceQROC ', function() {
 
+  describe('match, with numerical answers and solutions', function() {
+    [
+      { case:'when two numbers are strictly equal', answer: '0.123', solution: '0.123', expectedAnswerStatus: ANSWER_OK },
+      { case:'when 0 is added in front of the answer', answer: '0123', solution: '123', expectedAnswerStatus: ANSWER_OK },
+      { case:'when 0 is added behind the answer', answer: '1230', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer contains a dot followed by zero', answer: '123.0', solution: '123', expectedAnswerStatus: ANSWER_OK },
+      { case:'when answer contains a comma followed by zero', answer: '123,0', solution: '123', expectedAnswerStatus: ANSWER_OK },
+      { case:'when answer contains a comma followed by several zeros', answer: '123,000', solution: '123', expectedAnswerStatus: ANSWER_OK },
+      { case:'when answer contains a dot followed by a non-zero digit', answer: '123.4', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer contains two commas', answer: '123,,00', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer contains two dots', answer: '123..00', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer contains a comma and a dot', answer: '123,.00', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer is close to actual solution (inferior)', answer: '122,1', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer is close to actual solution (superior)', answer: '123,4', solution: '123', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer is different of the actual solution', answer: '123', solution: '123.4', expectedAnswerStatus: ANSWER_KO },
+      { case:'when answer and solution are equal but solutions contains a dot', answer: '123', solution: '123.0', expectedAnswerStatus: ANSWER_OK },
+    ].forEach((data) => {
+      it(`should return ${data.expectedAnswerStatus} when answer is ${data.answer} and solution is ${data.solution}`, function() {
+        const result = service.match(data.answer, data.solution);
+        expect(result).to.deep.equal(data.expectedAnswerStatus);
+      });
+    });
+  });
+
   describe('match, combining most weird cases without deactivations', function() {
 
     const successfulCases = [
-
       { case:'(single solution) same answer and solution', answer: 'Answer', solution: 'Answer' },
       { case:'(single solution) same answer and solution, but answer is lowercased, solution is uppercased', answer: 'answer', solution: 'ANSWER' },
       { case:'(single solution) answer with spaces, solution hasnt', answer: 'a b c d e', solution: 'abcde' },
       { case:'(single solution) answer with unbreakable spaces, solution hasnt', answer: 'a b c d e', solution: 'abcde' },
       { case:'(single solution) solution with trailing spaces', answer: 'abcd', solution: '    abcd   ' },
       { case:'(single solution) solution with trailing spaces and uppercase', answer: 'aaa bbb ccc', solution: '    AAABBBCCC   ' },
-      { case:'(single solution) answer is 0.1 away from solution', answer: '0123456789', solution: '123456789' },
-      { case:'(single solution) answer is 0.25 away from solution', answer: '01234', solution: '1234' },
       { case:'(single solution) solution contains too much spaces', answer: 'a b c d e', solution: 'a b c d e' },
       { case:'(single solution) answer without punctuation, but solution has', answer: ',.!p-u-n-c-t', solution: 'punct' },
       { case:'(single solution) answer with punctuation, but solution has not', answer: 'punct', solution: ',.!p-u-n-c-t' },
@@ -30,9 +51,10 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case:'(multiple solutions) answer is 0.25 away from the closest solution', answer: 'quak', solution: 'qvak\nqwak\nanything\n' },
     ];
 
-    successfulCases.forEach(function(caze) {
-      it (caze.case + ', should return "ok" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution)).to.deep.equal(ANSWER_OK);
+    successfulCases.forEach(function(data) {
+      it (data.case + ', should return "ok" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        const result = service.match(data.answer, data.solution);
+        expect(result).to.deep.equal(ANSWER_OK);
       });
     });
 
@@ -48,9 +70,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case:'(multiple solutions) answer is minimum 0.4 away from a solution', answer: 'quaks', solution: 'qvakes\nqwakes\nanything\n' },
     ];
 
-    failingCases.forEach(function(caze) {
-      it(caze.case + ', should return "ko" when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution)).to.deep.equal(ANSWER_KO);
+    failingCases.forEach(function(data) {
+      it(data.case + ', should return "ko" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution)).to.deep.equal(ANSWER_KO);
       });
     });
 
@@ -74,9 +96,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: {} },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -99,9 +121,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t1:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -124,9 +146,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t2:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -149,9 +171,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t3:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -174,9 +196,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t1:true, t2:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -199,9 +221,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t1:true, t3:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -224,9 +246,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t2:true, t3:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });
@@ -249,9 +271,9 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when:'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789',   solution: '\nvariant1\n0123456789\n',  deactivations: { t1:true, t2:true, t3:true } },
     ];
 
-    allCases.forEach(function(caze) {
-      it(caze.when + ', should return ' + caze.output + ' when answer is "' + caze.answer + '" and solution is "' + escape(caze.solution) + '"', function() {
-        expect(service.match(caze.answer, caze.solution, caze.deactivations)).to.deep.equal(caze.output);
+    allCases.forEach(function(data) {
+      it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
+        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
       });
     });
   });

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -24,6 +24,8 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case:'when answer is close to actual solution (superior)', answer: '123,4', solution: '123', expectedAnswerStatus: ANSWER_KO },
       { case:'when answer is different of the actual solution', answer: '123', solution: '123.4', expectedAnswerStatus: ANSWER_KO },
       { case:'when answer and solution are equal but solutions contains a dot', answer: '123', solution: '123.0', expectedAnswerStatus: ANSWER_OK },
+      { case:'when number has space', answer: '00025 000', solution: '25000', expectedAnswerStatus: ANSWER_OK },
+      { case:'(multiple solutions) when answer is correct but there are multiple solutions', answer: '123,00', solution: '123.0\n123', expectedAnswerStatus: ANSWER_OK },
     ].forEach((data) => {
       it(`should return ${data.expectedAnswerStatus} when answer is ${data.answer} and solution is ${data.solution}`, function() {
         const result = service.match(data.answer, data.solution);

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -26,6 +26,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case:'when answer and solution are equal but solutions contains a dot', answer: '123', solution: '123.0', expectedAnswerStatus: ANSWER_OK },
       { case:'when number has space', answer: '00025 000', solution: '25000', expectedAnswerStatus: ANSWER_OK },
       { case:'(multiple solutions) when answer is correct but there are multiple solutions', answer: '123,00', solution: '123.0\n123', expectedAnswerStatus: ANSWER_OK },
+      { case:'(multiple solutions) answer is not the first possible solution', answer: '23', solution: '21\n22\n23\n', expectedAnswerStatus: ANSWER_OK  },
     ].forEach((data) => {
       it(`should return ${data.expectedAnswerStatus} when answer is ${data.answer} and solution is ${data.solution}`, function() {
         const result = service.match(data.answer, data.solution);

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -9,6 +9,8 @@ const ANSWER_OK = AnswerStatus.OK;
 describe('Unit | Service | SolutionServiceQROC ', function() {
 
   describe('match, with numerical answers and solutions', function() {
+    const challengeFormat = 'nombre';
+
     [
       { case:'when two numbers are strictly equal', answer: '0.123', solution: '0.123', expectedAnswerStatus: ANSWER_OK },
       { case:'when 0 is added in front of the answer', answer: '0123', solution: '123', expectedAnswerStatus: ANSWER_OK },
@@ -29,7 +31,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case:'(multiple solutions) answer is not the first possible solution', answer: '23', solution: '21\n22\n23\n', expectedAnswerStatus: ANSWER_OK  },
     ].forEach((data) => {
       it(`should return ${data.expectedAnswerStatus} when answer is ${data.answer} and solution is ${data.solution}`, function() {
-        const result = service.match(data.answer, data.solution);
+        const result = service.match({ answer: data.answer, challengeFormat, solution: data.solution });
         expect(result).to.deep.equal(data.expectedAnswerStatus);
       });
     });
@@ -56,7 +58,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     successfulCases.forEach(function(data) {
       it (data.case + ', should return "ok" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        const result = service.match(data.answer, data.solution);
+        const result = service.match({ answer: data.answer, solution: data.solution });
         expect(result).to.deep.equal(ANSWER_OK);
       });
     });
@@ -75,7 +77,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     failingCases.forEach(function(data) {
       it(data.case + ', should return "ko" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution)).to.deep.equal(ANSWER_KO);
+        expect(service.match({ answer: data.answer, solution: data.solution })).to.deep.equal(ANSWER_KO);
       });
     });
 
@@ -101,7 +103,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -126,7 +128,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -151,7 +153,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -176,7 +178,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -201,7 +203,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -226,7 +228,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -251,7 +253,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });
@@ -276,7 +278,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
 
     allCases.forEach(function(data) {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
-        expect(service.match(data.answer, data.solution, data.deactivations)).to.deep.equal(data.output);
+        expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
     });
   });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../../../test-helper');
-const { isNumeric } = require('../../../../lib/infrastructure/utils/string-utils');
+const { isNumeric, splitIntoWordsAndRemoveBackspaces } = require('../../../../lib/infrastructure/utils/string-utils');
 
 describe('Unit | Utils | string-utils', () => {
   describe('isNumeric', () => {
@@ -22,6 +22,23 @@ describe('Unit | Utils | string-utils', () => {
         const result = isNumeric(data.case);
         // Then
         expect(result).to.be.equal(data.expectedResult);
+      });
+    });
+  });
+
+  describe('splitIntoWordsAndRemoveBackspaces', () => {
+    [
+      { case: 'abc', expectedResult: ['abc'] },
+      { case: 'qvak\nqwak\nanything\n', expectedResult: [ 'qvak', 'qwak', 'anything' ] },
+      { case: 'wîth àccénts êêê', expectedResult: [ 'wîth àccénts êêê' ] },
+      { case: ',.!p-u-n-c-t', expectedResult: [ ',.!p-u-n-c-t' ] },
+      { case: 'variant 1\nvariant 2\nvariant 3\n', expectedResult: [ 'variant 1', 'variant 2', 'variant 3' ] },
+    ].forEach((data) => {
+      it(`should return ${data.expectedResult} with ${data.case}`, () => {
+        // When
+        const result = splitIntoWordsAndRemoveBackspaces(data.case);
+        // Then
+        expect(result).to.be.deep.equal(data.expectedResult);
       });
     });
   });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../../../test-helper');
-const { isNumeric, splitIntoWordsAndRemoveBackspaces } = require('../../../../lib/infrastructure/utils/string-utils');
+const { isNumeric, cleanStringAndParseFloat, splitIntoWordsAndRemoveBackspaces } = require('../../../../lib/infrastructure/utils/string-utils');
 
 describe('Unit | Utils | string-utils', () => {
   describe('isNumeric', () => {
@@ -20,6 +20,25 @@ describe('Unit | Utils | string-utils', () => {
       it(`should return ${data.expectedResult} with ${data.case}`, () => {
         // When
         const result = isNumeric(data.case);
+        // Then
+        expect(result).to.be.equal(data.expectedResult);
+      });
+    });
+  });
+
+  describe('cleanStringAndParseFloat', () => {
+    [
+      { case: '0123', expectedResult: 123 },
+      { case: '1,23', expectedResult: 1.23 },
+      { case: '01,23', expectedResult: 1.23 },
+      { case: '1.23', expectedResult: 1.23 },
+      { case: '1.00', expectedResult: 1.00 },
+      { case: '1.00', expectedResult: 1 },
+      { case: '00025 000', expectedResult: 25000 },
+    ].forEach((data) => {
+      it(`should return ${data.expectedResult} with ${data.case}`, () => {
+        // When
+        const result = cleanStringAndParseFloat(data.case);
         // Then
         expect(result).to.be.equal(data.expectedResult);
       });

--- a/api/tests/unit/infrastructure/utils/string-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/string-utils_test.js
@@ -1,0 +1,28 @@
+const { expect } = require('../../../test-helper');
+const { isNumeric } = require('../../../../lib/infrastructure/utils/string-utils');
+
+describe('Unit | Utils | string-utils', () => {
+  describe('isNumeric', () => {
+    [
+      { case: 'abc', expectedResult: false },
+      { case: '123', expectedResult: true },
+      { case: '12.0', expectedResult: true },
+      { case: '13,0', expectedResult: true },
+      { case: 'abc.0', expectedResult: false },
+      { case: 'abc.c', expectedResult: false },
+      { case: '123.a', expectedResult: false },
+      { case: '123.897', expectedResult: true },
+      { case: '123.000', expectedResult: true },
+      { case: '0.123', expectedResult: true },
+      { case: '0,123', expectedResult: true },
+      { case: '25 000', expectedResult: true },
+    ].forEach((data) => {
+      it(`should return ${data.expectedResult} with ${data.case}`, () => {
+        // When
+        const result = isNumeric(data.case);
+        // Then
+        expect(result).to.be.equal(data.expectedResult);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème

Si la réponse à un QCU type nombre est 7 et si l'utilisateur ajoute un ou plusieurs zéro après une virgule OU un point alors la réponse doit être considérée comme valide.

ex : 7 = 7,0 = 7,00 = 7.0 = 7.00 etc

## :robot: Solution

- Ajout d'une méthode de validation du format de la réponse numéraire
- Split du process de validation suivant que la réponse de l'utilisateur est un numéraire ou littérale
- Refactorisation du code et update/ ajout de tests unitaires

## :rainbow: Remarques

Lors de la réalisation des tests, nous avons pris parti sur deux questions pouvant être considérées comme faisant partie du métier et sont donc amenées à être discutées davantage si besoin.

- Toute réponse non entière et inférieure à la solution (exemple: Réponse = 122.1 et Solution = 123) donne lieu à une réponse fausse
- Toute réponse contenant plusieurs caractères spéciaux ( virgules ou points uniquement - ex: 122,,1) donne lieu à une réponse fausse

## :100: Pour tester

- Réaliser l'épreuve avec pour recId : `recAsQI8VNgXcme11` en entrant la bonne réponse sous différents formats (Ex: 1 / 1.0 / 1.00 / 01)
