### PR TITLE
[FEATURE] Modifier le wording de l'étape 2 de la finalisation de session (PIX-1794)

### DIFF
--- a/certif/app/components/session-finalization-formbuilder-link-step.hbs
+++ b/certif/app/components/session-finalization-formbuilder-link-step.hbs
@@ -1,10 +1,15 @@
 <div class="session-finalization-formbuilder-link-step">
   <div class="session-finalization-formbuilder-link-step__text">
-    Pour transmettre le PV de session scanné, suivez ce lien
+    <span>
+      {{this.text}}
+    </span>
+      <a href={{this.linkTo}} target="_blank" rel="noopener noreferrer">
+        <FaIcon @icon='arrow-right' /> Formulaire 123formbuilder
+      </a>
   </div>
-  <div class="session-finalization-formbuilder-link-step__link">
-    <a href={{this.formBuilderLinkUrl}} target="_blank" rel="noopener noreferrer" >
-      <FaIcon @icon='arrow-right' /> Formulaire 123formbuilder
-    </a>
-  </div>
+  {{#if this.subText.length}}
+    <p class="session-finalization-formbuilder-link-step__sub-text">
+      {{this.subText}}
+    </p>
+  {{/if}}
 </div>

--- a/certif/app/components/session-finalization-formbuilder-link-step.js
+++ b/certif/app/components/session-finalization-formbuilder-link-step.js
@@ -2,5 +2,24 @@ import Component from '@glimmer/component';
 import config from '../config/environment';
 
 export default class SessionFinalizationFormBuilderLinkStep extends Component {
-  formBuilderLinkUrl = config.formBuilderLinkUrl;
+  formBuilderLinkUrlNoReportsCategorisation = config.formBuilderLinkUrlNoReportsCategorisation;
+  formBuilderLinkUrlReportsCategorisation = config.formBuilderLinkUrlReportsCategorisation;
+
+  get text() {
+    return this.args.isReportsCategorizationFeatureToggleEnabled ?
+      'Cette étape, facultative, vous permet de nous transmettre tout document que vous jugerez utile de nous communiquer pour le traitement des sessions (capture d\'écran d\'un problème technique, PV de fraude...). Pour cela, suivez ce lien' :
+      'Pour transmettre le PV de session scanné, suivez ce lien';
+  }
+
+  get subText() {
+    return this.args.isReportsCategorizationFeatureToggleEnabled ?
+      'Il n\'est plus obligatoire de nous transmettre la feuille d\'émargement et le PV d\'incident scannés. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à Pix en cas de besoin.' :
+      '';
+  }
+
+  get linkTo() {
+    return this.args.isReportsCategorizationFeatureToggleEnabled ?
+      this.formBuilderLinkUrlReportsCategorisation :
+      this.formBuilderLinkUrlNoReportsCategorisation;
+  }
 }

--- a/certif/app/controllers/authenticated/sessions/finalize.js
+++ b/certif/app/controllers/authenticated/sessions/finalize.js
@@ -33,6 +33,10 @@ export default class SessionsFinalizeController extends Controller {
     return this.uncheckedHasSeenEndTestScreenCount > 0;
   }
 
+  get stepTwoTitle() {
+    return this.isReportsCategorizationFeatureToggleEnabled ? 'Transmettre des documents (facultatif)' : 'Transmettre le PV de session scanné et autres documents éventuels' ;
+  }
+
   showErrorNotification(message) {
     this.notifications.error(message);
   }

--- a/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
+++ b/certif/app/styles/components/session-finalization-formbuilder-link-step.scss
@@ -5,10 +5,12 @@
 
   &__text {
     display: inline-block;
-    margin-right: 16px;
+    span {
+      margin-right: 16px;
+    }
   }
 
-  &__link {
-    display: inline-block;
+  &__sub-text {
+    font-weight: bold;
   }
 }

--- a/certif/app/templates/authenticated/sessions/finalize.hbs
+++ b/certif/app/templates/authenticated/sessions/finalize.hbs
@@ -25,10 +25,12 @@
 
   <SessionFinalizationStepContainer
           @number="2"
-          @title="Transmettre le PV de session scanné et autres documents éventuels"
+          @title={{this.stepTwoTitle}}
           @icon="/icons/session-finalization-send.svg"
           @iconAlt="">
-      <SessionFinalizationFormbuilderLinkStep/>
+      <SessionFinalizationFormbuilderLinkStep
+        @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+      />
   </SessionFinalizationStepContainer>
 
   <SessionFinalizationStepContainer

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -78,7 +78,8 @@ module.exports = function(environment) {
 
     matomo: {},
 
-    formBuilderLinkUrl: 'https://eu.123formbuilder.com/form-29080/certification-depot-du-pv-de-session-scanne',
+    formBuilderLinkUrlReportsCategorisation: 'https://form-eu.123formbuilder.com/41052/form',
+    formBuilderLinkUrlNoReportsCategorisation: 'https://eu.123formbuilder.com/form-29080/certification-depot-du-pv-de-session-scanne',
   };
 
   if (environment === 'development') {

--- a/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
+++ b/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
@@ -3,12 +3,44 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+import config from 'pix-certif/config/environment';
+
 module('Integration | Component | session-finalization-formbuilder-link-step', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
-    await render(hbs`<SessionFinalizationFormbuilderLinkStep />`);
+  module('When FT_REPORTS_CATEGORISATION is true', function() {
+    test('it renders', async function(assert) {
+      // given
+      const formBuilderLinkUrlReportsCategorisation = config.formBuilderLinkUrlReportsCategorisation;
+      this.set('isReportsCategorizationFeatureToggleEnabled', true);
 
-    assert.equal(this.element.textContent.trim().replace(/\s+/g, ' '), 'Pour transmettre le PV de session scanné, suivez ce lien Formulaire 123formbuilder');
+      // when
+      await render(hbs`<SessionFinalizationFormbuilderLinkStep 
+      @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+      />`);
+
+      // then
+      assert.contains('Cette étape, facultative, vous permet de nous transmettre tout document que vous jugerez utile de nous communiquer pour le traitement des sessions (capture d\'écran d\'un problème technique, PV de fraude...). Pour cela, suivez ce lien');
+      assert.contains('Il n\'est plus obligatoire de nous transmettre la feuille d\'émargement et le PV d\'incident scannés. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à Pix en cas de besoin.');
+      assert.equal(this.element.querySelector('a').getAttribute('href'), formBuilderLinkUrlReportsCategorisation);
+    });
+  });
+
+  module('When FT_REPORTS_CATEGORISATION is false', function() {
+    test('it renders ', async function(assert) {
+      // given
+      this.set('isReportsCategorizationFeatureToggleEnabled', false);
+      const formBuilderLinkUrlNoReportsCategorisation = config.formBuilderLinkUrlNoReportsCategorisation;
+
+      // when
+      await render(hbs`<SessionFinalizationFormbuilderLinkStep 
+      @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
+      />`);
+
+      // then
+      assert.contains('Pour transmettre le PV de session scanné, suivez ce lien');
+      assert.contains('');
+      assert.equal(this.element.querySelector('a').getAttribute('href'), formBuilderLinkUrlNoReportsCategorisation);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Il a été décidé qu’il n’est plus nécessaire pour les centres de certification de scanner et envoyer le PV de session. Néanmoins, d’autres documents peuvent toujours être partagés avec le pôle certif (PV de fraude, photos…).

## :robot: Solution
Modifier le wording de l'étape 2 de la finalisation de session dans Pix Certif : 

titre de la section : “Etape 2 : Transmettre des documents (facultatif)”

texte : Cette étape, facultative, vous permet de nous transmettre tout document que vous jugerez utile de nous communiquer pour le traitement des sessions (capture d'écran d'un problème technique, PV de fraude...). Pour cela, suivez ce lien → Formulaire 123formbuilder (lien à changer, à fournir par le pôle certif).

Il n'est plus obligatoire de nous transmettre la feuille d'émargement et le PV scanné. En revanche, ces deux documents doivent être conservés par votre établissement pendant une durée de 2 ans et pouvoir être fournis à Pix en cas de besoin.

## :rainbow: Remarques


## :100: Pour tester

TEST 1
- Se connecter à pix certif
- Finaliser une session de certification
- Constater le wording suivant pour l'étape 2:

![image](https://user-images.githubusercontent.com/37305474/103236671-be58e500-4945-11eb-8f93-e4a2311cb33b.png)

- Constater que le lien renvoi vers ce formulaire:

![image](https://user-images.githubusercontent.com/37305474/103236898-653d8100-4946-11eb-91f5-4674b50760c9.png)


TEST 2
- Activer  FT_REPORTS_CATEGORISATION=true côté api
- Finaliser une session de certification
- Constater le wording suivant pour l'étape 2:

![image](https://user-images.githubusercontent.com/37305474/103236763-00822680-4946-11eb-8577-66eafd781b6e.png)

- Constater que le lien renvoi vers ce formulaire: 

![image](https://user-images.githubusercontent.com/37305474/103236876-4f2fc080-4946-11eb-95ba-c09fe4a946e9.png)


