### PR TITLE
[TECH] Ajouter un composant pour chaque catégorie de signalement (PIX-1786)

### DIFF
--- a/certif/app/components/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/candidate-information-change-certification-issue-report-fields.hbs
@@ -1,0 +1,23 @@
+<fieldset class="candidate-information-change-certification-issue-report-fields">
+  <div class="candidate-information-change-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-candidate-information-change"
+      type="radio"
+      name="candidate-information-change"
+      checked={{@candidateInformationChangeCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @candidateInformationChangeCategory)}} />
+    <label for="input-radio-for-category-candidate-information-change">Modification infos candidat</label>
+  </div>
+  {{#if @candidateInformationChangeCategory.isChecked}}
+    <div class="candidate-information-change-certification-issue-report-fields__details">
+      <label for="text-area-for-category-candidate-information-change">Détaillez les changements</label>
+      <Textarea
+        id="text-area-for-category-candidate-information-change"
+        @class="session-finalization-reports-informations-step__textarea"
+        @value={{@candidateInformationChangeCategory.description}}
+        @maxlength={{@maxlength}}
+      />
+      <p class="candidate-information-change-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/candidate-information-change-certification-issue-report-fields.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class CandidateInformationChangeCertificationIssueReportFieldsComponent extends Component {
+  get reportLength() {
+    return this.args.candidateInformationChangeCategory.description
+      ? this.args.candidateInformationChangeCategory.description.length
+      : 0;
+  }
+}

--- a/certif/app/components/connexion-or-end-screen-certification-issue-report-fields.hbs
+++ b/certif/app/components/connexion-or-end-screen-certification-issue-report-fields.hbs
@@ -1,0 +1,23 @@
+<fieldset class="connexion-or-end-screen-certification-issue-report-fields">
+  <div class="connexion-or-end-screen-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-connexion-or-end-screen"
+      type="radio"
+      name="connexion-or-end-screen"
+      checked={{@connexionOrEndScreenCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @connexionOrEndScreenCategory)}} />
+    <label for="input-radio-for-category-connexion-or-end-screen">Connexion et fin de test</label>
+  </div>
+  {{#if @connexionOrEndScreenCategory.isChecked}}
+    <div class="connexion-or-end-screen-certification-issue-report-fields__details">
+      <label for="text-area-for-category-connexion-or-end-screen">Détaillez l'incident</label>
+      <Textarea
+        id="text-area-for-category-connexion-or-end-screen"
+        @class="session-finalization-reports-informations-step__textarea"
+        @value={{@connexionOrEndScreenCategory.description}}
+        @maxlength={{@maxlength}}
+      />
+      <p class="connexion-or-end-screen-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/connexion-or-end-screen-certification-issue-report-fields.js
+++ b/certif/app/components/connexion-or-end-screen-certification-issue-report-fields.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class ConnexionOrEndScreenCertificationIssueReportFieldsComponent extends Component {
+  get reportLength() {
+    return this.args.connexionOrEndScreenCategory.description
+      ? this.args.connexionOrEndScreenCategory.description.length
+      : 0;
+  }
+}

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -20,30 +20,11 @@
             @maxlength={{@maxlength}}
           />
 
-          <fieldset>
-            <div class="examiner-report-modal-content__report-category">
-              <input
-                id="input-radio-for-category-late-or-leaving"
-                type="radio"
-                name="other"
-                checked={{this.lateOrLeavingCategory.isChecked}}
-                {{on 'click' (fn this.toggleOnCategory this.lateOrLeavingCategory)}} />
-              <label for="input-radio-for-category-late-or-leaving">Retard, absence ou départ</label>
-            </div>
-            {{#if this.lateOrLeavingCategory.isChecked}}
-              <div class="examiner-report-modal-content__report-category-details">
-                <label for="text-area-for-category-late-or-leaving">Détaillez l'incident</label>
-                <Textarea
-                    id="text-area-for-category-late-or-leaving"
-                    @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.lateOrLeavingCategory.description}}
-                    @maxlength={{@maxlength}}
-                    {{on 'input' this.handleTextareaChange}}
-                    />
-                  <p class="examiner-report-modal-content__char-count">{{this.reportLength}} / 500</p>
-              </div>
-            {{/if}}
-          </fieldset>
+          <LateOrLeavingCertificationIssueReportFields
+            @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
 
           <fieldset>
             <div class="examiner-report-modal-content__report-category">

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -32,30 +32,11 @@
             @maxlength={{@maxlength}}
           />
 
-          <fieldset>
-            <div class="examiner-report-modal-content__report-category">
-              <input
-                id="input-radio-for-category-connexion-or-end-screen"
-                type="radio"
-                name="other"
-                checked={{this.connexionOrEndScreenCategory.isChecked}}
-                {{on 'click' (fn this.toggleOnCategory this.connexionOrEndScreenCategory)}} />
-              <label for="input-radio-for-category-connexion-or-end-screen">Connexion et fin de test</label>
-            </div>
-            {{#if this.connexionOrEndScreenCategory.isChecked}}
-              <div class="examiner-report-modal-content__report-category-details">
-                <label for="text-area-for-category-connexion-or-end-screen">Détaillez l'incident</label>
-                <Textarea
-                    id="text-area-for-category-connexion-or-end-screen"
-                    @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.connexionOrEndScreenCategory.description}}
-                    @maxlength={{@maxlength}}
-                    {{on 'input' this.handleTextareaChange}}
-                    />
-                  <p class="examiner-report-modal-content__char-count">{{this.reportLength}} / 500</p>
-              </div>
-            {{/if}}
-          </fieldset>
+          <ConnexionOrEndScreenCertificationIssueReportFields
+            @connexionOrEndScreenCategory={{this.connexionOrEndScreenCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
         </div>
 
         <div class="examiner-report-modal__actions">

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -14,30 +14,13 @@
 
       <div class="examiner-report-modal__content">
         <div class="examiner-report-modal-content">
-          <fieldset>
-            <div class="examiner-report-modal-content__report-category">
-              <input
-                  id="input-radio-for-category-other"
-                  type="radio"
-                  name="other"
-                  checked={{this.otherCategory.isChecked}}
-                  {{on 'click' (fn this.toggleOnCategory this.otherCategory)}} />
-              <label for="input-radio-for-category-other">Autre incident</label>
-            </div>
-            {{#if this.otherCategory.isChecked}}
-              <div class="examiner-report-modal-content__report-category-details">
-                <label for="text-area-for-category-other">Détaillez l'incident</label>
-                <Textarea
-                    id="text-area-for-category-other"
-                    @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.currentIssueReport.description}}
-                    @maxlength={{@maxlength}}
-                    {{on 'input' this.handleTextareaChange}}
-                    />
-                  <p class="examiner-report-modal-content__char-count">{{this.reportLength}} / 500</p>
-              </div>
-            {{/if}}
-          </fieldset>
+          <OtherCertificationIssueReportFields
+            @otherCategory={{this.otherCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @currentIssueReport={{this.currentIssueReport}}
+            @maxlength={{@maxlength}}
+            @handleTextareaChange={{this.handleTextareaChange}}
+          />
 
           <fieldset>
             <div class="examiner-report-modal-content__report-category">

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -26,30 +26,11 @@
             @maxlength={{@maxlength}}
           />
 
-          <fieldset>
-            <div class="examiner-report-modal-content__report-category">
-              <input
-                id="input-radio-for-category-candidate-informations-changes"
-                type="radio"
-                name="other"
-                checked={{this.candidateInformationsChangesCategory.isChecked}}
-                {{on 'click' (fn this.toggleOnCategory this.candidateInformationsChangesCategory)}} />
-              <label for="input-radio-for-category-candidate-informations-changes">Modification infos candidat</label>
-            </div>
-            {{#if this.candidateInformationsChangesCategory.isChecked}}
-              <div class="examiner-report-modal-content__report-category-details">
-                <label for="text-area-for-category-candidate-informations-changes">Détaillez l'incident</label>
-                <Textarea
-                    id="text-area-for-category-candidate-informations-changes"
-                    @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.candidateInformationsChangesCategory.description}}
-                    @maxlength={{@maxlength}}
-                    {{on 'input' this.handleTextareaChange}}
-                    />
-                  <p class="examiner-report-modal-content__char-count">{{this.reportLength}} / 500</p>
-              </div>
-            {{/if}}
-          </fieldset>
+          <CandidateInformationChangeCertificationIssueReportFields
+            @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
 
           <fieldset>
             <div class="examiner-report-modal-content__report-category">

--- a/certif/app/components/examiner-report-modal.hbs
+++ b/certif/app/components/examiner-report-modal.hbs
@@ -17,9 +17,7 @@
           <OtherCertificationIssueReportFields
             @otherCategory={{this.otherCategory}}
             @toggleOnCategory={{this.toggleOnCategory}}
-            @currentIssueReport={{this.currentIssueReport}}
             @maxlength={{@maxlength}}
-            @handleTextareaChange={{this.handleTextareaChange}}
           />
 
           <fieldset>
@@ -38,7 +36,7 @@
                 <Textarea
                     id="text-area-for-category-late-or-leaving"
                     @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.currentIssueReport.description}}
+                    @value={{this.lateOrLeavingCategory.description}}
                     @maxlength={{@maxlength}}
                     {{on 'input' this.handleTextareaChange}}
                     />
@@ -63,7 +61,7 @@
                 <Textarea
                     id="text-area-for-category-candidate-informations-changes"
                     @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.currentIssueReport.description}}
+                    @value={{this.candidateInformationsChangesCategory.description}}
                     @maxlength={{@maxlength}}
                     {{on 'input' this.handleTextareaChange}}
                     />
@@ -88,7 +86,7 @@
                 <Textarea
                     id="text-area-for-category-connexion-or-end-screen"
                     @class="session-finalization-reports-informations-step__textarea"
-                    @value={{this.currentIssueReport.description}}
+                    @value={{this.connexionOrEndScreenCategory.description}}
                     @maxlength={{@maxlength}}
                     {{on 'input' this.handleTextareaChange}}
                     />

--- a/certif/app/components/examiner-report-modal.js
+++ b/certif/app/components/examiner-report-modal.js
@@ -8,93 +8,54 @@ class RadioButtonCategory {
   @tracked isChecked;
   @tracked name;
 
-  constructor() {
+  constructor({ name }) {
+    this.name = name;
     this.isChecked = false;
+  }
+
+  toggle(categoryNameToBeingCheck) {
+    this.isChecked = this.name === categoryNameToBeingCheck;
+  }
+
+  issueReport(certificationReport) {
+    return {
+      category: this.name,
+      description: this.description,
+      certificationReport,
+    };
+  }
+}
+
+class RadioButtonCategoryWithDescription extends RadioButtonCategory {
+  @tracked description;
+
+  toggle(categoryNameToBeingCheck) {
+    super.toggle(categoryNameToBeingCheck);
+    this.description = '';
   }
 }
 
 export default class ExaminerReportModal extends Component {
   @service store
 
-  @tracked otherCategory = new RadioButtonCategory();
-  @tracked lateOrLeavingCategory = new RadioButtonCategory();
-  @tracked candidateInformationsChangesCategory = new RadioButtonCategory();
-  @tracked connexionOrEndScreenCategory = new RadioButtonCategory();
-  @tracked currentIssueReport = {
-    category: null,
-    description: null,
-    certificationReport: null,
-  };
+  @tracked otherCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.OTHER });
+  @tracked lateOrLeavingCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.LATE_OR_LEAVING });
+  @tracked candidateInformationsChangesCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES });
+  @tracked connexionOrEndScreenCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.CONNEXION_OR_END_SCREEN });
+  categories = [ this.otherCategory, this.lateOrLeavingCategory, this.candidateInformationsChangesCategory, this.connexionOrEndScreenCategory ];
+
   @tracked reportLength = 0;
 
