### PR TITLE
[TECH] Exécuter et tracer les résultats de test de charge d'une release.

### DIFF
--- a/high-level-tests/load-testing/README.md
+++ b/high-level-tests/load-testing/README.md
@@ -24,8 +24,26 @@ scalingo --app load-testing pgsql-console
 Exécuter la requête
 ``` sql
 DROP TABLE IF EXISTS test_executions;
-CREATE TABLE test_executions (id SERIAL PRIMARY KEY, api_version VARCHAR NOT NULL, started_at TIMESTAMP DEFAULT NOW(), ended_at TIMESTAMP, data JSONB);
+CREATE TABLE test_executions (id SERIAL PRIMARY KEY, api_version VARCHAR NOT NULL, started_at TIMESTAMP DEFAULT NOW(), ended_at TIMESTAMP, report JSONB);
 ```         
+
+Alimenter les variables d'environnement suivantes :
+- `TARGET_API_URL` : URL de l'application hébergeant l'API à tester (en général : load_testing_api)
+- `TARGET_API_APPLICATION_NAME` : Nom de l'application hébergeant l'API à tester (en général : load_testing_api)
+- `DATABASE_URL` : URL de connexion à la BDD où stocker les rapports de test (en général : load_testing)
+- `RELEASE_TAG`: Release sur laquelle effectuer les tests
+- `SCALINGO_TOKEN` : Token permettant de déployer une release
+- `GITHUB_TOKEN` : Token permettant de télécharger une archive de la release sur Github
+ 
+Exemple 
+``` shell script
+TARGET_API_URL=https://load-testing-api.osc-fr1.scalingo.io
+DATABASE_URL=<APPLICATION_ADDON__DATABASE_URL>
+TARGET_API_APPLICATION_NAME=load-testing-api
+RELEASE_TAG=v2.224.0
+SCALINGO_TOKEN=<TOKEN>
+GITHUB_TOKEN=<TOKEN>
+```
 
 ## Tester la connectivité
 
@@ -52,8 +70,8 @@ Vérifier la trace d'exécution
 SELECT id, started_at, ended_at, ( ended_at - started_at) AS duration FROM test_executions ORDER BY ended_at DESC LIMIT 5;
 SELECT jsonb_pretty(data) FROM test_executions; 
 SELECT
