### PR TITLE
[TECH] Empêcher une erreur interne API lors de la création d'un utilisateur.

### DIFF
--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -59,6 +59,11 @@ const userValidationJoiSchema = Joi.object({
       'boolean.base': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
       'any.only': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
     }),
+
+  mustValidateTermsOfService: Joi.boolean(),
+
+  hasSeenAssessmentInstructions: Joi.boolean(),
+
 }).xor('username', 'email')
   .required()
   .messages({

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -112,5 +112,41 @@ describe('Acceptance | Controller | users-controller', () => {
           .then(() => expect(mailer.sendEmail).to.have.been.calledWith(expectedMail));
       });
     });
+
+    context('user is invalid', async () => {
+
+      const validUserAttributes = {
+        'first-name': 'John',
+        'last-name': 'DoDoe',
+        'email': 'john.doe@example.net',
+        'password': 'Ab124B2C3#!',
+        'cgu': true,
+        'recaptcha-token': 'reCAPTCHAToken',
+      };
+
+      it('should return Unprocessable Entity (HTTP_422) with offending properties', async () => {
+
+        const invalidUserAttributes = { ...validUserAttributes, 'must-validate-terms-of-service': 'not_a_boolean'  };
+
+        const options = {
+          method: 'POST',
+          url: '/api/users',
+          payload: {
+            data: {
+              type: 'users',
+              attributes: invalidUserAttributes,
+              relationships: {},
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+        expect(response.result.errors[0].title).to.equal('Invalid data attribute "mustValidateTermsOfService"');
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/validators/user-validator_test.js
+++ b/api/tests/unit/domain/validators/user-validator_test.js
@@ -255,6 +255,37 @@ describe('Unit | Domain | Validators | user-validator', function() {
           expect(errors.invalidAttributes[2]).to.deep.equal(expectedMaxLengthEmailError);
           expect(errors.invalidAttributes[3]).to.deep.equal(expectedPasswordError);
         });
+
+        it('should reject with error on field "mustValidateTermsOfService" when incorrect', async() => {
+          // given
+          const expectedError = {
+            attribute: 'mustValidateTermsOfService',
+            message: '"mustValidateTermsOfService" must be a boolean',
+          };
+          user.mustValidateTermsOfService = 'not_a_boolean';
+
+          // when
+          const errors = await catchErr(userValidator.validate)({ user });
+
+          // then
+          _assertErrorMatchesWithExpectedOne(errors, expectedError);
+
+        });
+
+        it('should reject with error on field "hasSeenAssessmentInstructions" when incorrect', async() => {
+          // given
+          const expectedError = {
+            attribute: 'hasSeenAssessmentInstructions',
+            message: '"hasSeenAssessmentInstructions" must be a boolean',
+          };
+
+          user.hasSeenAssessmentInstructions = 1;
+
+          // when
+          const errors = await catchErr(userValidator.validate)({ user });
+          _assertErrorMatchesWithExpectedOne(errors, expectedError);
+
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Si l'on fourni une valeur non-booléene (true/false - ex: `"must-validate-terms-of-service":"false ,"`) lors de la création d'utilisateur sur les champs suivants, une erreur 500 est remontée
- must-validate-terms-of-service
- has-seen-assessment-instructions
```
curl https://api.pix.fr/api/users \
-H 'Content-Type: application/vnd.api+json' \
--data-raw '{"data":{"attributes":{"first-name":"foo","last-name":"bar","email":"foo@bar.com","username":null,"password":"dazazfd556465AAAA","cgu":true,"must-validate-terms-of-service":"false ,","has-seen-assessment-instructions":false,"recaptcha-token":null,"lang":"fr"},"type":"users"}}'
```

La cause est que ces champs ne sont pas validés par JOI et échouent lors de leur insertion en BDD
> originalStack: 'error: insert into "users" ("cgu", "createdAt", "email", "firstName", "hasSeenAssessmentInstructions", "lang", "lastName", "lastTermsOfServiceValidatedAt", "mustValidateTermsOfService", "password", "pixCertifTermsOfServiceAccepted", "pixOrgaTermsOfServiceAccepted", "shouldChangePassword", "updatedAt", "username") values ($1, $2, $3, $4, DEFAULT, $5, $6, DEFAULT, $7, $8, DEFAULT, DEFAULT, DEFAULT, $9, DEFAULT) returning * - invalid input syntax for type boolean: "false ,"\n' +`

## :robot: Solution
Ajouter une validation `Joi.boolean()`

## :rainbow: Remarques
Pas de tests automatisés

## :100: Pour tester
Exécuter la requête et vérifier que l'erreur 422 est remontée
```
curl  https://api-pr2229.review.pix.fr/api/users \
-H 'Content-Type: application/vnd.api+json' \
--data-raw '{"data":{"attributes":{"first-name":"foo","last-name":"bar","email":"foo@bar.com","username":null,"password":"dazazfd556465AAAA","cgu":true,"must-validate-terms-of-service":"false ,","has-seen-assessment-instructions":false,"recaptcha-token":null,"lang":"fr"},"type":"users"}}'
```
