### PR TITLE
[TECH] Le script configure charge les données de tests en bdd

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -86,11 +86,7 @@ function install_apps_dependencies() {
   echo "Installing Pix apps dependencies…"
 
   npm install
-  (cd admin && npm install --no-optional)
-  (cd api && npm install --no-optional)
-  (cd certif && npm install --no-optional)
-  (cd mon-pix && npm install --no-optional)
-  (cd orga && npm install --no-optional)
+  npm run ci:all
 
   echo "✅ Dependencies installed."
   echo ""

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -102,6 +102,15 @@ function setup_and_run_infrastructure() {
   echo ""
 }
 
+function load_seed() {
+  echo "Loading seed data"
+
+  (cd api && npm run db:seed)
+
+  echo "✅ Seed data loaded"
+  echo ""
+}
+
 function execute_apps_tests() {
   echo "Executing Pix apps tests…"
 
@@ -138,5 +147,6 @@ verify_prerequesite_programs
 generate_environment_config_file
 install_apps_dependencies
 setup_and_run_infrastructure
+load_seed
 execute_apps_tests
 display_footer


### PR DESCRIPTION
## :unicorn: Problème

Le script configure ne chargeait pas les données de test en BDD.

## :robot: Solution

Lancer `db:seed` dans le script configure.

## :rainbow: Remarques

J'en ai profiter pour utiliser la commande `ci:all` pour installer les packages que je ne connaissais pas et que j'aime déjà beaucoup :heart: 

## :100: Pour tester

- `docker-compose down`
- `npm run clean`
- `npm run configure`

Et l'application doit fonctionner et avoir les données chargées.