### PR TITLE
[BUGFIX] Traduire le texte affiché lorsque l’utilisateur n’a pas répondu. (PIX-1830).

### DIFF
--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -1,10 +1,5 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { computed } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 const classByResultValue = {
   ok: 'correction-qroc-box-answer--correct',
@@ -12,33 +7,27 @@ const classByResultValue = {
   aband: 'correction-qroc-box-answer--aband',
 };
 
-@classic
 export default class QrocSolutionPanel extends Component {
-  answer = null;
-  solution = null;
+  @service intl;
 
-  @computed('answer.result')
   get inputClass() {
-    return classByResultValue[this.answer.result] || '';
+    return classByResultValue[this.args.answer.result] || '';
   }
 
-  @computed('answer')
   get isResultOk() {
-    return this.answer.result === 'ok';
+    return this.args.answer.result === 'ok';
   }
 
-  @computed('answer')
   get answerToDisplay() {
-    const answer = this.answer.value;
+    const answer = this.args.answer.value;
     if (answer === '#ABAND#') {
       return 'Pas de réponse';
     }
     return answer;
   }
 
-  @computed('solution')
   get solutionToDisplay() {
-    const solutionVariants = this.solution;
+    const solutionVariants = this.args.solution;
     if (!solutionVariants) {
       return '';
     }

--- a/mon-pix/app/components/qroc-solution-panel.js
+++ b/mon-pix/app/components/qroc-solution-panel.js
@@ -21,7 +21,7 @@ export default class QrocSolutionPanel extends Component {
   get answerToDisplay() {
     const answer = this.args.answer.value;
     if (answer === '#ABAND#') {
-      return 'Pas de réponse';
+      return this.intl.t('pages.result-item.aband');
     }
     return answer;
   }

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -1,10 +1,4 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { computed } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
@@ -18,13 +12,11 @@ const classByResultValue = {
   aband: 'correction-qroc-box-answer--aband',
 };
 
-@classic
 export default class QrocmDepSolutionPanel extends Component {
-  @computed('challenge.proposals', 'answer.value')
   get inputFields() {
-    const escapedProposals = this.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
+    const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.answer.value, keys(labels));
+    const answers = answersAsObject(this.args.answer.value, keys(labels));
 
     return Object.keys(labels).map((key) => {
       const answerIsEmpty = answers[key] === '';
@@ -37,20 +29,17 @@ export default class QrocmDepSolutionPanel extends Component {
     });
   }
 
-  @computed('answer.result')
   get answerIsCorrect() {
-    return this.answer.result === 'ok';
+    return this.args.answer.result === 'ok';
   }
 
-  @computed('answer.result')
   get inputClass() {
-    return classByResultValue[this.answer.result];
+    return classByResultValue[this.args.answer.result];
   }
 
-  @computed('solution', 'inputFields.length')
   get expectedAnswers() {
     const inputFieldsCount = this.inputFields.length;
-    const solutions = jsyaml.safeLoad(this.solution);
+    const solutions = jsyaml.safeLoad(this.args.solution);
     const solutionsKeys = Object.keys(solutions);
 
     const expectedAnswers = solutionsKeys.slice(0, inputFieldsCount).map((key) => {

--- a/mon-pix/app/components/qrocm-dep-solution-panel.js
+++ b/mon-pix/app/components/qrocm-dep-solution-panel.js
@@ -4,6 +4,7 @@ import answersAsObject from 'mon-pix/utils/answers-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
 import keys from 'lodash/keys';
 import jsyaml from 'js-yaml';
+import { inject as service } from '@ember/service';
 
 const classByResultValue = {
   ok: 'correction-qroc-box-answer--correct',
@@ -13,6 +14,8 @@ const classByResultValue = {
 };
 
 export default class QrocmDepSolutionPanel extends Component {
+  @service intl;
+
   get inputFields() {
     const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
@@ -23,7 +26,7 @@ export default class QrocmDepSolutionPanel extends Component {
 
       return {
         label: labels[key],
-        answer: answerIsEmpty ? 'Pas de réponse' : answers[key],
+        answer: answerIsEmpty ? this.intl.t('pages.result-item.aband') : answers[key],
         inputClass: answerIsEmpty ? classByResultValue['aband'] : this.inputClass,
       };
     });

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -6,6 +6,7 @@ import answersAsObject from 'mon-pix/utils/answers-as-object';
 import solutionsAsObject from 'mon-pix/utils/solution-as-object';
 import labelsAsObject from 'mon-pix/utils/labels-as-object';
 import resultDetailsAsObject from 'mon-pix/utils/result-details-as-object';
+import { inject as service } from '@ember/service';
 
 function _computeAnswerOutcome(inputFieldValue, resultDetail) {
   if (inputFieldValue === '') {
@@ -25,6 +26,8 @@ function _computeInputClass(answerOutcome) {
 }
 
 export default class QrocmIndSolutionPanel extends Component {
+  @service intl;
+
   get inputFields() {
     if (!this.args.solution) {
       return undefined;
@@ -42,7 +45,7 @@ export default class QrocmIndSolutionPanel extends Component {
       const inputClass = _computeInputClass(answerOutcome);
 
       if (answers[labelKey] === '') {
-        answers[labelKey] = 'Pas de réponse';
+        answers[labelKey] = this.intl.t('pages.result-item.aband');
       }
 
       const inputField = {

--- a/mon-pix/app/components/qrocm-ind-solution-panel.js
+++ b/mon-pix/app/components/qrocm-ind-solution-panel.js
@@ -1,11 +1,5 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/template';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 import forEach from 'lodash/forEach';
 import keys from 'lodash/keys';
 import answersAsObject from 'mon-pix/utils/answers-as-object';
@@ -30,16 +24,16 @@ function _computeInputClass(answerOutcome) {
   return 'correction-qroc-box-answer--wrong';
 }
 
-@classic
-class QrocmIndSolutionPanel extends Component {
-  @computed('challenge.proposals', 'answer.value', 'solution')
+export default class QrocmIndSolutionPanel extends Component {
   get inputFields() {
-
-    const escapedProposals = this.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
+    if (!this.args.solution) {
+      return undefined;
+    }
+    const escapedProposals = this.args.challenge.get('proposals').replace(/(\n\n|\n)/gm, '<br>');
     const labels = labelsAsObject(htmlSafe(escapedProposals).string);
-    const answers = answersAsObject(this.answer.value, keys(labels));
-    const solutions = solutionsAsObject(this.solution);
-    const resultDetails = resultDetailsAsObject(this.answer.resultDetails);
+    const answers = answersAsObject(this.args.answer.value, keys(labels));
+    const solutions = solutionsAsObject(this.args.solution);
+    const resultDetails = resultDetailsAsObject(this.args.answer.resultDetails);
 
     const inputFields = [];
 
@@ -64,6 +58,4 @@ class QrocmIndSolutionPanel extends Component {
     return inputFields;
   }
 }
-
-export default QrocmIndSolutionPanel;
 

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -1,10 +1,4 @@
-/* eslint ember/no-classic-classes: 0 */
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
 const contentReference = {
@@ -30,30 +24,28 @@ const contentReference = {
   },
 };
 
-export default Component.extend({
-  classNames: ['result-item'],
+export default class ResultItemComponent extends Component {
+  @service intl;
 
-  intl: service(),
+  get resultItem() {
+    if (!this.args.answer.result) {
+      return undefined;
+    }
+    return contentReference[this.args.answer.result];
+  }
 
-  openComparison: null,
-
-  resultItem: computed('answer.result', function() {
-    if (!this.answer.result) return;
-    return contentReference[this.answer.result];
-  }),
-
-  resultTooltip: computed('resultItem', function() {
+  get resultTooltip() {
     return this.resultItem ? this.intl.t(`pages.result-item.${this.answer.result}`) : null;
-  }),
+  }
 
-  validationImplementedForChallengeType: computed('answer.challenge.type', function() {
+  get validationImplementedForChallengeType() {
     const implementedTypes = ['QCM', 'QROC', 'QCU', 'QROCM-ind', 'QROCM-dep'];
-    const challengeType = this.answer.get('challenge.type');
+    const challengeType = this.args.answer.get('challenge.type');
     return implementedTypes.includes(challengeType);
-  }),
+  }
 
-  textLength: computed('', function() {
+  get textLength() {
     return window.innerWidth <= 767 ? 60 : 110;
-  }),
+  }
 
-});
+}

--- a/mon-pix/app/components/result-item.js
+++ b/mon-pix/app/components/result-item.js
@@ -35,7 +35,7 @@ export default class ResultItemComponent extends Component {
   }
 
   get resultTooltip() {
-    return this.resultItem ? this.intl.t(`pages.result-item.${this.answer.result}`) : null;
+    return this.resultItem ? this.intl.t(`pages.comparison-window.results.${this.args.answer.result}.tooltip`) : null;
   }
 
   get validationImplementedForChallengeType() {

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -34,7 +34,7 @@
 
         <div class="assessment-results__list">
           {{#each @model.answersSinceLastCheckpoints as |answer|}}
-            <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{action "openComparisonWindow"}} />
+            <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{this.openComparisonWindow}} />
           {{/each}}
         </div>
         <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -1,4 +1,3 @@
-{{!-- template-lint-disable no-action --}}
 {{page-title this.pageTitle}}
 
 <div class="background-banner-wrapper assessment-challenge">
@@ -54,7 +53,7 @@
   </div>
 
   {{#if this.isShowingModal}}
-    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
+    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />
   {{/if}}
 
 </div>

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -1,4 +1,3 @@
-{{!-- template-lint-disable no-action --}}
 {{page-title (t 'pages.assessment-results.title')}}
 
 <div class="assessment-results">
@@ -14,7 +13,7 @@
 
     <div class="assessment-results__list">
       {{#each @model.answers as |answer|}}
-        <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{action "openComparisonWindow"}} />
+        <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{this.openComparisonWindow}} />
       {{/each}}
     </div>
 
@@ -32,7 +31,7 @@
   </div>
 
   {{#if this.isShowingModal}}
-    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{action "closeComparisonWindow"}} />
+    <ComparisonWindow @answer={{this.answer}} @closeComparisonWindow={{this.closeComparisonWindow}} />
   {{/if}}
 
 </div>

--- a/mon-pix/app/templates/components/qroc-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qroc-solution-panel.hbs
@@ -1,34 +1,33 @@
-{{!-- template-lint-disable no-implicit-this no-curly-component-invocation --}}
 <div class="correction-qroc-box rounded-panel">
   <div class="rounded-panel__row ">
 
     <div class="correction-qroc-box__answer">
-      {{#if (eq answer.challenge.format 'paragraphe')}}
-        <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{inputClass}}"
+      {{#if (eq @answer.challenge.format 'paragraphe')}}
+        <textarea class="correction-qroc-box-answer correction-qroc-box-answer--paragraph {{this.inputClass}}"
                   rows="5"
-                  value="{{answerToDisplay}}"
+                  value="{{this.answerToDisplay}}"
                   aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                   disabled>
         </textarea>
-      {{else if (eq answer.challenge.format 'phrase')}}
-        <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{inputClass}}"
-               value="{{answerToDisplay}}"
+      {{else if (eq @answer.challenge.format 'phrase')}}
+        <input class="correction-qroc-box-answer correction-qroc-box-answer--sentence {{this.inputClass}}"
+               value="{{this.answerToDisplay}}"
                aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                disabled>
       {{else}}
-        <input class="correction-qroc-box-answer {{inputClass}}"
-               size="{{get-qroc-input-size answer.challenge.format}}"
-               value="{{answerToDisplay}}"
+        <input class="correction-qroc-box-answer {{this.inputClass}}"
+               size="{{get-qroc-input-size @answer.challenge.format}}"
+               value="{{this.answerToDisplay}}"
                aria-label={{t 'pages.comparison-window.results.a11y.given-answer'}}
                disabled>
       {{/if}}
     </div>
 
-    {{#unless isResultOk}}
+    {{#unless this.isResultOk}}
       <div class="correction-qroc-box__solution">
         <img class="correction-qroc-box__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
         <span class="sr-only">{{t 'pages.comparison-window.results.a11y.the-answer-was'}}</span>
-        <div class="correction-qroc-box__solution-text">{{solutionToDisplay}}</div>
+        <div class="correction-qroc-box__solution-text">{{this.solutionToDisplay}}</div>
       </div>
     {{/unless}}
   </div>

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -1,17 +1,16 @@
-{{!-- template-lint-disable no-implicit-this no-curly-component-invocation --}}
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each inputFields as |field|}}
+    {{#each this.inputFields as |field|}}
       {{{field.label}}}
 
-      {{#if (eq challenge.format 'paragraphe')}}
+      {{#if (eq @challenge.format 'paragraphe')}}
         <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
                   rows="5"
                   value="{{field.answer}}"
                   id="{{field.label}}"
                   disabled>
         </textarea>
-      {{else if (eq challenge.format 'phrase')}}
+      {{else if (eq @challenge.format 'phrase')}}
         <input value="{{field.answer}}"
                class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
                id="{{field.label}}"
@@ -19,17 +18,17 @@
       {{else}}
         <div class="correction-qrocm__answer-wrapper">
           <input value="{{field.answer}}"
-                 size="{{get-qroc-input-size challenge.format}}"
+                 size="{{get-qroc-input-size @challenge.format}}"
                  class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
                  id="{{field.label}}"
                  disabled>
         </div>
       {{/if}}
     {{/each}}
-    {{#unless answerIsCorrect}}
+    {{#unless this.answerIsCorrect}}
       <div class="correction-qrocm__solution">
         <img class="correction-qrocm__solution-img" src="/images/comparison-window/icon-arrow-right.svg" alt="" role="none">
-        <div class="correction-qrocm__solution-text">{{expectedAnswers}}</div>
+        <div class="correction-qrocm__solution-text">{{this.expectedAnswers}}</div>
       </div>
     {{/unless}}
   </div>

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,10 +1,9 @@
-{{!-- template-lint-disable no-implicit-this  --}}
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each inputFields as |field|}}
+    {{#each this.inputFields as |field|}}
       {{{field.label}}}
 
-      {{#if (eq challenge.format 'paragraphe')}}
+      {{#if (eq @challenge.format 'paragraphe')}}
         <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
                   rows="5"
                   value="{{field.answer}}"
@@ -17,9 +16,9 @@
                 <div class="correction-qrocm__solution-text">{{field.solution}}</div>
             </div>
         {{/if}}
-      {{else if (eq challenge.format 'phrase')}}
+      {{else if (eq @challenge.format 'phrase')}}
         <input value="{{field.answer}}"
-               size="{{get-qroc-input-size challenge.format}}"
+               size="{{get-qroc-input-size @challenge.format}}"
                class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
                id="{{field.label}}"
                disabled>
@@ -32,7 +31,7 @@
       {{else}}
         <div class="correction-qrocm__answer-wrapper">
           <input value="{{field.answer}}"
-                 size="{{get-qroc-input-size challenge.format}}"
+                 size="{{get-qroc-input-size @challenge.format}}"
                  class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
                  id="{{field.label}}"
                  disabled>

--- a/mon-pix/app/templates/components/result-item.hbs
+++ b/mon-pix/app/templates/components/result-item.hbs
@@ -1,16 +1,17 @@
-{{!-- template-lint-disable no-implicit-this no-action --}}
-<div class="result-item__icon" title="{{resultTooltip}}">
-  {{fa-icon resultItem.icon class=(concat 'result-item__icon--' resultItem.color)}}
-</div>
+<div class="result-item">
+  <div class="result-item__icon" title="{{this.resultTooltip}}">
+    {{fa-icon this.resultItem.icon class=(concat 'result-item__icon--' this.resultItem.color)}}
+  </div>
 
-<div class="result-item__instruction">
-  {{strip-instruction (convert-to-html answer.challenge.instruction) textLength}}
-</div>
+  <div class="result-item__instruction">
+    {{strip-instruction (convert-to-html @answer.challenge.instruction) this.textLength}}
+  </div>
 
-<div class="result-item__correction">
-  {{#if validationImplementedForChallengeType}}
-    <button {{action openAnswerDetails answer}} class="result-item__correction-button link js-correct-answer" type="button">
-      {{t 'pages.result-item.actions.see-answers-and-tutorials.label'}}
-    </button>
-  {{/if}}
+  <div class="result-item__correction">
+    {{#if this.validationImplementedForChallengeType}}
+      <button {{on 'click' (fn @openAnswerDetails @answer)}} class="result-item__correction-button link js-correct-answer" type="button">
+        {{t 'pages.result-item.actions.see-answers-and-tutorials.label'}}
+      </button>
+    {{/if}}
+  </div>
 </div>

--- a/mon-pix/tests/integration/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qroc-solution-panel-test.js
@@ -17,7 +17,7 @@ describe('Integration | Component | QROC solution panel', function() {
       this.set('answer', answer);
 
       //when
-      await render(hbs`{{qroc-solution-panel answer=answer}}`);
+      await render(hbs`<QrocSolutionPanel @answer={{this.answer}}/>`);
 
       // then
       expect(find('input')).to.not.exist;
@@ -34,7 +34,7 @@ describe('Integration | Component | QROC solution panel', function() {
       this.set('answer', answer);
 
       //when
-      await render(hbs`{{qroc-solution-panel answer=answer}}`);
+      await render(hbs`<QrocSolutionPanel @answer={{this.answer}}/>`);
 
       // then
       expect(find('input.correction-qroc-box-answer--sentence')).to.have.attr('disabled');
@@ -52,10 +52,10 @@ describe('Integration | Component | QROC solution panel', function() {
         const challenge = EmberObject.create({ format: data.format });
         const answer = EmberObject.create({ challenge });
         this.set('answer', answer);
-        await render(hbs`{{qroc-solution-panel answer=answer}}`);
+        await render(hbs`<QrocSolutionPanel @answer={{this.answer}} />`);
 
         //when
-        await render(hbs`{{qroc-solution-panel answer=answer}}`);
+        await render(hbs`<QrocSolutionPanel @answer={{this.answer}} />`);
 
         // then
         expect(find('textarea.correction-qroc-box-answer--paragraph')).to.not.exist;
@@ -83,7 +83,7 @@ describe('Integration | Component | QROC solution panel', function() {
 
           // when
           this.set('answer', answer);
-          await render(hbs`{{qroc-solution-panel answer=answer}}`);
+          await render(hbs`<QrocSolutionPanel @answer={{this.answer}} />`);
         });
 
         it('should display the answer in bold green', async function() {
@@ -109,7 +109,7 @@ describe('Integration | Component | QROC solution panel', function() {
 
           // when
           this.set('answer', answer);
-          await render(hbs`{{qroc-solution-panel answer=answer}}`);
+          await render(hbs`<QrocSolutionPanel @answer={{this.answer}} />`);
         });
 
         it('should display the false answer with line-through', function() {
@@ -145,7 +145,7 @@ describe('Integration | Component | QROC solution panel', function() {
           this.set('answer', answer);
           this.set('isResultWithoutAnswer', true);
 
-          await render(hbs`{{qroc-solution-panel answer=answer}}`);
+          await render(hbs`<QrocSolutionPanel @answer={{this.answer}} />`);
         });
 
         it('should display "Pas de réponse" in italic', function() {

--- a/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-dep-solution-panel-test.js
@@ -61,7 +61,7 @@ describe('Integration | Component | QROCm dep solution panel', function() {
           this.set('answer', answer);
 
           // when
-          await render(hbs`{{qrocm-dep-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`);
         });
 
         it('should display the correct answer in green bold', function() {
@@ -92,7 +92,7 @@ describe('Integration | Component | QROCm dep solution panel', function() {
           this.set('answer', answer);
 
           // when
-          await render(hbs`{{qrocm-dep-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`);
         });
 
         it('should display one solution in bold green', async function() {
@@ -123,7 +123,7 @@ describe('Integration | Component | QROCm dep solution panel', function() {
           this.set('answer', answer);
 
           // when
-          await render(hbs`{{qrocm-dep-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`);
         });
 
         it('should display one solution in bold green', async function() {
@@ -171,7 +171,7 @@ describe('Integration | Component | QROCm dep solution panel', function() {
         this.challenge.set('format', data.format);
 
         //when
-        await render(hbs`{{qrocm-dep-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QrocmDepSolutionPanel @challenge={{this.challenge}} @solution={{this.solution}} @answer={{this.answer}} />`);
 
         //then
         expect(find(PARAGRAPH)).to.not.exist;

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -53,7 +53,10 @@ describe('Integration | Component | QROCm ind solution panel', function() {
         this.challenge.set('format', data.format);
 
         // when
-        await render(hbs`{{qrocm-ind-solution-panel answer=answer solution=solution challenge=challenge}}`);
+        await render(hbs`<QrocmIndSolutionPanel
+          @answer={{this.answer}}
+          @solution={{this.solution}}
+          @challenge={{this.challenge}} />`);
       });
 
       describe('When the answer is correct', function() {

--- a/mon-pix/tests/unit/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qroc-solution-panel-test.js
@@ -1,11 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import setupIntl from '../../helpers/setup-intl';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 describe('Unit | Component | qroc-solution-panel', function() {
 
   setupTest();
+  setupIntl();
   const rightAnswer = { result: 'ok' };
   const wrongAnswer = { result: 'ko' };
 

--- a/mon-pix/tests/unit/components/qroc-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qroc-solution-panel-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 describe('Unit | Component | qroc-solution-panel', function() {
 
@@ -12,20 +13,18 @@ describe('Unit | Component | qroc-solution-panel', function() {
 
     it('should return true when result is ok', function() {
       // given
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('answer', rightAnswer);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { answer: rightAnswer });
       // when
-      const isResultOk = component.get('isResultOk');
+      const isResultOk = component.isResultOk;
       // then
       expect(isResultOk).to.be.true;
     });
 
     it('should return true when result is not ok', function() {
       // given
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('answer', wrongAnswer);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { answer: wrongAnswer });
       // when
-      const isResultOk = component.get('isResultOk');
+      const isResultOk = component.isResultOk;
       // then
       expect(isResultOk).to.be.false;
     });
@@ -39,10 +38,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
       const answer = {
         value: '#ABAND#',
       };
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('answer', answer);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { answer });
       // when
-      const answerToDisplay = component.get('answerToDisplay');
+      const answerToDisplay = component.answerToDisplay;
       // then
       expect(answerToDisplay).to.equal('Pas de réponse');
     });
@@ -52,10 +50,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
       const answer = {
         value: 'La Reponse B',
       };
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('answer', answer);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { answer });
       // when
-      const answerToDisplay = component.get('answerToDisplay');
+      const answerToDisplay = component.answerToDisplay;
       // then
       expect(answerToDisplay).to.equal('La Reponse B');
     });
@@ -66,10 +63,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return the first solution if the solution has some variants', function() {
       // given
       const solution = 'Reponse\nreponse\nréponse';
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('solution', solution);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { solution });
       // when
-      const solutionToDisplay = component.get('solutionToDisplay');
+      const solutionToDisplay = component.solutionToDisplay;
       // then
       expect(solutionToDisplay).to.equal('Reponse');
     });
@@ -77,10 +73,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return the solution', function() {
       // given
       const solution = 'Reponse';
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('solution', solution);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { solution });
       // when
-      const solutionToDisplay = component.get('solutionToDisplay');
+      const solutionToDisplay = component.solutionToDisplay;
       // then
       expect(solutionToDisplay).to.equal('Reponse');
     });
@@ -88,10 +83,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return an empty string if the solution is null', function() {
       // given
       const emptySolution = '';
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('solution', emptySolution);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { solution: emptySolution });
       // when
-      const solutionToDisplay = component.get('solutionToDisplay');
+      const solutionToDisplay = component.solutionToDisplay;
       // then
       expect(solutionToDisplay).to.equal('');
     });
@@ -99,10 +93,9 @@ describe('Unit | Component | qroc-solution-panel', function() {
     it('should return an empty string if the solution is an empty String', function() {
       // given
       const solutionNull = null;
-      const component = this.owner.lookup('component:qroc-solution-panel');
-      component.set('solution', solutionNull);
+      const component = createGlimmerComponent('component:qroc-solution-panel', { solution: solutionNull });
       // when
-      const solutionToDisplay = component.get('solutionToDisplay');
+      const solutionToDisplay = component.solutionToDisplay;
       // then
       expect(solutionToDisplay).to.equal('');
     });

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
@@ -14,9 +15,7 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
       const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
       const answer = { value: 'smiley1: \':)\' smiley2: \'\'', result: 'ko' };
 
-      const component = this.owner.lookup('component:qrocm-dep-solution-panel');
-      component.set('challenge', challenge);
-      component.set('answer', answer);
+      const component = createGlimmerComponent('component:qrocm-dep-solution-panel', { challenge, answer });
 
       const expectedFieldsData = [{
         label: 'content : ',
@@ -29,7 +28,7 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
       }];
 
       //when
-      const inputFields = component.get('inputFields');
+      const inputFields = component.inputFields;
 
       //Then
       expect(inputFields).to.be.deep.equal(expectedFieldsData);
@@ -41,11 +40,10 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
     it('should return true', function() {
       //Given
-      const component = this.owner.lookup('component:qrocm-dep-solution-panel');
-      component.set('answer', { result: 'ok' });
+      const component = createGlimmerComponent('component:qrocm-dep-solution-panel', { answer: { result: 'ok' } });
 
       //when
-      const answerIsCorrect = component.get('answerIsCorrect');
+      const answerIsCorrect = component.answerIsCorrect;
 
       //Then
       expect(answerIsCorrect).to.be.true;
@@ -53,11 +51,10 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
     it('should return false', function() {
       //Given
-      const component = this.owner.lookup('component:qrocm-dep-solution-panel');
-      component.set('answer', { result: 'ko' });
+      const component = createGlimmerComponent('component:qrocm-dep-solution-panel', { answer: { result: 'ko' } });
 
       //when
-      const answerIsCorrect = component.get('answerIsCorrect');
+      const answerIsCorrect = component.answerIsCorrect;
 
       //Then
       expect(answerIsCorrect).to.be.false;
@@ -68,12 +65,16 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
     it('should return the expected answers', function() {
       //Given
-      const component = this.owner.lookup('component:qrocm-dep-solution-panel');
-      component.set('inputFields', [1, 2]);
-      component.set('solution', 'groupe 1:\n- horizontalité\n- organisation plate\ngroupe 2:\n- cadre');
+      const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
+      const component = createGlimmerComponent('component:qrocm-dep-solution-panel', {
+        challenge,
+        answer: { result: 'ko' },
+        inputFields: [1, 2],
+        solution: 'groupe 1:\n- horizontalité\n- organisation plate\ngroupe 2:\n- cadre',
+      });
 
       //when
-      const expectedAnswers = component.get('expectedAnswers');
+      const expectedAnswers = component.expectedAnswers;
 
       //Then
       expect(expectedAnswers).to.be.equal('horizontalité et cadre');
@@ -81,12 +82,16 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
     it('should return examples of good answers', function() {
       //Given
-      const component = this.owner.lookup('component:qrocm-dep-solution-panel');
-      component.set('inputFields', [1, 2]);
-      component.set('solution', 'groupe 1:\n- tag\n- slogan\ngroupe 2:\n- marche\n- sitting\ngroupe 3:\n- masque');
+      const challenge = EmberObject.create({ proposals: 'content : ${smiley1}\n\ntriste : ${smiley2}' });
+      const component = createGlimmerComponent('component:qrocm-dep-solution-panel', {
+        challenge,
+        answer: { result: 'ko' },
+        inputFields: [1, 2],
+        solution: 'groupe 1:\n- tag\n- slogan\ngroupe 2:\n- marche\n- sitting\ngroupe 3:\n- masque',
+      });
 
       //when
-      const expectedAnswers = component.get('expectedAnswers');
+      const expectedAnswers = component.expectedAnswers;
 
       //Then
       expect(expectedAnswers).to.be.equal('tag ou marche ou ...');

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
-import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
 describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
   setupTest();
+  setupIntl();
 
   describe('#inputFields', function() {
 

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -2,11 +2,13 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
-import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 
-describe('Unit | Component | qrocm-solution-panel', function() {
+describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
   setupTest();
+  setupIntl();
 
   describe('#inputFields', function() {
 

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import EmberObject from '@ember/object';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 describe('Unit | Component | qrocm-solution-panel', function() {
 
@@ -18,14 +19,6 @@ describe('Unit | Component | qrocm-solution-panel', function() {
       answer = {};
       solution = '';
     });
-
-    function _getComponentInputFields(context) {
-      const component = context.owner.lookup('component:qrocm-ind-solution-panel');
-      component.set('challenge', challenge);
-      component.set('answer', answer);
-      component.set('solution', solution);
-      return component.get('inputFields');
-    }
 
     it('should return an array with data to display (case when the answers are right)', function() {
       //Given
@@ -47,11 +40,15 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         inputClass: 'correction-qroc-box-answer--correct',
       }];
 
-      //when
-      const inputFields = _getComponentInputFields(this);
+      //When
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
       //Then
-      expect(inputFields).to.be.deep.equal(expectedFieldsData);
+      expect(component.inputFields).to.be.deep.equal(expectedFieldsData);
     });
 
     it('should return an array with data to display (case when there is wrong answers)', function() {
@@ -74,11 +71,14 @@ describe('Unit | Component | qrocm-solution-panel', function() {
       }];
 
       //When
-      const inputFields = _getComponentInputFields(this);
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      //then
-      expect(inputFields).to.be.deep.equal(result);
-
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (case when there is some empty answer)', function() {
@@ -102,10 +102,14 @@ describe('Unit | Component | qrocm-solution-panel', function() {
       }];
 
       //When
-      const inputFields = _getComponentInputFields(this);
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      //then
-      expect(inputFields).to.be.deep.equal(result);
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (proposals contains a dash ("-"))', function() {
@@ -155,11 +159,15 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         inputClass: 'correction-qroc-box-answer--wrong',
       }];
 
-      // when
-      const inputFields = _getComponentInputFields(this);
+      //When
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      // then
-      expect(inputFields).to.be.deep.equal(result);
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (proposals are questions)', function() {
@@ -182,11 +190,15 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         inputClass: 'correction-qroc-box-answer--wrong',
       }];
 
-      // when
-      const inputFields = _getComponentInputFields(this);
+      //When
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      // then
-      expect(inputFields).to.be.deep.equal(result);
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
     it('it should return "Pas de réponse" in each answer if the question was passed', function() {
@@ -209,11 +221,15 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         inputClass: 'correction-qroc-box-answer--aband',
       }];
 
-      // when
-      const inputFields = _getComponentInputFields(this);
+      //When
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      // then
-      expect(inputFields).to.be.deep.equal(result);
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
     /**
@@ -234,11 +250,15 @@ describe('Unit | Component | qrocm-solution-panel', function() {
         inputClass: 'correction-qroc-box-answer--correct',
       }];
 
-      // when
-      const inputFields = _getComponentInputFields(this);
+      //When
+      const component = createGlimmerComponent('component:qrocm-ind-solution-panel', {
+        challenge,
+        answer,
+        solution,
+      });
 
-      // then
-      expect(inputFields).to.be.deep.equal(result);
+      //Then
+      expect(component.inputFields).to.be.deep.equal(result);
     });
 
   });

--- a/mon-pix/tests/unit/components/result-item-test.js
+++ b/mon-pix/tests/unit/components/result-item-test.js
@@ -1,8 +1,9 @@
 import EmberObject from '@ember/object';
 import { expect } from 'chai';
-import { describe, it, beforeEach } from 'mocha';
+import { describe, it } from 'mocha';
 import setupIntl from '../../helpers/setup-intl';
 import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
 const undefinedAnswer = 'undefined';
 const answerWithEmptyResult = {
@@ -28,10 +29,6 @@ describe('Unit | Component | result-item-component', function() {
 
   let component;
 
-  beforeEach(function() {
-    component = this.owner.lookup('component:result-item');
-  });
-
   describe('#resultItem Computed property - undefined case', function() {
     [
       undefinedAnswer,
@@ -41,10 +38,10 @@ describe('Unit | Component | result-item-component', function() {
     ].forEach(function(answer) {
       it(`should returns undefined when answer provided is: ${answer.name}`, function() {
         // when
-        component.set('answer', answer);
+        component = createGlimmerComponent('component:result-item', { answer });
 
         // then
-        expect(component.get('resultItem')).to.be.undefined;
+        expect(component.resultItem).to.be.undefined;
       });
     });
 
@@ -63,11 +60,11 @@ describe('Unit | Component | result-item-component', function() {
         const answerWithOkResult = { result: `${data.result}` };
 
         // when
-        component.set('answer', answerWithOkResult);
+        component = createGlimmerComponent('component:result-item', { answer: answerWithOkResult });
 
         // then
-        expect(component.get('resultItem.color')).to.equal(`${data.expectedColor}`);
-        expect(component.get('resultItem.icon')).to.equal(`${data.expectedIcon}`);
+        expect(component.resultItem.color).to.equal(`${data.expectedColor}`);
+        expect(component.resultItem.icon).to.equal(`${data.expectedIcon}`);
       });
     });
   });
@@ -83,10 +80,10 @@ describe('Unit | Component | result-item-component', function() {
       it(`should return a tooltip text equal to ${data.expectedTooltip}`, function() {
         // given
         const answerWithOkResult = { result: `${data.result}` };
+        component = createGlimmerComponent('component:result-item', { answer: answerWithOkResult });
 
         // when
-        component.set('answer', answerWithOkResult);
-        const tooltipText = component.get('resultTooltip');
+        const tooltipText = component.resultTooltip;
 
         // then
         expect(tooltipText).to.equal(`${data.expectedTooltip}`);
@@ -101,7 +98,7 @@ describe('Unit | Component | result-item-component', function() {
       window.innerWidth = 600;
 
       //then
-      expect(component.get('textLength')).to.equal(60);
+      expect(component.textLength).to.equal(60);
     });
 
     it('should be 110 when it a tablet/desktop', function() {
@@ -109,7 +106,7 @@ describe('Unit | Component | result-item-component', function() {
       window.innerWidth = 1200;
 
       //then
-      expect(component.get('textLength')).to.equal(110);
+      expect(component.textLength).to.equal(110);
     });
   });
 
@@ -130,10 +127,10 @@ describe('Unit | Component | result-item-component', function() {
         const answer = EmberObject.create({ challenge });
 
         // when
-        component.set('answer', answer);
+        component = createGlimmerComponent('component:result-item', { answer });
 
         // then
-        expect(component.get('validationImplementedForChallengeType')).to.equal(data.expected);
+        expect(component.validationImplementedForChallengeType).to.equal(data.expected);
       });
     });
   });

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -709,7 +709,7 @@
             }
         },
         "result-item": {
-            "aband": "Sans réponse",
+            "aband": "Pas de réponse",
             "actions": {
                 "see-answers-and-tutorials": {
                     "label": "Réponses et tutos"


### PR DESCRIPTION
## :unicorn: Problème
Dans les écrans de réponse des questions de type QROC, QROC m-dep et QROC m-ind, dans le champ réponse, si l'utilisateur n'a pas répondu, le texte affiché est `Pas de réponse`, quelque soit la langue de l'interface.

## :robot: Solution
Utiliser le service `intl` pour afficher un texte traduit.

## :rainbow: Remarques
En passant sur les différents fichiers, beaucoup n'étaient pas converti aux dernières syntaxes (cf les nombreux commentaires désactivant des règles de lint).
Aussi les premiers commits sont des conversions.

## :100: Pour tester
Répondre en passant à des questions de type QROC, QROC m-dep et QROC m-ind.
Sur l'écran de récapitulation (checkpoint), changer la langue (en ajoutant `?lang=en` dans l'url).
Vérifier que les textes qui `Pas de réponse` sont désormais traduits et affichent `No answer`.