### PR TITLE
[FEATURE] Introduire le multi Accès Pix Certif (PIX-136).

### DIFF
--- a/api/lib/domain/read-models/CertificationPointOfContact.js
+++ b/api/lib/domain/read-models/CertificationPointOfContact.js
@@ -5,22 +5,17 @@ class CertificationPointOfContact {
     lastName,
     email,
     pixCertifTermsOfServiceAccepted,
-    certificationCenterId,
-    certificationCenterName,
-    certificationCenterType,
-    certificationCenterExternalId,
-    isRelatedOrganizationManagingStudents,
+    certificationCenters,
   }) {
     this.id = id;
     this.firstName = firstName;
     this.lastName = lastName;
     this.email = email;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
-    this.certificationCenterId = certificationCenterId;
-    this.certificationCenterName = certificationCenterName;
-    this.certificationCenterType = certificationCenterType;
-    this.certificationCenterExternalId = certificationCenterExternalId;
-    this.isRelatedOrganizationManagingStudents = Boolean(isRelatedOrganizationManagingStudents);
+    this.currentCertificationCenterId = certificationCenters[0].id;
+    this.certificationCenters = certificationCenters.map((certificationCenter) => {
+      return { ...certificationCenter, isRelatedOrganizationManagingStudents: Boolean(certificationCenter.isRelatedOrganizationManagingStudents) };
+    });
   }
 }
 

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -11,17 +11,20 @@ module.exports = {
         lastName: 'users.lastName',
         email: 'users.email',
         pixCertifTermsOfServiceAccepted: 'users.pixCertifTermsOfServiceAccepted',
-        certificationCenterId: 'certification-centers.id',
-        certificationCenterName: 'certification-centers.name',
-        certificationCenterType: 'certification-centers.type',
-        certificationCenterExternalId: 'certification-centers.externalId',
-        isRelatedOrganizationManagingStudents: 'organizations.isManagingStudents',
+        certificationCenters: knex.raw('JSON_AGG(JSON_BUILD_OBJECT(' +
+          '\'id\', "certification-centers"."id",' +
+          '\'name\', "certification-centers"."name",' +
+          '\'type\', "certification-centers"."type",' +
+          '\'externalId\', "certification-centers"."externalId",' +
+          '\'isRelatedOrganizationManagingStudents\', "organizations"."isManagingStudents"' +
+        ') ORDER BY "certification-center-memberships"."createdAt" DESC)'),
       })
       .from('users')
       .join('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')
       .join('certification-centers', 'certification-centers.id', 'certification-center-memberships.certificationCenterId')
       .leftJoin('organizations', 'organizations.externalId', 'certification-centers.externalId')
       .where('users.id', userId)
