### PR TITLE
[BUGFIX] Supprimer la phrase en bas du certificat partageable (PIX-1818).

### DIFF
--- a/api/lib/domain/models/ShareableCertificate.js
+++ b/api/lib/domain/models/ShareableCertificate.js
@@ -14,6 +14,7 @@ class ShareableCertificate {
     status,
     cleaCertificationStatus,
     resultCompetenceTree = null,
+    maxReachableLevelOnCertificationDate,
   } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -29,6 +30,7 @@ class ShareableCertificate {
     this.status = status;
     this.cleaCertificationStatus = cleaCertificationStatus;
     this.resultCompetenceTree = resultCompetenceTree;
+    this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
   }
 }
 

--- a/api/lib/domain/usecases/certificate/get-shareable-certificate.js
+++ b/api/lib/domain/usecases/certificate/get-shareable-certificate.js
@@ -12,6 +12,7 @@ module.exports = async function getShareableCertificate({
   return decorateWithCleaStatusAndCompetenceTree({
     certificationId: certificate.id,
     toBeDecorated: certificate,
+    maxReachableLevelOnCertificationDate: certificate.maxReachableLevelOnCertificationDate,
     cleaCertificationStatusRepository,
     assessmentResultRepository,
     competenceTreeRepository,

--- a/api/tests/acceptance/application/certifications/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications/certification-controller_test.js
@@ -25,6 +25,7 @@ describe('Acceptance | API | Certifications', () => {
       sessionId: session.id,
       userId,
       isPublished: true,
+      maxReachableLevelOnCertificationDate: 3,
     });
     assessment = databaseBuilder.factory.buildAssessment({
       userId,
@@ -379,6 +380,7 @@ describe('Acceptance | API | Certifications', () => {
               'pix-score': assessmentResult.pixScore,
               'status': assessmentResult.status,
               'clea-certification-status': 'not_passed',
+              'max-reachable-level-on-certification-date': certificationCourse.maxReachableLevelOnCertificationDate,
             },
             'id': `${certificationCourse.id}`,
             'relationships': {

--- a/mon-pix/app/components/user-certifications-detail-competences-list.js
+++ b/mon-pix/app/components/user-certifications-detail-competences-list.js
@@ -8,8 +8,4 @@ export default class UserCertificationsDetailCompetencesList extends Component {
   get maxReachableLevel() {
     return this.args.maxReachableLevelOnCertificationDate;
   }
-
-  get maxReachablePixCount() {
-    return this.args.maxReachableLevelOnCertificationDate * 8 * 16;
-  }
 }

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -38,4 +38,8 @@ export default class Certification extends Model {
   get fullName() {
     return capitalize(this.firstName) + ' ' + capitalize(this.lastName);
   }
+
+  get maxReachablePixCountOnCertificationDate() {
+    return this.maxReachableLevelOnCertificationDate * 8 * 16;
+  }
 }

--- a/mon-pix/app/styles/components/_user-certifications-detail-competences-list.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-competences-list.scss
@@ -11,11 +11,4 @@
       font-size: 0.75rem;
     }
   }
-
-  &__note {
-    color: $grey-60;
-    font-size: 0.875rem;
-    letter-spacing: 0.15px;
-    line-height: 22px;
-  }
 }

--- a/mon-pix/app/styles/pages/_user-certifications-get.scss
+++ b/mon-pix/app/styles/pages/_user-certifications-get.scss
@@ -17,6 +17,14 @@
   h2 {
     color: $grey-90;
   }
+
+  &__note {
+    color: $grey-60;
+    font-size: 0.875rem;
+    letter-spacing: 0.15px;
+    line-height: 22px;
+    max-width: 980px;
+  }
 }
 
 @mixin contentInColumn() {

--- a/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-competences-list.hbs
@@ -7,7 +7,4 @@
 
   {{/each}}
 
-  <p class="user-certifications-detail-competences-list__note">
-    {{t "pages.certificate.competences.informations" maxReachableLevel=this.maxReachableLevel maxReachablePixCount=this.maxReachablePixCount}}
-  </p>
 </div>

--- a/mon-pix/app/templates/user-certifications/get.hbs
+++ b/mon-pix/app/templates/user-certifications/get.hbs
@@ -16,4 +16,9 @@
     {{/if}}
   </div>
 
+  <p class="user-certifications-page-get__note">
+    {{t "pages.certificate.competences.information" maxReachableLevelOnCertificationDate=this.model.maxReachableLevelOnCertificationDate
+        maxReachablePixCountOnCertificationDate=this.model.maxReachablePixCountOnCertificationDate}}
+  </p>
+
 </PixBackgroundHeader>

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -135,7 +135,7 @@
                 "alternative": "Digital CléA certification"
             },
             "competences": {
-                "informations": "Your certified score was calculated based on the answers you gave whilst taking the certification. It may be different from the score shown on your profile. When you took the certification, it was possible to reach a maximum of level {maxReachableLevel} each skill and {maxReachablePixCount} pix.",
+                "information": "Your certified score was calculated based on the answers you gave whilst taking the certification. It may be different from the score shown on your profile. When you took the certification, it was possible to reach a maximum of level {maxReachableLevelOnCertificationDate} each skill and {maxReachablePixCountOnCertificationDate} pix.",
                 "subtitle": "(levels out of {maxReachableLevel})",
                 "title": "Certified skills"
             },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -135,7 +135,7 @@
                 "alternative": "Certification cléA numérique"
             },
             "competences": {
-                "informations": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau {maxReachableLevel} des compétences et {maxReachablePixCount} pix au maximum.",
+                "information": "Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau {maxReachableLevelOnCertificationDate} des compétences et {maxReachablePixCountOnCertificationDate} pix au maximum.",
                 "subtitle": "(niveaux sur {maxReachableLevel})",
                 "title": "Compétences certifiées"
             },


### PR DESCRIPTION
## :unicorn: Problème
En testant le niveau 6 on constate que la phrase en bas du certif partageable est erronée. En effet, le niveau n’est pas renseigné ni le nombre total de Pix atteignable.

## :robot: Solution
Supprimer cette phrase sur le certificat partageable.

## :100: Pour tester
Vérifier que la phrase `Votre score certifié a été calculé en fonction de vos réponses lors du passage de la certification. Il peut donc différer du nombre de Pix affiché dans votre profil. Le jour de votre certification il était possible d’atteindre le niveau 5 des compétences et 512 pix au maximum.` apparaît dans `/mes-certifications` mais qu'elle n'apparaît plus dans `/verification-certificat`. 

Elle dépend du niveau max à l'époque de la certif. Si on change la valeur  de `maxReachableLevelOnCertificationDate` dans la table `certification-courses` en base, elle change dans la phrase.
