### PR TITLE
[FEATURE] [PIXCONCOURS] L'utilisateur doit savoir à quelle épreuve il est (PIX-1729).

### DIFF
--- a/mon-pix/app/components/progress-bar.js
+++ b/mon-pix/app/components/progress-bar.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/string';
 import colorGradient from 'mon-pix/utils/color-gradient';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
+import ENV from 'mon-pix/config/environment';
 
 export default class ProgressBar extends Component {
   @service media;
@@ -12,6 +13,10 @@ export default class ProgressBar extends Component {
 
   get showProgressBar() {
     return this.args.assessment.showProgressBar && this.media.isDesktop;
+  }
+
+  get showProgressForContest() {
+    return ENV.APP.IS_PIX_CONTEST === 'true';
   }
 
   get currentStepIndex() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -19,10 +19,6 @@ export default class ChallengeController extends Controller {
     return this.model.assessment.showLevelup && this.newLevel;
   }
 
-  get hideProgressBar() {
-    return ENV.APP.IS_PIX_CONTEST === 'true';
-  }
-
   get pageTitle() {
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -11,9 +11,7 @@
   </div>
 
   <div class="assessment-challenge__content rounded-panel--over-background-banner">
-    {{#unless this.hideProgressBar}}
-      <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
-    {{/unless}}
+    <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
     <main>
       {{component (get-challenge-component-class @model.challenge)
                 challenge=@model.challenge

--- a/mon-pix/app/templates/components/progress-bar.hbs
+++ b/mon-pix/app/templates/components/progress-bar.hbs
@@ -1,32 +1,42 @@
-{{#if this.showProgressBar}}
-  <div class="progress-bar-container">
-    <h2 class="sr-only">{{t 'pages.challenge.parts.progress'}}</h2>
-    <div class="progress-bar-stepnums"
-         role="progressbar"
-         aria-valuenow={{this.currentStepNumber}}
-         aria-valuemin="1"
-         aria-valuemax="5"
-      >
-      {{#each this.steps as |step|}}
-        <div class="progress-bar-stepnum {{step.status}}">{{step.stepnum}}</div>
-      {{/each}}
-    </div>
-
-    <div class="progress-bar-background"></div>
-
-    <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
-
-    <div class="progress-bar-steps">
-      {{#each this.steps as |step|}}
-        <span class="progress-bar-step" style={{step.background}}></span>
-      {{/each}}
-    </div>
-  </div>
-{{else}}
+{{#if this.showProgressForContest}}
   <div class="assessment-progress">
     <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
     <div class="assessment-progress__value">
-      {{this.currentStepNumber}} / {{this.maxStepsNumber}}
+      {{this.currentStepNumber}}
     </div>
   </div>
+{{else}}
+  {{#if this.showProgressBar}}
+    <div class="progress-bar-container">
+      <h2 class="sr-only">{{t 'pages.challenge.parts.progress'}}</h2>
+      <div class="progress-bar-stepnums"
+           role="progressbar"
+           aria-valuenow={{this.currentStepNumber}}
+           aria-valuemin="1"
+           aria-valuemax="5"
+      >
+        {{#each this.steps as |step|}}
+          <div class="progress-bar-stepnum {{step.status}}">{{step.stepnum}}</div>
+        {{/each}}
+      </div>
+
+      <div class="progress-bar-background"></div>
+
+      <div class="progress-bar-progression" style={{this.progressionWidth}}></div>
+
+      <div class="progress-bar-steps">
+        {{#each this.steps as |step|}}
+          <span class="progress-bar-step" style={{step.background}}></span>
+        {{/each}}
+      </div>
+    </div>
+  {{else}}
+    <div class="assessment-progress">
+      <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
+      <div class="assessment-progress__value">
+        {{this.currentStepNumber}} / {{this.maxStepsNumber}}
+      </div>
+    </div>
+  {{/if}}
 {{/if}}
+

--- a/mon-pix/app/utils/progress-in-assessment.js
+++ b/mon-pix/app/utils/progress-in-assessment.js
@@ -7,6 +7,10 @@ function getMaxStepsNumber(assessment) {
     return PREVIEW_UNIQUE_STEP;
   }
 
+  if (ENV.APP.IS_PIX_CONTEST === 'true') {
+    return 20;
+  }
+
   if (assessment.hasCheckpoints) {
     return ENV.APP.NUMBER_OF_CHALLENGES_BETWEEN_TWO_CHECKPOINTS;
   }


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur ne sait pas à quelle épreuve il en est

## :robot: Solution
Afficher le numéro de l'épreuve en cours.

## :rainbow: Remarques
- Comme nombre max d'épreuve, on a 20 (purement arbitraire)

## :100: Pour tester
Sur la RA, lancer "Mener une recherche"