### PR TITLE
[FEATURE] Restreindre l'accès aux parcours Pole Emploi aux utilisateurs possédant un compte Pole Emploi (PIX-1636).

### DIFF
--- a/api/lib/domain/models/CampaignToJoin.js
+++ b/api/lib/domain/models/CampaignToJoin.js
@@ -16,6 +16,7 @@ class CampaignToJoin {
     organizationType,
     organizationLogoUrl,
     organizationIsManagingStudents,
+    organizationIsPoleEmploi,
     targetProfileName,
     targetProfileImageUrl,
   } = {}) {
@@ -33,6 +34,7 @@ class CampaignToJoin {
     this.organizationName = organizationName;
     this.organizationType = organizationType;
     this.organizationLogoUrl = organizationLogoUrl;
+    this.organizationIsPoleEmploi = organizationIsPoleEmploi;
     this.targetProfileName = targetProfileName;
     this.targetProfileImageUrl = targetProfileImageUrl;
   }

--- a/api/lib/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-to-join-repository.js
@@ -40,8 +40,13 @@ module.exports = {
         'targetProfileName': 'target-profiles.name',
         'targetProfileImageUrl': 'target-profiles.imageUrl',
       })
+      .select(knex.raw('EXISTS(SELECT true FROM "organization-tags" ' +
+        'JOIN tags ON "organization-tags"."tagId" = "tags".id ' +
+        'WHERE "tags"."name" = \'POLE EMPLOI\' AND "organization-tags"."organizationId" = "organizations".id) as "organizationIsPoleEmploi"'))
       .join('organizations', 'organizations.id', 'campaigns.organizationId')
       .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
+      .leftJoin('organization-tags', 'organization-tags.organizationId', 'organizations.id')
+      .leftJoin('tags', 'tags.id', 'organization-tags.tagId')
       .where('campaigns.code', code)
       .first();
 

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
       attributes: ['code', 'title', 'type', 'idPixLabel', 'customLandingPageText',
         'externalIdHelpImageUrl', 'alternativeTextToExternalIdHelpImage', 'isArchived',
         'isRestricted', 'organizationName', 'organizationType', 'organizationLogoUrl',
-        'targetProfileName', 'targetProfileImageUrl'],
+        'organizationIsPoleEmploi', 'targetProfileName', 'targetProfileImageUrl'],
     }).serialize(campaignsToJoin);
   },
 };

--- a/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-to-join-repository_test.js
@@ -85,6 +85,44 @@ describe('Integration | Repository | CampaignToJoin', () => {
       expect(actualCampaign.targetProfileImageUrl).to.deep.equal(targetProfile.imageUrl);
     });
 
