### PR TITLE
[FEATURE] Permettre à l'utilisateur de changer son email (PIX-1777).

### DIFF
--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -73,6 +73,10 @@ export default class User extends ApplicationAdapter {
       return url + '/has-seen-new-level-info';
     }
 
+    if (adapterOptions && adapterOptions.updateEmail) {
+      return url + '/email';
+    }
+
     if (adapterOptions && adapterOptions.updatePassword) {
       delete adapterOptions.updatePassword;
       const temporaryKey = adapterOptions.temporaryKey;

--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -1,8 +1,32 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import isEmailValid from '../utils/email-validator';
 
 export default class UserAccountPanel extends Component {
 
+  @tracked editionMode = false;
+  @tracked newEmail;
+
   get displayUsername() {
     return !!this.args.user.username;
+  }
+
+  get displayModifyButton() {
+    return !!this.args.user.email && !this.editionMode;
+  }
+
+  @action
+  toggleEditionMode() {
+    this.editionMode = !this.editionMode;
+  }
+
+  @action
+  save() {
+    if (isEmailValid(this.newEmail)) {
+      this.args.user.email = this.newEmail;
+      this.args.user.save({ adapterOptions: { updateEmail: true } });
+      this.editionMode = false;
+    }
   }
 }

--- a/mon-pix/app/styles/components/_user-account-panel.scss
+++ b/mon-pix/app/styles/components/_user-account-panel.scss
@@ -3,12 +3,16 @@
   &__item {
     margin: 20px 0;
     display: flex;
-    align-content: flex-start;
+    align-items: center;
     border-bottom: $grey-15 1px solid;
     padding-bottom: 1rem;
 
     &:last-child {
       border-bottom: none;
+    }
+
+    input {
+      height: 31px;
     }
   }
 }
@@ -21,5 +25,11 @@
 
   &__value {
     color: $grey-50;
+    min-width: 200px;
+  }
+
+  &__button {
+    margin: 0 5px;
+    padding: 6px;
   }
 }

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -9,7 +9,36 @@
   </div>
   <div class="user-account-panel__item">
     <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.email'}}</label>
