### PR TITLE
[TECH] Afficher expliciter les valeurs NULL dans les requêtes du client psql.

### DIFF
--- a/api/.psqlrc
+++ b/api/.psqlrc
@@ -1,0 +1,1 @@
+\pset null '(NULL)'


### PR DESCRIPTION
## :unicorn: Problème
La (non)valeur `NULL` est affichée par défaut ` `  (tu vois rien c'est normal, c'est un espace)  dans le client `psql` utilisé par `pgsql-console` sur les application Scalingo

## :robot: Solution
Ajout un fichier de configuration `.psqlrc` sur API avec l'instruction
`\pset null '(NULL)'`
 
## :rainbow: Remarques
Il ne faut PAS ajouter ce fichier au `slugignore`

Toutes les options éligibles sont dans la [doc](https://www.postgresql.org/docs/current/app-psql.html). Beware [exotic prompts](https://stackoverflow.com/questions/19139330/colors-in-the-psql-prompt) !  

Ceci dit un PROMPT rouge en production, pourquoi pas dans un autre ticket ?

## :100: Pour tester
Se connecter en RA
`scalingo --app pix-api-review-pr2216 pgsql-console`

Vérifier l'affichage suivant
```
psql (PostgreSQL) 12.5
Null display is "(NULL)".
```

Exécuter` SELECT NULL;` et vérifier l'affichage suivant
```
pix=# select NULL;
 ?column? 
----------
 (NULL)
(1 row)
```
