### PR TITLE
[TECH] Garantir la qualité du code dans Pix Certif.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,6 +181,9 @@ jobs:
           paths:
             - ~/.npm
       - run:
+          name: Lint
+          command: npm run lint:ci
+      - run:
           name: Test
           command: npm test
 

--- a/certif/package.json
+++ b/certif/package.json
@@ -25,6 +25,7 @@
     "clean": "rm -rf tmp dist node_modules",
     "dev": "ember serve",
     "lint": "npm run lint:js && npm run lint:hbs && npm run lint:scss",
+    "lint:ci": "npm run lint:js && npm run lint:hbs",
     "lint:js": "eslint .",
     "lint:hbs": "ember-template-lint .",
     "lint:scss": "stylelint app/styles/**/*.scss",


### PR DESCRIPTION
## :unicorn: Problème
Le linter n'est pas activé dans la CI sur Pix-Certif

## :robot: Solution
Ajouter le lint sur le code déjà mature (JS + HBS)

## :100: Pour tester
[Vérifier le CR de CI](https://app.circleci.com/pipelines/github/1024pix/pix/18124/workflows/18d7e6aa-15fd-4b01-aff5-2d1c343e3578/jobs/157614)
Pusher du code incorrect et vérifier que la CI sort en erreur