-    data->'aggregate'->'timestamp'                  AS executed_at,
-    data->'aggregate'->'scenarioDuration'->'median' AS median_duration_millis
+    report->'aggregate'->'timestamp'                  AS executed_at,
+    report->'aggregate'->'scenarioDuration'->'median' AS median_duration_millis
 FROM test_executions;
 ```
 

--- a/high-level-tests/load-testing/functions.js
+++ b/high-level-tests/load-testing/functions.js
@@ -2,7 +2,7 @@ const faker = require('faker');
 
 module.exports = {
   setupSignupFormData,
-  foundNextChallenge
+  foundNextChallenge,
 };
 
 function setupSignupFormData(context, events, done) {

--- a/high-level-tests/load-testing/helpers/deploy-release.js
+++ b/high-level-tests/load-testing/helpers/deploy-release.js
@@ -1,0 +1,79 @@
+require('dotenv').config();
+const scalingo = require('scalingo');
+const axios = require('axios');
+const SUCCESSFUL_EXIT_CODE = 0;
+const FAIL_EXIT_CODE = 0;
+const tenSeconds = 10 * 1000;
+
+const wait = (ms) => new Promise((res) => setTimeout(res, ms));
+
+const deployRelease = async function() {
+
+  let currentAPIVersion;
+
+  const apiUrl = process.env.TARGET_API_URL;
+  const getAPIVersionRequestUrl = process.env.TARGET_API_URL + '/api';
+  const apiApplicationName =  process.env.TARGET_API_APPLICATION_NAME;
+  const releaseTag = process.env.RELEASE_TAG;
+  const expectedAPIVersion = releaseTag;
+  const scalingoToken = process.env.SCALINGO_TOKEN;
+  const gitHubToken = process.env.GITHUB_TOKEN;
+
+  try {
+    currentAPIVersion = 'v' + (await axios.get(getAPIVersionRequestUrl)).data.version;
+  } catch (error) {
+    console.error(`API cannot be reached on URL ${getAPIVersionRequestUrl}, exiting..`);
+    process.exit(FAIL_EXIT_CODE);
+  }
+
+  console.info(`Current API version: ${currentAPIVersion}`);
+
+  if (currentAPIVersion === expectedAPIVersion) {
+    console.info(`API is already in expected version: ${expectedAPIVersion}`);
+    console.info('Nothing to do, exiting..');
+    process.exit(SUCCESSFUL_EXIT_CODE);
+  }
+
+  const client = await scalingo.clientFromToken(scalingoToken, { apiUrl });
+
+  //const user = await client.Users.self();
+  // console.info(`Connected as ${user.username}`);
+
+  const releaseArchiveUrl = `https://${gitHubToken}@github.com/1024pix/pix/archive/${releaseTag}.tar.gz`;
+
+  try {
+    await client.apiClient().post(
+      `https://api-osc-fr1.scalingo.com/v1/apps/${apiApplicationName}/deployments`,
+      {
+        deployment: {
+          git_ref: releaseTag,
+          source_url: releaseArchiveUrl,
+        },
+      });
+  } catch (error)
+  {
+    console.error('Deployment request failed, exiting');
+    console.dir(error);
+    process.exit(FAIL_EXIT_CODE);
+  }
+
+  console.info(`Deployment successfully asked for release ${releaseTag} on ${apiApplicationName}`);
+  console.info('Waiting for deployment to complete...');
+
+  while (currentAPIVersion !== expectedAPIVersion) {
+    await wait(tenSeconds);
+    currentAPIVersion = 'v' + (await axios.get(getAPIVersionRequestUrl)).data.version;
+    console.info(`Current API version: ${currentAPIVersion}`);
+  }
+
+  console.info('Deployment completed');
+
+};
+
+// (async function main() {
+//   await deployRelease();
+// })();
+
+module.exports = {
+  deployRelease,
+};

