### PR TITLE
[FEATURE] Déplacement du lien "Mes tutos" du menu utilisateur à la barre de navigation principale (PIX-1649).

### DIFF
--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -9,9 +9,6 @@
       </p>
     </div>
   {{/if}}
-  <LinkTo @route="user-tutorials" class="navbar-burger-menu-user-info__item">
-    {{t 'navigation.user.tutorials'}}
-  </LinkTo>
   <LinkTo @route="user-certifications" class="navbar-burger-menu-user-info__item">
     {{t 'navigation.user.certifications'}}
   </LinkTo>
@@ -29,6 +26,10 @@
 
     <LinkTo @route="certifications" class="navbar-burger-menu-navigation__item">
        {{t 'navigation.main.start-certification'}}
+    </LinkTo>
+
+    <LinkTo @route="user-tutorials" class="navbar-burger-menu-navigation__item">
+      {{t 'navigation.main.tutorials'}}
     </LinkTo>
 
     <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-burger-menu-navigation__item">

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -26,6 +26,11 @@
             </LinkTo>
           </li>
           <li class="navbar-desktop-header-menu__item">
+            <LinkTo @route="user-tutorials" class="navbar-desktop-header-menu__link">
+              {{t 'navigation.main.tutorials'}}
+            </LinkTo>
+          </li>
+          <li class="navbar-desktop-header-menu__item">
             <a href="{{t 'navigation.main.link-help'}}" target="_blank" class="navbar-desktop-header-menu__link">
               {{t 'navigation.main.help'}}
             </a>

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -23,11 +23,6 @@
             </LinkTo>
           </li>
           <li>
