### PR TITLE
[FEATURE] Faire l'envoi des résultats à Pôle Emploi lors du partage de la participation (PIX-1561).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -154,6 +154,7 @@ module.exports = (function() {
     poleEmploi: {
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
+      sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,
       userInfoUrl: process.env.POLE_EMPLOI_USER_INFO_URL,
     },
   };
@@ -202,6 +203,7 @@ module.exports = (function() {
 
     config.poleEmploi.clientSecret = 'PIX_POLE_EMPLOI_CLIENT_SECRET';
     config.poleEmploi.tokenUrl = 'http://tokenUrl.fr';
+    config.poleEmploi.sendingUrl = 'http://sendingUrl.fr';
     config.poleEmploi.userInfoUrl = 'http://userInfoUrl.fr';
 
     config.logging.enabled = false;

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -66,8 +66,8 @@ async function handlePoleEmploiParticipationShared({
         },
       },
     ).then(
-      () => poleEmploiSending.succeed(),
-      () => poleEmploiSending.fail(),
+      (response) => poleEmploiSending.succeed(response.status),
+      (error) => poleEmploiSending.fail(error.response.status),
     );
     return poleEmploiSendingRepository.create({ poleEmploiSending });
   }

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -11,7 +11,6 @@ async function handlePoleEmploiParticipationShared({
   campaignParticipationRepository,
   campaignParticipationResultRepository,
   organizationRepository,
-  poleEmploiSendingRepository,
   targetProfileRepository,
   userRepository,
   poleEmploiNotifier,
@@ -44,11 +43,7 @@ async function handlePoleEmploiParticipationShared({
       payload: JSON.stringify(payload),
     });
 
-    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
-    if (response.isSuccessful) poleEmploiSending.succeed(response.code);
-    if (!response.isSuccessful) poleEmploiSending.fail(response.code);
-
-    return poleEmploiSendingRepository.create({ poleEmploiSending });
+    return poleEmploiNotifier.notify(user.id, payload.toString(), poleEmploiSending);
   }
 }
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const dependencies = {
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
+  authenticationMethodRepository: require('../../infrastructure/repositories/authentication-method-repository'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   badgeCriteriaService: require('../services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const dependencies = {
   assessmentRepository: require('../../infrastructure/repositories/assessment-repository'),
   assessmentResultRepository: require('../../infrastructure/repositories/assessment-result-repository'),
-  authenticationMethodRepository: require('../../infrastructure/repositories/authentication-method-repository'),
   badgeAcquisitionRepository: require('../../infrastructure/repositories/badge-acquisition-repository'),
   badgeCriteriaService: require('../services/badge-criteria-service'),
   badgeRepository: require('../../infrastructure/repositories/badge-repository'),
@@ -23,6 +22,7 @@ const dependencies = {
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
+  poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
 };
 
 const partnerCertificationRepository = injectDependencies(

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -17,7 +17,6 @@ const dependencies = {
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
-  poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),

--- a/api/lib/domain/models/PoleEmploiSending.js
+++ b/api/lib/domain/models/PoleEmploiSending.js
@@ -17,14 +17,14 @@ class PoleEmploiSending {
     this.payload = payload;
   }
 
-  succeed() {
+  succeed(responseCode) {
     this.isSuccessful = true;
-    this.responseCode = 'PIX_FAKE_RESPONSE';
+    this.responseCode = responseCode;
   }
 
-  fail() {
+  fail(responseCode) {
     this.isSuccessful = false;
-    this.responseCode = 'PIX_FAKE_RESPONSE';
+    this.responseCode = responseCode;
   }
 }
 

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -1,0 +1,24 @@
+const _ = require('lodash');
+const authenticationMethodRepository = require('../../repositories/authentication-method-repository');
+const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
+const httpAgent = require('../../http/http-agent');
+const settings = require('../../../config');
+const { UnexpectedUserAccount } = require('../../../domain/errors');
+
+module.exports = {
+  async notify(userId, payload) {
+    const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI });
+    const accessToken = _.get(authenticationMethod, 'authenticationComplement.accessToken');
+    if (!accessToken) {
+      throw new UnexpectedUserAccount({ message: 'Le compte utilisateur n\'est pas rattaché à l\'organisation Pôle Emploi' });
+    }
+    const url = settings.poleEmploi.sendingUrl;
+    const headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-type': 'application/json',
+      'Accept': 'application/json',
+      'Service-source': 'Pix',
+    };
+    return httpAgent.post(url, payload, headers);
+  },
+};

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,0 +1,21 @@
+const axios = require('axios');
+
+module.exports = {
+  async post(url, payload, headers) {
+    const response = {
+      isSuccessful: false,
+      code: null,
+    };
+    try {
+      const httpResponse = await axios.post(url, payload, {
+        headers,
+      });
+      response.isSuccessful = true;
+      response.code = httpResponse.status;
+    } catch (httpErr) {
+      response.code = httpErr.response.status;
+    }
+
+    return response;
+  },
+};

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -15,7 +15,7 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
       await databaseBuilder.commit();
       const poleEmploiSending = domainBuilder.buildPoleEmploiSending({ campaignParticipationId });
-      poleEmploiSending.succeed();
+      poleEmploiSending.succeed('200');
 
       // when
       await poleEmploiSendingRepository.create({ poleEmploiSending });

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -167,6 +167,18 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
         // then
         expect(poleEmploiNotifier.notify).to.have.been.calledWith(userId, expectedResults, sinon.match.instanceOf(PoleEmploiSending));
       });
