### PR TITLE
[TECH] Suppression du feature toggle pour améliorer une compétence (PIX-760).

### DIFF
--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import config from 'mon-pix/config/environment';
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 
 export default class CompetenceCardDefault extends Component {
@@ -9,10 +8,6 @@ export default class CompetenceCardDefault extends Component {
   @service store;
   @service router;
   @service competenceEvaluation;
-
-  get displayImproveButton() {
-    return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
-  }
 
   get displayedLevel() {
     if (this.args.scorecard.isNotStarted) {

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -3,7 +3,6 @@ import Component from '@glimmer/component';
 import EmberObject, { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { A as EmberArray } from '@ember/array';
-import config from 'mon-pix/config/environment';
 import buttonStatusTypes from 'mon-pix/utils/button-status-types';
 
 export default class ScorecardDetails extends Component {
@@ -32,10 +31,6 @@ export default class ScorecardDetails extends Component {
 
   get displayResetButton() {
     return this.args.scorecard.remainingDaysBeforeReset === 0;
-  }
-
-  get displayImproveButton() {
-    return config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
   }
 
   get shouldWaitBeforeImproving() {

--- a/mon-pix/app/templates/components/competence-card-default.hbs
+++ b/mon-pix/app/templates/components/competence-card-default.hbs
@@ -36,20 +36,18 @@
   {{else}}
     <div class="competence-card__interactions">
       {{#if @scorecard.isFinished}}
-        {{#if this.displayImproveButton}}
-          {{#if this.shouldWaitBeforeImproving}}
-            <div class="competence-card-interactions__improvement-countdown">
-              <span class="competence-card-improvement-countdown__label">{{t 'pages.competence-details.actions.improve.description.waiting-text'}}</span>
-              <span class="competence-card-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown' daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
-            </div>
-          {{else}}
-            <PixButton class="button button--extra-thin button--round button--link button--green competence-card__button"
-              @action={{action "improveCompetenceEvaluation"}} @loading-color="white">
-              <span class="competence-card-button__label">{{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</span>
-              </span>
-              <span class="competence-card-button__arrow"><FaIcon @icon='long-arrow-alt-right'></FaIcon></span>
-            </PixButton>
-          {{/if}}
+        {{#if this.shouldWaitBeforeImproving}}
+          <div class="competence-card-interactions__improvement-countdown">
+            <span class="competence-card-improvement-countdown__label">{{t 'pages.competence-details.actions.improve.description.waiting-text'}}</span>
+            <span class="competence-card-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown' daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
+          </div>
+        {{else}}
+          <PixButton class="button button--extra-thin button--round button--link button--green competence-card__button"
+            @action={{action "improveCompetenceEvaluation"}} @loading-color="white">
+            <span class="competence-card-button__label">{{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</span>
+            </span>
+            <span class="competence-card-button__arrow"><FaIcon @icon='long-arrow-alt-right'></FaIcon></span>
+          </PixButton>
         {{/if}}
       {{else}}
         <LinkTo @route="competences.resume" @model={{@scorecard.competenceId}} class="button button--extra-thin button--round button--link button--green competence-card__button">

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -54,21 +54,19 @@
       {{/if}}
 
       {{#if @scorecard.isFinished}}
-        {{#if this.displayImproveButton}}
-          {{#if this.canImprove}}
-            {{#if this.shouldWaitBeforeImproving}}
-              <div class="scorecard-details__improvement-countdown">
-                <span class="scorecard-details-improvement-countdown__label">{{t 'pages.competence-details.actions.improve.description.waiting-text'}}</span>
-                <span class="scorecard-details-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown'
-                                                                                 daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
-              </div>
-            {{else}}
-              <PixButton class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button"
-                @action={{action "improveCompetenceEvaluation"}} @loading-color="white">
-                  {{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}</span>
-              </PixButton>
-              <span class="scorecard-details__improving-text">{{t 'pages.competence-details.actions.improve.improvingText' }}</span>
-            {{/if}}
+        {{#if this.canImprove}}
+          {{#if this.shouldWaitBeforeImproving}}
+            <div class="scorecard-details__improvement-countdown">
+              <span class="scorecard-details-improvement-countdown__label">{{t 'pages.competence-details.actions.improve.description.waiting-text'}}</span>
+              <span class="scorecard-details-improvement-countdown__count">{{t 'pages.competence-details.actions.improve.description.countdown'
+                                                                               daysBeforeImproving=@scorecard.remainingDaysBeforeImproving}}</span>
+            </div>
+          {{else}}
+            <PixButton class="button button--big button--thin button--round button--link button--green scorecard-details__improve-button"
+              @action={{action "improveCompetenceEvaluation"}} @loading-color="white">
+                {{t 'pages.competence-details.actions.improve.label'}}<span class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name }}</span>
+            </PixButton>
+            <span class="scorecard-details__improving-text">{{t 'pages.competence-details.actions.improve.improvingText' }}</span>
           {{/if}}
         {{/if}}
       {{else}}

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -57,7 +57,6 @@ module.exports = function(environment) {
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
-      FT_IMPROVE_COMPETENCE_EVALUATION: process.env.FT_IMPROVE_COMPETENCE_EVALUATION || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
 
@@ -148,7 +147,6 @@ module.exports = function(environment) {
       ENV.matomo.url = process.env.WEB_ANALYTICS_URL;
       ENV.matomo.debug = true;
     }
-    ENV.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
 
     ENV.APP.IS_POLE_EMPLOI_ENABLED = true;
     ENV['ember-simple-auth-oidc'].host = 'https://authentification-candidat.pole-emploi.fr',

--- a/mon-pix/tests/acceptance/competences-details-test.js
+++ b/mon-pix/tests/acceptance/competences-details-test.js
@@ -5,7 +5,6 @@ import { authenticateByEmail } from '../helpers/authentication';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
-import config from 'mon-pix/config/environment';
 
 describe('Acceptance | Competence details | Afficher la page de détails d\'une compétence', () => {
   setupApplicationTest();
@@ -185,20 +184,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
       });
 
       context('when it has remaining some days before improving', () => {
-        let configurationForImprovingCompetence;
-
-        before(() => {
-          configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
-        });
-
-        after(function() {
-          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
-        });
-
         it('should display remaining days before improving', async () => {
-          // given
-          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
-
           // when
           await visit(`/competences/${scorecardWithRemainingDaysBeforeImproving.competenceId}/details`);
 
@@ -210,20 +196,7 @@ describe('Acceptance | Competence details | Afficher la page de détails d\'une
       });
 
       context('when it has no remaining days before improving', () => {
-        let configurationForImprovingCompetence;
-
-        before(() => {
-          configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
-        });
-
-        after(function() {
-          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
-        });
-
         it('should display improving button', async () => {
-          // given
-          config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
-
           // when
           await visit(`/competences/${scorecardWithoutRemainingDaysBeforeImproving.competenceId}/details`);
 

--- a/mon-pix/tests/integration/components/competence-card-default-test.js
+++ b/mon-pix/tests/integration/components/competence-card-default-test.js
@@ -4,7 +4,6 @@ import  EmberObject  from '@ember/object';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import config from 'mon-pix/config/environment';
 
 describe('Integration | Component | competence-card-default', function() {
   setupIntlRenderingTest();
@@ -134,28 +133,10 @@ describe('Integration | Component | competence-card-default', function() {
     });
 
     context('when user has finished the competence', async function() {
-      const configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
-      afterEach(function() {
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
-      });
-
-      it('should not show the button to start or to continue', async function() {
-        // given
-        const scorecard = { area, level: 3, isFinished: true, isStarted: false };
-        this.set('scorecard', scorecard);
-
-        // when
-        await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
-
-        // then
-        expect(find('.competence-card-button__label')).to.be.null;
-      });
-
       it('should show the improving button when there is no remaining days before improving', async function() {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 0 };
         this.set('scorecard', scorecard);
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
 
         // when
         await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);
@@ -169,7 +150,6 @@ describe('Integration | Component | competence-card-default', function() {
         // given
         const scorecard = { area, level: 3, isFinished: true, isStarted: false, remainingDaysBeforeImproving: 3 };
         this.set('scorecard', scorecard);
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
 
         // when
         await render(hbs`<CompetenceCardDefault @scorecard={{this.scorecard}} />`);

--- a/mon-pix/tests/integration/components/scorecard-details-test.js
+++ b/mon-pix/tests/integration/components/scorecard-details-test.js
@@ -4,7 +4,6 @@ import { A } from '@ember/array';
 import EmberObject from '@ember/object';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import config from '../../../config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
 describe('Integration | Component | scorecard-details', function() {
@@ -100,15 +99,9 @@ describe('Integration | Component | scorecard-details', function() {
 
     context('When the user has finished a competence', async function() {
       let scorecard;
-      const configurationForImprovingCompetence = config.APP.FT_IMPROVE_COMPETENCE_EVALUATION;
-
-      afterEach(function() {
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = configurationForImprovingCompetence;
-      });
 
       beforeEach(function() {
         // given
-        config.APP.FT_IMPROVE_COMPETENCE_EVALUATION = true;
         scorecard = {
           remainingPixToNextLevel: 1,
           isFinished: true,


### PR DESCRIPTION
## :unicorn: Problème

Le feature toggle n'est plus utile la fonctionnalité étant désirée et fonctionnelle.

## :robot: Solution

Suppression du feature toggle.

## :rainbow: Remarques

Variable d'environnement à supprimer `FT_IMPROVE_COMPETENCE_EVALUATION` une fois en production

## :100: Pour tester

Sur la review app, mettre `FT_IMPROVE_COMPETENCE_EVALUATION` à false. Le bouton pour améliorer 
sa compétence doit toujours être présent.