### PR TITLE
[FEATURE] Envoi du parcours commencé à Pôle Emploi et enregistrement de la réponse (PIX-1734).

### DIFF
--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -1,6 +1,7 @@
 const { checkEventType } = require('./check-event-type');
 const CampaignParticipationStarted = require('./CampaignParticipationStarted');
 const PoleEmploiPayload = require('../../infrastructure/externals/pole-emploi/PoleEmploiPayload');
+const PoleEmploiSending = require('../models/PoleEmploiSending');
 
 const eventType = CampaignParticipationStarted;
 
@@ -9,8 +10,10 @@ async function handlePoleEmploiParticipationStarted({
   campaignRepository,
   campaignParticipationRepository,
   organizationRepository,
+  poleEmploiSendingRepository,
   targetProfileRepository,
   userRepository,
+  poleEmploiNotifier,
 }) {
   checkEventType(event, eventType);
 
@@ -19,9 +22,9 @@ async function handlePoleEmploiParticipationStarted({
   const participation = await campaignParticipationRepository.get(campaignParticipationId);
   const campaign = await campaignRepository.get(participation.campaignId);
   const organization = await organizationRepository.get(campaign.organizationId);
-  
+
   if (campaign.isAssessment() && organization.isPoleEmploi) {
-    
+
     const user = await userRepository.get(participation.userId);
     const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
 
@@ -32,7 +35,16 @@ async function handlePoleEmploiParticipationStarted({
       participation,
     });
 
-    console.log(payload.toString());
+    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+
+    const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({
+      campaignParticipationId,
+      payload: payload.toString(),
+      isSuccessful: response.isSuccessful,
+      responseCode: response.code,
+    });
+
+    return poleEmploiSendingRepository.create({ poleEmploiSending });
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on console logguait encore les résultats au début du parcours de Pôle Emploi.

## :robot: Solution
Faire le véritable envoi et stocker le code réponse en base.

## :rainbow: Remarques
Identique à ce qui a été fait sur le partage des résultats.

## :100: Pour tester
Passer une campagne pôle emploi (QWERTY789) en étant connecté en tant qu'utilisateur Pôle Emploi (credentials disponibles sur confluence) et vérifier en base le bon enregistrement de la réussite ou de l'échec de l'envoi.
