### PR TITLE
[FEATURE] Pix Concours: Afficher le nom et prénom de l'utilisateur (PIX-1710).

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -16,6 +16,10 @@ export default class NavbarDesktopHeader extends Component {
     return (this.isUserLogged || this._isExternalUser) ? [] : this._menuItems;
   }
 
+  get userFullname() {
+    return this.currentUser.user.get('lastName') + ' ' + this.currentUser.user.get('firstName');
+  }
+
   get _menuItems() {
     return [
       { name: this.intl.t('navigation.not-logged.sign-in'), link: 'login', class: 'navbar-menu-signin-link' },

--- a/mon-pix/app/components/resume-campaign-banner.js
+++ b/mon-pix/app/components/resume-campaign-banner.js
@@ -8,7 +8,10 @@ export default class ResumeCampaignBanner extends Component {
   @service currentUser;
 
   get notFinishedCampaignParticipations() {
-    return this.args.campaignParticipations.filter((campaignParticipation) => !campaignParticipation.assessment.get('isCompleted'));
+    if (ENV.APP.IS_PIX_CONTEST === 'true') {
+      return this.args.campaignParticipations.filter((campaignParticipation) => !campaignParticipation.assessment.get('isCompleted'));
+    }
+    return this.args.campaignParticipations.filter((campaignParticipation) => campaignParticipation.isShared === false);
   }
 
   get lastNotFinishedCampaignParticipation() {

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -50,6 +50,11 @@
     {{/if}}
 
     <!-- Links (right) -->
+    {{#if @isPixContest}}
+      <div class="navbar-desktop-header-right">
+        {{ this.userFullname }}
+      </div>
+    {{/if}}
     {{#unless @isPixContest}}
       <div class="navbar-desktop-header-right">
         <NavbarDesktopMenu @menu={{this.menu}} />


### PR DESCRIPTION
## :unicorn: Problème
Une fois sur Pix, l'utilisateur n'est pas assuré d'être connecté avec le bon compte.

## :robot: Solution
Afficher le nom et prénom du user dans la barre de menu, en haut à droite.

## :100: Pour tester
Vérifier que le nom et prénom de l'utilisateur est affiché en haut à droite de la barre de navigation.
