### PR TITLE
[BUGFIX] Empêcher l'appel à l'API quand le formulaire est invalide dans Pix App (PIX-215).

### DIFF
--- a/mon-pix/app/components/routes/register-form.js
+++ b/mon-pix/app/components/routes/register-form.js
@@ -196,6 +196,9 @@ export default class RegisterForm extends Component {
   @action
   async register() {
     this.set('isLoading', true);
+    if (this.isCreationFormNotValid) {
+      return this.set('isLoading', false);
+    }
     try {
       this.set('schoolingRegistrationDependentUser.password', this.password);
       this.set('schoolingRegistrationDependentUser.withUsername', this.loginWithUsername);

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -214,7 +214,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             await click('#submit-search');
 
             await fillIn('#username', 'jeanprescrit1012');
-            await fillIn('#password', 'pix123');
+            await fillIn('#password', 'Password123');
             await click('#submit-registration');
 
             // then

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -11,6 +11,7 @@ import {
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
@@ -249,6 +250,25 @@ describe('Integration | Component | routes/register-form', function() {
       });
     });
 
+    it('should not call api when email is invalid', async function() {
+      // given
+      const save = sinon.stub();
+      this.set('matchingStudentFound', true);
+      this.set('schoolingRegistrationDependentUser', EmberObject.create({ email : 'shi.fu' , unloadRecord() {return resolve();}, save  }));
+      await render(hbs`<Routes::RegisterForm @matchingStudentFound=true @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} /> `);
+
+      // when
+      await click('.pix-toggle__off');
+      await fillIn('#email', 'shi.fu');
+      await triggerEvent('#email', 'blur');
+      await click('#submit-registration');
+
+      // then
+      expect(find('#register-email-container #validationMessage-email').textContent).to.equal(EMPTY_EMAIL_ERROR_MESSAGE);
+      expect(find('#register-email-container .form-textfield__input-container--error')).to.exist;
+      sinon.assert.notCalled(save);
+    });
+
     [{ stringFilledIn: ' ' },
       { stringFilledIn: 'password' },
       { stringFilledIn: 'password1' },
@@ -269,6 +289,24 @@ describe('Integration | Component | routes/register-form', function() {
         expect(find('#register-password-container #validationMessage-password').textContent).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
         expect(find('#register-password-container .form-textfield__input-container--error')).to.exist;
       });
+    });
+
+    it('should not call api when password is invalid', async function() {
+      // given
+      const save = sinon.stub();
+      this.set('matchingStudentFound', true);
+      this.set('schoolingRegistrationDependentUser', EmberObject.create({ password : 'toto' , unloadRecord() {return resolve();}, save }));
+      await render(hbs`<Routes::RegisterForm @matchingStudentFound={{this.matchingStudentFound}} @schoolingRegistrationDependentUser={{this.schoolingRegistrationDependentUser}} />`);
+
+      // when
+      await fillIn('#password', 'toto');
+      await triggerEvent('#password', 'blur');
+      await click('#submit-registration');
+
+      // then
+      expect(find('#register-password-container #validationMessage-password').textContent).to.equal(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
+      expect(find('#register-password-container .form-textfield__input-container--error')).to.exist;
+      sinon.assert.notCalled(save);
     });
 
     const internalServerErrorMessage = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';


### PR DESCRIPTION
## :unicorn: Problème
Dans le formulaire d'inscription SCO (double-mire), lorsque le password ou l'adresse e-mail ne sont pas valides, il est toujours possible d'appeler l'API.

## :robot: Solution
Avant d'appeler l'API, vérifier que ces champs sont bien valides.

## :100: Pour tester
1 - sur la double mire, faire la pré-réconciliation (First Last 10/10/2010)
2 - Remplir le champ mot de passe avec un mot de passe non valide (123)
3 - Valider
4 - Constater que le navigateur n'a pas fait la requête au back alors que le mot de passe n'est pas valide et que le message le spécifiant était affiché.

Valable aussi sur l'email avec un message d'erreur "Votre email n’est pas valide." avant de valider, et "Votre adresse e-mail n’est pas correcte." après avoir validé.
