### PR TITLE
[TECH] Empêcher la suppression d'une instance de BDD sur Scalingo.

### DIFF
--- a/api/.slugignore
+++ b/api/.slugignore
@@ -1,1 +1,2 @@
 tests
+scripts/database/drop-database.js


### PR DESCRIPTION
## :unicorn: Problème
Le script `scripts/database/drop-database.js` exécuté par `npm run db:delete` n'est pas utilisé par les migrations en RA déclenchées par `npm run scalingo-post-ra-creation`.

Il est toutefois présent en RA et son exécution supprime l'instance, car l'utilisateur standard a ce droit sur l'instance
`GRANT ALL PRIVILEGES ON DATABASE <database> TO <username>`

https://doc.scalingo.com/databases/postgresql/start#database-users

Cela signifie que
- en production, une ligne non-intentionelle entraîne une rupture de service
- il est possible de recréer une instance, mais c'est laborieux (SQL avec modification de DATABASE_URL / recréation d'add-on)

## :robot: Solution
Ne pas livrer ce script sur Scalingo grâce au `slugignore`

## :rainbow: Remarques
Il est toujours possible de supprimer l'instance avec la commande SQL `DROP DATABASE`

Perspective:
Je pense qu'à terme le plus sécurisant (mais amène aussi de la complexité) c'est 
- d'avoir en local la même configuration que Scalingo (créer [utilisateur](https://doc.scalingo.com/databases/postgresql/start#database-users) avec script avec docker-compose)
- de remplacer le `npm run db:delete` par un `npm run db:drop-all-objects` comme sur la [réplication](https://github.com/1024pix/pix-db-replication/blob/master/steps.js#L145)

## :100: Pour tester
Exécuter 
`scalingo --app pix-api-review-pr2221 run "npm run db:delete"`

Vérifier qu'on obtient un message d'erreur
 `Error: Cannot find module '/app/scripts/database/drop-database'`

Vérifier que la BDD est accessible et contient des données
`scalingo --app pix-api-review-pr2221 pgsql-console`

```
SELECT 
 COUNT(1) 
FROM users;
```
