### PR TITLE
[TECH] Réparer les seeds suite à la remodélisation des accès par MDP (PIX-1823)

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -19,12 +19,12 @@ const PIX_MASTER_ROLE_ID = 1;
 
 function _buildPixAuthenticationMethod({
   userId,
-  password = 'Password123',
+  rawPassword = 'Password123',
   shouldChangePassword,
   createdAt,
   updatedAt,
 } = {}) {
-  const hashedPassword = encrypt.hashPasswordSync(password);
+  const hashedPassword = encrypt.hashPasswordSync(rawPassword);
 
   const values = {
     userId,
@@ -81,7 +81,7 @@ const buildUser = function buildUser({
   });
 };
 
-buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
+buildUser.withRawPassword = function buildUserWithRawPassword({
   id,
   firstName = faker.name.firstName(),
   lastName = faker.name.lastName(),
@@ -97,7 +97,7 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
   createdAt = new Date(),
   updatedAt = new Date(),
 
-  password = 'Password123',
+  rawPassword = 'Password123',
   shouldChangePassword = false,
 } = {}) {
 
@@ -118,7 +118,7 @@ buildUser.withUnencryptedPassword = function buildUserWithUnencryptedPassword({
 
   _buildPixAuthenticationMethod({
     userId: user.id,
-    password,
+    rawPassword,
     shouldChangePassword,
     createdAt,
     updatedAt,
@@ -142,7 +142,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
   createdAt = new Date(),
   updatedAt = new Date(),
 
-  password = 'Password123',
+  rawPassword = 'Password123',
   shouldChangePassword = false,
 } = {}) {
 
@@ -163,7 +163,7 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
 
   _buildPixAuthenticationMethod({
     userId: user.id,
-    password,
+    rawPassword,
     shouldChangePassword,
     createdAt, updatedAt,
   });
@@ -191,7 +191,7 @@ buildUser.withMembership = function buildUserWithMemberships({
   organizationRole = Membership.roles.ADMIN,
   organizationId = null,
 
-  password = 'Password123',
+  rawPassword = 'Password123',
   shouldChangePassword = false,
 } = {}) {
 
@@ -212,7 +212,7 @@ buildUser.withMembership = function buildUserWithMemberships({
 
   _buildPixAuthenticationMethod({
     userId: user.id,
-    password,
+    rawPassword,
     shouldChangePassword,
     createdAt, updatedAt,
   });

--- a/api/db/seeds/data/certification/users.js
+++ b/api/db/seeds/data/certification/users.js
@@ -12,7 +12,7 @@ const CERTIF_REGULAR_USER5_ID = 110;
 
 function certificationUsersBuilder({ databaseBuilder }) {
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: PIX_SCO_CERTIF_USER_ID,
     firstName: 'SCO',
     lastName: 'Certification',
@@ -21,7 +21,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: PIX_PRO_CERTIF_USER_ID,
     firstName: 'PRO',
     lastName: 'Certification',
@@ -30,7 +30,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: PIX_SUP_CERTIF_USER_ID,
     firstName: 'SUP',
     lastName: 'Certification',
@@ -39,7 +39,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: PIX_NONE_CERTIF_USER_ID,
     firstName: 'NONE',
     lastName: 'Certification',
@@ -48,7 +48,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_SUCCESS_USER_ID,
     firstName: 'AnneSuccess',
     lastName: 'Certif',
@@ -57,7 +57,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_FAILURE_USER_ID,
     firstName: 'AnneFailure',
     lastName: 'Certif',
@@ -66,7 +66,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_REGULAR_USER1_ID,
     firstName: 'AnneNormale1',
     lastName: 'Certif1',
@@ -75,7 +75,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_REGULAR_USER2_ID,
     firstName: 'AnneNormale2',
     lastName: 'Certif2',
@@ -84,7 +84,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_REGULAR_USER3_ID,
     firstName: 'AnneNormale3',
     lastName: 'Certif3',
@@ -93,7 +93,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_REGULAR_USER4_ID,
     firstName: 'AnneNormale4',
     lastName: 'Certif4',
@@ -102,7 +102,7 @@ function certificationUsersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: CERTIF_REGULAR_USER5_ID,
     firstName: 'AnneNormale5',
     lastName: 'Certif5',

--- a/api/db/seeds/data/organizations-pro-builder.js
+++ b/api/db/seeds/data/organizations-pro-builder.js
@@ -5,7 +5,7 @@ module.exports = function organizationsProBuilder({ databaseBuilder }) {
   const defaultPassword = 'pix123';
 
   /* PRIVATE COMPANY */
-  const proUser1 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const proUser1 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 2,
     firstName: 'Daenerys',
     lastName: 'Targaryen',
@@ -15,7 +15,7 @@ module.exports = function organizationsProBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
   });
 
-  const proUser2 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const proUser2 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 3,
     firstName: 'Thorgo',
     lastName: 'Nudo',
@@ -49,7 +49,7 @@ module.exports = function organizationsProBuilder({ databaseBuilder }) {
     organizationRole: Membership.roles.MEMBER,
   });
 
-  const userInvited = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const userInvited = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Viserys',
     lastName: 'Targaryen',
     email: 'pro.invited@example.net',

--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -7,7 +7,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   const SCO_EXTERNAL_ID = '1237457A';
 
   /* COLLEGE */
-  const scoUser1 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const scoUser1 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 4,
     firstName: 'John',
     lastName: 'Snow',
@@ -17,7 +17,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
   });
 
-  const scoUser2 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const scoUser2 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 5,
     firstName: 'Aemon',
     lastName: 'Targaryen',
@@ -50,7 +50,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     organizationRole: Membership.roles.MEMBER,
   });
 
-  const disabledUserId = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const disabledUserId = databaseBuilder.factory.buildUser.withRawPassword({
     id: 6,
     firstName: 'Mance',
     lastName: 'Rayder',
@@ -78,7 +78,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   });
 
   // schooling registration associated with username
-  const userWithUsername = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const userWithUsername = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'George',
     lastName: 'De Cambridge',
     email: null,
@@ -98,7 +98,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   });
 
   // schooling registration associated with username and email
-  const userWithEmailAndUsername = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const userWithEmailAndUsername = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Blue Ivy',
     lastName: 'Carter',
     email: 'blueivy.carter@example.net',
@@ -118,7 +118,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   });
 
   // schooling registration associated with email
