### PR TITLE
[TECH] Ajuster la taille des containers docker sur les différents jobs de la CI (PIX-1703)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ jobs:
   checkout:
     docker:
       - image: circleci/node:14.15.1
+    resource_class: small
     working_directory: ~/pix
     steps:
       - checkout
@@ -85,6 +86,7 @@ jobs:
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
+    resource_class: small
     working_directory: ~/pix/api
     steps:
       - attach_workspace:
@@ -142,6 +144,7 @@ jobs:
       - image: circleci/node:14.15.1-browsers
         environment:
           JOBS: 2
+    resource_class: small
     working_directory: ~/pix/orga
     steps:
       - attach_workspace:
@@ -167,6 +170,7 @@ jobs:
       - image: circleci/node:14.15.1-browsers
         environment:
           JOBS: 2
+    resource_class: small
     working_directory: ~/pix/certif
     steps:
       - attach_workspace:
@@ -192,6 +196,7 @@ jobs:
       - image: circleci/node:14.15.1-browsers
         environment:
           JOBS: 2
+    resource_class: small
     working_directory: ~/pix/admin
     steps:
       - attach_workspace:


### PR DESCRIPTION
## :unicorn: Problème
Depuis le changement de plan sur CircleCI, la manière de facturer / décompter le nombre de crédits dispo à changer.
On n'est plus sur une facturation fixe, mais sur une facturation qui peut varier selon le nombre de crédits consommés.
En fait, on va avoir à disposition sous peu (aujourd'hui on est encore en mode free trial donc c'est la fête !) un nombre de crédits à disposition qu'on va consommer via nos workflows.
Un des pans de la facturation en crédit repose sur les tailles des `executors`, c'est à dire dans notre cas des containers Docker utilisés. Dans l'ancien plan, on n'avait pas le luxe de pouvoir modifier la taille de ceux-ci, maintenant oui.

![taillepardefaut](https://user-images.githubusercontent.com/48727874/100332208-6854f280-2fd1-11eb-8fda-b728c730841e.png)

La taille par défaut est **medium**.
Tous les jobs n'ont pas besoin d'un container **medium**.

## :robot: Solution
Les crédits sont décomptés à la minute. On va supposer (worst case scenario) que pour une durée d'exécution de 1min 25s par exemple, CircleCI arrondit l'usage à 2 minutes.

J'ai sélectionné 6 workflows au hasard et ai pris la durée moyenne de chaque job.
Calcul de la consommation moyenne aujourd'hui : (A * B * C, A = nombre de minutes, B = parallélisme sinon 1, C = coût en crédits du docker)
**checkout** :  1 * 1 * 10 = 10
**api_build_and_test** : 4 * 1 * 10 = 40
**mon-pix-build_and_test** : 5 * 3 * 10 = 150
**admin_build_and_test** : 4 * 1 * 10 = 40
**certif_build_and_test** : 3 * 1 * 10 = 30
**orga_build_and_test** : 4 * 1 * 10 = 40
**e2e_test** : 10 * 4 * 15 = 600
**_TOTAL_** : 910 crédits

La différence entre les différents containers repose sur deux aspects : le nombre de processeurs logiques (utilisés pour les builds parallélisés sur mon-pix notamment) et sur la RAM à disposition.
Seul **mon-pix-build_and_test** profite du build parallélisé. Et je pense que seul **e2e_test** a besoin potentiellement d'autant de RAM (vu qu'il lance toutes les applis).
Ce qui veut dire que sur tous les autres jobs, on peut essayer de passer en **small**.
**checkout** :  1 * 1 * 5 = 5
**api_build_and_test** : 4 * 1 * 5 = 20
**mon-pix-build_and_test** : 5 * 3 * 10 = 150
**admin_build_and_test** : 4 * 1 * 5 = 20
**certif_build_and_test** : 3 * 1 * 5 = 15
**orga_build_and_test** : 4 * 1 * 5 = 20
**e2e_test** : 10 * 4 * 15 = 600
**_TOTAL_** : 830 crédits
Soit environ 8% de réduction de consommation de crédit. Sur le long terme, c'est intéressant (et la modif coûte pas cher).

## :rainbow: Remarques
Pour info, on peut voir la taille du conteneur en cliquant sur le job, puis ici -> 
![taille](https://user-images.githubusercontent.com/48727874/100334372-fb8f2780-2fd3-11eb-925d-806e7967e5ad.png)

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
