### PR TITLE
[FEATURE] Ajouter beaucoup de seeds de schooling registration avec classe

### DIFF
--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -1,11 +1,13 @@
 const _ = require('lodash');
 const {
-  STARTED_SESSION_ID,
-  STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
-  TO_FINALIZE_SESSION_ID,
-  NO_PROBLEM_FINALIZED_SESSION_ID,
-  PROBLEMS_FINALIZED_SESSION_ID,
-  PUBLISHED_SESSION_ID,
+  SUP_STARTED_SESSION_ID,
+  SUP_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+  SUP_TO_FINALIZE_SESSION_ID,
+  SUP_NO_PROBLEM_FINALIZED_SESSION_ID,
+  SUP_PROBLEMS_FINALIZED_SESSION_ID,
+  SUP_PUBLISHED_SESSION_ID,
+  SCO_STARTED_SESSION_ID,
+  SCO_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
 } = require('./certification-sessions-builder');
 const {
   CERTIF_SUCCESS_USER_ID,
@@ -32,43 +34,45 @@ function certificationCandidatesBuilder({ databaseBuilder }) {
 
   // Few candidates for the started session
   _.each([ CANDIDATE_DATA_SUCCESS, CANDIDATE_DATA_FAILURE, CANDIDATE_DATA_MISSING ], (candidate) => {
-    databaseBuilder.factory.buildCertificationCandidate({ ...candidate, sessionId: STARTED_SESSION_ID, userId: null });
+    databaseBuilder.factory.buildCertificationCandidate({ ...candidate, sessionId: SUP_STARTED_SESSION_ID, userId: null });
+    databaseBuilder.factory.buildCertificationCandidate({ ...candidate, sessionId: SCO_STARTED_SESSION_ID, userId: null });
   });
 
   // A LOT of candidates for the BIG started session
   for (let i = 0; i < A_LOT_OF_CANDIDATES_COUNT; ++i) {
-    databaseBuilder.factory.buildCertificationCandidate({ sessionId: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
+    databaseBuilder.factory.buildCertificationCandidate({ sessionId: SUP_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
+    databaseBuilder.factory.buildCertificationCandidate({ sessionId: SCO_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID, userId: null });
   }
 
-  let sessionId;
+  let supSessionId;
   const candidateDataSuccessWithUser = { ...CANDIDATE_DATA_SUCCESS, userId: CERTIF_SUCCESS_USER_ID };
   const candidateDataFailureWithUser = { ...CANDIDATE_DATA_FAILURE, userId: CERTIF_FAILED_USER_ID };
   const candidateDataMissingWithUser = { ...CANDIDATE_DATA_MISSING, userId: null };
   const candidateDataStartedWithUser = { ...CANDIDATE_DATA_STARTED, userId: CERTIF_REGULAR_USER5_ID };
 
   // Few candidates with some that have passed certification test
-  sessionId = TO_FINALIZE_SESSION_ID;
-  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_SESSION_TO_FINALIZE_ID, ...candidateDataSuccessWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_SESSION_TO_FINALIZE_ID, ...candidateDataFailureWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId });
+  supSessionId = SUP_TO_FINALIZE_SESSION_ID;
+  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_SESSION_TO_FINALIZE_ID, ...candidateDataSuccessWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_SESSION_TO_FINALIZE_ID, ...candidateDataFailureWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId: supSessionId });
 
   // Few candidates with some that have passed certification test with finalized courses in the ZERO problem session
-  sessionId = NO_PROBLEM_FINALIZED_SESSION_ID;
-  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ...candidateDataFailureWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId });
+  supSessionId = SUP_NO_PROBLEM_FINALIZED_SESSION_ID;
+  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_NO_PROBLEM_FINALIZED_SESSION_ID, ...candidateDataFailureWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId: supSessionId });
 
   // Few candidates with some that have passed certification test with finalized courses in the Problematic session
-  sessionId = PROBLEMS_FINALIZED_SESSION_ID;
-  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataFailureWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ id: STARTED_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataStartedWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId });
+  supSessionId = SUP_PROBLEMS_FINALIZED_SESSION_ID;
+  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataFailureWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: STARTED_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID, ...candidateDataStartedWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ ...candidateDataMissingWithUser, sessionId: supSessionId });
 
   // Two candidates for published session