-  constructor() {
-    super(...arguments);
-    this.otherCategory.name = certificationIssueReportCategories.OTHER;
-    this.lateOrLeavingCategory.name = certificationIssueReportCategories.LATE_OR_LEAVING;
-    this.candidateInformationsChangesCategory.name = certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES;
-    this.connexionOrEndScreenCategory.name = certificationIssueReportCategories.CONNEXION_OR_END_SCREEN;
-
-    const certificationReport = this.args.report;
-    const certificationIssueReports = certificationReport.certificationIssueReports;
-    const existingIssueReport = certificationIssueReports && certificationIssueReports[0];
-
-    if (existingIssueReport) {
-      this.currentIssueReport = existingIssueReport;
-      this.reportLength = existingIssueReport.description.length
-        ? existingIssueReport.description.length
-        : 0;
-
-      switch (existingIssueReport.category) {
-        case certificationIssueReportCategories.OTHER:
-          this.otherCategory.isChecked = true;
-          break;
-
-        case certificationIssueReportCategories.LATE_OR_LEAVING:
-          this.lateOrLeavingCategory.isChecked = true;
-          break;
-
-        case certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES:
-          this.candidateInformationsChangesCategory.isChecked = true;
-          break;
-
-        case certificationIssueReportCategories.CONNEXION_OR_END_SCREEN:
-          this.connexionOrEndScreenCategory.isChecked = true;
-          break;
-
-        default:
-          break;
-      }
-    } else {
-      this.currentIssueReport = { certificationReport: this.args.report };
-    }
-  }
-
   @action
