### PR TITLE
[FEATURE] Migration de la connexion Pole Emploi dans la table authentication-methods (PIX-1523).

### DIFF
--- a/api/db/database-builder/factory/build-authentication-method.js
+++ b/api/db/database-builder/factory/build-authentication-method.js
@@ -59,4 +59,32 @@ buildAuthenticationMethod.buildPasswordAuthenticationMethod = function({
   });
 };
 
+buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function({
+  id,
+  externalIdentifier = faker.random.word(),
+  accessToken = faker.random.uuid(),
+  refreshToken = faker.random.uuid(),
+  expiredDate = faker.date.recent(),
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  const values = {
+    id,
+    identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
+    authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({ accessToken, refreshToken, expiredDate }),
+    externalIdentifier,
+    userId,
+    createdAt,
+    updatedAt,
+  };
+  return databaseBuffer.pushInsertable({
+    tableName: 'authentication-methods',
+    values,
+  });
+};
+
 module.exports = buildAuthenticationMethod;

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -27,8 +27,6 @@ const buildUser = function buildUser({
   shouldChangePassword = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-
-  externalIdentityId,
 } = {}) {
 
   password = _.isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
@@ -36,7 +34,7 @@ const buildUser = function buildUser({
 
   const values = {
     id, firstName, lastName, email, username, password, cgu, lang, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
-    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, shouldChangePassword, createdAt, updatedAt, externalIdentityId,
+    pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, shouldChangePassword, createdAt, updatedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/migrations/20201119145715_drop_column_external_identity_id_from_users.js
+++ b/api/db/migrations/20201119145715_drop_column_external_identity_id_from_users.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'externalIdentityId';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -23,10 +23,32 @@ class PasswordAuthenticationMethod {
   }
 }
 
+class PoleEmploiAuthenticationComplement {
+  constructor({
+    accessToken,
+    refreshToken,
+    expiredDate,
+  } = {}) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+    this.expiredDate = expiredDate;
+
+    validateEntity(Joi.object({
+      accessToken: Joi.string().required(),
+      refreshToken: Joi.string().optional(),
+      expiredDate: Joi.date().required(),
+    }), this);
+  }
+}
+
 const validationSchema = Joi.object({
   id: Joi.number().optional(),
   identityProvider: Joi.string().valid(...Object.values(identityProviders)).required(),
-  authenticationComplement: Joi.when('identityProvider', { is: identityProviders.PIX, then: Joi.object().instance(PasswordAuthenticationMethod).required(), otherwise: Joi.any().forbidden() }),
+  authenticationComplement: Joi.when('identityProvider', [
+    { is: identityProviders.PIX, then: Joi.object().instance(PasswordAuthenticationMethod).required() },
+    { is: identityProviders.POLE_EMPLOI, then: Joi.object().instance(PoleEmploiAuthenticationComplement).required() },
+    { is: identityProviders.GAR, then: Joi.any().forbidden() },
+  ]),
   externalIdentifier: Joi.when('identityProvider', [
     { is: identityProviders.GAR, then: Joi.string().required() },
     { is: identityProviders.POLE_EMPLOI, then: Joi.string().required() },
@@ -68,4 +90,5 @@ class AuthenticationMethod {
 
 AuthenticationMethod.identityProviders = identityProviders;
 AuthenticationMethod.PasswordAuthenticationMethod = PasswordAuthenticationMethod;
+AuthenticationMethod.PoleEmploiAuthenticationComplement = PoleEmploiAuthenticationComplement;
 module.exports = AuthenticationMethod;

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -31,6 +31,8 @@ async function generateAccessToken({ code, clientId, redirectUri }) {
   return {
     accessToken: response.data['access_token'],
     idToken: response.data['id_token'],
+    expiresIn: response.data['expires_in'],
+    refreshToken: response.data['refresh_token'],
   };
 }
 

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -24,7 +24,7 @@ module.exports = async function authenticatePoleEmploiUser({
       cgu: false,
     });
 
-    let foundUser = await userRepository.findByExternalIdentityId(userInfo.externalIdentityId);
+    let foundUser = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
     if (!foundUser) {
       await DomainTransaction.execute(async (domainTransaction) => {
         foundUser = await userRepository.create(user, domainTransaction);

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -33,6 +33,12 @@ module.exports = async function authenticatePoleEmploiUser({
           identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
           userId: foundUser.id,
           externalIdentifier: userInfo.externalIdentityId,
+          authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+            accessToken: poleEmploiTokens.accessToken,
+            idToken: poleEmploiTokens.idToken,
+            expiresIn: poleEmploiTokens.expiresIn,
+            refreshToken: poleEmploiTokens.refreshToken,
+          }),
         });
         await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
       });

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -38,7 +38,7 @@ module.exports = async function authenticatePoleEmploiUser({
       });
     }
 
-    const accessToken = tokenService.createAccessTokenFromUser(foundUser, 'external');
+    const accessToken = tokenService.createAccessTokenFromUser(foundUser, 'pole_emploi_connect');
 
     return {
       access_token: accessToken,

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -1,6 +1,7 @@
 const User = require('../models/User');
 const AuthenticationMethod = require('../models/AuthenticationMethod');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
+const moment = require('moment');
 
 module.exports = async function authenticatePoleEmploiUser({
   code,
@@ -24,24 +25,26 @@ module.exports = async function authenticatePoleEmploiUser({
       cgu: false,
     });
 
+    const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+      accessToken: poleEmploiTokens.accessToken,
+      refreshToken: poleEmploiTokens.refreshToken,
+      expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
+    });
+
     let foundUser = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
     if (!foundUser) {
       await DomainTransaction.execute(async (domainTransaction) => {
         foundUser = await userRepository.create(user, domainTransaction);
-
         const authenticationMethod = new AuthenticationMethod({
           identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
           userId: foundUser.id,
           externalIdentifier: userInfo.externalIdentityId,
-          authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({
-            accessToken: poleEmploiTokens.accessToken,
-            idToken: poleEmploiTokens.idToken,
-            expiresIn: poleEmploiTokens.expiresIn,
-            refreshToken: poleEmploiTokens.refreshToken,
-          }),
+          authenticationComplement,
         });
         await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
       });
+    } else {
+      await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: foundUser.id });
     }
 
     const accessToken = tokenService.createAccessTokenFromUser(foundUser, 'pole_emploi_connect');

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -513,8 +513,14 @@ module.exports = {
 
   async findByExternalIdentityId(externalIdentityId) {
     const bookshelfUser = await BookshelfUser
-      .where({ externalIdentityId })
-      .fetch();
+      .query((qb) => {
+        qb.innerJoin('authentication-methods', function() {
+          this.on('users.id', 'authentication-methods.userId')
+            .andOnVal('authentication-methods.identityProvider', AuthenticationMethod.identityProviders.POLE_EMPLOI)
+            .andOnVal('authentication-methods.externalIdentifier', externalIdentityId);
+        });
+      })
+      .fetch({ withRelated: 'authenticationMethods' });
     return bookshelfUser ? _toDomain(bookshelfUser) : null;
   },
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -512,7 +512,7 @@ module.exports = {
     }
   },
 
-  async findByExternalIdentityId(externalIdentityId) {
+  async findByPoleEmploiExternalIdentifier(externalIdentityId) {
     const bookshelfUser = await BookshelfUser
       .query((qb) => {
         qb.innerJoin('authentication-methods', function() {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -14,6 +14,7 @@ const Organization = require('../../domain/models/Organization');
 const SchoolingRegistrationForAdmin = require('../../domain/read-models/SchoolingRegistrationForAdmin');
 const AuthenticationMethod = require('../../domain/models/AuthenticationMethod');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../DomainTransaction');
 
 const PIX_MASTER_ROLE_ID = 1;
 
@@ -296,10 +297,10 @@ module.exports = {
     return bookshelfUser ? _toDomain(bookshelfUser) : null;
   },
 
-  create(user) {
+  create(user, domainTransaction = DomainTransaction.emptyTransaction()) {
     const userToCreate = _adaptModelToDb(user);
     return new BookshelfUser(userToCreate)
-      .save()
+      .save(null, { transacting: domainTransaction.knexTransaction })
       .then((bookshelfUser) => bookshelfUser.toDomainEntity());
   },
 

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -204,4 +204,55 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       });
     });
   });
+
+  describe('#updatePoleEmploiAuthenticationComplementByUserId', () => {
+
+    context('When authentication method exists', async () => {
+
+      let poleEmploiAuthenticationMethod;
+
+      beforeEach(() => {
+        const userId = databaseBuilder.factory.buildUser().id;
+        poleEmploiAuthenticationMethod = databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          accessToken: 'to_be_updated',
+          refreshToken: 'to_be_updated',
+          expiredDate: Date.now(),
+          userId,
+        });
+        return databaseBuilder.commit();
+      });
+
+      it('should update authentication complement by userId and identity provider', async () => {
+        // given
+        const userId = poleEmploiAuthenticationMethod.userId;
+        const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+          accessToken: 'new_access_token',
+          refreshToken: 'new_refresh_token',
+          expiredDate: Date.now(),
+        });
+
+        // when
+        const updatedAuthenticationMethod = await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId });
+
+        // then
+        expect(updatedAuthenticationMethod.authenticationComplement).to.deep.equal(authenticationComplement);
+      });
+    });
+
+    context('When authentication method does not exist', async () => {
+
+      it('should throw a not found error', async () => {
+        // given
+        const userId = 12345;
+        const authenticationComplement = {};
+
+        // when
+        const error = await catchErr(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId)({ authenticationComplement, userId });
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+      });
+    });
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -149,8 +149,11 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       let userInDb;
 
       beforeEach(async () => {
-        userInDb = databaseBuilder.factory.buildUser({
-          externalIdentityId,
+        userInDb = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod({
+          identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
+          externalIdentifier: externalIdentityId,
+          userId: userInDb.id,
         });
         await databaseBuilder.commit();
       });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -142,7 +142,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       });
     });
 
