### PR TITLE
[TECH] Faciliter la connexion sur les utilisateurs créées par seeds.

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -16,7 +16,7 @@ const buildUser = function buildUser({
   lastName = faker.name.lastName(),
   email,
   username = firstName + '.' + lastName + faker.random.number({ min: 1000, max: 9999 }),
-  password,
+  password = 'pix123',
   cgu = true,
   lang = 'fr',
   lastTermsOfServiceValidatedAt = null,

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -29,11 +29,11 @@ const buildUser = function buildUser({
   updatedAt = new Date(),
 } = {}) {
 
-  password = _.isUndefined(password) ? encrypt.hashPasswordSync(faker.internet.password()) : encrypt.hashPasswordSync(password);
+  const encryptedPassword = encrypt.hashPasswordSync(password);
   email = _.isUndefined(email) ? faker.internet.exampleEmail(firstName, lastName).toLowerCase() : email || null;
 
   const values = {
-    id, firstName, lastName, email, username, password, cgu, lang, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
+    id, firstName, lastName, email, username, password: encryptedPassword, cgu, lang, lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions, shouldChangePassword, createdAt, updatedAt,
   };
 


### PR DESCRIPTION
## :unicorn: Problème
Certaines seeds (ex: `campaign-participations-builder.js`)  ne fournissent pas de mot de passe.
En conséquence, celui-ci est automatiquement généré avec `faker` puis encryptés.
Les comptes sont donc inutilisables en connexion (sauf à générer un token manuellement)
Cette stratégie avait un sens pour des données non encryptées, mais pas ici IMHO.

## :robot: Solution
Rajouter un mot de passe par défaut, comme dans `users-builder.js`, à `pix123`

## :rainbow: Remarques
Aucun impact en production: ce sont des seeds
Aucun impact GAR ou PE non plus à première vue, les tests passent

Possibilité de supprimer le mot de passe explicite dans `users-builder.js`

Possibilité d'avoir un mot de passe par défaut qui remplit les conditions de production, mais cela est pénalisant pour ceux qui n'utilisent pas de trousseau de mot de passe.

## :100: Pour tester
Se connecter sur [PixApp](https://app-pr2288.review.pix.fr/) avec
- email  `jaune.attend@example.org` 
- mot de passe `pix123`
 