### PR TITLE
[POC][ALGO][STASH] Rendre l'algorithme de sélection d'acquis plus bienveillant (PIX-1481).

### DIFF
--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -50,9 +50,9 @@ function findMaxRewardingSkills(...args) {
   )(...args);
 }
 
-function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements }) {
+function _getMaxRewardingSkills({ availableSkills, predictedLevel, tubes, knowledgeElements, wrongAnswersSuccessiveCount }) {
   return _.reduce(availableSkills, (acc, skill) => {
-    const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements });
+    const skillReward = _computeReward({ skill, predictedLevel, tubes, knowledgeElements, wrongAnswersSuccessiveCount });
     if (skillReward > acc.maxReward) {
       acc.maxReward = skillReward;
       acc.maxRewardingSkills = [skill];
@@ -70,12 +70,15 @@ function _clearSkillsIfNotRewarding(skills) {
   return _.filter(skills, (skill) => skill.reward !== 0);
 }
 
-function _computeReward({ skill, predictedLevel, tubes, knowledgeElements }) {
-  const proba = _probaOfCorrectAnswer(predictedLevel, skill.difficulty);
+function _computeReward({ skill, predictedLevel, tubes, knowledgeElements, wrongAnswersSuccessiveCount }) {
+  const successProba = _probaOfCorrectAnswer(predictedLevel, skill.difficulty);
   const extraSkillsIfSolvedCount = _getNewSkillsInfoIfSkillSolved(skill, tubes, knowledgeElements).length;
   const failedSkillsIfUnsolvedCount = _getNewSkillsInfoIfSkillUnsolved(skill, tubes, knowledgeElements).length;
 
-  return proba * extraSkillsIfSolvedCount + (1 - proba) * failedSkillsIfUnsolvedCount;
+  const failureProba = 1 - successProba;
+
+  return successProba * extraSkillsIfSolvedCount + failureProba * failedSkillsIfUnsolvedCount
+    + successProba * wrongAnswersSuccessiveCount;
 }
 
 // The probability P(gap) of giving the correct answer is given by the "logistic function"

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -24,7 +24,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
     challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
-    challengeRechInfo_7, challengeInfo_2, challengeCnil_1, challengeCnil_2;
+    challengeRechInfo_7, challengeInfo_2, challengeCnil_1, challengeCnil_2, cnil4, challengeCnil_4;
 
   beforeEach(() => {
     targetSkills = null;
@@ -50,6 +50,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     info2 = domainBuilder.buildSkill({ name: '@info2' });
     cnil1 = domainBuilder.buildSkill({ name: '@cnil1' });
     cnil2 = domainBuilder.buildSkill({ name: '@cnil2' });
+    cnil4 = domainBuilder.buildSkill({ name: '@cnil4' });
 
     // Challenges
     challengeWeb_1 = domainBuilder.buildChallenge({ id: 'recweb1', skills: [web1] });
@@ -68,6 +69,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     challengeRechInfo_7 = domainBuilder.buildChallenge({ id: 'recinfo7', skills: [rechInfo7] });
     challengeCnil_1 = domainBuilder.buildChallenge({ id: 'reccnil1', skills: [cnil1] });
     challengeCnil_2 = domainBuilder.buildChallenge({ id: 'reccnil2', skills: [cnil2] });
+    challengeCnil_4 = domainBuilder.buildChallenge({ id: 'reccnil4', skills: [cnil4] });
     challengeInfo_2 = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2] });
   });
 
@@ -317,6 +319,65 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].id).to.be.equal(rechInfo5.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeRechInfo_5.id);
+      });
+
+      it('should return easier skill when user failed a sufficient statistically times in a row', () => {
+        // given
+        targetSkills = [web1, web2, web3, web4, web5, web6, web7, url3, url4, rechInfo5, rechInfo7, url6, cnil1, cnil2, cnil4];
+
+        challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6,
+          challengeUrl_3, challengeUrl_4, challengeUrl_6, challengeRechInfo_5, challengeRechInfo_7, challengeCnil_1, challengeCnil_2, challengeCnil_4];
+
+        knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: web1.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'indirect',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: web2.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url3.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'indirect',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url4.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url6.id,
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+        ];
+
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeUrl_6.id, result: AnswerStatus.KO });
+        allAnswers = [
+          lastAnswer,
+          domainBuilder.buildAnswer({ challengeId: challengeWeb_2.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeUrl_4.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeUrl_3.id, result: AnswerStatus.KO }),
+          domainBuilder.buildAnswer({ challengeId: challengeUrl_4.id, result: AnswerStatus.KO }),
+        ];
+
+        // when
+        const { possibleSkillsForNextChallenge } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          lastAnswer,
+          allAnswers,
+        });
+
+        // then
+        expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(cnil1.id);
       });
 
       it('should ask a challenge of maximum difficulty when maximum difficulty (minus 1) was correctly answered (edge case test)', function() {


### PR DESCRIPTION
## :unicorn: Problème
L’algorithme cherche à poser des épreuves qui permettent d’avoir un maximum d’information sur l’utilisateur, ce qui permet de lui poser peu d’épreuves pour toute une compétence.
Mais l’algorithme ne prend pas en compte les échecs de l’utilisateur, qui pourraient le pousser à abandonner l’évaluation.


## :robot: Solution
Nous testons alors un POC portant sur la bienveillance de l’épreuve.

A chaque choix d’épreuve, un score est calculé par épreuve pour savoir quelle épreuve sera la plus intéressante à poser.

Actuellement, nous avons : 
```
Score(épreuve) = ([Nombre d’acquis validé si réussit] * [Probabilité de réussite] + [Nombre d’acquis invalidé si échouée] * [Probabilité d’échec])
```

Nous souhaitons prendre en compte le cas des utilisateurs qui viennent d’échouer plusieurs fois à la suite, et qui pourraient abandonner.

Pour cela, nous ajoutons une nouvelle information à ce score, ce qui amène à ce nouveau score : 
```
Score(épreuve) = ([Nombre d’acquis validé si réussi] * [Probabilité de réussite] + [Nombre d’acquis invalidé si échouée] * [Probabilité d’échec]) + [Probabilité de réussite] * [Nombre d’épreuve échouée à la suite dernièrement]
```


## :rainbow: Remarques
Cette PR sert à analyser les différences de comportement de l'alogrithme.

## :100: Pour tester
TBA