+
+      it('should notify with type CAMPAIGN_PARTICIPATION_SHARING', async () => {
+        // when
+        await handlePoleEmploiParticipationShared({
+          event,
+          ...dependencies,
+        });
+
+        // then
+        const poleEmploiSending = poleEmploiNotifier.notify.firstCall.args[2];
+        expect(poleEmploiSending.type).to.equal(PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING);
+      });
     });
 
     context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -197,7 +197,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
 
         it('it should record the sending', async () => {
           // given
-          sinon.stub(axios, 'post').resolves();
+          sinon.stub(axios, 'post').resolves({ status: '200' });
 
           // when
           await handlePoleEmploiParticipationShared({
@@ -211,7 +211,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
 
         context('when sending succeeds', () => {
           beforeEach(() => {
-            sinon.stub(axios, 'post').resolves();
+            sinon.stub(axios, 'post').resolves({ status: '200' });
           });
 
           it('it should send results', async () => {
@@ -244,7 +244,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
 
         context('when sending fails', () => {
           beforeEach(() => {
-            sinon.stub(axios, 'post').rejects();
+            sinon.stub(axios, 'post').rejects({ response: { status: '400' } });
           });
 
           it('it should record that the sending has failed', async () => {

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -11,7 +11,6 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
   const campaignParticipationRepository = { get: _.noop() };
   const campaignParticipationResultRepository = { getByParticipationId: _.noop() };
   const organizationRepository = { get: _.noop() };
-  const poleEmploiSendingRepository = { create: _.noop() };
   const targetProfileRepository = { get: _.noop() };
   const userRepository = { get: _.noop() };
   const poleEmploiNotifier = { notify: _.noop() };
@@ -21,7 +20,6 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
     campaignParticipationRepository,
     campaignParticipationResultRepository,
     organizationRepository,
-    poleEmploiSendingRepository,
     targetProfileRepository,
     userRepository,
     poleEmploiNotifier,
@@ -86,7 +84,6 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
     campaignParticipationRepository.get = sinon.stub();
     campaignParticipationResultRepository.getByParticipationId = sinon.stub();
     organizationRepository.get = sinon.stub();
-    poleEmploiSendingRepository.create = sinon.stub();
     targetProfileRepository.get = sinon.stub();
     userRepository.get = sinon.stub();
     poleEmploiNotifier.notify = sinon.stub();
@@ -160,13 +157,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
         );
       });
 
-      it('it should record the sending', async () => {
-        // given
-        poleEmploiNotifier.notify.withArgs(userId, expectedResults.toString()).resolves({
-          isSuccessful: 'anyValue',
-          code: 'anything',
-        });
-
+      it('should notify pole emploi', async () => {
         // when
         await handlePoleEmploiParticipationShared({
           event,
@@ -174,51 +165,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
         });
 
         // then
-        expect(poleEmploiSendingRepository.create).to.have.been.called;
-      });
-
-      context('when sending succeeds', () => {
-
-        it('it should record that the sending has succeeded', async () => {
-          // given
-          const code = 'someCode';
-          poleEmploiNotifier.notify.withArgs(userId, expectedResults.toString()).resolves({
-            isSuccessful: true,
-            code,
-          });
-          sinon.spy(PoleEmploiSending.prototype, 'succeed');
-
-          // when
-          await handlePoleEmploiParticipationShared({
-            event,
-            ...dependencies,
-          });
-
-          // then
-          expect(PoleEmploiSending.prototype.succeed).to.have.been.calledWithExactly(code);
-        });
-      });
-
-      context('when sending fails', () => {
-
-        it('it should record that the sending has failed', async () => {
-          // given
-          const code = 'someCode';
-          poleEmploiNotifier.notify.withArgs(userId, expectedResults.toString()).resolves({
-            isSuccessful: false,
-            code,
-          });
-          sinon.spy(PoleEmploiSending.prototype, 'fail');
-
-          // when
-          await handlePoleEmploiParticipationShared({
-            event,
-            ...dependencies,
-          });
-
-          // then
-          expect(PoleEmploiSending.prototype.fail).to.have.been.calledWithExactly(code);
-        });
+        expect(poleEmploiNotifier.notify).to.have.been.calledWith(userId, expectedResults, sinon.match.instanceOf(PoleEmploiSending));
       });
     });
 

--- a/api/tests/unit/domain/models/PoleEmploiSending_test.js
+++ b/api/tests/unit/domain/models/PoleEmploiSending_test.js
@@ -13,6 +13,18 @@ describe('Unit | Domain | Models | PoleEmploiSending', () => {
       // then
       expect(poleEmploiSending.isSuccessful).to.equal(true);
     });
+
+    it('should set responseCode', () => {
+      // given
+      const responseCode = '200';
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+
+      // when
+      poleEmploiSending.succeed(responseCode);
+
+      // then
+      expect(poleEmploiSending.responseCode).to.equal(responseCode);
+    });
   });
 
   describe('#fail', () => {
@@ -25,6 +37,18 @@ describe('Unit | Domain | Models | PoleEmploiSending', () => {
 
       // then
       expect(poleEmploiSending.isSuccessful).to.equal(false);
+    });
+
+    it('should set responseCode', () => {
+      // given
+      const responseCode = '400';
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+
+      // when
+      poleEmploiSending.fail(responseCode);
+
+      // then
+      expect(poleEmploiSending.responseCode).to.equal(responseCode);
     });
   });
 });

--- a/api/tests/unit/domain/services/obfuscation-service_test.js
+++ b/api/tests/unit/domain/services/obfuscation-service_test.js
@@ -7,7 +7,11 @@ const AuthenticationMethod = require('../../../../lib/domain/models/Authenticati
 describe('Unit | Service | user-authentication-method-obfuscation-service', () => {
 
   beforeEach(() => {
-    authenticationMethodRepository.findOneByUserIdAndIdentityProvider = sinon.stub().resolves();
+    sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
+  });
+
+  afterEach(() => {
+    authenticationMethodRepository.findOneByUserIdAndIdentityProvider.restore();
   });
 
   describe('#emailObfuscation', () => {

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -1,0 +1,72 @@
+const { expect, sinon, catchErr } = require('../../../../test-helper');
+const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
+const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
+const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
+const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
+const settings = require('../../../../../lib/config');
+const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
+
+describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', () => {
+
+  describe('#notify', () => {
+    const originPoleEmploiSendingUrl = settings.poleEmploi.sendingUrl;
+
+    beforeEach(() => {
+      sinon.stub(httpAgent, 'post');
+      sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
+    });
+
+    afterEach(() => {
+      settings.poleEmploi.sendingUrl = originPoleEmploiSendingUrl;
+      httpAgent.post.restore();
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.restore();
+    });
+
+    it('should throw an error if the user is not known as PoleEmploi user', async () => {
+      // given
+      const userId = 123;
+      const payload = 'somePayload';
+      httpAgent.post
+        .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+        .resolves(null);
+
+      // when
+      const error = await catchErr(notify)(userId, payload);
+
+      // then
+      expect(error).to.be.instanceOf(UnexpectedUserAccount);
+      expect(error.message).to.equal('Le compte utilisateur n\'est pas rattaché à l\'organisation Pôle Emploi');
+    });
+
+    it('should send the notification to Pole Emploi', async () => {
+      // given
+      const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+      settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+      const userId = 123;
+      const payload = 'somePayload';
+      const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+      const code = 'someCode';
+      const successState = 'someState';
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+        .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+        .resolves(authenticationMethod);
+      httpAgent.post
+        .withArgs(poleEmploiSendingUrl, payload, {
+          'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
+          'Content-type': 'application/json',
+          'Accept': 'application/json',
+          'Service-source': 'Pix',
+        })
+        .resolves({ isSuccessful: successState, code });
+
+      // when
+      const response = await notify(userId, payload);
+
+      // then
+      expect(response).to.deep.equal({
+        isSuccessful: successState,
+        code,
+      });
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -1,7 +1,8 @@
-const { expect, sinon, catchErr } = require('../../../../test-helper');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-helper');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
+const poleEmploiSendingRepository = require('../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const settings = require('../../../../../lib/config');
 const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
@@ -14,12 +15,14 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     beforeEach(() => {
       sinon.stub(httpAgent, 'post');
       sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
+      sinon.stub(poleEmploiSendingRepository, 'create');
     });
 
     afterEach(() => {
       settings.poleEmploi.sendingUrl = originPoleEmploiSendingUrl;
       httpAgent.post.restore();
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.restore();
+      poleEmploiSendingRepository.create.restore();
     });
 
     it('should throw an error if the user is not known as PoleEmploi user', async () => {
@@ -47,25 +50,87 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
       const code = 'someCode';
       const successState = 'someState';
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider
         .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
         .resolves(authenticationMethod);
-      httpAgent.post
-        .withArgs(poleEmploiSendingUrl, payload, {
-          'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
-          'Content-type': 'application/json',
-          'Accept': 'application/json',
-          'Service-source': 'Pix',
-        })
-        .resolves({ isSuccessful: successState, code });
+      httpAgent.post.resolves({ isSuccessful: successState, code });
 
       // when
-      const response = await notify(userId, payload);
+      await notify(userId, payload, poleEmploiSending);
 
       // then
-      expect(response).to.deep.equal({
-        isSuccessful: successState,
-        code,
+      expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiSendingUrl, payload, {
+        'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
+        'Content-type': 'application/json',
+        'Accept': 'application/json',
+        'Service-source': 'Pix',
+      });
+    });
+
+    it('it should record the sending', async () => {
+      // given
+      const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+      settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+      const userId = 123;
+      const payload = 'somePayload';
+      const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+      const code = 'someCode';
+      const successState = 'someState';
+      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
+      httpAgent.post.resolves({ isSuccessful: successState, code });
+
+      // when
+      await notify(userId, payload, poleEmploiSending);
+
+      // then
+      expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
+    });
+
+    context('when sending succeeds', () => {
+
+      it('it should record that the sending has succeeded', async () => {
+        // given
+        const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+        settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+        const userId = 123;
+        const payload = 'somePayload';
+        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+        const code = 'someCode';
+        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
+        httpAgent.post.resolves({ isSuccessful: true, code });
+        sinon.stub(poleEmploiSending, 'succeed');
+
+        // when
+        await notify(userId, payload, poleEmploiSending);
+
+        // then
+        expect(poleEmploiSending.succeed).to.have.been.calledWithExactly(code);
+      });
+    });
+
+    context('when sending fails', () => {
+
+      it('it should record that the sending has failed', async () => {
+        // given
+        const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+        settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+        const userId = 123;
+        const payload = 'somePayload';
+        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+        const code = 'someCode';
+        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
+        httpAgent.post.resolves({ isSuccessful: false, code });
+        sinon.stub(poleEmploiSending, 'fail');
+
+        // when
+        await notify(userId, payload, poleEmploiSending);
+
+        // then
+        expect(poleEmploiSending.fail).to.have.been.calledWithExactly(code);
       });
     });
   });

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -1,0 +1,53 @@
+const { expect, sinon } = require('../../../test-helper');
+const axios = require('axios');
+const { post } = require('../../../../lib/infrastructure/http/http-agent');
+
+describe('Unit | Infrastructure | http | http-agent', () => {
+
+  describe('#post', () => {
+
+    afterEach(() => {
+      axios.post.restore();
+    });
+
+    it('should return the response status and success from the http call when successful', async () => {
+      // given
+      const url = 'someUrl';
+      const payload = 'somePayload';
+      const headers = { a: 'someHeaderInfo' };
+      const axiosResponse = {
+        status: 'someStatus',
+      };
+      sinon.stub(axios, 'post').withArgs(url, payload, { headers }).resolves(axiosResponse);
+
+      // when
+      const actualResponse = await post(url, payload, headers);
+
+      // then
+      expect(actualResponse).to.deep.equal({
+        isSuccessful: true,
+        code: axiosResponse.status,
+      });
+    });
+
+    it('should return the error\'s response status and success from the http call when failed', async () => {
+      // given
+      const url = 'someUrl';
+      const payload = 'somePayload';
+      const headers = { a: 'someHeaderInfo' };
+      const axiosError = {
+        response: { status: 'someStatus' },
+      };
+      sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
+
+      // when
+      const actualResponse = await post(url, payload, headers);
+
+      // then
+      expect(actualResponse).to.deep.equal({
+        isSuccessful: false,
+        code: axiosError.response.status,
+      });
+    });
+  });
+});

--- a/mon-pix/app/routes/login-pe.js
+++ b/mon-pix/app/routes/login-pe.js
@@ -11,7 +11,7 @@ const { host, clientId, authEndpoint, loginHintName } = config;
 export default class LoginPeRoute extends Route.extend(OIDCAuthenticationRouteMixin) {
 
   _handleRedirectRequest(queryParams) {
-    const scope = `application_${clientId}%20api_peconnect-individuv1%20openid%20profile%20email`;
+    const scope = `application_${clientId}%20api_peconnect-individuv1%20openid%20profile%20serviceDigitauxExposition%20api_peconnect-servicesdigitauxv1`;
 
     const state = v4();
     const nonce = v4();


### PR DESCRIPTION
## :unicorn: Problème
Jusqu'alors on ne faisait qu'un console.log des résultats de Pôle Emploi. Or on veut véritablement envoyer les résultats d'un participant à une campagne Pôle Emploi, à Pôle Emploi.

## :robot: Solution
Faire le véritable appel.

## :rainbow: Remarques
Pour l'instant cela ne fonctionne pas (erreur 400) mais cela marchait il y a 3 jours...

## :100: Pour tester
En local, passer une campagne Pôle Emploi (QWERTY789) et partager les résultats. Regarder en base l'échec ou la réussite (bon ce sera échec au vu de la remarque ⬆️ ) avec la table `pole-emploi-sendings`.
