### PR TITLE
[FEAT] Rendre le renseignement du champ Commentaire Global vraiment facultatif dans PixCertif lors de la finalisation de session (PIX-1795)

### DIFF
--- a/certif/app/components/session-finalization-examiner-global-comment-step.hbs
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.hbs
@@ -1,17 +1,62 @@
 <div class="session-finalization-examiner-global-comment-step">
-  <div class="session-finalization-examiner-global-comment-step__header-container">
-    <label for="examiner-global-comment" class="session-finalization-examiner-global-comment-step__label">
-        Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.
-    </label>
-    <div class="session-finalization-examiner-global-comment-step__characters-information">
-      {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
+  {{#if @isReportsCategorizationFeatureToggleEnabled}}
+    <div class="session-finalization-examiner-global-comment-step__header-container">
+      <div>
+        <label for="session-finalization-examiner-global-comment-step-no-problem-encountered">
+          <input
+            type="radio"
+            id="session-finalization-examiner-global-comment-step-no-problem-encountered"
+            name="session-finalization-examiner-global-comment"
+            checked="true"
+            aria-label="Ne déclarer aucun incident"
+            {{on "change" (fn this.toggleDisplayExaminerGlobalCommentTextArea false)}}
+          >
+          Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé
+        </label>
+      </div>
+
+      <div>
+        <label for="session-finalization-examiner-global-comment-step-problem-encountered">
+          <input
+            type="radio"
+            id="session-finalization-examiner-global-comment-step-problem-encountered"
+            name="session-finalization-examiner-global-comment"
+            aria-label="Signaler un incident"
+            {{on "change" (fn this.toggleDisplayExaminerGlobalCommentTextArea true)}}
+          >
+          Je souhaite signaler un ou plusieurs incident(s) ayant impactés la session dans son ensemble
+        </label>
+      </div>
     </div>
-  </div>
-  <Textarea
-    @id="examiner-global-comment"
-    class="session-finalization-examiner-global-comment-step__textarea"
-    @value={{@session.examinerGlobalComment}}
-    {{on 'input' @updateExaminerGlobalComment}}
-    @maxlength={{@examinerGlobalCommentMaxLength}}
-  />
+    {{#if this.displayExaminerGlobalCommentTextArea}}
+      <div class="session-finalization-examiner-global-comment-step__header-container">
+        <div class="session-finalization-examiner-global-comment-step__characters-information">
+          {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
+        </div>
+      </div>
+      <Textarea
+              @id="examiner-global-comment"
+              class="session-finalization-examiner-global-comment-step__textarea"
+              @value={{@session.examinerGlobalComment}}
+        {{on 'input' @updateExaminerGlobalComment}}
+              @maxlength={{@examinerGlobalCommentMaxLength}}
+      />
+    {{/if}}
+  {{else}}
+    <div class="session-finalization-examiner-global-comment-step__header-container">
+      <label for="examiner-global-comment" class="session-finalization-examiner-global-comment-step__label">
+        Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.
+      </label>
+      <div class="session-finalization-examiner-global-comment-step__characters-information">
+        {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
+      </div>
+    </div>
+    <Textarea
+            @id="examiner-global-comment"
+            class="session-finalization-examiner-global-comment-step__textarea"
+            @value={{@session.examinerGlobalComment}}
+      {{on 'input' @updateExaminerGlobalComment}}
+            @maxlength={{@examinerGlobalCommentMaxLength}}
+    />
+  {{/if}}
 </div>

--- a/certif/app/components/session-finalization-examiner-global-comment-step.js
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.js
@@ -1,0 +1,15 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class SessionFinalizationExaminerGlobalCommentStep extends Component {
+  @tracked displayExaminerGlobalCommentTextArea = false;
+
+  @action
+  toggleDisplayExaminerGlobalCommentTextArea(shouldDisplayTextArea) {
+    if (!shouldDisplayTextArea) {
+      this.args.session.examinerGlobalComment = null;
+    }
+    this.displayExaminerGlobalCommentTextArea = shouldDisplayTextArea;
+  }
+}

--- a/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
@@ -6,6 +6,10 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+
+    input {
+      margin: 16px 0;
+    }
   }
 
   &__label {

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -38,6 +38,7 @@
           @iconAlt="">
       <SessionFinalizationExaminerGlobalCommentStep
               @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
               @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
               @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}} />
   </SessionFinalizationStepContainer>

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
@@ -1,45 +1,162 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, find } from '@ember/test-helpers';
+import { render, fillIn, find, click } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | session-finalization-examiner-global-comment-step', function(hooks) {
   setupRenderingTest(hooks);
 
-  let firstComment;
-  const updateExaminerGlobalCommentStub = sinon.stub().returns();
+  module('when feature categorizationOfReports is off', function() {
 
-  hooks.beforeEach(async function() {
-    firstComment = 'You are a wizard Harry !';
-    this.set('examinerGlobalCommentMaxLength', 500);
-    this.set('session', Object.create({ examinerGlobalComment: '' }));
-    this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+    test('it renders', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', false);
 
-    await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}} 
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
               @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
               @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
-    await fillIn('#examiner-global-comment', firstComment);
-  });
 
-  test('it renders', async function(assert) {
-    assert.dom('label').hasText(
-      'Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.',
-    );
-    assert.dom('div.session-finalization-examiner-global-comment-step__characters-information')
-      .hasText(this.session.examinerGlobalComment.length + ' / ' + this.examinerGlobalCommentMaxLength);
-    assert.equal(
-      find('textarea').value.trim(),
-      firstComment,
-    );
-  });
+      // then
+      assert.contains('Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.');
+    });
 
-  module('when changing textarea content', function() {
-    test('it calls the appropriate callback function', async function(assert) {
+    test('it should update the character count accordingly', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      const firstComment = 'You are a wizard Harry !';
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', false);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
+      await fillIn('#examiner-global-comment', firstComment);
+
+      // then
+      assert.dom('div.session-finalization-examiner-global-comment-step__characters-information')
+        .hasText(this.session.examinerGlobalComment.length + ' / ' + this.examinerGlobalCommentMaxLength);
+      assert.equal(
+        find('textarea').value.trim(),
+        firstComment,
+      );
+    });
+
+    test('it should call the appropriate callback function when typing in the text area', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', false);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
       await fillIn('#examiner-global-comment', 'You are no more a wizard Harry!');
+
+      // then
       assert.equal(updateExaminerGlobalCommentStub.called, true);
     });
   });
 
+  module('when feature categorizationOfReports is on', function() {
+
+    test('it renders the radio buttons', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
+
+      // then
+      assert.contains('Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé');
+      assert.contains('Je souhaite signaler un ou plusieurs incident(s) ayant impactés la session dans son ensemble');
+    });
+
+    test('it should display a text area to declare some incident when the appropriate choice is selected', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
+      await click('[aria-label="Signaler un incident"]');
+
+      // then
+      assert.dom('textarea').exists();
+    });
+
+    test('it should update the character count accordingly when declaring an incident', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      const firstComment = 'You are a wizard Harry !';
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
+      await click('[aria-label="Signaler un incident"]');
+      await fillIn('#examiner-global-comment', firstComment);
+
+      // then
+      assert.dom('div.session-finalization-examiner-global-comment-step__characters-information')
+        .hasText(this.session.examinerGlobalComment.length + ' / ' + this.examinerGlobalCommentMaxLength);
+      assert.equal(
+        find('textarea').value.trim(),
+        firstComment,
+      );
+    });
+
+    test('it should call the appropriate callback function when typing in the text area when declaring an incident', async function(assert) {
+      // given
+      const updateExaminerGlobalCommentStub = sinon.stub();
+      this.set('examinerGlobalCommentMaxLength', 500);
+      this.set('session', Object.create({ examinerGlobalComment: '' }));
+      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
+
+      // when
+      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
+              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
+              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
+      await click('[aria-label="Signaler un incident"]');
+      await fillIn('#examiner-global-comment', 'You are no more a wizard Harry!');
+
+      // then
+      assert.equal(updateExaminerGlobalCommentStub.called, true);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
La finalisation d'une session se fait en 3 étapes. La dernière étape est facultative et invite le référent de certification à laisser un commentaire général sur la session en cas de problème ayant affecté sensiblement celle-ci.
Malheureusement, l'intention n'a pas été très claire de notre côté, et ce commentaire est souvent rempli pour ne rien indiquer de spécial (messages type "RAS" ou "La session s'est bien déroulée"). Or, côté pôle-certif, ces sessions là remontent comme étant à problème car il existe un commentaire !

## :robot: Solution
Rendre vraiment facultatif l'ajout d'un tel commentaire via un radio button.
L'étape 3 est donc un choix :
- Tout s'est bien déroulé
- Un incident s'est produit ---> description de l'incident dans le champ prévu à cet effet

## :rainbow: Remarques

## :100: Pour tester
Soumis aux features toggles habituels