-    describe('#findByExternalIdentityId', () => {
+    describe('#findByPoleEmploiExternalIdentifier', () => {
 
       const externalIdentityId = 'external-identity-id';
 
@@ -160,7 +160,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       it('should return user informations for the given external identity id', async () => {
         // when
-        const user = await userRepository.findByExternalIdentityId(externalIdentityId);
+        const user = await userRepository.findByPoleEmploiExternalIdentifier(externalIdentityId);
 
         // then
         expect(user).to.be.an.instanceof(User);
@@ -172,7 +172,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         const badId = 'not-exist-external-identity-id';
 
         // when
-        const user = await userRepository.findByExternalIdentityId(badId);
+        const user = await userRepository.findByPoleEmploiExternalIdentifier(badId);
 
         // then
         return expect(user).to.be.null;

--- a/api/tests/tooling/domain-builder/factory/build-authentication-method.js
+++ b/api/tests/tooling/domain-builder/factory/build-authentication-method.js
@@ -50,4 +50,28 @@ buildAuthenticationMethod.buildPasswordAuthenticationMethod = function({
   });
 };
 
+buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod = function({
+  id,
+  externalIdentifier = faker.random.word(),
+  accessToken = faker.random.uuid(),
+  refreshToken = faker.random.uuid(),
+  expiredDate = faker.date.recent(),
+  userId,
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past(),
+} = {}) {
+
+  userId = isUndefined(userId) ? buildUser().id : userId;
+
+  return new AuthenticationMethod({
+    id,
+    identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
+    authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({ accessToken, refreshToken, expiredDate }),
+    externalIdentifier,
+    userId,
+    createdAt,
+    updatedAt,
+  });
+};
+
 module.exports = buildAuthenticationMethod;

--- a/api/tests/unit/domain/models/AuthenticationMethod_test.js
+++ b/api/tests/unit/domain/models/AuthenticationMethod_test.js
@@ -12,9 +12,15 @@ describe('Unit | Domain | Models | AuthenticationMethod', () => {
         .not.to.throw(ObjectValidationError);
     });
 
-    it('should successfully instantiate object when identityProvider is POLE_EMPLOI and externalIdentifier is defined', () => {
+    it('should successfully instantiate object when identityProvider is POLE_EMPLOI and externalIdentifier and authenticationComplements are defined', () => {
+      // given
+      const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiredDate: Date.now(),
+      });
       // when
-      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI, externalIdentifier: 'externalIdentifier', userId: 1 }))
+      expect(() => new AuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI, externalIdentifier: 'externalIdentifier', authenticationComplement, userId: 1 }))
         .not.to.throw(ObjectValidationError);
     });
 
