### PR TITLE
[BUGFIX] Renforce la contrainte d'accès à la prescription de certif SCO côté PixCertif en limitant l'accès aux centres de certification dont l'organisation soeur est isManagingStudents (PIX-1766)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -14,6 +14,8 @@ const encrypt = require('../../../lib/domain/services/encryption-service');
 const buildUserPixRole = require('./build-user-pix-role');
 const buildOrganization = require('./build-organization');
 const buildMembership = require('./build-membership');
+const buildCertificationCenter = require('./build-certification-center');
+const buildCertificationCenterMembership = require('./build-certification-center-membership');
 
 const PIX_MASTER_ROLE_ID = 1;
 
@@ -223,6 +225,54 @@ buildUser.withMembership = function buildUserWithMemberships({
     userId: user.id,
     organizationId,
     organizationRole,
+  });
+
+  return user;
+};
+
+buildUser.withCertificationCenterMembership = function buildUserWithCertificationCenterMembership({
+  id,
+  firstName = faker.name.firstName(),
+  lastName = faker.name.lastName(),
+  email,
+  username = firstName + '.' + lastName + faker.random.number({ min: 1000, max: 9999 }),
+  cgu = true,
+  lang = 'fr',
+  lastTermsOfServiceValidatedAt = null,
+  mustValidateTermsOfService = false,
+  pixOrgaTermsOfServiceAccepted = false,
+  pixCertifTermsOfServiceAccepted = false,
+  hasSeenAssessmentInstructions = false,
+  hasSeenNewLevelInfo = false,
+  createdAt = new Date(),
+  updatedAt = new Date(),
+
+  certificationCenterId = null,
+} = {}) {
+
+  const user = buildUser({
+    id,
+    firstName,
+    lastName,
+    username,
+    email,
+    cgu,
+    lang,
+    lastTermsOfServiceValidatedAt,
+    mustValidateTermsOfService,
+    pixOrgaTermsOfServiceAccepted,
+    pixCertifTermsOfServiceAccepted,
+    hasSeenAssessmentInstructions,
+    hasSeenNewLevelInfo,
+    createdAt,
+    updatedAt,
+  });
+
+  certificationCenterId = isNil(certificationCenterId) ? buildCertificationCenter().id : certificationCenterId;
+
+  buildCertificationCenterMembership({
+    userId: user.id,
+    certificationCenterId,
   });
 
   return user;

--- a/api/lib/domain/read-models/CertificationPointOfContact.js
+++ b/api/lib/domain/read-models/CertificationPointOfContact.js
@@ -9,6 +9,7 @@ class CertificationPointOfContact {
     certificationCenterName,
     certificationCenterType,
     certificationCenterExternalId,
+    isRelatedOrganizationManagingStudents,
   }) {
     this.id = id;
     this.firstName = firstName;
@@ -19,6 +20,7 @@ class CertificationPointOfContact {
     this.certificationCenterName = certificationCenterName;
     this.certificationCenterType = certificationCenterType;
     this.certificationCenterExternalId = certificationCenterExternalId;
+    this.isRelatedOrganizationManagingStudents = Boolean(isRelatedOrganizationManagingStudents);
   }
 }
 

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -5,20 +5,22 @@ const CertificationPointOfContact = require('../../domain/read-models/Certificat
 module.exports = {
   async get(userId) {
     const result = await knex
-      .select(
-        'users.id as id',
-        'users.firstName as firstName',
-        'users.lastName as lastName',
-        'users.email as email',
-        'users.pixCertifTermsOfServiceAccepted as pixCertifTermsOfServiceAccepted',
-        'certification-centers.id as certificationCenterId',
-        'certification-centers.name as certificationCenterName',
-        'certification-centers.type as certificationCenterType',
-        'certification-centers.externalId as certificationCenterExternalId',
-      )
+      .select({
+        id: 'users.id',
+        firstName: 'users.firstName',
+        lastName: 'users.lastName',
+        email: 'users.email',
+        pixCertifTermsOfServiceAccepted: 'users.pixCertifTermsOfServiceAccepted',
+        certificationCenterId: 'certification-centers.id',
+        certificationCenterName: 'certification-centers.name',
+        certificationCenterType: 'certification-centers.type',
+        certificationCenterExternalId: 'certification-centers.externalId',
+        isRelatedOrganizationManagingStudents: 'organizations.isManagingStudents',
+      })
       .from('users')
       .join('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
       .join('certification-centers', 'certification-centers.id', 'certification-center-memberships.certificationCenterId')
+      .leftJoin('organizations', 'organizations.externalId', 'certification-centers.externalId')
       .where('users.id', userId)
       .first();
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
       attributes: [
         'firstName', 'lastName', 'email', 'pixCertifTermsOfServiceAccepted',
         'certificationCenterId', 'certificationCenterName',
-        'certificationCenterType', 'certificationCenterExternalId',
+        'certificationCenterType', 'certificationCenterExternalId', 'isRelatedOrganizationManagingStudents',
         'sessions',
       ],
       sessions: {

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -10,24 +10,19 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
 
     it('should return CertificationPointOfContact with all the info if exists', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser({
-        firstName: 'Jean',
-        lastName: 'Acajou',
-        email: 'jean.acajou@example.net',
-        pixCertifTermsOfServiceAccepted: true,
-      }).id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
         name: 'Centre des papys gâteux',
         type: CertificationCenter.types.PRO,
         externalId: 'ABC123',
       }).id;
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        userId,
+      const userId = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+        firstName: 'Jean',
+        lastName: 'Acajou',
+        email: 'jean.acajou@example.net',
+        pixCertifTermsOfServiceAccepted: true,
         certificationCenterId,
-      });
-      const someOtherUserId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        userId: someOtherUserId,
+      }).id;
+      databaseBuilder.factory.buildUser.withCertificationCenterMembership({
         certificationCenterId,
       });
       await databaseBuilder.commit();
