### PR TITLE
[FEATURE]  Modification des urls de redirection présents dans les mails (PIX-1761).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -3,31 +3,63 @@ const mailer = require('../../infrastructure/mailers/mailer');
 const moment = require('moment');
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
-const PIX_NAME = 'PIX - Ne pas répondre';
 const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
+const PIX_NAME_FR = 'PIX - Ne pas répondre';
+const PIX_NAME_EN = 'PIX - Noreply';
+const ACCOUNT_CREATION_EMAIL_SUBJECT_FR = 'Votre compte Pix a bien été créé';
+const ACCOUNT_CREATION_EMAIL_SUBJECT_EN = 'Your Pix account has been created';
+const RESET_PASSWORD_EMAIL_SUBJECT_FR = 'Demande de réinitialisation de mot de passe PIX';
+const RESET_PASSWORD_EMAIL_SUBJECT_EN = 'Pix password reset request';
+
+let pixName;
+let accountCreationEmailSubject;
+let resetPasswordEmailSubject;
 
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
-  let variables = {
-    homeName: `pix${settings.domain.tldFr}`,
-    homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
-    redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldFr}/connexion`,
-    locale,
-  };
+
+  let variables;
 
   if (locale === 'fr') {
     variables = {
       homeName: `pix${settings.domain.tldOrg}`,
-      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
-      redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
+      redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion/?lang=fr`,
       locale,
     };
