### PR TITLE
[TECH] Utilise docker et docker-compose aussi pour les applications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:14
+
+# To run chrome headless with no-sandbox.
+ENV CI 1
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg --install google-chrome-stable_current_amd64.deb; apt-get update --yes && apt --fix-broken --yes install

--- a/api/sample.env
+++ b/api/sample.env
@@ -29,7 +29,7 @@
 # presence: optionnal
 # type: Url
 # default: none
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://redis:6379
 
 # =========
 # DATABASES
@@ -43,7 +43,7 @@ REDIS_URL=redis://localhost:6379
 # presence: required
 # type: Url
 # default: none
-DATABASE_URL=postgresql://postgres@localhost/pix
+DATABASE_URL=postgresql://postgres@postgres/pix
 
 # URL of the PostgreSQL databse used for API local testing.
 #
@@ -52,7 +52,7 @@ DATABASE_URL=postgresql://postgres@localhost/pix
 # presence: required
 # type: Url
 # default: none
-TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
+TEST_DATABASE_URL=postgresql://postgres@postgres/pix_test
 
 # ========
 # EMAILING

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,23 @@ version: '3'
 services:
   postgres:
     image: postgres:12.4-alpine
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_DB: pix
       POSTGRES_HOST_AUTH_METHOD: trust
 
   redis:
     image: redis:5.0.7-alpine
+
+  web:
+    build:
+      context: .
+    command: npx run-p start:api start:mon-pix start:admin
+    volumes:
+      - .:/code
+    working_dir: /code
     ports:
-      - "6379:6379"
+      - "4200:4200"
+      - "4202:4202"
+    depends_on:
+      - redis
+      - postgres


### PR DESCRIPTION
## :unicorn: Problème

J'aime bien ne pas avoir node ou npm installé sur ma machine et que chaque projet tourne exclusivement sous docker. Cela permet de bien isoler et d'avoir toujours la même procédure pour démarrer.

## :robot: Solution

J'ai ajouté un nouveau container `web` qui fait tourner node. 

## :rainbow: Remarques

Cela m'a permis de ne plus exposer les ports de postgres et redis en développement. Si il y a des outils qui utilisent ces ports externes on peut les remettre.

## :100: Pour tester

Si vous avez déjà un environnement configuré, un `docker-compose up -d` devrait faire l'affaire. Comme auparavant, l'application est disponible sur http://localhost:4200/

## :wrench: TODO

- [x] Mettre à jour le script de configuration initial