### PR TITLE
[BUGFIX] Désactivation de la fonctionnalité dashboard par défaut (PIX-1759).

### DIFF
--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -57,7 +57,7 @@ module.exports = function(environment) {
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
-      FT_DASHBOARD: _isFeatureEnabled(process.env.FT_DASHBOARD) || true,
+      FT_DASHBOARD: _isFeatureEnabled(process.env.FT_DASHBOARD) || false,
       FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,
 


### PR DESCRIPTION
## :unicorn: Problème

La variable d'environnement FT_DASHBOARD est initialisée à true impliquant des problèmes en recette.

## :robot: Solution

Désactivation de la variable d'environnement par défaut.

## :100: Pour tester

Aller sur la RA et vérifier l'absence du lien vers "Accueil"
Set la variable FT_DASHBOARD à true sur la RA et retourner sur la RA pour vérifier de la présence du lien vers "Accueil" dans la navbar et de la page associée au clic.