### PR TITLE
[FEATURE] Ajout de la catégorie de signalement "Problème technique" (PIX-1943)

### DIFF
--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -61,6 +61,12 @@ const categoryFraudJoiSchema = Joi.object({
   category: Joi.string().required().valid(CertificationIssueReportCategories.FRAUD),
 });
 
+const categoryTechnicalProblemJoiSchema = Joi.object({
+  certificationCourseId: Joi.number().required().empty(null),
+  category: Joi.string().required().valid(CertificationIssueReportCategories.TECHNICAL_PROBLEM),
+  description: Joi.string().trim().required(),
+});
+
 const categorySchemas = {
   [CertificationIssueReportCategories.OTHER]: categoryOtherJoiSchema,
   [CertificationIssueReportCategories.LATE_OR_LEAVING]: categoryLateOrLeavingJoiSchema,
@@ -68,6 +74,7 @@ const categorySchemas = {
   [CertificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: categoryConnectionOrEndScreenJoiSchema,
   [CertificationIssueReportCategories.IN_CHALLENGE]: categoryInChallengeJoiSchema,
   [CertificationIssueReportCategories.FRAUD]: categoryFraudJoiSchema,
+  [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: categoryTechnicalProblemJoiSchema,
 };
 
 class CertificationIssueReport {

--- a/api/lib/domain/models/CertificationIssueReportCategory.js
+++ b/api/lib/domain/models/CertificationIssueReportCategory.js
@@ -6,6 +6,7 @@ module.exports = {
     CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
     IN_CHALLENGE: 'IN_CHALLENGE',
     FRAUD: 'FRAUD',
+    TECHNICAL_PROBLEM: 'TECHNICAL_PROBLEM',
   },
   CertificationIssueReportSubcategories: {
     NAME_OR_BIRTHDATE: 'NAME_OR_BIRTHDATE',

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -271,5 +271,42 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         expect(() => CertificationIssueReport.new(certificationIssueReportDTO)).not.to.throw();
       });
     });
+
+    context('CATEGORY: TECHNICAL_PROBLEM', () => {
+      const certificationIssueReportDTO = {
+        certificationCourseId: 123,
+        category: CertificationIssueReportCategories.TECHNICAL_PROBLEM,
+        description: 'Une description obligatoire',
+      };
+
+      it('should create an TECHNICAL_PROBLEM CertificationIssueReport', () => {
+        expect(CertificationIssueReport.new(certificationIssueReportDTO)).to.be.an.instanceOf(CertificationIssueReport);
+      });
+
+      [
+        MISSING_VALUE,
+        EMPTY_VALUE,
+        UNDEFINED_VALUE,
+        WHITESPACES_VALUE,
+      ].forEach((emptyValue) => {
+        it(`should throw an InvalidCertificationIssueReportForSaving when description is of value ${emptyValue}`, () => {
+          // when
+          expect(() => CertificationIssueReport.new({ ...certificationIssueReportDTO, description: emptyValue }))
+            .to.throw(InvalidCertificationIssueReportForSaving);
+        });
+      });
+
+      [
+        MISSING_VALUE,
+        EMPTY_VALUE,
+        UNDEFINED_VALUE,
+      ].forEach((emptyValue) => {
+        it(`should create an TECHNICAL_PROBLEM CertificationIssueReport when subcategory is empty with value ${emptyValue}`, () => {
+          // when
+          expect(CertificationIssueReport.new({ ...certificationIssueReportDTO, subcategory: emptyValue }))
+            .to.be.an.instanceOf(CertificationIssueReport);
+        });
+      });
+    });
   });
 });

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -48,6 +48,12 @@
             @fraudCategory={{this.fraudCategory}}
             @toggleOnCategory={{this.toggleOnCategory}}
           />
