### PR TITLE
[BUGFIX] Imposer un identifiant valide lors de la création de compte (réconciliation) dans Pix App (PIX-1549). 

### DIFF
--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -28,6 +28,7 @@ exports.register = async function(server) {
                 'campaign-code': Joi.string().empty(Joi.string().regex(/^\s*$/)).required(),
                 password: Joi.string().pattern(XRegExp(passwordValidationPattern)).required(),
                 'with-username': Joi.boolean().required(),
+                username: Joi.string().pattern(XRegExp('^([a-z]+[.]+[a-z]+[0-9]{4})$')).allow(null),
               },
             },
           }),

--- a/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/index_test.js
@@ -24,98 +24,212 @@ describe('Integration | Application | Route | schooling-registration-dependent-u
     let payload;
     let response;
 
-    beforeEach(async () => {
-      // given
-      method = 'POST';
-      url = '/api/schooling-registration-dependent-users';
-      payload = {
-        data: {
-          attributes: {
-            'campaign-code': 'RESTRICTD',
-            'first-name': 'Robert',
-            'last-name': 'Smith',
-            birthdate: '2012-12-12',
-            username: 'robert.smith1212',
-            password: 'P@ssw0rd',
-            'with-username': true,
+    context('When registration succeed with email', () =>{
+
+      beforeEach(async () => {
+        // given
+        method = 'POST';
+        url = '/api/schooling-registration-dependent-users';
+        payload = {
+          data: {
+            attributes: {
+              'campaign-code': 'RESTRICTD',
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              email: 'robert.smith@example.net',
+              password: 'P@ssw0rd',
+              'with-username': false,
+              username: null,
+            },
           },
-        },
-      };
-    });
+        };
+      });
 
-    it('should succeed', async () => {
+      it('should return 204', async () => {
       // when
-      response = await httpTestServer.request(method, url, payload);
+        response = await httpTestServer.request(method, url, payload);
 
-      // then
-      expect(response.statusCode).to.equal(204);
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
     });
 
-    it('should return 400 when firstName is empty', async () => {
-      // given
-      payload.data.attributes['first-name'] = '';
+    context('When registration succeed with username', () =>{
 
-      // when
-      response = await httpTestServer.request(method, url, payload);
+      beforeEach(async () => {
+        // given
+        method = 'POST';
+        url = '/api/schooling-registration-dependent-users';
+        payload = {
+          data: {
+            attributes: {
+              'campaign-code': 'RESTRICTD',
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              username: 'robert.smith1212',
+              password: 'P@ssw0rd',
+              'with-username': true,
+              email: null,
+            },
+          },
+        };
+      });
 
-      // then
-      expect(response.statusCode).to.equal(400);
+      it('should return 204', async () => {
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
     });
 
-    it('should return 400 when lastName is empty', async () => {
-      // given
-      payload.data.attributes['last-name'] = '';
+    context('Error cases', () => {
 
-      // when
-      response = await httpTestServer.request(method, url, payload);
+      beforeEach(async () => {
+        // given
+        method = 'POST';
+        url = '/api/schooling-registration-dependent-users';
+        payload = {
+          data: {
+            attributes: {
+              'campaign-code': 'RESTRICTD',
+              'first-name': 'Robert',
+              'last-name': 'Smith',
+              birthdate: '2012-12-12',
+              username: 'robert.smith1212',
+              password: 'P@ssw0rd',
+              'with-username': true,
+            },
+          },
+        };
+      });
 
-      // then
-      expect(response.statusCode).to.equal(400);
+      it('should return 400 when firstName is empty', async () => {
+        // given
+        payload.data.attributes['first-name'] = '';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when lastName is empty', async () => {
+        // given
+        payload.data.attributes['last-name'] = '';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when birthDate is not a valid date', async () => {
+        // given
+        payload.data.attributes.birthdate = '2012*-12-12';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when campaignCode is empty', async () => {
+        // given
+        payload.data.attributes['campaign-code'] = '';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when password is not valid', async () => {
+        // given
+        payload.data.attributes.password = 'not_valid';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      it('should return 400 when withUsername is not a boolean', async () => {
+        // given
+        payload.data.attributes['with-username'] = 'not_a_boolean';
+
+        // when
+        response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+      context('when username is not valid', () => {
+
+        it('should return 400 when username is an email', async () => {
+          // given
+          payload.data.attributes.username = 'robert.smith1212@example.net';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when username has not dot between names', async () => {
+          // given
+          payload.data.attributes.username = 'robertsmith1212';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when username does not end with 4 digits', async () => {
+          // given
+          payload.data.attributes.username = 'robert.smith';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when username is capitalized', async () => {
+          // given
+          payload.data.attributes.username = 'Robert.Smith1212';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+
+        it('should return 400 when username is a phone number', async () => {
+          // given
+          payload.data.attributes.username = '0601010101';
+
+          // when
+          response = await httpTestServer.request(method, url, payload);
+          // then
+          expect(response.statusCode).to.equal(400);
+        });
+      });
     });
 
-    it('should return 400 when birthDate is not a valid date', async () => {
-      // given
-      payload.data.attributes.birthdate = '2012*-12-12';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return 400 when campaignCode is empty', async () => {
-      // given
-      payload.data.attributes['campaign-code'] = '';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return 400 when password is not valid', async () => {
-      // given
-      payload.data.attributes.password = 'not_valid';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
-
-    it('should return 400 when withUsername is not a boolean', async () => {
-      // given
-      payload.data.attributes['with-username'] = 'not_a_boolean';
-
-      // when
-      response = await httpTestServer.request(method, url, payload);
-
-      // then
-      expect(response.statusCode).to.equal(400);
-    });
   });
 
   describe('POST /api/schooling-registration-dependent-users/external-user-token', () => {

--- a/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/integration/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller_test.js
@@ -35,7 +35,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
         'birthdate': '2012-12-12',
         'campaign-code': 'RESTRICTD',
         'password': 'P@ssw0rd',
-        'username': 'Robert.Smith1212',
+        'username': 'robert.smith1212',
         'with-username': true,
       };
     });
@@ -49,6 +49,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
         it('should return an HTTP response with status code 204', async () => {
           // given
           payload.data.attributes.email = 'toto@example.net';
+          delete payload.data.attributes.username;
           payload.data.attributes['with-username'] = false;
           usecases.createAndReconcileUserToSchoolingRegistration.resolves(createdUser);
 
@@ -64,6 +65,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
         it('should return an HTTP response with status code 204', async () => {
           // given
+          delete payload.data.attributes.email;
           payload.data.attributes.username = 'robert.smith1212';
           payload.data.attributes['with-username'] = true;
           usecases.createAndReconcileUserToSchoolingRegistration.resolves(createdUser);
@@ -84,6 +86,7 @@ describe('Integration | Application | Schooling-registration-dependent-users | s
 
         it('should resolve a 404 HTTP response', async () => {
           // given
+          delete payload.data.attributes.username;
           usecases.createAndReconcileUserToSchoolingRegistration.rejects(new NotFoundError());
 
           // when

--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -45,6 +45,7 @@ export default class RegisterForm extends Component {
   schoolingRegistrationUserAssociation = null;
   isLoading = false;
   errorMessage = null;
+  displayRegisterErrorMessage = false;
   matchingStudentFound = false;
   isPasswordVisible = false;
   loginWithUsername = true;
@@ -77,13 +78,12 @@ export default class RegisterForm extends Component {
       || !isDayValid(this.dayOfBirth) || !isMonthValid(this.monthOfBirth) || !isYearValid(this.yearOfBirth);
   }
 
-  @computed('email', 'username', 'password')
+  @computed('email', 'password')
   get isCreationFormNotValid() {
     const isPasswordNotValid = !isPasswordValid(this.password);
-    const isUsernameNotValid = !isStringValid(this.username);
     const isEmailNotValid = !isEmailValid(this.email);
     if (this.loginWithUsername) {
-      return isUsernameNotValid || isPasswordNotValid;
+      return isPasswordNotValid;
     }
     return isEmailNotValid || isPasswordNotValid;
   }
@@ -111,10 +111,6 @@ export default class RegisterForm extends Component {
         message: null,
       },
       email: {
-        status: 'default',
-        message: null,
-      },
-      username: {
         status: 'default',
         message: null,
       },
@@ -196,6 +192,7 @@ export default class RegisterForm extends Component {
   @action
   async register() {
     this.set('isLoading', true);
+    this.set('displayRegisterErrorMessage', false);
     if (this.isCreationFormNotValid) {
       return this.set('isLoading', false);
     }
@@ -283,12 +280,17 @@ export default class RegisterForm extends Component {
 
   _updateInputsStatus() {
     const errors = this.schoolingRegistrationDependentUser.errors;
-    errors.forEach(({ attribute, message }) => {
-      const statusObject = 'validation.' + attribute + '.status';
-      const messageObject = 'validation.' + attribute + '.message';
-      this.set(statusObject, 'error');
-      this.set(messageObject, message);
-    });
+
+    if (errors) {
+      errors.forEach(({ attribute, message }) => {
+        const statusObject = 'validation.' + attribute + '.status';
+        const messageObject = 'validation.' + attribute + '.message';
+        this.set(statusObject, 'error');
+        this.set(messageObject, message);
+      });
+    } else {
+      this.set('displayRegisterErrorMessage', true);
+    }
   }
 
   _validateInputString(key, value) {

--- a/mon-pix/app/styles/components/_register-form.scss
+++ b/mon-pix/app/styles/components/_register-form.scss
@@ -83,4 +83,26 @@
       padding: 10px 10px 0 10px;
     }
   }
+
+  &-username-container {
+    display: flex;
+    flex-direction: column;
+    margin-top: 20px;
+
+    &__label {
+      font-size: 0.938rem;
+      font-weight: $font-medium;
+      color: $grey-80;
+      letter-spacing: 0.031rem;
+    }
+
+    &__span {
+      color: $grey-50;
+      font-family: $font-roboto;
+      font-size: 0.875rem;
+      background-color: $grey-20;
+      border-radius: 3px;
+      padding: 15px 10px;
+    }
+  }
 }

--- a/mon-pix/app/templates/components/routes/register-form.hbs
+++ b/mon-pix/app/templates/components/routes/register-form.hbs
@@ -76,16 +76,13 @@
 
   <form {{action 'register' on='submit'}} autocomplete="off">
     {{#if this.loginWithUsername}}
-        <div id="register-username-container">
-          <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.username.label'}}
-                         @textfieldName="username"
-                         @inputBindingValue={{this.username}}
-                         @onValidate={{action "triggerInputStringValidation" "username" this.username}}
-                         @validationStatus={{this.validation.username.status}}
-                         @validationMessage={{this.validation.username.message}}
-                         @disabled={{true}}
-                         @require={{true}} />
-        </div>
+      <div id="register-username-container" class="register-form-username-container">
+        <label class="register-form-username-container__label">
+          <abbr title="{{t 'common.form.mandatory'}}" class="mandatory-mark">*</abbr>
+          {{t 'pages.login-or-register.register-form.fields.username.label'}}
+        </label>
+        <span class="register-form-username-container__span" data-test-username>{{this.username}}</span>
+      </div>
     {{else}}
         <div id="register-email-container">
           <FormTextfield @label={{t 'pages.login-or-register.register-form.fields.email.label'}}
@@ -108,6 +105,10 @@
                      @validationMessage={{this.validation.password.message}}
                      @require={{true}} />
     </div>
+
+    {{#if this.displayRegisterErrorMessage}}
+      <div class="register-form__error" aria-live="polite">{{t 'pages.login-or-register.register-form.error'}}</div>
+    {{/if}}
 
     <div class="register-button-container">
       {{#if this.isLoading}}

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -203,6 +203,23 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
           it('should redirect to landing page when reconciliation and registration are done', async function() {
             // given
+            this.server.put('schooling-registration-user-associations/possibilities', () => {
+
+              const studentFoundWithUsernameGenerated = {
+                'data': {
+                  'attributes': {
+                    'last-name': 'JeanPrescrit',
+                    'first-name': 'Campagne',
+                    'birthdate': '2010-12-10',
+                    'campaign-code': 'RESTRICTD',
+                    'username': 'jeanprescrit.campagne1012',
+                  }, 'type': 'schooling-registration-user-associations',
+                },
+              };
+
+              return new Response(200, {}, studentFoundWithUsernameGenerated);
+            });
+
             await visit(`/campagnes/${campaign.code}`);
 
             // when
@@ -213,7 +230,6 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await fillIn('#yearOfBirth', '2000');
             await click('#submit-search');
 
-            await fillIn('#username', 'jeanprescrit1012');
             await fillIn('#password', 'Password123');
             await click('#submit-registration');
 
@@ -279,7 +295,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
 
             //go to username-based authentication window
             await click('.pix-toggle__off');
-            expect(find('#username').value).to.equal('first.last1010');
+            expect(find('span[data-test-username]').textContent).to.equal('first.last1010');
             expect(find('#password').value).to.equal('pix123');
 
           });

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -135,6 +135,65 @@ describe('Integration | Component | routes/register-form', function() {
 
   context('errors management', function() {
 
+    context('When authentication service fails', async function() {
+
+      it('Should display registerErrorMessage when authentication service fails with username error', async function() {
+        // given
+        const expectedRegisterErrorMessage =  this.intl.t('pages.login-or-register.register-form.error');
+
+        this.set('loginWithUsername', true);
+
+        const error = {
+          status: '400',
+          errorMessage: '"data.attributes.username" with value "pix.pix1010@example.net" fails to match the required pattern: /^([a-z]+[.]+[a-z]+[0-9]{4})$/',
+        };
+
+        this.owner.unregister('service:store');
+        this.owner.register('service:store', storeStub);
+        storeStub.prototype.createRecord = () => {
+          return EmberObject.create({
+
+            save(options) {
+              if (options && options.adapterOptions && options.adapterOptions.searchForMatchingStudent) {
+                return resolve({ username: 'pix.pix1010@example.net' });
+              }
+              return reject({ error });
+            },
+            unloadRecord() {
+              return resolve();
+            },
+          });
+        };
+        sessionStub.prototype.authenticate = function(authenticator, { login, password, scope }) {
+          this.authenticator = authenticator;
+          this.login = login;
+          this.password = password;
+          this.scope = scope;
+          return resolve();
+
+        };
+
+        // when
+        await render(hbs`<Routes::RegisterForm @loginWithUsername={{this.loginWithUsername}} />`);
+
+        await fillIn('#firstName', 'pix');
+        await fillIn('#lastName', 'pix');
+        await fillIn('#dayOfBirth', '10');
+        await fillIn('#monthOfBirth', '10');
+        await fillIn('#yearOfBirth', '2010');
+
+        await click('#submit-search');
+
+        await fillIn('#password', 'Mypassword1');
+
+        await click('#submit-registration');
+
+        // then
+        expect(find('.register-form__error')).to.exist;
+        expect(find('.register-form__error').innerHTML).to.equal(expectedRegisterErrorMessage);
+      });
+    });
+
     [{ stringFilledIn: '' },
       { stringFilledIn: ' ' },
     ].forEach(function({ stringFilledIn }) {
@@ -354,9 +413,9 @@ describe('Integration | Component | routes/register-form', function() {
       });
     });
 
-    describe('When student is already reconciled in the same organization', async function() {
+    context('When student is already reconciled in the same organization', async function() {
 
-      describe('When student account is authenticated by email only', async function() {
+      context('When student account is authenticated by email only', async function() {
 
         it('should display the error message related to the short code S61)', async function() {
           // given
@@ -405,7 +464,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by username only', async function() {
+      context('When student account is authenticated by username only', async function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
@@ -454,7 +513,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId only', async function() {
+      context('When student account is authenticated by SamlId only', async function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -503,7 +562,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId and username', async function() {
+      context('When student account is authenticated by SamlId and username', async function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -552,7 +611,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId and email', async function() {
+      context('When student account is authenticated by SamlId and email', async function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -601,7 +660,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by SamlId, email and username', async function() {
+      context('When student account is authenticated by SamlId, email and username', async function() {
 
         it('should display the error message related to the short code S63)', async function() {
           // given
@@ -650,7 +709,7 @@ describe('Integration | Component | routes/register-form', function() {
 
       });
 
-      describe('When student account is authenticated by email and username', async function() {
+      context('When student account is authenticated by email and username', async function() {
 
         it('should display the error message related to the short code S62)', async function() {
           // given
@@ -701,7 +760,7 @@ describe('Integration | Component | routes/register-form', function() {
 
     });
 
-    describe('When student is already reconciled in others organization', async function() {
+    context('When student is already reconciled in others organization', async function() {
 
       describe('When student account is authenticated by email only', async function() {
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -610,7 +610,8 @@
                     "text": "Sign up with:",
                     "username": "My username"
                 },
-                "title": "Sign up"
+                "title": "Sign up",
+                "error": "An error has occured. Please try again or contact the support."
             }
         },
         "not-connected": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -610,7 +610,8 @@
                     "text": "Je m'inscris avec :",
                     "username": "Mon identifiant"
                 },
-                "title": "Je m’inscris sur Pix"
+                "title": "Je m’inscris sur Pix",
+                "error": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
             }
         },
         "not-connected": {


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs sont parvenus à modifier l'identifiant généré par Pix lors de la création du compte, dans la double mire de réconciliation.
Résultat : des adresses e-mail et des numéros de téléphone ont étés trouvés dans le champ username.

## :robot: Solution

- Remplacer l'actuel champ (input) identifiant par une span.
- Ajouter, coté API, un pattern pour empêcher toute valeur ne correspondant pas à un identifiant valide chez Pix.

## :rainbow: Remarques
Coté design, nous avons stylisé la balise span pour garder visuellement l'existant.
<img width="337" alt="Capture d’écran 2020-12-08 à 12 03 33" src="https://user-images.githubusercontent.com/58915422/101476061-74d03800-394d-11eb-8dcd-1d899d8145a6.png">

## :100: Pour tester

- Aller sur `/campagnes`
- Entrer la campagne `BADGES123`
- Créer un compte avec l'utilisateur : 
`first`
`last`
`10-10-2010`

`scalingo -a pix-api-review-pr2242 --region osc-fr1 run "npm run db:seed"` pour relancer les seeds en RA.