### PR TITLE
[FEATURE] Envoi du parcours terminé à Pôle Emploi et enregistrement de la réponse (PIX-1735).

### DIFF
--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -11,6 +11,7 @@ async function handlePoleEmploiParticipationShared({
   campaignParticipationRepository,
   campaignParticipationResultRepository,
   organizationRepository,
+  poleEmploiSendingRepository,
   targetProfileRepository,
   userRepository,
   poleEmploiNotifier,
@@ -37,13 +38,16 @@ async function handlePoleEmploiParticipationShared({
       participationResult,
     });
 
-    const poleEmploiSending = new PoleEmploiSending({
+    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+
+    const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({
       campaignParticipationId,
-      type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
-      payload: JSON.stringify(payload),
+      payload: payload.toString(),
+      isSuccessful: response.isSuccessful,
+      responseCode: response.code,
     });
 
-    return poleEmploiNotifier.notify(user.id, payload.toString(), poleEmploiSending);
+    return poleEmploiSendingRepository.create({ poleEmploiSending });
   }
 }
 

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   competenceRepository: require('../../infrastructure/repositories/competence-repository'),
   knowledgeElementRepository: require('../../infrastructure/repositories/knowledge-element-repository'),
   organizationRepository: require('../../infrastructure/repositories/organization-repository'),
+  poleEmploiSendingRepository: require('../../infrastructure/repositories/pole-emploi-sending-repository'),
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),

--- a/api/lib/domain/models/PoleEmploiSending.js
+++ b/api/lib/domain/models/PoleEmploiSending.js
@@ -9,22 +9,59 @@ class PoleEmploiSending {
     campaignParticipationId,
     type,
     payload,
+    isSuccessful,
+    responseCode,
   }) {
     this.campaignParticipationId = campaignParticipationId;
     this.type = type;
-    this.isSuccessful = undefined;
-    this.responseCode = undefined;
+    this.isSuccessful = isSuccessful;
+    this.responseCode = responseCode;
     this.payload = payload;
   }
 
