### PR TITLE
[BUGFIX] Le bouton de téléchargement de la feuille d'émargement ne s'affiche pas pour les centres de certification SCO dans le cadre de la prescription de certif SCO (PIX-1831)

### DIFF
--- a/certif/app/components/session-finalization-examiner-global-comment-step.hbs
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.hbs
@@ -24,7 +24,7 @@
             aria-label="Signaler un incident"
             {{on "change" (fn this.toggleDisplayExaminerGlobalCommentTextArea true)}}
           >
-          Je souhaite signaler un ou plusieurs incident(s) ayant impactés la session dans son ensemble
+          Je souhaite signaler un ou plusieurs incident(s) ayant impacté la session dans son ensemble
         </label>
       </div>
     </div>

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -9,8 +9,7 @@ export default class SessionsDetailsController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
-  @alias('model.isCertifPrescriptionScoEnabled') isCertifPrescriptionScoEnabled;
-  @alias('model.isUserFromSco') isUserFromSco;
+  @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
   @computed('certificationCandidates.length')
   get certificationCandidatesCount() {
@@ -24,8 +23,8 @@ export default class SessionsDetailsController extends Controller {
     return certificationCandidatesCount > 0;
   }
 
-  @computed('hasOneOrMoreCandidates', 'isCertifPrescriptionScoEnabled', 'isResultRecipientEmailVisible', 'isUserFromSco')
+  @computed('hasOneOrMoreCandidates', 'shouldDisplayPrescriptionScoStudentRegistrationFeature', 'isResultRecipientEmailVisible')
   get shouldDisplayDownloadButton() {
-    return this.hasOneOrMoreCandidates && ((this.isUserFromSco && this.isCertifPrescriptionScoEnabled) || this.isResultRecipientEmailVisible);
+    return this.hasOneOrMoreCandidates && (this.shouldDisplayPrescriptionScoStudentRegistrationFeature || this.isResultRecipientEmailVisible);
   }
 }

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
@@ -91,7 +91,7 @@ module('Integration | Component | session-finalization-examiner-global-comment-s
 
       // then
       assert.contains('Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé');
-      assert.contains('Je souhaite signaler un ou plusieurs incident(s) ayant impactés la session dans son ensemble');
+      assert.contains('Je souhaite signaler un ou plusieurs incident(s) ayant impacté la session dans son ensemble');
     });
 
     test('it should display a text area to declare some incident when the appropriate choice is selected', async function(assert) {

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -62,67 +62,40 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
 
     module('when there is at least one enrolled candidate', function() {
 
-      module('when the toggle CertifPrescriptionSco is enabled', function() {
+      module('when it should display the CertifPrescriptionScoFeature', function() {
 
-        module('when the user is of type SCO', function() {
+        test('should return true ', function(assert) {
+          // given
+          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+          controller.model = {
+            certificationCandidates: ['candidate1', 'candidate2'],
+            shouldDisplayPrescriptionScoStudentRegistrationFeature: true,
+          };
 
-          test('should return true', function(assert) {
-            // given
-            const controller = this.owner.lookup('controller:authenticated/sessions/details');
-            controller.model = {
-              certificationCandidates: ['candidate1', 'candidate2'],
-              isUserFromSco: true,
-              isCertifPrescriptionScoEnabled: true,
-            };
+          // when
+          const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
 
-            // when
-            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
-
-            // then
-            assert.ok(shouldDisplayDownloadButton);
-          });
-        });
-
-        module('when user is not from sco', function() {
-
-          test('should return false', function(assert) {
-            // given
-            const controller = this.owner.lookup('controller:authenticated/sessions/details');
-            controller.model = {
-              certificationCandidates: ['candidate1', 'candidate2'],
-              isUserFromSco: false,
-              isCertifPrescriptionScoEnabled: true,
-            };
-
-            // when
-            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
-
-            // then
-            assert.notOk(shouldDisplayDownloadButton);
-          });
+          // then
+          assert.ok(shouldDisplayDownloadButton);
         });
 
       });
 
-      module('when the toggle CertifPrescriptionSco is not enabled', function() {
+      module('when it should not display the CertifPrescriptionScoFeature', function() {
 
-        module('when user is from sco', function() {
+        test('should return false ', function(assert) {
+          // given
+          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+          controller.model = {
+            certificationCandidates: ['candidate1', 'candidate2'],
+            shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
+          };
 
-          test('should return false ', function(assert) {
-            // given
-            const controller = this.owner.lookup('controller:authenticated/sessions/details');
-            controller.model = {
-              certificationCandidates: ['candidate1', 'candidate2'],
-              isUserFromSco: true,
-              isCertifPrescriptionScoEnabled: false,
-            };
+          // when
+          const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
 
-            // when
-            const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
-
-            // then
-            assert.notOk(shouldDisplayDownloadButton);
-          });
+          // then
+          assert.notOk(shouldDisplayDownloadButton);
         });
       });
 
@@ -133,8 +106,7 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
           const controller = this.owner.lookup('controller:authenticated/sessions/details');
           controller.model = {
             certificationCandidates: ['candidate1', 'candidate2'],
-            isUserFromSco: false,
-            isCertifPrescriptionScoEnabled: false,
+            shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
           };
 
           // when


### PR DESCRIPTION
## :unicorn: Problème
Le bouton pour télécharger la feuille d'émargement doit apparaitre à côté du numéro de la session dans le cadre d'un centre de certif répondant aux critères d'activation de la feature de prescription de certification SCO.
Il ne s'affiche malheureusement pas 😢 

## :robot: Solution
J'ai mal pris en compte le merge d'une PR un peu plus tôt. Du coup, le check conditionnel qui régit l'affichage du bouton retournait toujours faux, car je lisais des valeurs non définies.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Activer la toggle de prescrition de certif SCO
Se connecter avec certifsco@example.net
Aller sur une session de certif et y inscrire des candidats si ce n'est pas déjà fait.
Constater l'apparition du bouton Télécharger la feuille d'émargement en haut à côté du numéro de session.
