### PR TITLE
[FEATURE] Afficher le modèle du CSV ainsi que son info bulle seulement pour les organisations SCO AGRI et CFA (Pix-1672) 

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -208,7 +208,22 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     externalId: '1237457C',
     provinceCode: '12',
   });
+
+  const agricultureCFA = databaseBuilder.factory.buildOrganization({
+    id: 8,
+    type: 'SCO',
+    name: 'CFA Agricole',
+    isManagingStudents: true,
+    canCollectProfiles: true,
+    email: 'sco4.generic.account@example.net',
+    externalId: '1237457D',
+    provinceCode: '12',
+  });
+
   databaseBuilder.factory.buildOrganizationTag({ organizationId: 7, tagId: 1 });
+  
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: 8, tagId: 1 });
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: 8, tagId: 5 });
 
   databaseBuilder.factory.buildMembership({
     userId: scoUser1.id,
@@ -219,6 +234,18 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: scoUser2.id,
     organizationId: agriculture.id,
+    organizationRole: Membership.roles.MEMBER,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: scoUser1.id,
+    organizationId: agricultureCFA.id,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: scoUser2.id,
+    organizationId: agricultureCFA.id,
     organizationRole: Membership.roles.MEMBER,
   });
 };

--- a/api/db/seeds/data/tags-builder.js
+++ b/api/db/seeds/data/tags-builder.js
@@ -3,4 +3,5 @@ module.exports = function tagsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildTag({ id: 2, name: 'PUBLIC' });
   databaseBuilder.factory.buildTag({ id: 3, name: 'PRIVE' });
   databaseBuilder.factory.buildTag({ id: 4, name: 'POLE EMPLOI' });
+  databaseBuilder.factory.buildTag({ id: 5, name: 'CFA' });
 };

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -64,6 +64,10 @@ class Organization {
     return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AGRICULTURE));
   }
 
+  get isCFA() {
+    return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.CFA));
+  }
+
   get isPoleEmploi() {
     return Boolean(this.tags.find((tag) => tag.name === Tag.POLE_EMPLOI));
   }

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -12,4 +12,5 @@ class Tag {
 }
 Tag.AGRICULTURE = 'AGRICULTURE';
 Tag.POLE_EMPLOI = 'POLE EMPLOI';
+Tag.CFA = 'CFA';
 module.exports = Tag;

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -15,6 +15,7 @@ module.exports = {
           organization: {
             ...recordWithoutClass.userOrgaSettings.currentOrganization,
             isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization.isAgriculture,
+            isCFA: recordWithoutClass.userOrgaSettings.currentOrganization.isCFA,
           },
         };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
@@ -79,7 +80,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type', 'isAgriculture'],
+          attributes: ['name', 'type', 'isAgriculture', 'isCFA'],
         },
       },
     }).serialize(prescriber);

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -160,4 +160,39 @@ describe('Unit | Domain | Models | Organization', () => {
       expect(organization.isPoleEmploi).is.true;
     });
   });
