### PR TITLE
[BUGFIX] Le mauvais résultat de fin de compétence s'affiche lorsqu'on termine une évaluation de compétence sur PixApp (PIX-1835)

### DIFF
--- a/mon-pix/app/routes/competences/results.js
+++ b/mon-pix/app/routes/competences/results.js
@@ -7,8 +7,11 @@ import Route from '@ember/routing/route';
 export default class ResultsRoute extends Route.extend(SecuredRouteMixin) {
   async model(params) {
     const assessmentId = params.assessment_id;
-    const competenceEvaluations = await this.store.findAll('competenceEvaluation', { adapterOptions: { assessmentId } });
-    return competenceEvaluations.firstObject;
+    const competenceEvaluations = await this.store.findAll('competenceEvaluation', { reload: true, adapterOptions: { assessmentId } });
+    return competenceEvaluations
+      .sortBy('createdAt')
+      .reverse()
+      .find((competenceEvaluation) => competenceEvaluation.assessment.get('id') === assessmentId);
   }
 
   afterModel(competenceEvaluation) {

--- a/mon-pix/tests/acceptance/competences-results-test.js
+++ b/mon-pix/tests/acceptance/competences-results-test.js
@@ -27,11 +27,32 @@ describe('Acceptance | competences results', function() {
         state: 'completed',
       });
 
+      // Older competence-evaluation
+      const area = this.server.schema.areas.find(3);
+      const olderCompetenceScoreCard = this.server.create('scorecard', {
+        id: '1_9',
+        index: 5.1,
+        type: 'COMPETENCE_EVALUATION',
+        state: 'completed',
+        area,
+        earnedPix: 17,
+        level: 2,
+      });
+      const olderCompetence = this.server.create('competence-evaluation', {
+        id: 2,
+        assessmentId: assessmentId,
+        competenceId: 9,
+        userId: user.id,
+        createdAt: new Date('2020-01-01'),
+      });
+      olderCompetence.update({ scorecard: olderCompetenceScoreCard });
+
       this.server.create('competence-evaluation', {
         id: 1,
         assessmentId: assessmentId,
         competenceId: competenceId,
         userId: user.id,
+        createdAt: new Date('2020-02-01'),
       });
     });
 

--- a/mon-pix/tests/unit/routes/competences/results-test.js
+++ b/mon-pix/tests/unit/routes/competences/results-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
+import { A } from '@ember/array';
 
 describe('Unit | Route | Competences | Results', function() {
 
@@ -32,12 +33,16 @@ describe('Unit | Route | Competences | Results', function() {
       route.transitionTo = sinon.stub();
     });
 
-    it('should return the first competence-evaluation for a given assessment', async function() {
+    it('should return the most recent competence-evaluation for a given assessment', async function() {
       // Given
-      const expectedCompetenceEvaluation = { id: 1 };
+      const competenceEvaluationsInStore = A([
+        { id: 1, createdAt: new Date('2020-01-01'), assessment: { get: () => assessmentId } },
+        { id: 2, createdAt: new Date('2020-02-01'), assessment: { get: () => assessmentId } },
+        { id: 3, createdAt: new Date('2020-03-01'), assessment: { get: () => 456 } },
+      ]);
       findAllStub
-        .withArgs('competenceEvaluation', { adapterOptions: { assessmentId } })
-        .resolves({ firstObject: expectedCompetenceEvaluation });
+        .withArgs('competenceEvaluation', { reload: true, adapterOptions: { assessmentId } })
+        .resolves(competenceEvaluationsInStore);
 
       // When
       const model = await route.model({
@@ -45,7 +50,7 @@ describe('Unit | Route | Competences | Results', function() {
       });
 
       // Then
-      expect(model.id).to.equal(1);
+      expect(model.id).to.equal(2);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Reproduire : Commencer une compétence de zéro au choix, gagner un niveau. Quitter, puis commencer une autre compétence de zéro, et tout passer. A la page de résultats, on devrait être niveau 0. On verra en fait le résultat de la compétence précédente à savoir niveau 1.

## :robot: Solution
Introduit par : https://github.com/1024pix/pix/pull/2282
Il y avait deux bugs liés :
1. La méthode `findAll` retourne l'ensemble des modèles contenus dans le store pour un `modelName` donné (en l'occurrence `'competence-evaluations'`). Donc si durant l'usage de PixApp on a parcouru plusieurs compétences, `findAll` retournera toujours l'ensemble des `competence-evaluations` contenus dans le store, et pas seulement ceux renvoyés par la requête. En fait, la requête permet de "mettre à jour" le contenu du store. Dans notre cas de reproduction de bug, on a dans le store la `competence-evaluation` de la première competence, mais aussi la deuxième. Et donc, vu qu'on faisait un `firstObject` sur la collection retournée par `findAll`, on retombe toujours sur la première compétence passée :/.
2. La méthode `findAll`, par défaut, ne relance pas de requête vers l'API. Elle se contente de retourner l'existant du store. Il faut donc forcer le reload via un `{ reload: true }` en options de la méthode 

On doit donc en fait faire :
```js
  async model(params) {
    const assessmentId = params.assessment_id;
    const competenceEvaluations = await this.store.findAll('competenceEvaluation', { reload: true, adapterOptions: { assessmentId } });
    return competenceEvaluations
      .sortBy('createdAt')
      .reverse()
      .find((competenceEvaluation) => competenceEvaluation.assessment.get('id') === assessmentId);
  }
```
On s'assurer de bien récupérer le plus récent pour un assessment dans le cas où un utilisateur retente (sans avoir entre temps recharger la page / vider le store 🤷🏿‍♂️ )

## :rainbow: Remarques
Je me demande si la route ne devrait pas changer pour ne retourner qu'une seule competence-evaluation (la plus récente), positionner la competence-evaluation en relationship de l'assessment et ainsi côté front on pourrait faire :
```js
  async model(params) {
    const assessmentId = params.assessment_id;
    const assessment = await this.store.findRecord('assessment', assessmentId);
    await assessment.belongsTo('competenceEvaluation').reload();
    return assessment.competenceEvaluation;
  }
```

## :100: Pour tester
Tenter de reproduire le bug et ne pas y arriver
