### PR TITLE
[BUGFIX] Déplacer les vérifications contionnelles de birthCityCode / birthCity après les éléments required (Pix-1696)

### DIFF
--- a/api/lib/domain/validators/schooling-registration-validator.js
+++ b/api/lib/domain/validators/schooling-registration-validator.js
@@ -29,6 +29,15 @@ const validationSchema = Joi.object({
   lastName: Joi.string().max(MAX_LENGTH).required(),
   preferredLastName: Joi.string().max(MAX_LENGTH).optional(),
   birthdate: Joi.date().required().format('YYYY-MM-DD').empty(null),
+  birthProvinceCode: Joi.string().min(PROVINCE_CODE_MIN_LENGTH).max(PROVINCE_CODE_MAX_LENGTH).required(),
+  birthCountryCode: Joi.string()
+    .length(COUNTRY_CODE_LENGTH)
+    .regex(INSEE_REGEX.COUNTRY_CODE)
+    .required(),
+  status: Joi.string().valid(STUDENT,APPRENTICE).required(),
+  MEFCode: Joi.string().max(MAX_LENGTH).required(),
+  division: Joi.string().max(MAX_LENGTH).required(),
+  organizationId: Joi.number().integer().required(),
   birthCity: Joi.alternatives().conditional('birthCountryCode', {
     is: FRANCE_COUNTRY_CODE,
     then: Joi.string().max(MAX_LENGTH).optional(),
@@ -42,15 +51,6 @@ const validationSchema = Joi.object({
       .required(),
     otherwise: Joi.string().max(MAX_LENGTH).optional(),
   }),
-  birthProvinceCode: Joi.string().min(PROVINCE_CODE_MIN_LENGTH).max(PROVINCE_CODE_MAX_LENGTH).required(),
-  birthCountryCode: Joi.string()
-    .length(COUNTRY_CODE_LENGTH)
-    .regex(INSEE_REGEX.COUNTRY_CODE)
-    .required(),
-  status: Joi.string().valid(STUDENT,APPRENTICE).required(),
-  MEFCode: Joi.string().max(MAX_LENGTH).required(),
-  division: Joi.string().max(MAX_LENGTH).required(),
-  organizationId: Joi.number().integer().required(),
 });
 
 module.exports = {

--- a/api/tests/unit/domain/validators/schooling-registration-validator_test.js
+++ b/api/tests/unit/domain/validators/schooling-registration-validator_test.js
@@ -130,6 +130,20 @@ describe('Unit | Domain | Schooling Registration validator', () => {
         });
       });
 
+      it('throw an error when birthCountryCode before birthCityCode', async () => {
+        const error = await catchErr(checkValidation)({ ...validAttributes, birthCityCode: '', birthCountryCode: '12345' });
+
+        expect(error.key).to.equal('birthCountryCode');
+        expect(error.why).to.equal('not_valid_insee_code');
+      });
+
+      it('throw an error when birthCountryCode before birthCity', async () => {
+        const error = await catchErr(checkValidation)({ ...validAttributes, birthCity: '', birthCountryCode: '12345' });
+
+        expect(error.key).to.equal('birthCountryCode');
+        expect(error.why).to.equal('not_valid_insee_code');
+      });
+
       it('throw an error when birthCountryCode has not 5 characters', async () => {
         const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '123456' });
 
@@ -209,7 +223,7 @@ describe('Unit | Domain | Schooling Registration validator', () => {
 
     context('birthCity', () => {
       it('throw an error when birth country is not France and birthCity is undefined', async () => {
-        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '12345', birthCity: undefined });
+        const error = await catchErr(checkValidation)({ ...validAttributes, birthCountryCode: '99125', birthCity: undefined });
 
         expect(error.key).to.equal('birthCity');
         expect(error.why).to.equal('required');


### PR DESCRIPTION
## :unicorn: Problème
Les remonté d'erreur ne sont pas faite par ordre de priorité. Joi break a la première non validation d'un champs.

## :robot: Solution
Déplacer les erreurs conditionné à la fin. afin d'avoir les erreurs majeurs en premier

## :rainbow: Remarques

## :100: Pour tester
`Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
0123456789F;Léa;;;prenti;Cottonmouth;01/01/1780;;Corse;99;12345;AP;MEF1;Division 2`

=> remonte l'erreur INSEE en premier et non l'absence de birthCityCode ( required si birthCountry !== 99100 ) .