### PR TITLE
[BUGFIX] Ajouter une transaction a la creation de campagne (PIX-1689)

### DIFF
--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -7,6 +7,7 @@ const campaignAnalysisSerializer = require('../../infrastructure/serializers/jso
 const campaignAssessmentParticipationSerializer = require('../../infrastructure/serializers/jsonapi/campaign-assessment-participation-serializer');
 const campaignAssessmentParticipationResultSerializer = require('../../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer');
 const campaignProfileSerializer = require('../../infrastructure/serializers/jsonapi/campaign-profile-serializer');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = {
 
@@ -29,7 +30,9 @@ module.exports = {
     const { 
       event,
       campaignParticipation: campaignParticipationCreated,
-    } = await usecases.startCampaignParticipation({ campaignParticipation, userId });
+    } =  await DomainTransaction.execute((domainTransaction) => {
+      return usecases.startCampaignParticipation({ campaignParticipation, userId, domainTransaction });
+    });
     await events.eventDispatcher.dispatch(event);
 
     return h.response(serializer.serialize(campaignParticipationCreated)).created();

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -119,6 +119,16 @@ class Assessment {
       type: Assessment.types.CERTIFICATION,
     });
   }
+
+  static createForCampaign({ userId, campaignParticipationId }) {
+    return new Assessment({
+      userId,
+      state: Assessment.states.STARTED,
+      type: Assessment.types.CAMPAIGN,
+      courseId: Assessment.courseIdMessage.CAMPAIGN,
+      campaignParticipationId,
+    });
+  }
 }
 
 Assessment.courseIdMessage = courseIdMessage;

