### PR TITLE
[FEATURE] Permettre à l'utilisateur de changer son email - API (PIX-1748).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -226,6 +226,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToUpdatePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToUpdateEmailError) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.UserNotAuthorizedToCreateResourceError) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -8,4 +8,11 @@ module.exports = {
     }
     return true;
   },
+
+  async isMyAccountEnabled() {
+    if (!featureToggles.myAccount) {
+      throw new NotFoundError('cette route est désactivée');
+    }
+    return true;
+  },
 };

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -5,6 +5,7 @@ const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
+const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
 
 exports.register = async function(server) {
@@ -165,10 +166,16 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/users/{id}/email',
       config: {
-        pre: [{
-          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-          assign: 'requestedUserIsAuthenticatedUser',
-        }],
+        pre: [
+          {
+            method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+            assign: 'requestedUserIsAuthenticatedUser',
+          },
+          {
+            method: featureToggles.isMyAccountEnabled,
+            assign: 'isMyAccountEnabled',
+          },
+        ],
         handler: userController.updateEmail,
         validate: {
           options: {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -5,6 +5,7 @@ const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
+const { EntityValidationError } = require('../../domain/errors');
 
 exports.register = async function(server) {
   server.route([
@@ -180,6 +181,9 @@ exports.register = async function(server) {
               },
             },
           }),
+          failAction: (request, h, error) => {
+            return EntityValidationError.fromJoiErrors(error.details);
+          },
         },
         notes : [
           '- Met à jour l\'email d\'un utilisateur identifié par son id',

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -164,6 +164,10 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/users/{id}/email',
       config: {
+        pre: [{
+          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
+          assign: 'requestedUserIsAuthenticatedUser',
+        }],
         handler: userController.updateEmail,
         validate: {
           options: {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -183,6 +183,7 @@ exports.register = async function(server) {
           },
           payload: Joi.object({
             data: {
+              type: Joi.string().valid('users').required(),
               attributes: {
                 email: Joi.string().email().required(),
               },

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -162,6 +162,29 @@ exports.register = async function(server) {
     },
     {
       method: 'PATCH',
+      path: '/api/users/{id}/email',
+      config: {
+        handler: userController.updateEmail,
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          payload: Joi.object({
+            data: {
+              attributes: {
+                email: Joi.string().email().required(),
+              },
+            },
+          }),
+        },
+        notes : [
+          '- Met à jour l\'email d\'un utilisateur identifié par son id',
+        ],
+        tags: ['api', 'user'],
+      },
+    },
+    {
+      method: 'PATCH',
       path: '/api/users/{id}/password-update',
       config: {
         auth: false,

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -44,6 +44,18 @@ module.exports = {
     return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
   },
 
+  async updateEmail(request, h) {
+    const { email }  = request.payload.data.attributes;
+    const userId = parseInt(request.params.id);
+
+    await usecases.updateUserEmail({
+      email,
+      userId,
+    });
+
+    return h.response({}).code(204);
+  },
+
   async updatePassword(request) {
     const userId = parseInt(request.params.id);
     const user = userSerializer.deserialize(request.payload);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -134,6 +134,7 @@ module.exports = (function() {
       certifPrescriptionSco: isFeatureEnabled(process.env.FT_CERTIF_PRESCRIPTION_SCO),
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
       reportsCategorization: isFeatureEnabled(process.env.FT_REPORTS_CATEGORISATION),
+      myAccount: isFeatureEnabled(process.env.FT_MY_ACCOUNT),
     },
 
     infra: {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -584,6 +584,12 @@ class ArchivedCampaignError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToUpdateEmailError extends DomainError {
+  constructor(message = 'User is not authorized to update email') {
+    super(message);
+  }
+}
+
 class UserNotAuthorizedToAccessEntity extends DomainError {
   constructor(message = 'User is not authorized to access ressource') {
     super(message);
@@ -735,6 +741,7 @@ module.exports = {
   UserNotAuthorizedToUpdatePasswordError,
   UserNotAuthorizedToUpdateResourceError,
   UserNotFoundError,
+  UserNotAuthorizedToUpdateEmailError,
   UserNotMemberOfOrganizationError,
   UserOrgaSettingsCreationError,
   UserShouldChangePasswordError,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -224,5 +224,6 @@ module.exports = injectDependencies({
   updateSession: require('./update-session'),
   updateStudentNumber: require('./update-student-number'),
   updateUserDetailsForAdministration: require('./update-user-details-for-administration'),
+  updateUserEmail: require('./update-user-email'),
   updateUserPassword: require('./update-user-password'),
 }, dependencies);

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -1,0 +1,7 @@
+module.exports = async function updateUserEmail({
+  email,
+  userId,
+  userRepository,
+}) {
+  await userRepository.updateEmail({ id: userId, email });
+};

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -3,5 +3,6 @@ module.exports = async function updateUserEmail({
   userId,
   userRepository,
 }) {
+  await userRepository.isEmailAvailable(email);
   await userRepository.updateEmail({ id: userId, email });
 };

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -1,8 +1,14 @@
+const {  UserNotAuthorizedToUpdateEmailError } = require('../errors');
+
 module.exports = async function updateUserEmail({
   email,
   userId,
   userRepository,
 }) {
+  const user = await userRepository.get(userId);
+  if (!user.email) {
+    throw new UserNotAuthorizedToUpdateEmailError();
+  }
   await userRepository.isEmailAvailable(email);
   await userRepository.updateEmail({ id: userId, email });
 };

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -1,14 +1,22 @@
 const {  UserNotAuthorizedToUpdateEmailError } = require('../errors');
+const isEmpty = require('lodash/isEmpty');
 
 module.exports = async function updateUserEmail({
   email,
   userId,
   userRepository,
+  schoolingRegistrationRepository,
 }) {
   const user = await userRepository.get(userId);
   if (!user.email) {
     throw new UserNotAuthorizedToUpdateEmailError();
   }
+
+  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
+  if (!isEmpty(schoolingRegistrations)) {
+    throw new UserNotAuthorizedToUpdateEmailError();
+  }
+
   await userRepository.isEmailAvailable(email);
   await userRepository.updateEmail({ id: userId, email });
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -353,6 +353,19 @@ module.exports = {
       });
   },
 
+  updateEmail({ id, email }) {
+    return BookshelfUser
+      .where({ id })
+      .save({ email }, { patch: true, method: 'update' })
+      .then((bookshelfUser) => bookshelfUser.toDomainEntity())
+      .catch((err) => {
+        if (err instanceof BookshelfUser.NoRowsUpdatedError) {
+          throw new UserNotFoundError(`User not found for ID ${id}`);
+        }
+        throw err;
+      });
+  },
+
   async updateUserDetailsForAdministration(id, userAttributes) {
     try {
       const updatedUser = await BookshelfUser

--- a/api/tests/acceptance/application/feature-controller_tests.js
+++ b/api/tests/acceptance/application/feature-controller_tests.js
@@ -28,6 +28,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
             'certif-prescription-sco': false,
             'reports-categorization': false,
             'is-pole-emploi-enabled': false,
+            'my-account': false,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -69,6 +69,33 @@ describe('Acceptance | Controller | users-controller', () => {
         expect(response.statusCode).to.equal(403);
       });
 
+      it('should return 403 if user has no email', async () => {
+        // given
+        const userWithoutEmail = databaseBuilder.factory.buildUser({ email: null });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/users/${userWithoutEmail.id}/email`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(userWithoutEmail.id) },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: {
+                'email': 'new_email@example.net',
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
       it('should return 422 if email is invalid', async () => {
         // given
         const options = {

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
+const { featureToggles } = require('../../../../lib/config');
 
 describe('Acceptance | Controller | users-controller', () => {
 
@@ -119,6 +120,30 @@ describe('Acceptance | Controller | users-controller', () => {
         expect(response.statusCode).to.equal(422);
       });
 
+      it('should return 404 if FT_MY_ACCOUNT is not enabled', async () => {
+        // given
+        featureToggles.myAccount = false;
+
+        const options = {
+          method: 'PATCH',
+          url: `/api/users/${user.id}/email`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: {
+                'email': 'new_email@example.net',
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(404);
+      });
     });
   });
 });

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -1,0 +1,51 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | users-controller', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('PATCH /api/users/{id}/email', () => {
+
+    context('user is valid', () => {
+
+      let user;
+
+      beforeEach(async () => {
+        user = databaseBuilder.factory.buildUser({
+          email: 'old_email@example.net',
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should return status 204 with user', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/users/${user.id}/email`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: {
+                'email': 'new_email@example.net',
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -44,7 +44,29 @@ describe('Acceptance | Controller | users-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(204);
+      });
 
+      it('should return 403 if account is not his own', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/users/${user.id}/email`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id - 1) },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: {
+                'email': 'new_email@example.net',
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
       });
     });
   });

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -17,6 +17,8 @@ describe('Acceptance | Controller | users-controller', () => {
       let user;
 
       beforeEach(async () => {
+        featureToggles.myAccount = true;
+
         user = databaseBuilder.factory.buildUser({
           email: 'old_email@example.net',
         });
@@ -49,10 +51,12 @@ describe('Acceptance | Controller | users-controller', () => {
 
       it('should return 403 if account is not his own', async () => {
         // given
+        const wrongUserId = user.id - 1;
+
         const options = {
           method: 'PATCH',
           url: `/api/users/${user.id}/email`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id - 1) },
+          headers: { authorization: generateValidRequestAuthorizationHeader(wrongUserId) },
           payload: {
             data: {
               type: 'users',
@@ -95,29 +99,6 @@ describe('Acceptance | Controller | users-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(403);
-      });
-
-      it('should return 422 if email is invalid', async () => {
-        // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/users/${user.id}/email`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id - 1) },
-          payload: {
-            data: {
-              type: 'users',
-              attributes: {
-                'email': 'not_an_email',
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(422);
       });
 
       it('should return 404 if FT_MY_ACCOUNT is not enabled', async () => {

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -68,6 +68,30 @@ describe('Acceptance | Controller | users-controller', () => {
         // then
         expect(response.statusCode).to.equal(403);
       });
+
+      it('should return 422 if email is invalid', async () => {
+        // given
+        const options = {
+          method: 'PATCH',
+          url: `/api/users/${user.id}/email`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id - 1) },
+          payload: {
+            data: {
+              type: 'users',
+              attributes: {
+                'email': 'not_an_email',
+              },
+            },
+          },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(422);
+      });
+
     });
   });
 });

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -151,4 +151,45 @@ describe('Integration | Application | Users | Routes', () => {
       expect(response.statusCode).to.equal(200);
     });
   });
+
+  describe('PATCH /api/users/{id}/email', () => {
+
+    const url = '/api/users/1/email';
+
+    it('should return 422 if email is invalid', async () => {
+      // given
+      const payload = {
+        data: {
+          type: 'users',
+          attributes: {
+            email: 'not_an_email',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(methodPATCH, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+    });
+
+    it('should return 422 if type attribute is missing', async () => {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            email: 'user@example.net',
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(methodPATCH, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+    });
+
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -810,6 +810,29 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
     });
   });
 
+  describe('#updateEmail', () => {
+
+    let userInDb;
+
+    beforeEach(async () => {
+      userInDb = databaseBuilder.factory.buildUser({ ...userToInsert, email: 'old_email@example.net' });
+      await databaseBuilder.commit();
+    });
+
+    it('should update the user email', async () => {
+      // given
+      const newEmail = 'new_email@example.net';
+
+      // when
+      const updatedUser = await userRepository.updateEmail({ id: userInDb.id, email: newEmail });
+
+      // then
+      expect(updatedUser).to.be.an.instanceOf(User);
+      expect(updatedUser.email).to.equal(newEmail);
+    });
+
+  });
+
   describe('#updateTemporaryPassword', () => {
 
     let userInDb;

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -1,0 +1,31 @@
+const updateUserEmail = require('../../../../lib/domain/usecases/update-user-email');
+
+const { sinon, expect } = require('../../../test-helper');
+
+describe('Unit | UseCase | update-user-email', () => {
+
+  let userRepository;
+
+  beforeEach(() => {
+    userRepository = { updateEmail: sinon.stub() };
+  });
+
+  it('should call updateEmail', async () => {
+    // given
+    const userId = 1;
+    const newEmail = 'new_email@example.net';
+
+    // when
+    await updateUserEmail({
+      userId,
+      email: newEmail,
+      userRepository,
+    });
+
+    // then
+    expect(userRepository.updateEmail).to.have.been.calledWith({
+      id: userId,
+      email: newEmail,
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -1,13 +1,14 @@
 const updateUserEmail = require('../../../../lib/domain/usecases/update-user-email');
+const { AlreadyRegisteredEmailError } = require('../../../../lib/domain/errors');
 
-const { sinon, expect } = require('../../../test-helper');
+const { sinon, expect, catchErr } = require('../../../test-helper');
 
 describe('Unit | UseCase | update-user-email', () => {
 
   let userRepository;
 
   beforeEach(() => {
-    userRepository = { updateEmail: sinon.stub() };
+    userRepository = { updateEmail: sinon.stub(), isEmailAvailable: sinon.stub() };
   });
 
   it('should call updateEmail', async () => {
@@ -27,5 +28,22 @@ describe('Unit | UseCase | update-user-email', () => {
       id: userId,
       email: newEmail,
     });
+  });
+
+  it('throw AlreadyRegisteredEmailError if email already exist', async () => {
+    // given
+    userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
+    const userId = 1;
+    const newEmail = 'new_email@example.net';
+
+    // when
+    const error = await catchErr(updateUserEmail)({
+      userId,
+      email: newEmail,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(AlreadyRegisteredEmailError);
   });
 });

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -1,17 +1,22 @@
 const updateUserEmail = require('../../../../lib/domain/usecases/update-user-email');
 const { AlreadyRegisteredEmailError, UserNotAuthorizedToUpdateEmailError } = require('../../../../lib/domain/errors');
 
-const { sinon, expect, catchErr } = require('../../../test-helper');
+const { sinon, expect, catchErr, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | UseCase | update-user-email', () => {
 
   let userRepository;
+  let schoolingRegistrationRepository;
 
   beforeEach(() => {
     userRepository = {
       updateEmail: sinon.stub(),
       isEmailAvailable: sinon.stub(),
       get: sinon.stub().resolves({ email:'old_email@example.net' }),
+    };
+
+    schoolingRegistrationRepository = {
+      findByUserId: sinon.stub().resolves([]),
     };
   });
 
@@ -25,6 +30,7 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       email: newEmail,
       userRepository,
+      schoolingRegistrationRepository,
     });
 
     // then
@@ -45,6 +51,7 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       email: newEmail,
       userRepository,
+      schoolingRegistrationRepository,
     });
 
     // then
@@ -62,6 +69,25 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       email: newEmail,
       userRepository,
+      schoolingRegistrationRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
+  });
+
+  it('throw UserNotAuthorizedToUpdateEmailError if user is reconciled', async () => {
+    // given
+    const userId = 1;
+    const newEmail = 'new_email@example.net';
+    schoolingRegistrationRepository.findByUserId.resolves([domainBuilder.buildSchoolingRegistration()]);
+
+    // when
+    const error = await catchErr(updateUserEmail)({
+      userId,
+      email: newEmail,
+      userRepository,
+      schoolingRegistrationRepository,
     });
 
     // then


### PR DESCRIPTION
## :unicorn: Problème
Seul le support peut changer l'email d'un utilisateur dans Pix Admin, ce qui engendre un charge importante

## :robot: Solution
Permettre à l'utilisateur de changer son email dans Pix App

Refuser le changement si :
- l'email est déjà utilisé par un autre utilisateur
- l'utilisateur fait la demande pour quelqu'un d'autre (userId token <> URL {id}
- aucune donnée n'est fournie dans le champ email / champ manquant
- ce qui est fourni en entrée n'est pas un email (ex: johnexample.net)
- l'utilisateur n'a pas d'email 
- l'utilisateur est déjà réconcilié

## :rainbow: Remarques
Cet ticket contient uniquement la partie API, la partie front sera effectuée dans un autre ticket.
Fonctionnalité développée en mob programming
Cette fonctionnalité est active si le FT MY_ACCOUNT est actif

## :100: Pour tester
Utiliser curl
