### PR TITLE
[FEATURE] Afficher l'identifiant dans la page "Mon Compte" dans Pix App (PIX-1702).

### DIFF
--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -1,4 +1,8 @@
 import Component from '@glimmer/component';
 
 export default class UserAccountPanel extends Component {
+
+  get displayUsername() {
+    return !!this.args.user.username;
+  }
 }

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -11,4 +11,10 @@
     <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.email'}}</label>
     <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
   </div>
+  {{#if this.displayUsername}}
+  <div class="user-account-panel__item">
+    <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.username'}}</label>
+    <span class="user-account-panel-item__value" data-test-username>{{@user.username}}</span>
+  </div>
+  {{/if}}
 </PixBlock>

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -1,4 +1,4 @@
-import { currentURL, find } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
@@ -34,21 +34,6 @@ describe('Acceptance | User account page', function() {
 
       // then
       expect(currentURL()).to.equal('/mon-compte');
-    });
-  });
-
-  describe('Display', function() {
-    it('should display user values', async function() {
-      // given
-      await authenticateByEmail(user);
-
-      // when
-      await visit('/mon-compte');
-
-      // then
-      expect(find('span[data-test-firstName]').textContent).to.include(user.firstName);
-      expect(find('span[data-test-lastName]').textContent).to.include(user.lastName);
-      expect(find('span[data-test-email]').textContent).to.include(user.email);
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -15,6 +15,7 @@ describe('Integration | Component | user account panel', () => {
       firstName: 'John',
       lastName: 'DOE',
       email: 'john.doe@example.net',
+      username: 'john.doe0101',
     };
     this.set('user', user);
 
@@ -25,6 +26,23 @@ describe('Integration | Component | user account panel', () => {
     expect(find('span[data-test-firstName]').textContent).to.include(user.firstName);
     expect(find('span[data-test-lastName]').textContent).to.include(user.lastName);
     expect(find('span[data-test-email]').textContent).to.include(user.email);
+    expect(find('span[data-test-username]').textContent).to.include(user.username);
+  });
+
+  context('when user does not have a username', function() {
+
+    it('should not display username', async function() {
+
+      // given
+      const user = {};
+      this.set('user', user);
+
+      // when
+      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+
+      // then
+      expect(find('span[data-test-username]')).to.not.exist;
+    });
   });
 
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -989,7 +989,8 @@
             "account-panel": {
                 "first-name": "",
                 "last-name": "",
-                "email": ""
+                "email": "",
+                "username": ""
             },
             "certifications": "My certifications",
             "sign-out": "Log out",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -992,7 +992,8 @@
             "account-panel": {
                 "first-name": "Prénom",
                 "last-name": "Nom",
-                "email": "Adresse e-mail"
+                "email": "Adresse e-mail",
+                "username": "Identifiant"
             },
             "certifications": "Mes certifications",
             "sign-out": "Se déconnecter",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur la page "Mon Compte" il n'était pas possible de voir l'identifiant de l'utilisateur ( s'il disposait d'un identifiant).

## :robot: Solution
Ajout de la condition de l'affichage du username.

## :rainbow: Remarques
Ce ticket n'utilise pas de feature toggle

## :100: Pour tester

Utilisateur avec identifiant : 
- Se connecter avec blueivy.carter@example.net
- Aller sur /mon-compte
- Vérifier la présence de la partie "Identifiant" avec l'identifiant de l'utilisateur

Utilisateur sans identifiant : 
- Se connecter avec sco.admin@example.net 
- Aller sur /mon-compte
- La partie "Identifiant" n'est pas visible