### PR TITLE
[FEATURE ] QCU - Remplacer les chiffres par la réponse textuelle en cas de mauvaise réponse (PIX-1741).

### DIFF
--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -26,6 +26,14 @@ export default class QcuSolutionPanel extends Component {
     return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
   }
 
+  get solutionAsText() {
+    const answersProposedByUser = this.labeledRadios;
+    const correctAnswerIndex = this.solutionArray.indexOf(true);
+    const solutionAndStatus = answersProposedByUser[correctAnswerIndex];
+
+    return solutionAndStatus[0];
+  }
+
   @computed('answer')
   get labeledRadios() {
     const answer = this.answer.value;

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -36,7 +36,7 @@
         {{else}}
           <div class="answer-feedback__wrong-answer">{{t 'pages.comparison-window.results.feedback.wrong'
                                                          htmlSafe=true}}
-            <strong class="wrong-answer__expected-answer">{{this.solution}}</strong>
+            <strong class="wrong-answer__expected-answer">{{this.solutionAsText}}</strong>
           </div>
         {{/if}}
       </div>

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -11,6 +11,7 @@ const assessment = {};
 let challenge = null;
 let answer = null;
 let solution = null;
+let solutionAsText = null;
 
 describe('Integration | Component | qcu-solution-panel.js', function() {
   setupIntlRenderingTest();
@@ -123,6 +124,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         });
 
         solution = '2';
+        solutionAsText = 'bar';
       });
 
       it('should inform that the answer is wrong', async function() {
@@ -150,7 +152,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         // Then
         const correctAnswer = find('.wrong-answer__expected-answer');
         expect(correctAnswer).to.exist;
-        expect(correctAnswer.innerText).to.equal(solution);
+        expect(correctAnswer.innerText).to.equal(solutionAsText);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème

Lorsqu'une mauvaise réponse est donnée dans un QCU, la réponse donnée à l'utilisateur reprend le numéro de la réponse et non sa valeur, ce qui peut poser problème en cas par exemple de mauvais chargement de l'image reprenant la question.

## :robot: Solution

Extraire la valeur textuelle de la bonne réponse pour l'affichage.

## :rainbow: Remarques

Ajout d'une propriété `solutionAsText` dans le fichier de test d'intégration associé.
Discussion de la façon d'améliorer les tests ouverte.

## :100: Pour tester

Sur la RA, essayer l'épreuve `recfzlbSXEBOdWeRf`
