### PR TITLE
[BUGFIX] Empêcher la création de plusieurs assessments d'improvement simultanés en campagne (PIX-1575)

### DIFF
--- a/api/lib/application/campaignParticipations/campaign-participation-controller.js
+++ b/api/lib/application/campaignParticipations/campaign-participation-controller.js
@@ -26,8 +26,8 @@ module.exports = {
   async save(request, h) {
     const userId = request.auth.credentials.userId;
     const campaignParticipation = await serializer.deserialize(request.payload);
-  
-    const { 
+
+    const {
       event,
       campaignParticipation: campaignParticipationCreated,
     } =  await DomainTransaction.execute((domainTransaction) => {
@@ -61,12 +61,11 @@ module.exports = {
     const userId = request.auth.credentials.userId;
     const campaignParticipationId = parseInt(request.params.id);
 
-    const campaignParticipation = await usecases.beginCampaignParticipationImprovement({
+    await usecases.beginCampaignParticipationImprovement({
       campaignParticipationId,
       userId,
     });
-    return serializer.serialize(campaignParticipation);
-
+    return null;
   },
 
   async getAnalysis(request) {

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -117,17 +117,42 @@ class Assessment {
       certificationCourseId,
       state: Assessment.states.STARTED,
       type: Assessment.types.CERTIFICATION,
+      isImproving: false,
     });
   }
 
   static createForCampaign({ userId, campaignParticipationId }) {
     return new Assessment({
       userId,
+      campaignParticipationId,
       state: Assessment.states.STARTED,
       type: Assessment.types.CAMPAIGN,
       courseId: Assessment.courseIdMessage.CAMPAIGN,
-      campaignParticipationId,
+      isImproving: false,
     });
+  }
+
+  static createImprovingForCampaign({ userId, campaignParticipationId }) {
+    const assessment = this.createForCampaign({ userId, campaignParticipationId });
+    assessment.isImproving = true;
+    return assessment;
+  }
+
+  static createForCompetenceEvaluation({ userId, competenceId }) {
+    return new Assessment({
+      userId,
+      competenceId,
+      state: Assessment.states.STARTED,
+      type: Assessment.types.COMPETENCE_EVALUATION,
+      courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
+      isImproving: false,
+    });
+  }
+
+  static createImprovingForCompetenceEvaluation({ userId, competenceId }) {
+    const assessment = this.createForCompetenceEvaluation({ userId, competenceId });
+    assessment.isImproving = true;
+    return assessment;
   }
 }
 

--- a/api/lib/domain/services/scorecard-service.js
+++ b/api/lib/domain/services/scorecard-service.js
@@ -121,14 +121,7 @@ async function _resetCampaignAssessment({ assessment, resetSkills, assessmentRep
     return null;
   }
 
-  const newAssessment = new Assessment({
-    userId: assessment.userId,
-    state: Assessment.states.STARTED,
-    type: Assessment.types.CAMPAIGN,
-    campaignParticipationId: assessment.campaignParticipationId,
-    courseId: '[NOT USED] Campaign Assessment CourseId Not Used',
-  });
-
+  const newAssessment = Assessment.createForCampaign({ userId: assessment.userId, campaignParticipationId: assessment.campaignParticipationId });
   await assessmentRepository.abortByAssessmentId(assessment.id);
   return await assessmentRepository.save({ assessment: newAssessment });
 }

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -16,7 +16,7 @@ module.exports = async function beginCampaignParticipationImprovement({
     throw new AlreadySharedCampaignParticipationError();
   }
 
-  const latestAssessment = await assessmentRepository.getByCampaignParticipationId(campaignParticipation.id);
+  const latestAssessment = await assessmentRepository.getLatestByCampaignParticipationId(campaignParticipation.id);
   if (latestAssessment.isImproving && !latestAssessment.isCompleted()) {
     return null;
   }

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -20,13 +20,6 @@ module.exports = async function beginCampaignParticipationImprovement({
 };
 
 function _createImprovingAssessment({ userId, campaignParticipationId, assessmentRepository }) {
-  const assessment = new Assessment({
-    userId,
-    campaignParticipationId,
-    state: Assessment.states.STARTED,
-    type: Assessment.types.CAMPAIGN,
-    courseId: Assessment.courseIdMessage.CAMPAIGN,
-    isImproving: true,
-  });
+  const assessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
   return assessmentRepository.save({ assessment });
 }

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -17,8 +17,6 @@ module.exports = async function beginCampaignParticipationImprovement({
     throw new AlreadySharedCampaignParticipationError();
   }
   await _createImprovingAssessment({ userId, campaignParticipationId, assessmentRepository });
-
-  return campaignParticipation;
 };
 
 function _createImprovingAssessment({ userId, campaignParticipationId, assessmentRepository }) {

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -7,7 +7,6 @@ module.exports = async function beginCampaignParticipationImprovement({
   assessmentRepository,
   campaignParticipationRepository,
 }) {
-
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, {});
   if (campaignParticipation.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntity();
@@ -16,10 +15,12 @@ module.exports = async function beginCampaignParticipationImprovement({
   if (campaignParticipation.isShared) {
     throw new AlreadySharedCampaignParticipationError();
   }
-  await _createImprovingAssessment({ userId, campaignParticipationId, assessmentRepository });
-};
 
-function _createImprovingAssessment({ userId, campaignParticipationId, assessmentRepository }) {
+  const latestAssessment = await assessmentRepository.getByCampaignParticipationId(campaignParticipation.id);
+  if (latestAssessment.isImproving && !latestAssessment.isCompleted()) {
+    return null;
+  }
+
   const assessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
-  return assessmentRepository.save({ assessment });
-}
+  await assessmentRepository.save({ assessment });
+};

--- a/api/lib/domain/usecases/improve-competence-evaluation.js
+++ b/api/lib/domain/usecases/improve-competence-evaluation.js
@@ -21,14 +21,7 @@ module.exports = async function improveCompetenceEvaluation({
     throw new ImproveCompetenceEvaluationForbiddenError();
   }
 
-  const assessment = new Assessment({
-    userId,
-    competenceId,
-    state: Assessment.states.STARTED,
-    type: Assessment.types.COMPETENCE_EVALUATION,
-    courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
-    isImproving: true,
-  });
+  const assessment = Assessment.createImprovingForCompetenceEvaluation({ userId, competenceId });
   const { id: assessmentId } = await assessmentRepository.save({ assessment, domainTransaction });
 
   await competenceEvaluationRepository.updateAssessmentId({

--- a/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
+++ b/api/lib/domain/usecases/start-or-resume-competence-evaluation.js
@@ -38,13 +38,7 @@ async function _startCompetenceEvaluation({ userId, competenceId, assessmentRepo
 }
 
 function _createAssessment({ userId, competenceId, assessmentRepository }) {
-  const assessment = new Assessment({
-    userId,
-    competenceId,
-    state: Assessment.states.STARTED,
-    type: Assessment.types.COMPETENCE_EVALUATION,
-    courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
-  });
+  const assessment = Assessment.createForCompetenceEvaluation({ userId, competenceId });
   return assessmentRepository.save({ assessment });
 }
 

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -86,7 +86,7 @@ module.exports = {
       .then((result) => result ? result.attributes.id : null);
   },
 
-  getByCampaignParticipationId(campaignParticipationId) {
+  getLatestByCampaignParticipationId(campaignParticipationId) {
     return BookshelfAssessment
       .where({ 'campaign-participations.id': campaignParticipationId, 'assessments.type': 'CAMPAIGN' })
       .query((qb) => {

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -92,6 +92,7 @@ module.exports = {
       .query((qb) => {
         qb.innerJoin('campaign-participations', 'campaign-participations.id', 'assessments.campaignParticipationId');
       })
+      .orderBy('assessments.createdAt', 'DESC')
       .fetch({ require: true, withRelated: ['campaignParticipation.campaign'] })
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },

--- a/api/tests/acceptance/application/campaign-participation-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-controller_test.js
@@ -446,13 +446,13 @@ describe('Acceptance | API | Campaign Participations', () => {
         };
       });
 
-      it('should return 200 HTTP status code with updatedAssessment', () => {
+      it('should return 204 HTTP status code', () => {
         // when
         const promise = server.inject(options);
 
         // then
         return promise.then((response) => {
-          expect(response.statusCode).to.equal(200);
+          expect(response.statusCode).to.equal(204);
         });
       });
     });

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -255,38 +255,24 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
   });
 
   describe('#beginImprovement', () => {
-    const campaignParticipationId = 1;
-    const userId = 1;
-    let request;
 
-    beforeEach(() => {
-      request = {
+    it('should call the usecase to begin improvement', async () => {
+      // given
+      const campaignParticipationId = 1;
+      const userId = 2;
+      const request = {
         params: { id: campaignParticipationId },
         auth: { credentials: { userId } },
       };
-
       sinon.stub(usecases, 'beginCampaignParticipationImprovement');
-      sinon.stub(serializer, 'serialize');
-    });
-
-    it('should return an improving campaignParticipation', async () => {
-      // given
-      const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
       usecases.beginCampaignParticipationImprovement
-        .withArgs({ campaignParticipationId, userId })
-        .resolves(campaignParticipation);
-
-      const serializedCampaignParticipation = { id: campaignParticipationId, userId };
-      serializer.serialize
-        .withArgs(campaignParticipation)
-        .returns(serializedCampaignParticipation);
+        .resolves();
 
       // when
-      const response = await campaignParticipationController.beginImprovement(request);
+      await campaignParticipationController.beginImprovement(request);
 
       // then
-      expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnce;
-      expect(response).to.deep.equal(serializedCampaignParticipation);
+      expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnceWith({ campaignParticipationId, userId });
     });
   });
 });

--- a/api/tests/unit/domain/models/Assessment_test.js
+++ b/api/tests/unit/domain/models/Assessment_test.js
@@ -277,4 +277,103 @@ describe('Unit | Domain | Models | Assessment', () => {
     });
 
   });
+
+  describe('#createForCertificationCourse', () => {
+
+    it('should return a proper assessment for certification course', () => {
+      // given
+      const userId = 123;
+      const certificationCourseId = 456;
+
+      // when
+      const assessment = Assessment.createForCertificationCourse({ userId, certificationCourseId });
+
+      // then
+      expect(assessment.userId).to.equal(userId);
+      expect(assessment.certificationCourseId).to.equal(certificationCourseId);
+      expect(assessment.state).to.equal(Assessment.states.STARTED);
+      expect(assessment.type).to.equal(Assessment.types.CERTIFICATION);
+      expect(assessment.isImproving).to.be.false;
+    });
+  });
+
+  describe('#createForCampaign', () => {
+
+    it('should return a proper assessment for campaign', () => {
+      // given
+      const userId = 123;
+      const campaignParticipationId = 456;
+
+      // when
+      const assessment = Assessment.createForCampaign({ userId, campaignParticipationId });
+
+      // then
+      expect(assessment.userId).to.equal(userId);
+      expect(assessment.campaignParticipationId).to.equal(campaignParticipationId);
+      expect(assessment.state).to.equal(Assessment.states.STARTED);
+      expect(assessment.type).to.equal(Assessment.types.CAMPAIGN);
+      expect(assessment.courseId).to.equal(Assessment.courseIdMessage.CAMPAIGN);
+      expect(assessment.isImproving).to.be.false;
+    });
+  });
+
+  describe('#createImprovingForCampaign', () => {
+
+    it('should return a proper improving assessment for campaign', () => {
+      // given
+      const userId = 123;
+      const campaignParticipationId = 456;
+
+      // when
+      const assessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
+
+      // then
+      expect(assessment.userId).to.equal(userId);
+      expect(assessment.campaignParticipationId).to.equal(campaignParticipationId);
+      expect(assessment.state).to.equal(Assessment.states.STARTED);
+      expect(assessment.type).to.equal(Assessment.types.CAMPAIGN);
+      expect(assessment.courseId).to.equal(Assessment.courseIdMessage.CAMPAIGN);
+      expect(assessment.isImproving).to.be.true;
+    });
+  });
+
+  describe('#createForCompetenceEvaluation', () => {
+
+    it('should return a proper assessment for competence evaluation', () => {
+      // given
+      const userId = 123;
+      const competenceId = 'rec123ABC';
+
+      // when
+      const assessment = Assessment.createForCompetenceEvaluation({ userId, competenceId });
+
+      // then
+      expect(assessment.userId).to.equal(userId);
+      expect(assessment.competenceId).to.equal(competenceId);
+      expect(assessment.state).to.equal(Assessment.states.STARTED);
+      expect(assessment.type).to.equal(Assessment.types.COMPETENCE_EVALUATION);
+      expect(assessment.courseId).to.equal(Assessment.courseIdMessage.COMPETENCE_EVALUATION);
+      expect(assessment.isImproving).to.be.false;
+    });
+  });
+
+  describe('#createImprovingForCompetenceEvaluation', () => {
+
+    it('should return a proper improving assessment for competence evaluation', () => {
+      // given
+      const userId = 123;
+      const competenceId = 'rec123ABC';
+
+      // when
+      const assessment = Assessment.createImprovingForCompetenceEvaluation({ userId, competenceId });
+
+      // then
+      expect(assessment.userId).to.equal(userId);
+      expect(assessment.competenceId).to.equal(competenceId);
+      expect(assessment.state).to.equal(Assessment.states.STARTED);
+      expect(assessment.type).to.equal(Assessment.types.COMPETENCE_EVALUATION);
+      expect(assessment.courseId).to.equal(Assessment.courseIdMessage.COMPETENCE_EVALUATION);
+      expect(assessment.isImproving).to.be.true;
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -11,7 +11,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
   };
   const assessmentRepository = {
     save: sinon.stub(),
-    getByCampaignParticipationId: sinon.stub(),
+    getLatestByCampaignParticipationId: sinon.stub(),
   };
   const dependencies = { campaignParticipationRepository, assessmentRepository };
 
@@ -56,7 +56,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
       .withArgs(campaignParticipationId, {})
       .resolves(campaignParticipation);
     const ongoingAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
-    assessmentRepository.getByCampaignParticipationId
+    assessmentRepository.getLatestByCampaignParticipationId
       .withArgs(campaignParticipationId)
       .resolves(ongoingAssessment);
 
@@ -77,7 +77,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
       .resolves(campaignParticipation);
     const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
     latestAssessment.state = Assessment.states.COMPLETED;
-    assessmentRepository.getByCampaignParticipationId
+    assessmentRepository.getLatestByCampaignParticipationId
       .withArgs(campaignParticipationId)
       .resolves(latestAssessment);
     assessmentRepository.save.resolves({});

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -1,65 +1,99 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const usecases = require('../../../../lib/domain/usecases');
+const { beginCampaignParticipationImprovement } = require('../../../../lib/domain/usecases');
 const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 
 describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
 
-  const userId = 1;
-  const oldAssessmentId = 1;
-  const newAssessmentId = 2;
-  const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, isShared: false, assessmentId: oldAssessmentId });
-  const campaignParticipationId = campaignParticipation.id;
-  const campaignParticipationRepository = { get: () => undefined };
-  const assessmentRepository = { save: () => undefined };
+  const campaignParticipationRepository = {
+    get: sinon.stub(),
+  };
+  const assessmentRepository = {
+    save: sinon.stub(),
+    getByCampaignParticipationId: sinon.stub(),
+  };
+  const dependencies = { campaignParticipationRepository, assessmentRepository };
 
-  beforeEach(() => {
-    sinon.stub(campaignParticipationRepository, 'get');
-    sinon.stub(assessmentRepository, 'save');
-
-    campaignParticipationRepository.get.resolves(campaignParticipation);
-    assessmentRepository.save.resolves({ id: newAssessmentId });
-  });
-
-  it('should throw an error if the campaign participation does not linked to user', () => {
-    // when
-    const promise = usecases.beginCampaignParticipationImprovement({ campaignParticipationId, userId: 2, campaignParticipationRepository, assessmentRepository });
-
-    // then
-    return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
-  });
-
-  it('should throw an error if the campaign participation is shared', () => {
+  it('should throw an error if the campaign participation is not linked to user', async () => {
     // given
-    const campaignParticipationShared = domainBuilder.buildCampaignParticipation({ userId, isShared: true });
-    campaignParticipationRepository.get.resolves(campaignParticipationShared);
+    const userId = 1;
+    const campaignParticipationId = 2;
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId: userId + 1, id: campaignParticipationId });
+    campaignParticipationRepository.get
+      .withArgs(campaignParticipationId, {})
+      .resolves(campaignParticipation);
 
     // when
-    const promise = usecases.beginCampaignParticipationImprovement({ campaignParticipationId, userId , campaignParticipationRepository, assessmentRepository });
+    const error = await catchErr(beginCampaignParticipationImprovement)({ campaignParticipationId, userId, ...dependencies });
 
     // then
-    return expect(promise).to.be.rejectedWith(AlreadySharedCampaignParticipationError);
+    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
   });
 
-  it('should create a campaign assessment with the campaignParticipationId and isImproving at true', () => {
+  it('should throw an error if the campaign participation is shared', async () => {
     // given
+    const userId = 1;
+    const campaignParticipationId = 2;
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: true });
+    campaignParticipationRepository.get
+      .withArgs(campaignParticipationId, {})
+      .resolves(campaignParticipation);
+
+    // when
+    const error = await catchErr(beginCampaignParticipationImprovement)({ campaignParticipationId, userId, ...dependencies });
+
+    // then
+    expect(error).to.be.instanceOf(AlreadySharedCampaignParticipationError);
+  });
+
+  it('should not start another assessment when the current assessment of the campaign is of improving type and still ongoing', async () => {
+    // given
+    const userId = 1;
+    const campaignParticipationId = 2;
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: false });
+    campaignParticipationRepository.get
+      .withArgs(campaignParticipationId, {})
+      .resolves(campaignParticipation);
+    const ongoingAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
+    assessmentRepository.getByCampaignParticipationId
+      .withArgs(campaignParticipationId)
+      .resolves(ongoingAssessment);
+
+    // when
+    await beginCampaignParticipationImprovement({ campaignParticipationId, userId , ...dependencies });
+
+    // then
+    expect(assessmentRepository.save).to.not.have.been.called;
+  });
+
+  it('should create a campaign assessment with the campaignParticipationId and isImproving at true', async () => {
+    // given
+    const userId = 1;
+    const campaignParticipationId = 2;
+    const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: false });
+    campaignParticipationRepository.get
+      .withArgs(campaignParticipationId, {})
+      .resolves(campaignParticipation);
+    const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
+    latestAssessment.state = Assessment.states.COMPLETED;
+    assessmentRepository.getByCampaignParticipationId
+      .withArgs(campaignParticipationId)
+      .resolves(latestAssessment);
     assessmentRepository.save.resolves({});
 
     // when
-    const promise = usecases.beginCampaignParticipationImprovement({ campaignParticipationId, userId , campaignParticipationRepository, assessmentRepository });
+    await beginCampaignParticipationImprovement({ campaignParticipationId, userId, ...dependencies });
 
     // then
-    return promise.then(() => {
-      expect(assessmentRepository.save).to.have.been.called;
+    expect(assessmentRepository.save).to.have.been.called;
 
-      const assessmentToSave = assessmentRepository.save.firstCall.args[0].assessment;
-      expect(assessmentToSave.type).to.equal(Assessment.types.CAMPAIGN);
-      expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
-      expect(assessmentToSave.userId).to.equal(userId);
-      expect(assessmentToSave.courseId).to.equal('[NOT USED] Campaign Assessment CourseId Not Used');
-      expect(assessmentToSave.campaignParticipationId).to.equal(campaignParticipationId);
-      expect(assessmentToSave.isImproving).to.be.ok;
-    });
+    const assessmentToSave = assessmentRepository.save.firstCall.args[0].assessment;
+    expect(assessmentToSave.type).to.equal(Assessment.types.CAMPAIGN);
+    expect(assessmentToSave.state).to.equal(Assessment.states.STARTED);
+    expect(assessmentToSave.userId).to.equal(userId);
+    expect(assessmentToSave.courseId).to.equal('[NOT USED] Campaign Assessment CourseId Not Used');
+    expect(assessmentToSave.campaignParticipationId).to.equal(campaignParticipationId);
+    expect(assessmentToSave.isImproving).to.be.ok;
   });
 });

--- a/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/start-or-resume-competence-evaluation_test.js
@@ -71,13 +71,14 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
     context('When the user starts a new competence evaluation', () => {
       beforeEach(() => {
         competenceEvaluationRepository.getByCompetenceIdAndUserId.rejects(new NotFoundError);
-
-        assessmentRepository.save.withArgs({ assessment: new Assessment({
+        const expectedAssessment = {
+          userId,
+          competenceId,
+          state: Assessment.states.STARTED,
           courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
           type: Assessment.types.COMPETENCE_EVALUATION,
-          userId, state: Assessment.states.STARTED,
-          competenceId,
-        }) }).resolves({ id: assessmentId });
+        };
+        assessmentRepository.save.withArgs({ assessment: sinon.match(expectedAssessment) }).resolves({ id: assessmentId });
         const competenceEvaluationToSave = new CompetenceEvaluation({
           status: CompetenceEvaluation.statuses.STARTED,
           assessmentId,
@@ -115,13 +116,14 @@ describe('Unit | UseCase | start-or-resume-competence-evaluation', () => {
           .onFirstCall().resolves(resetCompetenceEvaluation)
           .onSecondCall().resolves(updatedCompetenceEvaluation);
 
-        assessmentRepository.save.withArgs({ assessment: new Assessment({
+        const expectedAssessment = {
+          userId,
+          competenceId,
+          state: Assessment.states.STARTED,
           courseId: Assessment.courseIdMessage.COMPETENCE_EVALUATION,
           type: Assessment.types.COMPETENCE_EVALUATION,
-          userId, state: Assessment.states.STARTED,
-          competenceId,
-        }) }).resolves({ id: newAssessmentId });
-
+        };
+        assessmentRepository.save.withArgs({ assessment: sinon.match(expectedAssessment) }).resolves({ id: newAssessmentId });
         competenceEvaluationRepository.updateStatusByUserIdAndCompetenceId.resolves();
         competenceEvaluationRepository.updateAssessmentId.resolves();
 


### PR DESCRIPTION
## :unicorn: Problème
Reproduire le bug en local :
- Clean sa BDD et lancer mon-pix + api
- Se connecter avec certif1@example.net
- Commencer la compétence 5.1 en autonomie "Résoudre les problèmes techniques" et répondre très rarement juste (une seule fois c'est bien) et aller jusqu'au bout de la compétence (vous pouvez passer)
- Participer à la campagne AZERTY123 et se rendre sur la page de partage de résultats sans partager
- Ouvrir la console du développeur, et sur la page de résultats faire plusieurs fois : appuyer sur je retente, faire "précédent" sur le navigateur...

On voit que plusieurs assessments différents sont créés.
![pr](https://user-images.githubusercontent.com/48727874/100715020-e5f47600-33b6-11eb-96e5-fced9decd975.png)


## :robot: Solution
- Ne pas créer de nouvel assessment si un est déjà en cours

## :rainbow: Remarques
Ce que ça donne après, on voit qu'on se fait rediriger toujours sur le même nouvel assessment
![bug_apres](https://user-images.githubusercontent.com/48727874/100886167-c8f19d00-34b3-11eb-9733-8e6f14814695.png)


## :100: Pour tester
Essayer de reproduire le bug ;)
