### PR TITLE
[FEATURE] Traduction du nom de la compétence sur la notification d'augmentation de niveau (PIX-1784)

### DIFF
--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -5,10 +5,9 @@ import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 
 export default class ChallengeController extends Controller {
-  queryParams = ['newLevel', 'competenceLeveled'];
+  queryParams = ['newLevel'];
   @service intl;
   @tracked newLevel = null;
-  @tracked competenceLeveled = null;
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -4,13 +4,12 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class CheckpointController extends Controller {
-  queryParams = ['finalCheckpoint', 'newLevel', 'competenceLeveled'];
+  queryParams = ['finalCheckpoint', 'newLevel'];
 
   @service intl;
 
   @tracked answer = null;
   @tracked challenge = null;
-  @tracked competenceLeveled = null;
   @tracked finalCheckpoint = false;
   @tracked isShowingModal = false;
   @tracked newLevel = null;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -25,5 +25,5 @@
 </div>
 
 {{#if this.showLevelup}}
-  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{@model.assessment.title}} />
 {{/if}}

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -59,5 +59,5 @@
 </div>
 
 {{#if this.showLevelup}}
-  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{@model.title}} />
 {{/if}}

--- a/mon-pix/tests/integration/components/levelup-notif-test.js
+++ b/mon-pix/tests/integration/components/levelup-notif-test.js
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | levelup-notif', function() {
+  setupIntlRenderingTest();
+
+  it('renders', async function() {
+    //when
+    await render(hbs`<LevelupNotif />`);
+    //then
+    expect(find('.levelup__competence')).to.exist;
+  });
+
+  it('displays the new reached level and associated competence name', async function() {
+    // given
+    this.set('newLevel', 2);
+    this.set('model', {
+      title: 'Mener une recherche et une veille d\'information',
+    });
+    // when
+    await render(hbs`<LevelupNotif @level={{this.newLevel}} @competenceName={{model.title}}/>`);
+    // then
+    expect(find('.levelup-competence__level').innerHTML).to.equal(this.intl.t('pages.levelup-notif.obtained-level', { level: this.newLevel }));
+    expect(find('.levelup-competence__name').innerHTML).to.equal('Mener une recherche et une veille d\'information');
+  });
+});
+


### PR DESCRIPTION
## :unicorn: Problème

Le nom de la compétence n'est pas traduit sur la notification d'augmentation de niveau.

## :robot: Solution

Passage des arguments nécessaires au composant `LevelUpNotif` sur les deux appels au sein de l'application:

 - `Challenge.hbs`
 - `Checkpoint.hbs`
 
<img width="1234" alt="Capture d’écran 2020-12-29 à 16 18 01" src="https://user-images.githubusercontent.com/36371437/103294617-7cd24380-49f2-11eb-9191-a1865c358ff7.png">

## :rainbow: Remarques

Cette solution a été choisie car il semble que le nom de la compétence soit autrement tiré des query parameters de l'URL et semble donc plus difficile à traduire à l'aide d'Ember-Intl.

## :100: Pour tester

Sur l'application (en anglais --> ?lang=en), choisir une compétence et gagner un niveau afin de visualiser la vignette de notification.
