### PR TITLE
[TECH] Ajouter le lien Github de la PR dans le commentaire des liens RA (PIX-1752).

### DIFF
--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -29,6 +29,7 @@ async function main() {
   const raCertifURL = `https://certif-pr${prNumber}.review.pix.fr`;
   const raAdminURL = `https://admin-pr${prNumber}.review.pix.fr`;
   const raAPIURL = `https://api-pr${prNumber}.review.pix.fr/api/`;
+  const prGithubURL = `https://github.com/1024pix/pix/pull/${prNumber}`;
 
   const scalingoCommentRegex = new RegExp(raAppURL, 'i');
 
@@ -57,7 +58,9 @@ async function main() {
       `- Orga : ${raOrgaURL}\n` +
       `- Certif : ${raCertifURL}\n` +
       `- Admin : ${raAdminURL}\n` +
-      `- API (Postman) : ${raAPIURL}`;
+      `- API : ${raAPIURL}\n\n` +
+
+    `Le lien Github de la PR : ${prGithubURL}`;
 
     console.log(`Posting Review apps urls for PR number: ${prNumber} to JIRA issue: ${issueCode}`);
 


### PR DESCRIPTION
## :unicorn: Problème
Il n'y a pas de moyen d'accéder au lien Github de la PR directement via le ticket sur JIRA.

## :robot: Solution
Enrichir le fichier existant donnant accès aux différents liens des RA, en ajoutant le lien Github de la PR.

Ainsi nous pourrons accéder à la PR directement via le commentaire qui est généré dans le ticket lorsque la PR est créée.

## :rainbow: Remarques

## :100: Pour tester
<img width="578" alt="Capture d’écran 2020-12-08 à 10 43 59" src="https://user-images.githubusercontent.com/58915422/101467276-629ccc80-3942-11eb-8853-12159eaedb31.png">
