### PR TITLE
[FEATURE] Changer le lien dans dans le bandeau d'informations Pix Certif SCO (PIX-1815)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -35,7 +35,7 @@
           <FaIcon @icon="exclamation-triangle" class="sco-temporary-banner-informations-text__triangle-icon" />
           <p>
             Il est important de vérifier que les élèves sont certifiables avant de les inscrire en session de certification. <br>
-            Vous pouvez faire une <a href="https://view.genial.ly/5f27d6e8302a810d2ff9f0f6" target="_blank" rel="noopener noreferrer">campagne de collecte de profil <FaIcon @icon="external-link-alt"/></a> pour vous en assurer.
+            Vous pouvez faire une <a href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea " target="_blank" rel="noopener noreferrer">campagne de collecte de profil <FaIcon @icon="external-link-alt"/></a> pour vous en assurer.
           </p>
         </span>
         <button type="button" class="sco-temporary-banner-button" {{on 'click' this.closeBanner}}>


### PR DESCRIPTION
## :unicorn: Problème
Un bandeau d’informations a été ajouté dans Pix certif pour les utilisateurs SCO afin de les inciter à réaliser une campagne de collecte de profil et vérifier la certificabilité des élèves avant de les convoquer à une session de certification. Ce bandeau comporte un lien vers la documentation de la création de campagne. Un nouveau document spécifique à la collecte de profil a été créé.

## :robot: Solution
Modifier le lien vers lequel pointe le texte “campagne de collecte de profil” dans le bandeau. Nouveau lien : https://view.genial.ly/5fda0b5aebe82c0d17f177ea 