-  const userWithEmail = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const userWithEmail = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Lyanna',
     lastName: 'Mormont',
     email: 'mormont.lyanna@example.net',

--- a/api/db/seeds/data/organizations-sup-builder.js
+++ b/api/db/seeds/data/organizations-sup-builder.js
@@ -3,7 +3,7 @@ const Membership = require('../../../lib/domain/models/Membership');
 module.exports = function organizationsSupBuilder({ databaseBuilder }) {
   const defaultPassword = 'pix123';
 
-  const supUser1 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const supUser1 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 7,
     firstName: 'Tyrion',
     lastName: 'Lannister',
@@ -13,7 +13,7 @@ module.exports = function organizationsSupBuilder({ databaseBuilder }) {
     pixOrgaTermsOfServiceAccepted: true,
   });
 
-  const supUser2 = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const supUser2 = databaseBuilder.factory.buildUser.withRawPassword({
     id: 8,
     firstName: 'Jaime',
     lastName: 'Lannister',
@@ -56,7 +56,7 @@ module.exports = function organizationsSupBuilder({ databaseBuilder }) {
   });
 
   // active imported
-  const aryaStark = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const aryaStark = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Arya',
     lastName: 'Stark',
     email: 'arya.stark@example.net',
@@ -73,7 +73,7 @@ module.exports = function organizationsSupBuilder({ databaseBuilder }) {
   });
 
   // supernumerary with student number
-  const sansaStark = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const sansaStark = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Sansa',
     lastName: 'Stark',
     email: 'sansa.stark@example.net',
@@ -92,7 +92,7 @@ module.exports = function organizationsSupBuilder({ databaseBuilder }) {
   });
 
   // supernumerary without student number
-  const branStark = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const branStark = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Bran',
     lastName: 'Stark',
     email: 'bran.stark@example.net',

