### PR TITLE
Remove CSS warning on start

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -8,7 +8,7 @@
   &__result-and-action {
     display: flex;
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
     padding-bottom: 48px;
     margin: auto;
 


### PR DESCRIPTION
## :unicorn: Problème
Message d'info lors du build
`⠸ building... [SassCompiler]autoprefixer: /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/mon-pix/assets/mon-pix.css:7507:3: start value has mixed support, consider using flex-start instead`


## :robot: Solution
> _Ajoutez à cet endroit, si nécessaire, des détails concernant la solution technique retenue et mise en oeuvre, des difficultés ou problèmes rencontrés._

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