-  sessionId = PUBLISHED_SESSION_ID;
-  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_PUBLISHED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId });
-  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_PUBLISHED_SESSION_ID, ...candidateDataFailureWithUser, sessionId });
+  supSessionId = SUP_PUBLISHED_SESSION_ID;
+  databaseBuilder.factory.buildCertificationCandidate({ id: SUCCESS_CANDIDATE_IN_PUBLISHED_SESSION_ID, ...candidateDataSuccessWithUser, sessionId: supSessionId });
+  databaseBuilder.factory.buildCertificationCandidate({ id: FAILURE_CANDIDATE_IN_PUBLISHED_SESSION_ID, ...candidateDataFailureWithUser, sessionId: supSessionId });
 }
 
 module.exports = {

--- a/api/db/seeds/data/certification/certification-sessions-builder.js
+++ b/api/db/seeds/data/certification/certification-sessions-builder.js
@@ -1,17 +1,29 @@
-const { SCO_CERTIF_CENTER_ID, SCO_CERTIF_CENTER_NAME } = require('./certification-centers-builder');
+const { SCO_CERTIF_CENTER_ID, SCO_CERTIF_CENTER_NAME, SUP_CERTIF_CENTER_ID, SUP_CERTIF_CENTER_NAME } = require('./certification-centers-builder');
 const { PIX_MASTER_ID } = require('./../users-builder');
-const EMPTY_SESSION_ID = 1;
-const STARTED_SESSION_ID = 2;
-const STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID = 3;
-const TO_FINALIZE_SESSION_ID = 4;
-const NO_PROBLEM_FINALIZED_SESSION_ID = 5;
-const PROBLEMS_FINALIZED_SESSION_ID = 6;
-const NO_CERTIF_CENTER_SESSION_ID = 7;
-const PUBLISHED_SESSION_ID = 8;
+const SUP_EMPTY_SESSION_ID = 1;
+const SUP_STARTED_SESSION_ID = 2;
+const SUP_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID = 3;
+const SUP_TO_FINALIZE_SESSION_ID = 4;
+const SUP_NO_PROBLEM_FINALIZED_SESSION_ID = 5;
+const SUP_PROBLEMS_FINALIZED_SESSION_ID = 6;
+const SUP_NO_CERTIF_CENTER_SESSION_ID = 7;
+const SUP_PUBLISHED_SESSION_ID = 8;
+
+const SCO_EMPTY_SESSION_ID = 9;
+const SCO_STARTED_SESSION_ID = 10;
+const SCO_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID = 11;
+const SCO_TO_FINALIZE_SESSION_ID = 12;
+const SCO_NO_PROBLEM_FINALIZED_SESSION_ID = 13;
+const SCO_PROBLEMS_FINALIZED_SESSION_ID = 14;
+const SCO_NO_CERTIF_CENTER_SESSION_ID = 15;
+const SCO_PUBLISHED_SESSION_ID = 16;
 
 function certificationSessionsBuilder({ databaseBuilder }) {
-  const certificationCenter = SCO_CERTIF_CENTER_NAME;
-  const certificationCenterId = SCO_CERTIF_CENTER_ID;
+  const scoCertificationCenterName = SCO_CERTIF_CENTER_NAME;
+  const scoCertificationCenterId = SCO_CERTIF_CENTER_ID;
+  const supCertificationCenterName = SUP_CERTIF_CENTER_NAME;
+  const supCertificationCenterId = SUP_CERTIF_CENTER_ID;
+
   const address = 'Anne-Star Street';
   const room = 'Salle Anne';
   const examiner = 'Anne-Quelquechose';
@@ -19,107 +31,162 @@ function certificationSessionsBuilder({ databaseBuilder }) {
   const time = '15:00';
 
   databaseBuilder.factory.buildSession({
-    id: EMPTY_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session pas commencée avec ZERO candidat inscrit.',
+    id: SUP_EMPTY_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup pas commencée avec ZERO candidat inscrit.',
     accessCode: 'ANNE01',
     examinerGlobalComment: null,
   });
 
   databaseBuilder.factory.buildSession({
-    id: STARTED_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session pas commencée avec quelques candidats inscrits non liés.',
+    id: SUP_STARTED_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup pas commencée avec quelques candidats inscrits non liés.',
     accessCode: 'ANNE02',
     examinerGlobalComment: null,
   });
 
   databaseBuilder.factory.buildSession({
-    id: STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
+    id: SUP_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
     description: 'Session pas commencée avec des candidats inscrits non liés.',
     accessCode: 'ANNE03',
     examinerGlobalComment: null,
   });
 
   databaseBuilder.factory.buildSession({
-    id: TO_FINALIZE_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session pas encore finalisée, avec des candidats ayant passés leur test de certification.',
+    id: SUP_TO_FINALIZE_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup pas encore finalisée, avec des candidats ayant passés leur test de certification.',
     accessCode: 'ANNE04',
     examinerGlobalComment: null,
   });
 
   databaseBuilder.factory.buildSession({
-    id: NO_PROBLEM_FINALIZED_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session finalisée sans problème, donc aucun commentaire et le surveillant a vu tous les écrans de fin de test.',
+    id: SUP_NO_PROBLEM_FINALIZED_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup finalisée sans problème, donc aucun commentaire et le surveillant a vu tous les écrans de fin de test.',
     accessCode: 'ANNE05',
     examinerGlobalComment: null,
     finalizedAt: new Date('2020-04-15T15:00:34Z'),
   });
 
   databaseBuilder.factory.buildSession({
-    id: PROBLEMS_FINALIZED_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session finalisée à problèmes et assignée !',
+    id: SUP_PROBLEMS_FINALIZED_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup finalisée à problèmes et assignée !',
     accessCode: 'ANNE06',
-    examinerGlobalComment: 'Une météorite est tombée sur le centre de certification pendant la session !!',
+    examinerGlobalComment: 'Une météorite est tombée sur le centre de certification pendant la session sup !!',
     finalizedAt: new Date('2020-05-05T15:00:34Z'),
     assignedCertificationOfficerId: PIX_MASTER_ID,
   });
 
   databaseBuilder.factory.buildSession({
-    id: NO_CERTIF_CENTER_SESSION_ID,
+    id: SUP_NO_CERTIF_CENTER_SESSION_ID,
     certificationCenterId: null, certificationCenter: 'Centre de certif pas dans la BDD !',
     address, room, examiner, date , time,
-    description: 'Session sans vrai certification center !',
+    description: 'Session sup sans vrai certification center !',
     accessCode: 'ANNE07',
     examinerGlobalComment: 'Salut les zouzous',
     finalizedAt: new Date('2020-06-05T15:00:34Z'),
   });
 
   databaseBuilder.factory.buildSession({
-    id: PUBLISHED_SESSION_ID,
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    description: 'Session publiée',
+    id: SUP_PUBLISHED_SESSION_ID,
+    certificationCenter: supCertificationCenterName, certificationCenterId: supCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sup publiée',
     accessCode: 'ANNE08',
     finalizedAt: new Date('2020-05-05T15:00:34Z'),
     publishedAt: new Date('2020-06-05T15:00:34Z'),
   });
 
-  // Some sessions to illustrate paginated sessions list order in PixAdmin
   databaseBuilder.factory.buildSession({
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    finalizedAt: null,
-    publishedAt: null,
+    id: SCO_EMPTY_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco pas commencée avec ZERO candidat inscrit.',
+    accessCode: 'ANNE09',
+    examinerGlobalComment: null,
   });
+
   databaseBuilder.factory.buildSession({
-    certificationCenter, certificationCenterId,
-    finalizedAt: new Date('2018-01-01T00:00:00Z'),
-    publishedAt: null,
+    id: SCO_STARTED_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco pas commencée avec quelques candidats inscrits non liés.',
+    accessCode: 'ANNE10',
+    examinerGlobalComment: null,
   });
+
   databaseBuilder.factory.buildSession({
-    certificationCenter, certificationCenterId,
-    finalizedAt: new Date('2018-01-02T00:00:00Z'),
-    publishedAt: null,
-    resultsSentToPrescriberAt: new Date('2018-01-04T00:00:00Z'),
+    id: SCO_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session pas commencée avec des candidats inscrits non liés.',
+    accessCode: 'ANNE11',
+    examinerGlobalComment: null,
   });
+
   databaseBuilder.factory.buildSession({
-    certificationCenter, certificationCenterId, address, room, examiner, date , time,
-    finalizedAt: new Date('2018-01-02T00:00:00Z'),
-    publishedAt: new Date('2018-01-03T00:00:00Z'),
+    id: SCO_TO_FINALIZE_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco pas encore finalisée, avec des candidats ayant passés leur test de certification.',
+    accessCode: 'ANNE12',
+    examinerGlobalComment: null,
+  });
+
+  databaseBuilder.factory.buildSession({
+    id: SCO_NO_PROBLEM_FINALIZED_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco finalisée sans problème, donc aucun commentaire et le surveillant a vu tous les écrans de fin de test.',
+    accessCode: 'ANNE12',
+    examinerGlobalComment: null,
+    finalizedAt: new Date('2020-04-15T15:00:34Z'),
+  });
+
+  databaseBuilder.factory.buildSession({
+    id: SCO_PROBLEMS_FINALIZED_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco finalisée à problèmes et assignée !',
+    accessCode: 'ANNE13',
+    examinerGlobalComment: 'Une météorite est tombée sur le centre de certification pendant la session sco !!',
+    finalizedAt: new Date('2020-05-05T15:00:34Z'),
+    assignedCertificationOfficerId: PIX_MASTER_ID,
+  });
+
+  databaseBuilder.factory.buildSession({
+    id: SCO_NO_CERTIF_CENTER_SESSION_ID,
+    certificationCenterId: null, certificationCenter: 'Centre de certif pas dans la BDD !',
+    address, room, examiner, date , time,
+    description: 'Session sco sans vrai certification center !',
+    accessCode: 'ANNE14',
+    examinerGlobalComment: 'Salut les zouzous',
+    finalizedAt: new Date('2020-06-05T15:00:34Z'),
+  });
+
+  databaseBuilder.factory.buildSession({
+    id: SCO_PUBLISHED_SESSION_ID,
+    certificationCenter: scoCertificationCenterName, certificationCenterId: scoCertificationCenterId, address, room, examiner, date , time,
+    description: 'Session sco publiée',
+    accessCode: 'ANNE15',
+    finalizedAt: new Date('2020-05-05T15:00:34Z'),
+    publishedAt: new Date('2020-06-05T15:00:34Z'),
   });
 }
 
 module.exports = {
   certificationSessionsBuilder,
-  EMPTY_SESSION_ID,
-  STARTED_SESSION_ID,
-  STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
-  TO_FINALIZE_SESSION_ID,
-  NO_PROBLEM_FINALIZED_SESSION_ID,
-  PROBLEMS_FINALIZED_SESSION_ID,
-  NO_CERTIF_CENTER_SESSION_ID,
-  PUBLISHED_SESSION_ID,
+  SUP_EMPTY_SESSION_ID,
+  SUP_STARTED_SESSION_ID,
+  SUP_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+  SUP_TO_FINALIZE_SESSION_ID,
+  SUP_NO_PROBLEM_FINALIZED_SESSION_ID,
+  SUP_PROBLEMS_FINALIZED_SESSION_ID,
+  SUP_NO_CERTIF_CENTER_SESSION_ID,
+  SUP_PUBLISHED_SESSION_ID,
+  SCO_EMPTY_SESSION_ID,
+  SCO_STARTED_SESSION_ID,
+  SCO_STARTED_SESSION_WITH_LOT_OF_CANDIDATES_ID,
+  SCO_TO_FINALIZE_SESSION_ID,
+  SCO_NO_PROBLEM_FINALIZED_SESSION_ID,
+  SCO_PROBLEMS_FINALIZED_SESSION_ID,
+  SCO_NO_CERTIF_CENTER_SESSION_ID,
+  SCO_PUBLISHED_SESSION_ID,
 };

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -5,6 +5,11 @@ const MIDDLE_SCHOOL_ID = 3;
 module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   const defaultPassword = 'pix123';
   const SCO_EXTERNAL_ID = '1237457A';
+  const NUMBER_IN_3A_DIVISION = 32;
+  const NUMBER_IN_3B_DIVISION = 30;
+  const NUMBER_IN_5D_DIVISION = 28;
+  const NUMBER_IN_1F_DIVISION = 31;
+  const NUMBER_IN_2G_DIVISION = 29;
 
   /* COLLEGE */
   const scoUser1 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
@@ -72,6 +77,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     lastName: 'Last',
     birthdate: '2010-10-10',
     organizationId: middleSchool.id,
+    division: '3A',
     userId: null,
     nationalStudentId: '123456789AB',
   });
