### PR TITLE
[BUGFIX] Afficher le certificat quand le code de vérification saisi est correct (PIX-1791).

### DIFF
--- a/mon-pix/app/routes/shared-certification.js
+++ b/mon-pix/app/routes/shared-certification.js
@@ -1,9 +1,10 @@
 import Route from '@ember/routing/route';
+import Model from '@ember-data/model';
 
 export default class SharedCertificationRoute extends Route {
 
   async redirect(model, transition) {
-    if (!model.data) {
+    if (!model || !(model instanceof Model)) {
       if (transition && transition.from) {
         transition.abort();
       } else {

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -21,6 +21,7 @@ import loadSchoolingRegistrationUserAssociationRoutes from './routes/schooling-r
 import loadSchoolingRegistrationDependentUserRoutes from './routes/schooling-registration-dependent-users/index';
 import loadUserRoutes from './routes/users/index';
 import putTutorialEvaluation from './routes/put-tutorial-evaluation';
+import postSharedCertifications from './routes/post-shared-certifications';
 
 /* eslint max-statements: off */
 export default function() {
@@ -77,4 +78,6 @@ export default function() {
   this.get('/feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
+
+  this.post('/shared-certifications', postSharedCertifications);
 }

--- a/mon-pix/mirage/routes/post-shared-certifications.js
+++ b/mon-pix/mirage/routes/post-shared-certifications.js
@@ -1,0 +1,378 @@
+import Response from 'ember-cli-mirage/response';
+
+export default function(schema, request) {
+  const params = JSON.parse(request.requestBody);
+  if (params.verificationCode === 'P-12345678') {
+    return new Response(404);
+  } else {
+    return validResponse;
+  }
+}
+
+const validResponse = {
+  'included': [
+    {
+      'type': 'result-competences',
+      'id': 'rec6rHqas39zvLZep',
+      'attributes': {
+        'index': '4.1',
+        'level': 5,
+        'name': 'Sécuriser l\'environnement numérique',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recofJCxg0NqTqTdP',
+      'attributes': {
+        'index': '4.2',
+        'level': -1,
+        'name': 'Protéger les données personnelles et la vie privée',
+        'score': 0,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recfr0ax8XrfvJ3ER',
+      'attributes': {
+        'index': '4.3',
+        'level': 5,
+        'name': 'Protéger la santé, le bien-être et l\'environnement',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'areas',
+      'id': 'recUcSnS2lsOhFIeE',
+      'attributes': {
+        'code': '4',
+        'name': '4. Protection et sécurité',
+        'title': 'Protection et sécurité',
+        'color': 'wild-strawberry',
+      },
+      'relationships': {
+        'result-competences': {
+          'data': [
+            {
+              'type': 'result-competences',
+              'id': 'rec6rHqas39zvLZep',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recofJCxg0NqTqTdP',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recfr0ax8XrfvJ3ER',
+            },
+          ],
+        },
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recIhdrmCuEmCDAzj',
+      'attributes': {
+        'index': '5.1',
+        'level': 5,
+        'name': 'Résoudre des problèmes techniques',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recudHE5Omrr10qrx',
+      'attributes': {
+        'index': '5.2',
+        'level': 4,
+        'name': 'Construire un environnement numérique',
+        'score': 39,
+      },
+    },
+    {
+      'type': 'areas',
+      'id': 'recnrCmBiPXGbgIyQ',
+      'attributes': {
+        'code': '5',
+        'name': '5. Environnement numérique',
+        'title': 'Environnement numérique',
+        'color': 'butterfly-bush',
+      },
+      'relationships': {
+        'result-competences': {
+          'data': [
+            {
+              'type': 'result-competences',
+              'id': 'recIhdrmCuEmCDAzj',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recudHE5Omrr10qrx',
+            },
+          ],
+        },
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recDH19F7kKrfL3Ii',
+      'attributes': {
+        'index': '2.1',
+        'level': 5,
+        'name': 'Interagir',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recgxqQfz3BqEbtzh',
+      'attributes': {
+        'index': '2.2',
+        'level': 3,
+        'name': 'Partager et publier',
+        'score': 26,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recMiZPNl7V1hyE1d',
+      'attributes': {
+        'index': '2.3',
+        'level': 5,
+        'name': 'Collaborer',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recFpYXCKcyhLI3Nu',
+      'attributes': {
+        'index': '2.4',
+        'level': 4,
+        'name': 'S\'insérer dans le monde numérique',
+        'score': 36,
+      },
+    },
+    {
+      'type': 'areas',
+      'id': 'recoB4JYOBS1PCxhh',
+      'attributes': {
+        'code': '2',
+        'name': '2. Communication et collaboration',
+        'title': 'Communication et collaboration',
+        'color': 'emerald',
+      },
+      'relationships': {
+        'result-competences': {
+          'data': [
+            {
+              'type': 'result-competences',
+              'id': 'recDH19F7kKrfL3Ii',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recgxqQfz3BqEbtzh',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recMiZPNl7V1hyE1d',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recFpYXCKcyhLI3Nu',
+            },
+          ],
+        },
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recOdC9UDVJbAXHAm',
+      'attributes': {
+        'index': '3.1',
+        'level': 5,
+        'name': 'Développer des documents textuels',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recbDTF8KwupqkeZ6',
+      'attributes': {
+        'index': '3.2',
+        'level': -1,
+        'name': 'Développer des documents multimedia',
+        'score': 0,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recHmIWG6D0huq6Kx',
+      'attributes': {
+        'index': '3.3',
+        'level': 5,
+        'name': 'Adapter les documents à leur finalité',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'rece6jYwH4WEw549z',
+      'attributes': {
+        'index': '3.4',
+        'level': 2,
+        'name': 'Programmer',
+        'score': 17,
+      },
+    },
+    {
+      'type': 'areas',
+      'id': 'recs7Gpf90ln8NCv7',
+      'attributes': {
+        'code': '3',
+        'name': '3. Création de contenu',
+        'title': 'Création de contenu',
+        'color': 'cerulean',
+      },
+      'relationships': {
+        'result-competences': {
+          'data': [
+            {
+              'type': 'result-competences',
+              'id': 'recOdC9UDVJbAXHAm',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recbDTF8KwupqkeZ6',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recHmIWG6D0huq6Kx',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'rece6jYwH4WEw549z',
+            },
+          ],
+        },
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recsvLz0W2ShyfD63',
+      'attributes': {
+        'index': '1.1',
+        'level': 5,
+        'name': 'Mener une recherche et une veille d’information',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recIkYm646lrGvLNT',
+      'attributes': {
+        'index': '1.2',
+        'level': 5,
+        'name': 'Gérer des données',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'result-competences',
+      'id': 'recNv8qhaY887jQb2',
+      'attributes': {
+        'index': '1.3',
+        'level': 5,
+        'name': 'Traiter des données',
+        'score': 40,
+      },
+    },
+    {
+      'type': 'areas',
+      'id': 'recvoGdo7z2z7pXWa',
+      'attributes': {
+        'code': '1',
+        'name': '1. Information et données',
+        'title': 'Information et données',
+        'color': 'jaffa',
+      },
+      'relationships': {
+        'result-competences': {
+          'data': [
+            {
+              'type': 'result-competences',
+              'id': 'recsvLz0W2ShyfD63',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recIkYm646lrGvLNT',
+            },
+            {
+              'type': 'result-competences',
+              'id': 'recNv8qhaY887jQb2',
+            },
+          ],
+        },
+      },
+    },
+    {
+      'type': 'result-competence-trees',
+      'id': '200-104537',
+      'attributes': {
+        'id': '200-104537',
+      },
+      'relationships': {
+        'areas': {
+          'data': [
+            {
+              'type': 'areas',
+              'id': 'recUcSnS2lsOhFIeE',
+            },
+            {
+              'type': 'areas',
+              'id': 'recnrCmBiPXGbgIyQ',
+            },
+            {
+              'type': 'areas',
+              'id': 'recoB4JYOBS1PCxhh',
+            },
+            {
+              'type': 'areas',
+              'id': 'recs7Gpf90ln8NCv7',
+            },
+            {
+              'type': 'areas',
+              'id': 'recvoGdo7z2z7pXWa',
+            },
+          ],
+        },
+      },
+    },
+  ],
+  'data': {
+    'type': 'certifications',
+    'id': '200',
+    'attributes': {
+      'certification-center': 'Centre SCO des Anne-Étoiles',
+      'birthdate': '2000-01-01',
+      'birthplace': 'Monroeberg',
+      'date': '2020-01-31T00:00:00.000Z',
+      'first-name': 'anne',
+      'delivered-at': '2020-06-05T15:00:34.000Z',
+      'is-published': true,
+      'last-name': 'success',
+      'status': 'validated',
+      'pix-score': 518,
+      'clea-certification-status': 'acquired',
+    },
+    'relationships': {
+      'result-competence-tree': {
+        'data': {
+          'type': 'result-competence-trees',
+          'id': '200-104537',
+        },
+      },
+    },
+  },
+};
+

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
@@ -1,10 +1,10 @@
 import { describe, it, context } from 'mocha';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
-import { pauseTest, click, visit, fillIn, currentURL, find } from '@ember/test-helpers';
+import { click, visit, fillIn, currentURL, find } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
-describe.only('Acceptance | Certificate verification', function() {
+describe('Acceptance | Certificate verification', function() {
   setupApplicationTest();
   setupMirage();
 
@@ -18,7 +18,7 @@ describe.only('Acceptance | Certificate verification', function() {
       await click('button[type=submit]');
 
       // Then
-      expect(currentURL()).to.not.equal('/verification-certificat');
+      expect(currentURL()).to.equal('/partage-certificat/200');
     });
   });
 
@@ -45,6 +45,16 @@ describe.only('Acceptance | Certificate verification', function() {
 
       // Then
       expect(find('.form__error--not-found')).to.exist;
+    });
+  });
+
+  context('when user visits /partage-certificat/200 directly', function() {
+    it('redirects to /verification-certificat', async function() {
+      // When
+      await visit('/partage-certificat/200');
+
+      // Then
+      expect(currentURL()).to.equal('/verification-certificat');
     });
   });
 

--- a/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
+++ b/mon-pix/tests/acceptance/fill-in-certificate-verification-code-test.js
@@ -1,0 +1,51 @@
+import { describe, it, context } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { pauseTest, click, visit, fillIn, currentURL, find } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+describe.only('Acceptance | Certificate verification', function() {
+  setupApplicationTest();
+  setupMirage();
+
+  context('when certificate verification code is valid', function() {
+    it('redirects to certificate details page', async function() {
+      // Given
+      await visit('/verification-certificat');
+      await fillIn('#certificate-verification-code', 'P-123VALID');
+
+      // When
+      await click('button[type=submit]');
+
+      // Then
+      expect(currentURL()).to.not.equal('/verification-certificat');
+    });
+  });
+
+  context('when certificate verification code is wrong', function() {
+    it('does not redirect to certificate details page', async function() {
+      // Given
+      await visit('/verification-certificat');
+      await fillIn('#certificate-verification-code', 'P-12345678');
+
+      // When
+      await click('button[type=submit]');
+
+      // Then
+      expect(currentURL()).to.equal('/verification-certificat');
+    });
+
+    it('shows error message', async function() {
+      // Given
+      await visit('/verification-certificat');
+      await fillIn('#certificate-verification-code', 'P-12345678');
+
+      // When
+      await click('button[type=submit]');
+
+      // Then
+      expect(find('.form__error--not-found')).to.exist;
+    });
+  });
+
+});

--- a/mon-pix/tests/unit/routes/shared-certification-test.js
+++ b/mon-pix/tests/unit/routes/shared-certification-test.js
@@ -1,4 +1,3 @@
-// import { expect } from 'chai';
 import sinon from 'sinon';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
@@ -15,10 +14,13 @@ describe('Unit | Route | shared-certification', function() {
   });
 
   it('should not redirect with certification', function() {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('certification', {});
+
     const route = this.owner.lookup('route:shared-certification');
     sinon.stub(route, 'replaceWith');
 
-    route.redirect({ data: {} }, {});
+    route.redirect(model, {});
     sinon.assert.notCalled(route.replaceWith);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Quand il saisit le code d'un certificat pour vérification, l'utilisateur n'est pas redirigé vers le certificat, même si le code saisi est valide.

## 🕵🏾 Analyse
Ce problème est apparu suite à la dernière montée de version de Ember.
La route `shared-certifications` regarde si `model.data` est bien rempli avec les données d'un certificat.
Le problème est que `data` est considéré comme privé par Ember et est déprécié depuis près de 2 ans.
Lors de la version, 3.23 d'Ember data, la dépréciation a été supprimée (cf [ce commit](https://github.com/emberjs/data/commit/6612b765b7cfd2944fc2c5c47a9b861a9ecffdc3))
Dès lors, `model.data` est toujours `undefined` et la route considère qu'elle n'a pas les données et ainsi annule la transition. C'est d'ailleurs le message d'erreur que l'on voit dans la console :
```
message: "TransitionAborted"
name: "TransitionAborted"
```

## :robot: Solution
Tester que le model est présent et est valide (ie. est une instance de model d'ember data) pour choisir de rediriger ou non l'utilisateur.


## :rainbow: Remarques
On aurait pu se rendre compte du bug si le test d'acceptance avait été existant lors de la montée de version.
Concernant la dépréciation de `mode.data`, un warning était présent dans la console lors du développement originel.
Il n'est pas évident et pas automatique de se rendre compte de tels warnings.
Une piste intéressante à creuser est l'option de lever une exception lors de l'usage de code obsolète : Ember propose ce type d'option.

## :100: Pour tester
Se rendre sur la RA à l'adresse `https://app-pr2297.review.pix.fr/verification-certificat`.
Saisir le code `P-9CXJX6T2`
Vérifier que le certificat est affiché.