-  toggleOnCategory(category) {
-    category.isChecked = !category.isChecked;
-    this._resetAllCurrentIssueReportData();
-    if (category.isChecked) {
-      this._toggleOffAllCategoryExceptOne(category.name);
-      this.currentIssueReport.category = category.name;
-    }
-  }
-
-  _resetAllCurrentIssueReportData() {
-    delete this.currentIssueReport.description;
-    this.reportLength = 0;
-  }
-
-  _toggleOffAllCategoryExceptOne(categoryToExcludeName) {
-    this.otherCategory.isChecked = this.otherCategory.name === categoryToExcludeName;
-    this.lateOrLeavingCategory.isChecked = this.lateOrLeavingCategory.name === categoryToExcludeName;
-    this.candidateInformationsChangesCategory.isChecked = this.candidateInformationsChangesCategory.name === categoryToExcludeName;
-    this.connexionOrEndScreenCategory.isChecked = this.connexionOrEndScreenCategory.name === categoryToExcludeName;
+  toggleOnCategory(selectedCategory) {
+    this.categories.forEach((category) => category.toggle(selectedCategory.name));
   }
 
   @action
   async submitReport(event) {
     event.preventDefault();
-    const issueReportToSave = this.store.createRecord('certification-issue-report', this.currentIssueReport);
+    const categoryToAdd = this.categories.find((category) => category.isChecked);
+    const issueReportToSave = this.store.createRecord('certification-issue-report', categoryToAdd.issueReport(this.args.report));
     await issueReportToSave.save();
     this.args.closeModal();
   }

--- a/certif/app/components/examiner-report-modal.js
+++ b/certif/app/components/examiner-report-modal.js
@@ -40,9 +40,9 @@ export default class ExaminerReportModal extends Component {
 
   @tracked otherCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.OTHER });
   @tracked lateOrLeavingCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.LATE_OR_LEAVING });
