### PR TITLE
[CLEANUP] Modifications mineures de la catégorisation des signalements (PIX-1829)

### DIFF
--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -17,7 +17,7 @@
         @selectedOption={{@candidateInformationChangeCategory.subcategory}}
         @onChange={{this.onChangeSubcategory}}
       />
-      <label for="text-area-for-category-candidate-information-change">Détaillez les changements</label>
+      <label for="text-area-for-category-candidate-information-change">{{this.subcategoryTextAreaLabel}}</label>
       <Textarea
         id="text-area-for-category-candidate-information-change"
         @class="session-finalization-reports-informations-step__textarea"

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -1,9 +1,18 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 
-import { certificationIssueReportSubcategories, subcategoryToLabel, subcategoryToCode } from 'pix-certif/models/certification-issue-report';
-
+import {
+  certificationIssueReportSubcategories,
+  subcategoryToCode,
+  subcategoryToLabel,
+  subcategoryToTextareaLabel,
+} from 'pix-certif/models/certification-issue-report';
 export default class CandidateInformationChangeCertificationIssueReportFieldsComponent extends Component {
+
+  @tracked
+  subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.candidateInformationChangeCategory.subcategory];
+
   get reportLength() {
     return this.args.candidateInformationChangeCategory.description
       ? this.args.candidateInformationChangeCategory.description.length
@@ -13,6 +22,7 @@ export default class CandidateInformationChangeCertificationIssueReportFieldsCom
   @action
   onChangeSubcategory(event) {
     this.args.candidateInformationChangeCategory.subcategory = event.target.value;
+    this.subcategoryTextAreaLabel = subcategoryToTextareaLabel[event.target.value];
   }
 
   options = [

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -12,7 +12,7 @@
   </div>
   {{#if @inChallengeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">
-      <label for="input-for-category-in-challenge-question-number">Numéro de question :</label>
+      <label for="input-for-category-in-challenge-question-number">Numéro d'épreuve :</label>
        <Input
               @id="input-for-category-in-challenge-question-number"
               @name="question-number"
@@ -29,7 +29,7 @@
                @onChange={{this.onChangeSubcategory}}
        />
       {{#if this.isOtherSubcategorySelected }}
-        <label for="text-area-for-category-in-challenge-subcategory-other">Détaillez les changements</label>
+        <label for="text-area-for-category-in-challenge-subcategory-other">Précisez</label>
         <Textarea
                 id="text-area-for-category-in-challenge-subcategory-other"
                 @class="session-finalization-reports-informations-step__textarea"

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
@@ -17,7 +17,7 @@
         @selectedOption={{@lateOrLeavingCategory.subcategory}}
         @onChange={{this.onChangeSubcategory}}
       />
-      <label for="text-area-for-category-late-or-leaving">Détaillez l'incident</label>
+      <label for="text-area-for-category-late-or-leaving">{{this.subcategoryTextAreaLabel}}</label>
       <Textarea
         id="text-area-for-category-late-or-leaving"
         @class="session-finalization-reports-informations-step__textarea"

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
@@ -1,8 +1,18 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { certificationIssueReportSubcategories, subcategoryToCode, subcategoryToLabel } from 'pix-certif/models/certification-issue-report';
+import { tracked } from '@glimmer/tracking';
+import {
+  certificationIssueReportSubcategories,
+  subcategoryToCode,
+  subcategoryToLabel,
+  subcategoryToTextareaLabel,
+} from 'pix-certif/models/certification-issue-report';
 
 export default class OtherCertificationissueReportFields extends Component {
+
+  @tracked
+  subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.lateOrLeavingCategory.subcategory];
+
   get reportLength() {
     return this.args.lateOrLeavingCategory.description
       ? this.args.lateOrLeavingCategory.description.length
@@ -12,6 +22,7 @@ export default class OtherCertificationissueReportFields extends Component {
   @action
   onChangeSubcategory(event) {
     this.args.lateOrLeavingCategory.subcategory = event.target.value;
+    this.subcategoryTextAreaLabel = subcategoryToTextareaLabel[event.target.value];
   }
 
   options = [

--- a/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
@@ -10,7 +10,7 @@
   </div>
   {{#if @otherCategory.isChecked}}
     <div class="other-certification-issue-report-fields__details">
-      <label for="text-area-for-category-other">Détaillez l'incident</label>
+      <label for="text-area-for-category-other">Décrivez l’incident</label>
       <Textarea
         id="text-area-for-category-other"
         @class="session-finalization-reports-informations-step__textarea"

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -28,17 +28,17 @@ export const categoryToLabel = {
   [certificationIssueReportCategories.OTHER]: 'Autre incident',
   [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'Modification infos candidat',
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'Retard, absence ou départ',
-  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat a passé les dernières questions, faute de temps',
-  [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une question',
   [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
   [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'Problème technique',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat n’a pas pu terminer, faute de temps',
+  [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une épreuve',
 };
 
 export const subcategoryToLabel = {
   [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Prénom/Nom/Date de naissance',
-  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Temps majoré',
-  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu (précisez ici pourquoi)',
-  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Etait présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Ajout/modification du temps majoré',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'L\'image ne s\'affiche pas',
   [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
   [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'Le simulateur/l\'application ne s\'affiche pas',
@@ -70,6 +70,13 @@ export const subcategoryToCode = {
   [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
   [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
   [certificationIssueReportSubcategories.OTHER]: 'E7',
+};
+
+export const subcategoryToTextareaLabel = {
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Précisez et indiquez l’heure de sortie',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Précisez',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Précisez les informations à modifier',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Précisez le temps majoré',
 };
 
 export default class CertificationIssueReport extends Model {

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
@@ -4,6 +4,7 @@ import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
+import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
 
 module('Integration | Component | candidate-information-change-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
@@ -72,5 +73,49 @@ module('Integration | Component | candidate-information-change-certification-iss
 
     // then
     assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  });
+
+  test('it should show "Précisez les informations à modifier" if subcategory NAME_OR_BIRTHDATE is selected', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = { isChecked: true, subcategory: certificationIssueReportSubcategories.NAME_OR_BIRTHDATE };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom(SUBCATEGORY_SELECTOR).exists();
+    assert.dom(TEXTAREA_SELECTOR).exists();
+    assert.contains('Précisez les informations à modifier');
+  });
+
+  test('it should show "Précisez le temps majoré" if subcategory EXTRA_TIME_PERCENTAGE is selected', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const candidateInformationChangeCategory = { isChecked: true, subcategory: certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
+        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom(SUBCATEGORY_SELECTOR).exists();
+    assert.dom(TEXTAREA_SELECTOR).exists();
+    assert.contains('Précisez le temps majoré');
   });
 });

--- a/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
+import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
 
 import sinon from 'sinon';
 
@@ -53,6 +54,50 @@ module('Integration | Component | late-or-leaving-certification-issue-report-fie
     // then
     assert.dom(SUBCATEGORY_SELECTOR).exists();
     assert.dom(TEXTAREA_SELECTOR).exists();
+  });
+
+  test('it should show "Précisez" if subcategory SIGNATURE_ISSUE is selected', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = { isChecked: true, subcategory: certificationIssueReportSubcategories.SIGNATURE_ISSUE };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom(SUBCATEGORY_SELECTOR).exists();
+    assert.dom(TEXTAREA_SELECTOR).exists();
+    assert.contains('Précisez');
+  });
+
+  test('it should show "Précisez et indiquez l’heure de sortie" if subcategory LEFT_EXAM_ROOM is selected', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const lateOrLeavingCategory = { isChecked: true, subcategory: certificationIssueReportSubcategories.LEFT_EXAM_ROOM };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::LateOrLeavingCertificationIssueReportFields
+        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom(SUBCATEGORY_SELECTOR).exists();
+    assert.dom(TEXTAREA_SELECTOR).exists();
+    assert.contains('Précisez et indiquez l’heure de sortie');
   });
 
   test('it should count textarea characters length', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème

Le document de référence concernant la catégorisation des signalements certif a évolué depuis le début de l’implémentation de cet épix. Il y a eu notamment des changements dans le wording de certaines catégories. Il faut donc faire une passe sur ce document   et s’assurer que la fonctionnalité dans Pix certif est iso

## :robot: Solution
Modification de wording : 

Nom de catégorie/sous-catégorie : 

- C2 Ajout/modification du temps majoré

- C3 Ecran de fin de test non vu (supprimer ce qu’il y a entre parenthèses)

- C5 Connexion et fin de test : le candidat n’a pas pu terminer, faute de temps

- E1-E7 Problème sur une épreuve (au lieu de “question”)


Libellé des champs texte : 

- C1 Prénom/Nom/Date de naissance : “Précisez les informations à modifier”

- C2 Ajout/modification du temps majoré : “Précisez le temps majoré”

- C3 Ecran de fin de test non vu : “Précisez et indiquez l’heure de sortie“

- C4 Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne : “Précisez”

- E7 autre : “Précisez”

- A2 Autre incident : “Décrivez l’incident”


## :100: Pour tester
- Lancer pix-api avec FT_REPORTS_CATEGORISATION=true
- Se connecter à pix certif
- Finaliser un session en ajoutant des signalements
- Constater que le wording dans la modale d'ajout de signalement correspond au wording ci-dessus
