### PR TITLE
[FEATURE] Ajout des codes de signalement pour les catégories et sous-catégories (PIX-1819)

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -7,6 +7,8 @@ import {
   certificationIssueReportSubcategories,
   categoryToLabel,
   subcategoryToLabel,
+  categoryToCode,
+  subcategoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
 export class RadioButtonCategory {
@@ -16,6 +18,7 @@ export class RadioButtonCategory {
     this.name = name;
     this.isChecked = isChecked;
     this.categoryLabel = categoryToLabel[name];
+    this.categoryCode = categoryToCode[name];
   }
 
   toggle(categoryNameBeingChecked) {
@@ -54,6 +57,7 @@ export class RadioButtonCategoryWithSubcategoryWithDescription extends RadioButt
   constructor({ name, subcategory, isChecked }) {
     super({ name, isChecked });
     this.subcategory = subcategory;
+    this.subcategoryCode = subcategoryToCode[name];
   }
 
   get subcategoryLabel() {

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -6,7 +6,7 @@
             name="candidate-information-change"
             checked={{@candidateInformationChangeCategory.isChecked}}
       {{on 'click' (fn @toggleOnCategory @candidateInformationChangeCategory)}} />
-    <label for="input-radio-for-category-candidate-information-change">{{@candidateInformationChangeCategory.categoryLabel}}</label>
+    <label for="input-radio-for-category-candidate-information-change"><span>{{@candidateInformationChangeCategory.categoryCode}}&nbsp;</span>{{@candidateInformationChangeCategory.categoryLabel}}</label>
   </div>
   {{#if @candidateInformationChangeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 
-import { certificationIssueReportSubcategories, subcategoryToLabel } from 'pix-certif/models/certification-issue-report';
+import { certificationIssueReportSubcategories, subcategoryToLabel, subcategoryToCode } from 'pix-certif/models/certification-issue-report';
 
 export default class CandidateInformationChangeCertificationIssueReportFieldsComponent extends Component {
   get reportLength() {
@@ -18,11 +18,11 @@ export default class CandidateInformationChangeCertificationIssueReportFieldsCom
   options = [
     {
       value: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
-      label: subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE],
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]} ${subcategoryToLabel[certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]}`,
     },
     {
       value: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE,
-      label: subcategoryToLabel[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE],
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]} ${subcategoryToLabel[certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]}`,
     },
   ];
 }

--- a/certif/app/components/issue-report-modal/connection-or-end-screen-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/connection-or-end-screen-certification-issue-report-fields.hbs
@@ -6,6 +6,6 @@
       name="connection-or-end-screen"
       checked={{@connectionOrEndScreenCategory.isChecked}}
       {{on 'click' (fn @toggleOnCategory @connectionOrEndScreenCategory)}} />
-    <label for="input-radio-for-category-connection-or-end-screen">{{@connectionOrEndScreenCategory.categoryLabel}}</label>
+    <label for="input-radio-for-category-connection-or-end-screen"><span>{{@connectionOrEndScreenCategory.categoryCode}}&nbsp;</span>{{@connectionOrEndScreenCategory.categoryLabel}}</label>
   </div>
 </fieldset>

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -8,7 +8,7 @@
             checked={{@inChallengeCategory.isChecked}}
       {{on 'click' (fn @toggleOnCategory @inChallengeCategory)}}
     />
-    <label for="input-radio-for-category-in-challenge">{{@inChallengeCategory.categoryLabel}}</label>
+    <label for="input-radio-for-category-in-challenge"><span>{{@inChallengeCategory.categoryCode}}&nbsp;</span>{{@inChallengeCategory.categoryLabel}}</label>
   </div>
   {{#if @inChallengeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { certificationIssueReportSubcategories, subcategoryToLabel } from 'pix-certif/models/certification-issue-report';
+import { certificationIssueReportSubcategories, subcategoryToLabel, subcategoryToCode } from 'pix-certif/models/certification-issue-report';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
   get reportLength() {
@@ -24,7 +24,7 @@ export default class InChallengeCertificationIssueReportFields extends Component
     const subcategory = certificationIssueReportSubcategories[subcategoryKey];
     return {
       value: certificationIssueReportSubcategories[subcategory],
-      label: subcategoryToLabel[subcategory],
+      label: `${subcategoryToCode[subcategory]} ${subcategoryToLabel[subcategory]}`,
     };
   })
 }

--- a/certif/app/components/issue-report-modal/issue-reports-modal.hbs
+++ b/certif/app/components/issue-report-modal/issue-reports-modal.hbs
@@ -19,13 +19,13 @@
             {{#each @report.certificationIssueReports as |issueReport|}}
               <li>
                 <p class="add-issue-report-modal-content__category-label">
-                  {{issueReport.categoryLabel}}
+                  {{issueReport.categoryCode}}&nbsp;{{issueReport.categoryLabel}}
                 <button type="button" aria-label="Supprimer le signalement" class="button--showed-as-link" {{on 'click' (fn this.handleClickOnDeleteButton issueReport)}}>
                   <FaIcon @icon="trash"/>
                 </button>
                 </p>
                 {{#if issueReport.subcategoryLabel}}
-                <p class="add-issue-report-modal-content__subcategory-label">{{issueReport.subcategoryLabel}}</p>
+                <p class="add-issue-report-modal-content__subcategory-label">{{issueReport.subcategoryCode}}&nbsp;{{issueReport.subcategoryLabel}}</p>
                 {{/if}}
               </li>
             {{/each}}

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
@@ -6,7 +6,7 @@
       name="late-or-leaving"
       checked={{@lateOrLeavingCategory.isChecked}}
       {{on 'click' (fn @toggleOnCategory @lateOrLeavingCategory)}} />
-    <label for="input-radio-for-category-late-or-leaving">{{@lateOrLeavingCategory.categoryLabel}}</label>
+    <label for="input-radio-for-category-late-or-leaving"><span>{{@lateOrLeavingCategory.categoryCode}}&nbsp;</span>{{@lateOrLeavingCategory.categoryLabel}}</label>
   </div>
   {{#if @lateOrLeavingCategory.isChecked}}
     <div class="late-or-leaving-certification-issue-report-fields__details">

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { certificationIssueReportSubcategories, subcategoryToLabel } from 'pix-certif/models/certification-issue-report';
+import { certificationIssueReportSubcategories, subcategoryToCode, subcategoryToLabel } from 'pix-certif/models/certification-issue-report';
 
 export default class OtherCertificationissueReportFields extends Component {
   get reportLength() {
@@ -17,11 +17,11 @@ export default class OtherCertificationissueReportFields extends Component {
   options = [
     {
       value: certificationIssueReportSubcategories.LEFT_EXAM_ROOM,
-      label: subcategoryToLabel[certificationIssueReportSubcategories.LEFT_EXAM_ROOM],
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.LEFT_EXAM_ROOM]} ${subcategoryToLabel[certificationIssueReportSubcategories.LEFT_EXAM_ROOM]}`,
     },
     {
       value: certificationIssueReportSubcategories.SIGNATURE_ISSUE,
-      label: subcategoryToLabel[certificationIssueReportSubcategories.SIGNATURE_ISSUE],
+      label: `${subcategoryToCode[certificationIssueReportSubcategories.SIGNATURE_ISSUE]} ${subcategoryToLabel[certificationIssueReportSubcategories.SIGNATURE_ISSUE]}`,
     },
   ];
 }

--- a/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
@@ -6,7 +6,7 @@
       name="other"
       checked={{@otherCategory.isChecked}}
       {{on 'click' (fn @toggleOnCategory @otherCategory)}} />
-    <label for="input-radio-for-category-other">{{@otherCategory.categoryLabel}}</label>
+    <label for="input-radio-for-category-other"><span>{{@otherCategory.categoryCode}}&nbsp;</span>{{@otherCategory.categoryLabel}}</label>
   </div>
   {{#if @otherCategory.isChecked}}
     <div class="other-certification-issue-report-fields__details">

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -44,6 +44,28 @@ export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.OTHER]: 'Autre',
 };
 
+export const categoryToCode = {
+  [certificationIssueReportCategories.OTHER]: 'A2',
+  [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'C1-C2',
+  [certificationIssueReportCategories.LATE_OR_LEAVING]: 'C3-C4',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
+  [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
+};
+
+export const subcategoryToCode = {
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'C1',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'C2',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'C4',
+  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E2',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E3',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E4',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
+  [certificationIssueReportSubcategories.OTHER]: 'E7',
+};
+
 export default class CertificationIssueReport extends Model {
   @attr('string') category;
   @attr('string') subcategory;
@@ -58,5 +80,13 @@ export default class CertificationIssueReport extends Model {
 
   get subcategoryLabel() {
     return this.subcategory ? subcategoryToLabel[this.subcategory] : '';
+  }
+
+  get categoryCode() {
+    return categoryToCode[this.category];
+  }
+
+  get subcategoryCode() {
+    return subcategoryToCode[this.subcategory];
   }
 }

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -33,7 +33,7 @@ export const categoryToLabel = {
 export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Prénom/Nom/Date de naissance',
   [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Temps majoré',
-  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'A quitté la salle d\'examen, sans l\'accord du surveillant',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu (précisez ici pourquoi)',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Etait présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'L\'image ne s\'affiche pas',
   [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -119,11 +119,20 @@
         min-width: 0;
         margin-bottom: 22px;
 
+        label[for^="input-radio-for-category"] {
+          span {
+            font-weight: bold;
+          }
+        }
+
         input[id|="input-radio-for-category"] {
           background-color: $communication-light;
           transform: scale(1.2);
           margin: 0;
           cursor: pointer;
+          span {
+            font-weight: bold;
+          }
         }
 
         input[id|="input-for-category-in-challenge-question-number"] {

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal-test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal-test.js
@@ -7,6 +7,7 @@ import EmberObject from '@ember/object';
 import {
   certificationIssueReportCategories,
   categoryToLabel,
+  categoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
 module('Integration | Component | add-issue-report-modal', function(hooks) {
@@ -39,7 +40,7 @@ module('Integration | Component | add-issue-report-modal', function(hooks) {
     assert.contains('Lisa Monpud');
   });
 
-  test('it should show all categories label', async function(assert) {
+  test('it should show all categories code & label', async function(assert) {
     // given
     const report = EmberObject.create({
       certificationCourseId: 1,
@@ -63,7 +64,7 @@ module('Integration | Component | add-issue-report-modal', function(hooks) {
 
     // then
     for (const category of Object.values(certificationIssueReportCategories)) {
-      assert.contains(categoryToLabel[category]);
+      assert.contains(`${categoryToCode[category]}\u00a0${categoryToLabel[category]}`);
     }
   });
 

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
@@ -8,6 +8,7 @@ import {
   categoryToLabel,
   certificationIssueReportSubcategories,
   subcategoryToLabel,
+  subcategoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 import { RadioButtonCategoryWithSubcategoryWithDescriptionAndQuestionNumber } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 
@@ -35,7 +36,7 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     assert.ok(toggleOnCategory.calledOnceWith(inChallengeCategory));
   });
 
-  test('it should show dropdown menu with subcategories when category is checked', async function(assert) {
+  test('it should show dropdown menu with code & subcategories when category is checked', async function(assert) {
     // given
     const toggleOnCategory = sinon.stub();
     const inChallengeCategory = new RadioButtonCategoryWithSubcategoryWithDescriptionAndQuestionNumber({ name: 'IN_CHALLENGE', isChecked: true });
@@ -52,13 +53,13 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     await click('[aria-label="Sélectionner la sous-catégorie"]');
 
     // then
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.LINK_NOT_WORKING]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.EMBED_NOT_WORKING]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED]);
-    assert.contains(subcategoryToLabel[certificationIssueReportSubcategories.OTHER]);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]} ${subcategoryToLabel[certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.LINK_NOT_WORKING]} ${subcategoryToLabel[certificationIssueReportSubcategories.LINK_NOT_WORKING]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.EMBED_NOT_WORKING]} ${subcategoryToLabel[certificationIssueReportSubcategories.EMBED_NOT_WORKING]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.FILE_NOT_OPENING]} ${subcategoryToLabel[certificationIssueReportSubcategories.FILE_NOT_OPENING]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]} ${subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.WEBSITE_BLOCKED]} ${subcategoryToLabel[certificationIssueReportSubcategories.WEBSITE_BLOCKED]}`);
+    assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.OTHER]} ${subcategoryToLabel[certificationIssueReportSubcategories.OTHER]}`);
   });
 
   test('it should show a textarea with characters length when selecting subcategory OTHER', async function(assert) {

--- a/certif/tests/unit/models/certification-issue-report-test.js
+++ b/certif/tests/unit/models/certification-issue-report-test.js
@@ -8,6 +8,8 @@ import {
   certificationIssueReportSubcategories,
   categoryToLabel,
   subcategoryToLabel,
+  categoryToCode,
+  subcategoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
 module('Unit | Model | certification issue report', function(hooks) {
@@ -38,6 +40,34 @@ module('Unit | Model | certification issue report', function(hooks) {
     // when / then
     for (const model of models) {
       assert.equal(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
+    }
+  });
+
+  test('it should return the right code for the category', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportCategories, (category) => {
+      return run(() => store.createRecord('certification-issue-report', { category }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.categoryCode, categoryToCode[model.category]);
+    }
+  });
+
+  test('it should return the right code for the subcategory', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportSubcategories, (subcategory) => {
+      return run(() => store.createRecord('certification-issue-report', { subcategory }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.subcategoryCode, subcategoryToCode[model.subcategory]);
     }
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Afin de permettre à la fois d’avoir accès aux différentes catégories/sous-catégories et de pouvoir renseigner un ou plusieurs signalements pour plusieurs candidats à la fois sur un même PV d’incident, nous avons mis en place un fonctionnement par code de signalement. Il faut donc permettre au référent de retrouver ces codes de signalement lors de la finalisation de session pour lui faciliter le report.

## :robot: Solution
Afficher les codes de signalements pour chaque catégorie et sous-catégorie sur la page de finalisation de session : 

![image](https://user-images.githubusercontent.com/37305474/103225516-56e16c00-492a-11eb-99f1-89534a31175d.png)

![image](https://user-images.githubusercontent.com/37305474/103225557-724c7700-492a-11eb-9640-19cc753ba79b.png)



## :100: Pour tester
- Mettre le toggle FT_REPORTS_CATEGORISATION=true côté api
- Se connecter à px-certif 
- Finaliser une session en ajoutant des signalements
- Constater que les codes de catégories et sous catégories sont bien affichés 