-  @tracked candidateInformationsChangesCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES });
+  @tracked candidateInformationChangeCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES });
   @tracked connexionOrEndScreenCategory = new RadioButtonCategoryWithDescription({ name: certificationIssueReportCategories.CONNEXION_OR_END_SCREEN });
-  categories = [ this.otherCategory, this.lateOrLeavingCategory, this.candidateInformationsChangesCategory, this.connexionOrEndScreenCategory ];
+  categories = [ this.otherCategory, this.lateOrLeavingCategory, this.candidateInformationChangeCategory, this.connexionOrEndScreenCategory ];
 
   @tracked reportLength = 0;
 

--- a/certif/app/components/examiner-report-modal.js
+++ b/certif/app/components/examiner-report-modal.js
@@ -4,13 +4,13 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 
-class RadioButtonCategory {
+export class RadioButtonCategory {
   @tracked isChecked;
   @tracked name;
 
-  constructor({ name }) {
+  constructor({ name, isChecked = false }) {
     this.name = name;
-    this.isChecked = false;
+    this.isChecked = isChecked;
   }
 
   toggle(categoryNameToBeingCheck) {
@@ -26,7 +26,7 @@ class RadioButtonCategory {
   }
 }
 
-class RadioButtonCategoryWithDescription extends RadioButtonCategory {
+export class RadioButtonCategoryWithDescription extends RadioButtonCategory {
   @tracked description;
 
   toggle(categoryNameToBeingCheck) {

--- a/certif/app/components/late-or-leaving-certification-issue-report-fields.hbs
+++ b/certif/app/components/late-or-leaving-certification-issue-report-fields.hbs
@@ -1,0 +1,23 @@
+<fieldset class="late-or-leaving-certification-issue-report-fields">
+  <div class="late-or-leaving-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-late-or-leaving"
+      type="radio"
+      name="late-or-leaving"
+      checked={{@lateOrLeavingCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @lateOrLeavingCategory)}} />
+    <label for="input-radio-for-category-late-or-leaving">Retard, absence ou départ</label>
+  </div>
+  {{#if @lateOrLeavingCategory.isChecked}}
+    <div class="late-or-leaving-certification-issue-report-fields__details">
+      <label for="text-area-for-category-late-or-leaving">Détaillez l'incident</label>
+      <Textarea
+        id="text-area-for-category-late-or-leaving"
+        @class="session-finalization-reports-informations-step__textarea"
+        @value={{@lateOrLeavingCategory.description}}
+        @maxlength={{@maxlength}}
+      />
+      <p class="late-or-leaving-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/late-or-leaving-certification-issue-report-fields.js
+++ b/certif/app/components/late-or-leaving-certification-issue-report-fields.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class OtherCertificationissueReportFields extends Component {
+  get reportLength() {
+    return this.args.lateOrLeavingCategory.description
+      ? this.args.lateOrLeavingCategory.description.length
+      : 0;
+  }
+}

--- a/certif/app/components/other-certification-issue-report-fields.hbs
+++ b/certif/app/components/other-certification-issue-report-fields.hbs
@@ -4,19 +4,18 @@
       id="input-radio-for-category-other"
       type="radio"
       name="other"
-      checked={{this.otherCategory.isChecked}}
-      {{on 'click' (fn @toggleOnCategory this.otherCategory)}} />
+      checked={{@otherCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @otherCategory)}} />
     <label for="input-radio-for-category-other">Autre incident</label>
   </div>
-  {{#if this.otherCategory.isChecked}}
+  {{#if @otherCategory.isChecked}}
     <div class="other-certification-issue-report-fields__details">
       <label for="text-area-for-category-other">Détaillez l'incident</label>
       <Textarea
         id="text-area-for-category-other"
         @class="session-finalization-reports-informations-step__textarea"
-        @value={{@currentIssueReport.description}}
+        @value={{@otherCategory.description}}
         @maxlength={{@maxlength}}
-        {{on 'input' this.handleTextareaChange}}
       />
       <p class="other-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
     </div>

--- a/certif/app/components/other-certification-issue-report-fields.hbs
+++ b/certif/app/components/other-certification-issue-report-fields.hbs
@@ -1,0 +1,24 @@
+<fieldset class="other-certification-issue-report-fields">
+  <div class="other-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-other"
+      type="radio"
+      name="other"
+      checked={{this.otherCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory this.otherCategory)}} />
+    <label for="input-radio-for-category-other">Autre incident</label>
+  </div>
+  {{#if this.otherCategory.isChecked}}
+    <div class="other-certification-issue-report-fields__details">
+      <label for="text-area-for-category-other">Détaillez l'incident</label>
+      <Textarea
+        id="text-area-for-category-other"
+        @class="session-finalization-reports-informations-step__textarea"
+        @value={{@currentIssueReport.description}}
+        @maxlength={{@maxlength}}
+        {{on 'input' this.handleTextareaChange}}
+      />
+      <p class="other-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/other-certification-issue-report-fields.js
+++ b/certif/app/components/other-certification-issue-report-fields.js
@@ -1,29 +1,11 @@
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
-import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
-import { action } from '@ember/object';
-
-class RadioButtonCategory {
-  @tracked isChecked;
-  @tracked name;
-
-  constructor() {
-    this.isChecked = false;
-  }
-}
+// import { computed } from '@ember/object';
 
 export default class OtherCertificationissueReportFields extends Component {
-  @tracked otherCategory = new RadioButtonCategory();
-  @tracked reportLength = 0;
-
-  constructor() {
-    super(...arguments);
-    this.otherCategory.isChecked = false;
-    this.otherCategory.name = certificationIssueReportCategories.OTHER;
-  }
-
-  @action
-  handleTextareaChange(e) {
-    this.reportLength = e.target.value.length;
+  // @computed('args.otherCategory.description.length')
+  get reportLength() {
+    return this.args.otherCategory.description
+      ? this.args.otherCategory.description.length
+      : 0;
   }
 }

--- a/certif/app/components/other-certification-issue-report-fields.js
+++ b/certif/app/components/other-certification-issue-report-fields.js
@@ -1,0 +1,29 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
+import { action } from '@ember/object';
+
+class RadioButtonCategory {
+  @tracked isChecked;
+  @tracked name;
+
+  constructor() {
+    this.isChecked = false;
+  }
+}
+
+export default class OtherCertificationissueReportFields extends Component {
+  @tracked otherCategory = new RadioButtonCategory();
+  @tracked reportLength = 0;
+
+  constructor() {
+    super(...arguments);
+    this.otherCategory.isChecked = false;
+    this.otherCategory.name = certificationIssueReportCategories.OTHER;
+  }
+
+  @action
+  handleTextareaChange(e) {
+    this.reportLength = e.target.value.length;
+  }
+}

--- a/certif/app/components/other-certification-issue-report-fields.js
+++ b/certif/app/components/other-certification-issue-report-fields.js
@@ -1,8 +1,6 @@
 import Component from '@glimmer/component';
-// import { computed } from '@ember/object';
 
 export default class OtherCertificationissueReportFields extends Component {
-  // @computed('args.otherCategory.description.length')
   get reportLength() {
     return this.args.otherCategory.description
       ? this.args.otherCategory.description.length

--- a/certif/app/styles/components/examiner-report-modal.scss
+++ b/certif/app/styles/components/examiner-report-modal.scss
@@ -35,31 +35,21 @@
         margin: 0;
         min-width: 0;
         margin-bottom: 22px;
-      }
 
-      &__report-category {
-
-        input[id|="input-radio-for-type"] {
+        input[id|="input-radio-for-category"] {
           background-color: $communication-light;
-          /* IE */
-          -ms-transform: scale(1.2);
-          /* FF */
-          -moz-transform: scale(1.2);
-          /* Safari and Chrome */
-          -webkit-transform: scale(1.2);
-          /* Opera */
-          -o-transform: scale(1.2);
           transform: scale(1.2);
           margin: 0;
           cursor: pointer;
         }
 
-        label[for|="input-radio-for-type"] {
+        label[for|="input-radio-for-category"] {
           margin-left: 16px;
+          cursor: pointer;
         }
       }
 
-      &__report-category-details {
+      div[class$="certification-issue-report-fields__details"] {
         margin-top: 16px;
         padding-left: 32px;
 
@@ -78,7 +68,7 @@
           }
         }
 
-        .examiner-report-modal-content__char-count {
+        p[class$="certification-issue-report-fields-details__char-count"] {
           margin-top: 6px;
           font-size: 12px;
           display: flex;

--- a/certif/tests/integration/components/candidate-information-change-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/candidate-information-change-certification-issue-report-fields-test.js
@@ -1,13 +1,16 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
+import { RadioButtonCategoryWithDescription } from 'pix-certif/components/examiner-report-modal';
 
 module('Integration | Component | candidate-information-change-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-candidate-information-change';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-candidate-information-change';
+  const CHAR_COUNT_SELECTOR = '.candidate-information-change-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -67,6 +70,26 @@ module('Integration | Component | candidate-information-change-certification-iss
 
     // then
     assert.dom('.candidate-information-change-certification-issue-report-fields__details').doesNotExist();
+  });
+
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = new RadioButtonCategoryWithDescription({ name: 'CANDIDATE_INFORMATION_CHANGE', isChecked: true });
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
   });
 
 });

--- a/certif/tests/integration/components/candidate-information-change-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/candidate-information-change-certification-issue-report-fields-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | candidate-information-change-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-candidate-information-change';
+
+  test('it should call toggle function on click radio button', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(candidateInformationChangeCategory));
+  });
+
+  test('it should show textarea if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.candidate-information-change-certification-issue-report-fields__details').exists();
+  });
+
+  test('it should not show textarea if category is unchecked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.candidate-information-change-certification-issue-report-fields__details').doesNotExist();
+  });
+
+});

--- a/certif/tests/integration/components/connexion-or-end-screen-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/connexion-or-end-screen-certification-issue-report-fields-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, fillIn } from '@ember/test-helpers';
+import { RadioButtonCategoryWithDescription } from 'pix-certif/components/examiner-report-modal';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
@@ -8,6 +9,8 @@ module('Integration | Component | connexion-or-end-screen-certification-issue-re
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-connexion-or-end-screen';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-connexion-or-end-screen';
+  const CHAR_COUNT_SELECTOR = '.connexion-or-end-screen-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -67,6 +70,26 @@ module('Integration | Component | connexion-or-end-screen-certification-issue-re
 
     // then
     assert.dom('.connexion-or-end-screen-certification-issue-report-fields__details').doesNotExist();
+  });
+
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const connexionOrEndScreenCategory = new RadioButtonCategoryWithDescription({ name: 'CONNEXION_OR_END_SCREEN', isChecked: true });
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('connexionOrEndScreenCategory', connexionOrEndScreenCategory);
+
+    // when
+    await render(hbs`
+      <ConnexionOrEndScreenCertificationIssueReportFields
+        @connexionOrEndScreenCategory={{this.connexionOrEndScreenCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6   / 500');
   });
 
 });

--- a/certif/tests/integration/components/connexion-or-end-screen-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/connexion-or-end-screen-certification-issue-report-fields-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | connexion-or-end-screen-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-connexion-or-end-screen';
+
+  test('it should call toggle function on click radio button', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const connexionOrEndScreenCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('connexionOrEndScreenCategory', connexionOrEndScreenCategory);
+
+    // when
+    await render(hbs`
+      <ConnexionOrEndScreenCertificationIssueReportFields
+        @connexionOrEndScreenCategory={{this.connexionOrEndScreenCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(connexionOrEndScreenCategory));
+  });
+
+  test('it should show textarea if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const connexionOrEndScreenCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('connexionOrEndScreenCategory', connexionOrEndScreenCategory);
+
+    // when
+    await render(hbs`
+      <ConnexionOrEndScreenCertificationIssueReportFields
+        @connexionOrEndScreenCategory={{this.connexionOrEndScreenCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.connexion-or-end-screen-certification-issue-report-fields__details').exists();
+  });
+
+  test('it should not show textarea if category is unchecked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const connexionOrEndScreenCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('connexionOrEndScreenCategory', connexionOrEndScreenCategory);
+
+    // when
+    await render(hbs`
+      <ConnexionOrEndScreenCertificationIssueReportFields
+        @connexionOrEndScreenCategory={{this.connexionOrEndScreenCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.connexion-or-end-screen-certification-issue-report-fields__details').doesNotExist();
+  });
+
+});

--- a/certif/tests/integration/components/examiner-report-modal-test.js
+++ b/certif/tests/integration/components/examiner-report-modal-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 
@@ -13,7 +12,6 @@ module('Integration | Component | examiner-report-modal', function(hooks) {
   const LABEL_FOR_RADIO_BUTTON_OF_CATEGORY_LATE_OR_LEAVING_SELECTOR = 'label[for="input-radio-for-category-late-or-leaving"]';
   const TEXT_AREA_OF_CATEGORY_OTHER_SELECTOR = '#text-area-for-category-other';
   const TEXT_AREA_OF_CATEGORY_LATE_OR_LEAVING_SELECTOR = '#text-area-for-category-late-or-leaving';
-  const REPORT_INPUT_LENGTH_INDICATOR = '.examiner-report-modal-content__char-count';
 
   test('it show candidate informations in title', async function(assert) {
     // given
@@ -40,84 +38,6 @@ module('Integration | Component | examiner-report-modal', function(hooks) {
     // then
     const reportModalTitleSelector = '.examiner-report-modal__title h3';
     assert.dom(reportModalTitleSelector).hasText('Lisa Monpud');
-  });
-
-  module('when there is already an issue report', function() {
-    module('when the issue report is of type OTHER', function() {
-      test('it should show OTHER textearea already filled', async function(assert) {
-        // given
-        const certificationCourseId = 1;
-        const certificationIssueReport = EmberObject.create({
-          category: certificationIssueReportCategories.OTHER,
-          description: 'coucou',
-        });
-        const report = EmberObject.create({
-          certificationCourseId,
-          firstName: 'Lisa',
-          lastName: 'Monpud',
-          certificationIssueReports: [ certificationIssueReport ],
-          hasSeenEndTestScreen: false,
-        });
-
-        const closeExaminerReportModalStub = sinon.stub();
-        this.set('closeExaminerReportModal', closeExaminerReportModalStub);
-        this.set('reportToEdit', report);
-        this.set('maxlength', 500);
-
-        // when
-        await render(hbs`
-          <ExaminerReportModal
-            @closeModal={{this.closeExaminerReportModal}}
-            @report={{this.reportToEdit}}
-            @maxlength={{@issueReportDescriptionMaxLength}}
-          />
-        `);
-
-        // then
-        const textAreaElement = document.querySelector(TEXT_AREA_OF_CATEGORY_OTHER_SELECTOR);
-        assert.dom(TEXT_AREA_OF_CATEGORY_LATE_OR_LEAVING_SELECTOR).doesNotExist();
-        assert.equal(textAreaElement.value, 'coucou');
-        assert.dom(REPORT_INPUT_LENGTH_INDICATOR).hasText(`${certificationIssueReport.description.length} / 500`);
-      });
-    });
-
-    module('when the issue report is of type LATE_OR_LEAVING', function() {
-      test('it should show LATE_OR_LEAVING textearea already filled', async function(assert) {
-        // given
-        const certificationCourseId = 1;
-        const certificationIssueReport = EmberObject.create({
-          category: certificationIssueReportCategories.LATE_OR_LEAVING,
-          description: 'coucou',
-        });
-        const report = EmberObject.create({
-          certificationCourseId,
-          firstName: 'Lisa',
-          lastName: 'Monpud',
-          certificationIssueReports: [ certificationIssueReport ],
-          hasSeenEndTestScreen: false,
-        });
-
-        const closeExaminerReportModalStub = sinon.stub();
-        this.set('closeExaminerReportModal', closeExaminerReportModalStub);
-        this.set('reportToEdit', report);
-        this.set('maxlength', 500);
-
-        // when
-        await render(hbs`
-          <ExaminerReportModal
-            @closeModal={{this.closeExaminerReportModal}}
-            @report={{this.reportToEdit}}
-            @maxlength={{@issueReportDescriptionMaxLength}}
-          />
-        `);
-
-        // then
-        const textAreaElement = document.querySelector(TEXT_AREA_OF_CATEGORY_LATE_OR_LEAVING_SELECTOR);
-        assert.dom(TEXT_AREA_OF_CATEGORY_OTHER_SELECTOR).doesNotExist();
-        assert.equal(textAreaElement.value, 'coucou');
-        assert.dom(REPORT_INPUT_LENGTH_INDICATOR).hasText(`${certificationIssueReport.description.length} / 500`);
-      });
-    });
   });
 
   module('when there is no issue report yet', function() {

--- a/certif/tests/integration/components/late-or-leaving-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/late-or-leaving-certification-issue-report-fields-test.js
@@ -1,13 +1,17 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { RadioButtonCategoryWithDescription } from 'pix-certif/components/examiner-report-modal';
+
 import sinon from 'sinon';
 
 module('Integration | Component | late-or-leaving-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-late-or-leaving';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-late-or-leaving';
+  const CHAR_COUNT_SELECTOR = '.late-or-leaving-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -69,4 +73,23 @@ module('Integration | Component | late-or-leaving-certification-issue-report-fie
     assert.dom('.late-or-leaving-certification-issue-report-fields__details').doesNotExist();
   });
 
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = new RadioButtonCategoryWithDescription({ name: 'LATE_OR_LEAVING', isChecked: true });
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  });
 });

--- a/certif/tests/integration/components/late-or-leaving-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/late-or-leaving-certification-issue-report-fields-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | late-or-leaving-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-late-or-leaving';
+
+  test('it should call toggle function on click radio button', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(lateOrLeavingCategory));
+  });
+
+  test('it should show textarea if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.late-or-leaving-certification-issue-report-fields__details').exists();
+  });
+
+  test('it should not show textarea if category is unchecked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.late-or-leaving-certification-issue-report-fields__details').doesNotExist();
+  });
+
+});

