### PR TITLE
[TECH] Suppression du warning lié à browserslist lors du build de `mon-pix`.

### DIFF
--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,6 +1,6 @@
 module.exports = {
   browsers: [
-    'ie 9',
+    'ie 11',
     'last 1 Chrome versions',
     'last 1 Firefox versions',
     'last 1 Safari versions',

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -125,12 +125,6 @@
             "node-releases": "^1.1.66"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001161",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-          "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.606",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.606.tgz",
@@ -6717,12 +6711,6 @@
             "node-releases": "^1.1.61"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001125",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-          "integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -9054,12 +9042,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.65"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001156",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz",
-          "integrity": "sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==",
-          "dev": true
         },
         "chokidar": {
           "version": "3.4.3",
@@ -15108,9 +15090,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001016",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-      "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
+      "version": "1.0.30001161",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
+      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
       "dev": true
     },
     "capture-exit": {
@@ -19303,12 +19285,6 @@
             "node-releases": "^1.1.66"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001161",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-          "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.7.0.tgz",
@@ -20696,12 +20672,6 @@
             "escalade": "^3.0.2",
             "node-releases": "^1.1.60"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001118",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001118.tgz",
-          "integrity": "sha512-RNKPLojZo74a0cP7jFMidQI7nvLER40HgNfgKQEJ2PFm225L0ectUungNQoK3Xk3StQcFbpBPNEvoWD59436Hg==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.6.5",
@@ -22242,12 +22212,6 @@
             "escalade": "^3.0.1",
             "node-releases": "^1.1.58"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001111",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
-          "integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.6.5",
@@ -23898,12 +23862,6 @@
             "escalade": "^3.1.0",
             "node-releases": "^1.1.61"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001144",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001144.tgz",
-          "integrity": "sha512-4GQTEWNMnVZVOFG3BK0xvGeaDAtiPAbG2N8yuMXuXzx/c2Vd4XoMPO8+E918zeXn5IF0FRVtGShBfkfQea2wHQ==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.6.5",
@@ -28129,12 +28087,6 @@
             "node-releases": "^1.1.58"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001111",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
-          "integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -29801,12 +29753,6 @@
             "escalade": "^3.0.1",
             "node-releases": "^1.1.58"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001096",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001096.tgz",
-          "integrity": "sha512-PFTw9UyVfbkcMEFs82q8XVlRayj7HKvnhu5BLcmjGpv+SNyiWasCcWXPGJuO0rK0dhLRDJmtZcJ+LHUfypbw1w==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.6.5",
@@ -32828,12 +32774,6 @@
             "node-releases": "^1.1.61"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001150",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz",
-          "integrity": "sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -34324,12 +34264,6 @@
             "escalade": "^3.1.0",
             "node-releases": "^1.1.61"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001148",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-          "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.6.5",
@@ -43585,12 +43519,6 @@
             "node-releases": "^1.1.60"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001118",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001118.tgz",
-          "integrity": "sha512-RNKPLojZo74a0cP7jFMidQI7nvLER40HgNfgKQEJ2PFm225L0ectUungNQoK3Xk3StQcFbpBPNEvoWD59436Hg==",
-          "dev": true
-        },
         "core-js-compat": {
           "version": "3.6.5",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.5.tgz",
@@ -46977,12 +46905,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.66"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001161",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-          "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
-          "dev": true
         },
         "chalk": {
           "version": "4.1.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -115,5 +115,6 @@
     "showdown": "^1.9.1",
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^20.0.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## :unicorn: Problème
Lors du build de `mon-pix`, le warning suivant est affiché:
```
Browserslist: caniuse-lite is outdated. Please run next command `npm update`
```

Celui-ci est du à la dépendence `caniuse-lite` utilisée par `browserslist` pour déterminer les transpilations nécessaires au support des différents navigateurs spécifiés dans le fichier `config/targets.js`.
Cette dépendance est présente plusieurs fois dans notre arbre de dépendance, comme le montre `npm ls caniuse-lite`:
```
mon-pix@2.223.0 /Users/GUL/Documents/Missions/gip-pix/pix/mon-pix
├─┬ @fortawesome/ember-fontawesome@0.2.2
│ └─┬ ember-cli-babel@7.22.1
│   └─┬ @babel/helper-compilation-targets@7.10.4
│     └─┬ browserslist@4.14.2
│       └── caniuse-lite@1.0.30001125 
├─┬ @sentry/ember@5.27.3
│ └─┬ ember-cli-babel@7.23.0
│   └─┬ @babel/helper-compilation-targets@7.12.5
│     └─┬ browserslist@4.14.6
│       └── caniuse-lite@1.0.30001156 
├─┬ ember-auto-import@1.5.3
│ └─┬ @babel/preset-env@7.7.7
│   └─┬ browserslist@4.8.2
│     └── caniuse-lite@1.0.30001016  deduped
├─┬ ember-cli-autoprefixer@0.8.1
│ └─┬ broccoli-autoprefixer@5.0.0
│   └─┬ autoprefixer@7.2.6
│     ├─┬ browserslist@2.11.3
│     │ └── caniuse-lite@1.0.30001016  deduped
│     └── caniuse-lite@1.0.30001016  deduped
├─┬ ember-cli-babel@7.23.0
│ ├─┬ @babel/helper-compilation-targets@7.12.5
│ │ └─┬ browserslist@4.14.7
│ │   └── caniuse-lite@1.0.30001161 
│ └─┬ @babel/preset-env@7.12.7
│   └─┬ core-js-compat@3.7.0
│     └─┬ browserslist@4.14.7
│       └── caniuse-lite@1.0.30001161 
├─┬ ember-cli-chai@0.5.0
│ └─┬ babel-preset-env@1.7.0
│   └─┬ browserslist@3.2.8
│     └── caniuse-lite@1.0.30001016  deduped
├─┬ ember-cli-clipboard@0.15.0
│ └─┬ ember-cli-babel@7.22.1
│   └─┬ @babel/helper-compilation-targets@7.10.4
│     └─┬ browserslist@4.14.0
│       └── caniuse-lite@1.0.30001118 
├─┬ ember-cli-head@1.0.0
│ ├─┬ ember-cli-babel@7.22.1
│ │ └─┬ @babel/helper-compilation-targets@7.10.4
│ │   └─┬ browserslist@4.13.0
│ │     └── caniuse-lite@1.0.30001111 
│ └─┬ ember-in-element-polyfill@1.0.0
│   └─┬ ember-cli-babel@7.22.1
│     └─┬ @babel/helper-compilation-targets@7.10.4
│       └─┬ browserslist@4.13.0
│         └── caniuse-lite@1.0.30001111 
├─┬ ember-cli-matomo-tag-manager@1.2.4
│ └─┬ ember-cli-babel@7.22.1
│   └─┬ @babel/helper-compilation-targets@7.10.4
│     └─┬ browserslist@4.14.5
│       └── caniuse-lite@1.0.30001144 
├─┬ UNMET PEER DEPENDENCY ember-fetch@7.1.0
│ └─┬ caniuse-api@3.0.0
│   └── caniuse-lite@1.0.30001016 
├─┬ ember-intl@5.3.1
│ └─┬ ember-cli-babel@7.21.0
│   └─┬ @babel/helper-compilation-targets@7.10.4
│     └─┬ browserslist@4.13.0
│       └── caniuse-lite@1.0.30001096 
├─┬ ember-simple-auth@3.0.1
│ └─┬ ember-cli-babel@7.23.0
│   └─┬ @babel/helper-compilation-targets@7.12.1
│     └─┬ browserslist@4.14.5
│       └── caniuse-lite@1.0.30001150 
├─┬ ember-simple-auth-oidc@3.0.0
│ └─┬ ember-cli-babel@7.23.0
│   └─┬ @babel/helper-compilation-targets@7.12.1
│     └─┬ browserslist@4.14.5
│       └── caniuse-lite@1.0.30001148 
└─┬ stylelint@13.8.0
  └─┬ autoprefixer@9.8.6
    ├─┬ browserslist@4.14.7
    │ └── caniuse-lite@1.0.30001161  deduped
    └── caniuse-lite@1.0.30001161 
```
## :robot: Solution
Browserslist [met à disposition un script](https://github.com/browserslist/browserslist#browsers-data-updating) qui permet de mettre à jour toutes les dépendances `caniuse-lite` de son application (ie. spécifié dans le `package-lock.json`).
Nous avons donc lancé ledit script :
```
npx browserslist@latest --update-db
```

## :rainbow: Remarques
Pour être sûr de ne pas avoir introduit de régression dans le support des anciens navigateurs, nous avons comparé le résultat du build avant / après. Ceux-ci sont strictement identiques.
La raison est le support spécifié de IE9 qui est suffisamment vieux pour couvrir tous les autres navigateurs.

Il sera important à l'avenir de lancer la mise à jour de `caniuse-lite` régulièrement.

## :100: Pour tester
Les builds avant/après étant strictement identiques, le passage de la CI est suffisant.
