### PR TITLE
[BUGFIX] Ajout de la traduction en EN pour deux labels sur Pix App (PIX-1792).

### DIFF
--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -147,8 +147,7 @@
 
   &__forgotten-password-link {
     align-self: flex-end;
-    margin-bottom: 20px;
-    margin-right: 10px;
+    margin: 5px 0 20px 0;
   }
 }
 

--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -40,7 +40,7 @@
     <form {{on 'submit' this.savePasswordResetDemand}} class="sign-form__body">
 
       <div class="sign-form-body__input">
-        <FormTextfield @label="Adresse e-mail" @textfieldName="email" @validationStatus="default"
+        <FormTextfield @label="{{t 'pages.password-reset-demand.fields.email.label'}}" @textfieldName="email" @validationStatus="default"
                        @inputBindingValue={{this.email}} @require="true" />
       </div>
 

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -16,7 +16,7 @@
     <form {{on 'submit' this.handleResetPassword}} class="sign-form__body">
 
       <div class="sign-form-body__input">
-        <FormTextfield @label="Mot de passe"
+        <FormTextfield @label="{{t 'pages.reset-password.fields.password.label'}}"
                        @textfieldName="password"
                        @validationStatus={{this.validation.status}}
                        @onValidate={{this.validatePassword}}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -638,6 +638,11 @@
         },
         "password-reset-demand": {
             "title": "Forgotten your password?",
+            "fields": {
+                "email": {
+                    "label": "Email address"
+                }
+            },
             "actions": {
                 "back-home": "Return to homepage",
                 "back-sign-in": "Return to log in page",
@@ -695,6 +700,11 @@
         },
         "reset-password": {
             "title": "Change my password",
+            "fields": {
+                "password": {
+                    "label": "Password"
+                }
+            },
             "actions": {
                 "submit": "Send",
                 "sign-in": "Log in"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -638,6 +638,11 @@
         },
         "password-reset-demand": {
             "title": "Mot de passe oublié ?",
+            "fields": {
+                "email": {
+                    "label": "Adresse e-mail"
+                }
+            },
             "actions": {
                 "back-home": "Retour à l'accueil",
                 "back-sign-in": "Retour à la page de connexion",
@@ -695,6 +700,11 @@
         },
         "reset-password": {
             "title": "Changer mon mot de passe",
+            "fields": {
+                "password": {
+                    "label": "Mot de passe"
+                }
+            },
             "actions": {
                 "submit": "Envoyer",
                 "sign-in": "Connectez-vous"


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App en ORG EN, deux labels n'étaient pas traduits : 
- Sur l'écran du mot de passe oublié : Forgotten your Password? - Le label reste "Adresse e-mail"
<img width="278" alt="Capture d’écran 2021-01-04 à 15 49 56" src="https://user-images.githubusercontent.com/58915422/103547296-83563480-4ea4-11eb-9723-fc6f8bf36875.png">

- Sur l'écran de saisie du nouveau mot de passe. - Le label reste "Mot de passe"
<img width="283" alt="Capture d’écran 2021-01-04 à 15 48 21" src="https://user-images.githubusercontent.com/58915422/103547148-4c801e80-4ea4-11eb-8235-a86cde74f0c0.png">

## :robot: Solution
Les deux labels étaient écrits en dur => les ajouter dans les json FR et EN.

## :rainbow: Remarques
Petite modification CSS sur le margin de "Forgotten your password?", suite à un retour de @manux-pix.

## :100: Pour tester

- Aller sur Pix App en localhost.org/lang=?en (si test en local)
- Sur Forgotten your Password?, s'assurer que le label "Adresse e-mail" a bien été traduit. (vérifier qu'il est ok en fr aussi)
- Pour le second cas, créer un compte avec une adresse e-mail viable pour recevoir le mail "password reset request" et accéder à la page de saisie du nouveau mot de passe, s'assurer que le label "Mot de passe" est traduit (fr ok aussi)