--- a/certif/tests/integration/components/other-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/other-certification-issue-report-fields-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | other-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-other';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-other';
+  const CHAR_COUNT_SELECTOR = '.other-certification-issue-report-fields-details__char-count';
+
+  test('it should show textearea when clicking on radio button', async function(assert) {
+    // given
+    const toggleOnCategory = (otherCategory) => {
+      otherCategory.isChecked = !otherCategory.isChecked;
+    };
+    this.set('toggleOnCategory', toggleOnCategory);
+
+    // when
+    await render(hbs`
+      <OtherCertificationIssueReportFields
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @currentIssueReport={{null}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.other-certification-issue-report-fields__details').exists();
+  });
+
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = (otherCategory) => {
+      otherCategory.isChecked = !otherCategory.isChecked;
+    };
+    this.set('toggleOnCategory', toggleOnCategory);
+
+    // when
+    await render(hbs`
+      <OtherCertificationIssueReportFields
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @currentIssueReport={{null}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  });
+});

--- a/certif/tests/integration/components/other-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/other-certification-issue-report-fields-test.js
@@ -1,14 +1,16 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { RadioButtonCategoryWithDescription } from 'pix-certif/components/examiner-report-modal';
 import sinon from 'sinon';
 
 module('Integration | Component | other-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-other';
-  // const TEXTAREA_SELECTOR = '#text-area-for-category-other';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-other';
+  const CHAR_COUNT_SELECTOR = '.other-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -70,25 +72,23 @@ module('Integration | Component | other-certification-issue-report-fields', func
     assert.dom('.other-certification-issue-report-fields__details').doesNotExist();
   });
 
