### PR TITLE
[FEATURE] Ajout de sous-catégories de support pour les fichiers "image" (PIX-1639).

### DIFF
--- a/mon-pix/app/static-data/feedback-panel-issue-labels.js
+++ b/mon-pix/app/static-data/feedback-panel-issue-labels.js
@@ -53,9 +53,13 @@ const questions = {
   ],
   'picture': [
     {
-      name: 'image',
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.picture-not-displayed.label',
       type: 'tutorial',
-      content: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.picture-not-displayed',
+      content: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.picture-not-displayed.solution',
+    },
+    {
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.picture-other',
+      type: 'textbox',
     },
   ],
   'link': [

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -194,9 +194,8 @@ describe('Integration | Component | feedback-panel', function() {
       it('with a tuto should directly display the tuto without the textbox nor the send button', async function() {
         // when
         await fillIn('.feedback-panel__dropdown', PICK_CATEGORY_WITH_TUTORIAL);
-
         // then
-        expect(findAll(DROPDOWN).length).to.equal(1);
+        expect(findAll(DROPDOWN).length).to.equal(2);
         expect(find(BUTTON_SEND)).to.not.exist;
         expect(find(TEXTAREA)).to.not.exist;
       });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -316,9 +316,13 @@
                                 "other-challenge-proposal": "I have a (great) idea to suggest for a question",
                                 "other-site-improvement": "I have a suggestion for improving the platform",
                                 "other-difficulty": "I have another problem",
+                                "picture-not-displayed": {
+                                    "label": "",
+                                    "solution": ""
+                                },
+                                "picture-other": "",
                                 "question-improvement": "I want to suggest an improvement to the question",
                                 "question-not-understood": "I do not understand the question",
-                                "picture-not-displayed": "Your internet connection may not be strong enough.'<br>'Refresh the page by clicking on the refresh button'<object type=\"image/svg+xml\" class=\"tuto-icon\" data=\"/images/icons/icon-reload.svg\"></object>' next to the address bar. Wait a little while, the simulator might display. '<br><br>'If it doesn’t, you can try again later or from another location with a better connection.",
                                 "tutorial-link-error": "The link to the tutorial is to another page or an error page",
                                 "tutorial-not-accepted": "The tutorial is not helpful to the question",
                                 "tutorial-proposal": "I have a tutorial to suggest"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -316,9 +316,13 @@
                                 "other-challenge-proposal": "J’ai une idée (géniale) d’épreuve à proposer",
                                 "other-site-improvement": "J’ai une suggestion d’amélioration de la plateforme",
                                 "other-difficulty": "J’ai un autre problème",
+                                "picture-not-displayed": {
+                                    "label": "L'image ne s'affiche pas",
+                                    "solution": "Votre connexion internet est peut-être trop faible.'<br>'Rechargez la page en appuyant sur le bouton actualiser '<object type=\"image/svg+xml\" class=\"tuto-icon\" data=\"/images/icons/icon-reload.svg\"></object>' à côté de la barre d’adresse. Attendez un peu, l'image va peut-être s’afficher. '<br><br>'Si ce n’est pas le cas, pouvez-vous retenter à un autre moment ou depuis un autre endroit avec une meilleure connexion ?"
+                                },
+                                "picture-other":  "L'image a un autre problème",
                                 "question-improvement": "Je souhaite proposer une amélioration de la question",
                                 "question-not-understood": "Je ne comprends pas la question",
-                                "picture-not-displayed": "Votre connexion internet est peut-être trop faible.'<br>'Rechargez la page en appuyant sur le bouton actualiser '<object type=\"image/svg+xml\" class=\"tuto-icon\" data=\"/images/icons/icon-reload.svg\"></object>' à côté de la barre d’adresse. Attendez un peu, le simulateur va peut-être s’afficher. '<br><br>'Si ce n’est pas le cas, pouvez-vous retenter à un autre moment ou depuis un autre endroit avec une meilleure connexion ?",
                                 "tutorial-link-error": "Le lien vers le tutoriel mène vers une autre page ou une page d’erreur",
                                 "tutorial-not-accepted": "Le tutoriel n’est pas adapté",
                                 "tutorial-proposal": "J’ai un tutoriel à vous proposer"


### PR DESCRIPTION
## :unicorn: Problème

Depuis une page épreuve, quand je clique sur "Signaler un problème" puis dans la liste déroulante, sur l'image, ajouter deux sous catégories : 

- L'image ne s'affiche pas
- L'image a un autre problème 

Réponse apportée à "L'image ne s'affiche pas" : 
"Votre connexion internet est peut-être trop faible.
Rechargez la page en appuyant sur le bouton "actualiser" à côté de la barre d’adresse. Attendez un peu, l'image va peut-être s’afficher.
Si ce n’est pas le cas, retentez à un autre moment ou depuis un autre endroit avec une meilleure connexion."

Réponse apportée à "Limage a un autre problème" :
Précisez votre problème (champ libre)

## :robot: Solution

Ajout de nouvelles catégories sur `feedback-panel-issue-labels.js`
Ajout des traductions associées aux nouvelles catégories

## :rainbow: Remarques

N/A

## :100: Pour tester

- Réaliser une épreuve et utiliser le lien "Signaler un problème" en bas de page en sélectionnant la catégorie "image"
