### PR TITLE
[BUGFIX] Lever une erreur correctement dans le script de création d'apprentis lorsqu'un ID externe d'organisation est introuvable (PIX-1694).

### DIFF
--- a/api/scripts/prod/import-apprentices.js
+++ b/api/scripts/prod/import-apprentices.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-sync */
 // Usage: node import-apprentices path/file.csv
-
+const { OrganizationNotFoundError } = require('../../lib/domain/errors');
 const { CsvColumn } = require('../../lib/infrastructure/serializers/csv/csv-registration-parser');
+
 const SchoolingRegistrationParser = require('../../lib/infrastructure/serializers/csv/schooling-registration-parser');
 const fs = require('fs');
 const { knex } = require('../../db/knex-database-connection');
@@ -23,7 +24,13 @@ class CsvApprenticesParser extends SchoolingRegistrationParser {
       if (column.isDate) {
         registrationAttributes[column.name] = this._buildDateAttribute(value);
       } else if (column.name === 'uai') {
-        registrationAttributes.organizationId = this.organizationByUai[value];
+        const organizationId = this.organizationByUai[value];
+
+        if (!organizationId) {
+          throw new OrganizationNotFoundError(`l'uai : ${value} n'est rattaché à aucune organisation. Veuillez vérifier votre fichier`);
+        }
+
+        registrationAttributes.organizationId = organizationId;
       } else {
         registrationAttributes[column.name] = value;
       }


### PR DESCRIPTION
## :unicorn: Problème
si l'organization est manquante nous ne devrions pas tenter d'inserer la données en base.

## :robot: Solution
remonter une exception lors de la tentative d'import pour notifier qu'un problème est présent dans le fichier

## :rainbow: Remarques

## :100: Pour tester
