### PR TITLE
[TECH] Remplacer la route GET /api/competence-evaluations?filter[assessmentId=123] par GET /api/assessments/123/competence-evaluations (PIX-1788)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -6,6 +6,7 @@ const logger = require('../../infrastructure/logger');
 const assessmentRepository = require('../../infrastructure/repositories/assessment-repository');
 const assessmentSerializer = require('../../infrastructure/serializers/jsonapi/assessment-serializer');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
+const competenceEvaluationSerializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer');
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
@@ -81,6 +82,15 @@ module.exports = {
     });
 
     return null;
+  },
+
+  async findCompetenceEvaluations(request) {
+    const userId = request.auth.credentials.userId;
+    const assessmentId = parseInt(request.params.id);
+
+    const competenceEvaluations = await usecases.findCompetenceEvaluationsByAssessment({ userId, assessmentId });
+
+    return competenceEvaluationSerializer.serialize(competenceEvaluations);
   },
 };
 

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -1,3 +1,4 @@
+const Joi = require('@hapi/joi');
 const assessmentController = require('./assessment-controller');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
 
@@ -58,6 +59,23 @@ exports.register = async function(server) {
         }],
         handler: assessmentController.completeAssessment,
         tags: ['api'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/assessments/{id}/competence-evaluations',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required(),
+          }),
+        },
+        handler: assessmentController.findCompetenceEvaluations,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Récupération des competence-evaluations d\'un assessment',
+        ],
+        tags: ['api', 'competence-evaluations'],
       },
     },
   ]);