-    <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
+    {{#if this.editionMode}}
+      <Input
+        data-test-modify-email-input
+        class="user-account-panel-item__value"
+        @value={{this.newEmail}}
+      />
+      <PixButton
+          data-test-cancel-button
+          class="button button--grey user-account-panel-item__button"
+          @triggerAction={{this.toggleEditionMode}}>
+        {{t 'common.actions.cancel'}}
+      </PixButton>
+      <PixButton
+          data-test-save-button
+          class="button user-account-panel-item__button"
+          @triggerAction={{this.save}}>
+        {{t 'common.actions.save'}}
+      </PixButton>
+    {{else}}
+      <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
+    {{/if}}
+
+    {{#if this.displayModifyButton}}
+      <PixButton
+          data-test-modify-button
+          class="button user-account-panel-item__button"
+          @triggerAction={{this.toggleEditionMode}}>
+        {{t 'common.actions.modify'}}
+      </PixButton>
+    {{/if}}
   </div>
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -33,9 +33,16 @@ export default function index(config) {
       return new Response(204);
     }
   });
+
   config.patch('/users/:id/remember-user-has-seen-assessment-instructions', (schema, request) => {
     const user = schema.users.find(request.params.id);
     user.hasSeenAssessmentInstructions = true;
     return user;
+  });
+
+  config.patch('/users/:id/email', (schema, request) => {
+    const newEmail = JSON.parse(request.requestBody).data.attributes.email;
+    const user = schema.users.find(request.params.id);
+    return user.update({ email: newEmail });
   });
 }

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -2,11 +2,12 @@ import { currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
-import visit from '../helpers/visit';
+import { click, fillIn, find, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 describe('Acceptance | User account page', function() {
+
   setupApplicationTest();
   setupMirage();
   let user;
@@ -35,5 +36,21 @@ describe('Acceptance | User account page', function() {
       // then
       expect(currentURL()).to.equal('/mon-compte');
     });
+  });
+
+  it('should update user email on click to save button', async function() {
+    // given
+    const newEmail = 'new_email@example.net';
+
+    await authenticateByEmail(user);
+    await visit('/mon-compte');
+    await click('button[data-test-modify-button]');
+    await fillIn('input[data-test-modify-email-input]', newEmail);
+
+    // when
+    await click('button[data-test-save-button]');
+
+    // then
+    expect(find('span[data-test-email]').textContent).to.equal(newEmail);
   });
 });

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { describe, it, beforeEach } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { find, render } from '@ember/test-helpers';
+import { click, fillIn, find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 describe('Integration | Component | user account panel', () => {
@@ -45,4 +46,98 @@ describe('Integration | Component | user account panel', () => {
     });
   });
 
+  context('when user does have an email', function() {
+
+    let user;
+
+    beforeEach(function() {
+      // given
+      user = {
+        firstName: 'John',
+        lastName: 'DOE',
+        username: 'john.doe0101',
+        email: 'john.doe@example.net',
+        save: sinon.stub(),
+      };
+      this.set('user', user);
+    });
+
+    it('should display a modify button', async function() {
+      // when
+      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+
+      // then
+      expect(find('button[data-test-modify-button]')).to.exist;
+
+    });
+
+    context('When modify button is clicked', () => {
+
+      beforeEach(async () => {
+        // given
+        await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+        await click('button[data-test-modify-button]');
+      });
+
+      it('should display an input field', async function() {
+        // then
+        expect(find('input[data-test-modify-email-input]')).to.exist;
+      });
+
+      it('should display a save button', async function() {
+        // then
+        expect(find('button[data-test-save-button]')).to.exist;
+      });
+
+      it('should display a cancel button', async function() {
+        // then
+        expect(find('button[data-test-cancel-button]')).to.exist;
+      });
+
+      it('should hide input field when cancel button is clicked', async function() {
+        // when
+        await click('button[data-test-cancel-button]');
+
+        // then
+        expect(find('input[data-test-modify-email-input]')).to.not.exist;
+      });
+
+      it('should call user save function when save button is clicked', async function() {
+        // when
+        await fillIn('input', 'new_email@example.net');
+        await click('button[data-test-save-button]');
+
+        // then
+        sinon.assert.called(user.save);
+      });
+
+      it('should not call user save function when email is not valid', async function() {
+        // when
+        await fillIn('input', 'not_valid');
+        await click('button[data-test-save-button]');
+
+        // then
+        sinon.assert.notCalled(user.save);
+      });
+    });
+  });
+
+  context('when user does not have an email', function() {
+
+    it('should not display a modify button', async function() {
+      // given
+      const user = {
+        firstName: 'John',
+        lastName: 'DOE',
+        username: 'john.doe0101',
+      };
+      this.set('user', user);
+
+      // when
+      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+
+      // then
+      expect(find('button[data-test-modify-button]')).to.not.exist;
+    });
+  });
 });

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -90,6 +90,15 @@ describe('Unit | Adapters | user', function() {
       expect(url.endsWith('/users/123/lang/en')).to.be.true;
     });
 
+    it('should redirect to email', async function() {
+      // when
+      const options = { adapterOptions: { updateEmail: true } };
+      const url = await adapter.urlForUpdateRecord(123, 'user', options);
+
+      // then
+      expect(url.endsWith('/users/123/email')).to.be.true;
+    });
+
   });
 
   describe('#createRecord', () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -30,7 +30,9 @@
             "back": "Back",
             "cancel": "Cancel",
             "close": "Close",
+            "modify": "",
             "quit": "Exit",
+            "save": "Save",
             "sign-out": "Sign out"
         },
         "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -30,7 +30,9 @@
             "back": "Retour",
             "cancel": "Annuler",
             "close": "Fermer",
+            "modify": "Modifier",
             "quit": "Quitter",
+            "save": "Enregistrer",
             "sign-out": "Se déconnecter"
         },
         "form": {


### PR DESCRIPTION
## :unicorn: Problème
Voir PR #1702 

## :robot: Solution
Si l'utilisateur a un email, afficher un bouton
Si clic desssus, faire apparaitre une zone de saisie qui remplace l’email existant

## :rainbow: Remarques
Invisible en production en navigation directe (pas de lien dans le menu principal)
Réalisé en mob programming

## :100: Pour tester
Se conncter et consulter /mon-compte
