### PR TITLE
[TECH] Fixer la version de pix-ui dans pix-certif

### DIFF
--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -19900,7 +19900,7 @@
     },
     "pix-ui": {
       "version": "git://github.com/1024pix/pix-ui.git#c996f74d88673ae189e7b3c537b3e8d8055d9771",
-      "from": "git://github.com/1024pix/pix-ui.git",
+      "from": "git://github.com/1024pix/pix-ui.git#v1.0.1",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -88,7 +88,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.0.1",
     "qunit-dom": "^1.4.0",
     "sass": "^1.26.3",
     "stylelint": "^13.7.2",


### PR DESCRIPTION
## :unicorn: Problème 

PB soulevé par @jonathanperret
 
Pour les dépendances Git, npm ne regarde pas le package-lock.json (même lors d’un npm ci ) et installe systématiquement la dernière version qui matche ce qui est spécifié dans le package.json. 

Du coup pour avoir des installations reproductibles il est crucial d’avoir une version précise dans le package.json…

Actuellement, tout nouveau commit sur pix-ui sera embarqué par le prochain déploiement de pix-certif
## :robot: Solution
Fixer la version de pix-ui dans pix-certif