-  succeed(responseCode) {
-    this.isSuccessful = true;
-    this.responseCode = responseCode;
+  static buildForParticipationStarted({
+    campaignParticipationId,
+    payload,
+    isSuccessful,
+    responseCode,
+  }) {
+    return new PoleEmploiSending({
+      campaignParticipationId,
+      type: TYPES.CAMPAIGN_PARTICIPATION_START,
+      payload,
+      isSuccessful,
+      responseCode,
+    });
   }
 
-  fail(responseCode) {
-    this.isSuccessful = false;
-    this.responseCode = responseCode;
+  static buildForParticipationFinished({
+    campaignParticipationId,
+    payload,
+    isSuccessful,
+    responseCode,
+  }) {
+    return new PoleEmploiSending({
+      campaignParticipationId,
+      type: TYPES.CAMPAIGN_PARTICIPATION_COMPLETION,
+      payload,
+      isSuccessful,
+      responseCode,
+    });
+  }
+
+  static buildForParticipationShared({
+    campaignParticipationId,
+    payload,
+    isSuccessful,
+    responseCode,
+  }) {
+    return new PoleEmploiSending({
+      campaignParticipationId,
+      type: TYPES.CAMPAIGN_PARTICIPATION_SHARING,
+      payload,
+      isSuccessful,
+      responseCode,
+    });
   }
 }
 

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,21 +1,30 @@
 const axios = require('axios');
 
+class HttpResponse {
+  constructor({
+    code,
+    isSuccessful,
+  }) {
+    this.code = code;
+    this.isSuccessful = isSuccessful;
+  }
+}
+
 module.exports = {
   async post(url, payload, headers) {
-    const response = {
-      isSuccessful: false,
-      code: null,
-    };
     try {
       const httpResponse = await axios.post(url, payload, {
         headers,
       });
-      response.isSuccessful = true;
-      response.code = httpResponse.status;
+      return new HttpResponse({
+        code: httpResponse.status,
+        isSuccessful: true,
+      });
     } catch (httpErr) {
-      response.code = httpErr.response.status;
+      return new HttpResponse({
+        code: httpErr.response.status,
+        isSuccessful: false,
+      });
     }
-
-    return response;
   },
 };

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -15,7 +15,6 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation().id;
       await databaseBuilder.commit();
       const poleEmploiSending = domainBuilder.buildPoleEmploiSending({ campaignParticipationId });
-      poleEmploiSending.succeed('200');
 
       // when
       await poleEmploiSendingRepository.create({ poleEmploiSending });

--- a/api/tests/tooling/domain-builder/factory/build-pole-emploi-sending.js
+++ b/api/tests/tooling/domain-builder/factory/build-pole-emploi-sending.js
@@ -6,6 +6,9 @@ const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSendi
 const buildPoleEmploiSending = function({
   type = PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING,
   campaignParticipationId,
+  isSuccessful = true,
+  responseCode = '200',
+  payload = null,
   createdAt = faker.date.past(),
 } = {}) {
 
@@ -14,7 +17,9 @@ const buildPoleEmploiSending = function({
   return new PoleEmploiSending({
     campaignParticipationId,
     type,
-    payload: null,
+    isSuccessful,
+    responseCode,
+    payload,
     createdAt,
   });
 };

--- a/api/tests/unit/domain/models/PoleEmploiSending_test.js
+++ b/api/tests/unit/domain/models/PoleEmploiSending_test.js
@@ -1,54 +1,87 @@
+const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSending');
 const { expect, domainBuilder } = require('../../../test-helper');
 
 describe('Unit | Domain | Models | PoleEmploiSending', () => {
+  let expectedPoleEmploiSending;
 
-  describe('#succeed', () => {
-    it('should set isSuccessful to true', () => {
-      // given
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-
-      // when
-      poleEmploiSending.succeed();
-
-      // then
-      expect(poleEmploiSending.isSuccessful).to.equal(true);
+  describe('buildForParticipationStarted', () => {
+    beforeEach(() => {
+      expectedPoleEmploiSending = domainBuilder.buildPoleEmploiSending({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_START, payload: {} });
     });
 
-    it('should set responseCode', () => {
-      // given
-      const responseCode = '200';
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-
+    it('should build a PoleEmploiSending', () => {
       // when
-      poleEmploiSending.succeed(responseCode);
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({});
 
       // then
-      expect(poleEmploiSending.responseCode).to.equal(responseCode);
+      expect(poleEmploiSending).to.be.instanceOf(PoleEmploiSending);
+    });
+
+    it('should build PoleEmploiSending with type CAMPAIGN_PARTICIPATION_START and given arguments', () => {
+      // when
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationStarted({
+        campaignParticipationId: expectedPoleEmploiSending.campaignParticipationId,
+        payload: {},
+        isSuccessful: expectedPoleEmploiSending.isSuccessful,
+        responseCode: expectedPoleEmploiSending.responseCode,
+      });
+
+      // then
+      expect(poleEmploiSending).to.deep.equal(expectedPoleEmploiSending);
     });
   });
 
-  describe('#fail', () => {
-    it('should set isSuccessful to false', () => {
-      // given
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-
-      // when
-      poleEmploiSending.fail();
-
-      // then
-      expect(poleEmploiSending.isSuccessful).to.equal(false);
+  describe('buildForParticipationFinished', () => {
+    beforeEach(() => {
+      expectedPoleEmploiSending = domainBuilder.buildPoleEmploiSending({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_COMPLETION, payload: {} });
     });
 
-    it('should set responseCode', () => {
-      // given
-      const responseCode = '400';
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-
+    it('should build a PoleEmploiSending', () => {
       // when
-      poleEmploiSending.fail(responseCode);
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({});
 
       // then
-      expect(poleEmploiSending.responseCode).to.equal(responseCode);
+      expect(poleEmploiSending).to.be.instanceOf(PoleEmploiSending);
+    });
+
+    it('should build PoleEmploiSending with type CAMPAIGN_PARTICIPATION_COMPLETION and given arguments', () => {
+      // when
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({
+        campaignParticipationId: expectedPoleEmploiSending.campaignParticipationId,
+        payload: {},
+        isSuccessful: expectedPoleEmploiSending.isSuccessful,
+        responseCode: expectedPoleEmploiSending.responseCode,
+      });
+
+      // then
+      expect(poleEmploiSending).to.deep.equal(expectedPoleEmploiSending);
+    });
+  });
+
+  describe('buildForParticipationShared', () => {
+    beforeEach(() => {
+      expectedPoleEmploiSending = domainBuilder.buildPoleEmploiSending({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING, payload: {} });
+    });
+
+    it('should build a PoleEmploiSending', () => {
+      // when
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({});
+
+      // then
+      expect(poleEmploiSending).to.be.instanceOf(PoleEmploiSending);
+    });
+
+    it('should build PoleEmploiSending with type CAMPAIGN_PARTICIPATION_SHARING and given arguments', () => {
+      // when
+      const poleEmploiSending = PoleEmploiSending.buildForParticipationShared({
+        campaignParticipationId: expectedPoleEmploiSending.campaignParticipationId,
+        payload: {},
+        isSuccessful: expectedPoleEmploiSending.isSuccessful,
+        responseCode: expectedPoleEmploiSending.responseCode,
+      });
+
+      // then
+      expect(poleEmploiSending).to.deep.equal(expectedPoleEmploiSending);
     });
   });
 });

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -2,7 +2,6 @@ const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-hel
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
-const poleEmploiSendingRepository = require('../../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const settings = require('../../../../../lib/config');
 const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
@@ -15,14 +14,12 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     beforeEach(() => {
       sinon.stub(httpAgent, 'post');
       sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
-      sinon.stub(poleEmploiSendingRepository, 'create');
     });
 
     afterEach(() => {
       settings.poleEmploi.sendingUrl = originPoleEmploiSendingUrl;
       httpAgent.post.restore();
       authenticationMethodRepository.findOneByUserIdAndIdentityProvider.restore();
-      poleEmploiSendingRepository.create.restore();
     });
 
     it('should throw an error if the user is not known as PoleEmploi user', async () => {
@@ -65,72 +62,6 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         'Content-type': 'application/json',
         'Accept': 'application/json',
         'Service-source': 'Pix',
-      });
-    });
-
-    it('it should record the sending', async () => {
-      // given
-      const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
-      settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
-      const userId = 123;
-      const payload = 'somePayload';
-      const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
-      const code = 'someCode';
-      const successState = 'someState';
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-      authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
-      httpAgent.post.resolves({ isSuccessful: successState, code });
-
-      // when
-      await notify(userId, payload, poleEmploiSending);
-
-      // then
-      expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
-    });
-
-    context('when sending succeeds', () => {
-
-      it('it should record that the sending has succeeded', async () => {
-        // given
-        const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
-        settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
-        const userId = 123;
-        const payload = 'somePayload';
-        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
-        const code = 'someCode';
-        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
-        httpAgent.post.resolves({ isSuccessful: true, code });
-        sinon.stub(poleEmploiSending, 'succeed');
-
-        // when
-        await notify(userId, payload, poleEmploiSending);
-
-        // then
-        expect(poleEmploiSending.succeed).to.have.been.calledWithExactly(code);
-      });
-    });
-
-    context('when sending fails', () => {
-
-      it('it should record that the sending has failed', async () => {
-        // given
-        const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
-        settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
-        const userId = 123;
-        const payload = 'somePayload';
-        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
-        const code = 'someCode';
-        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-        authenticationMethodRepository.findOneByUserIdAndIdentityProvider.resolves(authenticationMethod);
-        httpAgent.post.resolves({ isSuccessful: false, code });
-        sinon.stub(poleEmploiSending, 'fail');
-
-        // when
-        await notify(userId, payload, poleEmploiSending);
-
-        // then
-        expect(poleEmploiSending.fail).to.have.been.calledWithExactly(code);
       });
     });
   });


### PR DESCRIPTION
🦄 Problème
Actuellement on console logguait encore les résultats à la fin du parcours de Pôle Emploi.

🤖 Solution
Faire le véritable envoi et stocker le code réponse en base.

🌈 Remarques
Identique à ce qui a été fait sur le partage des résultats.

💯 Pour tester
Passer une campagne pôle emploi (QWERTY789) en étant connecté en tant qu'utilisateur Pôle Emploi (credentials disponibles sur confluence) et vérifier en base le bon enregistrement de la réussite ou de l'échec de l'envoi.