### PR TITLE
[FEATURE] Afficher le nombre correct de signalements d'une certification sur la page de finalisation de session PixCertif (PIX-1813)

### DIFF
--- a/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-report-serializer.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const { Serializer, Deserializer } = require('jsonapi-serializer');
 
 const CertificationReport = require('../../../domain/models/CertificationReport');
@@ -13,16 +11,21 @@ module.exports = {
         'lastName',
         'examinerComment',
         'hasSeenEndTestScreen',
+        'certificationIssueReports',
       ],
+      certificationIssueReports: {
+        ref: 'id',
+        attributes: [
+          'category',
+          'description',
+        ],
+      },
     }).serialize(certificationReports);
   },
 
   async deserialize(jsonApiData) {
     const deserializer = new Deserializer({ keyForAttribute: 'camelCase' });
     const deserializedReport = await deserializer.deserialize(jsonApiData);
-    if (_.isEmpty(_.trim(deserializedReport.examinerComment))) {
-      deserializedReport.examinerComment = CertificationReport.NO_EXAMINER_COMMENT;
-    }
     return new CertificationReport(deserializedReport);
   },
 };

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -31,24 +31,22 @@ describe('Integration | Repository | CertificationReport', function() {
         const certificationReports = await certificationReportRepository.findBySessionId(sessionId);
 
         // then
-        const expectedCertificationReport1 = {
+        const expectedCertificationReport1 = domainBuilder.buildCertificationReport({
           id: CertificationReport.idFromCertificationCourseId(certificationCourse1.id),
           certificationCourseId: certificationCourse1.id,
           firstName: certificationCourse1.firstName,
           lastName: certificationCourse1.lastName,
-          examinerComment: certificationIssueReport1.description,
           certificationIssueReports: [ certificationIssueReport1 ],
           hasSeenEndTestScreen: certificationCourse1.hasSeenEndTestScreen,
-        };
-        const expectedCertificationReport2 = {
+        });
+        const expectedCertificationReport2 = domainBuilder.buildCertificationReport({
           id: CertificationReport.idFromCertificationCourseId(certificationCourse2.id),
           certificationCourseId: certificationCourse2.id,
           firstName: certificationCourse2.firstName,
           lastName: certificationCourse2.lastName,
-          examinerComment: null,
           certificationIssueReports: [],
           hasSeenEndTestScreen: certificationCourse2.hasSeenEndTestScreen,
-        };
+        });
         expect(certificationReports).to.deep.equal([expectedCertificationReport1, expectedCertificationReport2]);
       });
     });
@@ -101,14 +99,12 @@ describe('Integration | Repository | CertificationReport', function() {
           sessionId,
           certificationCourseId: certificationCourseId1,
           hasSeenEndTestScreen: true,
-          examinerComment: null,
         });
 
         const certificationReport2 = domainBuilder.buildCertificationReport({
           sessionId,
           certificationCourseId: certificationCourseId2,
           hasSeenEndTestScreen: false,
-          examinerComment: 'J\'aime les fruits et les poulets',
         });
 
         // when