-  // test('it should count textarea characters length', async function(assert) {
-  //   // given
-  //   const toggleOnCategory = sinon.stub();
-  //   const otherCategory = { isChecked: true, description: '' };
-  //   this.set('toggleOnCategory', toggleOnCategory);
-  //   this.set('otherCategory', otherCategory);
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const otherCategory = new RadioButtonCategoryWithDescription({ name: 'OTHER', isChecked: true });
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('otherCategory', otherCategory);
 
-  //   // when
-  //   await render(hbs`
-  //     <OtherCertificationIssueReportFields
-  //       @otherCategory={{this.otherCategory}}
-  //       @toggleOnCategory={{this.toggleOnCategory}}
-  //       @maxlength={{500}}
-  //     />`);
-  //   await click(INPUT_RADIO_SELECTOR);
-  //   await fillIn(TEXTAREA_SELECTOR, 'Coucou');
-  //   // await pauseTest();
+    // when
+    await render(hbs`
+      <OtherCertificationIssueReportFields
+        @otherCategory={{this.otherCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
 
-  //   // then
-  //   assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
-  // });
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  });
 });

--- a/certif/tests/integration/components/other-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/other-certification-issue-report-fields-test.js
@@ -1,27 +1,47 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
 
 module('Integration | Component | other-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-other';
-  const TEXTAREA_SELECTOR = '#text-area-for-category-other';
-  const CHAR_COUNT_SELECTOR = '.other-certification-issue-report-fields-details__char-count';
+  // const TEXTAREA_SELECTOR = '#text-area-for-category-other';
 
-  test('it should show textearea when clicking on radio button', async function(assert) {
+  test('it should call toggle function on click radio button', async function(assert) {
     // given
-    const toggleOnCategory = (otherCategory) => {
-      otherCategory.isChecked = !otherCategory.isChecked;
-    };
+    const toggleOnCategory = sinon.stub();
+    const otherCategory = { isChecked: false };
     this.set('toggleOnCategory', toggleOnCategory);
+    this.set('otherCategory', otherCategory);
 
     // when
     await render(hbs`
       <OtherCertificationIssueReportFields
+        @otherCategory={{this.otherCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
-        @currentIssueReport={{null}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(otherCategory));
+  });
+
+  test('it should show textarea if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const otherCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('otherCategory', otherCategory);
+
+    // when
+    await render(hbs`
+      <OtherCertificationIssueReportFields
+        @otherCategory={{this.otherCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
         @maxlength={{500}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
@@ -30,24 +50,45 @@ module('Integration | Component | other-certification-issue-report-fields', func
     assert.dom('.other-certification-issue-report-fields__details').exists();
   });
 
-  test('it should count textarea characters length', async function(assert) {
+  test('it should not show textarea if category is unchecked', async function(assert) {
     // given
-    const toggleOnCategory = (otherCategory) => {
-      otherCategory.isChecked = !otherCategory.isChecked;
-    };
+    const toggleOnCategory = sinon.stub();
+    const otherCategory = { isChecked: false };
     this.set('toggleOnCategory', toggleOnCategory);
+    this.set('otherCategory', otherCategory);
 
     // when
     await render(hbs`
       <OtherCertificationIssueReportFields
+        @otherCategory={{this.otherCategory}}
         @toggleOnCategory={{this.toggleOnCategory}}
-        @currentIssueReport={{null}}
         @maxlength={{500}}
       />`);
     await click(INPUT_RADIO_SELECTOR);
-    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
 
     // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+    assert.dom('.other-certification-issue-report-fields__details').doesNotExist();
   });
+
+  // test('it should count textarea characters length', async function(assert) {
+  //   // given
+  //   const toggleOnCategory = sinon.stub();
+  //   const otherCategory = { isChecked: true, description: '' };
+  //   this.set('toggleOnCategory', toggleOnCategory);
+  //   this.set('otherCategory', otherCategory);
+
+  //   // when
+  //   await render(hbs`
+  //     <OtherCertificationIssueReportFields
+  //       @otherCategory={{this.otherCategory}}
+  //       @toggleOnCategory={{this.toggleOnCategory}}
+  //       @maxlength={{500}}
+  //     />`);
+  //   await click(INPUT_RADIO_SELECTOR);
+  //   await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+  //   // await pauseTest();
+
+  //   // then
+  //   assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  // });
 });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement la modale qui permet d'ajouter un signalement en certification affiche 4 catégories différentes.
Si l'on check une catégorie cela affiche un textearea.
Cependant, de nouvelles catégories vont être rajoutées, chacune affichant de nouveaux champs spécifiques si on les coches. De même, certaines catégories existantes aujourd'hui sont vouées à être "complexifiées" pour la suite.

Aujourd'hui nous avons un seul composant pour toute la modale. Ce composant est déjà assez gros avec seulement 4 catégories différentes (et ayant la même logique).

## :robot: Solution
Couper un peu le code en différentes parties : chaque radio button ainsi que les champs qu'il permet d'afficher seront séparer dans de nouveau composants.
Cela facilitera la maintenance ainsi que l'ajout de nouvelles catégories.

## :rainbow: Remarques
TODO : 
- [x] créer le composant pour la catégorie `late-or-leaving`
- [x] créer le composant pour la catégorie `informations-changes`
- [x] créer le composant pour la catégorie `connexion-or-end-screen`
- [x] refacto des redondances
- [x] réparer le style

## :100: Pour tester
- Lancer l'API avec : `FT_REPORTS_CATEGORISATION=true FT_CERTIF_PRESCRIPTION_SCO=true npm start`
- Lancer certif se co avec un compte sco `certifsco@example.net` 
- Aller sur la page de finalization d'une session (session 4 par exemple)
- Ajouter des signalements, constater qu'une requête est bien envoyée et que le signalement est enregistré en BDD
