### PR TITLE
[FEATURE] Amélioration du script de création des memberships des centres de certification (PIX-1942).

### DIFF
--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -49,14 +49,14 @@ async function fetchCertificationCenterMembershipsByExternalId(externalId) {
 }
 
 function prepareDataForInsert(rawExternalIds) {
-  return Promise.all(_.map(rawExternalIds, ({ externalId }) => {
+  const externalIds = _.uniq(_.map(rawExternalIds, 'externalId'));
+  return Promise.all(_.map(externalIds, (externalId) => {
     return fetchCertificationCenterMembershipsByExternalId(externalId);
   }))
     .then((certificationCenterMemberships) => {
       return _(certificationCenterMemberships)
         .compact()
         .flattenDeep()
-        .union()
         .value();
     });
 }

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -8,7 +8,6 @@ const { checkCsvExtensionFile, parseCsvWithHeader } = require('./helpers/csvHelp
 const Membership = require('../lib/domain/models/Membership');
 
 const { knex } = require('../lib/infrastructure/bookshelf');
-const Bookshelf = require('../lib/infrastructure/bookshelf');
 
 async function getCertificationCenterIdByExternalId(externalId) {
   const certificationCenter = await knex('certification-centers')
@@ -52,7 +51,7 @@ async function prepareDataForInsert(rawExternalIds) {
 }
 
 async function createCertificationCenterMemberships(certificationCenterMemberships) {
-  return Bookshelf.knex.batchInsert('certification-center-memberships', certificationCenterMemberships);
+  return knex.batchInsert('certification-center-memberships', certificationCenterMemberships);
 }
 
 async function main() {

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -9,7 +9,7 @@ const Membership = require('../lib/domain/models/Membership');
 
 const { knex } = require('../lib/infrastructure/bookshelf');
 
-async function getCertificationCenterIdByExternalId(externalId) {
+async function getCertificationCenterWithoutMembershipIdByExternalId(externalId) {
   const certificationCenter = await knex('certification-centers')
     .first('certification-centers.id')
     .leftJoin('certification-center-memberships', 'certification-center-memberships.certificationCenterId', 'certification-centers.id')
@@ -36,7 +36,7 @@ function buildCertificationCenterMemberships({ certificationCenterId, membership
 }
 
 async function fetchCertificationCenterMembershipsByExternalId(externalId) {
-  const certificationCenterId = await getCertificationCenterIdByExternalId(externalId);
+  const certificationCenterId = await getCertificationCenterWithoutMembershipIdByExternalId(externalId);
   if (!certificationCenterId) {
     return [];
   }
@@ -93,7 +93,7 @@ if (require.main === module) {
 }
 
 module.exports = {
-  getCertificationCenterIdByExternalId,
+  getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   buildCertificationCenterMemberships,
   fetchCertificationCenterMembershipsByExternalId,

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -16,11 +16,13 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
   const externalId1 = '1234567A';
   const externalId2 = '7654321B';
+  const externalId3 = '1231231C';
 
   let organizationId1;
   let organizationId2;
   let certificationCenterId1;
   let certificationCenterId2;
+  let certificationCenterId3;
 
   let adminUserId1a;
   let adminUserId1b;
@@ -60,6 +62,13 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     certificationCenterId2 = databaseBuilder.factory.buildCertificationCenter({
       externalId: externalId2,
     }).id;
+    certificationCenterId3 = databaseBuilder.factory.buildCertificationCenter({
+      externalId: externalId3,
+    }).id;
+    databaseBuilder.factory.buildCertificationCenterMembership({
+      certificationCenterId: certificationCenterId3,
+      userId: userId1,
+    });
 
     await databaseBuilder.commit();
   });
@@ -72,6 +81,14 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
       // then
       expect(certificationCenter.externalId).to.equal(externalId1);
+    });
+
+    it('should not return certification center with a membership', async () => {
+      // when
+      const result = await getCertificationCenterByExternalId(externalId3);
+
+      // then
+      expect(result).to.be.null;
     });
   });
 
@@ -87,6 +104,19 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       // then
       const userIds = memberships.map((membership) => _.pick(membership, 'userId'));
       expect(userIds).to.deep.have.members(expectedUserIds);
+    });
+
+    it('should return an empty array if organization has no admin membership', async () => {
+      // given
+      const externalId = '1212121A';
+      databaseBuilder.factory.buildOrganization({ externalId }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const memberships = await getAdminMembershipsByOrganizationExternalId(externalId);
+
+      // then
+      expect(memberships).to.have.lengthOf(0);
     });
   });
 
@@ -123,6 +153,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       const result = await prepareDataForInsert([
         { externalId: externalId1 },
         { externalId: externalId2 },
+        { externalId: externalId3 },
       ]);
 
       // then

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -6,7 +6,8 @@ const Membership = require('../../../lib/domain/models/Membership');
 const BookshelfCertificationCenterMembership = require('../../../lib/infrastructure/data/certification-center-membership');
 
 const {
-  getCertificationCenterIdByExternalId, getAdminMembershipsByOrganizationExternalId,
+  getCertificationCenterIdByExternalId,
+  getAdminMembershipsUserIdByOrganizationExternalId,
   fetchCertificationCenterMembershipsByExternalId,
   prepareDataForInsert,
   createCertificationCenterMemberships,
@@ -92,18 +93,17 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     });
   });
 