+
+          <IssueReportModal::TechnicalProblemCertificationIssueReportFields
+              @technicalProblemCategory={{this.technicalProblemCategory}}
+              @toggleOnCategory={{this.toggleOnCategory}}
+              @maxlength={{@maxlength}}
+          />
         </div>
 
         {{#if this.showCategoryMissingError}}

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.hbs
@@ -14,8 +14,8 @@
 
       <div class="add-issue-report-modal__content">
         <div class="add-issue-report-modal-content">
-          <IssueReportModal::OtherCertificationIssueReportFields
-            @otherCategory={{this.otherCategory}}
+          <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
+            @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
             @toggleOnCategory={{this.toggleOnCategory}}
             @maxlength={{@maxlength}}
           />
@@ -26,20 +26,8 @@
             @maxlength={{@maxlength}}
           />
 
-          <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
-            @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-
           <IssueReportModal::ConnectionOrEndScreenCertificationIssueReportFields
             @connectionOrEndScreenCategory={{this.connectionOrEndScreenCategory}}
-            @toggleOnCategory={{this.toggleOnCategory}}
-            @maxlength={{@maxlength}}
-          />
-
-          <IssueReportModal::InChallengeCertificationIssueReportFields
-            @inChallengeCategory={{this.inChallengeCategory}}
             @toggleOnCategory={{this.toggleOnCategory}}
             @maxlength={{@maxlength}}
           />
@@ -49,10 +37,22 @@
             @toggleOnCategory={{this.toggleOnCategory}}
           />
 
+          <IssueReportModal::InChallengeCertificationIssueReportFields
+            @inChallengeCategory={{this.inChallengeCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
+
           <IssueReportModal::TechnicalProblemCertificationIssueReportFields
-              @technicalProblemCategory={{this.technicalProblemCategory}}
-              @toggleOnCategory={{this.toggleOnCategory}}
-              @maxlength={{@maxlength}}
+            @technicalProblemCategory={{this.technicalProblemCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
+          />
+
+          <IssueReportModal::OtherCertificationIssueReportFields
+            @otherCategory={{this.otherCategory}}
+            @toggleOnCategory={{this.toggleOnCategory}}
+            @maxlength={{@maxlength}}
           />
         </div>
 

--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -116,6 +116,9 @@ export default class AddIssueReportModal extends Component {
   @tracked fraudCategory = new RadioButtonCategory({
     name: certificationIssueReportCategories.FRAUD,
   });
+  @tracked technicalProblemCategory = new RadioButtonCategoryWithDescription({
+    name: certificationIssueReportCategories.TECHNICAL_PROBLEM,
+  });
   categories = [
     this.otherCategory,
     this.lateOrLeavingCategory,
@@ -123,6 +126,7 @@ export default class AddIssueReportModal extends Component {
     this.connectionOrEndScreenCategory,
     this.inChallengeCategory,
     this.fraudCategory,
+    this.technicalProblemCategory,
   ];
 
   @tracked reportLength = 0;

--- a/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.hbs
@@ -1,0 +1,25 @@
+<fieldset class="technical-problem-certification-issue-report-fields">
+  <div class="technical-problem-certification-issue-report-fields__radio-button">
+    <input
+      id="input-radio-for-category-technical-problem"
+      type="radio"
+      name="technical-problem"
+      checked={{@technicalProblemCategory.isChecked}}
+      {{on 'click' (fn @toggleOnCategory @technicalProblemCategory)}} />
+    <label for="input-radio-for-category-technical-problem"><span>{{@technicalProblemCategory.categoryCode}}&nbsp;</span>{{@technicalProblemCategory.categoryLabel}}</label>
+  </div>
+  {{#if @technicalProblemCategory.isChecked}}
+    <div class="technical-problem-certification-issue-report-fields__details">
+      <label for="text-area-for-category-technical-problem">Décrivez l'incident rencontré</label>
+      <Textarea
+        id="text-area-for-category-technical-problem"
+        @class="session-finalization-reports-informations-step__textarea"
+        @value={{@technicalProblemCategory.description}}
+        @maxlength={{@maxlength}}
+        @placeholder="L'ordinateur s'est éteint, lenteur significative du réseau et/ou de l'appareil, etc..."
+        required
+      />
+      <p class="technical-problem-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.js
@@ -1,0 +1,9 @@
+import Component from '@glimmer/component';
+
+export default class IssueReportModalTechnicalProblemCertificationIssueReportFieldsComponent extends Component {
+  get reportLength() {
+    return this.args.technicalProblemCategory.description
+      ? this.args.technicalProblemCategory.description.length
+      : 0;
+  }
+}

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -7,6 +7,7 @@ export const certificationIssueReportCategories = {
   CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
   IN_CHALLENGE: 'IN_CHALLENGE',
   FRAUD: 'FRAUD',
+  TECHNICAL_PROBLEM: 'TECHNICAL_PROBLEM',
 };
 
 export const certificationIssueReportSubcategories = {
@@ -30,6 +31,7 @@ export const categoryToLabel = {
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat a passé les dernières questions, faute de temps',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une question',
   [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
+  [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'Problème technique',
 };
 
 export const subcategoryToLabel = {
@@ -53,6 +55,7 @@ export const categoryToCode = {
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
   [certificationIssueReportCategories.FRAUD]: 'C6',
+  [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
 };
 
 export const subcategoryToCode = {

--- a/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
@@ -1,0 +1,74 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, fillIn } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
+import sinon from 'sinon';
+
+module('Integration | Component | issue-report-modal/technical-problem-certification-issue-report-fields', function(hooks) {
+  setupRenderingTest(hooks);
+
+  const INPUT_RADIO_SELECTOR = '#input-radio-for-category-technical-problem';
+  const TEXTAREA_SELECTOR = '#text-area-for-category-technical-problem';
+  const CHAR_COUNT_SELECTOR = '.technical-problem-certification-issue-report-fields-details__char-count';
+
+  test('it should call toggle function on click radio button', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const technicalProblemCategory = { isChecked: false };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('technicalProblemCategory', technicalProblemCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::TechnicalProblemCertificationIssueReportFields
+        @technicalProblemCategory={{this.technicalProblemCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.ok(toggleOnCategory.calledOnceWith(technicalProblemCategory));
+  });
+
+  test('it should show textarea if category is checked', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const technicalProblemCategory = { isChecked: true };
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('technicalProblemCategory', technicalProblemCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::TechnicalProblemCertificationIssueReportFields
+        @technicalProblemCategory={{this.technicalProblemCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await click(INPUT_RADIO_SELECTOR);
+
+    // then
+    assert.dom('.technical-problem-certification-issue-report-fields__details').exists();
+  });
+
+  test('it should count textarea characters length', async function(assert) {
+    // given
+    const toggleOnCategory = sinon.stub();
+    const technicalProblemCategory = new RadioButtonCategoryWithDescription({ name: 'TECHNICAL_PROBLEM', isChecked: true });
+    this.set('toggleOnCategory', toggleOnCategory);
+    this.set('technicalProblemCategory', technicalProblemCategory);
+
+    // when
+    await render(hbs`
+      <IssueReportModal::TechnicalProblemCertificationIssueReportFields
+        @technicalProblemCategory={{this.technicalProblemCategory}}
+        @toggleOnCategory={{this.toggleOnCategory}}
+        @maxlength={{500}}
+      />`);
+    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
+
+    // then
+    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le nombre de certification Pix ne cessant de croître, notamment avec le lancement de la certification Pix dans les collèges et les lycées cette année, il devient difficile pour le pôle certif de gérer chaque signalement de certification.

L'epix Catégorisation des Signalements vise donc à permettre aux utilisateurs de catégoriser leur signalement. Ce qui permettra ensuite au pôle de certification de gérer plusieurs signalements du même genre en même temps.

Beaucoup de catégories et sous-catégories de signalements sont déjà disponibles dans Pix certif pour nos utilisateurs. Néanmoins, il reste une catégorie à implémenter qui a été ajoutée et jugée nécessaire.

Cette PR permet de rajouter la catégorie: le problème technique.

## :robot: Solution
Ajouter la dernière catégorie : 

        A1 Problème technique : le candidat a rencontré un problème lié au matériel : 

        Affiche une zone de saisie libre avec le libellé suivant : “Décrivez l'incident rencontré, ex : l'ordinateur s’est éteint, lenteur significative du réseau et/ou de l'appareil, etc...)” - OBLIGATOIRE

Afficher les catégories dans le même ordre que dans le fichier de référence:

![image (8)](https://user-images.githubusercontent.com/34715194/103666890-7b19fa00-4f75-11eb-9d3a-e5b1e13334a0.png)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer l'API avec 2 feature toggle actif : `FT_REPORTS_CATEGORISATION=true FT_CERTIF_PRESCRIPTION_SCO=true npm start`
- Lancer l'application Pix Certif
- Se connecter avec notre compte sco : certifsco@example.net | pix123
- Cliquer sur la session 4
- Cliquer sur "Finaliser la session"
- Cliquer sur "Ajouter" dans la colonne "Signalement" pour n'importe quel candidat
- Constater qu'un nouveau radio button apparaît avec le label "Problème technique".
- Cliquer sur ce radio button
- Constater qu'un champ de texte libre s'affiche
- Cliquer sur "Ajouter" et constater qu'une requête s'envoie correctement (+ regarder en base dans la table "certification-issue-report" si votre signalement apparaît bien, cad s'il y a une ligne avec une catégorie nommée "TECHNICAL_PROBLEM")
