### PR TITLE
[TECH] Supprimer l'avertissement CSS "start value has mixed support".

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -8,7 +8,7 @@
   &__result-and-action {
     display: flex;
     flex-direction: column;
-    align-items: start;
+    align-items: flex-start;
     padding-bottom: 48px;
     margin: auto;
 


### PR DESCRIPTION
## :unicorn: Problème
Message d'info lors du build
`⠸ building... [SassCompiler]autoprefixer: /home/topi/Documents/OCTO/Missions/Pix/code/repo/pix/mon-pix/assets/mon-pix.css:7507:3: start value has mixed support, consider using flex-start instead`

## :robot: Solution
Remplacer `start` par `flex-start`

## :100: Pour tester
Récupérer un utilisateur avec des assements
```
SELECT
    u.email,
    'https://app-pr2285.review.pix.fr/campagnes/' || c.code || '/evaluation/resultats/' || a.id AS URL 
FROM
   "campaign-participations" cp
        INNER JOIN assessments a ON a."campaignParticipationId" = cp.id
        INNER JOIN campaigns c ON c.id = cp."campaignId"
        INNER JOIN organizations o ON o.id = c."organizationId"
        INNER JOIN users u on cp."userId" = u.id
```

Vérifier sur la page que le comportement est le même