@@ -117,10 +113,8 @@ describe('Integration | Repository | CertificationReport', function() {
         // then
         const actualCertificationReports = await certificationReportRepository.findBySessionId(sessionId);
         const actualReport1 = _.find(actualCertificationReports, { id: certificationReport1.id });
-        const actualReport2 = _.find(actualCertificationReports, { id: certificationReport2.id });
 
         expect(actualReport1.hasSeenEndTestScreen).to.equal(true);
-        expect(actualReport2.examinerComment).to.equal('J\'aime les fruits et les poulets');
       });
 
       it('should save only not null examiner comment into certification-issue-report', async () => {
@@ -136,12 +130,11 @@ describe('Integration | Repository | CertificationReport', function() {
         }).id;
         await databaseBuilder.commit();
 
-        const notNullExaminerComment = 'Un commentaire examinateur';
         const nullExaminerComment = null;
 
         const certificationReportWithNotNullExaminerComment = domainBuilder.buildCertificationReport({
           certificationCourseId: certificationCourseId1,
-          examinerComment: notNullExaminerComment,
+          examinerComment: 'Un commentaire examinateur',
         });
         const certificationReportWithNullExaminerComment = domainBuilder.buildCertificationReport({
           certificationCourseId: certificationCourseId2,
@@ -154,7 +147,7 @@ describe('Integration | Repository | CertificationReport', function() {
         // then
         const actualCertificationReports = await certificationReportRepository.findBySessionId(sessionId);
 
-        expect(actualCertificationReports[0].certificationIssueReports[0].description).to.equal(notNullExaminerComment);
+        expect(actualCertificationReports[0].certificationIssueReports[0].description).to.equal('Un commentaire examinateur');
         expect(actualCertificationReports[1].certificationIssueReports.length).to.equal(0);
       });
 
@@ -198,7 +191,7 @@ describe('Integration | Repository | CertificationReport', function() {
         const actualReport1 = _.find(actualCertificationReports, { id: certificationReport1.id });
         const actualReport2 = _.find(actualCertificationReports, { id: certificationReport2.id });
 
-        expect(actualReport1.examinerComment).to.equal(null);
+        expect(actualReport1.certificationIssueReports).to.deep.equal([]);
         expect(actualReport2.hasSeenEndTestScreen).to.equal(false);
         expect(error).to.be.an.instanceOf(CertificationCourseUpdateError);
       });

--- a/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-report-repository_test.js
@@ -68,60 +68,6 @@ describe('Integration | Repository | CertificationReport', function() {
     });
   });
 
-  describe('#finalize', () => {
-
-    afterEach(() => {
-      return knex('certification-issue-reports').delete();
-    });
-
-    describe('when saving informations from certification report', () => {
-
-      it('should save hasSeenEndTestScreen into certification course', async () => {
-        // given
-        const sessionId = databaseBuilder.factory.buildSession().id;
-        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-          sessionId,
-        }).id;
-        await databaseBuilder.commit();
-
-        // when
-        const hasSeenEndTestScreen = true;
-        const certificationReport = domainBuilder.buildCertificationReport({
-          certificationCourseId,
-          hasSeenEndTestScreen,
-        });
-        await certificationReportRepository.finalize({ certificationReport });
-
-        // then
-        const actualCertificationReports = await certificationReportRepository.findBySessionId(sessionId);
-
-        expect(actualCertificationReports[0].hasSeenEndTestScreen).to.equal(true);
-      });
-
-      it('should save examiner comment into certification-issue-report', async () => {
-        // given
-        const sessionId = databaseBuilder.factory.buildSession().id;
-        const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({
-          sessionId,
-        }).id;
-        await databaseBuilder.commit();
-
-        // when
-        const examinerComment = 'Un commentaire examinateur';
-        const certificationReport = domainBuilder.buildCertificationReport({
-          certificationCourseId,
-          examinerComment,
-        });
-        await certificationReportRepository.finalize({ certificationReport });
-
-        // then
-        const actualCertificationReports = await certificationReportRepository.findBySessionId(sessionId);
-
-        expect(actualCertificationReports[0].examinerComment).to.equal(examinerComment);
-      });
-    });
-  });
-
   describe('#finalizeAll', () => {
     let sessionId;
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-issue-report.js
@@ -1,11 +1,11 @@
-const faker = require('faker');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
+const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
 module.exports = function buildCertificationIssueReport({
-  id = faker.random.number(),
+  id = 123,
   certificationCourseId,
-  category,
-  description = null,
+  category = CertificationIssueReportCategories.OTHER,
+  description = 'Une super description',
 } = {}) {
   return new CertificationIssueReport({
     id,

--- a/api/tests/tooling/domain-builder/factory/build-certification-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-report.js
@@ -1,5 +1,6 @@
 const faker = require('faker');
 const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+const buildCertificationIssueReport = require('./build-certification-issue-report');
 
 module.exports = function buildCertificationReport(
   {
@@ -7,8 +8,9 @@ module.exports = function buildCertificationReport(
     // attributes
     firstName = faker.name.firstName(),
     lastName = faker.name.lastName(),
-    examinerComment = faker.lorem.sentence(),
     hasSeenEndTestScreen = false,
+    examinerComment,
+    certificationIssueReports,
     // references
     certificationCourseId = faker.random.number(),
   } = {}) {
@@ -18,7 +20,10 @@ module.exports = function buildCertificationReport(
     certificationCourseId,
     firstName,
     lastName,
-    examinerComment,
     hasSeenEndTestScreen,
+    examinerComment,
+    certificationIssueReports: certificationIssueReports
+      ? certificationIssueReports
+      : [buildCertificationIssueReport({ certificationCourseId })],
   });
 };

--- a/api/tests/unit/domain/models/CertificationReport_test.js
+++ b/api/tests/unit/domain/models/CertificationReport_test.js
@@ -1,0 +1,17 @@
+const { expect, EMPTY_BLANK_AND_NULL } = require('../../../test-helper');
+const CertificationReport = require('../../../../lib/domain/models/CertificationReport');
+
+describe('Unit | Domain | Models | CertificationReport', () => {
+
+  describe('#constructor', () => {
+    EMPTY_BLANK_AND_NULL.forEach((examinerComment) => {
+      it(`should return no examiner comment if comment is "${examinerComment}"`, () => {
+        // when
+        const certificationReport = new CertificationReport({ examinerComment });
+
+        // then
+        expect(certificationReport.examinerComment).to.equal(CertificationReport.NO_EXAMINER_COMMENT);
+      });
+    });
+  });
+});

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -33,7 +33,13 @@
                   <button type="button" class="button--showed-as-link add-button" {{on 'click' (fn this.openExaminerReportModal report)}}>
                     Ajouter / modifier
                   </button>
-                  <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}"> 1 signalement </p>
+                  <p data-test-id="finalization-report-has-examiner-comment_{{report.certificationCourseId}}">
+                    {{#if (gt report.certificationIssueReports.length 1)}}
+                      {{report.certificationIssueReports.length}} signalements
+                    {{else}}
+                      1 signalement
+                    {{/if}}
+                  </p>
                 {{else}}
                   <button type="button" class="button--showed-as-link add-button" {{on 'click' (fn this.openExaminerReportModal report)}}>
                     Ajouter ?

--- a/certif/app/components/session-finalization-reports-informations-step.js
+++ b/certif/app/components/session-finalization-reports-informations-step.js
@@ -4,6 +4,8 @@ import { tracked } from '@glimmer/tracking';
 
 export default class SessionFinalizationReportsInformationsStep extends Component {
   textareaMaxLength = 500;
+
+  @tracked
   reportToEdit = null;
 
   @tracked

--- a/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
+++ b/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
@@ -72,8 +72,20 @@ module('Integration | Component | session-finalization-reports-informations-step
 
   module('when feature categorizationOfReports is on', function() {
 
-    test('it shows "1 Signalement" only if there is a certification issue report', async function(assert) {
+    test('it shows "1 signalement" if there is exactly one certification issue report', async function(assert) {
       // given
+      const certificationIssueReport = run(() => store.createRecord('certification-issue-report', {
+        description: 'Coucou',
+        category: certificationIssueReportCategories.OTHER,
+      }));
+      const certificationReport = run(() => store.createRecord('certification-report', {
+        certificationCourseId: 1234,
+        firstName: 'Alice',
+        lastName: 'Alister',
+        certificationIssueReports: [certificationIssueReport],
+        hasSeenEndTestScreen: null,
+      }));
+      this.set('certificationReports', [certificationReport]);
       this.set('isReportsCategorizationFeatureToggleEnabled', true);
 
       // when
@@ -89,8 +101,43 @@ module('Integration | Component | session-finalization-reports-informations-step
       `);
 
       // then
-      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportA.certificationCourseId}"]`).hasText('1 signalement');
-      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${reportB.certificationCourseId}"]`).doesNotExist();
+      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('1 signalement');
+    });
+
+    test('it shows "X signalements" (plural) if there is more than one certification issue reports', async function(assert) {
+      // given
+      const certificationIssueReport1 = run(() => store.createRecord('certification-issue-report', {
+        description: 'Coucou',
+        category: certificationIssueReportCategories.OTHER,
+      }));
+      const certificationIssueReport2 = run(() => store.createRecord('certification-issue-report', {
+        description: 'Les zouzous',
+        category: certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
+      }));
+      const certificationReport = run(() => store.createRecord('certification-report', {
+        certificationCourseId: 1234,
+        firstName: 'Alice',
+        lastName: 'Alister',
+        certificationIssueReports: [certificationIssueReport1, certificationIssueReport2],
+        hasSeenEndTestScreen: null,
+      }));
+      this.set('certificationReports', [certificationReport]);
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`
+        <SessionFinalizationReportsInformationsStep
+          @certificationReports={{this.certificationReports}}
+          @updateCertificationIssueReport={{this.updateCertificationIssueReport}}
+          @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
+          @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}
+          @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+          @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+        />
+      `);
+
+      // then
+      assert.dom(`[data-test-id="finalization-report-has-examiner-comment_${certificationReport.certificationCourseId}"]`).hasText('2 signalements');
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le système d'ajout de signalements sur une certification lors de la finalisation de session a été réalisé de sorte à ce chaque signalement soit enregistré auprès de l'API au fur et à mesure (et non au clic sur "Finaliser"). Cela permet à la personne qui finalise de pouvoir ajouter des signalements sans forcément finaliser la session de suite, de sorte à ne pas perdre son travail.
A ce jour, l'utilisateur n'avait aucune information concernant le nombre de signalements déjà déclarés sur des certifications en cours de finalisation.

## :robot: Solution
Afficher le nombre correct de signalements déjà déclarés d'une certification sur la page de finalisation de session.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer l'API avec les toggles appropriés : `FT_CERTIF_PRESCRIPTION_SCO=true FT_REPORTS_CATEGORISATION=true npm start`
Se connecter avec certifsco@example.net, puis se rendre sur la page d'une session à finaliser.
Ajouter un signalement, puis fermer la page et réouvrir (pour vider le storage ember), constater le bon nombre de signalements affiché.
