### PR TITLE
[FEATURE] Ajout de la catégorie fraude (PIX-1933)

### DIFF
--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -56,12 +56,18 @@ const categoryInChallengeJoiSchema = Joi.object({
     }),
 });
 
+const categoryFraudJoiSchema = Joi.object({
+  certificationCourseId: Joi.number().required().empty(null),
+  category: Joi.string().required().valid(CertificationIssueReportCategories.FRAUD),
+});
+
 const categorySchemas = {
   [CertificationIssueReportCategories.OTHER]: categoryOtherJoiSchema,
   [CertificationIssueReportCategories.LATE_OR_LEAVING]: categoryLateOrLeavingJoiSchema,
   [CertificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: categoryCandidateInformationChangesJoiSchema,
   [CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: categoryConnectionOrEndScreenJoiSchema,
   [CertificationIssueReportCategories.IN_CHALLENGE]: categoryInChallengeJoiSchema,
+  [CertificationIssueReportCategories.FRAUD]: categoryFraudJoiSchema,
 };
 
 class CertificationIssueReport {

--- a/api/lib/domain/models/CertificationIssueReportCategory.js
+++ b/api/lib/domain/models/CertificationIssueReportCategory.js
@@ -5,6 +5,7 @@ module.exports = {
     LATE_OR_LEAVING: 'LATE_OR_LEAVING',
     CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
     IN_CHALLENGE: 'IN_CHALLENGE',
+    FRAUD: 'FRAUD',
   },
   CertificationIssueReportSubcategories: {
     NAME_OR_BIRTHDATE: 'NAME_OR_BIRTHDATE',

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -12,15 +12,15 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
 
   describe('#new', () => {
 
-    context('CATEGORY : OTHER', () => {
+    context('CATEGORY: OTHER', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.OTHER,
         description: 'Une description obligatoire',
       };
 
-      it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
+      it('should create an OTHER CertificationIssueReport', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -41,15 +41,15 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         EMPTY_VALUE,
         UNDEFINED_VALUE,
       ].forEach((emptyValue) => {
-        it(`should not throw any error when subcategory is empty with value ${emptyValue}`, () => {
+        it(`should create an OTHER CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
-            .to.not.throw(InvalidCertificationIssueReportForSaving);
+          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+            .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
     });
 
-    context('CATEGORY : LATE_OR_LEAVING', () => {
+    context('CATEGORY: LATE_OR_LEAVING', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.LATE_OR_LEAVING,
@@ -57,8 +57,9 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         subcategory: CertificationIssueReportSubcategories.LEFT_EXAM_ROOM,
       };
 
-      it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
+      it('should create a LATE_OR_LEAVING CertificationIssueReport of category', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+          .to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -77,10 +78,10 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       // Test dynamically all subcategories
       [...Object.values(CertificationIssueReportSubcategories)].forEach((subcategory) => {
         if ([CertificationIssueReportSubcategories.LEFT_EXAM_ROOM, CertificationIssueReportSubcategories.SIGNATURE_ISSUE].includes(subcategory)) {
-          it(`should not throw any error when subcategory is of value ${subcategory}`, () => {
+          it(`should create a LATE_OR_LEAVING CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
-              .to.not.throw(InvalidCertificationIssueReportForSaving);
+            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+              .to.be.an.instanceOf(CertificationIssueReport);
           });
         } else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
@@ -92,7 +93,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       });
     });
 
-    context('CATEGORY : CANDIDATE_INFORMATIONS_CHANGES', () => {
+    context('CATEGORY: CANDIDATE_INFORMATIONS_CHANGES', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES,
@@ -100,8 +101,9 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         subcategory: CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE,
       };
 
-      it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
+      it('should create a CANDIDATE_INFORMATIONS_CHANGES CertificationIssueReport', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+          .to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -120,10 +122,10 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       // Test dynamically all subcategories
       [...Object.values(CertificationIssueReportSubcategories)].forEach((subcategory) => {
         if ([CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE, CertificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE].includes(subcategory)) {
-          it(`should not throw any error when subcategory is of value ${subcategory}`, () => {
+          it(`should create a CANDIDATE_INFORMATIONS_CHANGES CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
-              .to.not.throw(InvalidCertificationIssueReportForSaving);
+            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory }))
+              .to.be.an.instanceOf(CertificationIssueReport);
           });
         } else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
@@ -135,14 +137,15 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       });
     });
 
-    context('CATEGORY : CONNECTION_OR_END_SCREEN', () => {
+    context('CATEGORY: CONNECTION_OR_END_SCREEN', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN,
       };
 
-      it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
+      it('should create a CONNECTION_OR_END_SCREEN CertificationIssueReport', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+          .to.be.an.instanceOf(CertificationIssueReport);
       });
 
       [
@@ -151,10 +154,10 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         UNDEFINED_VALUE,
         WHITESPACES_VALUE,
       ].forEach((emptyValue) => {
-        it(`should not throw any error when description is empty with value ${emptyValue}`, () => {
+        it(`should create a CONNECTION_OR_END_SCREEN CertificationIssueReport when description is empty with value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
-            .to.not.throw(InvalidCertificationIssueReportForSaving);
+          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+            .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
 
@@ -163,15 +166,15 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         EMPTY_VALUE,
         UNDEFINED_VALUE,
       ].forEach((emptyValue) => {
-        it(`should not throw any error when subcategory is empty with value ${emptyValue}`, () => {
+        it(`should create CONNECTION_OR_END_SCREEN CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
           // when
-          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
-            .to.not.throw(InvalidCertificationIssueReportForSaving);
+          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+            .to.be.an.instanceOf(CertificationIssueReport);
         });
       });
     });
 
-    context('CATEGORY : IN_CHALLENGE', () => {
+    context('CATEGORY: IN_CHALLENGE', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.IN_CHALLENGE,
@@ -179,8 +182,9 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         questionNumber: 5,
       };
 
-      it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
+      it('should create an IN_CHALLENGE CertificationIssueReport', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO))
+          .to.be.an.instanceOf(CertificationIssueReport);
       });
 
       // Test dynamically all subcategories
@@ -194,10 +198,10 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
           CertificationIssueReportSubcategories.OTHER,
         ].includes(subcategory)) {
-          it(`should not throw any error when subcategory is of value ${subcategory}`, () => {
+          it(`should create an IN_CHALLENGE CertificationIssueReport when subcategory is of value ${subcategory}`, () => {
             // when
-            expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory, description: subcategory === CertificationIssueReportSubcategories.OTHER ? 'salut' : null }))
-              .to.not.throw(InvalidCertificationIssueReportForSaving);
+            expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory, description: subcategory === CertificationIssueReportSubcategories.OTHER ? 'salut' : null }))
+              .to.be.an.instanceOf(CertificationIssueReport);
           });
         } else {
           it(`should throw an InvalidCertificationIssueReportForSaving when subcategory is ${subcategory}`, () => {
@@ -216,7 +220,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE,
         CertificationIssueReportSubcategories.WEBSITE_BLOCKED,
       ].forEach((subcategory) => {
-        it(`should throw an InvalidCertificationIssueReportForSaving when description is not emptyfor subcategory ${subcategory}`, () => {
+        it(`should throw an InvalidCertificationIssueReportForSaving when description is not empty for subcategory ${subcategory}`, () => {
           // when
           expect(() => CertificationIssueReport.new({
             ...certificationIssueReportDTO,
@@ -257,7 +261,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           .to.throw(InvalidCertificationIssueReportForSaving);
       });
     });
-    context('CATEGORY : FRAUD', () => {
+    context('CATEGORY: FRAUD', () => {
       const certificationIssueReportDTO = {
         certificationCourseId: 123,
         category: CertificationIssueReportCategories.FRAUD,

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -257,5 +257,15 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
           .to.throw(InvalidCertificationIssueReportForSaving);
       });
     });
+    context('CATEGORY : FRAUD', () => {
+      const certificationIssueReportDTO = {
+        certificationCourseId: 123,
+        category: CertificationIssueReportCategories.FRAUD,
+      };
+
+      it('it should be valid', () => {
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).not.to.throw();
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -20,7 +20,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw;
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
       });
 
       [
@@ -58,7 +58,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw;
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
       });
 
       [
@@ -101,7 +101,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw;
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
       });
 
       [
@@ -142,7 +142,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw;
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
       });
 
       [
@@ -180,7 +180,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
       };
 
       it('should not throw any error', () => {
-        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw;
+        expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).to.not.throw();
       });
 
       // Test dynamically all subcategories

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -43,6 +43,11 @@
             @toggleOnCategory={{this.toggleOnCategory}}
             @maxlength={{@maxlength}}
           />
+
+          <IssueReportModal::FraudCertificationIssueReportFields
+            @fraudCategory={{this.fraudCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+          />
         </div>
 
         {{#if this.showCategoryMissingError}}

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -113,7 +113,17 @@ export default class AddIssueReportModal extends Component {
     name: certificationIssueReportCategories.IN_CHALLENGE,
     subcategory: certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING,
   });
-  categories = [ this.otherCategory, this.lateOrLeavingCategory, this.candidateInformationChangeCategory, this.connectionOrEndScreenCategory, this.inChallengeCategory ];
+  @tracked fraudCategory = new RadioButtonCategory({
+    name: certificationIssueReportCategories.FRAUD,
+  });
+  categories = [
+    this.otherCategory,
+    this.lateOrLeavingCategory,
+    this.candidateInformationChangeCategory,
+    this.connectionOrEndScreenCategory,
+    this.inChallengeCategory,
+    this.fraudCategory,
+  ];
 
   @tracked reportLength = 0;
   @tracked showCategoryMissingError = false;

--- a/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/fraud-certification-issue-report-fields.hbs
@@ -1,0 +1,16 @@
+<fieldset class="fraud-certification-issue-report-fields">
+  <div class="fraud-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-fraud"
+      type="radio"
+      name="fraud"
+      checked={{@fraudCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @fraudCategory)}} />
+    <label for="input-radio-for-category-fraud"><span>{{@fraudCategory.categoryCode}}&nbsp;</span>{{@fraudCategory.categoryLabel}}</label>
+  </div>
+  {{#if @fraudCategory.isChecked}}
+    <div class="fraud-certification-issue-report-fields__details">
+      <p>Merci de joindre le procès-verbal de fraude rempli pendant la session de certification en utilisant le formulaire 123formbuilder accessible à l'étape suivante de cette finalisation de session.</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -6,6 +6,7 @@ export const certificationIssueReportCategories = {
   LATE_OR_LEAVING: 'LATE_OR_LEAVING',
   CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
   IN_CHALLENGE: 'IN_CHALLENGE',
+  FRAUD: 'FRAUD',
 };
 
 export const certificationIssueReportSubcategories = {
@@ -28,6 +29,7 @@ export const categoryToLabel = {
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'Retard, absence ou départ',
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat a passé les dernières questions, faute de temps',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une question',
+  [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
 };
 
 export const subcategoryToLabel = {
@@ -50,6 +52,7 @@ export const categoryToCode = {
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'C3-C4',
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
+  [certificationIssueReportCategories.FRAUD]: 'C6',
 };
 
 export const subcategoryToCode = {

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -1,5 +1,6 @@
 .add-issue-report-modal {
-  min-width: 600px;
+  min-width: 650px;
+  max-width: 650px;
 
   &__title {
     font-family: $open-sans;

--- a/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
@@ -44,6 +44,6 @@ module('Integration | Component | issue-report-modal/fraud-certification-issue-r
     await click(INPUT_RADIO_SELECTOR);
 
     // then
-    assert.contains('Merci de joindre le procès-verbal de fraude remplit pendant la session de certification en utilisant le formulaire 123formbuilder accessible à l\'étape 2 de cette finalisation de session.');
+    assert.contains('Merci de joindre le procès-verbal de fraude rempli pendant la session de certification en utilisant le formulaire 123formbuilder accessible à l\'étape suivante de cette finalisation de session.');
   });
 });

--- a/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import sinon from 'sinon';
+
+module('Integration | Component | issue-report-modal/fraud-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-fraud';
+
+  test('it should call toggle function on click radio button', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const fraudCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('fraudCategory', fraudCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::FraudCertificationIssueReportFields
+        @fraudCategory={{this.fraudCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(fraudCategory));
+  });
+
+  test('it should show text if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const fraudCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('fraudCategory', fraudCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::FraudCertificationIssueReportFields
+        @fraudCategory={{this.fraudCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.contains('Merci de joindre le procès-verbal de fraude remplit pendant la session de certification en utilisant le formulaire 123formbuilder accessible à l\'étape 2 de cette finalisation de session.');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le nombre de certification Pix ne cessant de croître, notamment avec le lancement de la certification Pix dans les collèges et les lycées cette année, il devient difficile pour le pôle certif de gérer chaque signalement de certification. 

L'epix Catégorisation des Signalements vise donc à permettre aux utilisateurs de catégoriser leur signalement. Ce qui permettra ensuite au pôle de certification de gérer plusieurs signalements du même genre en même temps.

Beaucoup de catégories et sous-catégories de signalements sont déjà disponibles dans Pix certif pour nos utilisateurs. Néanmoins, il reste 2 catégories à implémenter qui ont été ajoutées et jugées nécessaires.

Cette PR permet de rajouter une de ces 2 catégorie : la suspicion de fraude.

## :robot: Solution
1. Ajouter la catégorie C6 Suspicion de fraude : 
- lorsque l’utilisateur sélectionne cette catégorie, le texte suivant s’affiche : “Merci de joindre le procès-verbal de fraude remplit pendant la session de certification en utilisant le formulaire 123formbuilder accessible à l'étape 2 de cette finalisation de session”  
- ajout direct de ce signalement (pas de zone de saisie libre ni sous-catégorie)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer l'API avec 2 feature toggle actif : `FT_REPORTS_CATEGORISATION=true FT_CERTIF_PRESCRIPTION_SCO=true npm start`
- Lancer l'application Pix Certif
- Se connecter avec notre compte sco : `certifsco@example.net` | `pix123` 
- Cliquer sur la session 4
- Cliquer sur "Finaliser la session"
- Cliquer sur "Ajouter" dans la colonne "Signalement" pour n'importe quel candidat
- Constater qu'un nouveau radio button apparaît avec le label "Suspicion de fraude".
- Cliquer sur ce radio button
- Constater qu'un descriptif s'affiche
- Cliquer sur "Ajouter" et constater qu'une requête s'envoie correctement (+ regarder en base dans la table "certification-issue-report" si votre signalement apparaît bien, cad s'il y a une ligne avec une catégorie nommée "FRAUD")
