### PR TITLE
[TECH] Serialiser correctement le prescripteur et ses informations (PIX-1724).

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -32,7 +32,7 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['name', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,
@@ -80,7 +80,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type', 'isAgriculture', 'isCFA'],
+          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA'],
         },
       },
     }).serialize(prescriber);

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -32,7 +32,15 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['name', 'externalId'],
+        },
+      },
+      userOrgaSettings: {
+        ref: 'id',
+        attributes: ['organization', 'user'],
+        organization: {
+          ref: 'id',
+          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,
@@ -73,14 +81,6 @@ module.exports = {
               },
             },
           },
-        },
-      },
-      userOrgaSettings: {
-        ref: 'id',
-        attributes: ['organization', 'user'],
-        organization: {
-          ref: 'id',
-          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA'],
         },
       },
     }).serialize(prescriber);

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -32,7 +32,7 @@ module.exports = {
         attributes: ['organizationRole', 'organization'],
         organization: {
           ref: 'id',
-          attributes: ['code', 'credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/acceptance/application/prescriber-controller_test.js
+++ b/api/tests/acceptance/application/prescriber-controller_test.js
@@ -114,7 +114,7 @@ describe('Acceptance | Controller | Prescriber-controller', () => {
 
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser();
-      organization = databaseBuilder.factory.buildOrganization();
+      organization = databaseBuilder.factory.buildOrganization({ credit: 5, isManagingStudents: true, canCollectProfiles: true });
       membership = databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
       userOrgaSettingsId = databaseBuilder.factory.buildUserOrgaSettings({ currentOrganizationId: organization.id, userId: user.id }).id;
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -5,7 +5,7 @@ const Membership = require('../../../../../lib/domain/models/Membership');
 
 describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
 
-  function createExpectedPrescriberSerializedWithIsAgriculture({ prescriber, membership, userOrgaSettings, organization }) {
+  function createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField, field }) {
     return {
       data: {
         id: prescriber.id.toString(),
@@ -36,13 +36,11 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
           id: organization.id.toString(),
           type: 'organizations',
           attributes: {
-            'can-collect-profiles': organization.canCollectProfiles,
             'external-id': organization.externalId,
-            'is-managing-students': organization.isManagingStudents,
             'name': organization.name,
             'type': organization.type,
             'credit': organization.credit,
-            'is-agriculture': true,
+            [serializedField]: organization[field],
           },
           relationships: {
             memberships: {
@@ -132,9 +130,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
           id: organization.id.toString(),
           type: 'organizations',
           attributes: {
-            'can-collect-profiles': organization.canCollectProfiles,
             'external-id': organization.externalId,
-            'is-managing-students': organization.isManagingStudents,
             'name': organization.name,
             'type': organization.type,
             'credit': organization.credit,
@@ -198,7 +194,187 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
 
   describe('#serialize', () => {
 
-    context('when isAgriculture should be true', () => {
+    context('when canCollectProfiles is true', () => {
+      it('should serialize prescriber with canCollectProfiles', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const organization = domainBuilder.buildOrganization({ canCollectProfiles: true });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const  expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'can-collect-profiles', field: 'canCollectProfiles' });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when canCollectProfiles is false', () => {
+      it('should serialize prescriber without canCollectProfiles', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const organization = domainBuilder.buildOrganization({ canCollectProfiles: false });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const  expectedPrescriberSerialized = createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSettings, organization });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when isManagingStudents is true', () => {
+      it('should serialize prescriber with isManagingStudents', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const organization = domainBuilder.buildOrganization({ isManagingStudents: true });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const  expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-managing-students', field: 'isManagingStudents' });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when isManagingStudents is false', () => {
+      it('should serialize prescriber without isManagingStudents', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const  expectedPrescriberSerialized = createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSettings, organization });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when isAgriculture is true', () => {
       it('should serialize prescriber with isAgriculture', () => {
         // given
         const user = domainBuilder.buildUser({
@@ -234,7 +410,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
           userOrgaSettings,
         });
 
-        const  expectedPrescriberSerialized = createExpectedPrescriberSerializedWithIsAgriculture({ prescriber, membership, userOrgaSettings, organization });
+        const  expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-agriculture', field: 'isAgriculture' });
 
         // when
         const result = serializer.serialize(prescriber);
@@ -244,7 +420,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       });
     });
 
-    context('when isAgriculture should be false', () => {
+    context('when isAgriculture is false', () => {
       it('should serialize prescriber without isAgriculture', () => {
         // given
         const user = domainBuilder.buildUser({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la sérialisation du prescripteur était faite comme telle :
```
  attributes: [ [...], 'memberships', 'userOrgaSettings' ],
  memberships: {
    ref: 'id',
    attributes: ['organizationRole', 'organization'],
    organization: {
      ref: 'id',
      attributes: ['credit', 'name', 'type', 'isManagingStudents', 'canCollectProfiles', 'externalId', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
      memberships: { ... },
      targetProfiles: {...},
      students: {...},
      organizationInvitations: {...},
    },
  },
  userOrgaSettings: {
    ref: 'id',
    attributes: ['organization', 'user'],
    organization: {
      ref: 'id',
      attributes: ['name', 'type', 'isAgriculture'],
    },
  },
```
Le problème, c'est qu'un certain nombre de données, ne sont utiles que dans l'organisation courante obtenue avec (`userOrgaSettings`) mais sont serialisées avec les `memberships`. Pour une organisation sur laquelle on se serait pas encore (disponible via le menu de changement d'organisation), il n'y a nul besoin d'avoir accès à tout cela :
- credit,
- isManagingStudents
- canCollectProfiles

Ainsi que les liens pour accéder à d'autres sous-ressources :
- targetProfiles
- memberships
- students
- organizationInvitations

## :robot: Solution
Ré-ordonner la sérialisation.

## :rainbow: Remarques
- À la sérilisation, l'organisation demandée par le `membership` et celle demandée par `userOrgaSettings` fusionnent pour ne former qu'un seul objet dans `include`.
- Du fait de cette fusion, certains attributs falsy sont omis (des crédits à 0, un booléen à false, ...), cela ne nous pose pas de problèmes actuellement.

## :100: Pour tester
Non-régression :
Se connecter à Pix Orga, naviguer dans les onglets, changer d'organisation.
