### PR TITLE
[FEATURE] Permettre le téléchargement du pv de session aux utilisateurs sco  (PIX-1787)

### DIFF
--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -9,6 +9,8 @@ export default class SessionsDetailsController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
+  @alias('model.isCertifPrescriptionScoEnabled') isCertifPrescriptionScoEnabled;
+  @alias('model.isUserFromSco') isUserFromSco;
 
   @computed('certificationCandidates.length')
   get certificationCandidatesCount() {
@@ -20,5 +22,10 @@ export default class SessionsDetailsController extends Controller {
   get hasOneOrMoreCandidates() {
     const certificationCandidatesCount = this.certificationCandidates.length;
     return certificationCandidatesCount > 0;
+  }
+
+  @computed('hasOneOrMoreCandidates', 'isCertifPrescriptionScoEnabled', 'isResultRecipientEmailVisible', 'isUserFromSco')
+  get shouldDisplayDownloadButton() {
+    return this.hasOneOrMoreCandidates && ((this.isUserFromSco && this.isCertifPrescriptionScoEnabled) || this.isResultRecipientEmailVisible);
   }
 }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -3,13 +3,11 @@
     <div class="session-details-header__title">
       <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
       <h1 class="page-title">Session {{this.session.id}}</h1>
-      {{#if this.isResultRecipientEmailVisible}}
-      {{#if this.hasOneOrMoreCandidates}}
+      {{#if this.shouldDisplayDownloadButton}}
       <a class="button button--link" href="{{this.session.urlToDownloadAttendanceSheet}}" target="_blank"
         rel="noopener noreferrer" download>
         Télécharger le PV
       </a>
-      {{/if}}
       {{/if}}
     </div>
 

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -1,11 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
+import config from 'pix-certif/config/environment';
+
 module('Unit | Controller | authenticated/sessions/details', function(hooks) {
   setupTest(hooks);
 
   module('#certificationCandidatesCount', function() {
-    test('should return a string the the candidate count if more than 0 candidate', function(assert) {
+    test('should return a string that matches the candidate count if more than 0 candidate', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/details');
       controller.model = { certificationCandidates: ['candidate1', 'candidate2'] };
@@ -27,6 +29,139 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
 
       // then
       assert.equal(certificationCandidatesCountResult, '');
+    });
+  });
+
+  module('#hasOneOrMoreCandidates', function() {
+    test('should return true if session has at least 1 candidate', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = { certificationCandidates: ['candidate1', 'candidate2'] };
+
+      // when
+      const hasOneOrMoreCandidates = controller.hasOneOrMoreCandidates;
+
+      // then
+      assert.ok(hasOneOrMoreCandidates);
+    });
+
+    test('should return false if session has 0 candidate', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = { certificationCandidates: [] };
+
+      // when
+      const hasOneOrMoreCandidates = controller.hasOneOrMoreCandidates;
+
+      // then
+      assert.notOk(hasOneOrMoreCandidates);
+    });
+  });
+
+  module('#shouldDisplayDownloadButton', function() {
+
+    module('when there is at least one enrolled candidate', function() {
+
+      module('when the toggle CertifPrescriptionSco is enabled', function() {
+
+        module('when the user is of type SCO', function() {
+
+          test('should return true', function(assert) {
+            // given
+            const controller = this.owner.lookup('controller:authenticated/sessions/details');
+            controller.model = {
+              certificationCandidates: ['candidate1', 'candidate2'],
+              isUserFromSco: true,
+              isCertifPrescriptionScoEnabled: true,
+            };
+
+            // when
+            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
+
+            // then
+            assert.ok(shouldDisplayDownloadButton);
+          });
+        });
+
+        module('when user is not from sco', function() {
+
+          test('should return false', function(assert) {
+            // given
+            const controller = this.owner.lookup('controller:authenticated/sessions/details');
+            controller.model = {
+              certificationCandidates: ['candidate1', 'candidate2'],
+              isUserFromSco: false,
+              isCertifPrescriptionScoEnabled: true,
+            };
+
+            // when
+            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
+
+            // then
+            assert.notOk(shouldDisplayDownloadButton);
+          });
+        });
+
+      });
+
+      module('when the toggle CertifPrescriptionSco is not enabled', function() {
+
+        module('when user is from sco', function() {
+
+          test('should return false ', function(assert) {
+            // given
+            const controller = this.owner.lookup('controller:authenticated/sessions/details');
+            controller.model = {
+              certificationCandidates: ['candidate1', 'candidate2'],
+              isUserFromSco: true,
+              isCertifPrescriptionScoEnabled: false,
+            };
+
+            // when
+            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
+
+            // then
+            assert.notOk(shouldDisplayDownloadButton);
+          });
+        });
+      });
+
+      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
+        test('Should return true', function(assert) {
+          // given
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+          controller.model = {
+            certificationCandidates: ['candidate1', 'candidate2'],
+            isUserFromSco: false,
+            isCertifPrescriptionScoEnabled: false,
+          };
+
+          // when
+          const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
+
+          // then
+          assert.ok(shouldDisplayDownloadButton);
+        });
+      });
+    });
+  });
+
+  module('when there is no enrolled candidate', function() {
+    test('Should return false.', function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/sessions/details');
+      controller.model = {
+        certificationCandidates: [],
+        isUserFromSco: true,
+        isCertifPrescriptionScoEnabled: true,
+      };
+
+      // when
+      const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
+
+      // then
+      assert.notOk(shouldDisplayDownloadButton);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix 'Envoi auto des résultats', nous allons permettre aux utilisateurs Pix certif de télécharger le PV de session de certification depuis un bouton “Télécharger le PV” affiché à côté du numéro de session sur la page de détails de la session dans Pix Certif.

Cette fonctionnalité est sous toggle et ne sera activée en PROD que lorsque l’envoi auto des résultats sera finalisée… donc après que la prescription de certif SCO soit elle-même activée en PROD pour les utilisateurs SCO. Sauf que sans ce bouton, les utilisateurs SCO n’ont aujourd’hui aucun moyen de télécharger le PV de session.

## :robot: Solution
Afficher le bouton “Télécharger le PV” pour les utilisateurs Pix Certif SCO uniquement (pour les autres utilisateurs, le bouton sera affiché lors de l’activation de la fonctionnalité d’envoi automatique des résultats)


## :100: Pour tester
- Activer le toggle  FT_CERTIF_PRESCRIPTION_SCO=true côté api
- Se connecter sur pix certif avec un user SCO
- Aller sur le détail d'une session ayant déjà au moins un candidat d'inscrit
- Constater que le bouton "Télécharger le PV" est présent

![image](https://user-images.githubusercontent.com/37305474/102206651-40b8c200-3ecd-11eb-8932-934b03f3b9d1.png)