--- a/high-level-tests/load-testing/helpers/log-test-execution.js
+++ b/high-level-tests/load-testing/helpers/log-test-execution.js
@@ -1,0 +1,54 @@
+require('dotenv').config();
+const fs = require('fs');
+
+const axios = require('axios');
+const { Client } = require('pg');
+
+const logTestHasStarted = async function() {
+
+  const requestUrl = process.env.TARGET_API_URL + '/api';
+  const response = await axios.get(requestUrl);
+
+  const APIVersion = response.data.version;
+
+  const client = await new Client({
+    connectionString: process.env.DATABASE_URL,
+  });
+
+  await client.connect();
+
+  const startTestQuery = 'INSERT INTO test_executions (api_version) VALUES ($1)';
+  const startTestValues = [APIVersion];
+  await client.query(startTestQuery, startTestValues) ;
+  await client.end();
+
+};
+
+const logTestHasEnded = async function() {
+
+  const report = fs.readFileSync('./report/index.json');
+  const reportJSON = JSON.parse(report);
+  const reportString = JSON.stringify(reportJSON);
+
+  const client = await new Client({
+    connectionString: process.env.DATABASE_URL,
+  });
+
+  await client.connect();
+
+  const endTestQuery = 'UPDATE test_executions SET ended_at = NOW(), report=$1 WHERE ended_at IS NULL';
+  const endTestValues = [reportString];
+  await client.query(endTestQuery, endTestValues);
+  await client.end();
+
+};
+
+// (async function main() {
+//   await logTestHasStarted();
+//   await logTestHasEnded();
+// })();
+
+module.exports = {
+  logTestHasStarted,
+  logTestHasEnded,
+};

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -1005,6 +1005,11 @@
       "resolved": "https://registry.npmjs.org/isnumber/-/isnumber-1.0.0.tgz",
       "integrity": "sha1-Dj+XWbWB2Z3YUIbw7Cp0kJz63QE="
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -1589,6 +1594,47 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scalingo": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.1.4.tgz",
+      "integrity": "sha512-Qsp03SZO3BJ44lvEcKHWmmRYv8OW3ojOFbKMfijBTAqRXFaRxZC8FHoBhC3vWf9OJQVOkNC8dD9o/ffJ7IzNFQ==",
+      "requires": {
+        "axios": "0.19.x",
+        "isomorphic-ws": "4.x",
+        "ws": "7.x"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ws": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
+          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ=="
+        }
+      }
     },
     "semver": {
       "version": "5.7.0",

--- a/high-level-tests/load-testing/package-lock.json
+++ b/high-level-tests/load-testing/package-lock.json
@@ -237,6 +237,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axios": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -291,6 +299,11 @@
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
       }
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "callsite": {
       "version": "1.0.0",
@@ -572,6 +585,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "driftless": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/driftless/-/driftless-2.0.3.tgz",
@@ -728,6 +746,11 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/filtrex/-/filtrex-0.5.4.tgz",
       "integrity": "sha1-mAddUY8GjE9Yt7WJoifZi9n2OV0="
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1301,6 +1324,11 @@
         "semver": "^5.1.0"
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
@@ -1335,6 +1363,60 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pg": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.5.1.tgz",
+      "integrity": "sha512-9wm3yX9lCfjvA98ybCyw2pADUivyNWT/yIP4ZcDVpMN0og70BUWYEGXPCTAQdGTAqnytfRADb7NERrY1qxhIqw==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.4.0",
+        "pg-pool": "^3.2.2",
+        "pg-protocol": "^1.4.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.2.tgz",
+      "integrity": "sha512-ORJoFxAlmmros8igi608iVEbQNNZlp89diFVx6yV5v+ehmpMY9sK6QgpmgoXbmkNaBAx8cOOZh9g80kJv1ooyA=="
+    },
+    "pg-protocol": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.4.0.tgz",
+      "integrity": "sha512-El+aXWcwG/8wuFICMQjM5ZSAm6OWiJicFdNYo+VY3QP+8vI4SvLIWVe51PppTzMhikUJR+PsyIFKqfdXPz/yxA=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "requires": {
+        "split2": "^3.1.1"
+      }
+    },
     "pidusage": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-1.2.0.tgz",
@@ -1344,6 +1426,29 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1389,6 +1494,16 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       }
     },
     "registry-auth-token": {
@@ -1569,6 +1684,14 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "optional": true
+    },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1927,6 +2050,11 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "2.1.2",

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -13,14 +13,21 @@
     "report": "artillery report report/index.json",
     "start": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/signup-and-placement.yml",
     "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js",
-    "load-test:test-connectivity:local": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/test-connectivity.yml",
-    "load-test:test-connectivity:review-app": "artillery run --config config/common.yml -e review-app -o report/index.json scenarios/test-connectivity.yml"
+    "load-test:test-connectivity:local": "npm run load-test:log-start && npm run load-test:test-connectivity:local:run-test && npm run load-test:log-end",
+    "load-test:test-connectivity:local:run-test": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/test-connectivity.yml",
+    "load-test:test-connectivity:review-app":"npm run load-test:log-start && npm run load-test:test-connectivity:review-app:run-test && npm run load-test:log-end",
+    "load-test:test-connectivity:review-app:run-test": "artillery run --config config/common.yml -e review-app -o report/index.json scenarios/test-connectivity.yml",
+    "load-test:log-start": "node -e \"(require('./helpers/log-test-execution')).logTestHasStarted()\" ",
+    "load-test:log-end": "node -e \"(require('./helpers/log-test-execution')).logTestHasEnded()\" "
   },
   "license": "ISC",
   "dependencies": {
     "artillery": "^1.6.0-27",
     "artillery-plugin-expect": "^1.3.0",
+    "axios": "^0.21.0",
+    "dotenv": "^8.2.0",
     "faker": "^5.1.0",
-    "js2xmlparser": "^4.0.1"
+    "js2xmlparser": "^4.0.1",
+    "pg": "^8.5.1"
   }
 }

