### PR TITLE
[TECH] Améliorer l'encryption-service.

### DIFF
--- a/api/lib/domain/services/authentication-service.js
+++ b/api/lib/domain/services/authentication-service.js
@@ -12,11 +12,11 @@ async function getUserByUsernameAndPassword({
   userRepository,
 }) {
   const foundUser = await userRepository.getByUsernameOrEmailWithRolesAndPassword(username);
-  const hashedPassword = foundUser.authenticationMethods[0].authenticationComplement.password;
+  const passwordHash = foundUser.authenticationMethods[0].authenticationComplement.password;
 
   await encryptionService.checkPassword({
-    rawPassword: password,
-    hashedPassword,
+    password,
+    passwordHash,
   });
 
   return foundUser;

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -4,19 +4,11 @@ const PasswordNotMatching = require('../errors').PasswordNotMatching;
 const NUMBER_OF_SALT_ROUNDS = 5;
 
 module.exports = {
-  hashPassword: (password) => {
-    return new Promise((resolve, reject) => {
-      bcrypt.hash(password, NUMBER_OF_SALT_ROUNDS, (err, hash) => {
-        if (err) reject(err);
-        resolve(hash);
-      });
-    });
-  },
 
-  hashPasswordSync: (password) => {
-    /* eslint-disable-next-line no-sync */
-    return bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS);
-  },
+  hashPassword: (password) => bcrypt.hash(password, NUMBER_OF_SALT_ROUNDS),
+
+  /* eslint-disable-next-line no-sync */
+  hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS),
 
   checkPassword: ({ rawPassword, hashedPassword }) => {
     return new Promise((resolve, reject) => {

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -13,9 +13,6 @@ module.exports = {
     });
   },
 
-  /**
-   * Not for usage on server. Script only, as the function is very CPU intensive and would block the server thread
-   */
   hashPasswordSync: (password) => {
     /* eslint-disable-next-line no-sync */
     return bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS);

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -10,8 +10,8 @@ module.exports = {
   /* eslint-disable-next-line no-sync */
   hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS),
 
-  checkPassword: async ({ rawPassword, hashedPassword }) => {
-    const matching = await bcrypt.compare(rawPassword, hashedPassword);
+  checkPassword: async ({ password, passwordHash }) => {
+    const matching = await bcrypt.compare(password, passwordHash);
     if (!matching) {
       throw new PasswordNotMatching();
     }

--- a/api/lib/domain/services/encryption-service.js
+++ b/api/lib/domain/services/encryption-service.js
@@ -10,11 +10,11 @@ module.exports = {
   /* eslint-disable-next-line no-sync */
   hashPasswordSync: (password) => bcrypt.hashSync(password, NUMBER_OF_SALT_ROUNDS),
 
-  checkPassword: ({ rawPassword, hashedPassword }) => {
-    return new Promise((resolve, reject) => {
-      bcrypt.compare(rawPassword, hashedPassword, (err, res) => {
-        (res) ? resolve() : reject(new PasswordNotMatching());
-      });
-    });
+  checkPassword: async ({ rawPassword, hashedPassword }) => {
+    const matching = await bcrypt.compare(rawPassword, hashedPassword);
+    if (!matching) {
+      throw new PasswordNotMatching();
+    }
   },
+
 };

--- a/api/tests/unit/domain/services/authentication-service_test.js
+++ b/api/tests/unit/domain/services/authentication-service_test.js
@@ -56,7 +56,7 @@ describe('Unit | Domain | Services | authentication-service', () => {
 
       it('should call the encryptionService check function', async () => {
         // given
-        const expectedHashedPassword = authenticationMethod.authenticationComplement.password;
+        const expectedPasswordHash = authenticationMethod.authenticationComplement.password;
 
         // when
         await service.getUserByUsernameAndPassword({
@@ -65,8 +65,8 @@ describe('Unit | Domain | Services | authentication-service', () => {
 
         // then
         expect(encryptionService.checkPassword).to.has.been.calledWith({
-          rawPassword: password,
-          hashedPassword: expectedHashedPassword,
+          password,
+          passwordHash: expectedPasswordHash,
         });
       });
 

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -8,38 +8,68 @@ describe('Unit | Service | Encryption', () => {
 
   describe('#checkPassword', () => {
 
-    describe('#when password and hash are matching', async() => {
-      it('should resolve', async () => {
+    describe('when password and hash are matching', async() => {
+
+      it('should resolve to undefined', async () => {
+
         // given
         const password = 'my-real-password';
         /* eslint-disable no-sync */
-        const passwordHashed = bcrypt.hashSync(password, 1);
+        const passwordHash = bcrypt.hashSync(password, 1);
 
         // when
-        const error = await catchErr(encryptionService.checkPassword)({
-          password,
-          passwordHashed,
+        const result = await encryptionService.checkPassword({
+          rawPassword: password,
+          hashedPassword: passwordHash,
         });
 
         // then
-        expect(error).to.be.an.instanceof(PasswordNotMatching);
+        expect(result).to.be.undefined;
+
       });
     });
 
-    describe('#when password and hash are not matching', async () => {
+    describe('when password and hash are not matching', async () => {
+
       it('should reject a PasswordNotMatching error ', async () => {
+
         // given
         const password = 'my-expected-password';
-        const passwordHashed = 'ABCDEF1234';
+        const passwordHash = 'ABCDEF1234';
 
         // when
         const error = await catchErr(encryptionService.checkPassword)({
-          password,
-          passwordHashed,
+          rawPassword: password,
+          hashedPassword: passwordHash,
         });
+
         // then
         expect(error).to.be.an.instanceof(PasswordNotMatching);
+
       });
+
+    });
+
+    describe('when password is not supplied', async () => {
+
+      it('should reject, but not a PasswordNotMatching error ', async () => {
+
+        // given
+        const password = undefined;
+        /* eslint-disable no-sync */
+        const passwordHash = bcrypt.hashSync('my-real-password', 1);
+
+        try {
+          await encryptionService.checkPassword({
+            rawPassword: password,
+            hashedPassword: passwordHash,
+          });
+        } catch (error) {
+          expect(error).not.to.be.an.instanceof(PasswordNotMatching);
+        }
+
+      });
+
     });
 
   });

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -1,45 +1,47 @@
-/* eslint-disable no-sync */
-const bcrypt = require('bcrypt');
-
 const { catchErr, expect } = require('../../../test-helper');
 
-const PasswordNotMatching = require('../../../../lib/domain/errors').PasswordNotMatching;
-
+const bcrypt = require('bcrypt');
 const encryptionService = require('../../../../lib/domain/services/encryption-service');
+const PasswordNotMatching = require('../../../../lib/domain/errors').PasswordNotMatching;
 
 describe('Unit | Service | Encryption', () => {
 
   describe('#checkPassword', () => {
 
-    it('should reject when passwords are not matching', async () => {
-      // given
-      const rawPassword = 'my-expected-password';
-      const hashedPassword = 'ABCDEF1234';
+    describe('#when password and hash are matching', async() => {
+      it('should resolve', async () => {
+        // given
+        const password = 'my-real-password';
+        /* eslint-disable no-sync */
+        const passwordHashed = bcrypt.hashSync(password, 1);
 
-      // when
-      const error = await catchErr(encryptionService.checkPassword)({
-        rawPassword,
-        hashedPassword,
+        // when
+        const error = await catchErr(encryptionService.checkPassword)({
+          password,
+          passwordHashed,
+        });
+
+        // then
+        expect(error).to.be.an.instanceof(PasswordNotMatching);
       });
-
-      // then
-      expect(error).to.be.an.instanceof(PasswordNotMatching);
     });
 
-    it('should resolve to undefined when passwords are matching', async () => {
-      // given
-      const rawPassword = 'Password123';
-      const hashedPassword = bcrypt.hashSync(rawPassword, 1);
+    describe('#when password and hash are not matching', async () => {
+      it('should reject a PasswordNotMatching error ', async () => {
+        // given
+        const password = 'my-expected-password';
+        const passwordHashed = 'ABCDEF1234';
 
-      // when
-      const result = await encryptionService.checkPassword({
-        rawPassword,
-        hashedPassword,
+        // when
+        const error = await catchErr(encryptionService.checkPassword)({
+          password,
+          passwordHashed,
+        });
+        // then
+        expect(error).to.be.an.instanceof(PasswordNotMatching);
       });
-
-      // then
-      expect(result).to.be.undefined;
     });
+
   });
 
 });

--- a/api/tests/unit/domain/services/encryption-service_test.js
+++ b/api/tests/unit/domain/services/encryption-service_test.js
@@ -19,8 +19,8 @@ describe('Unit | Service | Encryption', () => {
 
         // when
         const result = await encryptionService.checkPassword({
-          rawPassword: password,
-          hashedPassword: passwordHash,
+          password,
+          passwordHash,
         });
 
         // then
@@ -39,8 +39,8 @@ describe('Unit | Service | Encryption', () => {
 
         // when
         const error = await catchErr(encryptionService.checkPassword)({
-          rawPassword: password,
-          hashedPassword: passwordHash,
+          password,
+          passwordHash,
         });
 
         // then
@@ -61,8 +61,8 @@ describe('Unit | Service | Encryption', () => {
 
         try {
           await encryptionService.checkPassword({
-            rawPassword: password,
-            hashedPassword: passwordHash,
+            password,
+            passwordHash,
           });
         } catch (error) {
           expect(error).not.to.be.an.instanceof(PasswordNotMatching);


### PR DESCRIPTION
## :unicorn: Problème

Le code suivant de 2018 emballe le retour de `hash` dans une promesse, mais le retour de `hash` est déjà une promesse
```
    return new Promise((resolve, reject) => {
      bcrypt.hash(password, NUMBER_OF_SALT_ROUNDS, (err, hash) => {
        if (err) reject(err);
        resolve(hash);
      });
    });
```

De plus, si l'un des arguments passés à `compare` n'est pas renseigné, on lève l'erreur `PasswordNotMatching`

## :robot: Solution
Retourner le  résulat de l'appel de `hash`
Laisser se propager l'erreur native levée par `compare`

## :rainbow: Remarques
Suppression de la  documentation de `hashPasswordSync` : la directive de lint `eslint-disable-next-line no-sync` est explicite

Remplacement des termes
- `encryptedPassword` 
- `hashedPassword` 

Par
- `passwordHash`  

Voir PR https://github.com/1024pix/pix/pull/2220#discussion_r547231307

## :100: Pour tester
Créer un compte, se déconnecter, puis se reconnecter
