### PR TITLE
[BUGFIX] Ajouter un  placeholder sur le champ de recherche du créateur des campagnes (PIX-1767).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -20,6 +20,7 @@
             <Table::HeaderFilterInput
               @field="creatorName"
               @value={{@creatorNameFilter}}
+              @placeholder="Rechercher un créateur"
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -43,7 +43,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
-                  @campaigns={{campaigns}}
+                  @campaigns={{this.campaigns}}
                   @triggerFiltering={{this.triggerFilteringSpy}}
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
@@ -216,6 +216,38 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
 
       // then
       assert.dom('[aria-label="Campagne"]').containsText('4');
+    });
+
+    test('it should display the placeholder of the filter by campaign field', async function(assert) {
+      // given
+      const campaigns = [];
+      campaigns.meta = { rowCount: 0 };
+      this.set('campaigns', campaigns);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::List
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+
+      // then
+      assert.dom('[placeholder="Rechercher une campagne"]').exists();
+    });
+
+    test('it should display the placeholder of the filter by creater field', async function(assert) {
+      // given
+      const campaigns = [];
+      campaigns.meta = { rowCount: 0 };
+      this.set('campaigns', campaigns);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::List
+                  @campaigns={{campaigns}}
+                  @triggerFiltering={{this.triggerFilteringSpy}}
+                  @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
+
+      // then
+      assert.dom('[placeholder="Rechercher un créateur"]').exists();
     });
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -226,7 +226,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
-                  @campaigns={{campaigns}}
+                  @campaigns={{this.campaigns}}
                   @triggerFiltering={{this.triggerFilteringSpy}}
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 
@@ -234,7 +234,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
       assert.dom('[placeholder="Rechercher une campagne"]').exists();
     });
 
-    test('it should display the placeholder of the filter by creater field', async function(assert) {
+    test('it should display the placeholder of the filter by creator field', async function(assert) {
       // given
       const campaigns = [];
       campaigns.meta = { rowCount: 0 };
@@ -242,7 +242,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::List
-                  @campaigns={{campaigns}}
+                  @campaigns={{this.campaigns}}
                   @triggerFiltering={{this.triggerFilteringSpy}}
                   @goToCampaignPage={{this.goToCampaignPageSpy}} />`);
 


### PR DESCRIPTION
## :unicorn: Problème
Il y a pas de placeholder pour les filtres de recherche de campagnes 

## :robot: Solution
Rajouter des placeholders

## :rainbow: Remarques
RAS

## :100: Pour tester

Se connecter à PixOrga
Afficher la list des campagnes 
Constater qu'il y a bien le placeholder dans les champs de filtres