### PR TITLE
[FEATURE] Ajouter l'ID de l'organisation dans les diverses listes d'organisations dans PixAdmin (PIX-1817)

### DIFF
--- a/admin/app/components/organizations/list-items.hbs
+++ b/admin/app/components/organizations/list-items.hbs
@@ -3,11 +3,19 @@
     <table>
       <thead>
         <tr>
+          <th>ID</th>
           <th>Nom</th>
           <th>Type</th>
           <th>Identifiant externe</th>
         </tr>
         <tr>
+          <th>
+            <input id="id"
+                   type="text"
+                   value={{@id}}
+                   oninput={{fn @triggerFiltering 'id'}}
+                   class="table-admin-input form-control" />
+          </th>
           <th>
             <input id="name"
                    type="text"
@@ -36,6 +44,7 @@
         <tbody>
         {{#each @organizations as |organization|}}
           <tr aria-label="Organisation" role="button" {{on "click" (fn @goToOrganizationPage organization.id)}} class="tr--clickable">
+            <td>{{organization.id}}</td>
             <td>{{organization.name}}</td>
             <td>{{organization.type}}</td>
             <td>{{organization.externalId}}</td>

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -25,6 +25,7 @@
 
   <Organizations::ListItems
     @organizations={{@organizations}}
+    @id={{@id}}
     @name={{@name}}
     @type={{@type}}
     @externalId={{@externalId}}

--- a/admin/app/controllers/authenticated/organizations/list.js
+++ b/admin/app/controllers/authenticated/organizations/list.js
@@ -8,11 +8,12 @@ const DEFAULT_PAGE_NUMBER = 1;
 
 export default class ListController extends Controller {
 
-  queryParams = ['pageNumber', 'pageSize', 'name', 'type', 'externalId'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
+  @tracked id = null;
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -9,11 +9,12 @@ import config from 'pix-admin/config/environment';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class TargetProfileOrganizationsController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'name', 'type', 'externalId'];
+  queryParams = ['pageNumber', 'pageSize', 'id', 'name', 'type', 'externalId'];
   DEBOUNCE_MS = config.pagination.debounce;
 
   @tracked pageNumber = DEFAULT_PAGE_NUMBER;
   @tracked pageSize = 10;
+  @tracked id = null;
   @tracked name = null;
   @tracked type = null;
   @tracked externalId = null;

--- a/admin/app/routes/authenticated/organizations/list.js
+++ b/admin/app/routes/authenticated/organizations/list.js
@@ -6,6 +6,7 @@ export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    id: { refreshModel: true },
     name: { refreshModel: true },
     type: { refreshModel: true },
     externalId: { refreshModel: true },
@@ -14,6 +15,7 @@ export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
   model(params) {
     return this.store.query('organization', {
       filter: {
+        id: params.id ? params.id.trim() : '',
         name: params.name ? params.name.trim() : '',
         type: params.type ? params.type.trim() : '',
         externalId: params.externalId ? params.externalId.trim() : '',
@@ -29,6 +31,7 @@ export default class ListRoute extends Route.extend(AuthenticatedRouteMixin) {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 10;
+      controller.id = null;
       controller.name = null;
       controller.type = null;
       controller.externalId = null;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -5,6 +5,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
+    id: { refreshModel: true },
     name: { refreshModel: true },
     type: { refreshModel: true },
     externalId: { refreshModel: true },
@@ -15,6 +16,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
     await targetProfile.hasMany('organizations').reload({ adapterOptions: {
       'page[size]': params.pageSize,
       'page[number]': params.pageNumber,
+      'filter[id]': params.id,
       'filter[name]': params.name,
       'filter[type]': params.type,
       'filter[externalId]': params.externalId,
@@ -26,6 +28,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 10;
+      controller.id = null;
       controller.name = null;
       controller.type = null;
       controller.externalId = null;

--- a/admin/app/templates/authenticated/organizations/list.hbs
+++ b/admin/app/templates/authenticated/organizations/list.hbs
@@ -11,6 +11,7 @@
   <section class="page-section">
     <Organizations::ListItems
       @organizations={{@model}}
+      @id={{this.id}}
       @name={{this.name}}
       @type={{this.type}}
       @externalId={{this.externalId}}

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -1,5 +1,6 @@
 <TargetProfiles::Organizations
   @organizations={{@model.organizations}}
+  @id={{this.id}}
   @name={{this.name}}
   @type={{this.type}}
   @externalId={{this.externalId}}

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
@@ -15,14 +15,15 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     this.goToOrganizationPage = goToOrganizationPage;
   });
 
-  test('it should display header with name, type and externalId', async function(assert) {
+  test('it should display header with id, name, type and externalId', async function(assert) {
     // when
     await render(hbs`<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
 
     // then
-    assert.dom('table thead tr:first-child th:first-child').hasText('Nom');
-    assert.dom('table thead tr:first-child th:nth-child(2)').hasText('Type');
-    assert.dom('table thead tr:first-child th:nth-child(3)').hasText('Identifiant externe');
+    assert.dom('table thead tr:first-child th:first-child').hasText('ID');
+    assert.dom('table thead tr:first-child th:nth-child(2)').hasText('Nom');
+    assert.dom('table thead tr:first-child th:nth-child(3)').hasText('Type');
+    assert.dom('table thead tr:first-child th:nth-child(4)').hasText('Identifiant externe');
   });
 
   test('if should display search inputs', async function(assert) {
@@ -30,6 +31,7 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     await render(hbs`<Organizations::ListItems @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
 
     // then
+    assert.dom('table thead tr:nth-child(2) input#id').exists();
     assert.dom('table thead tr:nth-child(2) input#name').exists();
     assert.dom('table thead tr:nth-child(2) input#type').exists();
     assert.dom('table thead tr:nth-child(2) input#externalId').exists();
@@ -52,9 +54,10 @@ module('Integration | Component | routes/authenticated/organizations | list-item
     await render(hbs`<Organizations::ListItems @organizations={{this.organizations}} @triggerFiltering={{this.triggerFiltering}} @goToOrganizationPage={{this.goToOrganizationPage}} />`);
 
     // then
-    assert.dom('table tbody tr:first-child td:first-child').hasText('École ACME');
-    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('SCO');
-    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText(externalId);
+    assert.dom('table tbody tr:first-child td:first-child').hasText('1');
+    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('École ACME');
+    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('SCO');
+    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText(externalId);
     assert.dom('table tbody tr').exists({ count: 3 });
   });
 });

--- a/admin/tests/unit/routes/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list-test.js
@@ -26,10 +26,11 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
 
     module('when queryParams filters are falsy', function() {
 
-      test('it should call store.query with no filters on name, type and externalId', async function(assert) {
+      test('it should call store.query with no filters on id, name, type and externalId', async function(assert) {
         // when
         await route.model(params);
         expectedQueryArgs.filter = {
+          id: '',
           name: '',
           type: '',
           externalId: '',
@@ -45,10 +46,12 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
 
       test('it should call store.query with filters containing trimmed values', async function(assert) {
         // given
+        params.id = ' someId';
         params.name = ' someName';
         params.type = 'someType ';
         params.externalId = 'someExternalId';
         expectedQueryArgs.filter = {
+          id: 'someId',
           name: 'someName',
           type: 'someType',
           externalId: 'someExternalId',
@@ -72,6 +75,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
+        id: 'someId',
         name: 'someName',
         type: 'someType',
         externalId: 'someExternalId',
@@ -87,6 +91,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
         // then
         assert.equal(controller.pageNumber, 1);
         assert.equal(controller.pageSize, 10);
+        assert.equal(controller.id, null);
         assert.equal(controller.name, null);
         assert.equal(controller.type, null);
         assert.equal(controller.externalId, null);
@@ -102,6 +107,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
         // then
         assert.equal(controller.pageNumber, 'somePageNumber');
         assert.equal(controller.pageSize, 'somePageSize');
+        assert.equal(controller.id, 'someId');
         assert.equal(controller.name, 'someName');
         assert.equal(controller.type, 'someType');
         assert.equal(controller.externalId, 'someExternalId');

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -94,6 +94,7 @@ exports.register = async (server) => {
             id: Joi.number().integer().required(),
           }),
           query: Joi.object({
+            'filter[id]': Joi.number().integer().empty('').allow(null).optional(),
             'filter[name]': Joi.string().empty('').allow(null).optional(),
             'filter[type]': Joi.string().empty('').allow(null).optional(),
             'filter[external-id]': Joi.string().empty('').allow(null).optional(),

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -46,7 +46,10 @@ function _toDomain(bookshelfOrganization) {
 }
 
 function _setSearchFiltersForQueryBuilder(filter, qb) {
-  const { name, type, externalId } = filter;
+  const { id, name, type, externalId } = filter;
+  if (id) {
+    qb.where('organizations.id', id);
+  }
   if (name) {
     qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
   }


### PR DESCRIPTION
## :unicorn: Problème
Une demande du métier sur slack -> https://1024pix.slack.com/archives/C66CN9STX/p1608558903003700
En substance : 

> Bonjour, J'aimerais suggérer une amélioration de Pix admin qui nous serait bien utile coté sup : Ajouter dans l'écran des profils cibles et des orga qui ont ce profil l'ID de l'orga. En fait, très régulièrement on doit rattacher aux orgas qui ont tel profil cible un autre profil cible (ex de ce matin : Pix+Droit Domaine 4, je dois le mettre à ceux qui ont Pix+Droit Domaine 1). Comme pour rattacher un profil à une orga il faut l'orga ID si on l'avait directement ca serait plus facile que d'aller le chercher orga par orga.

## :robot: Solution
Ajouter la colonne ID dans le composant dédié + prendre en compte le filtre par ID côté API

## :rainbow: Remarques

## :100: Pour tester
Se rendre sur l'onglet Organisations et jouer avec la liste des organisations et le champ ID.
Se rendre sur l'onglet Profils cibles -> aller sur le profil cible ID 1 -> jouer avec la liste des organisations et le champ ID.