@@ -76,6 +82,45 @@ describe('Unit | Domain | Models | AuthenticationMethod', () => {
         expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, shouldChangePassword: 'not_valid' }))
           .to.throw(ObjectValidationError);
         expect(() => new AuthenticationMethod.PasswordAuthenticationMethod({ ...validArguments, shouldChangePassword: undefined }))
+          .to.throw(ObjectValidationError);
+      });
+    });
+
+    context('PoleEmploiAuthenticationComplement', () => {
+
+      let validArguments;
+      beforeEach(() => {
+        validArguments = {
+          accessToken: 'accessToken',
+          refreshToken: 'refreshToken',
+          expiredDate: Date.now(),
+        };
+      });
+
+      it('should successfully instantiate object when passing all valid arguments', () => {
+        // when
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement(validArguments)).not.to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when accessToken is not valid', () => {
+        // when
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement({ ...validArguments, accessToken: 1234 }))
+          .to.throw(ObjectValidationError);
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement({ ...validArguments, accessToken: undefined }))
+          .to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when refreshToken is not valid', () => {
+        // when
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement({ ...validArguments, refreshToken: 1234 }))
+          .to.throw(ObjectValidationError);
+      });
+
+      it('should throw an ObjectValidationError when expiredDate is not valid', () => {
+        // when
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement({ ...validArguments, expiredDate: 'not_valid' }))
+          .to.throw(ObjectValidationError);
+        expect(() => new AuthenticationMethod.PoleEmploiAuthenticationComplement({ ...validArguments, expiredDate: undefined }))
           .to.throw(ObjectValidationError);
       });
     });

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -93,15 +93,17 @@ describe('Unit | Domain | Services | authentication', () => {
 
   describe('#generateAccessToken', () => {
 
-    it('should return access token and id token', async () => {
+    it('should return access token, id token and validity period', async () => {
       // given
       const code = 'code';
       const clientId = 'clientId';
       const redirectUri = 'redirectUri';
       const accessToken = 'accessToken';
       const idToken = 'idToken';
+      const expiresIn = 60;
+      const refreshToken = 'refreshToken';
 
-      const expectedResult = { accessToken, idToken };
+      const expectedResult = { accessToken, idToken, expiresIn, refreshToken };
 
       const expectedUrl = settings.poleEmploi.tokenUrl;
       const expectedData = `client_secret=${settings.poleEmploi.clientSecret}&grant_type=authorization_code&code=${code}&client_id=${clientId}&redirect_uri=${redirectUri}`;
@@ -111,6 +113,8 @@ describe('Unit | Domain | Services | authentication', () => {
         data: {
           access_token: accessToken,
           id_token: idToken,
+          expires_in: expiresIn,
+          refresh_token: refreshToken,
         },
       };
       sinon.stub(axios, 'post').resolves(response);

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -155,7 +155,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
     });
 
     // then
-    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(user, 'external');
+    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(user, 'pole_emploi_connect');
   });
 
   it('should return accessToken and idToken', async () => {

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -14,6 +14,8 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
 
   const accessToken = 'accessToken';
   const idToken = 'idToken';
+  const expiresIn = 60;
+  const refreshToken = 'refreshToken';
 
   const firstName = 'firstname';
   const lastName = 'lastname';
@@ -38,7 +40,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
     };
 
     authenticationService = {
-      generateAccessToken: sinon.stub().resolves({ accessToken, idToken }),
+      generateAccessToken: sinon.stub().resolves({ accessToken, idToken, expiresIn, refreshToken }),
       getPoleEmploiUserInfo: sinon.stub().resolves(userInfo),
     };
 
@@ -110,6 +112,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
       const expectedAuthenticationMethod = new AuthenticationMethod({
         identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
         externalIdentifier: externalIdentityId,
+        authenticationComplement: new AuthenticationMethod.PoleEmploiAuthenticationComplement({ accessToken, idToken, expiresIn, refreshToken }),
         userId,
       });
 

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -50,7 +50,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
 
     userRepository = {
       create: sinon.stub().resolves({ id: userId }),
-      findByExternalIdentityId: sinon.stub().resolves(),
+      findByPoleEmploiExternalIdentifier: sinon.stub().resolves(),
     };
 
     authenticationMethodRepository = {
@@ -90,7 +90,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
         firstName, lastName, externalIdentityId,
       };
       authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
-      userRepository.findByExternalIdentityId.resolves(null);
+      userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
 
       // when
       await authenticatePoleEmploiUser({
@@ -108,7 +108,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
         firstName, lastName, externalIdentityId,
       };
       authenticationService.getPoleEmploiUserInfo.resolves(userInfo);
-      userRepository.findByExternalIdentityId.resolves(null);
+      userRepository.findByPoleEmploiExternalIdentifier.resolves(null);
       const expectedAuthenticationMethod = new AuthenticationMethod({
         identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
         externalIdentifier: externalIdentityId,
@@ -131,7 +131,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
 
     it('should not call user repository create function', async () => {
       // given
-      userRepository.findByExternalIdentityId.resolves({ id: 1 });
+      userRepository.findByPoleEmploiExternalIdentifier.resolves({ id: 1 });
 
       // when
       await authenticatePoleEmploiUser({
@@ -149,7 +149,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
     const user = new User({ firstName, lastName });
     user.externalIdentityId = externalIdentityId;
 
-    userRepository.findByExternalIdentityId.resolves(user);
+    userRepository.findByPoleEmploiExternalIdentifier.resolves(user);
 
     // when
     await authenticatePoleEmploiUser({

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -3,6 +3,7 @@ import { isEmpty } from '@ember/utils';
 
 import OIDCAuthenticator from 'ember-simple-auth-oidc/authenticators/oidc';
 import getAbsoluteUrl from 'ember-simple-auth-oidc/utils/absoluteUrl';
+import { decodeToken } from 'mon-pix/helpers/jwt';
 
 import config from 'ember-simple-auth-oidc/config';
 import ENV from 'mon-pix/config/environment';
@@ -39,10 +40,13 @@ export default OIDCAuthenticator.extend({
     });
 
     const data = await response.json();
+    const decodedAccessToken = decodeToken(data.access_token);
 
     return {
       access_token: data.access_token,
       id_token: data.id_token,
+      source: decodedAccessToken.source,
+      user_id: decodedAccessToken.user_id,
       redirectUri,
     };
   },
@@ -71,7 +75,7 @@ export default OIDCAuthenticator.extend({
       params.push(`id_token_hint=${idToken}`);
     }
 
-    this._redirectToUrl(`${getAbsoluteUrl(endSessionEndpoint, host)}?${params.join('&')}`);
+    location.replace(`${getAbsoluteUrl(endSessionEndpoint, host)}?${params.join('&')}`);
   },
 
 });

--- a/mon-pix/app/routes/logout.js
+++ b/mon-pix/app/routes/logout.js
@@ -6,6 +6,7 @@ import ENV from 'mon-pix/config/environment';
 import get from 'lodash/get';
 
 const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_MEDIACENTRE;
+const AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI = ENV.APP.AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI;
 
 @classic
 export default class LogoutRoute extends Route {
@@ -19,7 +20,7 @@ export default class LogoutRoute extends Route {
     if (session.get('isAuthenticated')) {
       if (get(session, 'data.authenticated.id_token')) {
         const { id_token } = session.data.authenticated;
-        session.singleLogout(id_token);
+        return session.singleLogout(id_token);
       }
 
       return session.invalidate();
@@ -29,7 +30,7 @@ export default class LogoutRoute extends Route {
   afterModel() {
     if (this.source === AUTHENTICATED_SOURCE_FROM_MEDIACENTRE) {
       return this._redirectToDisconnectedPage();
-    } else {
+    } else if (this.source !== AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI) {
       return this._redirectToHome();
     }
   }

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -84,6 +84,7 @@ module.exports = function(environment) {
         },
       },
       AUTHENTICATED_SOURCE_FROM_MEDIACENTRE: 'external',
+      AUTHENTICATED_SOURCE_FROM_POLE_EMPLOI: 'pole_emploi_connect',
     },
 
     googleFonts: [


### PR DESCRIPTION
## :unicorn: Problème
Suite à la création de la table `authentication-methods`, les différentes méthodes de connexion existantes doivent être migrées. Le but de ce ticket est d'effectuer la migration des données pour la méthode de connexion POLE_EMPLOI.

## :robot: Solution
- Supprimer la colonne `externalIdentityId` de la table `users`.
- Modifier les méthodes de repository et les usecases qui insèrent et lisent un `externalIdentityId`.

## :rainbow: Remarques
En supplément, cette PR stocke l'accessToken, l'idToken et l'attribut expiresIn en JSONB dans la table `authentication-methods`. 

## :100: Pour tester
Tester la connexion à Pole Emploi, une première fois, pour créer l'utilisateur et l'`authentication-method` POLE_EMPLOI, puis une deuxième fois, afin de vérifier que l'utilisateur est bien retrouvé en base.