--- a/api/lib/domain/usecases/start-campaign-participation.js
+++ b/api/lib/domain/usecases/start-campaign-participation.js
@@ -12,8 +12,9 @@ module.exports = async function startCampaignParticipation({ campaignParticipati
   }
 
   const createdCampaignParticipation = await _saveCampaignParticipation(campaignParticipation, userId, campaignParticipationRepository);
+
   if (campaign.isAssessment()) {
-    await _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation);
+    await _createCampaignAssessment(userId, createdCampaignParticipation.id, assessmentRepository);
   }
 
   return {
@@ -22,14 +23,8 @@ module.exports = async function startCampaignParticipation({ campaignParticipati
   };
 };
 
-async function _createCampaignAssessment(userId, assessmentRepository, createdCampaignParticipation) {
-  const assessment = new Assessment({
-    userId,
-    state: Assessment.states.STARTED,
-    type: Assessment.types.CAMPAIGN,
-    courseId: Assessment.courseIdMessage.CAMPAIGN,
-    campaignParticipationId: createdCampaignParticipation.id,
-  });
+async function _createCampaignAssessment(userId, campaignParticipationId, assessmentRepository) {
+  const assessment = Assessment.createForCampaign({ userId, campaignParticipationId });
   return assessmentRepository.save({ assessment });
 }
 

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -13,6 +13,7 @@ const knowledgeElementSnapshotRepository = require('./knowledge-element-snapshot
 
 const fp = require('lodash/fp');
 const _ = require('lodash');
+const DomainTransaction = require('../DomainTransaction');
 
 function _toDomain(bookshelfCampaignParticipation) {
   return new CampaignParticipation({
@@ -43,9 +44,9 @@ module.exports = {
     return _toDomain(campaignParticipation);
   },
 
-  save(campaignParticipation) {
+  save(campaignParticipation, domainTransaction = DomainTransaction.emptyTransaction()) {
     return new BookshelfCampaignParticipation(_adaptModelToDb(campaignParticipation))
-      .save()
+      .save(null, { transacting: domainTransaction.knexTransaction })
       .then(_toDomain);
   },
 

--- a/api/tests/integration/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/integration/domain/usecases/start-campaign-participation_test.js
@@ -1,0 +1,87 @@
+const { expect, databaseBuilder, domainBuilder, knex, catchErr } = require('../../../test-helper');
+const startCampaignParticipation = require('../../../../lib/domain/usecases/start-campaign-participation');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
+const campaignParticipationRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-repository');
+const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
+
+describe('Integration | UseCases | start-campaign-participation', () => {
+
+  let userId;
+  let organizationId;
+  let targetProfileId;
+  let campaignId;
+
+  beforeEach(async () => {
+    organizationId = databaseBuilder.factory.buildOrganization().id;
+    userId = databaseBuilder.factory.buildUser().id;
+    databaseBuilder.factory.buildMembership({
+      organizationId, userId,
+    });
+    targetProfileId = databaseBuilder.factory.buildTargetProfile({ organizationId }).id;
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('assessments').delete();
+    await knex('campaign-participations').delete();
+  });
+
+  it('should save a campaign participation and its assessment', async () => {
+    // given
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', creatorId: userId, organizationId, targetProfileId }).id;
+    await databaseBuilder.commit();
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+    // when
+    // when
+    await DomainTransaction.execute(async (domainTransaction) => {
+      await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
+    });
+
+    // then
+    const campaignParticipations = await knex('campaign-participations');
+    expect(campaignParticipations).to.have.lengthOf(1);
+    const assessments = await knex('assessments');
+    expect(assessments).to.have.lengthOf(1);
+  });
+
+  it('should save only a campaign participation', async () => {
+    // given
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'PROFILES_COLLECTION', creatorId: userId, organizationId, targetProfileId: null }).id;
+    await databaseBuilder.commit();
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+    // when
+    await DomainTransaction.execute(async (domainTransaction) => {
+      await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
+    });
+
+    // then
+    const campaignParticipations = await knex('campaign-participations');
+    expect(campaignParticipations).to.have.lengthOf(1);
+    const assessments = await knex('assessments');
+    expect(assessments).to.have.lengthOf(0);
+  });
+
+  it('should throw an error and not create anything', async () => {
+    // given
+    campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', creatorId: userId, organizationId, targetProfileId }).id;
+    await databaseBuilder.commit();
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ campaignId });
+
+    // when
+    await catchErr(async () => {
+      await DomainTransaction.execute(async (domainTransaction) => {
+        await startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
+        throw new Error('an error occurs within the domain transaction');
+      });
+    });
+
+    // then
+    const campaignParticipations = await knex('campaign-participations');
+    expect(campaignParticipations).to.have.lengthOf(0);
+    const assessments = await knex('assessments');
+    expect(assessments).to.have.lengthOf(0);
+  });
+});

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -8,6 +8,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
 describe('Unit | Application | Controller | Campaign-Participation', () => {
 
@@ -157,6 +158,9 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     it('should call the usecases to start the campaign participation', async () => {
       // given
       usecases.startCampaignParticipation.resolves(new CampaignParticipationStarted());
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
 
       // when
       await campaignParticipationController.save(request, hFake);
@@ -177,6 +181,9 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
       // given
       const campaignParticipationStartedEvent = new CampaignParticipationStarted();
       usecases.startCampaignParticipation.resolves({ event: campaignParticipationStartedEvent });
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
+      });
 
       // when
       await campaignParticipationController.save(request, hFake);
@@ -191,6 +198,9 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
       usecases.startCampaignParticipation.resolves({
         event: new CampaignParticipationStarted({ campaignParticipationId: campaignParticipation.id }),
         campaignParticipation,
+      });
+      sinon.stub(DomainTransaction, 'execute').callsFake((callback) => {
+        return callback();
       });
 
       const serializedCampaignParticipation = { id: 88, assessmentId: 12 };

--- a/api/tests/unit/domain/usecases/start-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/start-campaign-participation_test.js
@@ -12,6 +12,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
   const campaignRepository = { get: () => undefined };
   const campaignParticipationRepository = { save: () => undefined, findOneByCampaignIdAndUserId: () => undefined };
   const assessmentRepository = { save: () => undefined };
+  const domainTransaction = Symbol('DomainTransaction');
 
   beforeEach(() => {
     sinon.stub(campaignRepository, 'get');
@@ -28,7 +29,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignRepository.get.resolves(null);
 
     // when
-    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
     // then
     return expect(error).to.be.instanceOf(NotFoundError);
@@ -39,7 +40,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.findOneByCampaignIdAndUserId.resolves({});
 
     // when
-    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const error = await catchErr(usecases.startCampaignParticipation)({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
     // then
     return expect(error).to.be.instanceOf(AlreadyExistingCampaignParticipationError);
@@ -52,7 +53,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.save.resolves({});
 
     // when
-    await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
     // then
     expect(campaignParticipationRepository.save).to.have.been.called;
@@ -76,7 +77,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
       campaignParticipationRepository.save.resolves({ id: 1 });
 
       // when
-      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
       // then
       expect(assessmentRepository.save).to.have.been.called;
@@ -100,7 +101,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
       campaignParticipationRepository.save.resolves({ id: 1 });
 
       // when
-      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+      await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
       // then
       expect(assessmentRepository.save).to.not.have.been.called;
@@ -116,7 +117,7 @@ describe('Unit | UseCase | start-campaign-participation', () => {
     campaignParticipationRepository.save.resolves(campaignParticipation);
 
     // when
-    const { event } = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository });
+    const { event } = await usecases.startCampaignParticipation({ campaignParticipation, userId, campaignParticipationRepository, assessmentRepository, campaignRepository, domainTransaction });
 
     // then
     expect(event).to.deep.equal(campaignParticipationStartedEvent);


### PR DESCRIPTION
## :unicorn: Problème

Suite à un ticket support (numéro 17691)
> J'ai un problème avec un élève qui lorsqu'il se connecte à la plateforme obtient une page blanche. Le problème se reproduit quelque soit l'ordinateur et le navigateur.

L'erreur identifiée est que l'assessment associé à la campagne participation n'a pas été créé.

## :robot: Solution

Faire un sorte de mettre la création de l'assessement dans la même transaction que la campagne participation. Par conséquent, si l'un des 2 échoue, il n'y aura pas d'état instable en base de données.

## :rainbow: Remarques

- 2 petits BSR de refactoring ont été inclus dans la PR.

## :100: Pour tester

Test de non-régression:
1. Démarrer une campagne d'évaluation
2. Vérifier que l'on accède bien à la campagne et que l'on peut la démarrer.