### PR TITLE
[BUGFIX] Ne plus pouvoir accéder à n'importe quelle campagne si un utilisateur est réconcilié 1 fois (PIX-1692).

### DIFF
--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -14,7 +14,7 @@ export default class JoinRoute extends Route {
     return this.modelFor('campaigns');
   }
 
-  async afterModel(campaign) {
+  async redirect(campaign) {
     if (!this.session.get('data.externalUser')) {
       let schoolingRegistration = await this.store.queryRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code });
 

--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -81,9 +81,16 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
       && !this.state.hasUserCompletedRestrictedCampaignAssociation;
   }
 
+  _shouldResetState(campaignCode) {
+    return campaignCode !== this.state.campaignCode;
+  }
+
   beforeModel(transition) {
     this.authenticationRoute = 'inscription';
     const campaign = this.modelFor('campaigns');
+    if (this._shouldResetState(campaign.code)) {
+      this._resetState();
+    }
     this._updateStateFrom({ campaign, queryParams: transition.to.queryParams, session: this.session });
 
     if (this._shouldLoginToAccessRestrictedCampaign) {
@@ -106,6 +113,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
 
   _resetState() {
     this.state = {
+      campaignCode: null,
       isCampaignRestricted: false,
       isCampaignForSCOOrganization: false,
       hasUserCompletedRestrictedCampaignAssociation: false,
@@ -124,6 +132,7 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     const hasUserSeenLandingPage = this._handleQueryParamBoolean(queryParams.hasUserSeenLandingPage, this.state.hasUserSeenLandingPage);
     const hasUserSeenJoinPage = this._handleQueryParamBoolean(queryParams.hasUserSeenJoinPage, this.state.hasUserSeenJoinPage);
     this.state = {
+      campaignCode: get(campaign, 'code', this.state.campaignCode),
       isCampaignRestricted: get(campaign, 'isRestricted', this.state.isCampaignRestricted),
       isCampaignForSCOOrganization: get(campaign, 'organizationType') === 'SCO',
       hasUserCompletedRestrictedCampaignAssociation,

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
@@ -11,7 +11,7 @@ const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_
 describe('Unit | Route | campaigns/restricted/join', function() {
   setupTest();
 
-  describe('#afterModel', function() {
+  describe('#redirect', function() {
 
     it('should redirect to campaigns.start-or-resume when an association already exists', async function() {
       // given
@@ -28,7 +28,7 @@ describe('Unit | Route | campaigns/restricted/join', function() {
       const transition = { to: { queryParams: {} } };
 
       // when
-      await route.afterModel(campaign, transition);
+      await route.redirect(campaign, transition);
 
       // then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });

--- a/mon-pix/tests/unit/routes/campaigns/start-or-resume-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/start-or-resume-test.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { describe, it, beforeEach } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | Start-or-resume', function() {
+  setupTest();
+
+  let route;
+
+  const campaign = {
+    code: 'NEW_CODE',
+    isRestricted: true,
+  };
+
+  beforeEach(function() {
+    route = this.owner.lookup('route:campaigns.start-or-resume');
+  });
+
+  describe('#beforeModel', function() {
+    it('should reset state', async function() {
+      // given
+      route.state.campaignCode = 'OLD_CODE';
+      route.state.hasUserCompletedRestrictedCampaignAssociation = true;
+      const transition = { to: { queryParams: { } } };
+      route.modelFor = sinon.stub().returns(campaign);
+      route.session = { isAuthenticated: true };
+      route.currentUser = { user: { mustValidateTermsOfService: false } };
+      route.replaceWith = sinon.stub();
+
+      // when
+      await route.beforeModel(transition);
+
+      // then
+      expect(route.state.hasUserCompletedRestrictedCampaignAssociation).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Si un utilisateur est réconcilié au moins une fois, et cherchait à rejoindre un parcours d'une autre organisation, on ne cherchait même pas à savoir s'il était réconcilié dans la nouvelle organisation, l'utilisateur accédait directement au parcours.

## :robot: Solution
Il s'avère que c'est un problème de gestion d'état. Lorsque coup sur coup on rejoint 2 parcours de 2 organisations différentes, la page `start-or-resume` n'est pas  réinitialisée et donc on ne passe pas par le `constructor`, qui s'occupait de reset le state. Il faut donc le faire manuellement, si on se rend compte que la campagne actuelle n'a plus le même code que la campagne que l'on gardé en mémoire : cela signifie que l'on est plus sur la même campagne.

## :rainbow: Remarques
bonus : remplacement du `afterModel` par un `redirect` dans la page `join`.

## :100: Pour tester
- se connecter à Pix App avec userpix1@example.net ;
- saisir le code campagne SNAP789 ;
- remplir les informations de réconciliation SUP ;
- envoyer le profil ;
- retourner au profil ;
- saisir un nouveau code campagne SNAP456 ;
- vérifier que l'on arrive bien sur la page de réconciliation (saisie du nom - prénom - date de naissance ) et non sur la page de début de parcours.