+
+    pixName = PIX_NAME_FR;
+    accountCreationEmailSubject = ACCOUNT_CREATION_EMAIL_SUBJECT_FR;
+  }
+
+  else if (locale === 'en') {
+    variables = {
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
+      redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion/?lang=en`,
+      locale,
+    };
+
+    pixName = PIX_NAME_EN;
+    accountCreationEmailSubject = ACCOUNT_CREATION_EMAIL_SUBJECT_EN;
+  }
+
+  else {
+    variables = {
+      homeName: `pix${settings.domain.tldFr}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+      redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldFr}/connexion`,
+      locale,
+    };
+
+    pixName = PIX_NAME_FR;
+    accountCreationEmailSubject = ACCOUNT_CREATION_EMAIL_SUBJECT_FR;
   }
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME,
+    fromName: pixName,
     to: email,
-    subject: 'Création de votre compte PIX',
+    subject: accountCreationEmailSubject,
     template: mailer.accountCreationTemplateId,
     variables,
   });
@@ -50,7 +82,7 @@ function sendCertificationResultEmail({
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME,
+    fromName: pixName,
     to: email,
     template: mailer.certificationResultTemplateId,
     variables,
@@ -58,27 +90,49 @@ function sendCertificationResultEmail({
 }
 
 function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
-  let variables = {
-    homeName: `pix${settings.domain.tldFr}`,
-    homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
-    resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
-    locale,
-  };
+  let variables;
 
   if (locale === 'fr') {
     variables = {
       homeName: `pix${settings.domain.tldOrg}`,
-      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
-      resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
+      resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
       locale,
     };
+
+    pixName = PIX_NAME_FR;
+    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_FR;
+  }
+
+  else if (locale === 'en') {
+    variables = {
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
+      resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=en`,
+      locale,
+    };
+
+    pixName = PIX_NAME_EN;
+    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_EN;
+  }
+
+  else {
+    variables = {
+      homeName: `pix${settings.domain.tldFr}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+      resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
+      locale,
+    };
+
+    pixName = PIX_NAME_FR;
+    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_FR;
   }
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_NAME,
+    fromName: pixName,
     to: email,
-    subject: 'Demande de réinitialisation de mot de passe PIX',
+    subject: resetPasswordEmailSubject,
     template: mailer.passwordResetTemplateId,
     variables,
   });

--- a/api/lib/infrastructure/utils/url-builder.js
+++ b/api/lib/infrastructure/utils/url-builder.js
@@ -6,6 +6,11 @@ function getCampaignUrl(locale, campaignCode) {
   if (!campaignCode) {
     return null;
   }
-  const tld = locale === 'fr' ? settings.domain.tldOrg : settings.domain.tldFr;
-  return `${settings.domain.pixApp + tld}/campagnes/${campaignCode}`;
+  if (locale === 'fr') {
+    return `${settings.domain.pixApp + settings.domain.tldOrg}/campagnes/${campaignCode}/?lang=fr`;
+  }
+  if (locale === 'en') {
+    return `${settings.domain.pixApp + settings.domain.tldOrg}/campagnes/${campaignCode}/?lang=en`;
+  }
+  return `${settings.domain.pixApp + settings.domain.tldFr}/campagnes/${campaignCode}`;
 }

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -93,7 +93,7 @@ describe('Acceptance | Controller | users-controller', () => {
         const expectedMail = {
           from: 'ne-pas-repondre@pix.fr',
           fromName: 'PIX - Ne pas répondre',
-          subject: 'Création de votre compte PIX',
+          subject: 'Votre compte Pix a bien été créé',
           template: 'test-account-creation-template-id',
           to: 'john.dodoe@example.net',
           variables: {

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -14,7 +14,7 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendAccountCreationEmail', () => {
 
-    it('should use mailer to send an email with locale', async () => {
+    it('should use mailer to send an email with locale "fr-fr"', async () => {
       // given
       const locale = 'fr-fr';
       const domainFr = 'pix.fr';
@@ -22,7 +22,7 @@ describe('Unit | Service | MailService', () => {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',
         to: userEmailAddress,
-        subject: 'Création de votre compte PIX',
+        subject: 'Votre compte Pix a bien été créé',
         template: 'test-account-creation-template-id',
         variables: {
           homeName: `${domainFr}`,
@@ -48,7 +48,7 @@ describe('Unit | Service | MailService', () => {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',
         to: userEmailAddress,
-        subject: 'Création de votre compte PIX',
+        subject: 'Votre compte Pix a bien été créé',
         template: 'test-account-creation-template-id',
         variables: {
           homeName: `${domainFr}`,
@@ -145,9 +145,36 @@ describe('Unit | Service | MailService', () => {
           subject: 'Demande de réinitialisation de mot de passe PIX',
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=fr`,
             homeName: `${domainOrg}`,
-            homeUrl: `https://${domainOrg}`,
+            homeUrl: `https://${domainOrg}/fr/`,
+            locale,
+          },
+        };
+
+        // when
+        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+
+      it('should call mailer with locale en', async () => {
+        // given
+        const fakeTemporaryKey = 'token';
+        const locale = 'en';
+        const domainOrg = 'pix.org';
+
+        const expectedOptions = {
+          from: senderEmailAddress,
+          fromName: 'PIX - Noreply',
+          to: userEmailAddress,
+          subject: 'Pix password reset request',
+          template: 'test-password-reset-template-id',
+          variables: {
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=en`,
+            homeName: `${domainOrg}`,
+            homeUrl: `https://${domainOrg}/en-gb/`,
             locale,
           },
         };

--- a/api/tests/unit/infrastructure/utils/url-builder_test.js
+++ b/api/tests/unit/infrastructure/utils/url-builder_test.js
@@ -17,7 +17,11 @@ describe('Unit | Utils | url-builder', () => {
       });
 
       it('should return campaignUrl with org domain when locale is fr', () => {
-        expect(getCampaignUrl('fr', campaignCode)).to.be.equal(`https://app.pix.org/campagnes/${campaignCode}`);
+        expect(getCampaignUrl('fr', campaignCode)).to.be.equal(`https://app.pix.org/campagnes/${campaignCode}/?lang=fr`);
+      });
+
+      it('should return campaignUrl with org domain when locale is en', () => {
+        expect(getCampaignUrl('en', campaignCode)).to.be.equal(`https://app.pix.org/campagnes/${campaignCode}/?lang=en`);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La demande initiale était d'inclure la traduction GB dans les 2 mails 'Création de compte' et 'Réinitialisation du mot de passe' via SendinBlue. _( exemple ci-dessous du template SendinBlue avec les trois possibilités en fonction de la locale )_
<img width="348" alt="Capture d’écran 2020-12-11 à 10 15 27" src="https://user-images.githubusercontent.com/58915422/101885002-cff66a80-3b99-11eb-9be6-c4fc8fb7a689.png">

Il fallait donc mettre à jour les différents URLs des liens présents dans les mails pour renvoyer l'utilisateur vers Pix.fr ou Pix.org ( en anglais ou français ).

## :robot: Solution

Mise à jour des URLs :
- Sur l'url de redirection : précision de la langue pour Pix.org ( /?lang=en ou /?lang=fr )
`${settings.domain.pixApp + settings.domain.tldOrg}/connexion/?lang=en`
- Sur l'url du HomeUrl : précision de fr ou en-gb.
`${settings.domain.pix + settings.domain.tldOrg}/en-gb/`
- Précision de la langue pour la redirection vers la page Campagne lorsque l'utilisateur créer un compte via la double mire. 

Modification du sujet du mail "Création de compte" : _Création de votre compte PIX -> Votre compte Pix a bien été créé_

Traduction apportée pour les deux sujets des mails.

## :rainbow: Remarques
Locale "fr-fr" pour un utilisateur venant de Pix.fr
Locale "fr" pour un utilisateur venant de Pix.org en français
Locale "en" pour un utilisateur venant de Pix.org en anglais.

## :100: Pour tester
Dans votre .env, ajouter : 

```
MAILING_ENABLED=true
MAILING_PROVIDER=sendinblue
SENDINBLUE_API_KEY= 42796e662aXXX
SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID=72
SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID=73
```
Pour la création de compte classique et réinitialisation de password : 

Pour un utilisateur sur Pix.fr : 

- `localhost.fr:4200/inscription` -> Créez un compte avec votre adresse-mail
- Vous recevrez le mail de "création de compte"
- Testez les différents liens présents dans le mail ( le logo Pix, le bouton bleu, les liens page support, présence de la Marianne pour ce mail uniquement)
- Déconnectez-vous et faites "Mot de passe oublié"
- Vous recevrez le mail de "réinitialisation de mot de passe"
- Testez les différents liens présents dans le mail ( le logo Pix, le bouton bleu, les liens page support )

Pour un utilisateur sur Pix.org en français : 
`localhost.org:4200/inscription/?lang=fr`

Pour un utilisateur sur Pix.org en anglais : 
`localhost.org:4200/inscription/?lang=en`

--------

Pour la création de compte via la double mire : 

Lorsque vous recevez le mail de "Création de compte", vérifiez la redirection vers la page de campagne.