+
+  describe('get#isCFA', () => {
+    context('when organization is not SCO', ()  =>  {
+      it('should return false when the organization has the "CFA" tag', () => {
+        // given
+        const tag = domainBuilder.buildTag({ name: Tag.CFA });
+        const organization = domainBuilder.buildOrganization({ type: 'SUP', tags: [tag] });
+
+        // when / then
+        expect(organization.isCFA).is.false;
+      });
+    });
+
+    context('when organization is SCO', ()  =>  {
+      it('should return true when organization is of type SCO and has the "CFA" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: Tag.CFA });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isCFA).is.true;
+      });
+
+      it('should return false when when organization is of type SCO and has not the "CFA" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: 'To infinity…and beyond!' });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isCFA).is.false;
+      });
+    });
+  });
 });

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -2,7 +2,7 @@
   <div class="page__title page-title">Élèves</div>
   {{#if this.currentUser.isAdminInOrganization}}
     <div class="list-students-page__import-students-button">
-      {{#if this.currentUser.isAgriculture}}
+      {{#if this.displayLearnMoreAndLinkTemplate }}
         <PixTooltip
           @text={{this.textTooltipForAgri}}
           @position='bottom'

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -25,6 +25,10 @@ export default class ListItems extends Component {
     return '.xml';
   }
 
+  get displayLearnMoreAndLinkTemplate() {
+    return this.currentUser.isAgriculture && this.currentUser.isCFA;
+  }
+
   get urlToDownloadCsvTemplate() {
     return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
   }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -8,6 +8,7 @@ export default class Organization extends Model {
   @attr('boolean') isManagingStudents;
   @attr('boolean') canCollectProfiles;
   @attr('boolean') isAgriculture;
+  @attr('boolean') isCFA;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -13,6 +13,7 @@ export default class CurrentUserService extends Service {
   @tracked isSCOManagingStudents;
   @tracked isSUPManagingStudents;
   @tracked isAgriculture;
+  @tracked isCFA;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -45,14 +46,19 @@ export default class CurrentUserService extends Service {
 
   async _setOrganizationProperties(membership) {
     const organization = await membership.organization;
+
     const isAdminInOrganization = membership.isAdmin;
+
     const isSCOManagingStudents = organization.isSco && organization.isManagingStudents;
     const isSUPManagingStudents = organization.isSup && organization.isManagingStudents;
 
-    this.organization = organization;
     this.isAdminInOrganization = isAdminInOrganization;
     this.isSCOManagingStudents = isSCOManagingStudents;
     this.isSUPManagingStudents = isSUPManagingStudents;
+
     this.isAgriculture = organization.isAgriculture;
+    this.isCFA = organization.isCFA;
+
+    this.organization = organization;
   }
 }

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -291,11 +291,11 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           assert.contains('Importer (.xml)');
         });
 
-        test('it should not display download template csv file button', async function(assert) {
+        test('it should not display download template csv file button for agriculture/cfa organization', async function(assert) {
           assert.notContains('Télécharger le modèle');
         });
 
-        test('it should not display the tooltip for agriculture organization', async function(assert) {
+        test('it should not display the tooltip for agriculture/cfa organization', async function(assert) {
           assert.notContains('En savoir plus');
         });
 
@@ -324,12 +324,40 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
           assert.contains('Importer (.csv)');
         });
 
+        test('it should not display download template csv button', async function(assert) {
+          // then
+          assert.notContains('Télécharger le modèle');
+        });
+
+        test('it should not display the tooltip', async function(assert) {
+          assert.notContains('En savoir plus');
+        });
+      });
+
+      module('when organization is SCO and tagged as Agriculture and CFA', (hooks) => {
+        hooks.beforeEach(function() {
+          class CurrentUserStub extends Service {
+            isAdminInOrganization = true;
+            isAgriculture = true;
+            isCFA = true;
+            organization = {};
+          }
+
+          this.set('importStudentsSpy', () => {});
+          this.owner.register('service:current-user', CurrentUserStub);
+          return render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
+        });
+
+        test('it should still display import CSV file button', async function(assert) {
+          assert.contains('Importer (.csv)');
+        });
+
         test('it should display download template csv button', async function(assert) {
           // then
           assert.contains('Télécharger le modèle');
         });
 
-        test('it should not display the tooltip', async function(assert) {
+        test('it should display the tooltip', async function(assert) {
           assert.contains('En savoir plus');
         });
       });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les professeurs de lycées voient les boutons "ne savoir plus" et "télécharger le template" et certains décident de les ajouter à la main. Créant alors plein d'apprentis dans les orgas lycées.

Seul les orgas CFA peuvent importer des apprentis.

## :robot: Solution
Contextualiser ces deux elements avec le tag CFA en plus de celui d'agriculture
## :rainbow: Remarques
Création d'un seed Agri/CFA

## :100: Pour tester
sco.admin@example.net. => lycée agricole ( pas d'affichage des éléments), lycée agricole & cfa (affichage des éléments) .