### PR TITLE
[FEATURE]  Télécharger un PV d'incident pour une session de certification (PIX-1535)

### DIFF
--- a/certif/app/components/certification-candidates-sco.hbs
+++ b/certif/app/components/certification-candidates-sco.hbs
@@ -2,7 +2,7 @@
   <div class="certification-candidates-sco-actions">
     <img src="/images/adding_candidate.svg" alt="" role="none">
     <p>Ajouter une liste d'élèves et c'est partix !</p>
-    <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link">
+    <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link" aria-label="Ajouter des candidats">
       Ajouter des candidats
     </LinkTo>
   </div>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -7,7 +7,7 @@
       {{/if}}
     </div>
     {{#if @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-      <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link enrolled-candidate__add-students">
+      <LinkTo @route="authenticated.sessions.add-student" @model={{@sessionId}} class="button button--link enrolled-candidate__add-students" aria-label="Ajouter des candidats">
         Ajouter des candidats
       </LinkTo>
     {{else}}

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -9,6 +9,7 @@ export default class SessionsDetailsController extends Controller {
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
+  @alias('model.isReportsCategorizationFeatureToggleEnabled') isReportsCategorizationFeatureToggleEnabled;
   @alias('model.shouldDisplayPrescriptionScoStudentRegistrationFeature') shouldDisplayPrescriptionScoStudentRegistrationFeature;
 
   @computed('certificationCandidates.length')

--- a/certif/app/models/session.js
+++ b/certif/app/models/session.js
@@ -54,4 +54,8 @@ export default class Session extends Model {
   get displayStatus() {
     return statusToDisplayName[this.status];
   }
+
+  get urlToDownloadSessionIssueReportSheet() {
+    return ENV.urlToDownloadSessionIssueReportSheet;
+  }
 }

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -3,11 +3,20 @@
     <div class="session-details-header__title">
       <PixReturnTo @route="authenticated.sessions.list" class="session-details-content__return-button" />
       <h1 class="page-title">Session {{this.session.id}}</h1>
+      {{#if this.isReportsCategorizationFeatureToggleEnabled}}
+        <a class="button button--link" href="{{this.session.urlToDownloadSessionIssueReportSheet}}" target="_blank"
+          aria-label="Télécharger le pv d'incident"
+          rel="noopener noreferrer" download>
+          PV d'incident&nbsp;
+          <FaIcon @icon="file-download" />
+        </a>
+      {{/if}}
       {{#if this.shouldDisplayDownloadButton}}
-      <a class="button button--link" href="{{this.session.urlToDownloadAttendanceSheet}}" target="_blank"
-        rel="noopener noreferrer" download>
-        Télécharger la feuille d'émargement
-      </a>
+        <a class="button button--link" href="{{this.session.urlToDownloadAttendanceSheet}}" target="_blank" aria-label="Télécharger la feuille d'émargement"
+          rel="noopener noreferrer" download>
+          Feuille d'émargement&nbsp;
+          <FaIcon @icon="file-download" />
+        </a>
       {{/if}}
     </div>
 

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -80,6 +80,7 @@ module.exports = function(environment) {
 
     formBuilderLinkUrlReportsCategorisation: 'https://form-eu.123formbuilder.com/41052/form',
     formBuilderLinkUrlNoReportsCategorisation: 'https://eu.123formbuilder.com/form-29080/certification-depot-du-pv-de-session-scanne',
+    urlToDownloadSessionIssueReportSheet: 'https://cloud.pix.fr/s/XmS23tRyjHbffJn/download',
   };
 
   if (environment === 'development') {

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -265,7 +265,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
             // when
             await visit(`/sessions/${session.id}/candidats`);
-            await click('.button.button--link');
+            await click('[aria-label="Ajouter des candidats"]');
 
             // then
             assert.equal(currentURL(), `/sessions/${session.id}/ajout-eleves`);

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -90,6 +90,22 @@ module('Acceptance | Session Details', function(hooks) {
         assert.dom('.session-details-header-datetime__time .content-text').hasText('14:00');
       });
 
+      module('when FT_REPORTS_CATEGORISATION is on', function() {
+
+        test('it should show issue report sheet download button', async function(assert) {
+        // given
+          const sessionWithCandidates = server.create('session');
+          server.createList('certification-candidate', 3, { isLinked: true, sessionId: 1234321 });
+          server.create('feature-toggle', { id: 0, reportsCategorization: true });
+
+          // when
+          await visit(`/sessions/${sessionWithCandidates.id}`);
+
+          // then
+          assert.dom('[aria-label="Télécharger le pv d\'incident"]').hasText('PV d\'incident\u00a0');
+        });
+      });
+
       module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is on', function(hooks) {
 
         const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
@@ -102,7 +118,7 @@ module('Acceptance | Session Details', function(hooks) {
           config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
         });
 
-        test('it should show download button when there is one or more candidate', async function(assert) {
+        test('it should show attendance sheet download button when there is one or more candidate', async function(assert) {
           // given
           const sessionWithCandidates = server.create('session');
           server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionWithCandidates.id });
@@ -111,10 +127,10 @@ module('Acceptance | Session Details', function(hooks) {
           await visit(`/sessions/${sessionWithCandidates.id}`);
 
           // then
-          assert.dom('.session-details-header__title .button').hasText('Télécharger la feuille d\'émargement');
+          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').hasText('Feuille d\'émargement\u00a0');
         });
 
-        test('it should not show download button where there is no candidate', async function(assert) {
+        test('it should not show download attendance sheet button where there is no candidate', async function(assert) {
           // given
           const sessionWithoutCandidate = server.create('session');
 
@@ -122,7 +138,7 @@ module('Acceptance | Session Details', function(hooks) {
           await visit(`/sessions/${sessionWithoutCandidate.id}`);
 
           // then
-          assert.dom('.session-details-header__title .button').doesNotExist();
+          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').doesNotExist();
         });
       });
 
@@ -138,7 +154,7 @@ module('Acceptance | Session Details', function(hooks) {
           config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
         });
 
-        test('it should not show download button', async function(assert) {
+        test('it should not show download attendance sheet button', async function(assert) {
           // given
           const sessionWithCandidates = server.create('session');
           server.createList('certification-candidate', 3, { isLinked: true });
@@ -147,7 +163,7 @@ module('Acceptance | Session Details', function(hooks) {
           await visit(`/sessions/${sessionWithCandidates.id}`);
 
           // then
-          assert.dom('.session-details-header__title .button').doesNotExist();
+          assert.dom('[aria-label="Télécharger la feuille d\'émargement"]').doesNotExist();
         });
       });
     });

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -10,6 +10,7 @@ module('Unit | Model | session', function(hooks) {
   module('#displayStatus', function() {
 
     test('it should return the correct displayName', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const model1 = run(() => store.createRecord('session', {
         id: 123,
@@ -20,26 +21,44 @@ module('Unit | Model | session', function(hooks) {
         status: FINALIZED,
       }));
 
+      // when/then
       assert.equal(model1.displayStatus, 'Créée');
       assert.equal(model2.displayStatus, 'Finalisée');
     });
   });
 
-  module('#urlToDownloadAttendanceSheet', function() {
-
+  module('#urlToUpload', function() {
     test('it should return the correct urlToUpload', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const model = run(() => store.createRecord('session', { id: 1 }));
 
+      // when/then
       assert.equal(model.urlToUpload, `${config.APP.API_HOST}/api/sessions/1/certification-candidates/import`);
     });
+  });
 
+  module('#urlToDownloadAttendanceSheet', function() {
     test('it should return the correct urlToDownloadAttendanceSheet', function(assert) {
+      // given
       const store = this.owner.lookup('service:store');
       const model = run(() => store.createRecord('session', { id: 1 }));
       model.session = { data: { authenticated: { access_token: '123' } } };
 
+      // when/then
       assert.equal(model.urlToDownloadAttendanceSheet, `${config.APP.API_HOST}/api/sessions/1/attendance-sheet?accessToken=123`);
+    });
+  });
+
+  module('#urlToDownloadSessionIssueReportSheet', function() {
+    test('it should return the correct urlToDownloadSessionIssueReportSheet', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const model = run(() => store.createRecord('session', { id: 1 }));
+      model.session = { data: { authenticated: { access_token: '123' } } };
+
+      // when/then
+      assert.equal(model.urlToDownloadSessionIssueReportSheet, config.urlToDownloadSessionIssueReportSheet);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème

Dans le cadre de l'épix “Catégorisation des signalements en certif”, on va permettre aux utilisateurs Pix Certif d’ajouter des signalements candidats en sélectionnant des catégories spécifiques. Avant d'être reportés dans Pix certif sur la page de finalisation de session par le référent Pix du centre (ou autre ayant accès la plateforme), les signalements sons relevés par le surveillant pendant la session de certification. Jusqu’ici, les surveillants avaient dans le PV de session un champ libre “Signalement” leur permettant de renseigner tout problème rencontré. Néanmoins, avec l’intégration des catégories côté Pix certif, il s’agit de faciliter le travail de report des signalements sur la page de finalisation de session, et donc de donner accès à ces catégories au surveillant.

## :robot: Solution
Permettre aux utilisateurs Pix certif de télécharger un PV d’incident avec les catégories telles qu’elles existent sur la page de finalisation de session, à fournir au surveillant qui va administrer la session

## :rainbow: Remarques
![image](https://user-images.githubusercontent.com/37305474/103660817-553d2700-4f6e-11eb-86c9-a85f5a482394.png)

## :100: Pour tester
- Se connecter à pix-certif
- Constater que le bouton de téléchargement du pv d'incident est visible sur la page de détail d'une cession et que le pv se télécharge correctement