-  describe('#getAdminMembershipsByOrganizationExternalId', () => {
+  describe('#getAdminMembershipsUserIdByOrganizationExternalId', () => {
 
     it('should get admin memberships by organization externalId', async () => {
       // given
-      const expectedUserIds = [{ userId: adminUserId1a }, { userId: adminUserId1b }];
+      const expectedUserIds = [adminUserId1a, adminUserId1b];
 
       // when
-      const memberships = await getAdminMembershipsByOrganizationExternalId(externalId1);
+      const userIds = await getAdminMembershipsUserIdByOrganizationExternalId(externalId1);
 
       // then
-      const userIds = memberships.map((membership) => _.pick(membership, 'userId'));
-      expect(userIds).to.deep.have.members(expectedUserIds);
+      expect(userIds).to.deep.equal(expectedUserIds);
     });
 
     it('should return an empty array if organization has no admin membership', async () => {
@@ -113,7 +113,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       await databaseBuilder.commit();
 
       // when
-      const memberships = await getAdminMembershipsByOrganizationExternalId(externalId);
+      const memberships = await getAdminMembershipsUserIdByOrganizationExternalId(externalId);
 
       // then
       expect(memberships).to.have.lengthOf(0);

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -6,7 +6,7 @@ const Membership = require('../../../lib/domain/models/Membership');
 const BookshelfCertificationCenterMembership = require('../../../lib/infrastructure/data/certification-center-membership');
 
 const {
-  getCertificationCenterByExternalId, getAdminMembershipsByOrganizationExternalId,
+  getCertificationCenterIdByExternalId, getAdminMembershipsByOrganizationExternalId,
   fetchCertificationCenterMembershipsByExternalId,
   prepareDataForInsert,
   createCertificationCenterMemberships,
@@ -73,22 +73,22 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     await databaseBuilder.commit();
   });
 
-  describe('#getCertificationCenterByExternalId', () => {
+  describe('#getCertificationCenterIdByExternalId', () => {
 
     it('should get certification center by externalId', async () => {
       // when
-      const certificationCenter = await getCertificationCenterByExternalId(externalId1);
+      const certificationCenterId = await getCertificationCenterIdByExternalId(externalId1);
 
       // then
-      expect(certificationCenter.externalId).to.equal(externalId1);
+      expect(certificationCenterId).to.equal(certificationCenterId1);
     });
 
-    it('should return empty array when certification center does not have membership', async () => {
+    it('should return null when certification center does not have membership', async () => {
       // when
-      const result = await getCertificationCenterByExternalId(externalId3);
+      const result = await getCertificationCenterIdByExternalId(externalId3);
 
       // then
-      expect(result).to.have.lengthOf(0);
+      expect(result).to.be.null;
     });
   });
 
@@ -134,6 +134,14 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
       // then
       expect(result).to.deep.have.members(expectedCertificationCenterMemberships);
+    });
+
+    it('should return empty array when certification center is not found', async () => {
+      // when
+      const result = await fetchCertificationCenterMembershipsByExternalId(externalId3);
+
+      // then
+      expect(result).to.have.lengthOf(0);
     });
   });
 

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -6,7 +6,7 @@ const Membership = require('../../../lib/domain/models/Membership');
 const BookshelfCertificationCenterMembership = require('../../../lib/infrastructure/data/certification-center-membership');
 
 const {
-  getCertificationCenterIdByExternalId,
+  getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   fetchCertificationCenterMembershipsByExternalId,
   prepareDataForInsert,
@@ -17,13 +17,13 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
   const externalId1 = '1234567A';
   const externalId2 = '7654321B';
-  const externalId3 = '1231231C';
+  const externalIdForCertificationCenterWithMembership = '1231231C';
 
   let organizationId1;
   let organizationId2;
   let certificationCenterId1;
   let certificationCenterId2;
-  let certificationCenterId3;
+  let certificationCenterWithMembershipId;
 
   let adminUserId1a;
   let adminUserId1b;
@@ -63,11 +63,11 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     certificationCenterId2 = databaseBuilder.factory.buildCertificationCenter({
       externalId: externalId2,
     }).id;
-    certificationCenterId3 = databaseBuilder.factory.buildCertificationCenter({
-      externalId: externalId3,
+    certificationCenterWithMembershipId = databaseBuilder.factory.buildCertificationCenter({
+      externalId: externalIdForCertificationCenterWithMembership,
     }).id;
     databaseBuilder.factory.buildCertificationCenterMembership({
-      certificationCenterId: certificationCenterId3,
+      certificationCenterId: certificationCenterWithMembershipId,
       userId: userId1,
     });
 
@@ -78,15 +78,15 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
     it('should get certification center by externalId', async () => {
       // when
-      const certificationCenterId = await getCertificationCenterIdByExternalId(externalId1);
+      const certificationCenterId = await getCertificationCenterWithoutMembershipIdByExternalId(externalId1);
 
       // then
       expect(certificationCenterId).to.equal(certificationCenterId1);
     });
 
-    it('should return null when certification center does not have membership', async () => {
+    it('should return null when certification center has a membership', async () => {
       // when
-      const result = await getCertificationCenterIdByExternalId(externalId3);
+      const result = await getCertificationCenterWithoutMembershipIdByExternalId(externalIdForCertificationCenterWithMembership);
 
       // then
       expect(result).to.be.null;
@@ -136,9 +136,9 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       expect(result).to.deep.have.members(expectedCertificationCenterMemberships);
     });
 
-    it('should return empty array when certification center is not found', async () => {
+    it('should return empty array when certification center has membership', async () => {
       // when
-      const result = await fetchCertificationCenterMembershipsByExternalId(externalId3);
+      const result = await fetchCertificationCenterMembershipsByExternalId(externalIdForCertificationCenterWithMembership);
 
       // then
       expect(result).to.have.lengthOf(0);
@@ -161,7 +161,7 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       const result = await prepareDataForInsert([
         { externalId: externalId1 },
         { externalId: externalId2 },
-        { externalId: externalId3 },
+        { externalId: externalIdForCertificationCenterWithMembership },
       ]);
 
       // then

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -83,12 +83,12 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       expect(certificationCenter.externalId).to.equal(externalId1);
     });
 
-    it('should not return certification center with a membership', async () => {
+    it('should return empty array when certification center does not have membership', async () => {
       // when
       const result = await getCertificationCenterByExternalId(externalId3);
 
       // then
-      expect(result).to.be.null;
+      expect(result).to.have.lengthOf(0);
     });
   });
 

--- a/api/tests/unit/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/unit/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -8,7 +8,7 @@ describe('Unit | Scripts | create-certification-center-memberships-from-organiza
 
     it('should build the list of certification center memberships', () => {
       // given
-      const memberships = [{ userId: 1 }, { userId: 5 }];
+      const membershipUserIds = [1, 5];
       const certificationCenterId = 100;
 
       const expectedCertificationCenterMemberships = [
@@ -17,7 +17,7 @@ describe('Unit | Scripts | create-certification-center-memberships-from-organiza
       ];
 
       // when
-      const result = buildCertificationCenterMemberships({ certificationCenterId, memberships });
+      const result = buildCertificationCenterMemberships({ certificationCenterId, membershipUserIds });
 
       // then
       expect(result).to.deep.equal(expectedCertificationCenterMemberships);


### PR DESCRIPTION
## :unicorn: Problème
Il existe un script permettant de créer des `certification-center-memberships` depuis des `memberships` d'organisations ayant le rôle ADMIN à partir d'une liste d'UAI. Cependant, si l'organisation partir de laquelle on cherche à récupérer des `memberships` de type ADMIN, n'en possède pas, le script renvoie une erreur. De plus, si le centre de certification pour lequel on cherche à créer les `certification-center-memberships` en possède déjà, le script renvoie une erreur car il existe une contrainte d'unicité sur le couple `userId`/`certificationCenterId`.

## :robot: Solution
Ne pas stopper le script si une organisation ne possède pas de memberships et ne pas tenter de recréer des `certification-center-memberships` pour les centre de certification qui en possèdent déjà. 

## :100: Pour tester
- Lancer le script pour une organisation n'ayant pas de memberships et pour une centre de certification ayant déjà un membership et vérifier que le script ne cause pas d'erreurs.