--- a/high-level-tests/load-testing/package.json
+++ b/high-level-tests/load-testing/package.json
@@ -15,10 +15,11 @@
     "generate-bulk-data:schooling-registrations": "node ./data/generate-schooling-registrations.js",
     "load-test:test-connectivity:local": "npm run load-test:log-start && npm run load-test:test-connectivity:local:run-test && npm run load-test:log-end",
     "load-test:test-connectivity:local:run-test": "artillery run --config config/common.yml -e localhost -o report/index.json scenarios/test-connectivity.yml",
-    "load-test:test-connectivity:review-app":"npm run load-test:log-start && npm run load-test:test-connectivity:review-app:run-test && npm run load-test:log-end",
+    "load-test:test-connectivity:review-app": "npm run deploy-release && npm run load-test:log-start && npm run load-test:test-connectivity:review-app:run-test && npm run load-test:log-end",
     "load-test:test-connectivity:review-app:run-test": "artillery run --config config/common.yml -e review-app -o report/index.json scenarios/test-connectivity.yml",
     "load-test:log-start": "node -e \"(require('./helpers/log-test-execution')).logTestHasStarted()\" ",
-    "load-test:log-end": "node -e \"(require('./helpers/log-test-execution')).logTestHasEnded()\" "
+    "load-test:log-end": "node -e \"(require('./helpers/log-test-execution')).logTestHasEnded()\" ",
+    "deploy-release": "node -e \"(require('./helpers/deploy-release')).deployRelease()\" "
   },
   "license": "ISC",
   "dependencies": {
@@ -28,6 +29,7 @@
     "dotenv": "^8.2.0",
     "faker": "^5.1.0",
     "js2xmlparser": "^4.0.1",
-    "pg": "^8.5.1"
+    "pg": "^8.5.1",
+    "scalingo": "^0.1.4"
   }
 }

--- a/high-level-tests/load-testing/scenarios/test-connectivity.yml
+++ b/high-level-tests/load-testing/scenarios/test-connectivity.yml
@@ -1,11 +1,12 @@
 config:
   phases:
-    - duration: 1
-      arrivalRate: 1
+    - duration: 3
+      arrivalRate: 2
       name: "Test connectivity"
 plugins:
   expect: {}
 scenarios:
+
   - name: 'Obtenir la version de l API'
     flow:
       - get:


### PR DESCRIPTION
## :unicorn: Problème
Les tests de charge produisent un rapport en JSON qui n'est pas persisté.
Les test de charge sont lancés sur une branche, pas une version d'API.

## :robot: Solution
Persister les rapports en BDD.
Inclure le déploiement d'une release dans le test de charge.

## :rainbow: Remarques
Cette branche est basée sur #2218 
Pour déployer une release sur Scalingo, utiliser l'API Scalingo comme pix-bot [ici](https://developers.scalingo.com/deployments#trigger-manually-a-deployment-from-an-archive)

## :100: Pour tester
Voir README.md

Exécuter le test
``` shell script        
scalingo run --app load-testing npm run load-test:test-connectivity:review-app
```

Vérifier le rapport
``` shell script      
scalingo --app load-testing pgsql-console
```

``` sql
SELECT
    report->'aggregate'->'timestamp'                  AS executed_at,
    report->'aggregate'->'scenarioDuration'->'median' AS median_duration_millis
FROM test_executions;
```