### PR TITLE
[FEATURE] Permettre la connexion à Pole Emploi pour un utilisateur connecté à Pix (PIX-1736).

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -55,10 +55,10 @@ module.exports = {
     if (!featureToggles.isPoleEmploiEnabled) {
       throw new BadRequestError('This feature is not enable!');
     }
-    const userId = get(request.auth, 'credentials.userId');
+    const authenticatedUserId = get(request.auth, 'credentials.userId');
     const { code, 'client_id': clientId, 'redirect_uri': redirectUri } = request.payload;
 
-    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri, userId });
+    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri, authenticatedUserId });
 
     return h.response(response).code(200);
   },

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -4,6 +4,8 @@ const { BadRequestError } = require('../http-errors');
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
 
+const get = require('lodash/get');
+
 module.exports = {
 
   /**
@@ -53,10 +55,10 @@ module.exports = {
     if (!featureToggles.isPoleEmploiEnabled) {
       throw new BadRequestError('This feature is not enable!');
     }
-
+    const userId = get(request.auth, 'credentials.userId');
     const { code, 'client_id': clientId, 'redirect_uri': redirectUri } = request.payload;
 
-    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri });
+    const response = await usecases.authenticatePoleEmploiUser({ code, clientId, redirectUri, userId });
 
     return h.response(response).code(200);
   },

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -76,7 +76,7 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/pole-emploi/token',
       config: {
-        auth: false,
+        auth: { mode: 'optional' },
         payload: {
           allow: 'application/x-www-form-urlencoded',
         },

--- a/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
+++ b/api/lib/application/schooling-registration-dependent-users/schooling-registration-dependent-user-controller.js
@@ -31,7 +31,7 @@ module.exports = {
 
     const createdUser = await usecases.createUserAndReconcileToSchoolingRegistrationFromExternalUser({ campaignCode, token, birthdate });
 
-    const accessToken = tokenService.createAccessTokenFromUser(createdUser, 'external');
+    const accessToken = tokenService.createAccessTokenFromUser(createdUser.id, 'external');
 
     const response = {
       data: {

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -7,6 +7,7 @@ const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase  = require('./u
 const checkUserBelongsToOrganizationUseCase  = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization  = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
 const Organization = require('../../lib/domain/models/Organization');
+const boom = require('boom');
 
 const JSONAPIError = require('jsonapi-serializer').Error;
 const _ = require('lodash');
@@ -40,6 +41,10 @@ function _replyWithAuthorizationError(h) {
 }
 
 function checkUserIsAuthenticated(request, h) {
+
+  if (request.auth.mode === 'optional' && !request.headers.authorization) {
+    return boom.unauthorized(null, 'jwt-access-token');
+  }
 
   const authorizationHeader = request.headers.authorization;
   const accessToken = tokenService.extractTokenFromAuthChain(authorizationHeader);

--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -11,7 +11,7 @@ async function getUserByUsernameAndPassword({ username, password, userRepository
   return foundUser;
 }
 
-async function generateAccessToken({ code, clientId, redirectUri }) {
+async function generatePoleEmploiTokens({ code, clientId, redirectUri }) {
   const data = {
     client_secret: settings.poleEmploi.clientSecret,
     grant_type: 'authorization_code',
@@ -48,7 +48,7 @@ async function getPoleEmploiUserInfo(idToken) {
 }
 
 module.exports = {
-  generateAccessToken,
+  generatePoleEmploiTokens,
   getPoleEmploiUserInfo,
   getUserByUsernameAndPassword,
 };

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -2,9 +2,9 @@ const jsonwebtoken = require('jsonwebtoken');
 const { InvalidTemporaryKeyError, InvalidExternalUserTokenError } = require('../../domain/errors');
 const settings = require('../../config');
 
-function createAccessTokenFromUser(user, source) {
+function createAccessTokenFromUser(userId, source) {
   return jsonwebtoken.sign({
-    user_id: user.id,
+    user_id: userId,
     source,
   }, settings.authentication.secret, { expiresIn: settings.authentication.tokenLifespan });
 }

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -14,7 +14,7 @@ module.exports = async function authenticatePoleEmploiUser({
 }) {
 
   try {
-    const poleEmploiTokens = await authenticationService.generateAccessToken({ code, clientId, redirectUri });
+    const poleEmploiTokens = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
 
     const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -18,13 +18,6 @@ module.exports = async function authenticatePoleEmploiUser({
 
     const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 
-    const user = new User({
-      firstName: userInfo.firstName,
-      lastName: userInfo.lastName,
-      password: '',
-      cgu: false,
-    });
-
     const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
       accessToken: poleEmploiTokens.accessToken,
       refreshToken: poleEmploiTokens.refreshToken,
@@ -33,6 +26,14 @@ module.exports = async function authenticatePoleEmploiUser({
 
     let foundUser = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
     if (!foundUser) {
+
+      const user = new User({
+        firstName: userInfo.firstName,
+        lastName: userInfo.lastName,
+        password: '',
+        cgu: false,
+      });
+
       await DomainTransaction.execute(async (domainTransaction) => {
         foundUser = await userRepository.create(user, domainTransaction);
         const authenticationMethod = new AuthenticationMethod({

--- a/api/lib/domain/usecases/authenticate-pole-emploi-user.js
+++ b/api/lib/domain/usecases/authenticate-pole-emploi-user.js
@@ -1,5 +1,6 @@
 const User = require('../models/User');
 const AuthenticationMethod = require('../models/AuthenticationMethod');
+const { UnexpectedUserAccount } = require('../errors');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
 const moment = require('moment');
 
@@ -14,70 +15,69 @@ module.exports = async function authenticatePoleEmploiUser({
   authenticationMethodRepository,
 }) {
 
-  try {
-    const poleEmploiTokens = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
+  const poleEmploiTokens = await authenticationService.generatePoleEmploiTokens({ code, clientId, redirectUri });
 
-    const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
+  const userInfo = await authenticationService.getPoleEmploiUserInfo(poleEmploiTokens.idToken);
 
-    const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
-      accessToken: poleEmploiTokens.accessToken,
-      refreshToken: poleEmploiTokens.refreshToken,
-      expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
-    });
+  const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+    accessToken: poleEmploiTokens.accessToken,
+    refreshToken: poleEmploiTokens.refreshToken,
+    expiredDate: moment().add(poleEmploiTokens.expiresIn, 's').toDate(),
+  });
 
-    let accessToken;
+  let accessToken;
 
-    if (authenticatedUserId) {
-      const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId: authenticatedUserId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI });
+  if (authenticatedUserId) {
+    const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId: authenticatedUserId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI });
 
-      if (authenticationMethod) {
+    if (authenticationMethod) {
 
-        await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: authenticatedUserId });
-
-      } else {
-
-        const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: authenticatedUserId });
-        await authenticationMethodRepository.create({ authenticationMethod });
+      if (authenticationMethod.externalIdentifier !== userInfo.externalIdentityId) {
+        throw new UnexpectedUserAccount({ message: 'Le compte Pix connecté n\'est pas celui qui est attendu.' });
       }
+      await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: authenticatedUserId });
 
-      accessToken = tokenService.createAccessTokenFromUser(authenticatedUserId, 'pole_emploi_connect');
     } else {
 
-      const user = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
-
-      if (!user) {
-
-        const user = new User({
-          firstName: userInfo.firstName,
-          lastName: userInfo.lastName,
-          password: '',
-          cgu: false,
-        });
-
-        let createdUserId;
-        await DomainTransaction.execute(async (domainTransaction) => {
-          createdUserId = (await userRepository.create(user, domainTransaction)).id;
-
-          const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: createdUserId });
-          await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
-        });
-
-        accessToken = tokenService.createAccessTokenFromUser(createdUserId, 'pole_emploi_connect');
-      } else {
-
-        await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: user.id });
-        accessToken = tokenService.createAccessTokenFromUser(user.id, 'pole_emploi_connect');
-
-      }
+      const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: authenticatedUserId });
+      await authenticationMethodRepository.create({ authenticationMethod });
     }
 
-    return {
-      access_token: accessToken,
-      id_token: poleEmploiTokens.idToken,
-    };
-  } catch (error) {
-    console.log(error);
+    accessToken = tokenService.createAccessTokenFromUser(authenticatedUserId, 'pole_emploi_connect');
+  } else {
+
+    const user = await userRepository.findByPoleEmploiExternalIdentifier(userInfo.externalIdentityId);
+
+    if (!user) {
+
+      const user = new User({
+        firstName: userInfo.firstName,
+        lastName: userInfo.lastName,
+        password: '',
+        cgu: false,
+      });
+
+      let createdUserId;
+      await DomainTransaction.execute(async (domainTransaction) => {
+        createdUserId = (await userRepository.create(user, domainTransaction)).id;
+
+        const authenticationMethod = _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId: createdUserId });
+        await authenticationMethodRepository.create({ authenticationMethod, domainTransaction });
+      });
+
+      accessToken = tokenService.createAccessTokenFromUser(createdUserId, 'pole_emploi_connect');
+    } else {
+
+      await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId: user.id });
+      accessToken = tokenService.createAccessTokenFromUser(user.id, 'pole_emploi_connect');
+
+    }
   }
+
+  return {
+    access_token: accessToken,
+    id_token: poleEmploiTokens.idToken,
+  };
 };
 
 function _buildPoleEmploiAuthenticationMethod({ userInfo, authenticationComplement, userId }) {

--- a/api/lib/domain/usecases/authenticate-user.js
+++ b/api/lib/domain/usecases/authenticate-user.js
@@ -54,7 +54,7 @@ module.exports = async function authenticateUser({
     if (!foundUser.shouldChangePassword) {
       _checkUserAccessScope(scope, foundUser);
       await _checkScoUserAccessCertifScope({ scope, user: foundUser, certificationCenterMembershipRepository });
-      return tokenService.createAccessTokenFromUser(foundUser, source);
+      return tokenService.createAccessTokenFromUser(foundUser.id, source);
     } else {
       throw new UserShouldChangePasswordError();
     }

--- a/api/lib/domain/usecases/get-external-authentication-redirection-url.js
+++ b/api/lib/domain/usecases/get-external-authentication-redirection-url.js
@@ -15,7 +15,7 @@ module.exports = async function getExternalAuthenticationRedirectionUrl({
   const user = await userRepository.getBySamlId(externalUser.samlId);
 
   if (user) {
-    const token = tokenService.createAccessTokenFromUser(user, 'external');
+    const token = tokenService.createAccessTokenFromUser(user.id, 'external');
 
     return `/?token=${encodeURIComponent(token)}&user-id=${user.id}`;
   } else {

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -1,8 +1,12 @@
-const { expect, databaseBuilder, knex } = require('../../test-helper');
+const { expect, databaseBuilder, knex, sinon, nock } = require('../../test-helper');
 const querystring = require('querystring');
-
+const jsonwebtoken = require('jsonwebtoken');
+const settings = require('../../../lib/config');
 const createServer = require('../../../server');
 const tokenService = require('../../../lib/domain/services/token-service');
+const moment = require('moment');
+
+const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
 
 describe('Acceptance | Controller | authentication-controller', () => {
 
@@ -200,6 +204,153 @@ describe('Acceptance | Controller | authentication-controller', () => {
         expect(response.statusCode).to.equal(409);
         expect(response.result.errors[0].code).to.equal('UNEXPECTED_USER_ACCOUNT');
         expect(response.result.errors[0].detail).to.equal('Ce compte utilisateur n\'est pas celui qui est attendu.');
+      });
+    });
+  });
+
+  describe('POST /api/pole-emploi/token', () => {
+
+    let clock;
+    let options;
+    let getAccessTokenRequest;
+    let getAccessTokenResponse;
+    let idToken;
+
+    const firstName = 'John';
+    const lastName = 'Doe';
+    const externalIdentifier = 'idIdentiteExterne';
+
+    beforeEach(async () => {
+      sinon.stub(settings.featureToggles, 'isPoleEmploiEnabled').value(true);
+
+      clock = sinon.useFakeTimers({
+        now: Date.now(),
+        toFake: ['Date'],
+      });
+
+      const code = 'code';
+      const client_id = 'client_id';
+      const redirect_uri = 'redirect_uri';
+
+      options = {
+        method: 'POST',
+        url: '/api/pole-emploi/token',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        payload: querystring.stringify({
+          code,
+          client_id,
+          redirect_uri,
+        }),
+      };
+
+      idToken = jsonwebtoken.sign({
+        given_name: firstName,
+        family_name: lastName,
+        nonce: 'nonce',
+        idIdentiteExterne: externalIdentifier,
+      }, 'secret');
+
+      getAccessTokenResponse = {
+        access_token: 'access_token',
+        id_token: idToken,
+        expires_in: 60,
+        refresh_token: 'refresh_token',
+      };
+
+      getAccessTokenRequest = nock(settings.poleEmploi.tokenUrl)
+        .post('/')
+        .reply(200, getAccessTokenResponse);
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    context('When user does not exist', () => {
+
+      afterEach(async () => {
+        await knex('authentication-methods').delete();
+        await knex('users').delete();
+      });
+
+      it('should create a user with firstName and lastName contained in the pole emploi idToken', async () => {
+        // when
+        await server.inject(options);
+
+        // then
+        const users = await knex('users').where({ firstName, lastName });
+        expect(users[0]).to.exist;
+      });
+
+      it('should create a POLE_EMPLOI authentication method for the created user', async () => {
+        // when
+        await server.inject(options);
+
+        // then
+        const users = await knex('users').where({ firstName, lastName });
+        const authenticationMethods = await knex('authentication-methods').where({ userId: users[0].id });
+        expect(authenticationMethods[0].identityProvider).to.equal(AuthenticationMethod.identityProviders.POLE_EMPLOI);
+        expect(authenticationMethods[0].externalIdentifier).to.equal(externalIdentifier);
+        expect(authenticationMethods[0].authenticationComplement.accessToken).to.equal(getAccessTokenResponse['access_token']);
+        expect(authenticationMethods[0].authenticationComplement.expiredDate).to.equal(moment().add(getAccessTokenResponse['expires_in'], 's').toISOString());
+        expect(authenticationMethods[0].authenticationComplement.refreshToken).to.equal(getAccessTokenResponse['refresh_token']);
+      });
+
+      it('should return an 200 with access_token and id_token when authentication is ok', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(getAccessTokenRequest.isDone()).to.be.true;
+        expect(response.result['access_token']).to.exist;
+        expect(response.result['id_token']).to.equal(idToken);
+      });
+    });
+
+    context('When user and POLE EMPLOI authentication method exist', () => {
+
+      let userId;
+
+      beforeEach(async () => {
+        userId = databaseBuilder.factory.buildUser({
+          firstName,
+          lastName,
+        }).id;
+
+        databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+          externalIdentifier,
+          accessToken: 'old_access_token',
+          refreshToken: 'old_refresh_token',
+          expiresIn: 1000,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+      });
+
+      it('should update POLE_EMPLOI authentication method authentication complement', async () => {
+        // when
+        await server.inject(options);
+
+        // then
+        const authenticationMethods = await knex('authentication-methods').where({ userId });
+        expect(authenticationMethods[0].authenticationComplement.accessToken).to.equal(getAccessTokenResponse['access_token']);
+        expect(authenticationMethods[0].authenticationComplement.expiredDate).to.equal(moment().add(getAccessTokenResponse['expires_in'], 's').toISOString());
+        expect(authenticationMethods[0].authenticationComplement.refreshToken).to.equal(getAccessTokenResponse['refresh_token']);
+      });
+
+      it('should return an 200 with access_token and id_token when authentication is ok', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(getAccessTokenRequest.isDone()).to.be.true;
+        expect(response.result['access_token']).to.exist;
+        expect(response.result['id_token']).to.equal(idToken);
       });
     });
   });

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -22,7 +22,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     }));
     sinon.stub(authenticationController, 'authenticatePoleEmploiUser').callsFake((request, h) => h.response('ok').code(200));
 
-    httpTestServer = new HttpTestServer(moduleUnderTest);
+    httpTestServer = new HttpTestServer(moduleUnderTest, true);
   });
 
   describe('POST /api/token', () => {

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -29,10 +29,7 @@ afterEach(function() {
  * @returns string
  */
 function generateValidRequestAuthorizationHeader(userId = 1234) {
-  const user = {
-    id: userId,
-  };
-  const accessToken = tokenService.createAccessTokenFromUser(user, 'pix');
+  const accessToken = tokenService.createAccessTokenFromUser(userId, 'pix');
   return `Bearer ${accessToken}`;
 }
 

--- a/api/tests/tooling/server/http-test-server.js
+++ b/api/tests/tooling/server/http-test-server.js
@@ -1,6 +1,8 @@
 const Hapi = require('@hapi/hapi');
 const Inert = require('@hapi/inert');
 
+const security = require('../../../lib/infrastructure/security');
+
 const preResponseUtils = require('../../../lib/application/pre-response-utils');
 const { handleFailAction } = require('../../../lib/validate');
 
@@ -25,7 +27,7 @@ const routesConfig = {
  */
 class HttpTestServer {
 
-  constructor(moduleUnderTest) {
+  constructor(moduleUnderTest, enableAuthentication = false) {
     this.hapiServer = Hapi.server(routesConfig);
 
     this.hapiServer.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
@@ -34,6 +36,11 @@ class HttpTestServer {
       console.error(event.error);
     });
 
+    if (enableAuthentication) {
+      this.hapiServer.auth.scheme('jwt-access-token', security.scheme);
+      this.hapiServer.auth.strategy('default', 'jwt-access-token');
+      this.hapiServer.auth.default('default');
+    }
     this.hapiServer.register(Inert);
     this.hapiServer.register(moduleUnderTest);
   }

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -185,6 +185,7 @@ describe('Unit | Application | Controller | Authentication', () => {
         code,
         clientId: client_id,
         redirectUri: redirect_uri,
+        userId: undefined,
       };
 
       // when

--- a/api/tests/unit/application/authentication/authentication-controller_test.js
+++ b/api/tests/unit/application/authentication/authentication-controller_test.js
@@ -185,7 +185,7 @@ describe('Unit | Application | Controller | Authentication', () => {
         code,
         clientId: client_id,
         redirectUri: redirect_uri,
-        userId: undefined,
+        authenticatedUserId: undefined,
       };
 
       // when

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -22,7 +22,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
 
       const accessToken = 'valid.access.token';
       const authorizationHeader = `Bearer ${accessToken}`;
-      const request = { headers: { authorization: authorizationHeader } };
+      const request = { headers: { authorization: authorizationHeader }, auth: {} };
 
       beforeEach(() => {
         tokenService.extractTokenFromAuthChain.returns('valid.access.token');
@@ -45,7 +45,7 @@ describe('Unit | Application | SecurityPreHandlers', () => {
       let request;
 
       beforeEach(() => {
-        request = { headers: {} };
+        request = { headers: {}, auth: {} };
       });
 
       it('should disallow access to resource when access token is missing', async () => {
@@ -84,6 +84,16 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         // then
         expect(response.statusCode).to.equal(401);
         expect(response.isTakeOver).to.be.true;
+      });
+
+      it('should return an error object if auth mode is optional and there is no authorization header', async () => {
+        // given
+        request.auth.mode = 'optional';
+        request.headers.authorization = undefined;
+
+        const error = await securityPreHandlers.checkUserIsAuthenticated(request, hFake);
+
+        expect(error.output.statusCode).to.equal(401);
       });
     });
   });

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -91,7 +91,7 @@ describe('Unit | Domain | Services | authentication', () => {
     });
   });
 
-  describe('#generateAccessToken', () => {
+  describe('#generatePoleEmploiTokens', () => {
 
     it('should return access token, id token and validity period', async () => {
       // given
@@ -120,7 +120,7 @@ describe('Unit | Domain | Services | authentication', () => {
       sinon.stub(axios, 'post').resolves(response);
 
       // when
-      const result = await service.generateAccessToken({ code, clientId, redirectUri });
+      const result = await service.generatePoleEmploiTokens({ code, clientId, redirectUri });
 
       // then
       expect(result).to.deep.equal(expectedResult);

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -3,7 +3,6 @@ const jsonwebtoken = require('jsonwebtoken');
 
 const { catchErr, expect } = require('../../../test-helper');
 
-const User = require('../../../../lib/domain/models/User');
 const { InvalidTemporaryKeyError, InvalidExternalUserTokenError } = require('../../../../lib/domain/errors');
 const settings = require('../../../../lib/config');
 
@@ -71,8 +70,8 @@ describe('Unit | Domain | Service | Token Service', () => {
 
     it('should return userId if the accessToken is valid', () => {
       // given
-      const user = new User({ id: 123 });
-      const accessToken = tokenService.createAccessTokenFromUser(user, 'pix');
+      const userId = 123;
+      const accessToken = tokenService.createAccessTokenFromUser(userId, 'pix');
 
       // when
       const result = tokenService.extractUserId(accessToken);

--- a/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-pole-emploi-user_test.js
@@ -45,7 +45,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
     };
 
     authenticationService = {
-      generateAccessToken: sinon.stub().resolves({ accessToken, idToken, expiresIn, refreshToken }),
+      generatePoleEmploiTokens: sinon.stub().resolves({ accessToken, idToken, expiresIn, refreshToken }),
       getPoleEmploiUserInfo: sinon.stub().resolves(userInfo),
     };
 
@@ -78,7 +78,7 @@ describe('Unit | Application | Use Case | authenticate-pole-emploi-user', () => 
     });
 
     // then
-    expect(authenticationService.generateAccessToken).to.have.been.calledWith({ code, redirectUri, clientId });
+    expect(authenticationService.generatePoleEmploiTokens).to.have.been.calledWith({ code, redirectUri, clientId });
   });
 
   it('should call get pole emploi user info with id token parameter', async () => {

--- a/api/tests/unit/domain/usecases/authenticate-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-user_test.js
@@ -42,7 +42,7 @@ describe('Unit | Application | Use Case | authenticate-user', () => {
     expect(authenticationService.getUserByUsernameAndPassword).to.have.been.calledWithExactly({
       username: userEmail, password: userPassword, userRepository,
     });
-    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWithExactly(user, source);
+    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWithExactly(user.id, source);
   });
 
   it('should rejects an error when given username (email) does not match an existing one', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui,  seuls les utilisateurs non connectés à PIx peuvent s'y connecter à travers Pôle Emploi Connect. 
Cette connexion permet, lors de la première connexion à Pix, de créer un utilisateur et de lui créer une méthode de connexion Pôle Emploi. Puis, lors des futures connexions, de pouvoir retrouver l'utilisateur et mettre à jour sa méthode de connexion. 
Néanmoins, il n'existe aucun mécanisme permettant d'ajouter une méthode de connexion Pôle Emploi à un utilisateur déjà connecté à Pix.

## :robot: Solution
Permettre à un utilisateur connecté à Pix de se connecter à son compte Pôle Emploi afin d'ajouter la méthode d'authentification Pôle emploi lors de sa première connexion, puis de la mettre à jour lors des prochaines connexions.

## :rainbow: Remarques
Afin de permettre l'accès au endpoint d'authentification d'un utilisateur Pôle emploi, à la fois pour un utilisateur non connecté à Pix et connecté à Pix, nous avons dû utiliser un nouveau mode d'authentification : `optional` (https://hapi.dev/tutorials/auth/?lang=en_US#route)

## :100: Pour tester
Pas testable sur les RA car:
- L'environnement de PROD ne semble pas encore accepté les scopes présents dans le code (en dur) alors qu'ils fonctionnent sur leur environnement de recette.
- Ajouter ou modifier une url de redirection sur l'environnement de recette entraîne la disparition du refresh _token.