@@ -81,6 +87,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     firstName: 'George',
     lastName: 'De Cambridge',
     email: null,
+    division: '3A',
     username: 'george.decambridge2207',
     rawPassword: defaultPassword,
     cgu: false,
@@ -90,6 +97,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     firstName: userWithUsername.firstName,
     lastName: userWithUsername.lastName,
     birthdate: '2013-07-22',
+    division: '3A',
     organizationId: middleSchool.id,
     userId: userWithUsername.id,
     nationalStudentId: '123123123A',
@@ -101,6 +109,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     lastName: 'Carter',
     email: 'blueivy.carter@example.net',
     username: 'blueivy.carter0701',
+    division: '3A',
     rawPassword: defaultPassword,
     cgu: false,
   });
@@ -109,6 +118,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     firstName: userWithEmailAndUsername.firstName,
     lastName: userWithEmailAndUsername.lastName,
     birthdate: '2012-01-07',
+    division: '3A',
     organizationId: middleSchool.id,
     userId: userWithEmailAndUsername.id,
     nationalStudentId: '123123123B',
@@ -127,6 +137,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     firstName: userWithEmail.firstName,
     lastName: userWithEmail.lastName,
     birthdate: '2002-01-07',
+    division: '3A',
     organizationId: middleSchool.id,
     userId: userWithEmail.id,
     nationalStudentId: '123123123C',
