### PR TITLE
[FEATURE] Rejeter une recherche sur une organisation si l'identifiant est non numérique (PIX-1936).

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,5 +1,5 @@
 const Joi = require('@hapi/joi');
-const { sendJsonApiError, PayloadTooLargeError, NotFoundError } = require('../http-errors');
+const { sendJsonApiError, PayloadTooLargeError, NotFoundError, BadRequestError } = require('../http-errors');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const organizationController = require('./organization-controller');
@@ -26,6 +26,20 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+        validate: {
+          options: {
+            allowUnknown: true,
+          },
+          query: Joi.object({
+            'filter[id]': Joi.number().integer().empty('').allow(null).optional(),
+            'filter[name]': Joi.string().empty('').allow(null).optional(),
+            'page[number]': Joi.number().integer().empty('').allow(null).optional(),
+            'page[size]': Joi.number().integer().empty('').allow(null).optional(),
+          }),
+          failAction: (request, h) => {
+            return sendJsonApiError(new BadRequestError('Un des champs de recherche saisis est invalide.'), h);
+          },
+        },
         handler: organizationController.findPaginatedFilteredOrganizations,
         tags: ['api', 'organizations'],
         notes: [

--- a/api/tests/unit/application/organizations/index_test.js
+++ b/api/tests/unit/application/organizations/index_test.js
@@ -26,16 +26,29 @@ describe('Unit | Router | organization-router', () => {
 
   describe('GET /api/organizations', () => {
 
-    it('should exist', async () => {
+    it('should return OK (200) when request is valid', async () => {
       // given
       const method = 'GET';
-      const url = '/api/organizations?filter[name]=DRA&filter[type]=AZ&filter[type]=SCO&page[number]=3&page[size]=25';
+      const url = '/api/organizations?filter[id]=&filter[name]=DRA&filter[type]=SCO&page[number]=3&page[size]=25';
 
       // when
       const response = await httpTestServer.request(method, url);
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return BadRequest (400) when request is invalid', async () => {
+      // given
+      const method = 'GET';
+      const idNotNumeric = 'foo';
+      const url = `/api/organizations?filter[id]=${idNotNumeric}`;
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Si, dans Pix Admin, lors de la recherche par ID d'organisation, on ne fournit pas un nombre
- une erreur est levée par la BDD
- un message est affiché dans Pix admin  "Erreur dans Ember"

## :robot: Solution
Ne pas causer d'erreur en BDD, mais rejeter la requête (400)

## :rainbow: Remarques
Ceci est un quick fix captain pour ne voir les autres erreurs de BDD
Dans Pix Admin, le message  "Erreur dans Ember" est toujours affiché

## :100: Pour tester
Tester:
- aucun critère de recherche
- ID existant
- ID texte (foo)
