### PR TITLE
[BUGFIX] Permettre aux scripts de pouvoir être lancés (PIX-1941).  

### DIFF
--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -82,7 +82,7 @@ async function main() {
     console.log('ok');
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsvWithHeader(filePath);
+    const csvData = await parseCsvWithHeader(filePath);
     console.log('ok');
 
     console.log('Data preparation before insertion into the database...');

--- a/api/scripts/create-sco-certification-centers.js
+++ b/api/scripts/create-sco-certification-centers.js
@@ -27,7 +27,7 @@ async function main() {
     console.log('ok');
 
     console.log('Reading and parsing csv data file... ');
-    const csvData = parseCsvWithHeader(filePath);
+    const csvData = await parseCsvWithHeader(filePath);
     console.log('ok');
 
     console.log('Preparing data and add SCO type... ');

--- a/api/scripts/populate-organizations-email.js
+++ b/api/scripts/populate-organizations-email.js
@@ -35,7 +35,7 @@ async function main() {
     }
 
     console.log('Reading and parsing csv file (checking headers)... ');
-    const csvData = parseCsvWithHeader(filePath);
+    const csvData = await parseCsvWithHeader(filePath);
     console.log(`Successfully read ${csvData.length} records.`);
 
     console.log('Populating organizations (existing emails will be updated)... ');

--- a/api/scripts/send-invitations-to-sco-organizations.js
+++ b/api/scripts/send-invitations-to-sco-organizations.js
@@ -59,7 +59,7 @@ async function main() {
     const tags = argTags ? [argTags] : TAGS;
 
     console.log('Reading and parsing csv file... ');
-    const csvData = parseCsvWithHeader(filePath);
+    const csvData = await parseCsvWithHeader(filePath);
     console.log(`Succesfully read ${csvData.length} records.`);
 
     console.log('Preparing data before sending... ');


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne pouvons plus lancer les scripts car une tâche asynchrone est lancée mais la réponse n'est pas attendue. 

## :robot: Solution
Ajouter un `await`  au moment du `parseCsvWithHeader()`.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer les scripts et constater le bon fonctionnement.
`node scripts/create-certification-center-memberships-from-organization-admins.js /le_bon_fichier.csv`
`node scripts/create-sco-certification-centers.js /le_bon_fichier.csv`
`node scripts/populate-organizations-email.js /le_bon_fichier.csv`
`node scripts/send-invitations-to-sco-organizations.js /le_bon_fichier.csv`