### PR TITLE
[TECH] Réduit les occurrences de timeout sur les tests du knex-utils

### DIFF
--- a/api/tests/integration/infrastructure/utils/knex-utils_test.js
+++ b/api/tests/integration/infrastructure/utils/knex-utils_test.js
@@ -10,21 +10,21 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
     it('should fetch the given page and return results and pagination data', async () => {
       // given
       const letterA = 'a'.charCodeAt(0);
-      _.times(26, (index) => databaseBuilder.factory.buildCampaign({ name: `${String.fromCharCode(letterA + index)}` }));
+      _.times(5, (index) => databaseBuilder.factory.buildCampaign({ name: `${String.fromCharCode(letterA + index)}` }));
       await databaseBuilder.commit();
 
       // when
       const query = knex.select('name').from('campaigns').orderBy('name', 'ASC');
-      const { results, pagination } = await fetchPage(query, { number: 2, size: 5 });
+      const { results, pagination } = await fetchPage(query, { number: 2, size: 2 });
 
       // then
-      expect(results).to.have.lengthOf(5);
-      expect(results.map((result) => result.name)).exactlyContainInOrder(['f', 'g', 'h', 'i', 'j']);
+      expect(results).to.have.lengthOf(2);
+      expect(results.map((result) => result.name)).exactlyContainInOrder(['c', 'd']);
       expect(pagination).to.deep.equal({
         page: 2,
-        pageSize: 5,
-        rowCount: 26,
-        pageCount: 6,
+        pageSize: 2,
+        rowCount: 5,
+        pageCount: 3,
       });
     });
 
@@ -49,9 +49,9 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
     context('#pagination.page', () => {
       it('should return the requested page when there are results', async () => {
         // given
-        const pageNumber = 5;
+        const pageNumber = 2;
         const pageSize = 1;
-        const total = 50;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -68,7 +68,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
         // given
         const pageNumber = 10000;
         const pageSize = 1;
-        const total = 50;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -85,7 +85,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
         // given
         const pageNumber = 0;
         const pageSize = 1;
-        const total = 50;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -101,7 +101,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the DEFAULT_PAGINATION.PAGE when not indicating the page', async () => {
         // given
         const pageSize = 1;
-        const total = 50;
+        const total = 1;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -119,8 +119,8 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the requested pageSize when there are results', async () => {
         // given
         const pageNumber = 1;
-        const pageSize = 5;
-        const total = 50;
+        const pageSize = 2;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -133,11 +133,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
         expect(pagination.pageSize).to.equal(pageSize);
       });
 
-      it('should return the requested page even when there less results than expected', async () => {
+      it('should return the requested page size even when there less results than expected', async () => {
         // given
         const pageNumber = 1;
-        const total = 50;
-        const pageSize = total + 3;
+        const total = 3;
+        const pageSize = 6;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -150,11 +150,11 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
         expect(pagination.pageSize).to.equal(pageSize);
       });
 
-      it('should return the requested page even when there are no results', async () => {
+      it('should return the requested page size even when there are no results', async () => {
         // given
         const pageNumber = 1000;
         const pageSize = 5;
-        const total = 50;
+        const total = 1;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -170,7 +170,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the DEFAULT_PAGINATION.PAGE_SIZE when not indicating the size', async () => {
         // given
         const pageNumber = 1;
-        const total = 50;
+        const total = DEFAULT_PAGINATION.PAGE_SIZE + 1;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -188,8 +188,8 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the rowCount for the whole query when pagination has results', async () => {
         // given
         const pageNumber = 1;
-        const pageSize = 5;
-        const total = 50;
+        const pageSize = 3;
+        const total = 5;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -205,8 +205,8 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the rowCount for the whole query even if there are no results with requested pagination', async () => {
         // given
         const pageNumber = 100000;
-        const pageSize = 5;
-        const total = 50;
+        const pageSize = 2;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -224,8 +224,8 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
       it('should return the pageCount according to the total row count for the whole query according to the requested page size', async () => {
         // given
         const pageNumber = 1;
-        const pageSize = 5;
-        const total = 50;
+        const pageSize = 2;
+        const total = 10;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -235,14 +235,14 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
 
         // then
         expect(results).to.not.be.empty;
-        expect(pagination.pageCount).to.equal(10);
+        expect(pagination.pageCount).to.equal(5);
       });
 
       it('should return the pageCount even when the last page would be partially filled', async () => {
         // given
         const pageNumber = 1;
-        const pageSize = 6;
-        const total = 50;
+        const pageSize = 2;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -252,14 +252,14 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
 
         // then
         expect(results).to.not.be.empty;
-        expect(pagination.pageCount).to.equal(9);
+        expect(pagination.pageCount).to.equal(2);
       });
 
       it('should return the pageCount even if there are no results with requested pagination', async () => {
         // given
         const pageNumber = 100000;
-        const pageSize = 5;
-        const total = 50;
+        const pageSize = 2;
+        const total = 3;
         _.times(total, (index) => databaseBuilder.factory.buildCampaign({ name: `c-${index}` }));
         await databaseBuilder.commit();
 
@@ -269,7 +269,7 @@ describe('Integration | Infrastructure | Utils | Knex utils', () => {
 
         // then
         expect(results).to.be.empty;
-        expect(pagination.pageCount).to.equal(10);
+        expect(pagination.pageCount).to.equal(2);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Les setups des tests du knex-utils sont parfois un peu costauds et prévoient la création de plusieurs objets en BDD pour tester les fonctionnalités de pagination.
Du coup, ce volume important de création / suppression provoque parfois du timeout sur ces tests.

## :robot: Solution
On peut réduire la quantité de données de test tout en garantissant la même couverture.

## :rainbow: Remarques

## :100: Pour tester
