### PR TITLE
[FEATURE] Retourner sur le site pix.org/en-gb quand on se déconnecte de app.pix.org en anglais (PIX-1621).

### DIFF
--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -6,15 +6,21 @@ const FRENCH_DOMAIN_EXTENSION = 'fr';
 
 export default class Url extends Service {
   @service currentDomain;
-  definedHomeUrl = ENV.APP.HOME_URL;
+
+  definedHomeUrl= ENV.rootURL;
 
   get isFrenchDomainExtension() {
     return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
   }
 
   get homeUrl() {
-    const homeUrl = `https://pix.${this.currentDomain.getExtension()}`;
-    return this.definedHomeUrl || homeUrl;
+    const isDevEnvironment = ENV.environment === 'development';
+    const isRA = ENV.APP.REVIEW_APP === 'true';
+
+    if (isDevEnvironment || isRA) {
+      return this.definedHomeUrl;
+    }
+    return `https://pix.${this.currentDomain.getExtension()}`;
   }
 
   get cguUrl() {

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -1,11 +1,12 @@
 import Service  from '@ember/service';
 import { inject as service } from '@ember/service';
-import ENV from '../config/environment';
+import ENV from 'mon-pix/config/environment';
 
 const FRENCH_DOMAIN_EXTENSION = 'fr';
 
 export default class Url extends Service {
   @service currentDomain;
+  @service intl;
 
   definedHomeUrl= ENV.rootURL;
 
@@ -18,7 +19,8 @@ export default class Url extends Service {
     const isRA = ENV.APP.REVIEW_APP === 'true';
 
     if (isDevEnvironment || isRA) {
-      return this.definedHomeUrl;
+      const currentLanguage = this.intl.t('current-lang');
+      return `${this.definedHomeUrl}?lang=${currentLanguage}`;
     }
     return `https://pix.${this.currentDomain.getExtension()}`;
   }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -22,10 +22,19 @@ export default class Url extends Service {
       const currentLanguage = this.intl.t('current-lang');
       return `${this.definedHomeUrl}?lang=${currentLanguage}`;
     }
-    return `https://pix.${this.currentDomain.getExtension()}`;
+    return this._showcaseWebsiteUrl;
   }
 
   get cguUrl() {
     return `https://pix.${this.currentDomain.getExtension()}/conditions-generales-d-utilisation`;
+  }
+
+  get _showcaseWebsiteUrl() {
+    const currentLanguage = this.intl.t('current-lang');
+
+    if (currentLanguage === 'en') {
+      return `https://pix.${this.currentDomain.getExtension()}/en-gb`;
+    }
+    return `https://pix.${this.currentDomain.getExtension()}`;
   }
 }

--- a/mon-pix/app/services/url.js
+++ b/mon-pix/app/services/url.js
@@ -15,14 +15,13 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    const isDevEnvironment = ENV.environment === 'development';
-    const isRA = ENV.APP.REVIEW_APP === 'true';
+    const isProdEnv = ENV.APP.IS_PROD_ENVIRONMENT;
 
-    if (isDevEnvironment || isRA) {
-      const currentLanguage = this.intl.t('current-lang');
-      return `${this.definedHomeUrl}?lang=${currentLanguage}`;
+    if (isProdEnv) {
+      return this._showcaseWebsiteUrl;
     }
-    return this._showcaseWebsiteUrl;
+    const currentLanguage = this.intl.t('current-lang');
+    return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 
   get cguUrl() {

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -45,7 +45,6 @@ module.exports = function(environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
       API_HOST: process.env.API_HOST || '',
-      HOME_URL: process.env.HOME_URL,
       isChallengeTimerEnable: true,
       MESSAGE_DISPLAY_DURATION: 1500,
       isMobileSimulationEnabled: false,
@@ -60,6 +59,7 @@ module.exports = function(environment) {
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
+      REVIEW_APP: process.env.REVIEW_APP || false,
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {
@@ -143,7 +143,6 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     // Redefined in custom initializer 'initializers/configure-pix-api-host.js'
-    ENV.APP.HOME_URL = process.env.HOME_URL || '/';
     if (analyticsEnabled) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
@@ -168,7 +167,6 @@ module.exports = function(environment) {
 
     ENV.googleFonts = null;
     ENV.APP.API_HOST = 'http://localhost:3000';
-    ENV.APP.HOME_URL = '/';
     ENV.APP.isChallengeTimerEnable = false;
     ENV.APP.MESSAGE_DISPLAY_DURATION = 0;
     ENV.APP.isMobileSimulationEnabled = true;

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -59,7 +59,7 @@ module.exports = function(environment) {
       BANNER_TYPE: process.env.BANNER_TYPE || '',
       FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
-      REVIEW_APP: process.env.REVIEW_APP || false,
+      IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
 
       API_ERROR_MESSAGES: {
         BAD_REQUEST: {

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
+import ENV from 'mon-pix/config/environment';
+
 describe('Unit | Service | locale', function() {
   setupTest();
 
@@ -32,44 +34,81 @@ describe('Unit | Service | locale', function() {
 
   describe('#homeUrl', function() {
 
-    it('should get default home url when is defined', function() {
-      // given
-      const service = this.owner.lookup('service:url');
-      service.definedHomeUrl = 'pix.test.fr';
+    [
+      { environment: 'development', isRA: 'false' },
+      { environment: 'production', isRA: 'true' },
+    ].forEach((testCase) => {
+      context(`when environnement=‘${testCase.environment}‘ and isRA=${testCase.isRA}`, function() {
+        const defaultEnvironment = ENV.environment;
+        const defaultIsReviewApp = ENV.APP.REVIEW_APP;
 
-      // when
-      const homeUrl = service.homeUrl;
+        beforeEach(function() {
+          ENV.environment = testCase.environment;
+          ENV.APP.REVIEW_APP = testCase.isRA;
+        });
 
-      // then
-      expect(homeUrl).to.equal(service.definedHomeUrl);
+        afterEach(function() {
+          ENV.environment = defaultEnvironment;
+          ENV.APP.REVIEW_APP = defaultIsReviewApp;
+        });
+
+        it('should get default home url', function() {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.definedHomeUrl = 'pix.test.fr';
+
+          // when
+          const homeUrl = service.homeUrl;
+
+          // then
+          expect(homeUrl).to.equal(service.definedHomeUrl);
+        });
+      });
     });
 
-    it('should get "pix.fr" url when current domain contains pix.fr', function() {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedHomeUrl = 'https://pix.fr';
-      service.definedHomeUrl = undefined;
-      service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+    context('when it is not a Review App and environnement is ‘production‘', function() {
 
-      // when
-      const homeUrl = service.homeUrl;
+      const defaultEnvironment = ENV.environment;
+      const defaultIsReviewApp = ENV.APP.REVIEW_APP;
 
-      // then
-      expect(homeUrl).to.equal(expectedHomeUrl);
-    });
+      beforeEach(function() {
+        ENV.environment = 'production';
+        ENV.APP.REVIEW_APP = 'false';
+      });
 
-    it('should get "pix.org" url when current domain contains pix.org', function() {
-      // given
-      const service = this.owner.lookup('service:url');
-      const expectedHomeUrl = 'https://pix.org';
-      service.definedHomeUrl = undefined;
-      service.currentDomain = { getExtension: sinon.stub().returns('org') };
+      afterEach(function() {
+        ENV.environment = defaultEnvironment;
+        ENV.APP.REVIEW_APP = defaultIsReviewApp;
+      });
 
-      // when
-      const homeUrl = service.homeUrl;
+      it('should get "pix.fr" url when current domain contains pix.fr', function() {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedHomeUrl = 'https://pix.fr';
+        service.definedHomeUrl = undefined;
+        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
 
-      // then
-      expect(homeUrl).to.equal(expectedHomeUrl);
+        // when
+        const homeUrl = service.homeUrl;
+
+        // then
+        expect(homeUrl).to.equal(expectedHomeUrl);
+      });
+
+      it('should get "pix.org" url when current domain contains pix.org', function() {
+        // given
+        const service = this.owner.lookup('service:url');
+        const expectedHomeUrl = 'https://pix.org';
+        service.definedHomeUrl = undefined;
+        service.currentDomain = { getExtension: sinon.stub().returns('org') };
+
+        // when
+        const homeUrl = service.homeUrl;
+
+        // then
+        expect(homeUrl).to.equal(expectedHomeUrl);
+      });
+
     });
 
   });

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -4,9 +4,11 @@ import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
 import ENV from 'mon-pix/config/environment';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
 describe('Unit | Service | locale', function() {
   setupTest();
+  setupIntl();
 
   it('should have a frenchDomainExtension when the current domain contains pix.fr', function() {
     // given
@@ -61,7 +63,8 @@ describe('Unit | Service | locale', function() {
           const homeUrl = service.homeUrl;
 
           // then
-          expect(homeUrl).to.equal(service.definedHomeUrl);
+          const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.t('current-lang')}`;
+          expect(homeUrl).to.equal(expectedDefinedHomeUrl);
         });
       });
     });

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -36,54 +36,43 @@ describe('Unit | Service | locale', function() {
 
   describe('#homeUrl', function() {
 
-    [
-      { environment: 'development', isRA: 'false' },
-      { environment: 'production', isRA: 'true' },
-    ].forEach((testCase) => {
-      context(`when environnement=‘${testCase.environment}‘ and isRA=${testCase.isRA}`, function() {
-        const defaultEnvironment = ENV.environment;
-        const defaultIsReviewApp = ENV.APP.REVIEW_APP;
+    context('when environnement not prod', function() {
+      const defaultIsProdEnv = ENV.APP.IS_PROD_ENVIRONMENT;
 
-        beforeEach(function() {
-          ENV.environment = testCase.environment;
-          ENV.APP.REVIEW_APP = testCase.isRA;
-        });
+      beforeEach(function() {
+        ENV.APP.IS_PROD_ENVIRONMENT = false;
+      });
 
-        afterEach(function() {
-          ENV.environment = defaultEnvironment;
-          ENV.APP.REVIEW_APP = defaultIsReviewApp;
-        });
+      afterEach(function() {
+        ENV.APP.IS_PROD_ENVIRONMENT = defaultIsProdEnv;
+      });
 
-        it('should get default home url', function() {
-          // given
-          const service = this.owner.lookup('service:url');
-          service.definedHomeUrl = 'pix.test.fr';
+      it('should get default home url', function() {
+        // given
+        const service = this.owner.lookup('service:url');
+        service.definedHomeUrl = 'pix.test.fr';
 
-          // when
-          const homeUrl = service.homeUrl;
+        // when
+        const homeUrl = service.homeUrl;
 
-          // then
-          const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.t('current-lang')}`;
-          expect(homeUrl).to.equal(expectedDefinedHomeUrl);
-        });
+        // then
+        const expectedDefinedHomeUrl = `${service.definedHomeUrl}?lang=${this.intl.t('current-lang')}`;
+        expect(homeUrl).to.equal(expectedDefinedHomeUrl);
       });
     });
 
     context('when it is not a Review App and environnement is ‘production‘', function() {
 
-      const defaultEnvironment = ENV.environment;
-      const defaultIsReviewApp = ENV.APP.REVIEW_APP;
+      const defaultIsProdEnv = ENV.APP.IS_PROD_ENVIRONMENT;
       let defaultLocale;
 
       beforeEach(function() {
-        ENV.environment = 'production';
-        ENV.APP.REVIEW_APP = 'false';
+        ENV.APP.IS_PROD_ENVIRONMENT = true;
         defaultLocale = this.intl.t('current-lang');
       });
 
       afterEach(function() {
-        ENV.environment = defaultEnvironment;
-        ENV.APP.REVIEW_APP = defaultIsReviewApp;
+        ENV.APP.IS_PROD_ENVIRONMENT = defaultIsProdEnv;
         this.intl.setLocale(defaultLocale);
       });
 

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -73,47 +73,42 @@ describe('Unit | Service | locale', function() {
 
       const defaultEnvironment = ENV.environment;
       const defaultIsReviewApp = ENV.APP.REVIEW_APP;
+      let defaultLocale;
 
       beforeEach(function() {
         ENV.environment = 'production';
         ENV.APP.REVIEW_APP = 'false';
+        defaultLocale = this.intl.t('current-lang');
       });
 
       afterEach(function() {
         ENV.environment = defaultEnvironment;
         ENV.APP.REVIEW_APP = defaultIsReviewApp;
+        this.intl.setLocale(defaultLocale);
       });
 
-      it('should get "pix.fr" url when current domain contains pix.fr', function() {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedHomeUrl = 'https://pix.fr';
-        service.definedHomeUrl = undefined;
-        service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+      [
+        { language: 'fr', currentDomainExtension: 'fr', expectedHomeUrl: 'https://pix.fr' },
+        { language: 'fr', currentDomainExtension: 'org', expectedHomeUrl: 'https://pix.org' },
+        { language: 'en', currentDomainExtension: 'fr', expectedHomeUrl: 'https://pix.fr/en-gb' },
+        { language: 'en', currentDomainExtension: 'org', expectedHomeUrl: 'https://pix.org/en-gb' },
+      ].forEach(function(testCase) {
+        it(`should get "${testCase.expectedHomeUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function() {
+          // given
+          const service = this.owner.lookup('service:url');
+          service.definedHomeUrl = '/';
+          service.currentDomain = { getExtension: sinon.stub().returns(testCase.currentDomainExtension) };
+          this.intl.setLocale([testCase.language]);
 
-        // when
-        const homeUrl = service.homeUrl;
+          // when
+          const homeUrl = service.homeUrl;
 
-        // then
-        expect(homeUrl).to.equal(expectedHomeUrl);
-      });
-
-      it('should get "pix.org" url when current domain contains pix.org', function() {
-        // given
-        const service = this.owner.lookup('service:url');
-        const expectedHomeUrl = 'https://pix.org';
-        service.definedHomeUrl = undefined;
-        service.currentDomain = { getExtension: sinon.stub().returns('org') };
-
-        // when
-        const homeUrl = service.homeUrl;
-
-        // then
-        expect(homeUrl).to.equal(expectedHomeUrl);
+          // then
+          expect(homeUrl).to.equal(testCase.expectedHomeUrl);
+        });
       });
 
     });
-
   });
 
   describe('#cguUrl', function() {


### PR DESCRIPTION
## :unicorn: Problème
Après déconnexion de app.pix.org?lang=en **en anglais**, l'utilisateur est redirigé vers le site vitrine **en français**

## :robot: Solution
- en prod:
    - après déconnexion, l'utilisateur est redirigé vers le site vitrine
    - récupérer la locale de l'utilisateur pour suffixer `/en-gb` si la locale="en"
- en RA/local:
    - après déconnexion, l'utilisateur reste sur pix-app mais est redirigé vers `/`, qui le redirige vers `/connexion` car il n'est pas connecté
    - récupérer la locale de l'utilisateur pour suffixer `?lang=fr` ou `?lang=en`

## :rainbow: Remarques
- En local ou en RA, l'utilisateur n'est pas être redirigé vers le site vitrine mais vers la page de connexion
- La variable d'environnement `ENV.APP.REVIEW_APP` était déjà existante sur Scalingo. Elle est réutilisée dans cette PR.

## :100: Pour tester
| environnement  | domain | langue utilisateur | url après déconnexion |
|---|---|---|---|
| local/RA | .fr | fr | {local/RA}.fr/connexion (page en français) |
| local/RA | .org | fr | {local/RA}.org/connexion (page en français) |
| local/RA | .fr | en | {local/RA}.fr/connexion (page en anglais) |
| local/RA | .org | en | {local/RA}.org/connexion (page en anglais) |
| prod | .fr | fr | pix.fr |
| prod | .org | fr | pix.org |
| prod | .fr | en | pix.fr/en-gb/ |
| prod | .org | en | pix.org/en-gb |

==> pour simuler le comportement de prod en RA, changer la variable d'env: `ENV.APP.REVIEW_APP=false`