@@ -51,14 +46,16 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
 
     it('should return CertificationRPointOfContact with isRelatedOrganizationManagingStudents as true when the certification center is related to an organization that manages students', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
         externalId: 'ABC123',
       }).id;
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        userId,
+      const userId = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+        firstName: 'Jean',
+        lastName: 'Acajou',
+        email: 'jean.acajou@example.net',
+        pixCertifTermsOfServiceAccepted: true,
         certificationCenterId,
-      });
+      }).id;
       databaseBuilder.factory.buildOrganization({
         externalId: 'ABC123',
         isManagingStudents: true,
@@ -76,9 +73,7 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
       // given
       const userId = databaseBuilder.factory.buildUser().id;
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
-      const someOtherUserId = databaseBuilder.factory.buildUser().id;
-      databaseBuilder.factory.buildCertificationCenterMembership({
-        userId: someOtherUserId,
+      databaseBuilder.factory.buildUser.withCertificationCenterMembership({
         certificationCenterId,
       });
       await databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -46,21 +46,36 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
       expect(certificationPointOfContact.certificationCenterName).to.equal('Centre des papys gâteux');
       expect(certificationPointOfContact.certificationCenterType).to.equal(CertificationCenter.types.PRO);
       expect(certificationPointOfContact.certificationCenterExternalId).to.equal('ABC123');
+      expect(certificationPointOfContact.isRelatedOrganizationManagingStudents).to.be.false;
+    });
+
+    it('should return CertificationRPointOfContact with isRelatedOrganizationManagingStudents as true when the certification center is related to an organization that manages students', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+        externalId: 'ABC123',
+      }).id;
+      databaseBuilder.factory.buildCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+      });
+      databaseBuilder.factory.buildOrganization({
+        externalId: 'ABC123',
+        isManagingStudents: true,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+
+      // then
+      expect(certificationPointOfContact.isRelatedOrganizationManagingStudents).to.be.true;
     });
 
     it('should throw NotFoundError when point of contact does not exist', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser({
-        firstName: 'Jean',
-        lastName: 'Acajou',
-        email: 'jean.acajou@example.net',
-        pixCertifTermsOfServiceAccepted: true,
-      }).id;
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
-        name: 'Centre des papys gâteux',
-        type: CertificationCenter.types.PRO,
-        externalId: 'ABC123',
-      }).id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const someOtherUserId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCertificationCenterMembership({
         userId: someOtherUserId,

--- a/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
@@ -12,6 +12,7 @@ module.exports = function buildCertificationPointOfContact(
     certificationCenterName = 'Centre de la prairie verdoyante',
     certificationCenterType = CertificationCenter.types.PRO,
     certificationCenterExternalId = 'CHEVRE456',
+    isRelatedOrganizationManagingStudents = false,
   } = {}) {
 
   return new CertificationPointOfContact({
@@ -24,5 +25,6 @@ module.exports = function buildCertificationPointOfContact(
     certificationCenterName,
     certificationCenterType,
     certificationCenterExternalId,
+    isRelatedOrganizationManagingStudents,
   });
 };

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -38,6 +38,7 @@ describe('Unit | Controller | certifications-point-of-contact-controller', () =>
             'certification-center-name': certificationPointOfContact.certificationCenterName,
             'certification-center-type': certificationPointOfContact.certificationCenterType,
             'certification-center-external-id': certificationPointOfContact.certificationCenterExternalId,
+            'is-related-organization-managing-students': certificationPointOfContact.isRelatedOrganizationManagingStudents,
           },
           relationships: {
             sessions: {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -26,6 +26,7 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
             'certification-center-name': certificationPointOfContact.certificationCenterName,
             'certification-center-type': certificationPointOfContact.certificationCenterType,
             'certification-center-external-id': certificationPointOfContact.certificationCenterExternalId,
+            'is-related-organization-managing-students': certificationPointOfContact.isRelatedOrganizationManagingStudents,
           },
           relationships: {
             sessions: {

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -6,7 +6,7 @@
         <div class="panel-header__mandatory-warning">Les champs marqués de * sont obligatoires</div>
       {{/if}}
     </div>
-    {{#if this.isScoSession}}
+    {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
       <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link enrolled-candidate__add-students">
         Ajouter des candidats
       </LinkTo>
@@ -61,14 +61,14 @@
             Pays de naissance
           </th>
           {{#if this.isResultRecipientEmailVisible}}
-            {{#unless this.isScoSession}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th>Adresse e-mail du destinataire des résultats</th>
             {{/unless}}
           {{/if}}
-            {{#unless this.isScoSession}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <th>Adresse e-mail de convocation</th>
             {{/unless}}
-          {{#unless this.isScoSession}}
+          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
             <th>Identifiant externe</th>
           {{/unless}}
           <th class="certification-candidates-table__column-time">Temps majoré</th>
@@ -94,14 +94,14 @@
             <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
             <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
             {{#if this.isResultRecipientEmailVisible}}
-              {{#unless this.isScoSession}}
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
                 <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
               {{/unless}}
             {{/if}}
-              {{#unless this.isScoSession}}
+              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
                 <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
               {{/unless}}
-            {{#unless this.isScoSession}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
             {{/unless}}
             <td data-test-id='panel-candidate__extraTimePercentage__{{candidate.id}}'>{{format-percentage candidate.extraTimePercentage}}</td>

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -18,10 +18,6 @@ export default class EnrolledCandidates extends Component {
     return this.candidatesInStaging.length > 0;
   }
 
-  get isScoSession() {
-    return this.args.isCertifPrescriptionScoEnabled && this.args.isUserFromSco;
-  }
-
   @action
   async deleteCertificationCandidate(certificationCandidate) {
     this.notifications.clearAll();

--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -9,16 +9,15 @@ const LINK_OTHER = 'http://cloud.pix.fr/s/fLSG4mYCcX7GDRF';
 export default class AuthenticatedController extends Controller {
 
   @tracked isBannerVisible = true;
-  @service currentUser;
   @service router;
 
   get showBanner() {
     const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';
-    return this.currentUser.isFromSco && this.isBannerVisible && !isOnFinalizationPage;
+    return this.model.isScoManagingStudents && this.isBannerVisible && !isOnFinalizationPage;
   }
 
   get documentationLink() {
-    if (this.model.isSco) {
+    if (this.model.isScoManagingStudents) {
       return LINK_SCO;
     }
     return LINK_OTHER;

--- a/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
+++ b/certif/app/controllers/authenticated/sessions/details/certification-candidates.js
@@ -9,8 +9,7 @@ export default class CertificationCandidatesController extends Controller {
   @alias('model.session') currentSession;
   @alias('model.certificationCandidates') certificationCandidates;
   @alias('model.reloadCertificationCandidate') reloadCertificationCandidate;
-  @alias('model.isUserFromSco') isUserFromSco;
-  @alias('model.isCertifPrescriptionScoEnabled') isCertifPrescriptionScoEnabled;
+  @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
   @computed('certificationCandidates', 'certificationCandidates.@each.isLinked')
   get importAllowed() {

--- a/certif/app/models/certification-point-of-contact.js
+++ b/certif/app/models/certification-point-of-contact.js
@@ -1,4 +1,5 @@
 import Model, { hasMany, attr } from '@ember-data/model';
+import { computed } from '@ember/object';
 import { equal } from '@ember/object/computed';
 
 export default class CertificationPointOfContact extends Model {
@@ -10,8 +11,14 @@ export default class CertificationPointOfContact extends Model {
   @attr() certificationCenterName;
   @attr() certificationCenterType;
   @attr() certificationCenterExternalId;
+  @attr() isRelatedOrganizationManagingStudents;
   @hasMany('session') sessions;
   @equal('certificationCenterType', 'SCO') isSco;
+
+  @computed('certificationCenterType', 'isRelatedOrganizationManagingStudents')
+  get isScoManagingStudents() {
+    return this.certificationCenterType === 'SCO' && this.isRelatedOrganizationManagingStudents;
+  }
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -11,15 +11,15 @@ export default class SessionsDetailsRoute extends Route {
       sessionId: params.session_id,
     });
     const certificationCandidates = await loadCertificationCandidates();
-    const isUserFromSco = this.currentUser.isFromSco;
+    const isScoManagingStudents = this.currentUser.certificationPointOfContact.isScoManagingStudents;
     const featureToggles = this.store.peekRecord('feature-toggle', 0);
     const isCertifPrescriptionScoEnabled = featureToggles.certifPrescriptionSco;
+    const shouldDisplayPrescriptionScoStudentRegistrationFeature = isScoManagingStudents && isCertifPrescriptionScoEnabled;
 
     return EmberObject.create({
       session,
       certificationCandidates,
-      isUserFromSco,
-      isCertifPrescriptionScoEnabled,
+      shouldDisplayPrescriptionScoStudentRegistrationFeature,
       async reloadCertificationCandidate() {
         const certificationCandidates = await loadCertificationCandidates();
         this.set('certificationCandidates', certificationCandidates);

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -1,11 +1,10 @@
-{{#if (and this.isUserFromSco this.isCertifPrescriptionScoEnabled)}}
+{{#if this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
   {{#unless this.hasOneOrMoreCandidates}}
     <CertificationCandidatesSco @sessionId={{this.currentSession.id}}></CertificationCandidatesSco>
   {{/unless}}
   {{#if this.hasOneOrMoreCandidates}}
   <EnrolledCandidates
-        @isUserFromSco={{this.isUserFromSco}}
-        @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+        @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
         @sessionId={{this.currentSession.id}}
         @certificationCandidates={{this.certificationCandidates}}
         @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />
@@ -17,8 +16,7 @@
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @importAllowed={{this.importAllowed}}/>
   <EnrolledCandidates
-          @isUserFromSco={{this.isUserFromSco}}
-          @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+          @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
           @sessionId={{this.currentSession.id}}
           @certificationCandidates={{this.certificationCandidates}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}} />

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -1,11 +1,11 @@
 import { module, test } from 'qunit';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { createCertificationPointOfContactWithTermsOfServiceAccepted, authenticateSession } from '../helpers/test-init';
+import { createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted, authenticateSession } from '../helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Add Students', function(hooks) {
+module('Acceptance | Session Add Sco Students', function(hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -15,7 +15,7 @@ module('Acceptance | Session Add Students', function(hooks) {
 
   hooks.beforeEach(function() {
     server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
-    certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted('SCO');
+    certificationPointOfContact = createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted('SCO');
     session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
   });
 

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -3,7 +3,7 @@ import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import moment from 'moment';
 import {
-  createScoCertificationPointOfContactWithTermsOfServiceAccepted,
+  createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted,
   createCertificationPointOfContactWithTermsOfServiceAccepted,
   authenticateSession,
 } from '../helpers/test-init';
@@ -254,12 +254,13 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
           });
         });
 
-        module('when certificationPointOfContact is SCO', function() {
+        module('when certificationPointOfContact is SCO managing students', function() {
 
           test('it should display the list of students for session', async function(assert) {
             // given
             server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
             certificationPointOfContact.update({ certificationCenterType: 'SCO' });
+            certificationPointOfContact.update({ isRelatedOrganizationManagingStudents: true });
             server.createList('student', 10);
 
             // when
@@ -282,7 +283,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
       hooks.beforeEach(async () => {
         session = server.create('session');
-        scocertificationPointOfContact = createScoCertificationPointOfContactWithTermsOfServiceAccepted();
+        scocertificationPointOfContact = createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted();
       });
 
       [

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -5,7 +5,7 @@ import { contains, notContains } from './contains';
 QUnit.assert.contains = contains;
 QUnit.assert.notContains = notContains;
 
-export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix') {
+export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix', isRelatedOrganizationManagingStudents = false) {
   const certificationPointOfContact = server.create('certification-point-of-contact', {
     firstName: 'Harry',
     lastName: 'Cover',
@@ -15,18 +15,19 @@ export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepte
     certificationCenterName,
     certificationCenterType,
     certificationCenterExternalId: 'ABC123',
+    isRelatedOrganizationManagingStudents,
   });
   certificationPointOfContact.save();
 
   return certificationPointOfContact;
 }
 
-export function createScoCertificationPointOfContactWithTermsOfServiceAccepted() {
-  return createCertificationPointOfContactWithTermsOfServiceAccepted('SCO', 'Centre de certification SCO du pix');
+export function createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted() {
+  return createCertificationPointOfContactWithTermsOfServiceAccepted('SCO', 'Centre de certification SCO du pix', true);
 }
 
-export function createCertificationPointOfContactWithTermsOfServiceAccepted(certificationCenterType = undefined, certificationCenterName = 'Centre de certification du pix') {
-  return createCertificationPointOfContact(true, certificationCenterType, certificationCenterName);
+export function createCertificationPointOfContactWithTermsOfServiceAccepted(certificationCenterType = undefined, certificationCenterName = 'Centre de certification du pix', isRelatedOrganizationManagingStudents = false) {
+  return createCertificationPointOfContact(true, certificationCenterType, certificationCenterName, isRelatedOrganizationManagingStudents);
 }
 
 export function createCertificationPointOfContactWithTermsOfServiceNotAccepted() {

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -71,13 +71,11 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
     ];
 
     this.set('certificationCandidates', certificationCandidates);
-    this.set('isUserFromSco', true);
 
     await render(hbs`
       <EnrolledCandidates
         @sessionId="1"
-        @certificationCandidates={{this.certificationCandidates}}
-        @isUserFromSco={{this.isUserFromSco}}>
+        @certificationCandidates={{this.certificationCandidates}}>
       </EnrolledCandidates>
     `);
 
@@ -93,43 +91,26 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
 
     [
       {
-        isSco: true,
-        toggle: true,
+        shouldDisplayPrescriptionScoStudentRegistrationFeature: true,
         multipleButtonVisible: true,
-        it: 'it does display button to add multiple candidates if user is sco and feature toggle is on',
+        it: 'it does display button to add multiple candidates if prescription sco feature is allowed',
       },
       {
-        isSco: true,
-        toggle: false,
+        shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
         multipleButtonVisible: false,
-        it: 'it does not display button to add multiple candidates if user is sco and feature toggle is off',
+        it: 'it does not display button to add multiple candidates if prescription sco feature is not allowed',
       },
-      {
-        isSco: false,
-        toggle: false,
-        multipleButtonVisible: false,
-        it: 'it does not display button to add multiple candidates if user is not sco and feature toggle is on',
-      },
-      {
-        isSco: false,
-        toggle: true,
-        multipleButtonVisible: false,
-        it: 'it does not display button to add multiple candidates if user is not sco and feature toggle is off',
-      },
-    ].forEach(({ isSco, toggle, multipleButtonVisible, it }) =>
+    ].forEach(({ shouldDisplayPrescriptionScoStudentRegistrationFeature, multipleButtonVisible, it }) =>
       test(it, async function(assert) {
         const certificationCandidates = [];
 
         this.set('certificationCandidates', certificationCandidates);
-        this.set('isUserFromSco', isSco);
-        this.set('isCertifPrescriptionScoEnabled', toggle);
-
+        this.set('shouldDisplayPrescriptionScoStudentRegistrationFeature', shouldDisplayPrescriptionScoStudentRegistrationFeature);
         await render(hbs`
         <EnrolledCandidates
           @sessionId="1"
           @certificationCandidates={{this.certificationCandidates}}
-          @isUserFromSco={{this.isUserFromSco}}
-          @isCertifPrescriptionScoEnabled={{this.isCertifPrescriptionScoEnabled}}
+          @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
         >
         </EnrolledCandidates>
         `);
@@ -146,11 +127,9 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   });
 
   [
-    { isSco: true, toggle: true, shouldColumnsBeEmpty: true, it: 'it hides externalId and email columns if user is sco and feature toggle is on' },
-    { isSco: true, toggle: false, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is sco and feature toggle is off' },
-    { isSco: false, toggle: false, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is not sco and feature toggle is off' },
-    { isSco: false, toggle: true, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if user is not sco and feature toggle is on' },
-  ].forEach(({ isSco, toggle, shouldColumnsBeEmpty, it }) =>
+    { shouldDisplayPrescriptionScoStudentRegistrationFeature: true, shouldColumnsBeEmpty: true, it: 'it hides externalId and email columns if prescription sco feature allowed' },
+    { shouldDisplayPrescriptionScoStudentRegistrationFeature: false, shouldColumnsBeEmpty: false, it: 'it shows externalId and email columns if prescription sco feature not allowed' },
+  ].forEach(({ shouldDisplayPrescriptionScoStudentRegistrationFeature, shouldColumnsBeEmpty, it }) =>
     test(it, async function(assert) {
       const candidate = _buildCertificationCandidate({});
       const certificationCandidates = [
@@ -158,15 +137,13 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
       ];
 
       this.set('certificationCandidates', certificationCandidates);
-      this.set('isUserFromSco', isSco);
-      this.set('isCertifPrescriptionScoEnabled', toggle);
+      this.set('shouldDisplayPrescriptionScoStudentRegistrationFeature', shouldDisplayPrescriptionScoStudentRegistrationFeature);
 
       await render(hbs`
       <EnrolledCandidates
         @sessionId="1"
         @certificationCandidates={{certificationCandidates}}
-        @isUserFromSco={{isUserFromSco}}
-        @isCertifPrescriptionScoEnabled={{isCertifPrescriptionScoEnabled}}
+        @shouldDisplayPrescriptionScoStudentRegistrationFeature={{this.shouldDisplayPrescriptionScoStudentRegistrationFeature}}
       >
       </EnrolledCandidates>
     `);

--- a/certif/tests/unit/controllers/authenticated-test.js
+++ b/certif/tests/unit/controllers/authenticated-test.js
@@ -5,14 +5,14 @@ module('Unit | Controller | authenticated', function(hooks) {
   setupTest(hooks);
 
   module('#get documentationLink', function() {
-    test('should return a different link whether the center is SCO or not', function(assert) {
+    test('should return a different link whether the center is SCO managing students or not', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated');
 
       // when
-      controller.model = { isSco: true };
+      controller.model = { isScoManagingStudents: true };
       const actualScoLink = controller.documentationLink;
-      controller.model = { isSco: false };
+      controller.model = { isScoManagingStudents: false };
       const actualOtherLink = controller.documentationLink;
 
       // then

--- a/certif/tests/unit/routes/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details-test.js
@@ -16,13 +16,15 @@ module('Unit | Route | authenticated/sessions/details', function(hooks) {
     const returnedCertifCandidates = [Symbol('certification-candidate')];
 
     hooks.beforeEach(function() {
-      route.currentUser = { isFromSco: true };
       route.store.findRecord = sinon.stub().resolves(returnedSession);
-      route.store.peekRecord = sinon.stub().returns({ certifPrescriptionSco: false });
       route.store.query = sinon.stub().withArgs('certification-candidate', { sessionId: session_id }).resolves(returnedCertifCandidates);
     });
 
-    test('it should return the session', async function(assert) {
+    test('it should return the session and the certification candidates', async function(assert) {
+      // given
+      route.store.peekRecord = sinon.stub().returns({ certifPrescriptionSco: false });
+      route.currentUser = { certificationPointOfContact: { isScoManagingStudents: true } };
+
       // when
       const model = await route.model({ session_id });
 
@@ -30,8 +32,26 @@ module('Unit | Route | authenticated/sessions/details', function(hooks) {
       sinon.assert.calledWith(route.store.findRecord, 'session', session_id);
       assert.equal(model.session, returnedSession);
       assert.equal(model.certificationCandidates, returnedCertifCandidates);
-      assert.equal(model.isUserFromSco, true);
-      assert.equal(model.isCertifPrescriptionScoEnabled, false);
+      assert.equal(model.shouldDisplayPrescriptionScoStudentRegistrationFeature, false);
     });
+
+    [
+      { isScoManagingStudents: true, certifPrescriptionSco: true, it: 'it should allow prescription sco feature when certif center is SCO managing students and FT enabled' },
+      { isScoManagingStudents: false, certifPrescriptionSco: true, it: 'it should not allow prescription sco feature when certif center is not SCO managing students and FT enabled' },
+      { isScoManagingStudents: true, certifPrescriptionSco: false, it: 'it should not allow prescription sco feature when certif center is SCO managing students but FT disabled' },
+      { isScoManagingStudents: false, certifPrescriptionSco: false, it: 'it should not allow prescription sco feature when neither certif center is SCO managing students nor FT enabled' },
+    ].forEach(({ isScoManagingStudents, certifPrescriptionSco, it }) =>
+      test(it, async function(assert) {
+        // given
+        route.store.peekRecord = sinon.stub().returns({ certifPrescriptionSco });
+        route.currentUser = { certificationPointOfContact: { isScoManagingStudents } };
+
+        // when
+        const model = await route.model({ session_id });
+
+        // then
+        assert.equal(model.shouldDisplayPrescriptionScoStudentRegistrationFeature, isScoManagingStudents && certifPrescriptionSco);
+      }),
+    );
   });
 });

--- a/high-level-tests/e2e/cypress/fixtures/certification-centers.json
+++ b/high-level-tests/e2e/cypress/fixtures/certification-centers.json
@@ -1,8 +1,8 @@
 [
   {
     "id": 1,
-    "type": "SCO",
-    "name": "Centre de certification Sco"
+    "type": "PRO",
+    "name": "Centre de certification Pro"
   },
   {
     "id": 2,

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -58,8 +58,8 @@
   {
     "id": 7,
     "firstName": "Certif",
-    "lastName": "Sco",
-    "email": "certif.sco@example.net",
+    "lastName": "Pro",
+    "email": "certif.pro@example.net",
     "cgu": true,
     "pixCertifTermsOfServiceAccepted": true,
     "password": "",

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-candidates-management.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-candidates-management.feature
@@ -4,7 +4,7 @@ Fonctionnalité: Gestion des candidats inscrits à une session de certification
   Contexte:
     Étant donné que je vais sur Pix Certif
     Et que les données de test sont chargées
-    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+    Et que je suis connecté à Pix Certif avec le mail "certif.pro@example.net"
     Lorsque je clique sur la session de certification dont la salle est "Salle de la session 1"
     Et que je clique sur l'onglet des Candidats de la session de certification
 

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-creation.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-creation.feature
@@ -4,7 +4,7 @@ Fonctionnalité: Création d'une session de certification
   Contexte:
     Étant donné que je vais sur Pix Certif
     Et que les données de test sont chargées
-    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+    Et que je suis connecté à Pix Certif avec le mail "certif.pro@example.net"
 
   Scénario: Je confirme la création d'une session de certification
     Lorsque je clique sur "Créer une session"

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-finalization.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-finalization.feature
@@ -4,7 +4,7 @@ Fonctionnalité: Finalisation d'une session de certification
   Contexte:
     Étant donné que je vais sur Pix Certif
     Et que les données de test sont chargées
-    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+    Et que je suis connecté à Pix Certif avec le mail "certif.pro@example.net"
 
   Scénario: Je finalise une session de certification
     Lorsque je clique sur la session de certification dont la salle est "Salle de la session 2"

--- a/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-update.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-certif/certification-session-update.feature
@@ -4,7 +4,7 @@ Fonctionnalité: Modification d'une session de certification
   Contexte:
     Étant donné que je vais sur Pix Certif
     Et que les données de test sont chargées
-    Et que je suis connecté à Pix Certif avec le mail "certif.sco@example.net"
+    Et que je suis connecté à Pix Certif avec le mail "certif.pro@example.net"
 
   Scénario: Je confirme la modification d'une session de certification
     Lorsque je clique sur la session de certification dont la salle est "Salle de la session 1"


### PR DESCRIPTION
## :unicorn: Problème
L'accès à la nouvelle fonctionnalité d'inscription d'élèves à une session de certif depuis la liste des élèves de l'organisation correspondante n'était pas assez restreint.
En effet, l'accès était restreint aux centres de certif dont l'organisation soeur existe et est de type SCO. Or cela ne suffit pas, car à ce jour, il existe encore certaines organisations SCO non restreintes (donc en campagne ouverte) et donc qui ne présente pas de liste d'élèves. Du coup, on risque de mettre ces organisations en situation où elles vont être dans l'incapacité d'inscrire des élèves à la certification.

## :robot: Solution
Ajouter une vérification de contrainte sur l'organisation soeur : il faut que celle-ci possède une liste d'élèves ; en d'autres termes, il faut qu'elle soit `isManagingStudents` à `true`.
On ajoute cette indication dans le modèle du currentUser de l'application PixCertif, à savoir le CertificationReferent.

## :rainbow: Remarques
J'ai pris la liberté de restreindre également la documentation spécifique SCO aux SCO isManagingStudents (car la doc indique le process avec la nouvelle feature de prescription sco). TODO : à check avec le pôle certif.

## :100: Pour tester
Tester que pour un centre de certif ayant pour orga soeur une orga de type SCO non restreinte, on a toujours l'accès à l'inscription habituelle. Tandis que pour les centres de certif ayant une orga soeur de type SCO + isManagingStudents, là la feature de prescription sco est visible
