### PR TITLE
[FEATURE] Autoriser la suppression de signalement pendant la finalisation d'une session de certification (PIX-1488)

### DIFF
--- a/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
+++ b/api/lib/application/certification-issue-reports/certification-issue-report-controller.js
@@ -1,0 +1,14 @@
+const usecases = require('../../domain/usecases');
+
+module.exports = {
+  async deleteCertificationIssueReport(request) {
+    const userId = request.auth.credentials.userId;
+    const certificationIssueReportId = parseInt(request.params.id);
+    await usecases.deleteCertificationIssueReport({
+      certificationIssueReportId,
+      userId,
+    });
+
+    return null;
+  },
+};

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -1,0 +1,20 @@
+const certificationIssueReportController = require('./certification-issue-report-controller');
+
+exports.register = async (server) => {
+  server.route([
+    {
+      method: 'DELETE',
+      path: '/api/certification-issue-reports/{id}',
+      config: {
+        handler: certificationIssueReportController.deleteCertificationIssueReport,
+        tags: ['api', 'certification-issue-reports'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n',
+          '- Elle permet de supprimer un signalement',
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'certification-issue-reports-api';

--- a/api/lib/domain/usecases/delete-certification-issue-report.js
+++ b/api/lib/domain/usecases/delete-certification-issue-report.js
@@ -1,0 +1,28 @@
+const { ForbiddenAccess } = require('../errors');
+
+module.exports = async function deleteCertificationIssueReport({
+  certificationIssueReportId,
+  userId,
+  certificationCourseRepository,
+  certificationIssueReportRepository,
+  sessionRepository,
+  sessionAuthorizationService,
+}) {
+  const certificationIssueReport = await certificationIssueReportRepository.get(certificationIssueReportId);
+
+  const certificationCourse = await certificationCourseRepository.get(certificationIssueReport.certificationCourseId);
+
+  const isAuthorized = await sessionAuthorizationService.isAuthorizedToAccessSession({
+    userId,
+    sessionId: certificationCourse.sessionId,
+  });
+  if (!isAuthorized) {
+    throw new ForbiddenAccess('Certification issue report deletion forbidden');
+  }
+  const isFinalized = await sessionRepository.isFinalized(certificationCourse.sessionId);
+  if (isFinalized) {
+    throw new ForbiddenAccess('Certification issue report deletion forbidden');
+  }
+
+  return certificationIssueReportRepository.delete(certificationIssueReportId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -121,6 +121,7 @@ module.exports = injectDependencies({
   createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
   createSession: require('./create-session'),
   createUser: require('./create-user'),
+  deleteCertificationIssueReport: require('./delete-certification-issue-report'),
   deleteUnlinkedCertificationCandidate: require('./delete-unlinked-certification-candidate'),
   disableMembership: require('./disable-membership'),
   dissociateUserFromSchoolingRegistration: require('./dissociate-user-from-schooling-registration'),

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -1,4 +1,3 @@
-
 const CertificationIssueReportBookshelf = require('../data/certification-issue-report');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 
@@ -6,5 +5,18 @@ module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(certificationIssueReport).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
+  },
+
+  async delete(id) {
+    try {
+      await CertificationIssueReportBookshelf
+        .where({ id })
+        .destroy({ require: true });
+      return true;
+    } catch (err) {
+      if (err instanceof CertificationIssueReportBookshelf.NoRowsDeletedError) {
+        return false;
+      }
+    }
   },
 };

--- a/api/lib/infrastructure/repositories/certification-issue-report-repository.js
+++ b/api/lib/infrastructure/repositories/certification-issue-report-repository.js
@@ -1,3 +1,4 @@
+const { NotFoundError } = require('../../domain/errors');
 const CertificationIssueReportBookshelf = require('../data/certification-issue-report');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 
@@ -5,6 +6,20 @@ module.exports = {
   async save(certificationIssueReport) {
     const newCertificationIssueReport = await new CertificationIssueReportBookshelf(certificationIssueReport).save();
     return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, newCertificationIssueReport);
+  },
+
+  async get(id) {
+    try {
+      const certificationIssueReport = await CertificationIssueReportBookshelf
+        .where({ id })
+        .fetch({ require: true });
+      return bookshelfToDomainConverter.buildDomainObject(CertificationIssueReportBookshelf, certificationIssueReport);
+    } catch (err) {
+      if (err instanceof CertificationIssueReportBookshelf.NotFoundError) {
+        throw new NotFoundError('Le signalement n\'existe pas');
+      }
+      throw err;
+    }
   },
 
   async delete(id) {

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -12,6 +12,7 @@ module.exports = [
   require('./application/certification-courses'),
   require('./application/certification-point-of-contacts'),
   require('./application/certification-reports'),
+  require('./application/certification-issue-reports'),
   require('./application/certifications'),
   require('./application/challenges'),
   require('./application/competence-evaluations'),

--- a/api/tests/acceptance/application/certification-issue-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-issue-report-controller_test.js
@@ -1,0 +1,37 @@
+const {
+  expect,
+  databaseBuilder,
+  generateValidRequestAuthorizationHeader,
+} = require('../../test-helper');
+const createServer = require('../../../server');
+
+describe('Acceptance | Controller | certification-issue-report-controller', () => {
+
+  describe('DELETE /api/certification-issue-reports/{id}', () => {
+
+    it('should return 204 HTTP status code', async () => {
+      // given
+      const server = await createServer();
+      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId }).id;
+      const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({ sessionId }).id;
+      const certificationIssueReportId = databaseBuilder.factory.buildCertificationIssueReport({ certificationCourseId }).id;
+      const request = {
+        method: 'DELETE',
+        url: `/api/certification-issue-reports/${certificationIssueReportId}`,
+        headers: {
+          authorization: generateValidRequestAuthorizationHeader(userId),
+        },
+      };
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/acceptance/application/certification-report-controller_test.js
+++ b/api/tests/acceptance/application/certification-report-controller_test.js
@@ -6,22 +6,17 @@ const {
 } = require('../../test-helper');
 const createServer = require('../../../server');
 
-describe('Acceptance | Controller | certification-report-controller-save-certification-issue-report', () => {
+describe('Acceptance | Controller | certification-report-controller', () => {
 
-  let server;
+  describe('POST /api/certification-reports/{id}/certification-issue-reports', () => {
 
-  beforeEach(async () => {
-    server = await createServer();
-  });
-
-  afterEach(async () => {
-    await knex('certification-issue-reports').delete();
-  });
-
-  describe('POST /api/certification-reports/{id}/certification-issue-reports', function() {
+    afterEach(() => {
+      return knex('certification-issue-reports').delete();
+    });
 
     it('should return 201 HTTP status code', async () => {
       // given
+      const server = await createServer();
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
       const userId = databaseBuilder.factory.buildUser().id;
       databaseBuilder.factory.buildCertificationCenterMembership({ userId, certificationCenterId }).id;
@@ -63,5 +58,4 @@ describe('Acceptance | Controller | certification-report-controller-save-certifi
       expect(response.result.data.attributes.description).to.equal('Houston nous avons un problème');
     });
   });
-
 });

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -5,7 +5,7 @@ const certificationIssueReportRepository = require('../../../../lib/infrastructu
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
-describe('Integration | Repository | Certification Issue Course', function() {
+describe('Integration | Repository | Certification Issue Report', function() {
 
   afterEach(async () => {
     await knex('certification-issue-reports').delete();

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -1,7 +1,6 @@
+const _ = require('lodash');
 const { expect, databaseBuilder, knex } = require('../../../test-helper');
-const omit = require('lodash/omit');
 const certificationIssueReportRepository = require('../../../../lib/infrastructure/repositories/certification-issue-report-repository');
-
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
@@ -35,8 +34,48 @@ describe('Integration | Repository | Certification Issue Report', function() {
         subcategory: null,
       };
 
-      expect(omit(savedCertificationIssueReport, 'id')).to.deep.equal(expectedSavedCertificationIssueReport);
+      expect(_.omit(savedCertificationIssueReport, 'id')).to.deep.equal(expectedSavedCertificationIssueReport);
       expect(savedCertificationIssueReport).to.be.an.instanceOf(CertificationIssueReport);
+    });
+  });
+
+  describe('#delete', () => {
+
+    it('should delete the issue report when it exists in certification course id', async () => {
+      // given
+      const certificationIssueReportToDeleteId = databaseBuilder.factory.buildCertificationIssueReport().id;
+      databaseBuilder.factory.buildCertificationIssueReport();
+      await databaseBuilder.commit();
+
+      // when
+      await certificationIssueReportRepository.delete(certificationIssueReportToDeleteId);
+
+      // then
+      const exists = await knex('certification-issue-reports').where({ id: certificationIssueReportToDeleteId }).first();
+      expect(Boolean(exists)).to.be.false;
+    });
+
+    it('should return true when deletion happened', async () => {
+      // given
+      const certificationIssueReportToDeleteId = databaseBuilder.factory.buildCertificationIssueReport().id;
+      await databaseBuilder.commit();
+
+      // when
+      const deleted = await certificationIssueReportRepository.delete(certificationIssueReportToDeleteId);
+
+      // then
+      expect(deleted).to.be.true;
+    });
+
+    it('should return false when there was nothing to delete', async () => {
+      // given
+      const certificationIssueReportToDeleteId = databaseBuilder.factory.buildCertificationIssueReport().id;
+
+      // when
+      const deleted = await certificationIssueReportRepository.delete(certificationIssueReportToDeleteId);
+
+      // then
+      expect(deleted).to.be.false;
     });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-issue-report-repository_test.js
@@ -1,8 +1,9 @@
 const _ = require('lodash');
-const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const { expect, databaseBuilder, knex, catchErr } = require('../../../test-helper');
 const certificationIssueReportRepository = require('../../../../lib/infrastructure/repositories/certification-issue-report-repository');
 const CertificationIssueReport = require('../../../../lib/domain/models/CertificationIssueReport');
 const { CertificationIssueReportCategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const { NotFoundError } = require('../../../../lib/domain/errors');
 
 describe('Integration | Repository | Certification Issue Report', function() {
 
@@ -78,4 +79,28 @@ describe('Integration | Repository | Certification Issue Report', function() {
       expect(deleted).to.be.false;
     });
   });
+
+  describe('#get', () => {
+    it('should return a certification issue report', async () => {
+      // given
+      const expectedIssueReport = databaseBuilder.factory.buildCertificationIssueReport();
+      await databaseBuilder.commit();
+
+      // when
+      const result = await certificationIssueReportRepository.get(expectedIssueReport.id);
+
+      // then
+      expect(result).to.deep.equal(expectedIssueReport);
+      expect(result).to.be.instanceOf(CertificationIssueReport);
+    });
+
+    it('should throw a notFound error', async () => {
+      // when
+      const error = await catchErr(certificationIssueReportRepository.get)(1234);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
 });

--- a/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
+++ b/api/tests/unit/application/certification-issue-reports/certification-issue-report-controller_test.js
@@ -1,0 +1,32 @@
+const { sinon, expect, hFake } = require('../../../test-helper');
+const certificationIssueReportController = require('../../../../lib/application/certification-issue-reports/certification-issue-report-controller');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | Controller | certification-issue-report-controller', () => {
+
+  describe('#deleteCertificationIssueReport', () => {
+
+    it('should proceed to deletion', async () => {
+      // given
+      const certificationIssueReportId = 456;
+      const userId = 789;
+      const request = {
+        params: {
+          id: certificationIssueReportId,
+        },
+        auth: {
+          credentials: { userId },
+        },
+      };
+      sinon.stub(usecases, 'deleteCertificationIssueReport')
+        .withArgs({ certificationIssueReportId, userId })
+        .resolves();
+
+      // when
+      const response = await certificationIssueReportController.deleteCertificationIssueReport(request, hFake);
+
+      // then
+      expect(response).to.be.null;
+    });
+  });
+});

--- a/api/tests/unit/application/certification-issue-reports/index_test.js
+++ b/api/tests/unit/application/certification-issue-reports/index_test.js
@@ -1,0 +1,18 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const certificationIssueReportModule = require('../../../../lib/application/certification-issue-reports');
+const certificationIssueReportController = require('../../../../lib/application/certification-issue-reports/certification-issue-report-controller');
+
+describe('Unit | Application | Certifications Issue Report | Route', () => {
+
+  it('DELETE /api/certification-issue-reports/{id} should exist', async () => {
+    // given
+    sinon.stub(certificationIssueReportController, 'deleteCertificationIssueReport').returns('ok');
+    const httpTestServer = new HttpTestServer(certificationIssueReportModule);
+
+    // when
+    const response = await httpTestServer.request('DELETE', '/api/certification-issue-reports/1');
+
+    // then
+    expect(response.statusCode).to.equal(200);
+  });
+});

--- a/api/tests/unit/application/certification-report/certification-report-controller_test.js
+++ b/api/tests/unit/application/certification-report/certification-report-controller_test.js
@@ -1,0 +1,57 @@
+const { sinon, expect, hFake, domainBuilder } = require('../../../test-helper');
+const certificationReportController = require('../../../../lib/application/certification-reports/certification-report-controller');
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | Controller | certification-issue-report-controller', () => {
+
+  describe('#saveCertificationIssueReport', () => {
+
+    it('should return serialized certification issue report with code 201', async () => {
+      // given
+      const certificationReportId = 123;
+      const userId = 456;
+      const request = {
+        params: {
+          id: certificationReportId,
+        },
+        auth: {
+          credentials: { userId },
+        },
+        payload: {
+          data: {
+            attributes: {
+              category: 'someCategory',
+              description: 'someDescription',
+              subcategory: 'someSubcategory',
+            },
+          },
+        },
+      };
+      const certificationIssueReportDeserialized = {
+        certificationCourseId: certificationReportId,
+        category: 'someCategory',
+        description: 'someDescription',
+        subcategory: 'someSubcategory',
+      };
+      const savedCertificationIssueReport = domainBuilder.buildCertificationIssueReport();
+      sinon.stub(usecases, 'saveCertificationIssueReport')
+        .withArgs({ userId, certificationIssueReportDTO: certificationIssueReportDeserialized })
+        .resolves(savedCertificationIssueReport);
+
+      // when
+      const response = await certificationReportController.saveCertificationIssueReport(request, hFake);
+
+      // then
+      expect(response.source.data).to.deep.equal({
+        type: 'certification-issue-reports',
+        id: savedCertificationIssueReport.id.toString(),
+        attributes: {
+          category: savedCertificationIssueReport.category,
+          description: savedCertificationIssueReport.description,
+          subcategory: savedCertificationIssueReport.subcategory,
+        },
+      });
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+});

--- a/api/tests/unit/application/certification-report/index_test.js
+++ b/api/tests/unit/application/certification-report/index_test.js
@@ -1,0 +1,18 @@
+const { expect, HttpTestServer, sinon } = require('../../../test-helper');
+const certificationReportModule = require('../../../../lib/application/certification-reports');
+const certificationReportController = require('../../../../lib/application/certification-reports/certification-report-controller');
+
+describe('Unit | Application | Certifications Report | Route', () => {
+
+  it('POST /api/certification-reports/{id}/certification-issue-reports should exist', async () => {
+    // given
+    sinon.stub(certificationReportController, 'saveCertificationIssueReport').returns('ok');
+    const httpTestServer = new HttpTestServer(certificationReportModule);
+
+    // when
+    const response = await httpTestServer.request('POST', '/api/certification-reports/1/certification-issue-reports');
+
+    // then
+    expect(response.statusCode).to.equal(200);
+  });
+});

--- a/api/tests/unit/domain/usecases/delete-certification-issue-report_test.js
+++ b/api/tests/unit/domain/usecases/delete-certification-issue-report_test.js
@@ -1,0 +1,91 @@
+const _ = require('lodash');
+const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
+const deleteCertificationIssueReport = require('../../../../lib/domain/usecases/delete-certification-issue-report');
+const { ForbiddenAccess } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | delete-certification-issue-report', () => {
+
+  const certificationCourseRepository = { get: () => _.noop() };
+  const certificationIssueReportRepository = {
+    delete: () => _.noop(),
+    get: () => _.noop(),
+  };
+  const sessionRepository = { isFinalized: () => _.noop() };
+  const sessionAuthorizationService = { isAuthorizedToAccessSession: () => _.noop() };
+  const certificationIssueReportId = 456;
+  const userId = 789;
+  const sessionId = 159;
+
+  beforeEach(() => {
+    const certificationIssueReport = domainBuilder.buildCertificationIssueReport({ id: certificationIssueReportId });
+    const certificationCourse = domainBuilder.buildCertificationCourse({
+      id: certificationIssueReport.certificationCourseId,
+      sessionId,
+    });
+    sinon.stub(certificationCourseRepository, 'get');
+    certificationCourseRepository.get.withArgs(certificationIssueReport.certificationCourseId).resolves(certificationCourse);
+    sinon.stub(certificationIssueReportRepository, 'delete');
+    sinon.stub(certificationIssueReportRepository, 'get');
+    certificationIssueReportRepository.get.withArgs(certificationIssueReportId).resolves(certificationIssueReport);
+    sinon.stub(sessionRepository, 'isFinalized');
+    sinon.stub(sessionAuthorizationService, 'isAuthorizedToAccessSession');
+  });
+
+  it('should throw a ForbiddenAccess error when user is not allowed to delete certification issue report', async () => {
+    // given
+    sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(false);
+
+    // when
+    const error = await catchErr(deleteCertificationIssueReport)({
+      certificationIssueReportId,
+      userId,
+      certificationCourseRepository,
+      certificationIssueReportRepository,
+      sessionRepository,
+      sessionAuthorizationService,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(ForbiddenAccess);
+  });
+
+  it('should throw a ForbiddenAccess error when session is already finalized', async () => {
+    // given
+    sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(true);
+    sessionRepository.isFinalized.withArgs(sessionId).resolves(true);
+
+    // when
+    const error = await catchErr(deleteCertificationIssueReport)({
+      certificationIssueReportId,
+      userId,
+      certificationCourseRepository,
+      certificationIssueReportRepository,
+      sessionRepository,
+      sessionAuthorizationService,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(ForbiddenAccess);
+  });
+
+  it('should return deletion result', async () => {
+    // given
+    const deletionResult = Symbol('someValue');
+    sessionAuthorizationService.isAuthorizedToAccessSession.withArgs({ userId, sessionId }).resolves(true);
+    sessionRepository.isFinalized.withArgs(sessionId).resolves(false);
+    certificationIssueReportRepository.delete.withArgs(certificationIssueReportId).resolves(deletionResult);
+
+    // when
+    const actualDeletionResult = await deleteCertificationIssueReport({
+      certificationIssueReportId,
+      userId,
+      certificationCourseRepository,
+      certificationIssueReportRepository,
+      sessionRepository,
+      sessionAuthorizationService,
+    });
+
+    // then
+    expect(actualDeletionResult).to.equal(deletionResult);
+  });
+});

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -43,6 +43,10 @@
           <PixMessage @type='alert'>Veuillez selectionner une catégorie</PixMessage>
         {{/if}}
 
+        {{#if this.showIssueReportSubmitError}}
+          <PixMessage @type='alert'>Une erreur s'est produite lors de l'ajout du signalement. Merci de réessayer</PixMessage>
+        {{/if}}
+
         <div class="add-issue-report-modal__actions">
           <button type="button" class="button--showed-as-link" {{on "click" @closeModal}}>Annuler</button>
           <button type="submit" class="button button--extra-thin">Valider</button>

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -93,10 +93,12 @@ export default class AddIssueReportModal extends Component {
 
   @tracked reportLength = 0;
   @tracked showCategoryMissingError = false;
+  @tracked showIssueReportSubmitError = false;
 
   @action
   toggleOnCategory(selectedCategory) {
     this.showCategoryMissingError = false;
+    this.showIssueReportSubmitError = false;
     this.categories.forEach((category) => category.toggle(selectedCategory.name));
   }
 
@@ -104,12 +106,17 @@ export default class AddIssueReportModal extends Component {
   async submitReport(event) {
     event.preventDefault();
     const categoryToAdd = this.categories.find((category) => category.isChecked);
-    if (categoryToAdd) {
-      const issueReportToSave = this.store.createRecord('certification-issue-report', categoryToAdd.issueReport(this.args.report));
+    if (!categoryToAdd) {
+      this.showCategoryMissingError = true;
+      return;
+    }
+    const issueReportToSave = this.store.createRecord('certification-issue-report', categoryToAdd.issueReport(this.args.report));
+    try {
       await issueReportToSave.save();
       this.args.closeModal();
-    } else {
-      this.showCategoryMissingError = true;
+    } catch (err) {
+      issueReportToSave.rollbackAttributes();
+      this.showIssueReportSubmitError = true;
     }
   }
 

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -1,7 +1,7 @@
 <AppModal @containerClass="pix-modal-dialog--wide" @onClose={{@closeModal}}>
   <div class="add-issue-report-modal">
     <div class="pix-modal__close-button">
-      <button type="button" data-test-id="finalize-session-modal__close-cross" {{on "click" @closeModal}}>Fermer
+      <button type="button" aria-label="Fermer" data-test-id="finalize-session-modal__close-cross" {{on "click" @closeModal}}>Fermer
         <img src="/icons/icon-close-modal.svg" alt="Fermer la fenêtre de confirmation" width="24" height="24">
       </button>
     </div>
@@ -20,7 +20,7 @@
               <li>
                 <p class="add-issue-report-modal-content__category-label">
                   {{issueReport.categoryLabel}}
-                <button type="button" class="button--showed-as-link" {{on 'click' (fn this.handleClickOnDeleteButton issueReport)}}>
+                <button type="button" aria-label="Supprimer le signalement" class="button--showed-as-link" {{on 'click' (fn this.handleClickOnDeleteButton issueReport)}}>
                   <FaIcon @icon="trash"/>
                 </button>
                 </p>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -30,7 +30,7 @@
               </li>
             {{/each}}
           </ul>
-          <button type="button" class="button__secondary" {{on 'click' (fn @onClickIssueReport @report)}}>
+          <button type="button" aria-label="Ajouter un signalement" class="button__secondary" {{on 'click' (fn @onClickIssueReport @report)}}>
             <FaIcon @icon="plus"/>Ajouter un signalement
           </button>
         </div>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -18,7 +18,12 @@
           <ul>
             {{#each @report.certificationIssueReports as |issueReport|}}
               <li>
-                <p class="add-issue-report-modal-content__category-label">{{issueReport.categoryLabel}}</p>
+                <p class="add-issue-report-modal-content__category-label">
+                  {{issueReport.categoryLabel}}
+                <button type="button" class="button--showed-as-link" {{on 'click' (fn this.handleClickOnDeleteButton issueReport)}}>
+                  <FaIcon @icon="trash"/>
+                </button>
+                </p>
                 {{#if issueReport.subcategoryLabel}}
                 <p class="add-issue-report-modal-content__subcategory-label">{{issueReport.subcategoryLabel}}</p>
                 {{/if}}
@@ -29,6 +34,10 @@
             <FaIcon @icon="plus"/>Ajouter un signalement
           </button>
         </div>
+
+        {{#if this.showDeletionError}}
+          <PixMessage @type='alert'>Une erreur s'est produite lors de la suppression du signalement. Merci de réessayer</PixMessage>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/certif/app/components/issue-report-modal/issue-reports-modal.js
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.js
@@ -1,4 +1,17 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-export default class IssueReportsModalComponent extends Component {
+export default class IssueReportsModal extends Component {
+  @tracked showDeletionError = false;
+
+  @action
+  async handleClickOnDeleteButton(issueReport) {
+    this.showDeletionError = false;
+    try {
+      await this.args.onClickDeleteIssueReport(issueReport);
+    } catch (err) {
+      this.showDeletionError = true;
+    }
+  }
 }

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -77,6 +77,7 @@
     <IssueReportModal::IssueReportsModal
       @closeModal={{this.closeIssueReportsModal}}
       @onClickIssueReport={{this.openAddIssueReportModal}}
+      @onClickDeleteIssueReport={{@handleClickOnDeleteIssueReportButton}}
       @report={{this.reportToEdit}}
       />
   {{/if}}

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -58,6 +58,11 @@ export default class SessionsFinalizeController extends Controller {
   }
 
   @action
+  deleteCertificationIssueReport(certificationIssueReport) {
+    return certificationIssueReport.destroyRecord();
+  }
+
+  @action
   updateExaminerGlobalComment(event) {
     const inputText = event.target.value;
     if (inputText.length <= this.examinerGlobalCommentMaxLength) {

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -54,8 +54,16 @@
         font-family: $roboto;
         padding: 0;
         margin: 0;
-      }
+        display: flex;
+        justify-content: space-between;
+        line-height: 32px;
 
+        svg {
+          font-size: 20px;
+          margin: 0;
+          padding: 0;
+        }
+      }
 
       .add-issue-report-modal-content__subcategory-label {
         font-family: $roboto;
@@ -73,15 +81,31 @@
     }
 
     .add-issue-report-modal-content {
-
-      label[for^="subcategory-for-category"], label[for^="text-area-for-category"] {
+      label[for^="subcategory-for-category"],
+      label[for^="text-area-for-category"] {
         display: block;
         margin-bottom: 4px;
       }
 
-      select[id^="subcategory-for-category"] {
-        font-size: 14px;
-        color: $grey-90;
+      .pix-select {
+        height: 35px;
+        background: $white;
+        border: 1.2px solid $grey-45;
+        border-radius: 4px;
+
+        select[id^="subcategory-for-category"] {
+          font-size: 14px;
+          color: $grey-90;
+        }
+
+        svg {
+          width: 14px;
+          height: 16px;
+          color: $blue-zodia;
+          font-size: 16px;
+          font-weight: normal;
+          letter-spacing: 0px;
+        }
       }
 
       label[for^="text-area-for-category"] {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -18,7 +18,9 @@
         @updateCertificationIssueReport={{this.updateCertificationIssueReport}}
         @issueReportDescriptionMaxLength={{this.issueReportDescriptionMaxLength}}
         @toggleCertificationReportHasSeenEndTestScreen={{this.toggleCertificationReportHasSeenEndTestScreen}}
-        @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}} />
+        @toggleAllCertificationReportsHasSeenEndTestScreen={{this.toggleAllCertificationReportsHasSeenEndTestScreen}}
+        @handleClickOnDeleteIssueReportButton={{this.deleteCertificationIssueReport}}
+    />
   </SessionFinalizationStepContainer>
 
   <SessionFinalizationStepContainer

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -72,6 +72,14 @@ export default function() {
     return schema.certificationIssueReports.create({ certificationReport, description, category });
   });
 
+  this.delete('/certification-issue-reports/:id', function(schema, request) {
+    const certificationIssueReportId = request.params.id;
+    const certificationIssueReport = schema.certificationIssueReports.find(certificationIssueReportId);
+
+    certificationIssueReport.destroy();
+    return { data: null };
+  });
+
   this.get('/sessions/:id/certification-reports', function(schema, request) {
     const sessionId = request.params.id;
 

--- a/certif/mirage/factories/certification-issue-report.js
+++ b/certif/mirage/factories/certification-issue-report.js
@@ -1,0 +1,16 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  category() {
+    return 'Issue report category';
+  },
+
+  subcategory() {
+    return 'Issue report sub category';
+  },
+
+  description() {
+    return 'a not so random description';
+  },
+});

--- a/certif/mirage/serializers/certification-issue-report.js
+++ b/certif/mirage/serializers/certification-issue-report.js
@@ -1,0 +1,3 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({});

--- a/certif/mirage/serializers/certification-report.js
+++ b/certif/mirage/serializers/certification-report.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+const include = ['certification-issue-reports'];
+
+export default ApplicationSerializer.extend({
+  include,
+  alwaysIncludeLinkageData: true,
+});

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -105,6 +105,32 @@ module('Acceptance | Session Finalization', function(hooks) {
             assert.dom(BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_2).hasText(expectedTextWithIssueReport);
           });
         });
+
+        module('when we delete a certification issue report', function() {
+          test('it should show the remaining count of issue reports', async function(assert) {
+            // given
+            const BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_1 = '[data-test-id="finalization-report-certification-issue-reports_1"] .button--showed-as-link';
+
+            server.create('feature-toggle', { id: 0, reportsCategorization: true });
+
+            const certificationReport = server.create('certification-report', { certificationCourseId: 1 });
+            const certificationIssueReport1 = server.create('certification-issue-report', { certificationReportId: certificationReport.id });
+            const certificationIssueReport2 = server.create('certification-issue-report', { certificationReportId: certificationReport.id });
+
+            const certificationIssueReports = [certificationIssueReport1, certificationIssueReport2];
+            certificationReport.update({ certificationIssueReports });
+            session.update({ certificationReports: [certificationReport] });
+
+            // when
+            await visit(`/sessions/${session.id}/finalisation`);
+            await click(BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_1);
+            await click('button[aria-label="Supprimer le signalement"]');
+            await click('button[aria-label="Fermer"]');
+
+            // then
+            assert.contains('1 signalement');
+          });
+        });
       });
 
       module('when reportsCategorization toggle is off', function(hooks) {

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal-test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal-test.js
@@ -1,0 +1,221 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | issue-report-modal', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it show candidate informations in title', async function(assert) {
+    // given
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+    });
+    this.set('report', report);
+    this.set('closeModal', sinon.stub());
+    this.set('onClickIssueReport', sinon.stub());
+    this.set('onClickDeleteIssueReport', sinon.stub());
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    // then
+    assert.contains('Lisa Monpud');
+  });
+
+  test('it shows the number of issue reports', async function(assert) {
+    // given
+    const issue1 = EmberObject.create({
+      description: 'issue1',
+    });
+
+    const issue2 = EmberObject.create({
+      description: 'issue2',
+    });
+
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+      certificationIssueReports: [issue1, issue2],
+
+    });
+    this.set('report', report);
+    this.set('closeModal', sinon.stub());
+    this.set('onClickIssueReport', sinon.stub());
+    this.set('onClickDeleteIssueReport', sinon.stub());
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    // then
+    assert.contains('Mes signalements (2)');
+  });
+
+  test('it shows a list of issue reports', async function(assert) {
+    // given
+    const issue1 = EmberObject.create({
+      categoryLabel: 'categoryLabel1',
+      subcategoryLabel: 'subcategoryLabel1',
+    });
+
+    const issue2 = EmberObject.create({
+      categoryLabel: 'categoryLabel2',
+      subcategoryLabel: 'subcategoryLabel2',
+    });
+
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+      certificationIssueReports: [issue1, issue2],
+
+    });
+    this.set('report', report);
+    this.set('closeModal', sinon.stub());
+    this.set('onClickIssueReport', sinon.stub());
+    this.set('onClickDeleteIssueReport', sinon.stub());
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    // then
+    assert.contains('categoryLabel1');
+    assert.contains('subcategoryLabel1');
+    assert.contains('categoryLabel2');
+    assert.contains('subcategoryLabel2');
+  });
+
+  test('it calls a function linked to the close button', async function(assert) {
+    // given
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+    });
+
+    const closeModal = sinon.stub();
+
+    this.set('report', report);
+    this.set('closeModal', closeModal);
+    this.set('onClickIssueReport', sinon.stub());
+    this.set('onClickDeleteIssueReport', sinon.stub());
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    await click('[aria-label="Fermer"]');
+
+    // then
+    sinon.assert.calledOnce(closeModal);
+    assert.ok(true);
+  });
+
+  test('it calls a function linked to the add button', async function(assert) {
+    // given
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+    });
+
+    const onClickIssueReport = sinon.stub();
+
+    this.set('report', report);
+    this.set('closeModal', sinon.stub());
+    this.set('onClickIssueReport', onClickIssueReport);
+    this.set('onClickDeleteIssueReport', sinon.stub());
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    await click('[aria-label="Ajouter un signalement"]');
+
+    // then
+    sinon.assert.calledOnce(onClickIssueReport);
+    assert.ok(true);
+  });
+
+  test('it calls a function linked to the delete button', async function(assert) {
+    // given
+    const issue = EmberObject.create({
+      categoryLabel: 'categoryLabel1',
+      subcategoryLabel: 'subcategoryLabel1',
+    });
+
+    const report = EmberObject.create({
+      certificationCourseId: 1,
+      firstName: 'Lisa',
+      lastName: 'Monpud',
+      hasSeenEndTestScreen: false,
+      certificationIssueReports: [issue],
+    });
+
+    const onClickDeleteIssueReport = sinon.stub();
+
+    this.set('report', report);
+    this.set('closeModal', sinon.stub());
+    this.set('onClickIssueReport', sinon.stub());
+    this.set('onClickDeleteIssueReport', onClickDeleteIssueReport);
+
+    // when
+    await render(hbs`
+    <IssueReportModal::IssueReportsModal
+      @closeModal={{this.closeModal}}
+      @onClickIssueReport={{this.onClickIssueReport}}
+      @onClickDeleteIssueReport={{this.onClickDeleteIssueReport}}
+      @report={{this.report}}
+      />
+    `);
+
+    await click('[aria-label="Supprimer le signalement"]');
+
+    // then
+    sinon.assert.calledOnce(onClickDeleteIssueReport);
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les signalements ne sont pas déclarés par batch au moment de finaliser la session dans PixCertif. Ils sont créés en BDD au fur et à mesure. Il faut donc pouvoir autoriser le rapporteur à supprimer un signalement en cas d'erreur de saisie ou autre.

## :robot: Solution
Ajout d'un bouton à côté de chaque signalement existant pour pouvoir le supprimer

## :rainbow: Remarques
On en profite pour passer le bugfix sur l'affichage du nombre de signalements qui continuait d'augmenter même si l'envoi du signalement était en échec + affichage d'un mot d'erreur générique en cas d'erreur d'envoi.

## :100: Pour tester
Ajouter des signalements puis les supprimer. En flippant les toggles correctement, utiliser certifsco@example.net et la session 4
