### PR TITLE
[BUGFIX] Renseigner la bonne traduction sur la page de présentation de la campagne (PIX-1825).

### DIFF
--- a/mon-pix/app/templates/campaigns.hbs
+++ b/mon-pix/app/templates/campaigns.hbs
@@ -1,3 +1,3 @@
-{{page-title (t 'pages.campaign.title')}}
+{{page-title (t 'pages.campaign-participation.title')}}
 
 <div>{{outlet}}</div>


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de présentation de la campagne, un message d'information s'affiche lorsqu'on survole l'onglet dans le navigateur.
Il nous indique qu'il manque une traduction "pages.campaign.title"

 
<img width="309" alt="Capture d’écran 2020-12-24 à 10 52 51" src="https://user-images.githubusercontent.com/46494361/103085364-c7625300-45e1-11eb-89a5-9b0fd7e8db80.png">


En fouillant on a trouvé que cette traduction a été récemment déplacée dans "pages.campaign-participation.title"

## :robot: Solution
Corriger la clé de traduction

## :100: Pour tester
Accéder à une campagne et vérifier que le message d'avertissement n'apparait plus
[Via ce lien par exemple](https://app-pr2318.review.pix.fr/campagnes/AZERTY123/presentation)