@@ -151,6 +162,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     firstName: userWithGAR.firstName,
     lastName: userWithGAR.lastName,
     birthdate: '2002-01-07',
+    division: '3A',
     organizationId: middleSchool.id,
     userId: userWithGAR.id,
     nationalStudentId: '123123123D',
@@ -187,6 +199,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     lastName: userWithEmailAndUsername.lastName,
     birthdate: userWithEmailAndUsername.birtdate,
     organizationId: highSchool.id,
+    division: '2A',
     nationalStudentId: schoolingRegistrationAssociated2.nationalStudentId,
     createdAt: new Date('2020-08-14'),
   });
@@ -196,11 +209,47 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     userId: null,
     firstName: userWithUsername.firstName,
     lastName: userWithUsername.lastName,
+    division: '2A',
     birthdate: userWithUsername.birthdate,
     organizationId: highSchool.id,
     nationalStudentId: schoolingRegistrationAssociated.nationalStudentId,
     createdAt: new Date('2020-08-14'),
   });
+
+  for (let i = 0; i < NUMBER_IN_5D_DIVISION; ++i) {
+    databaseBuilder.factory.buildSchoolingRegistration({ 
+      division: '5D',
+      organizationId: middleSchool.id,
+    });
+  }
+
+  for (let i = 0; i < NUMBER_IN_3A_DIVISION; ++i) {
+    databaseBuilder.factory.buildSchoolingRegistration({ 
+      division: '3A',
+      organizationId: middleSchool.id,
+    });
+  }
+
+  for (let i = 0; i < NUMBER_IN_3B_DIVISION; ++i) {
+    databaseBuilder.factory.buildSchoolingRegistration({ 
+      division: '3B',
+      organizationId: middleSchool.id,
+    });
+  }
+
+  for (let i = 0; i < NUMBER_IN_1F_DIVISION; ++i) {
+    databaseBuilder.factory.buildSchoolingRegistration({ 
+      division: '1F',
+      organizationId: highSchool.id,
+    });
+  }
+
+  for (let i = 0; i < NUMBER_IN_2G_DIVISION; ++i) {
+    databaseBuilder.factory.buildSchoolingRegistration({ 
+      division: '2G',
+      organizationId: highSchool.id,
+    });
+  }
 
   /* AGRICULTURE */
   const agriculture = databaseBuilder.factory.buildOrganization({


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il est difficile de tester les fonctionnalités de pagination et filtre par classe lors d'ajout de candidats à une session de certification SCO

## :robot: Solution
Ajouter au moins une centaine d'élèves répartis sur plusieurs classes

## :100: Pour tester
- Activer le toggle FT_CERTIF_PRESCRIPTION_SCO=true
- Se connecter à pix certif en tant que certifsco
- Essayer d'ajouter des élèves à une session et constater qu'il y en a une centaine répartis sur 3 classes
