### PR TITLE
[TECH] Corrige l'intégration Jira au merge (PIX-1753)

### DIFF
--- a/.github/workflows/on-dev-merge.yml
+++ b/.github/workflows/on-dev-merge.yml
@@ -29,4 +29,4 @@ jobs:
       if: ${{ steps.find.outputs.issue }}
       with:
         issue: ${{ steps.find.outputs.issue }}
-        transition: "Move to 'Deployed in Staging'"
+        transition: "Move to 'Deployed in Integration'"


### PR DESCRIPTION
## :unicorn: Problème

L'action GitHub pour déplacer un ticket de "Review" a "Deployed in Integration" ne fonctionne pas actuellement.

## :robot: Solution

La colonne était nommée auparavant "Deployed in Staging", mais est nommée "Deployed in Integration" maintenant, mais le changement n'a pas été fait dans l'action.

## :rainbow: Remarques

Nous avons crée un ticket pour tester que cela fonctionnera une fois cette PR mergé. Pas d'autres tests héla.

## :100: Pour tester

Vous mergez cette belle PR, et c'est sur ça marche ®.
