### PR TITLE
[FEATURE] Enregistrement du succès ou de l'échec de l'envoi des résultats à Pôle Emploi au partage (PIX-1708).

### DIFF
--- a/api/db/migrations/20201201151026_create-pole-emploi-sendings-table.js
+++ b/api/db/migrations/20201201151026_create-pole-emploi-sendings-table.js
@@ -1,0 +1,17 @@
+const TABLE_NAME = 'pole-emploi-sendings';
+
+exports.up = async (knex) => {
+  await knex.schema.createTable(TABLE_NAME, (t) => {
+    t.increments('id').primary();
+    t.integer('campaignParticipationId').references('campaign-participations.id').index();
+    t.string('type').notNullable();
+    t.boolean('isSuccessful').notNullable();
+    t.text('responseCode').notNullable();
+    t.json('payload');
+    t.dateTime('createdAt').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -1,6 +1,7 @@
 const { checkEventType } = require('./check-event-type');
 const CampaignParticipationResultsShared = require('./CampaignParticipationResultsShared');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
+const PoleEmploiSending = require('../models/PoleEmploiSending');
 
 const eventType = CampaignParticipationResultsShared;
 
@@ -10,6 +11,7 @@ async function handlePoleEmploiParticipationShared({
   campaignParticipationRepository,
   campaignParticipationResultRepository,
   organizationRepository,
+  poleEmploiSendingRepository,
   targetProfileRepository,
   userRepository,
 }) {
@@ -35,7 +37,17 @@ async function handlePoleEmploiParticipationShared({
       participationResult,
     });
 
-    console.log(payload.toString());
+    const poleEmploiSending = new PoleEmploiSending({
+      campaignParticipationId,
+      type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+      payload: JSON.stringify(payload),
+    });
+
+    await Promise.resolve(console.log(payload.toString())).then(
+      () => poleEmploiSending.succeed(),
+      () => poleEmploiSending.fail(),
+    );
+    await poleEmploiSendingRepository.create({ poleEmploiSending });
   }
 }
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
+  poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),

--- a/api/lib/domain/models/PoleEmploiSending.js
+++ b/api/lib/domain/models/PoleEmploiSending.js
@@ -1,0 +1,33 @@
+const TYPES = {
+  CAMPAIGN_PARTICIPATION_START: 'CAMPAIGN_PARTICIPATION_START',
+  CAMPAIGN_PARTICIPATION_COMPLETION: 'CAMPAIGN_PARTICIPATION_COMPLETION',
+  CAMPAIGN_PARTICIPATION_SHARING: 'CAMPAIGN_PARTICIPATION_SHARING',
+};
+
+class PoleEmploiSending {
+  constructor({
+    campaignParticipationId,
+    type,
+    payload,
+  }) {
+    this.campaignParticipationId = campaignParticipationId;
+    this.type = type;
+    this.isSuccessful = undefined;
+    this.responseCode = undefined;
+    this.payload = payload;
+  }
+
+  succeed() {
+    this.isSuccessful = true;
+    this.responseCode = 'PIX_FAKE_RESPONSE';
+  }
+
+  fail() {
+    this.isSuccessful = false;
+    this.responseCode = 'PIX_FAKE_RESPONSE';
+  }
+}
+
+PoleEmploiSending.TYPES = TYPES;
+module.exports = PoleEmploiSending;
+

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -56,6 +56,7 @@ const dependencies = {
   organizationInvitationRepository: require('../../infrastructure/repositories/organization-invitation-repository'),
   passwordGenerator: require('../../domain/services/password-generator'),
   pickChallengeService: require('../services/pick-challenge-service'),
+  poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   prescriberRepository: require('../../infrastructure/repositories/prescriber-repository'),
   resetPasswordService: require('../../domain/services/reset-password-service'),
   reCaptchaValidator: require('../../infrastructure/validators/grecaptcha-validator'),

--- a/api/lib/infrastructure/data/pole-emploi-sending.js
+++ b/api/lib/infrastructure/data/pole-emploi-sending.js
@@ -1,0 +1,19 @@
+const Bookshelf = require('../bookshelf');
+
+require('./campaign-participation');
+
+const modelName = 'PoleEmploiSending';
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'pole-emploi-sendings',
+  hasTimestamps: ['createdAt'],
+  requireFetch: false,
+
+  campaignParticipation() {
+    return this.belongsTo('CampaignParticipation', 'campaignParticipationId');
+  },
+
+}, {
+  modelName,
+});

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -1,0 +1,7 @@
+const BookshelfPoleEmploiSending = require('../../infrastructure/data/pole-emploi-sending');
+
+module.exports = {
+  create({ poleEmploiSending }) {
+    return new BookshelfPoleEmploiSending(poleEmploiSending).save();
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -1,0 +1,29 @@
+const _ = require('lodash');
+const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
+const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
+
+describe('Integration | Repository | PoleEmploiSending', () => {
+
+  describe('#create', () => {
+
+    afterEach(() => {
+      return knex('pole-emploi-sendings').delete();
+    });
+
+    it('should save PoleEmploiSending', async () => {
+      // given
+      const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
+      await databaseBuilder.commit();
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending({ campaignParticipationId });
+      poleEmploiSending.succeed();
+
+      // when
+      await poleEmploiSendingRepository.create({ poleEmploiSending });
+
+      // then
+      const poleEmploiSendings = await knex('pole-emploi-sendings').select();
+      expect(poleEmploiSendings).to.have.lengthOf(1);
+      expect(_.omit(poleEmploiSendings[0], ['id', 'createdAt'])).to.deep.equal(poleEmploiSending);
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-pole-emploi-sending.js
+++ b/api/tests/tooling/domain-builder/factory/build-pole-emploi-sending.js
@@ -1,0 +1,22 @@
+const buildCampaignParticipation = require('./build-campaign-participation');
+const isUndefined = require('lodash/isUndefined');
+const faker = require('faker');
+const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
+
+const buildPoleEmploiSending = function({
+  type = PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+  campaignParticipationId,
+  createdAt = faker.date.past(),
+} = {}) {
+
+  campaignParticipationId = isUndefined(campaignParticipationId) ? buildCampaignParticipation().id : campaignParticipationId;
+
+  return new PoleEmploiSending({
+    campaignParticipationId,
+    type,
+    payload: null,
+    createdAt,
+  });
+};
+
+module.exports = buildPoleEmploiSending;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -42,6 +42,7 @@ module.exports = {
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationTag: require('./build-organization-tag'),
   buildPixRole: require('./build-pix-role'),
+  buildPoleEmploiSending: require('./build-pole-emploi-sending'),
   buildPrescriber: require('./build-prescriber'),
   buildPrivateCertificate: require('./build-private-certificate'),
   buildPrivateCertificateWithCompetenceTree: require('./build-private-certificate-with-competence-tree'),

--- a/api/tests/unit/domain/models/PoleEmploiSending_test.js
+++ b/api/tests/unit/domain/models/PoleEmploiSending_test.js
@@ -1,0 +1,30 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | PoleEmploiSending', () => {
+
+  describe('#succeed', () => {
+    it('should set isSuccessful to true', () => {
+      // given
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+
+      // when
+      poleEmploiSending.succeed();
+
+      // then
+      expect(poleEmploiSending.isSuccessful).to.equal(true);
+    });
+  });
+
+  describe('#fail', () => {
+    it('should set isSuccessful to false', () => {
+      // given
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+
+      // when
+      poleEmploiSending.fail();
+
+      // then
+      expect(poleEmploiSending.isSuccessful).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Il se peut pour une raison ou une autre, que l'envoi des résultats à Pôle Emploi échoue. On veut pouvoir garder trace du succès ou de l'échec de cette requête.

## :robot: Solution
Création de cet enregistrement en base via une nouvelle table événementielle.

## :rainbow: Remarques
Je ne suis pas totalement satisfaite du placement de `PoleEmploiSending` dans les modèles du domaine.

## :100: Pour tester
Partager une campagne Pôle Emploi, en review app, "QWERTY789" et regarder aller vérifier en base l'enregistrement effectif.
