### PR TITLE
[BSR] Prévenir l'usage non intentionnel de console.log dans les tests API.

### DIFF
--- a/api/tests/.eslintrc.yaml
+++ b/api/tests/.eslintrc.yaml
@@ -2,3 +2,7 @@ extends: '../.eslintrc.yaml'
 
 env:
   mocha: true
+
+rules:
+  no-console:
+    - error

--- a/api/tests/integration/scripts/populate-organizations-email_test.js
+++ b/api/tests/integration/scripts/populate-organizations-email_test.js
@@ -12,6 +12,7 @@ describe('Integration | Scripts | populate-organizations-email.js', () => {
     beforeEach(async () => {
       databaseBuilder.factory.buildOrganization({ externalId: externalId1, email: 'first.last@example.net' });
       databaseBuilder.factory.buildOrganization({ externalId: externalId2 });
+      // eslint-disable-next-line no-console
       sinon.stub(console, 'error');
 
       await databaseBuilder.commit();
@@ -33,6 +34,7 @@ describe('Integration | Scripts | populate-organizations-email.js', () => {
       expect(organizations).to.deep.include(csvData[0]);
       expect(organizations).to.deep.include(csvData[1]);
       expect(organizations).to.not.deep.include(csvData[2]);
+      // eslint-disable-next-line no-console
       expect(console.error).to.have.been.calledWith('Organization not found for External ID unknown');
     });
   });

--- a/api/tests/tooling/database-builder/database-builder.js
+++ b/api/tests/tooling/database-builder/database-builder.js
@@ -23,6 +23,7 @@ module.exports = class DatabaseBuilder {
       }
       await trx.commit();
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error(`Erreur dans databaseBuilder.commit() : ${err}`);
       this._purgeDirtiness();
       throw err;

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -30,6 +30,7 @@ class HttpTestServer {
 
     this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
     this.hapiServer.events.on({ name: 'request', channels: 'error' }, (request, event) => {
+      // eslint-disable-next-line no-console
       console.error(event.error);
     });
 

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -122,7 +122,9 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         });
 
         // then
+        // eslint-disable-next-line no-console
         expect(console.log).to.have.been.calledOnce;
+        // eslint-disable-next-line no-console
         const results = console.log.firstCall.args[0];
         expect(results).to.deep.equal(expectedResults);
       });
@@ -137,7 +139,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
           createdAt: new Date('2020-01-02'),
         });
         event = new AssessmentCompleted({ campaignParticipationId: campaignParticipation.id });
-    
+
         campaignParticipationRepositoryStub.withArgs(campaignParticipation.id).resolves(campaignParticipation);
         campaignRepositoryStub.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT', organizationId }));
         organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: false });
@@ -152,6 +154,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         });
 
         // then
+        // eslint-disable-next-line no-console
         sinon.assert.notCalled(console.log);
       });
     });
@@ -165,7 +168,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
           createdAt: new Date('2020-01-02'),
         });
         event = new AssessmentCompleted({ campaignParticipationId: campaignParticipation.id });
-        
+
         campaignParticipationRepositoryStub.withArgs(campaignParticipation.id).resolves(campaignParticipation);
         campaignRepositoryStub
           .withArgs(campaignId)
@@ -182,6 +185,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         });
 
         // then
+        // eslint-disable-next-line no-console
         sinon.assert.notCalled(console.log);
       });
     });

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const { catchErr, expect, sinon, domainBuilder } = require('../../../test-helper');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -103,7 +103,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         targetProfileRepositoryStub.withArgs('targetProfileId1').resolves({ name: 'Diagnostic initial' });
 
         event = new CampaignParticipationStarted({ campaignParticipationId });
-        
+
         sinon.stub(console, 'log');
       });
 
@@ -115,7 +115,9 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         });
 
         // then
+        // eslint-disable-next-line no-console
         expect(console.log).to.have.been.calledOnce;
+        // eslint-disable-next-line no-console
         const results = console.log.firstCall.args[0];
         expect(results).to.deep.equal(expectedResults);
       });
@@ -129,13 +131,13 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
           campaignId,
           createdAt: new Date('2020-01-02'),
         });
-        
+
         campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(campaignParticipation);
         campaignRepositoryStub.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT', organizationId }));
         organizationRepositoryStub.withArgs(organizationId).resolves({ isPoleEmploi: false });
-        
+
         event = new CampaignParticipationStarted({ campaignParticipationId });
-        
+
         sinon.stub(console, 'log');
       });
 
@@ -147,6 +149,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         });
 
         // then
+        // eslint-disable-next-line no-console
         sinon.assert.notCalled(console.log);
       });
     });
@@ -159,7 +162,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
           campaignId,
           createdAt: new Date('2020-01-02'),
         });
-        
+
         campaignParticipationRepositoryStub.withArgs(campaignParticipationId).resolves(campaignParticipation);
         campaignRepositoryStub
           .withArgs(campaignId)
@@ -179,6 +182,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
         });
 
         // then
+        // eslint-disable-next-line no-console
         sinon.assert.notCalled(console.log);
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Lors de débogage de tests API, on laisse parfois trainer un console.log

## :robot: Solution
Ajouter la règle `no-console`

## :rainbow: Remarques
Le commit aurait pu être séparé en deux #LJA:
- correction des tests existants
- ajout de la règle

## :100: Pour tester
En local, rajouter un `console.log` et vérifier que `npm run lint` sort en erreur
