### PR TITLE
[FEATURE] Suppression du fallback sur le choix de la langue des épreuves (PIX-1778).

### DIFF
--- a/api/lib/domain/services/pick-challenge-service.js
+++ b/api/lib/domain/services/pick-challenge-service.js
@@ -1,6 +1,5 @@
 const _ = require('lodash');
 const hashInt = require('hash-int');
-const { FRENCH_FRANCE, FRENCH_SPOKEN } = require('../constants').LOCALE;
 const UNEXISTING_ITEM = null;
 const VALIDATED_STATUSES = ['validé', 'validé sans test', 'pré-validé'];
 
@@ -13,9 +12,7 @@ module.exports = {
     const keyForChallenge = Math.abs(hashInt(randomSeed + 1));
     const chosenSkill = skills[keyForSkill % skills.length];
 
-    return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge)
-        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_SPOKEN, keyForChallenge)
-        || _pickLocaleChallengeAtIndex(chosenSkill.challenges, FRENCH_FRANCE, keyForChallenge);
+    return _pickLocaleChallengeAtIndex(chosenSkill.challenges, locale, keyForChallenge);
   },
 };
 

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-for-competence-evaluation_test.js
@@ -50,6 +50,7 @@ const secondChallenge = airtableBuilder.factory.buildChallenge.untimed({
   statut: 'validé',
   acquix: [skillWeb3Id],
   acquis: [skillWeb3Name],
+  langues: ['Franco Français'],
 });
 const thirdChallengeId = 'recThirdChallenge';
 const thirdChallenge = airtableBuilder.factory.buildChallenge.untimed({

--- a/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-get-next-challenge-locale-management.js
@@ -115,44 +115,6 @@ describe('Acceptance | API | assessment-controller-get-next-challenge-locale-man
           });
         });
       });
-
-      context('when there is no challenge in the accepted language (fr-fr)', () => {
-        beforeEach(async () => {
-          airtableBuilder.mockList({ tableName: 'Epreuves' })
-            .returns([frenchSpokenChallenge])
-            .activate();
-
-          databaseBuilder.factory.buildUser({ id: userId });
-          databaseBuilder.factory.buildAssessment({
-            id: assessmentId,
-            type: Assessment.types.COMPETENCE_EVALUATION,
-            userId,
-            competenceId,
-          });
-          databaseBuilder.factory.buildCompetenceEvaluation({ assessmentId, competenceId, userId });
-          await databaseBuilder.commit();
-        });
-
-        it('should return the challenge in the fallback language (fr)', () => {
-          // given
-          const options = {
-            method: 'GET',
-            url: `/api/assessments/${assessmentId}/next`,
-            headers: {
-              authorization: generateValidRequestAuthorizationHeader(userId),
-              'accept-language': FRENCH_FRANCE,
-            },
-          };
-
-          // when
-          const promise = server.inject(options);
-
-          // then
-          return promise.then((response) => {
-            expect(response.result.data.id).to.equal(frenchSpokenChallenge.id);
-          });
-        });
-      });
     });
   });
 });

--- a/api/tests/unit/domain/services/pick-challenge-service_test.js
+++ b/api/tests/unit/domain/services/pick-challenge-service_test.js
@@ -51,58 +51,6 @@ describe('Unit | Service | PickChallengeService', () => {
 
     });
 
-    context('when challenge in selected locale does not exist', () => {
-
-      it('should return challenge in other locale', () => {
-        // given
-        const skills = [{ challenges: [frenchChallenge] }];
-
-        // when
-        const challenge = pickChallengeService.pickChallenge({
-          skills,
-          randomSeed,
-          locale: FRENCH_SPOKEN,
-        });
-
-        // then
-        expect(challenge).to.equal(frenchChallenge);
-      });
-      context('when no challenge in selected non-french locale', () => {
-        it('should return FR challenge', () => {
-          // given
-          const skills = [{ challenges: [frenchChallenge, frenchSpokenChallenge] }];
-
-          // when
-          const challenge = pickChallengeService.pickChallenge({
-            skills,
-            randomSeed,
-            locale: ENGLISH_SPOKEN,
-          });
-
-          // then
-          expect(challenge).to.equal(frenchSpokenChallenge);
-        });
-
-        context('and no FR challenge', () => {
-          it('should return FR-FR challenge', () => {
-            // given
-            const skills = [{ challenges: [frenchChallenge] }];
-
-            // when
-            const challenge = pickChallengeService.pickChallenge({
-              skills,
-              randomSeed,
-              locale: ENGLISH_SPOKEN,
-            });
-
-            // then
-            expect(challenge).to.equal(frenchChallenge);
-          });
-        });
-      });
-
-    });
-
     context('when there is no skills', () => {
 
       it('should return null', () => {
@@ -131,7 +79,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: FRENCH_FRANCE,
+          locale: FRENCH_SPOKEN,
         });
 
         // then
@@ -148,7 +96,7 @@ describe('Unit | Service | PickChallengeService', () => {
         const challenge = pickChallengeService.pickChallenge({
           skills,
           randomSeed,
-          locale: FRENCH_FRANCE,
+          locale: FRENCH_SPOKEN,
         });
 
         // then

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -7,7 +7,8 @@
     "cgu": true,
     "pixOrgaTermsOfServiceAccepted": true,
     "password": "",
-    "shouldChangePassword": false
+    "shouldChangePassword": false,
+    "lang": "fr-fr"
   },
   {
     "id": 2,


### PR DESCRIPTION
## :unicorn: Problème
Si l'utilisateur est anglophone et qu'il se rend sur une épreuve n'ayant pas de version anglaise il est redirigé vers la version française. Hors toutes les épreuves sont maintenant disponibles en anglais.

## :robot: Solution
Retirer le fallback de sélection de challenge en fonction de la locale.

## :rainbow: Remarques
Suppression des tests vérifiant le fallback

## :100: Pour tester
Vérifier qu'il n'y a pas de régression et que l’épreuve affichée correspond a la locale.
