### PR TITLE
[TECH] Re-positionner le job e2e au même niveau que les autres jobs dans la CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,7 @@ workflows:
       - e2e_test:
           context: Pix
           requires:
-            - api_build_and_test
-            - mon_pix_build_and_test
-            - orga_build_and_test
-            - certif_build_and_test
-            - admin_build_and_test
+            - checkout
 
 jobs:
   checkout:


### PR DESCRIPTION
## :unicorn: Problème
Lorsque nous étions sur l'ancien plan GithubMarketPlace de CircleCI, nous avions une limite de parallélisme de container.
Du coup, pour ralentir le moins possible le workflow, on avait décidé de rendre le déclenchement du job e2e dépendant du succès des autres jobs. En effet, le job e2e étant le plus consommateur de ressources (avec le parallélisme notamment), il était préférable de ne pas le lancer si jamais les autres jobs n'étaient pas verts.

## :robot: Solution
On est enfin sur un plan CircleCI qui nous offre une grande limite de parallélisme, on peut donc repositionner le job e2e avec ses copains !

![clafete](https://user-images.githubusercontent.com/48727874/100206650-e6989280-2f06-11eb-8ff9-077e58ff403e.png)


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