+    context('when the organization of the campaign has the POLE EMPLOI tag', () => {
+      it('should return true for organizationIsPoleEmploi', async () => {
+        // given
+        const code = 'LAURA456';
+        const organization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildCampaign({ code, organizationId: organization.id });
+        databaseBuilder.factory.buildOrganizationTag({
+          organizationId: organization.id,
+          tagId: databaseBuilder.factory.buildTag({ name: 'POLE EMPLOI' }).id,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const actualCampaign = await campaignToJoinRepository.getByCode(code);
+
+        // then
+        expect(actualCampaign).to.be.instanceOf(CampaignToJoin);
+        expect(actualCampaign.organizationIsPoleEmploi).to.be.true;
+      });
+    });
+
+    context('when the organization of the campaign does not have the POLE EMPLOI tag', () => {
+      it('should return false for organizationIsPoleEmploi', async () => {
+        // given
+        const code = 'LAURA456';
+        const organization = databaseBuilder.factory.buildOrganization();
+        databaseBuilder.factory.buildCampaign({ code, organizationId: organization.id });
+        await databaseBuilder.commit();
+
+        // when
+        const actualCampaign = await campaignToJoinRepository.getByCode(code);
+
+        // then
+        expect(actualCampaign).to.be.instanceOf(CampaignToJoin);
+        expect(actualCampaign.organizationIsPoleEmploi).to.be.false;
+      });
+    });
+
     it('should throw a NotFoundError when no campaign exists with given code', async () => {
       // given
       const code = 'LAURA123';

--- a/api/tests/tooling/domain-builder/factory/build-campaign-to-join.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-to-join.js
@@ -16,6 +16,7 @@ module.exports = function buildCampaignToJoin({
   organizationType = types.PRO,
   organizationLogoUrl = 'baseCodeOrgaLogoImage',
   organizationIsManagingStudents = false,
+  organizationIsPoleEmploi = false,
   targetProfileName = 'Le profil cible',
   targetProfileImageUrl = 'targetProfileImageUrl',
 } = {}) {
@@ -34,6 +35,7 @@ module.exports = function buildCampaignToJoin({
     organizationType,
     organizationLogoUrl,
     organizationIsManagingStudents,
+    organizationIsPoleEmploi,
     targetProfileName,
     targetProfileImageUrl,
   });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -207,6 +207,7 @@ describe('Unit | Application | Controller | Campaign', () => {
           'alternative-text-to-external-id-help-image': campaignToJoin.alternativeTextToExternalIdHelpImage,
           'is-archived': campaignToJoin.isArchived,
           'is-restricted': campaignToJoin.isRestricted,
+          'organization-is-pole-emploi': campaignToJoin.organizationIsPoleEmploi,
           'organization-name': campaignToJoin.organizationName,
           'organization-type': campaignToJoin.organizationType,
           'organization-logo-url': campaignToJoin.organizationLogoUrl,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
@@ -27,6 +27,7 @@ describe('Unit | Serializer | JSONAPI | campaign-to-join-serializer', () => {
             'alternative-text-to-external-id-help-image': campaignToJoin.alternativeTextToExternalIdHelpImage,
             'is-archived': campaignToJoin.isArchived,
             'is-restricted': campaignToJoin.isRestricted,
+            'organization-is-pole-emploi': campaignToJoin.organizationIsPoleEmploi,
             'organization-name': campaignToJoin.organizationName,
             'organization-type': campaignToJoin.organizationType,
             'organization-logo-url': campaignToJoin.organizationLogoUrl,

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -13,6 +13,7 @@ export default class Campaign extends Model {
   @attr('string') organizationName;
   @attr('string') organizationType;
   @attr('string') organizationLogoUrl;
+  @attr('boolean') organizationIsPoleEmploi;
   @attr('string') targetProfileName;
   @attr('string') targetProfileImageUrl;
 

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -5,6 +5,7 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 import Route from '@ember/routing/route';
 
 import { inject as service } from '@ember/service';
+import get from 'lodash/get';
 
 export default Route.extend(ApplicationRouteMixin, {
 
@@ -49,7 +50,14 @@ export default Route.extend(ApplicationRouteMixin, {
   async sessionAuthenticated() {
     const _super = this._super;
     await this._getUserAndLocal();
-    _super.call(this, ...arguments);
+
+    const nextURL = this.session.data.nextURL;
+    if (nextURL && get(this.session, 'data.authenticated.source') === 'pole_emploi_connect') {
+      this.session.set('data.nextURL', undefined);
+      this.replaceWith(nextURL);
+    } else {
+      _super.call(this, ...arguments);
+    }
   },
 
   // We need to override the sessionInvalidated from ApplicationRouteMixin

--- a/mon-pix/app/routes/login-pe.js
+++ b/mon-pix/app/routes/login-pe.js
@@ -12,6 +12,7 @@ export default class LoginPeRoute extends Route {
 
   @service session;
   @service router;
+  @service location;
 
   get redirectUri() {
     const { protocol, host } = location;
@@ -60,14 +61,22 @@ export default class LoginPeRoute extends Route {
     this.session.set('data.state', state);
 
     /**
-     * Store the `nextURL` in the localstorage so when the user returns after
+     * Store the `attemptedTransition` in the localstorage so when the user returns after
      * the login he can be sent to the initial destination.
      */
-    if (!this.session.get('data.nextURL')) {
-      this.session.set(
-        'data.nextURL',
-        this.session.get('attemptedTransition.intent.url'),
-      );
+    if (this.session.get('attemptedTransition')) {
+      /**
+       * There is two types of intent in transition (see: https://github.com/tildeio/router.js/blob/9b3d00eb923e0bbc34c44f08c6de1e05684b907a/ARCHITECTURE.md#transitionintent)
+       * When the route is accessed by url (/campagnes/:code), the url is provided
+       * When the route is accessed by the submit of the campaign code, the route name (campaigns.start-or-resume) and contexts ([Campaign]) are provided
+       */
+
+      let { url } = this.session.get('attemptedTransition.intent');
+      const { name, contexts } = this.session.get('attemptedTransition.intent');
+      if (!url) {
+        url = this.router.urlFor(name, contexts[0]);
+      }
+      this.session.set('data.nextURL', url);
     }
 
     const search = [
@@ -83,7 +92,7 @@ export default class LoginPeRoute extends Route {
 
     const updatedAuthEndpoint = `${authEndpoint}?realm=%2Findividu`;
 
-    location.replace(`${getAbsoluteUrl(host)}${updatedAuthEndpoint}&${search}`);
+    this.location.replace(`${getAbsoluteUrl(host)}${updatedAuthEndpoint}&${search}`);
   }
 }
 

--- a/mon-pix/app/services/location.js
+++ b/mon-pix/app/services/location.js
@@ -1,0 +1,8 @@
+import Service from '@ember/service';
+
+export default class LocationService extends Service {
+
+  replace(url) {
+    return location.replace(url);
+  }
+}

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -27,4 +27,17 @@ export default function index(config) {
     };
     return new Response(200, {}, response);
   });
+
+  config.post('/pole-emploi/token', (schema) => {
+    const createdUser = schema.users.create({
+      firstName: 'Paul',
+      lastName: 'Emploi',
+    });
+
+    return {
+      access_token: 'aaa.' + btoa(`{"user_id":${createdUser.id},"source":"pole_emploi_connect","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      id_token: 'id_token',
+      user_id: createdUser.id,
+    };
+  });
 }


### PR DESCRIPTION
## :unicorn: Problème
L'accès au parcours Pole Emploi ne nécessite pas aujourd'hui de posséder un compte Pole Emploi.

## :robot: Solution
Restreindre l'accès au parcours Pole Emploi aux utilisateurs possédant un compte Pole Emploi.

## :rainbow: Remarques
Pas testable actuellement sur l'environnement de production de Pole Emploi.

## :100: Pour tester
En local : Ajouter les variables dans le .env (voir  [wiki](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1949663259/PoC+Int+gration+P+le+Emploi+Connect+dans+Mon-Pix)) 

Tester en local avec le code parcours QWERTY789.