### PR TITLE
[CLEANUP] Retirer les "classic" des adapters sur Mon-pix.

### DIFF
--- a/mon-pix/app/adapters/application.js
+++ b/mon-pix/app/adapters/application.js
@@ -1,4 +1,3 @@
-import classic from 'ember-classic-decorator';
 import { inject as service } from '@ember/service';
 import JSONAPIAdapter from '@ember-data/adapter/json-api';
 import DataAdapterMixin from 'ember-simple-auth/mixins/data-adapter-mixin';
@@ -8,12 +7,9 @@ const FRENCH_DOMAIN_EXTENSION = 'fr';
 const FRENCH_LOCALE = 'fr-fr';
 const FRENCHSPOKEN_LOCALE = 'fr';
 
-@classic
 export default class Application extends JSONAPIAdapter.extend(DataAdapterMixin) {
-  @service
-  currentDomain;
-  @service
-  ajaxQueue;
+  @service currentDomain;
+  @service ajaxQueue;
   @service intl;
 
   host = ENV.APP.API_HOST;

--- a/mon-pix/app/adapters/assessment.js
+++ b/mon-pix/app/adapters/assessment.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class Assessment extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);

--- a/mon-pix/app/adapters/campaign-participation.js
+++ b/mon-pix/app/adapters/campaign-participation.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class CampaignParticipation extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     const url = super.urlForUpdateRecord(...arguments);

--- a/mon-pix/app/adapters/certification-candidate.js
+++ b/mon-pix/app/adapters/certification-candidate.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class CertificationCandidate extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions }) {
     const url = super.urlForCreateRecord(...arguments);

--- a/mon-pix/app/adapters/certification.js
+++ b/mon-pix/app/adapters/certification.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class Certification extends ApplicationAdapter {
 
   queryRecord(store, type, query) {

--- a/mon-pix/app/adapters/challenge.js
+++ b/mon-pix/app/adapters/challenge.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class Challenge extends ApplicationAdapter {
   urlForQueryRecord(query) {
     const url = `${this.host}/${this.namespace}/assessments/${query.assessmentId}/next`;

--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class CompetenceEvaluation extends ApplicationAdapter {
   urlForQueryRecord(query) {
     if (query.startOrResume) {

--- a/mon-pix/app/adapters/external-user-authentication-request.js
+++ b/mon-pix/app/adapters/external-user-authentication-request.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class ExternalUserAuthenticationRequest extends ApplicationAdapter {
 
   urlForCreateRecord() {

--- a/mon-pix/app/adapters/external-user.js
+++ b/mon-pix/app/adapters/external-user.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class ExternalUser extends ApplicationAdapter {
 
   urlForCreateRecord() {

--- a/mon-pix/app/adapters/schooling-registration-user-association.js
+++ b/mon-pix/app/adapters/schooling-registration-user-association.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class SchoolingRegistrationUserAssociation extends ApplicationAdapter {
   urlForCreateRecord(modelName, { adapterOptions }) {
     const url = super.urlForCreateRecord(...arguments);

--- a/mon-pix/app/adapters/scorecard.js
+++ b/mon-pix/app/adapters/scorecard.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class Scorecard extends ApplicationAdapter {
   urlForUpdateRecord(id, modelName, { adapterOptions }) {
     if (adapterOptions.resetCompetence) {

--- a/mon-pix/app/adapters/user-tutorial.js
+++ b/mon-pix/app/adapters/user-tutorial.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class UserTutorial extends ApplicationAdapter {
   createRecord(store, type, { adapterOptions }) {
     const url = `${this.host}/${this.namespace}/users/tutorials/${adapterOptions.tutorialId}`;

--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import ApplicationAdapter from './application';
 
-@classic
 export default class User extends ApplicationAdapter {
 
   shouldBackgroundReloadRecord() {


### PR DESCRIPTION
## :unicorn: Problème
- Plusieurs adapters avaient encore le décorateur "Classic"

## :robot: Solution
- Les retirer

## :rainbow: Remarques
- Application Adapter utilise DataAdapterMixin de EmberSimpleAuth. Cette Mixin est déprécié et devra être retiré.

## :100: Pour tester
Tester l'application.