### PR TITLE
[BUGFIX] Corriger le premier déploiement des review apps.

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -25,7 +25,6 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "preinstall": "npx check-engine",
-    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:lint": "npm test && npm run lint",

--- a/api/package.json
+++ b/api/package.json
@@ -117,7 +117,6 @@
     "preinstall": "npx check-engine",
     "scalingo-background-job": "node scripts/reload-cache-everyday.js",
     "scalingo-postbuild": "echo 'nothing to do'",
-    "scalingo-post-ra-creation": "npm run postdeploy && npm run db:seed",
     "start": "node bin/www",
     "start:watch": "nodemon bin/www",
     "test": "NODE_ENV=test npm run db:prepare && npm run test:api",

--- a/api/scripts/scalingo-post-ra-creation.sh
+++ b/api/scripts/scalingo-post-ra-creation.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+npm run postdeploy
+npm run db:seed

--- a/certif/package.json
+++ b/certif/package.json
@@ -30,7 +30,6 @@
     "lint:hbs": "ember-template-lint .",
     "lint:scss": "stylelint app/styles/**/*.scss",
     "preinstall": "npx check-engine",
-    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:lint": "npm test && npm run lint",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -30,7 +30,6 @@
     "lint:scss": "stylelint app/styles/**/*.scss",
     "build": "ember build --environment $BUILD_ENVIRONMENT",
     "preinstall": "npx check-engine",
-    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:lint": "npm test && npm run lint",

--- a/orga/package.json
+++ b/orga/package.json
@@ -29,7 +29,6 @@
     "lint:js": "eslint .",
     "lint:hbs": "ember-template-lint .",
     "preinstall": "npx check-engine",
-    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "ember serve --proxy http://localhost:3000",
     "test": "ember test --reporter dot",
     "test:lint": "npm test && npm run lint",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "lint:orga": "cd orga && npm run lint",
     "lint:scripts": "cd scripts && eslint .",
     "preinstall": "npx check-engine",
-    "scalingo-post-ra-creation": "echo 'nothing to do'",
     "start": "run-p --print-label start:api start:mon-pix start:orga start:certif start:admin",
     "start:admin": "cd admin && npm start",
     "start:api": "cd api && npm run start:watch",

--- a/scalingo.json
+++ b/scalingo.json
@@ -15,7 +15,7 @@
     }
   },
   "scripts": {
-    "first-deploy": "npm run scalingo-post-ra-creation"
+    "first-deploy": "./scripts/scalingo-post-ra-creation.sh"
   },
   "addons": [
     "postgresql:postgresql-sandbox",

--- a/scripts/scalingo-post-ra-creation.sh
+++ b/scripts/scalingo-post-ra-creation.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "nothing to do"


### PR DESCRIPTION
## :unicorn: Problème
Depuis la [PR 2197](https://github.com/1024pix/pix/pull/2197), `node` est supprimé du containeur front.
Cela ne pose aucun soucis sur les environnements `recette` et `production`, mais pour les review apps, le scrript actuel appelé par scalingo lors du premier déploiement (`first-deploy` dans `scalingo.json`) utilise `npm` (et donc `node`).
Cela a pour conséquence de faire échouer tous les premiers déploiements des review apps front.

## :robot: Solution
Extraire la commande `npm scalingo-post-ra-creation` dans un script bash dédié, et changer la commande en question dans `scalingo.json`.
On en profite pour supprimer les scripts désormais obsolètes dans les `package.json`.

## :rainbow: Remarques
Le script front ne fait rien (`echo 'nothing to do'`) mais il est nécessaire car toutes les review apps partagent le même template.
Le script api sert à insérer des données dans la base (via les seeds).

Cette PR a pris un peu de temps à cause d'un bug chez Scalingo.
Voir l'échange avec Scalingo sur le compte de dev pour tous les détails dudit bug.

## :100: Pour tester
✅ Le premier déploiement de cette PR a bien appelé les scripts bash en lieu et place des commandes `npm`.
> Postdeploy hook detected, starting './scripts/scalingo-post-ra-creation.sh'
