### PR TITLE
[TECH] Déplacer un ticket JIRA quand sa PR est mergée sur dev

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -1,0 +1,32 @@
+name: Merge on Dev
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  transition-issue:
+    name: Transition Issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: Login
+      uses: atlassian/gajira-login@master
+      env:
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+    - name: Find Issue Key
+      id: find
+      uses: atlassian/gajira-find-issue-key@master
+      with:
+        from: commits
+
+    - name: Transition issue
+      uses: atlassian/gajira-transition@master
+      if: ${{ steps.find.outputs.issue }}
+      with:
+        issue: ${{ steps.find.outputs.issue }}
+        transition: "Move to 'Deployed in Staging'"


### PR DESCRIPTION
## :unicorn: Problème

Avec l'auto-merge les PRs sont automatiquement mergées sur dev, mais on doit toujours manuellement bouger leurs tickets JIRA quand celles-ci sont mergées. 

## :robot: Solution

Utiliser une GitHub Action qui se déclenche aux `push` sur la branche `dev`
- Se logger à JIRA (grâce à l'action https://github.com/atlassian/gajira-login)
- Identifier le numéro du ticket dans le commit de merge (grâce à l'action https://github.com/atlassian/gajira-find-issue-key)
- Faire la transition si le numéro de ticket a été identifié (grâce à l'action https://github.com/atlassian/gajira-transition)

## :rainbow: Remarques

Nécessite l'ajout de 3 secrets:
- `JIRA_BASE_URL`
- `JIRA_USER_EMAIL`
- `JIRA_API_TOKEN`