-            <LinkTo @route="user-tutorials" data-test-tutorials-link class="logged-user-menu__link">
-              {{t 'navigation.user.tutorials'}}
-            </LinkTo>
-          </li>
-          <li>
             <LinkTo @route="user-certifications" data-test-certifications-link class="logged-user-menu__link">
               {{t 'navigation.user.certifications'}}
             </LinkTo>

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'navigation.user.tutorials')}}
+{{page-title (t 'pages.user-tutorials.title')}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />

--- a/mon-pix/tests/acceptance/navigation-test.js
+++ b/mon-pix/tests/acceptance/navigation-test.js
@@ -61,7 +61,7 @@ describe('Acceptance | Navbar', function() {
 
     it('should contain link to pix.fr/aide', async function() {
       // given
-      const helpItem = find('.navbar-desktop-header-container__menu').children[2];
+      const helpItem = find('.navbar-desktop-header-container__menu').children[3];
       const helpLink = helpItem.children[0].getAttribute('href');
       // when
       await visit('/profil');

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -24,7 +24,7 @@ describe('Integration | Component | navbar-burger-menu', function() {
   });
 
   it('should display logged user details informations', function() {
-    const MENU_ITEMS_COUNT = 4;
+    const MENU_ITEMS_COUNT = 3;
 
     // then
     expect(find('.navbar-burger-menu__user-info')).to.exist;
@@ -32,18 +32,19 @@ describe('Integration | Component | navbar-burger-menu', function() {
     expect(findAll('.navbar-burger-menu-user-info__item')).to.have.lengthOf(MENU_ITEMS_COUNT);
     expect(find('.navbar-burger-menu-user-info-item__name').textContent.trim()).to.equal('Bobby Carotte');
     expect(find('.navbar-burger-menu-user-info-item__email').textContent.trim()).to.equal('bobby.carotte@example.net');
-    expect(findAll('.navbar-burger-menu-user-info__item')[1].textContent.trim()).to.equal('Mes tutos');
-    expect(findAll('.navbar-burger-menu-user-info__item')[2].textContent.trim()).to.equal('Mes certifications');
-    expect(findAll('.navbar-burger-menu-user-info__item')[3].textContent.trim()).to.equal('Se déconnecter');
+    expect(findAll('.navbar-burger-menu-user-info__item')[1].textContent.trim()).to.equal('Mes certifications');
+    expect(findAll('.navbar-burger-menu-user-info__item')[2].textContent.trim()).to.equal('Se déconnecter');
   });
 
   it('should display the navigation menu with expected elements outside of campaign results', function() {
     // then
     expect(find('.navbar-burger-menu__navigation')).to.exist;
 
-    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(4);
+    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(5);
     expect(findAll('.navbar-burger-menu-navigation__item')[0].textContent.trim()).to.equal('Profil');
     expect(findAll('.navbar-burger-menu-navigation__item')[1].textContent.trim()).to.equal('Certification');
-    expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Aide');
+    expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Mes tutos');
+    expect(findAll('.navbar-burger-menu-navigation__item')[3].textContent.trim()).to.equal('Aide');
+    expect(findAll('.navbar-burger-menu-navigation__item')[4].textContent.trim()).to.equal('J\'ai un code');
   });
 });

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -102,9 +102,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
     it('should display the navigation menu with expected elements', function() {
       // then
       expect(find('.navbar-desktop-header-container__menu')).to.exist;
-      expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(3);
+      expect(findAll('.navbar-desktop-header-menu__item')).to.have.lengthOf(4);
       expect(contains('Profil')).to.exist;
       expect(contains('Certification')).to.exist;
+      expect(contains('Mes tutos')).to.exist;
       expect(contains('Aide')).to.exist;
     });
   });

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -62,7 +62,7 @@ describe('Integration | Component | user logged menu', function() {
 
     it('should display a user menu, when user-name is clicked', async function() {
       // given
-      const MENU_ITEMS_COUNT = 4;
+      const MENU_ITEMS_COUNT = 3;
       await render(hbs`{{user-logged-menu}}`);
 
       // when
@@ -77,23 +77,13 @@ describe('Integration | Component | user logged menu', function() {
       });
     });
 
-    it('should display link to user tutorials', async function() {
-      // when
-      await render(hbs`{{user-logged-menu _canDisplayMenu=true}}`);
-
-      return settled().then(() => {
-        // then
-        expect(findAll('.logged-user-menu__link')[1].textContent.trim()).to.equal(this.intl.t('navigation.user.tutorials'));
-      });
-    });
-
     it('should display link to user certifications', async function() {
       // when
       await render(hbs`{{user-logged-menu _canDisplayMenu=true}}`);
 
       return settled().then(() => {
         // then
-        expect(findAll('.logged-user-menu__link')[2].textContent.trim()).to.equal('Mes certifications');
+        expect(findAll('.logged-user-menu__link')[1].textContent.trim()).to.equal('Mes certifications');
       });
     });
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -977,7 +977,8 @@
             "help": "Help",
             "link-help": "https://pix.org/help",
             "profile": "Profile",
-            "start-certification": "Certification"
+            "start-certification": "Certification",
+            "tutorials": ""
         },
         "not-logged": {
             "sign-in": "Log in",
@@ -993,8 +994,7 @@
                 "username": ""
             },
             "certifications": "My certifications",
-            "sign-out": "Log out",
-            "tutorials": "My tutorials"
+            "sign-out": "Log out"
         },
         "user-logged-menu": {
             "details": "Check my details"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -977,7 +977,8 @@
             "help": "Aide",
             "link-help": "https://pix.fr/aide",
             "profile": "Profil",
-            "start-certification": "Certification"
+            "start-certification": "Certification",
+            "tutorials":  "Mes tutos"
         },
         "not-logged": {
             "sign-in": "Se connecter",
@@ -996,8 +997,7 @@
                 "username": "Identifiant"
             },
             "certifications": "Mes certifications",
-            "sign-out": "Se déconnecter",
-            "tutorials": "Mes tutos"
+            "sign-out": "Se déconnecter"
         }
     }
 }


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre du développement du tableau de bord, nous souhaitons rendre la section des tutos plus visible.

## :robot: Solution

Déplacement du lien concerné du menu utilisateur (dropdown en desktop/ menu burger en mobile) à la barre de navigation principale.

## :100: Pour tester

Constater le déplacement du lien "Mes tutos" sur la RA.