--- a/api/db/seeds/data/pix-aile-builder.js
+++ b/api/db/seeds/data/pix-aile-builder.js
@@ -1,6 +1,6 @@
 module.exports = function addPixAileUserAndRelations({ databaseBuilder }) {
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: 1,
     firstName: 'Pix',
     lastName: 'Aile',

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -5,7 +5,7 @@ const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationM
 
 function usersBuilder({ databaseBuilder }) {
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: PIX_MASTER_ID,
     firstName: 'Pix',
     lastName: 'Master',
@@ -14,7 +14,7 @@ function usersBuilder({ databaseBuilder }) {
     cgu: true,
   });
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: 10,
     firstName: 'Lance',
     lastName: 'Low',
@@ -32,9 +32,9 @@ function usersBuilder({ databaseBuilder }) {
     cgu: false,
     shouldChangePassword: true,
   };
-  databaseBuilder.factory.buildUser.withUnencryptedPassword(userShouldChangePassword);
+  databaseBuilder.factory.buildUser.withRawPassword(userShouldChangePassword);
 
-  const userWithSamlId = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  const userWithSamlId = databaseBuilder.factory.buildUser.withRawPassword({
     firstName: 'Margaery',
     lastName: 'Tyrell',
     email: null,
@@ -57,7 +57,7 @@ function usersBuilder({ databaseBuilder }) {
     mustValidateTermsOfService: false,
     lastTermsOfServiceValidatedAt: '2020-07-22',
   };
-  databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceValidated);
+  databaseBuilder.factory.buildUser.withRawPassword(userWithLastTermsOfServiceValidated);
 
   const userWithLastTermsOfServiceNotValidated = {
     firstName: 'lasttermsofservice',
@@ -68,9 +68,9 @@ function usersBuilder({ databaseBuilder }) {
     mustValidateTermsOfService: true,
     lastTermsOfServiceValidatedAt: null,
   };
-  databaseBuilder.factory.buildUser.withUnencryptedPassword(userWithLastTermsOfServiceNotValidated);
+  databaseBuilder.factory.buildUser.withRawPassword(userWithLastTermsOfServiceNotValidated);
 
-  databaseBuilder.factory.buildUser.withUnencryptedPassword({
+  databaseBuilder.factory.buildUser.withRawPassword({
     id: 200,
     firstName: 'Pix',
     lastName: 'Masteur',

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -23,9 +23,9 @@ describe('Acceptance | Controller | authentication-controller', () => {
   beforeEach(async () => {
     server = await createServer();
 
-    userId = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    userId = databaseBuilder.factory.buildUser.withRawPassword({
       email: userEmailAddress,
-      password: userPassword,
+      rawPassword: userPassword,
       cgu: true,
     }).id;
 
@@ -75,9 +75,9 @@ describe('Acceptance | Controller | authentication-controller', () => {
       const username = 'username123';
       const shouldChangePassword = true;
 
-      databaseBuilder.factory.buildUser.withUnencryptedPassword({
+      databaseBuilder.factory.buildUser.withRawPassword({
         username,
-        password: userPassword,
+        rawPassword: userPassword,
         cgu: true,
         shouldChangePassword,
       });
@@ -120,9 +120,9 @@ describe('Acceptance | Controller | authentication-controller', () => {
         lastName: 'jackson',
         samlId: 'SAMLJACKSONID',
       };
-      const user = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+      const user = databaseBuilder.factory.buildUser.withRawPassword({
         username: 'saml.jackson1234',
-        password: password,
+        rawPassword: password,
       });
       const expectedExternalToken = tokenService.createIdTokenForUserReconciliation(userAttributes);
 
@@ -177,15 +177,15 @@ describe('Acceptance | Controller | authentication-controller', () => {
 
       it('should return a 401 Unauthorized', async () => {
         // given
-        const password = 'Password123';
-        const user = databaseBuilder.factory.buildUser.withUnencryptedPassword({
-          password,
+        const rawPassword = 'Password123';
+        const user = databaseBuilder.factory.buildUser.withRawPassword({
+          rawPassword,
           shouldChangePassword: true,
         });
         await databaseBuilder.commit();
 
         options.payload.data.attributes.username = user.email;
-        options.payload.data.attributes.password = password;
+        options.payload.data.attributes.password = rawPassword;
 
         // when
         const response = await server.inject(options);

--- a/api/tests/acceptance/application/password-controller_test.js
+++ b/api/tests/acceptance/application/password-controller_test.js
@@ -257,9 +257,9 @@ describe('Acceptance | Controller | password-controller', () => {
     };
 
     beforeEach(async () => {
-      databaseBuilder.factory.buildUser.withUnencryptedPassword({
+      databaseBuilder.factory.buildUser.withRawPassword({
         username,
-        password: expiredPassword,
+        rawPassword: expiredPassword,
         shouldChangePassword: true,
       });
       await databaseBuilder.commit();
@@ -313,9 +313,9 @@ describe('Acceptance | Controller | password-controller', () => {
       it('should respond 403 HTTP status code', async () => {
         // given
         const username = 'jean.oubliejamais0105';
-        databaseBuilder.factory.buildUser.withUnencryptedPassword({
+        databaseBuilder.factory.buildUser.withRawPassword({
           username,
-          password: expiredPassword,
+          rawPassword: expiredPassword,
           shouldChangePassword: false,
         });
 

--- a/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-dependent-user-controller_test.js
@@ -152,7 +152,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
         type: 'SCO',
         isManagingStudents: true,
       }).id;
-      const userId = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+      const userId = databaseBuilder.factory.buildUser.withRawPassword({
         username: null,
       }).id;
       databaseBuilder.factory.buildMembership({ organizationId, userId });
@@ -274,7 +274,7 @@ describe('Acceptance | Controller | Schooling-registration-dependent-user', () =
 
     it('should return a 200 status after having successfully updated the password', async () => {
       // given
-      const userId = databaseBuilder.factory.buildUser.withUnencryptedPassword().id;
+      const userId = databaseBuilder.factory.buildUser.withRawPassword().id;
       const schoolingRegistrationId = databaseBuilder.factory.buildSchoolingRegistration({
         organizationId, userId,
       }).id;

--- a/api/tests/acceptance/application/users/users-controller-update-password_test.js
+++ b/api/tests/acceptance/application/users/users-controller-update-password_test.js
@@ -14,7 +14,7 @@ describe('Acceptance | Controller | users-controller-update-password', () => {
   beforeEach(async () => {
     server = await createServer();
 
-    user = databaseBuilder.factory.buildUser.withUnencryptedPassword({
+    user = databaseBuilder.factory.buildUser.withRawPassword({
       email: 'harry.cover@truc.so',
       rawPassword: 'Password2020',
     });


### PR DESCRIPTION
## :unicorn: Problème
Lors du merge de https://github.com/1024pix/pix/pull/2220, une coquille a été introduite concernant la mise en place de mot de passe via le builder user dans les seeds.

## :robot: Solution
Correction des builders

## :rainbow: Remarques

## :100: Pour tester
Faire un npm run db:reset en local et vérifier que la connexion aux applis fonctionne
