### PR TITLE
[CLEANUP] Retirer les "classic" des transform et controller sur Mon-Pix

### DIFF
--- a/mon-pix/app/controllers/certification-course.js
+++ b/mon-pix/app/controllers/certification-course.js
@@ -1,8 +1,7 @@
-import classic from 'ember-classic-decorator';
 import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
 
-@classic
 export default class CertificationCourseController extends Controller {
-  queryParams = 'code';
-  code = null;
+  @tracked queryParams = 'code';
+  @tracked code = null;
 }

--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -1,10 +1,8 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import classic from 'ember-classic-decorator';
 import { tracked } from '@glimmer/tracking';
 
-@classic
 export default class TermsOfServiceController extends Controller {
   @service session;
   @service currentUser;

--- a/mon-pix/app/transforms/array.js
+++ b/mon-pix/app/transforms/array.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import Transform from '@ember-data/serializer/transform';
 
-@classic
 export default class Array extends Transform {
   deserialize(serialized) {
     return serialized;

--- a/mon-pix/app/transforms/date-only.js
+++ b/mon-pix/app/transforms/date-only.js
@@ -1,7 +1,5 @@
-import classic from 'ember-classic-decorator';
 import Transform from '@ember-data/serializer/transform';
 
-@classic
 export default class DateOnly extends Transform {
   serialize(date) {
     return date;


### PR DESCRIPTION
## :unicorn: Problème
 - Plusieurs adapters avaient encore le décorateur "Classic"

## :robot: Solution
- Les retirer

## :rainbow: Remarques
R.A.S

## :100: Pour tester
Vérifier que tout fonctionne
