### PR TITLE
[CLEANUP] Supprimer les commentaires peu utilisés "// attributes", ...

### DIFF
--- a/api/lib/domain/models/Answer.js
+++ b/api/lib/domain/models/Answer.js
@@ -5,29 +5,23 @@ class Answer {
 
   constructor({
     id,
-    // attributes
     elapsedTime,
     result,
     resultDetails,
     timeout,
     value,
-    // includes
     levelup,
-    // references
     assessmentId,
     challengeId,
   } = {}) {
     this.id = id;
-    // attributes
     this.elapsedTime = elapsedTime;
     // XXX result property should not be auto-created from result to an AnswerStatus Object
     this.result = AnswerStatus.from(result);
     this.resultDetails = resultDetails;
     this.timeout = timeout;
     this.value = value;
-    // includes
     this.levelup = levelup;
-    // references
     this.assessmentId = assessmentId;
     this.challengeId = challengeId;
   }

--- a/api/lib/domain/models/AnswerStatus.js
+++ b/api/lib/domain/models/AnswerStatus.js
@@ -8,16 +8,10 @@ const UNIMPLEMENTED = 'unimplemented';
 
 class AnswerStatus {
   constructor({
-    // attributes
     status,
-    // includes
-    // references
   } = {}) {
-    // attributes
     // TODO: throw a BadAnswerStatus error if the status is bad + adapt the tests
     this.status = status;
-    // includes
-    // references
   }
 
   /* PUBLIC INTERFACE */

--- a/api/lib/domain/models/Area.js
+++ b/api/lib/domain/models/Area.js
@@ -2,24 +2,18 @@ class Area {
 
   constructor({
     id,
-    // attributes
     code,
     name,
     title,
     color,
-    // includes
     competences = [], // list of Competence domain objects
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.code = code;
     this.name = name;
     this.title = title;
     this.color = color;
-    // includes
     this.competences = competences;
-    // references
   }
 }
 

--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -28,19 +28,16 @@ const TYPES_OF_ASSESSMENT_NEEDING_USER = [
 class Assessment {
   constructor({
     id,
-    // attributes
     createdAt,
     updatedAt,
     state,
     title,
     type,
     isImproving,
-    // includes
     answers = [],
     campaignParticipation,
     course,
     targetProfile,
-    // references
     courseId,
     certificationCourseId,
     userId,
@@ -48,19 +45,16 @@ class Assessment {
     campaignParticipationId,
   } = {}) {
     this.id = id;
-    // attributes
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.state = state;
     this.title = title;
     this.type = type;
     this.isImproving = isImproving;
-    // includes
     this.answers = answers;
     this.campaignParticipation = campaignParticipation;
     this.course = course;
     this.targetProfile = targetProfile;
-    // references
     this.courseId = courseId;
     this.certificationCourseId = certificationCourseId;
     this.userId = userId;

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -8,7 +8,6 @@ class AssessmentResult {
   // FIXME: assessmentId && juryId to replace by assessment && jury domain objects
   constructor({
     id,
-    // attributes
     commentForCandidate,
     commentForJury,
     commentForOrganization,
@@ -16,14 +15,11 @@ class AssessmentResult {
     emitter,
     pixScore,
     status,
-    // includes
     competenceMarks = [],
-    // references
     assessmentId,
     juryId,
   } = {}) {
     this.id = id;
-    // attributes
     this.commentForCandidate = commentForCandidate;
     this.commentForJury = commentForJury;
     this.commentForOrganization = commentForOrganization;
@@ -31,9 +27,7 @@ class AssessmentResult {
     this.emitter = emitter;
     this.pixScore = pixScore;
     this.status = status;
-    // includes
     this.competenceMarks = competenceMarks;
-    // references
     this.assessmentId = assessmentId;
     this.juryId = juryId;
   }

--- a/api/lib/domain/models/Authentication.js
+++ b/api/lib/domain/models/Authentication.js
@@ -1,16 +1,10 @@
 class Authentication {
 
   constructor({
-    // attributes
     token,
-    // includes
-    // references
     userId,
   } = {}) {
-    // attributes
     this.token = token;
-    // includes
-    // references
     this.userId = userId;
   }
 

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -63,25 +63,19 @@ class AuthenticationMethod {
 
   constructor({
     id,
-    // attributes
     identityProvider,
     authenticationComplement,
     externalIdentifier,
     createdAt,
     updatedAt,
-    // includes
-    // references
     userId,
   } = {}) {
     this.id = id;
-    // attributes
     this.identityProvider = identityProvider;
     this.authenticationComplement = authenticationComplement;
     this.externalIdentifier = externalIdentifier;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
-    // includes
-    // references
     this.userId = userId;
 
     validateEntity(validationSchema, this);

--- a/api/lib/domain/models/Badge.js
+++ b/api/lib/domain/models/Badge.js
@@ -1,29 +1,23 @@
 class Badge {
   constructor({
     id,
-    // attributes
     key,
     altMessage,
     imageUrl,
     message,
     title,
-    // includes
     badgeCriteria = [],
     badgePartnerCompetences = [],
-    // references
     targetProfileId,
   } = {}) {
     this.id = id;
-    // attributes
     this.altMessage = altMessage;
     this.imageUrl = imageUrl;
     this.message = message;
     this.title = title;
     this.key = key;
-    // includes
     this.badgeCriteria = badgeCriteria;
     this.badgePartnerCompetences = badgePartnerCompetences;
-    // references
     this.targetProfileId = targetProfileId;
   }
 }

--- a/api/lib/domain/models/BadgeAcquisition.js
+++ b/api/lib/domain/models/BadgeAcquisition.js
@@ -1,18 +1,12 @@
 class BadgeAcquisition {
   constructor({
     id,
-    // attributes
-    // includes
     badge,
-    // references
     userId,
     badgeId,
   } = {}) {
     this.id = id;
-    // attributes
-    // includes
     this.badge = badge;
-    // references
     this.userId = userId;
     this.badgeId = badgeId;
   }

--- a/api/lib/domain/models/BadgeCriterion.js
+++ b/api/lib/domain/models/BadgeCriterion.js
@@ -2,18 +2,12 @@ class BadgeCriterion {
 
   constructor({
     id,
-    // attributes
     scope,
     threshold,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.scope = scope;
     this.threshold = threshold;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/BadgePartnerCompetence.js
+++ b/api/lib/domain/models/BadgePartnerCompetence.js
@@ -2,19 +2,13 @@ class BadgePartnerCompetence {
 
   constructor({
     id,
-    // attributes
     name,
     color,
-    // includes
-    // references
     skillIds,
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.color = color;
-    // includes
-    // references
     this.skillIds = skillIds;
   }
 }

--- a/api/lib/domain/models/Campaign.js
+++ b/api/lib/domain/models/Campaign.js
@@ -7,7 +7,6 @@ class Campaign {
 
   constructor({
     id,
-    // attributes
     name,
     code,
     title,
@@ -22,17 +21,14 @@ class Campaign {
     isRestricted = false,
     archivedAt,
     type,
-    // includes
     targetProfile,
     campaignReport,
     creator,
-    // references
     organizationId,
     targetProfileId,
     creatorId,
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.code = code;
     this.title = title;
@@ -47,11 +43,9 @@ class Campaign {
     this.isRestricted = isRestricted;
     this.archivedAt = archivedAt;
     this.type = type;
-    // includes
     this.targetProfile = targetProfile;
     this.campaignReport = campaignReport;
     this.creator = creator;
-    // references
     this.organizationId = organizationId;
     this.targetProfileId = targetProfileId;
     this.creatorId = creatorId;

--- a/api/lib/domain/models/CampaignParticipation.js
+++ b/api/lib/domain/models/CampaignParticipation.js
@@ -4,16 +4,13 @@ class CampaignParticipation {
 
   constructor({
     id,
-    // attributes
     createdAt,
     isShared,
     participantExternalId,
     sharedAt,
-    // includes
     assessments,
     campaign,
     user,
-    // references
     assessmentId,
     campaignId,
     userId,

--- a/api/lib/domain/models/CampaignParticipationBadge.js
+++ b/api/lib/domain/models/CampaignParticipationBadge.js
@@ -4,18 +4,15 @@ class CampaignParticipationBadge extends Badge {
 
   constructor({
     id,
-    // attributes
     key,
     altMessage,
     imageUrl,
     message,
     title,
     isAcquired,
-    // includes
     badgeCriteria = [],
     badgePartnerCompetences = [],
     partnerCompetenceResults = [],
-    // references
     targetProfileId,
   } = {}) {
     super({

--- a/api/lib/domain/models/CampaignParticipationResult.js
+++ b/api/lib/domain/models/CampaignParticipationResult.js
@@ -7,7 +7,6 @@ const _ = require('lodash');
 class CampaignParticipationResult {
   constructor({
     id,
-    // attributes
     isCompleted,
     totalSkillsCount,
     testedSkillsCount,
@@ -20,7 +19,6 @@ class CampaignParticipationResult {
     stageCount,
   } = {}) {
     this.id = id;
-    // attributes
     this.isCompleted = isCompleted;
     this.totalSkillsCount = totalSkillsCount;
     this.testedSkillsCount = testedSkillsCount;

--- a/api/lib/domain/models/CampaignReport.js
+++ b/api/lib/domain/models/CampaignReport.js
@@ -1,13 +1,11 @@
 class CampaignReport {
   constructor({
     id,
-    // attributes
     participationsCount,
     sharedParticipationsCount,
     stages,
   } = {}) {
     this.id = id;
-    // attributes
     this.participationsCount = participationsCount;
     this.sharedParticipationsCount = sharedParticipationsCount;
     this.stages = stages;

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -44,7 +44,6 @@ class CertificationCandidate {
   constructor(
     {
       id,
-      // attributes
       firstName,
       lastName,
       birthCity,
@@ -56,14 +55,11 @@ class CertificationCandidate {
       birthdate,
       extraTimePercentage,
       createdAt,
-      // includes
-      // references
       sessionId,
       userId,
       schoolingRegistrationId = null,
     } = {}) {
     this.id = id;
-    // attributes
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthCity = birthCity;
@@ -75,7 +71,6 @@ class CertificationCandidate {
     this.birthdate = birthdate;
     this.extraTimePercentage = !isNil(extraTimePercentage) ? parseFloat(extraTimePercentage) : extraTimePercentage;
     this.createdAt = createdAt;
-    // references
     this.sessionId = sessionId;
     this.userId = userId;
     this.schoolingRegistrationId = schoolingRegistrationId;

--- a/api/lib/domain/models/CertificationCenter.js
+++ b/api/lib/domain/models/CertificationCenter.js
@@ -12,22 +12,16 @@ class CertificationCenter {
 
   constructor({
     id,
-    // attributes
     name,
     externalId,
     type,
     createdAt,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.externalId = externalId;
     this.type = type;
     this.createdAt = createdAt;
-    // includes
-    // references
   }
 
   get isSco() {

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -2,13 +2,9 @@ class CertificationCenterMembership {
 
   constructor({
     id,
-    // attributes
-    // includes
     certificationCenter,
   } = {}) {
     this.id = id;
-    // attributes
-    // references
     this.certificationCenter = certificationCenter;
   }
 }

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -1,20 +1,14 @@
 class CertificationChallenge {
   constructor({
     id,
-    // attributes
     associatedSkillName,
-    // includes
-    // references
     associatedSkillId,
     challengeId,
     courseId,
     competenceId,
   } = {}) {
     this.id = id;
-    // attributes
     this.associatedSkillName = associatedSkillName;
-    // includes
-    // references
     this.associatedSkillId = associatedSkillId;
     this.challengeId = challengeId;
     this.competenceId = competenceId;

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -2,7 +2,6 @@ class CertificationCourse {
   constructor(
     {
       id,
-      // attributes
       firstName,
       lastName,
       birthdate,
@@ -14,17 +13,14 @@ class CertificationCourse {
       isPublished = false,
       isV2Certification = false,
       verificationCode,
-      // includes
       assessment,
       challenges,
       certificationIssueReports,
-      // references
       userId,
       sessionId,
       maxReachableLevelOnCertificationDate,
     } = {}) {
     this.id = id;
-    // attributes
     this.firstName = firstName;
     this.lastName = lastName;
     this.birthplace = birthplace;
@@ -36,11 +32,9 @@ class CertificationCourse {
     this.isPublished = isPublished;
     this.isV2Certification = isV2Certification;
     this.verificationCode = verificationCode;
-    // includes
     this.assessment = assessment;
     this.challenges = challenges;
     this.certificationIssueReports = certificationIssueReports;
-    // references
     this.userId = userId;
     this.sessionId = sessionId;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;

--- a/api/lib/domain/models/Challenge.js
+++ b/api/lib/domain/models/Challenge.js
@@ -45,7 +45,6 @@ class Challenge {
   constructor(
     {
       id,
-      // attributes
       attachments,
       embedHeight,
       embedTitle,
@@ -61,15 +60,12 @@ class Challenge {
       type,
       locales,
       autoReply,
-      // includes
       answer,
       skills = [],
-      // references
       validator,
       competenceId,
     } = {}) {
     this.id = id;
-    // attributes
     this.answer = answer;
     this.attachments = attachments;
     this.embedHeight = embedHeight;
@@ -86,10 +82,8 @@ class Challenge {
     this.locales = locales;
     this.autoReply = autoReply;
     this.alternativeInstruction = alternativeInstruction;
-    // includes
     this.skills = skills;
     this.validator = validator;
-    // references
     this.competenceId = competenceId;
   }
 

--- a/api/lib/domain/models/Competence.js
+++ b/api/lib/domain/models/Competence.js
@@ -2,24 +2,20 @@ class Competence {
 
   constructor({
     id,
-    // attributes
     area,
     name,
     index,
     description,
     origin,
-    // includes
     skillIds = [],
   } = {}) {
     this.id = id;
-    // attributes
     this.area = area;
     this.name = name;
     this.index = index;
     this.description = description;
     this.origin = origin;
     this.level = -1;
-    // includes
     this.skillIds = skillIds;
   }
 

--- a/api/lib/domain/models/CompetenceEvaluation.js
+++ b/api/lib/domain/models/CompetenceEvaluation.js
@@ -7,27 +7,22 @@ class CompetenceEvaluation {
 
   constructor({
     id,
-    // attributes
     createdAt,
     updatedAt,
     status,
-    // includes
     assessment,
     scorecard,
-    // references
     assessmentId,
     competenceId,
     userId,
   } = {}) {
     this.id = id;
-    // attributes
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
     this.status = status;
     //includes
     this.assessment = assessment;
     this.scorecard = scorecard;
-    // references
     this.assessmentId = assessmentId;
     this.competenceId = competenceId;
     this.userId = userId;

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -14,25 +14,19 @@ const schema = Joi.object({
 class CompetenceMark {
   constructor({
     id,
-    // attributes
     area_code,
     competence_code,
     competenceId,
     level,
     score,
-    // includes
-    // references
     assessmentResultId,
   } = {}) {
     this.id = id;
-    // attributes
     this.area_code = area_code;
     this.competence_code = competence_code;
     this.competenceId = competenceId;
     this.level = level;
     this.score = score;
-    // includes
-    // references
     this.assessmentResultId = assessmentResultId;
   }
 

--- a/api/lib/domain/models/CompetenceResult.js
+++ b/api/lib/domain/models/CompetenceResult.js
@@ -1,7 +1,6 @@
 class CompetenceResult {
   constructor({
     id,
-    // attributes
     name,
     index,
     areaColor,
@@ -11,7 +10,6 @@ class CompetenceResult {
     validatedSkillsCount,
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.index = index;
     this.areaColor = areaColor;

--- a/api/lib/domain/models/CompetenceTree.js
+++ b/api/lib/domain/models/CompetenceTree.js
@@ -2,16 +2,10 @@ class CompetenceTree {
 
   constructor({
     id = 1,
-    // attributes
-    // includes
     areas = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
-    // includes
     this.areas = areas;
-    // references
   }
 }
 

--- a/api/lib/domain/models/Correction.js
+++ b/api/lib/domain/models/Correction.js
@@ -4,22 +4,16 @@ class Correction {
 
   constructor({
     id,
-    // attributes
     solution,
-    // includes
     hints = [],
     tutorials = [],
     learningMoreTutorials = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.solution = solution;
-    // includes
     this.hints = hints;
     this.tutorials = tutorials;
     this.learningMoreTutorials = learningMoreTutorials;
-    // references
   }
 
   get relevantHint() {

--- a/api/lib/domain/models/Course.js
+++ b/api/lib/domain/models/Course.js
@@ -2,22 +2,16 @@ class Course {
 
   constructor({
     id,
-    // attributes
     description,
     imageUrl,
     name,
-    // includes
-    // references
     challenges = [],
     competences = [],
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.description = description;
     this.imageUrl = imageUrl;
-    // includes
-    // references
     this.challenges = challenges; // Array of Record IDs
     this.competences = competences; // Array of Record IDs
   }

--- a/api/lib/domain/models/Examiner.js
+++ b/api/lib/domain/models/Examiner.js
@@ -7,15 +7,9 @@ const AnswerStatus = require('./AnswerStatus');
 class Examiner {
 
   constructor({
-    // attributes
     validator,
-    // includes
-    // references
   } = {}) {
-    // attributes
     this.validator = validator;
-    // includes
-    // references
   }
 
   evaluate({ answer, challengeFormat }) {

--- a/api/lib/domain/models/Hint.js
+++ b/api/lib/domain/models/Hint.js
@@ -1,17 +1,11 @@
 class Hint {
 
   constructor({
-    // attributes
     skillName,
     value,
-    // includes
-    // references
   } = {}) {
-    // attributes
     this.skillName = skillName;
     this.value = value;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/KnowledgeElement.js
+++ b/api/lib/domain/models/KnowledgeElement.js
@@ -21,13 +21,10 @@ class KnowledgeElement {
 
   constructor({
     id,
-    // attributes
     createdAt,
     source,
     status,
     earnedPix,
-    // includes
-    // references
     answerId,
     assessmentId,
     skillId,
@@ -35,13 +32,10 @@ class KnowledgeElement {
     competenceId,
   } = {}) {
     this.id = id;
-    // attributes
     this.createdAt = createdAt;
     this.source = source;
     this.status = status;
     this.earnedPix = earnedPix;
-    // includes
-    // references
     this.answerId = answerId;
     this.assessmentId = assessmentId;
     this.skillId = skillId;

--- a/api/lib/domain/models/Membership.js
+++ b/api/lib/domain/models/Membership.js
@@ -7,22 +7,16 @@ class Membership {
 
   constructor({
     id,
-    // attributes
     organizationRole = roles.MEMBER,
     updatedByUserId,
-    // includes
     organization,
     user,
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.organizationRole = organizationRole;
     this.updatedByUserId = updatedByUserId;
-    // includes
     this.organization = organization;
     this.user = user;
-    // references
   }
 
   get isAdmin() {

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -10,7 +10,6 @@ class Organization {
 
   constructor({
     id,
-    // attributes
     name,
     type,
     logoUrl,
@@ -20,16 +19,13 @@ class Organization {
     credit,
     canCollectProfiles,
     email,
-    // includes
     memberships = [],
     targetProfileShares = [],
     students = [],
     organizationInvitations = [],
     tags = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.type = type;
     this.logoUrl = logoUrl;
@@ -39,13 +35,11 @@ class Organization {
     this.credit = credit;
     this.canCollectProfiles = canCollectProfiles;
     this.email = email;
-    // includes
     this.memberships = memberships;
     this.targetProfileShares = targetProfileShares;
     this.students = students;
     this.organizationInvitations = organizationInvitations;
     this.tags = tags;
-    // references
   }
 
   get isSup() {

--- a/api/lib/domain/models/OrganizationInvitation.js
+++ b/api/lib/domain/models/OrganizationInvitation.js
@@ -7,7 +7,6 @@ class OrganizationInvitation {
 
   constructor({
     id,
-    // attributes
     email,
     status,
     code,
@@ -19,7 +18,6 @@ class OrganizationInvitation {
     organizationId,
   } = {}) {
     this.id = id;
-    // attributes
     this.email = email;
     this.status = status;
     this.code = code;

--- a/api/lib/domain/models/OrganizationTag.js
+++ b/api/lib/domain/models/OrganizationTag.js
@@ -2,12 +2,10 @@ class OrganizationTag {
 
   constructor({
     id,
-    // references
     organizationId,
     tagId,
   } = {}) {
     this.id = id;
-    // references
     this.organizationId = organizationId;
     this.tagId = tagId;
   }

--- a/api/lib/domain/models/PixRole.js
+++ b/api/lib/domain/models/PixRole.js
@@ -2,16 +2,10 @@ class PixRole {
 
   constructor({
     id,
-    // attributes
     name,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/PlacementProfile.js
+++ b/api/lib/domain/models/PlacementProfile.js
@@ -6,12 +6,10 @@ const _ = require('lodash');
 class PlacementProfile {
   constructor(
     {
-      // attributes
       profileDate,
       userId,
       userCompetences,
     } = {}) {
-    // attributes
     this.profileDate = profileDate;
     this.userId = userId;
     this.userCompetences = userCompetences;

--- a/api/lib/domain/models/Progression.js
+++ b/api/lib/domain/models/Progression.js
@@ -10,22 +10,16 @@ class Progression {
 
   constructor({
     id,
-    // attributes
-    // includes
     targetedSkills = [],
     knowledgeElements = [],
     isProfileCompleted = false,
-    // references
   }) {
     this.id = id;
-    // attributes
-    // includes
     this.knowledgeElements = knowledgeElements;
     this.targetedSkills = targetedSkills;
     this.targetedSkillsIds = _.map(targetedSkills, 'id');
     this.targetedKnowledgeElements = _.filter(knowledgeElements, (ke) => _.includes(this.targetedSkillsIds, ke.skillId));
     this.isProfileCompleted = isProfileCompleted;
-    // references
   }
 
   _getTargetedSkillsAlreadyTestedCount() {

--- a/api/lib/domain/models/ResultCompetence.js
+++ b/api/lib/domain/models/ResultCompetence.js
@@ -1,22 +1,16 @@
 class ResultCompetence {
   constructor({
     id,
-    // attributes
     index,
     level,
     name,
     score,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.index = index;
     this.level = level;
     this.name = name;
     this.score = score;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/ResultCompetenceTree.js
+++ b/api/lib/domain/models/ResultCompetenceTree.js
@@ -8,16 +8,10 @@ class ResultCompetenceTree {
 
   constructor({
     id = 1,
-    // attributes
-    // includes
     areas = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
-    // includes
     this.areas = areas;
-    // references
   }
 
   static generateTreeFromCompetenceMarks({ competenceTree, competenceMarks }) {

--- a/api/lib/domain/models/SchoolingRegistration.js
+++ b/api/lib/domain/models/SchoolingRegistration.js
@@ -6,7 +6,6 @@ class SchoolingRegistration {
 
   constructor({
     id,
-    // attributes
     lastName,
     preferredLastName,
     firstName,
@@ -23,12 +22,10 @@ class SchoolingRegistration {
     nationalApprenticeId,
     division,
     updatedAt,
-    // references
     userId,
     organizationId,
   } = {}) {
     this.id = id;
-    // attributes
     this.lastName = lastName;
     this.preferredLastName = preferredLastName;
     this.firstName = firstName;
@@ -45,7 +42,6 @@ class SchoolingRegistration {
     this.nationalApprenticeId = nationalApprenticeId;
     this.division = division;
     this.updatedAt = updatedAt;
-    // references
     this.userId = userId;
     this.organizationId = organizationId;
   }

--- a/api/lib/domain/models/Scorecard.js
+++ b/api/lib/domain/models/Scorecard.js
@@ -30,7 +30,6 @@ class Scorecard {
   } = {}) {
 
     this.id = id;
-    // attributes
     this.name = name;
     this.description = description;
     this.competenceId = competenceId;

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -17,7 +17,6 @@ const NO_EXAMINER_GLOBAL_COMMENT = null;
 class Session {
   constructor({
     id,
-    // attributes
     accessCode,
     address,
     certificationCenter,
@@ -30,14 +29,11 @@ class Session {
     finalizedAt,
     resultsSentToPrescriberAt,
     publishedAt,
-    // includes
     certificationCandidates,
-    // references
     certificationCenterId,
     assignedCertificationOfficerId,
   } = {}) {
     this.id = id;
-    // attributes
     this.accessCode = accessCode;
     this.address = address;
     this.certificationCenter = certificationCenter;
@@ -50,9 +46,7 @@ class Session {
     this.finalizedAt = finalizedAt;
     this.resultsSentToPrescriberAt = resultsSentToPrescriberAt;
     this.publishedAt = publishedAt;
-    // includes
     this.certificationCandidates = certificationCandidates;
-    // references
     this.certificationCenterId = certificationCenterId;
     this.assignedCertificationOfficerId = assignedCertificationOfficerId;
   }

--- a/api/lib/domain/models/Skill.js
+++ b/api/lib/domain/models/Skill.js
@@ -3,21 +3,15 @@ const _ = require('lodash');
 class Skill {
   constructor({
     id,
-    // attributes
     name,
     pixValue,
-    // includes
-    // references
     competenceId,
     tutorialIds = [],
     tubeId,
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
     this.pixValue = pixValue;
-    // includes
-    // references
     this.competenceId = competenceId;
     this.tutorialIds = tutorialIds;
     this.tubeId = tubeId;

--- a/api/lib/domain/models/Solution.js
+++ b/api/lib/domain/models/Solution.js
@@ -20,26 +20,20 @@ class Solution {
    */
   constructor({
     id,
-    // attributes
     isT1Enabled = false,
     isT2Enabled = false,
     isT3Enabled = false,
     scoring,
     type,
     value,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.isT1Enabled = isT1Enabled;
     this.isT2Enabled = isT2Enabled;
     this.isT3Enabled = isT3Enabled;
     this.scoring = scoring;
     this.type = type;
     this.value = value;
-    // includes
-    // references
   }
 
   get enabledTreatments() {

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -2,11 +2,9 @@ class Tag {
 
   constructor({
     id,
-    // attributes
     name,
   } = {}) {
     this.id = id;
-    // attributes
     this.name = name;
   }
 }

--- a/api/lib/domain/models/Tube.js
+++ b/api/lib/domain/models/Tube.js
@@ -3,27 +3,21 @@ const _ = require('lodash');
 class Tube {
 
   constructor({
-    // attributes
     id,
     name,
     title,
     description,
     practicalTitle,
     practicalDescription,
-    // includes
     skills = [],
-    // references
     competenceId,
   } = {}) {
-    // attributes
     this.id = id;
     this.title = title;
     this.description = description;
     this.practicalTitle = practicalTitle;
     this.practicalDescription = practicalDescription;
-    // includes
     this.skills = skills;
-    // references
     this.competenceId = competenceId;
 
     if (name) {

--- a/api/lib/domain/models/Tutorial.js
+++ b/api/lib/domain/models/Tutorial.js
@@ -2,24 +2,18 @@ class Tutorial {
 
   constructor({
     id,
-    // attributes
     duration,
     format,
     link,
     source,
     title,
-    // includes
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.duration = duration;
     this.format = format;
     this.link = link;
     this.source = source;
     this.title = title;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -4,7 +4,6 @@ class User {
 
   constructor({
     id,
-    // attributes
     cgu,
     pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted,
@@ -20,17 +19,14 @@ class User {
     shouldChangePassword,
     mustValidateTermsOfService,
     lang,
-    // includes
     memberships = [],
     certificationCenterMemberships = [],
     pixRoles = [],
     pixScore,
     scorecards = [],
     campaignParticipations = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.firstName = firstName;
     this.lastName = lastName;
     this.username = username;
@@ -46,14 +42,12 @@ class User {
     this.knowledgeElements = knowledgeElements;
     this.shouldChangePassword = shouldChangePassword;
     this.lang = lang;
-    // includes
     this.pixRoles = pixRoles;
     this.pixScore = pixScore;
     this.memberships = memberships;
     this.certificationCenterMemberships = certificationCenterMemberships;
     this.scorecards = scorecards;
     this.campaignParticipations = campaignParticipations;
-    // references
   }
 
   get hasRolePixMaster() {

--- a/api/lib/domain/models/UserCompetence.js
+++ b/api/lib/domain/models/UserCompetence.js
@@ -9,26 +9,20 @@ class UserCompetence {
 
   constructor({
     id,
-    // attributes
     index,
     name,
     area,
     pixScore,
     estimatedLevel,
-    // includes
     skills = [],
-    // references
   } = {}) {
     this.id = id;
-    // attributes
     this.index = index;
     this.name = name;
     this.area = area;
     this.pixScore = pixScore;
     this.estimatedLevel = estimatedLevel;
-    // includes
     this.skills = skills;
-    // references
   }
 
   addSkill(newSkill) {

--- a/api/lib/domain/models/UserOrgaSettings.js
+++ b/api/lib/domain/models/UserOrgaSettings.js
@@ -2,12 +2,10 @@ class UserOrgaSettings {
 
   constructor({
     id,
-    // includes
     currentOrganization,
     user,
   } = {}) {
     this.id = id;
-    // includes
     this.currentOrganization = currentOrganization;
     this.user = user;
   }

--- a/api/lib/domain/models/Validation.js
+++ b/api/lib/domain/models/Validation.js
@@ -6,17 +6,11 @@
 class Validation {
 
   constructor({
-    // attributes
     result,
     resultDetails,
-    // includes
-    // references
   } = {}) {
-    // attributes
     this.result = result;
     this.resultDetails = resultDetails;
-    // includes
-    // references
   }
 }
 

--- a/api/lib/domain/models/Validator.js
+++ b/api/lib/domain/models/Validator.js
@@ -7,15 +7,9 @@ const Validation = require('./Validation');
 class Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
-    // attributes
-    // includes
     this.solution = solution;
-    // references
   }
 
   assess() {

--- a/api/lib/domain/models/ValidatorQCM.js
+++ b/api/lib/domain/models/ValidatorQCM.js
@@ -8,15 +8,9 @@ const Validator = require('./Validator');
 class ValidatorQCM extends Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
     super({ solution });
-    // attributes
-    // includes
-    // references
   }
 
   assess({ answer }) {

--- a/api/lib/domain/models/ValidatorQCU.js
+++ b/api/lib/domain/models/ValidatorQCU.js
@@ -8,15 +8,9 @@ const Validator = require('./Validator');
 class ValidatorQCU extends Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
     super({ solution });
-    // attributes
-    // includes
-    // references
   }
 
   assess({ answer }) {

--- a/api/lib/domain/models/ValidatorQROC.js
+++ b/api/lib/domain/models/ValidatorQROC.js
@@ -8,15 +8,9 @@ const Validator = require('./Validator');
 class ValidatorQROC extends Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
     super({ solution });
-    // attributes
-    // includes
-    // references
   }
 
   assess({ answer, challengeFormat }) {

--- a/api/lib/domain/models/ValidatorQROCMDep.js
+++ b/api/lib/domain/models/ValidatorQROCMDep.js
@@ -8,15 +8,9 @@ const Validator = require('./Validator');
 class ValidatorQROCMDep extends Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
     super({ solution });
-    // attributes
-    // includes
-    // references
   }
 
   assess({ answer }) {

--- a/api/lib/domain/models/ValidatorQROCMInd.js
+++ b/api/lib/domain/models/ValidatorQROCMInd.js
@@ -8,15 +8,9 @@ const Validator = require('./Validator');
 class ValidatorQROCMInd extends Validator {
 
   constructor({
-    // attributes
-    // includes
     solution,
-    // references
   } = {}) {
     super({ solution });
-    // attributes
-    // includes
-    // references
   }
 
   assess({ answer }) {

--- a/api/lib/domain/read-models/Prescriber.js
+++ b/api/lib/domain/read-models/Prescriber.js
@@ -6,7 +6,6 @@ class Prescriber {
     lastName,
     pixOrgaTermsOfServiceAccepted,
     areNewYearSchoolingRegistrationsImported,
-    // includes
     memberships = [],
     userOrgaSettings,
   } = {}) {
@@ -15,7 +14,6 @@ class Prescriber {
     this.lastName = lastName;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.areNewYearSchoolingRegistrationsImported = areNewYearSchoolingRegistrationsImported;
-    // includes
     this.memberships = memberships;
     this.userOrgaSettings = userOrgaSettings;
   }


### PR DESCRIPTION
## :unicorn: Problème

Dans le répertoire `api/lib/domain/models`, on a des commentaires `// attributes`, `// references`, `// includes` qui ont été utilisés quelques fois il y a deux ou trois ans pour générer des graphiques de relations entre les entités.

Depuis, ces commentaires n'ont pas été utilisés. Je fais l'hypothèse qu'ils sont peu entretenus, qu'ils manquent dans certains fichiers, et qu'ils peuvent ralentir la lecture.

## :robot: Solution

Je propose de les supprimer, qui en a l'usage et souhaite les conserver ?

## :rainbow: Remarques

```
for f in api/lib/domain/**/*
do
  sed -i '' -E '\:// attributes|// references|// includes:d' $f
done
```

## 💯 Tester

Tu peux pas test.
