### PR TITLE
[TECH] Lance le lint des fichiers js sur mon-pix sur la CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,11 +129,8 @@ jobs:
           paths:
             - ~/.npm
       - run:
-          name: Lint templates
-          command: npm run lint:hbs
-      - run:
-          name: Lint style sheets
-          command: npm run lint:scss
+          name: Lint
+          command: npm run lint
       - run:
          name: Test
          command: |


### PR DESCRIPTION
## :unicorn: Problème

Sur la CI, le lint était fait automatiquement pour les templates et les feuilles de styles

## :robot: Solution

Lancer la tache `lint` qui lance le lint sur les templates, les feuilles de styles et les fichiers javascript.

## :rainbow: Remarques

:popcorn:

## :100: Pour tester

Si la CI passe, ca passe bien.