--- a/api/lib/application/competence-evaluations/index.js
+++ b/api/lib/application/competence-evaluations/index.js
@@ -28,6 +28,10 @@ exports.register = async function(server) {
       },
     },
     {
+      /**
+       * @deprecated Method that should be deleted at some point, when replacement working.
+       * Replacement in assessment-controller::findCompetenceEvaluations
+       */
       method: 'GET',
       path: '/api/competence-evaluations',
       config: {

--- a/api/lib/domain/usecases/find-competence-evaluations-by-assessment.js
+++ b/api/lib/domain/usecases/find-competence-evaluations-by-assessment.js
@@ -1,0 +1,14 @@
+const { UserNotAuthorizedToAccessEntity } = require('../errors');
+
+module.exports = async function findCompetenceEvaluationsByAssessment({
+  userId,
+  assessmentId,
+  assessmentRepository,
+  competenceEvaluationRepository,
+}) {
+  if (!(await assessmentRepository.ownedByUser({ id: assessmentId, userId }))) {
+    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this competence evaluation');
+  }
+
+  return competenceEvaluationRepository.findByAssessmentId(assessmentId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -137,6 +137,7 @@ module.exports = injectDependencies({
   findCampaignParticipationsRelatedToAssessment: require('./find-campaign-participations-related-to-assessment'),
   findCampaignProfilesCollectionParticipationSummaries: require('./find-campaign-profiles-collection-participation-summaries'),
   findCompetenceEvaluations: require('./find-competence-evaluations'),
+  findCompetenceEvaluationsByAssessment: require('./find-competence-evaluations-by-assessment'),
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),

--- a/api/lib/infrastructure/repositories/competence-evaluation-repository.js
+++ b/api/lib/infrastructure/repositories/competence-evaluation-repository.js
@@ -72,6 +72,14 @@ module.exports = {
     return queryBuilder.find(BookshelfCompetenceEvaluation, options);
   },
 
+  findByAssessmentId(assessmentId) {
+    return BookshelfCompetenceEvaluation
+      .where({ assessmentId })
+      .orderBy('createdAt', 'desc')
+      .fetchAll()
+      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfCompetenceEvaluation, results));
+  },
+
   async existsByCompetenceIdAndUserId({ competenceId, userId }) {
     let isCompetenceEvaluationExists = true;
     try {

--- a/api/tests/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-find-competence-evaluations_test.js
@@ -1,0 +1,36 @@
+const { expect, generateValidRequestAuthorizationHeader, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | API | assessment-controller-find-competence-evaluations', () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/assessments/:id/competence-evaluations', () => {
+
+    it('should return 200 HTTP status code', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+      const competenceEvaluationId = databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, userId }).id;
+      await databaseBuilder.commit();
+      const options = {
+        method: 'GET',
+        url: `/api/assessments/${assessmentId}/competence-evaluations`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data[0].id).to.deep.equal(competenceEvaluationId.toString());
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-evaluation-repository_test.js
@@ -255,6 +255,41 @@ describe('Integration | Repository | Competence Evaluation', () => {
     });
   });
 
+  describe('#findByAssessmentId', () => {
+    let assessmentId;
+    let competenceEvaluationExpected;
+
+    beforeEach(() => {
+      // given
+      assessmentId = databaseBuilder.factory.buildAssessment({
+        type: Assessment.types.COMPETENCE_EVALUATION,
+      }).id;
+
+      competenceEvaluationExpected = databaseBuilder.factory.buildCompetenceEvaluation({
+        competenceId: '1',
+        assessmentId,
+        createdAt: new Date('2018-01-01'),
+        status: STARTED,
+      });
+      databaseBuilder.factory.buildCompetenceEvaluation({
+        competenceId: '2',
+        createdAt: new Date('2017-01-01'),
+        status: STARTED,
+      });
+
+      return databaseBuilder.commit();
+    });
+
+    it('should return the competence evaluation linked to the assessmentId', async () => {
+      // when
+      const competenceEvaluations = await competenceEvaluationRepository.findByAssessmentId(assessmentId);
+
+      // then
+      expect(competenceEvaluations).to.have.length(1);
+      expect(_.omit(competenceEvaluations[0], ['assessment', 'scorecard'])).to.deep.equal(_.omit(competenceEvaluationExpected, ['assessment']));
+    });
+  });
+
   describe('#updateStatusByAssessmentId', () => {
     let assessment;
 

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -20,6 +20,7 @@ describe('Integration | Route | AssessmentRoute', () => {
     sinon.stub(assessmentController, 'getNextChallenge').returns('ok');
     sinon.stub(assessmentController, 'findByFilters').returns('ok');
     sinon.stub(assessmentController, 'get').returns('ok');
+    sinon.stub(assessmentController, 'findCompetenceEvaluations').returns('ok');
     sinon.stub(assessmentAuthorization, 'verify').returns('userId');
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster');
 
@@ -78,6 +79,25 @@ describe('Integration | Route | AssessmentRoute', () => {
 
       // then
       sinon.assert.called(assessmentAuthorization.verify);
+    });
+  });
+
+  describe('GET /api/assessments/{id}/competence-evaluations', () => {
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/assessments/123/competence-evaluations');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should do throw a 400 status code when assessmentId provided is not a number', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/assessments/not_a_number/competence-evaluations');
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
@@ -1,0 +1,52 @@
+const _ = require('lodash');
+const { expect, sinon, catchErr } = require('../../../test-helper');
+const findCompetenceEvaluationsByAssessment = require('../../../../lib/domain/usecases/find-competence-evaluations-by-assessment');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | find-competence-evaluations-by-assessment', () => {
+
+  const userId = 1;
+  const assessmentId = 2;
+  const assessmentRepository = { ownedByUser: _.noop() };
+  const competenceEvaluationRepository = { findByAssessmentId: _.noop() };
+
+  beforeEach(() => {
+    assessmentRepository.ownedByUser = sinon.stub();
+    competenceEvaluationRepository.findByAssessmentId = sinon.stub();
+  });
+
+  it('should throw an UserNotAuthorizedToAccessEntity error when user is not the owner of the assessment', async () => {
+    // given
+    assessmentRepository.ownedByUser.withArgs({ id: assessmentId, userId }).resolves(false);
+
+    // when
+    const error = await catchErr(findCompetenceEvaluationsByAssessment)({
+      userId,
+      assessmentId,
+      competenceEvaluationRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+  });
+
+  it('should return the assessment competence-evaluations', async () => {
+    // given
+    const expectedCompetenceEvaluations = Symbol('competenceEvaluations');
+    assessmentRepository.ownedByUser.withArgs({ id: assessmentId, userId }).resolves(true);
+    competenceEvaluationRepository.findByAssessmentId.withArgs(assessmentId).resolves(expectedCompetenceEvaluations);
+
+    // when
+    const actualCompetenceEvaluations = await findCompetenceEvaluationsByAssessment({
+      userId,
+      assessmentId,
+      competenceEvaluationRepository,
+      assessmentRepository,
+    });
+
+    // then
+    expect(actualCompetenceEvaluations).to.deep.equal(expectedCompetenceEvaluations);
+  });
+
+});

--- a/mon-pix/app/adapters/competence-evaluation.js
+++ b/mon-pix/app/adapters/competence-evaluation.js
@@ -1,6 +1,18 @@
 import ApplicationAdapter from './application';
 
 export default class CompetenceEvaluation extends ApplicationAdapter {
+  urlForFindAll(modelName, { adapterOptions }) {
+    const url = super.urlForFindAll(...arguments);
+
+    if (adapterOptions && adapterOptions.assessmentId) {
+      const assessmentId = adapterOptions.assessmentId;
+      delete adapterOptions.assessmentId;
+      return `${this.host}/${this.namespace}/assessments/${assessmentId}/competence-evaluations`;
+    }
+
+    return url;
+  }
+
   urlForQueryRecord(query) {
     if (query.startOrResume) {
       delete query.startOrResume;

--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -6,11 +6,8 @@ import Route from '@ember/routing/route';
 @classic
 export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
   async model(params) {
-    const competenceEvaluations = await this.store.query('competenceEvaluation', {
-      filter: {
-        assessmentId: params.assessment_id,
-      },
-    });
+    const assessmentId = params.assessment_id;
+    const competenceEvaluations = await this.store.findAll('competenceEvaluation', { adapterOptions: { assessmentId } });
     return competenceEvaluations.firstObject;
   }
 

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -3,7 +3,7 @@ import getCampaigns from './routes/get-campaigns';
 import getCertifications from './routes/get-certifications';
 import getChallenge from './routes/get-challenge';
 import getChallenges from './routes/get-challenges';
-import getCompetenceEvaluations from './routes/get-competence-evaluations';
+import getCompetenceEvaluationsByAssessment from './routes/get-competence-evaluations-by-assessment';
 import getProgression from './routes/get-progression';
 import getScorecard from './routes/get-scorecard';
 import getScorecardsTutorials from './routes/get-scorecards-tutorials';
@@ -41,6 +41,8 @@ export default function() {
   loadSchoolingRegistrationDependentUserRoutes(this);
   loadUserRoutes(this);
 
+  this.get('/assessments/:id/competence-evaluations', getCompetenceEvaluationsByAssessment);
+
   this.get('/campaigns', getCampaigns);
   this.get('/campaigns/:id?include=targetProfile', (schema, request) => {
     return schema.campaigns.find(request.params['id?include=targetProfile']);
@@ -53,7 +55,6 @@ export default function() {
   this.get('/challenges', getChallenges);
   this.get('/challenges/:id', getChallenge);
 
-  this.get('/competence-evaluations', getCompetenceEvaluations);
   this.post('/competence-evaluations/start-or-resume', postCompetenceEvaluation);
 
   this.get('/progressions/:id', getProgression);

--- a/mon-pix/mirage/routes/get-competence-evaluations-by-assessment.js
+++ b/mon-pix/mirage/routes/get-competence-evaluations-by-assessment.js
@@ -1,0 +1,4 @@
+export default function(schema, request) {
+  const { id } = request.params;
+  return schema.competenceEvaluations.where({ assessmentId: id });
+}

--- a/mon-pix/mirage/routes/get-competence-evaluations.js
+++ b/mon-pix/mirage/routes/get-competence-evaluations.js
@@ -1,3 +1,0 @@
-export default function(schema) {
-  return schema.competenceEvaluations.all();
-}

--- a/mon-pix/tests/unit/adapters/competence-evaluation-test.js
+++ b/mon-pix/tests/unit/adapters/competence-evaluation-test.js
@@ -6,6 +6,25 @@ import { setupTest } from 'ember-mocha';
 describe('Unit | Adapters | competence-evaluation', function() {
   setupTest();
 
+  describe('#urlForFindAll', () => {
+
+    let adapter;
+
+    beforeEach(function() {
+      adapter = this.owner.lookup('adapter:competence-evaluation');
+    });
+
+    it('should build url for fetching competence-evaluations based on assessment route', async function() {
+      // when
+      const assessmentId = 123;
+      const url = await adapter.urlForFindAll('competenceEvaluation', { adapterOptions: { assessmentId } });
+
+      // then
+      expect(url.endsWith(`/assessments/${assessmentId}/competence-evaluations`)).to.be.true;
+    });
+
+  });
+
   describe('#urlQueryForRecord', () => {
 
     let adapter;

--- a/mon-pix/tests/unit/routes/competences/results-test.js
+++ b/mon-pix/tests/unit/routes/competences/results-test.js
@@ -15,12 +15,12 @@ describe('Unit | Route | Competences | Results', function() {
     let route;
     let storeStub;
     let sessionStub;
-    let queryStub;
+    let findAllStub;
 
     beforeEach(function() {
-      queryStub = sinon.stub();
+      findAllStub = sinon.stub();
       storeStub = Service.create({
-        query: queryStub,
+        findAll: findAllStub,
       });
       sessionStub = Service.create({
         isAuthenticated: true,
@@ -34,8 +34,10 @@ describe('Unit | Route | Competences | Results', function() {
 
     it('should return the first competence-evaluation for a given assessment', async function() {
       // Given
-      const expectedCompetenceEvaluation = [{ id: 1 }];
-      queryStub.resolves(expectedCompetenceEvaluation);
+      const expectedCompetenceEvaluation = { id: 1 };
+      findAllStub
+        .withArgs('competenceEvaluation', { adapterOptions: { assessmentId } })
+        .resolves({ firstObject: expectedCompetenceEvaluation });
 
       // When
       const model = await route.model({
@@ -43,7 +45,6 @@ describe('Unit | Route | Competences | Results', function() {
       });
 
       // Then
-      sinon.assert.calledWith(queryStub, 'competenceEvaluation', { filter: { assessmentId } });
       expect(model.id).to.equal(1);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Initialement j'avais envie de voir si c'était possible de se débarrasser des méthodes obscures et peu utilisées du `api/lib/infrastructure/utils/query-builder.js`. L'intention était initialement noble : il s'agissait de proposer un builder générique pour du querying via knex. Dans les faits, les méthodes sont tellement génériques que personne n'a osé y toucher (car trop opaques). Exemple d'une méthode : 
```js
async function find(BookShelfClass, options) {
  const query = BookShelfClass
    .where(options.filter)
    .query((qb) => {
      options.sort.forEach((sort) => {
        const isDesc = sort.charAt(0) === '-';
        const column = isDesc ? sort.substring(1) : sort;
        const order = isDesc ? 'desc' : 'asc';

        qb.orderBy(column, order);
      });
    });

  const withRelated = options.include;

  if (_.isEmpty(options.page)) {
    const results = await query.fetchAll({ withRelated });

    return {
      models: bookshelfToDomainConverter.buildDomainObjects(BookShelfClass, results.models),
    };
  }

  const results = await query.fetchPage({
    page: options.page.number,
    pageSize: options.page.size,
    withRelated,
  });

  return {
    pagination: results.pagination,
    models: bookshelfToDomainConverter.buildDomainObjects(BookShelfClass, results.models),
  };
}
```
J'ai donc voulu essayer de les supprimer, et par effet de mikado, je me suis retrouvée à remplacer la manière de récupérer les `competence-evaluations` par `assessmentId` 😁 

## :robot: Solution
La route d'origine n'est pas très simple à lire. C'est un find qui ballade un objet fourre-tout options (qui peut, ou pas, contenir moult filtres). Dans les faits, cet objet fourre-tout ne contient qu'un `assessmentId`. Du coup, on propose une nouvelle route/usecase pour passer de : `GET /api/competence-evaluations?filter[assessmentId=123]` à `GET /api/assessments/123/competence-evaluations`.
On conserve l'ancienne route en attendant que Datadog nous démontre la non-activité de celle-ci.

## :rainbow: Remarques
L'idée donc est que dès lors que l'ancienne route est dépréciée, on en enlève toute trace. De faire, cela retirera au passage la méthode `competenceEvaluationRepository::find` ainsi que la méthode `find` du `query-utils`

## :100: Pour tester
Tester la non régression des résultats d'une competence-evaluation lorsqu'on finit l'assessment.
