### PR TITLE
[BUGFIX] Ignorer les doublons de rattachement de profils cible dans le script associé (PIX-1709).

### DIFF
--- a/api/lib/infrastructure/repositories/target-profile-share-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-share-repository.js
@@ -1,11 +1,15 @@
-const Bookshelf = require('../bookshelf');
+const { knex } = require('../bookshelf');
 
 module.exports = {
-  addTargetProfilesToOrganization({ organizationId, targetProfileIdList }) {
+
+  async addTargetProfilesToOrganization({ organizationId, targetProfileIdList }) {
     const targetProfileShareToAdd = targetProfileIdList.map((targetProfileId) => {
       return { organizationId, targetProfileId };
     });
-    return Bookshelf.knex.batchInsert('target-profile-shares', targetProfileShareToAdd)
-      .then(() => null);
+
+    return knex('target-profile-shares')
+      .insert(targetProfileShareToAdd)
+      .onConflict(['targetProfileId', 'organizationId'])
+      .ignore();
   },
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4835,24 +4835,21 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "knex": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.4.tgz",
-      "integrity": "sha512-vUrR4mJBKWJPouV9C7kqvle9cTpiuuzBWqrQXP7bAv+Ua9oeKkEhhorJwArzcjVrVBojZYPMMtNVliW9B00sTA==",
+      "version": "0.21.12",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.12.tgz",
+      "integrity": "sha512-AEyyiTM9p/x/Pb38TPZkvphKPmn8UWxP7MdIphzjAOielOfFFeU6pjP6y3M7UJ7rxrQsCrAYHwdonLQ3l1JCDw==",
       "requires": {
         "colorette": "1.2.1",
         "commander": "^5.1.0",
         "debug": "4.1.1",
         "esm": "^3.2.25",
         "getopts": "2.2.5",
-        "inherits": "~2.0.4",
         "interpret": "^2.2.0",
         "liftoff": "3.1.0",
-        "lodash": "^4.17.19",
-        "mkdirp": "^1.0.4",
+        "lodash": "^4.17.20",
         "pg-connection-string": "2.3.0",
-        "tarn": "^3.0.0",
+        "tarn": "^3.0.1",
         "tildify": "2.0.0",
-        "uuid": "^7.0.3",
         "v8flags": "^3.2.0"
       },
       "dependencies": {
@@ -4869,30 +4866,15 @@
             "ms": "^2.1.1"
           }
         },
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
       }
     },
@@ -7694,9 +7676,9 @@
       }
     },
     "tarn": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.0.tgz",
-      "integrity": "sha512-PKUnlDFODZueoA8owLehl8vLcgtA8u4dRuVbZc92tspDYZixjJL6TqYOmryf/PfP/EBX+2rgNcrj96NO+RPkdQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
+      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw=="
     },
     "term-size": {
       "version": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -55,7 +55,7 @@
     "jsonapi-serializer": "^3.6.6",
     "jsonwebtoken": "^8.5.1",
     "jszip": "^3.5.0",
-    "knex": "^0.21.4",
+    "knex": "^0.21.9",
     "lodash": "^4.17.19",
     "moment": "^2.27.0",
     "moment-timezone": "^0.5.31",

--- a/api/scripts/prod/add-target-profile-shares-to-organizations.js
+++ b/api/scripts/prod/add-target-profile-shares-to-organizations.js
@@ -4,9 +4,9 @@
 
 'use strict';
 require('dotenv').config();
-const targetProfileShareRepository = require('../lib/infrastructure/repositories/target-profile-share-repository');
-const { findOrganizationsByExternalIds, organizeOrganizationsByExternalId } = require('./helpers/organizations-by-external-id-helper');
-const { parseCsv } = require('./helpers/csvHelpers');
+const targetProfileShareRepository = require('../../lib/infrastructure/repositories/target-profile-share-repository');
+const { findOrganizationsByExternalIds, organizeOrganizationsByExternalId } = require('../helpers/organizations-by-external-id-helper');
+const { parseCsv } = require('../helpers/csvHelpers');
 
 function checkData({ csvData }) {
   return csvData.map(([externalIdLowerCase, targetProfileList]) => {

--- a/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-share-repository_test.js
@@ -36,6 +36,20 @@ describe('Integration | Repository | Target-profile-share', () => {
       expect(_.map(targetProfileShares, 'targetProfileId')).exactlyContain([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
     });
 
+    it('should not create another target profile share nor throw an error when it already exists', async function() {
+      // given
+      databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: targetProfileIdA });
+      const targetProfileIdList = [targetProfileIdA, targetProfileIdB, targetProfileIdC];
+
+      // when
+      await targetProfileShareRepository.addTargetProfilesToOrganization({ organizationId, targetProfileIdList });
+
+      // then
+      const targetProfileShares = await knex('target-profile-shares').where({ organizationId });
+      expect(targetProfileShares).to.have.lengthOf(3);
+      expect(_.map(targetProfileShares, 'targetProfileId')).to.have.members([targetProfileIdA, targetProfileIdB, targetProfileIdC]);
+    });
+
     it('should not erase old target profil share', async function() {
       // given
       databaseBuilder.factory.buildTargetProfileShare({ organizationId, targetProfileId: targetProfileIdA });

--- a/api/tests/unit/scripts/add-target-profile-shares-to-organizations_test.js
+++ b/api/tests/unit/scripts/add-target-profile-shares-to-organizations_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon } = require('../../test-helper');
 
-const { addTargetProfileSharesToOrganizations, checkData } = require('../../../scripts/add-target-profile-shares-to-organizations');
+const { addTargetProfileSharesToOrganizations, checkData } = require('../../../scripts/prod/add-target-profile-shares-to-organizations');
 const targetProfileShareRepository = require('../../../lib/infrastructure/repositories/target-profile-share-repository');
 
 describe('Acceptance | Scripts | add-target-profile-shares-to-organizations.js', () => {


### PR DESCRIPTION
## :unicorn: Problème
Récemment a été ajouté une règle en base de données interdisant les doublons de `target-profile-share`.

## :robot: Solution
Prendre en compte cette nouvelle règle dans le script de rattachement des profils cibles.

## :rainbow: Remarques
knex a été updaté, car `onConflict` n'était pas disponible dans la version inférieure.

## :100: Pour tester
Lancer le script de rattachement avec un fichier csv sous la forme | organizationId | targetProfileId, otherTargetProfileId |
