### PR TITLE
[BUGFIX] Modification du titre du bouton "Continuer" de la version anglaise afin que l'affichage soit sur une seule ligne (PIX-1934).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -403,7 +403,7 @@
             },
             "actions": {
                 "next-page": {
-                    "continue": "Continue my personalised test",
+                    "continue": "Continue",
                     "results": "See my results"
                 }
             },


### PR DESCRIPTION
## :unicorn: Problème
Sur la version anglaise, dans l'écran intermédiaire réponses et tuto, une partie du titre du bouton et la flèche sont affichées en dehors du bouton.

## :robot: Solution
Changer le texte par `Continue` afin que l'affichage se fasse correctement dans le bouton.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur l'application en anglais (`?lang=en`), répondre à quelques questions et vérifier que le bouton sur l'écran intermédiaire affiche `Continue` et la flèche correctement. 