+      .groupBy('users.id')
       .first();
 
     if (!result) {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer.js
@@ -4,20 +4,24 @@ module.exports = {
 
   serialize(certificationPointOfContact) {
     return new Serializer('certification-point-of-contact', {
-
       attributes: [
-        'firstName', 'lastName', 'email', 'pixCertifTermsOfServiceAccepted',
-        'certificationCenterId', 'certificationCenterName',
-        'certificationCenterType', 'certificationCenterExternalId', 'isRelatedOrganizationManagingStudents',
-        'sessions',
+        'firstName', 'lastName', 'email', 'pixCertifTermsOfServiceAccepted', 'currentCertificationCenterId',
+        'certificationCenters', 'sessions',
       ],
+      certificationCenters: {
+        ref: 'id',
+        included: true,
+        attributes: [
+          'name', 'type', 'externalId', 'isRelatedOrganizationManagingStudents',
+        ],
+      },
       sessions: {
         ref: 'id',
         ignoreRelationshipData: true,
         nullIfMissing: true,
         relationshipLinks: {
           related: function(record) {
-            return `/api/certification-centers/${record.certificationCenterId}/sessions`;
+            return `/api/certification-centers/${record.currentCertificationCenterId}/sessions`;
           },
         },
       },

--- a/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-point-of-contact-repository_test.js
@@ -15,20 +15,21 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
         type: CertificationCenter.types.PRO,
         externalId: 'ABC123',
       }).id;
-      const userId = databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+      const userId = databaseBuilder.factory.buildUser({
         firstName: 'Jean',
         lastName: 'Acajou',
         email: 'jean.acajou@example.net',
         pixCertifTermsOfServiceAccepted: true,
-        certificationCenterId,
       }).id;
-      databaseBuilder.factory.buildUser.withCertificationCenterMembership({
+      databaseBuilder.factory.buildCertificationCenterMembership({
         certificationCenterId,
+        userId,
       });
       await databaseBuilder.commit();
 
       // when
       const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+      const firstCertificationCenter = certificationPointOfContact.certificationCenters[0];
 
       // then
       expect(certificationPointOfContact).to.be.instanceOf(CertificationPointOfContact);
@@ -37,14 +38,16 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
       expect(certificationPointOfContact.lastName).to.equal('Acajou');
       expect(certificationPointOfContact.email).to.equal('jean.acajou@example.net');
       expect(certificationPointOfContact.pixCertifTermsOfServiceAccepted).to.be.true;
-      expect(certificationPointOfContact.certificationCenterId).to.equal(certificationCenterId);
-      expect(certificationPointOfContact.certificationCenterName).to.equal('Centre des papys gâteux');
-      expect(certificationPointOfContact.certificationCenterType).to.equal(CertificationCenter.types.PRO);
-      expect(certificationPointOfContact.certificationCenterExternalId).to.equal('ABC123');
-      expect(certificationPointOfContact.isRelatedOrganizationManagingStudents).to.be.false;
+
+      expect(certificationPointOfContact.certificationCenters).to.have.lengthOf(1);
+      expect(firstCertificationCenter.id).to.equal(certificationCenterId);
+      expect(firstCertificationCenter.name).to.equal('Centre des papys gâteux');
+      expect(firstCertificationCenter.type).to.equal(CertificationCenter.types.PRO);
+      expect(firstCertificationCenter.externalId).to.equal('ABC123');
+      expect(firstCertificationCenter.isRelatedOrganizationManagingStudents).to.be.false;
     });
 
-    it('should return CertificationRPointOfContact with isRelatedOrganizationManagingStudents as true when the certification center is related to an organization that manages students', async () => {
+    it('should return CertificationPointOfContact with isRelatedOrganizationManagingStudents as true when the certification center is related to an organization that manages students', async () => {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
         externalId: 'ABC123',
@@ -66,7 +69,7 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
       const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
 
       // then
-      expect(certificationPointOfContact.isRelatedOrganizationManagingStudents).to.be.true;
+      expect(certificationPointOfContact.certificationCenters[0].isRelatedOrganizationManagingStudents).to.be.true;
     });
 
     it('should throw NotFoundError when point of contact does not exist', async () => {
@@ -84,6 +87,40 @@ describe('Integration | Repository | CertificationPointOfContact', function() {
       // then
       expect(error).to.be.instanceOf(NotFoundError);
     });
-  });
 
+    context('When there is more than one membership', () => {
+
+      it('should return all the CertificationCenterMembership', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+        databaseBuilder.factory.buildCertificationCenterMembership({ userId });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+
+        // then
+        expect(certificationPointOfContact.certificationCenters).to.have.lengthOf(3);
+      });
+
+      it('should order CertificationCenterMembership by the most recently created membership', async () => {
+        // given
+        const userId = databaseBuilder.factory.buildUser().id;
+        const thirdCreatedMembership = databaseBuilder.factory.buildCertificationCenterMembership({ userId, createdAt: new Date('2016-02-15T00:00:00Z') });
+        const firstCreatedMembership = databaseBuilder.factory.buildCertificationCenterMembership({ userId, createdAt: new Date('2020-02-15T00:00:00Z') });
+        const secondCreatedMembership = databaseBuilder.factory.buildCertificationCenterMembership({ userId, createdAt: new Date('2018-02-15T00:00:00Z') });
+        await databaseBuilder.commit();
+
+        // when
+        const certificationPointOfContact = await certificationPointOfContactRepository.get(userId);
+
+        // then
+        expect(certificationPointOfContact.certificationCenters[0].id).to.equal(firstCreatedMembership.certificationCenterId);
+        expect(certificationPointOfContact.certificationCenters[1].id).to.equal(secondCreatedMembership.certificationCenterId);
+        expect(certificationPointOfContact.certificationCenters[2].id).to.equal(thirdCreatedMembership.certificationCenterId);
+      });
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-point-of-contact.js
@@ -1,5 +1,4 @@
 const CertificationPointOfContact = require('../../../../lib/domain/read-models/CertificationPointOfContact');
-const CertificationCenter = require('../../../../lib/domain/models/CertificationCenter');
 
 module.exports = function buildCertificationPointOfContact(
   {
@@ -8,23 +7,16 @@ module.exports = function buildCertificationPointOfContact(
     lastName = 'Brebis',
     email = 'chevre.brebis@example.net',
     pixCertifTermsOfServiceAccepted = true,
-    certificationCenterId = 456,
-    certificationCenterName = 'Centre de la prairie verdoyante',
-    certificationCenterType = CertificationCenter.types.PRO,
-    certificationCenterExternalId = 'CHEVRE456',
-    isRelatedOrganizationManagingStudents = false,
+    currentCertificationCenterId = 456,
+    certificationCenters,
   } = {}) {
-
   return new CertificationPointOfContact({
     id,
     firstName,
     lastName,
     email,
     pixCertifTermsOfServiceAccepted,
-    certificationCenterId,
-    certificationCenterName,
-    certificationCenterType,
-    certificationCenterExternalId,
-    isRelatedOrganizationManagingStudents,
+    currentCertificationCenterId,
+    certificationCenters,
   });
 };

--- a/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
+++ b/api/tests/unit/application/certification-point-of-contacts/certification-point-of-contact-controller_test.js
@@ -13,7 +13,8 @@ describe('Unit | Controller | certifications-point-of-contact-controller', () =>
     it('should return a serialized CertificationReferent', async () => {
       // given
       const userId = 123;
-      const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact();
+      const certificationCenter = { id: 1, name: 'Serre tiff', type: 'SCO', externalId: 'externalId', isRelatedOrganizationManagingStudents: false };
+      const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({ certificationCenters: [certificationCenter] });
       const request = {
         auth: {
           credentials: { userId },
@@ -34,20 +35,36 @@ describe('Unit | Controller | certifications-point-of-contact-controller', () =>
             'last-name': certificationPointOfContact.lastName,
             email: certificationPointOfContact.email,
             'pix-certif-terms-of-service-accepted': certificationPointOfContact.pixCertifTermsOfServiceAccepted,
-            'certification-center-id': certificationPointOfContact.certificationCenterId,
-            'certification-center-name': certificationPointOfContact.certificationCenterName,
-            'certification-center-type': certificationPointOfContact.certificationCenterType,
-            'certification-center-external-id': certificationPointOfContact.certificationCenterExternalId,
-            'is-related-organization-managing-students': certificationPointOfContact.isRelatedOrganizationManagingStudents,
+            'current-certification-center-id': certificationPointOfContact.currentCertificationCenterId,
           },
           relationships: {
+            'certification-centers': {
+              data: [
+                {
+                  type: 'certificationCenters',
+                  id: certificationCenter.id.toString(),
+                },
+              ],
+            },
             sessions: {
               links: {
-                related: `/api/certification-centers/${certificationPointOfContact.certificationCenterId}/sessions`,
+                related: `/api/certification-centers/${certificationPointOfContact.currentCertificationCenterId}/sessions`,
               },
             },
           },
         },
+        included: [
+          {
+            type: 'certificationCenters',
+            id: certificationCenter.id.toString(),
+            attributes: {
+              name: certificationCenter.name,
+              type: certificationCenter.type,
+              'external-id': certificationCenter.externalId,
+              'is-related-organization-managing-students': certificationCenter.isRelatedOrganizationManagingStudents,
+            },
+          },
+        ],
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-point-of-contact-serializer_test.js
@@ -7,7 +7,8 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
 
     it('should convert a CertificationReferent model object into JSON API data', () => {
       // given
-      const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact();
+      const certificationCenter = { id: 1, name: 'Serre tiff', type: 'SCO', externalId: 'externalId', isRelatedOrganizationManagingStudents: false };
+      const certificationPointOfContact = domainBuilder.buildCertificationPointOfContact({ certificationCenters: [certificationCenter] });
 
       // when
       const jsonApi = certificationPointOfContactSerializer.serialize(certificationPointOfContact);
@@ -22,20 +23,36 @@ describe('Unit | Serializer | JSONAPI | certification-point-of-contact-serialize
             'last-name': certificationPointOfContact.lastName,
             email: certificationPointOfContact.email,
             'pix-certif-terms-of-service-accepted': certificationPointOfContact.pixCertifTermsOfServiceAccepted,
-            'certification-center-id': certificationPointOfContact.certificationCenterId,
-            'certification-center-name': certificationPointOfContact.certificationCenterName,
-            'certification-center-type': certificationPointOfContact.certificationCenterType,
-            'certification-center-external-id': certificationPointOfContact.certificationCenterExternalId,
-            'is-related-organization-managing-students': certificationPointOfContact.isRelatedOrganizationManagingStudents,
+            'current-certification-center-id': certificationPointOfContact.currentCertificationCenterId,
           },
           relationships: {
+            'certification-centers': {
+              data: [
+                {
+                  type: 'certificationCenters',
+                  id: certificationCenter.id.toString(),
+                },
+              ],
+            },
             sessions: {
               links: {
-                related: `/api/certification-centers/${certificationPointOfContact.certificationCenterId}/sessions`,
+                related: `/api/certification-centers/${certificationPointOfContact.currentCertificationCenterId}/sessions`,
               },
             },
           },
         },
+        included: [
+          {
+            type: 'certificationCenters',
+            id: certificationCenter.id.toString(),
+            attributes: {
+              name: certificationCenter.name,
+              type: certificationCenter.type,
+              'external-id': certificationCenter.externalId,
+              'is-related-organization-managing-students': certificationCenter.isRelatedOrganizationManagingStudents,
+            },
+          },
+        ],
       });
     });
   });

--- a/certif/app/components/user-logged-menu.js
+++ b/certif/app/components/user-logged-menu.js
@@ -10,12 +10,12 @@ export default class UserLoggedMenu extends Component {
   @tracked isMenuOpen = false;
 
   get certificationCenterNameAndExternalId() {
-    const certificationPointOfContact = this.currentUser.certificationPointOfContact;
+    const certificationCenter = this.currentUser.currentCertificationCenter;
 
-    if (certificationPointOfContact.certificationCenterExternalId) {
-      return `${certificationPointOfContact.certificationCenterName} (${certificationPointOfContact.certificationCenterExternalId})`;
+    if (certificationCenter.externalId) {
+      return `${certificationCenter.name} (${certificationCenter.externalId})`;
     }
-    return certificationPointOfContact.certificationCenterName;
+    return certificationCenter.name;
   }
 
   get userFullName() {

--- a/certif/app/models/certification-center.js
+++ b/certif/app/models/certification-center.js
@@ -1,0 +1,16 @@
+import Model, { attr } from '@ember-data/model';
+import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
+
+export default class CertificationCenter extends Model {
+  @attr() name;
+  @attr() type;
+  @attr() externalId;
+  @attr() isRelatedOrganizationManagingStudents;
+  @equal('type', 'SCO') isSco;
+
+  @computed('type', 'isRelatedOrganizationManagingStudents')
+  get isScoManagingStudents() {
+    return this.type === 'SCO' && this.isRelatedOrganizationManagingStudents;
+  }
+}

--- a/certif/app/models/certification-point-of-contact.js
+++ b/certif/app/models/certification-point-of-contact.js
@@ -1,24 +1,13 @@
 import Model, { hasMany, attr } from '@ember-data/model';
-import { computed } from '@ember/object';
-import { equal } from '@ember/object/computed';
 
 export default class CertificationPointOfContact extends Model {
   @attr() firstName;
   @attr() lastName;
   @attr() email;
   @attr() pixCertifTermsOfServiceAccepted;
-  @attr() certificationCenterId;
-  @attr() certificationCenterName;
-  @attr() certificationCenterType;
-  @attr() certificationCenterExternalId;
-  @attr() isRelatedOrganizationManagingStudents;
+  @attr() currentCertificationCenterId;
   @hasMany('session') sessions;
-  @equal('certificationCenterType', 'SCO') isSco;
-
-  @computed('certificationCenterType', 'isRelatedOrganizationManagingStudents')
-  get isScoManagingStudents() {
-    return this.certificationCenterType === 'SCO' && this.isRelatedOrganizationManagingStudents;
-  }
+  @hasMany('certification-center') certificationCenters;
 
   get fullName() {
     return `${this.firstName} ${this.lastName}`;

--- a/certif/app/routes/authenticated.js
+++ b/certif/app/routes/authenticated.js
@@ -17,6 +17,6 @@ export default class AuthenticatedRoute extends Route.extend(AuthenticatedRouteM
   }
 
   model() {
-    return this.currentUser.certificationPointOfContact;
+    return this.currentUser.currentCertificationCenter;
   }
 }

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -10,7 +10,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
 
   async model(params) {
     const session = await this.store.findRecord('session', params.session_id);
-    const { certificationCenterId } = this.modelFor('authenticated');
+    const { id: certificationCenterId } = this.modelFor('authenticated');
 
     const certificationCandidates = await this.store.query('certification-candidate', { sessionId: params.session_id });
     const divisions = await this.store.query('division', { certificationCenterId });

--- a/certif/app/routes/authenticated/sessions/details.js
+++ b/certif/app/routes/authenticated/sessions/details.js
@@ -11,7 +11,7 @@ export default class SessionsDetailsRoute extends Route {
       sessionId: params.session_id,
     });
     const certificationCandidates = await loadCertificationCandidates();
-    const isScoManagingStudents = this.currentUser.certificationPointOfContact.isScoManagingStudents;
+    const isScoManagingStudents = this.currentUser.currentCertificationCenter.isScoManagingStudents;
     const featureToggles = this.store.peekRecord('feature-toggle', 0);
     const isCertifPrescriptionScoEnabled = featureToggles.certifPrescriptionSco;
     const isReportsCategorizationFeatureToggleEnabled = featureToggles.reportsCategorization;

--- a/certif/app/routes/authenticated/sessions/new.js
+++ b/certif/app/routes/authenticated/sessions/new.js
@@ -5,7 +5,7 @@ export default class SessionsNewRoute extends Route {
   @service currentUser;
 
   model() {
-    return this.store.createRecord('session', { certificationCenterId: this.currentUser.certificationPointOfContact.certificationCenterId });
+    return this.store.createRecord('session', { certificationCenterId: this.currentUser.certificationPointOfContact.currentCertificationCenterId });
   }
 
   deactivate() {

--- a/certif/app/services/current-user.js
+++ b/certif/app/services/current-user.js
@@ -6,6 +6,7 @@ export default class CurrentUserService extends Service {
   @service session;
   @service store;
   @tracked certificationPointOfContact;
+  @tracked currentCertificationCenter;
 
   get isFromSco() {
     return this.certificationPointOfContact.isSco;
@@ -14,7 +15,8 @@ export default class CurrentUserService extends Service {
   async load() {
     if (this.session.isAuthenticated) {
       try {
-        this.certificationPointOfContact = await this.store.findRecord('certification-point-of-contact', this.session.data.authenticated.user_id);
+        this.certificationPointOfContact = await this.store.findRecord('certification-point-of-contact', this.session.data.authenticated.user_id, { include: 'certificationCenters' });
+        this.currentCertificationCenter = this.certificationPointOfContact.certificationCenters.findBy('id', String(this.certificationPointOfContact.currentCertificationCenterId));
       } catch (error) {
         if (get(error, 'errors[0].code') === 401) {
           return this.session.invalidate();

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -50,7 +50,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
     hooks.beforeEach(async () => {
       certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
-      session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
+      session = server.create('session', { certificationCenterId: certificationPointOfContact.currentCertificationCenterId });
       await authenticateSession(certificationPointOfContact.id);
     });
 
@@ -259,8 +259,9 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
           test('it should display the list of students for session', async function(assert) {
             // given
             server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
-            certificationPointOfContact.update({ certificationCenterType: 'SCO' });
-            certificationPointOfContact.update({ isRelatedOrganizationManagingStudents: true });
+            const certificationCenter = server.schema.certificationCenters.findBy({ id: certificationPointOfContact.currentCertificationCenterId });
+            certificationCenter.update({ type: 'SCO' });
+            certificationCenter.update({ isRelatedOrganizationManagingStudents: true });
             server.createList('student', 10);
 
             // when

--- a/certif/tests/helpers/test-init.js
+++ b/certif/tests/helpers/test-init.js
@@ -6,16 +6,22 @@ QUnit.assert.contains = contains;
 QUnit.assert.notContains = notContains;
 
 export function createCertificationPointOfContact(pixCertifTermsOfServiceAccepted = false, certificationCenterType, certificationCenterName = 'Centre de certification du pix', isRelatedOrganizationManagingStudents = false) {
+  const certificationCenter = server.create('certification-center', {
+    id: 1,
+    name: certificationCenterName,
+    type: certificationCenterType,
+    externalId: 'ABC123',
+    isRelatedOrganizationManagingStudents,
+  });
+  certificationCenter.save();
+
   const certificationPointOfContact = server.create('certification-point-of-contact', {
     firstName: 'Harry',
     lastName: 'Cover',
     email: 'harry@cover.com',
     pixCertifTermsOfServiceAccepted,
-    certificationCenterId: 1,
-    certificationCenterName,
-    certificationCenterType,
-    certificationCenterExternalId: 'ABC123',
-    isRelatedOrganizationManagingStudents,
+    certificationCenters: [certificationCenter],
+    currentCertificationCenterId: 1,
   });
   certificationPointOfContact.save();
 

--- a/certif/tests/integration/components/user-logged-menu-test.js
+++ b/certif/tests/integration/components/user-logged-menu-test.js
@@ -10,17 +10,21 @@ module('Integration | Component | user-logged-menu', function(hooks) {
   setupRenderingTest(hooks);
 
   let certificationPointOfContact;
+  let currentCertificationCenter;
 
   hooks.beforeEach(async function() {
     // given
+    currentCertificationCenter = Object.create({
+      name: 'givenCertificationCenterName',
+      externalId: 'givenCertificationCenterExternalId',
+    });
+
     certificationPointOfContact = Object.create({
       firstName: 'givenFirstName',
       lastName: 'givenLastName',
-      certificationCenterName: 'givenCertificationCenterName',
-      certificationCenterExternalId: 'givenCertificationCenterExternalId',
     });
 
-    this.owner.register('service:current-user', Service.extend({ certificationPointOfContact }));
+    this.owner.register('service:current-user', Service.extend({ certificationPointOfContact, currentCertificationCenter }));
 
     // when
     await render(hbs`<UserLoggedMenu/>`);
@@ -35,13 +39,13 @@ module('Integration | Component | user-logged-menu', function(hooks) {
 
     test('should display the user certification center name only', async function(assert) {
       // given
-      delete certificationPointOfContact.certificationCenterExternalId;
+      delete currentCertificationCenter.externalId;
 
       // when
       await render(hbs`<UserLoggedMenu/>`);
 
       // then
-      assert.contains(certificationPointOfContact.certificationCenterName);
+      assert.contains(currentCertificationCenter.name);
     });
   });
 
@@ -49,7 +53,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
 
     test('should display the user certification center name and certification center externalId', function(assert) {
       // then
-      assert.contains(`${certificationPointOfContact.certificationCenterName} (${certificationPointOfContact.certificationCenterExternalId})`);
+      assert.contains(`${currentCertificationCenter.name} (${currentCertificationCenter.externalId})`);
     });
   });
 

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -33,7 +33,7 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       const findRecordStub = sinon.stub();
       findRecordStub.withArgs('session', session_id).resolves(session);
       route.store.findRecord = findRecordStub;
-      route.modelFor = sinon.stub().returns({ certificationCenterId });
+      route.modelFor = sinon.stub().returns({ id: certificationCenterId });
       route.store.query = sinon.stub();
       route.store.query.onCall(0).resolves([Symbol('a candidate')]);
       route.store.query.onCall(1).resolves(divisions);

--- a/certif/tests/unit/routes/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details-test.js
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/sessions/details', function(hooks) {
     test('it should return the session and the certification candidates', async function(assert) {
       // given
       route.store.peekRecord = sinon.stub().returns({ certifPrescriptionSco: false });
-      route.currentUser = { certificationPointOfContact: { isScoManagingStudents: true } };
+      route.currentUser = { currentCertificationCenter: { isScoManagingStudents: true } };
 
       // when
       const model = await route.model({ session_id });
@@ -44,7 +44,7 @@ module('Unit | Route | authenticated/sessions/details', function(hooks) {
       test(it, async function(assert) {
         // given
         route.store.peekRecord = sinon.stub().returns({ certifPrescriptionSco });
-        route.currentUser = { certificationPointOfContact: { isScoManagingStudents } };
+        route.currentUser = { currentCertificationCenter: { isScoManagingStudents } };
 
         // when
         const model = await route.model({ session_id });

--- a/certif/tests/unit/routes/authenticated/sessions/new-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/new-test.js
@@ -16,7 +16,7 @@ module('Unit | Route | authenticated/sessions/new', function(hooks) {
 
     hooks.beforeEach(function() {
       route.store.createRecord = sinon.stub().resolves(createdSession);
-      route.currentUser = { certificationPointOfContact: { certificationCenterId } };
+      route.currentUser = { certificationPointOfContact: { currentCertificationCenterId: certificationCenterId } };
     });
 
     test('it should return the recently created session', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix Certif, lorsqu'un utilisateur se connecte à son compte, il n'a accès qu'à un centre de certification.
S'il est rattaché à d'autres centres, il ne peut pas y accéder depuis le même compte.

## :robot: Solution
Renvoyer un tableau trié des centres de certification auxquels l'utilisateur est rattaché. ( Le premier étant le centre rattaché en dernier )

## :rainbow: Remarques
Pas visible coté front, prévu pour le prochain ticket Multi Accès Pix Certif.

## :100: Pour tester

Pour le test tech : 

Ajouter manuellement un deuxième centre de certification à un utilisateur et vérifier que l'on renvoie un tableau trié. 