### PR TITLE
[FEATURE] Permettre le refresh de l'access token avant l'envoi des résultats à Pôle Emploi (PIX-1939).

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -155,6 +155,7 @@ module.exports = (function() {
     },
 
     poleEmploi: {
+      clientId: process.env.POLE_EMPLOI_CLIENT_ID,
       clientSecret: process.env.POLE_EMPLOI_CLIENT_SECRET,
       tokenUrl: process.env.POLE_EMPLOI_TOKEN_URL,
       sendingUrl: process.env.POLE_EMPLOI_SENDING_URL,

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -24,7 +24,7 @@ module.exports = {
         client_id: settings.poleEmploi.clientId,
       };
 
-      await httpAgent.post(
+      const tokenResponse = await httpAgent.post(
         settings.poleEmploi.tokenUrl,
         querystring.stringify(data),
         {
@@ -32,6 +32,12 @@ module.exports = {
         },
       );
 
+      if (!tokenResponse.isSuccessful) {
+        return {
+          isSuccessful: tokenResponse.isSuccessful,
+          code: tokenResponse.code,
+        };
+      }
     }
 
     const url = settings.poleEmploi.sendingUrl;

--- a/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
+++ b/api/lib/infrastructure/externals/pole-emploi/pole-emploi-notifier.js
@@ -3,6 +3,7 @@ const authenticationMethodRepository = require('../../repositories/authenticatio
 const AuthenticationMethod = require('../../../domain/models/AuthenticationMethod');
 const httpAgent = require('../../http/http-agent');
 const settings = require('../../../config');
+const querystring = require('querystring');
 const { UnexpectedUserAccount } = require('../../../domain/errors');
 
 module.exports = {
@@ -12,6 +13,27 @@ module.exports = {
     if (!accessToken) {
       throw new UnexpectedUserAccount({ message: 'Le compte utilisateur n\'est pas rattaché à l\'organisation Pôle Emploi' });
     }
+
+    const expiredDate = _.get(authenticationMethod, 'authenticationComplement.expiredDate');
+    const refreshToken = _.get(authenticationMethod, 'authenticationComplement.refreshToken');
+    if (!refreshToken || expiredDate <= new Date()) {
+      const data = {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_secret: settings.poleEmploi.clientSecret,
+        client_id: settings.poleEmploi.clientId,
+      };
+
+      await httpAgent.post(
+        settings.poleEmploi.tokenUrl,
+        querystring.stringify(data),
+        {
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        },
+      );
+
+    }
+
     const url = settings.poleEmploi.sendingUrl;
     const headers = {
       'Authorization': `Bearer ${accessToken}`,

--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -3,9 +3,11 @@ const axios = require('axios');
 class HttpResponse {
   constructor({
     code,
+    data,
     isSuccessful,
   }) {
     this.code = code;
+    this.data = data;
     this.isSuccessful = isSuccessful;
   }
 }
@@ -18,11 +20,13 @@ module.exports = {
       });
       return new HttpResponse({
         code: httpResponse.status,
+        data: httpResponse.data,
         isSuccessful: true,
       });
     } catch (httpErr) {
       return new HttpResponse({
         code: httpErr.response.status,
+        data: httpErr.response.data,
         isSuccessful: false,
       });
     }

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -1,11 +1,12 @@
+const querystring = require('querystring');
+const moment = require('moment');
 const { expect, sinon, catchErr, domainBuilder } = require('../../../../test-helper');
+const settings = require('../../../../../lib/config');
+const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
 const AuthenticationMethod = require('../../../../../lib/domain/models/AuthenticationMethod');
+const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
-const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
-const settings = require('../../../../../lib/config');
-const querystring = require('querystring');
-const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
 
 describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', () => {
 
@@ -16,6 +17,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
     beforeEach(() => {
       sinon.stub(httpAgent, 'post');
       sinon.stub(authenticationMethodRepository, 'findOneByUserIdAndIdentityProvider');
+      sinon.stub(authenticationMethodRepository, 'updatePoleEmploiAuthenticationComplementByUserId');
     });
 
     afterEach(() => {
@@ -49,7 +51,9 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
         const userId = 123;
         const payload = 'somePayload';
-        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+        const refreshToken = 'someRefreshToken';
+        const expiredDate = moment().add(10, 'm').toDate();
+        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken', expiredDate, refreshToken } };
         const code = 'someCode';
         const successState = 'someState';
         const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
@@ -82,7 +86,7 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         const expiredDate = new Date('2021-01-01');
         const refreshToken = 'someRefreshToken';
         const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken', expiredDate, refreshToken } };
-        const data = {
+        const params = {
           grant_type: 'refresh_token',
           refresh_token: refreshToken,
           client_secret: settings.poleEmploi.clientSecret,
@@ -94,14 +98,114 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
         authenticationMethodRepository.findOneByUserIdAndIdentityProvider
           .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
           .resolves(authenticationMethod);
-        httpAgent.post.resolves({ isSuccessful: successState, code });
+        const data = {
+          'access_token': 'accessToken',
+          'refresh_token': 'refreshToken',
+          'expires_in': 10,
+        };
+        httpAgent.post.resolves({ isSuccessful: successState, code, data });
 
         // when
         await notify(userId, payload, poleEmploiSending);
 
         // then
-        expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiTokenUrl, querystring.stringify(data), {
+        expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiTokenUrl, querystring.stringify(params), {
           headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        });
+      });
+
+      context('when it succeeds', () => {
+        let clock;
+
+        beforeEach(() => {
+          clock = sinon.useFakeTimers(Date.now());
+        });
+
+        afterEach(() => {
+          clock.restore();
+        });
+
+        it('should update the authentication method', async () => {
+          // given
+          const poleEmploiTokenUrl = 'someUrlToPoleEmploi';
+          settings.poleEmploi.tokenUrl = poleEmploiTokenUrl;
+          const userId = 123;
+          const payload = 'somePayload';
+          const expiredDate = new Date('2021-01-01');
+          const refreshToken = 'someRefreshToken';
+          const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken', expiredDate, refreshToken } };
+          const code = 'someCode';
+          const successState = 'someState';
+          const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+          authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+            .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+            .resolves(authenticationMethod);
+          const data = {
+            'access_token': 'accessToken',
+            'refresh_token': 'refreshToken',
+            'expires_in': 10,
+          };
+          httpAgent.post.resolves({ isSuccessful: successState, code, data });
+          const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+            accessToken: data['access_token'],
+            refreshToken: data['refresh_token'],
+            expiredDate: moment().add(data['expires_in'], 's').toDate(),
+          });
+
+          // when
+          await notify(userId, payload, poleEmploiSending);
+
+          // then
+          expect(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId).to.have.been.calledWith({ authenticationComplement, userId });
+        });
+
+        it('should send the notification to Pole Emploi', async () => {
+          // given
+          const poleEmploiTokenUrl = 'someUrlToPoleEmploi';
+          settings.poleEmploi.tokenUrl = poleEmploiTokenUrl;
+          const userId = 123;
+          const payload = 'somePayload';
+          const expiredDate = new Date('2021-01-01');
+          const refreshToken = 'someRefreshToken';
+          const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken', expiredDate, refreshToken } };
+          const code = 'someCode';
+          const successState = true;
+          const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+          settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+          const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+          const data = {
+            'access_token': 'accessToken',
+            'refresh_token': 'refreshToken',
+            'expires_in': 10,
+          };
+          const authenticationComplement = new AuthenticationMethod.PoleEmploiAuthenticationComplement({
+            accessToken: data['access_token'],
+            refreshToken: data['refresh_token'],
+            expiredDate: moment().add(data['expires_in'], 's').toDate(),
+          });
+
+          authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId
+            .withArgs({ authenticationComplement, userId })
+            .resolves();
+
+          authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+            .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+            .resolves(authenticationMethod);
+
+          httpAgent.post
+            .onFirstCall().resolves({ isSuccessful: successState, code, data })
+            .onSecondCall().resolves({ isSuccessful: successState, code });
+
+          // when
+          await notify(userId, payload, poleEmploiSending);
+
+          // then
+          expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiSendingUrl, payload, {
+            'Authorization': `Bearer ${authenticationComplement.accessToken}`,
+            'Content-type': 'application/json',
+            'Accept': 'application/json',
+            'Service-source': 'Pix',
+          });
         });
       });
 

--- a/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
+++ b/api/tests/unit/infrastructure/externals/pole-emploi/pole-emploi-notifier_test.js
@@ -4,6 +4,7 @@ const httpAgent = require('../../../../../lib/infrastructure/http/http-agent');
 const authenticationMethodRepository = require('../../../../../lib/infrastructure/repositories/authentication-method-repository');
 const { notify } = require('../../../../../lib/infrastructure/externals/pole-emploi/pole-emploi-notifier');
 const settings = require('../../../../../lib/config');
+const querystring = require('querystring');
 const { UnexpectedUserAccount } = require('../../../../../lib/domain/errors');
 
 describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier', () => {
@@ -38,31 +39,70 @@ describe('Unit | Infrastructure | Externals/Pole-Emploi | pole-emploi-notifier',
       expect(error.message).to.equal('Le compte utilisateur n\'est pas rattaché à l\'organisation Pôle Emploi');
     });
 
-    it('should send the notification to Pole Emploi', async () => {
-      // given
-      const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
-      settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
-      const userId = 123;
-      const payload = 'somePayload';
-      const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
-      const code = 'someCode';
-      const successState = 'someState';
-      const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
-      authenticationMethodRepository.findOneByUserIdAndIdentityProvider
-        .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
-        .resolves(authenticationMethod);
-      httpAgent.post.resolves({ isSuccessful: successState, code });
+    context('when access token is valid', () => {
 
-      // when
-      await notify(userId, payload, poleEmploiSending);
+      it('should send the notification to Pole Emploi', async () => {
+        // given
+        const poleEmploiSendingUrl = 'someUrlToPoleEmploi';
+        settings.poleEmploi.sendingUrl = poleEmploiSendingUrl;
+        const userId = 123;
+        const payload = 'somePayload';
+        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken' } };
+        const code = 'someCode';
+        const successState = 'someState';
+        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+          .resolves(authenticationMethod);
+        httpAgent.post.resolves({ isSuccessful: successState, code });
 
-      // then
-      expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiSendingUrl, payload, {
-        'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
-        'Content-type': 'application/json',
-        'Accept': 'application/json',
-        'Service-source': 'Pix',
+        // when
+        await notify(userId, payload, poleEmploiSending);
+
+        // then
+        expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiSendingUrl, payload, {
+          'Authorization': `Bearer ${authenticationMethod.authenticationComplement.accessToken}`,
+          'Content-type': 'application/json',
+          'Accept': 'application/json',
+          'Service-source': 'Pix',
+        });
       });
     });
+
+    context('when access token is invalid', () => {
+
+      it('should try to refresh the access token', async () => {
+        // given
+        const poleEmploiTokenUrl = 'someUrlToPoleEmploi';
+        settings.poleEmploi.tokenUrl = poleEmploiTokenUrl;
+        const userId = 123;
+        const payload = 'somePayload';
+        const expiredDate = new Date('2021-01-01');
+        const refreshToken = 'someRefreshToken';
+        const authenticationMethod = { authenticationComplement: { accessToken: 'someAccessToken', expiredDate, refreshToken } };
+        const data = {
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_secret: settings.poleEmploi.clientSecret,
+          client_id: settings.poleEmploi.clientId,
+        };
+        const code = 'someCode';
+        const successState = 'someState';
+        const poleEmploiSending = domainBuilder.buildPoleEmploiSending();
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider
+          .withArgs({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
+          .resolves(authenticationMethod);
+        httpAgent.post.resolves({ isSuccessful: successState, code });
+
+        // when
+        await notify(userId, payload, poleEmploiSending);
+
+        // then
+        expect(httpAgent.post).to.have.been.calledWithExactly(poleEmploiTokenUrl, querystring.stringify(data), {
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        });
+      });
+    });
+
   });
 });

--- a/api/tests/unit/infrastructure/http/http-agent_test.js
+++ b/api/tests/unit/infrastructure/http/http-agent_test.js
@@ -16,6 +16,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
       const payload = 'somePayload';
       const headers = { a: 'someHeaderInfo' };
       const axiosResponse = {
+        data: Symbol('data'),
         status: 'someStatus',
       };
       sinon.stub(axios, 'post').withArgs(url, payload, { headers }).resolves(axiosResponse);
@@ -27,6 +28,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
       expect(actualResponse).to.deep.equal({
         isSuccessful: true,
         code: axiosResponse.status,
+        data: axiosResponse.data,
       });
     });
 
@@ -36,7 +38,10 @@ describe('Unit | Infrastructure | http | http-agent', () => {
       const payload = 'somePayload';
       const headers = { a: 'someHeaderInfo' };
       const axiosError = {
-        response: { status: 'someStatus' },
+        response: {
+          data: Symbol('data'),
+          status: 'someStatus',
+        },
       };
       sinon.stub(axios, 'post').withArgs(url, payload, { headers }).rejects(axiosError);
 
@@ -47,6 +52,7 @@ describe('Unit | Infrastructure | http | http-agent', () => {
       expect(actualResponse).to.deep.equal({
         isSuccessful: false,
         code: axiosError.response.status,
+        data: axiosError.response.data,
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
L'access token à une durée de 19 minutes, ainsi lorsqu'il n'était plus valide, nous ne pouvions pas envoyer les résultats d'un candidat à Pôle Emploi.
## :robot: Solution
Implémenter la route du refresh token pour mettre à jour l'access token invalide, et permettre ainsi l'envoi des résultats.

## :rainbow: Remarques


## :100: Pour tester

Tester en local avec le seed [Emilie.Brabant](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1961295916/Environnements+P+le+emploi)

- Se connecter via PE Connect 
- Renseigner le parcours QWERTY789
- Commencer et finir le parcours jusqu'à l'envoi des résultats
- Attendre que l'access token soit invalide ( attendre 18 minutes )
- Envoyer les résultats => vérifier en base que l'access token, expiredDate et refreshToken ont étés mis à jour.