### PR TITLE
[BUGFIX] Problème d'affichage des réponses des QCU (PIX-1949).

### DIFF
--- a/mon-pix/app/components/qcm-solution-panel.js
+++ b/mon-pix/app/components/qcm-solution-panel.js
@@ -1,35 +1,21 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { classNames } from '@ember-decorators/component';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import isEmpty from 'lodash/isEmpty';
 
-@classic
-@classNames('qcm-solution-panel')
 export default class QcmSolutionPanel extends Component {
-  answer = null;
-  solution = null;
-  challenge = null;
 
-  @computed('solution')
   get solutionArray() {
-    const solution = this.solution;
+    const solution = this.args.solution;
     return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
   }
 
-  @computed('answer')
   get labeledCheckboxes() {
-    const answer = this.answer.value;
+    const answer = this.args.answer.value;
     let checkboxes = [];
     if (!isEmpty(answer)) {
-      const proposals = this.challenge.get('proposals');
+      const proposals = this.args.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       checkboxes = labeledCheckboxes(proposalsArray, answerArray);

--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -1,28 +1,15 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-computed-property-dependencies: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
-import { classNames } from '@ember-decorators/component';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
-import classic from 'ember-classic-decorator';
+import Component from '@glimmer/component';
 import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import isEmpty from 'lodash/isEmpty';
 import ENV from 'mon-pix/config/environment';
 
-@classic
-@classNames('qcu-solution-panel')
 export default class QcuSolutionPanel extends Component {
-  answer = null;
-  solution = null;
-  challenge = null;
   featureFlagDisplayForWrongAnswers = ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
 
-  @computed('solution')
   get solutionArray() {
-    const solution = this.solution;
+    const solution = this.args.solution;
     return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];
   }
 
@@ -34,12 +21,11 @@ export default class QcuSolutionPanel extends Component {
     return solutionAndStatus[0];
   }
 
-  @computed('answer')
   get labeledRadios() {
-    const answer = this.answer.value;
+    const answer = this.args.answer.value;
     let radiosArray = [];
     if (!isEmpty(answer)) {
-      const proposals = this.challenge.get('proposals');
+      const proposals = this.args.challenge.get('proposals');
       const proposalsArray = proposalsAsArray(proposals);
       const answerArray = valueAsArrayOfBoolean(answer);
       radiosArray = labeledCheckboxes(proposalsArray, answerArray);
@@ -49,9 +35,9 @@ export default class QcuSolutionPanel extends Component {
   }
 
   get isAnswerValid() {
-    if (!this.answer) {
+    if (!this.args.answer) {
       return false;
     }
-    return this.solution === this.answer.value;
+    return this.args.solution === this.args.answer.value;
   }
 }

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -35,8 +35,9 @@ export default class CheckpointController extends Controller {
   }
 
   @action
-  openComparisonWindow(answer) {
+  async openComparisonWindow(answer) {
     this.answer = answer;
+    await answer.correction;
     this.isShowingModal = true;
   }
 

--- a/mon-pix/app/controllers/assessments/results.js
+++ b/mon-pix/app/controllers/assessments/results.js
@@ -7,8 +7,9 @@ export default class ResultsController extends Controller {
   @tracked answer = null;
 
   @action
-  openComparisonWindow(answer) {
+  async openComparisonWindow(answer) {
     this.answer = answer;
+    await answer.correction;
     this.isShowingModal = true;
   }
 

--- a/mon-pix/app/routes/assessments/results.js
+++ b/mon-pix/app/routes/assessments/results.js
@@ -1,5 +1,4 @@
 import Route from '@ember/routing/route';
-import RSVP from 'rsvp';
 
 export default class ResultsRoute extends Route {
   model() {
@@ -10,10 +9,5 @@ export default class ResultsRoute extends Route {
     if (assessment.isCertification) {
       return this.transitionTo('index');
     }
-    const answers = await assessment.answers;
-    await RSVP.all([
-      ...answers.map((answer) => answer.challenge),
-      ...answers.map((answer) => answer.correction),
-    ]);
   }
 }

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -34,7 +34,7 @@
 
         <div class="assessment-results__list">
           {{#each @model.answersSinceLastCheckpoints as |answer|}}
-            <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{this.openComparisonWindow}} />
+            <ResultItem @answer={{answer}} @openAnswerDetails={{this.openComparisonWindow}} />
           {{/each}}
         </div>
         <CheckpointContinue @assessmentId={{@model.id}} @nextPageButtonText={{this.nextPageButtonText}} />

--- a/mon-pix/app/templates/assessments/results.hbs
+++ b/mon-pix/app/templates/assessments/results.hbs
@@ -13,7 +13,7 @@
 
     <div class="assessment-results__list">
       {{#each @model.answers as |answer|}}
-        <ResultItem @answer={{answer}} @correction={{answer.correction}} @openAnswerDetails={{this.openComparisonWindow}} />
+        <ResultItem @answer={{answer}} @openAnswerDetails={{this.openComparisonWindow}} />
       {{/each}}
     </div>
 

--- a/mon-pix/app/templates/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcm-solution-panel.hbs
@@ -1,14 +1,13 @@
-{{!-- template-lint-disable no-implicit-this  --}}
-<div class="qcm-panel__proposals rounded-panel">
+<div class="qcm-solution-panel qcm-panel__proposals rounded-panel">
   <div class="rounded-panel__row qcm-panel__proposal-list">
-    {{#each labeledCheckboxes as |labeledCheckbox index|}}
+    {{#each this.labeledCheckboxes as |labeledCheckbox index|}}
       <p class="qcm-panel__proposal-item">
         <label class="qcm-panel__proposal-label qcm-proposal-label">
 
           <input type="checkbox" class="qcm-panel__proposal-checkbox" checked={{if labeledCheckbox.[1] 'checked' ''}} disabled="disabled">
 
           <span class="qcm-proposal-label__oracle"
-                data-goodness="{{if (get solutionArray (concat index)) 'good' 'bad'}}"
+                data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
                 data-checked={{if labeledCheckbox.[1] 'yes' 'no'}}>
             {{labeledCheckbox.[0]}}
           </span>

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -1,7 +1,6 @@
-{{!-- template-lint-disable no-implicit-this  --}}
-<div class="qcu-panel__proposals rounded-panel">
+<div class="qcu-solution-panel qcu-panel__proposals rounded-panel">
   <div class="rounded-panel__row qcu-panel__proposal-list">
-    {{#each labeledRadios as |labeledItemRadio index|}}
+    {{#each this.labeledRadios as |labeledItemRadio index|}}
       <p class="qcu-panel__proposal-item">
 
         <label class="qcu-panel__proposal-label qcu-proposal-label">
@@ -22,7 +21,7 @@
           {{/if}}
 
           <span class="qcu-proposal-label__oracle"
-                data-goodness="{{if (get solutionArray (concat index)) 'good' 'bad'}}"
+                data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
                 data-checked={{if labeledItemRadio.[1] 'yes' 'no'}}>
             {{labeledItemRadio.[0]}}
           </span>

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -4,16 +4,21 @@ import { expect } from 'chai';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'mon-pix/config/environment';
 
 describe('Acceptance | Displaying a QCU challenge', () => {
   setupApplicationTest();
   setupMirage();
   let assessment;
   let qcuChallenge;
+  const CURRENT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
 
   beforeEach(async () => {
     assessment = server.create('assessment', 'ofCompetenceEvaluationType');
     qcuChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QCU');
+  });
+  afterEach(() => {
+    ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = CURRENT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
   });
 
   describe('When challenge is not already answered', () => {
@@ -98,63 +103,139 @@ describe('Acceptance | Displaying a QCU challenge', () => {
     });
   });
 
-  describe('When challenge is already answered and user wants to see answers', () => {
-    let correction, tutorial, learningMoreTutorial;
-    beforeEach(async () => {
-      // given
-      tutorial = server.create('tutorial');
-      learningMoreTutorial = server.create('tutorial');
-      correction = server.create('correction', {
-        solution: '1',
-        hint: 'Cliquer sur 1',
-        tutorials: [tutorial],
-        learningMoreTutorials: [learningMoreTutorial],
-      });
-      server.create('answer', {
-        value: '2',
-        result: 'ko',
-        assessmentId: assessment.id,
-        challengeId: qcuChallenge.id,
-        correction,
-      });
-
-      // when
-      await visit(`/assessments/${assessment.id}/checkpoint`);
+  describe('When the feature toggle for improving display of answer is on ', () => {
+    beforeEach(() => {
+      ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = true;
     });
 
-    it('should show the result of previous challenge in checkpoint', async () => {
-      // then
-      expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
-      expect(find('.result-item__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
-      expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
-    });
+    describe('When challenge is already answered and user wants to see answers', () => {
+      let correction, tutorial, learningMoreTutorial;
+      beforeEach(async () => {
+        // given
+        tutorial = server.create('tutorial');
+        learningMoreTutorial = server.create('tutorial');
+        correction = server.create('correction', {
+          solution: '1',
+          hint: 'Cliquer sur 1',
+          tutorials: [tutorial],
+          learningMoreTutorials: [learningMoreTutorial],
+        });
+        server.create('answer', {
+          value: '2',
+          result: 'ko',
+          assessmentId: assessment.id,
+          challengeId: qcuChallenge.id,
+          correction,
+        });
 
-    it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
-      // when
-      await click('.result-item__correction-button');
+        // when
+        await visit(`/assessments/${assessment.id}/checkpoint`);
+      });
 
-      // then
-      expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
-      expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
+      it('should show the result of previous challenge in checkpoint', async () => {
+        // then
+        expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
+        expect(find('.result-item__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
+        expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
+      });
 
-      const goodAnswer = findAll('.qcu-proposal-label__oracle')[0];
-      const badAnswerFromUserResult = findAll('.qcu-proposal-label__oracle')[1];
-      expect(goodAnswer.getAttribute('data-goodness')).to.equal('good');
-      expect(goodAnswer.getAttribute('data-checked')).to.equal('no');
-      expect(badAnswerFromUserResult.getAttribute('data-goodness')).to.equal('bad');
-      expect(badAnswerFromUserResult.getAttribute('data-checked')).to.equal('yes');
+      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+        // when
+        await click('.result-item__correction-button');
 
-      expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
+        // then
+        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
+        expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
 
-      const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-item')[0];
-      const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-item')[0];
+        const goodAnswer = findAll('.qcu-proposal-label__oracle')[0];
+        const badAnswerFromUserResult = findAll('.qcu-proposal-label__oracle')[1];
+        expect(goodAnswer.getAttribute('data-goodness')).to.equal('good');
+        expect(goodAnswer.getAttribute('data-checked')).to.equal('no');
+        expect(badAnswerFromUserResult.getAttribute('data-goodness')).to.equal('bad');
+        expect(badAnswerFromUserResult.getAttribute('data-checked')).to.equal('yes');
 
-      expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
-      expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
+        expect(find('.wrong-answer__expected-answer').textContent).to.contains(1);
 
-      expect(find('.feedback-panel')).to.exist;
+        expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 
+        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-item')[0];
+        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-item')[0];
+
+        expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
+        expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
+
+        expect(find('.feedback-panel')).to.exist;
+
+      });
     });
   });
+
+  describe('When the feature toggle for improving display of answer is off ', () => {
+    beforeEach(() => {
+      ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = false;
+    });
+
+    describe('When challenge is already answered and user wants to see answers', () => {
+      let correction, tutorial, learningMoreTutorial;
+      beforeEach(async () => {
+        // given
+        tutorial = server.create('tutorial');
+        learningMoreTutorial = server.create('tutorial');
+        correction = server.create('correction', {
+          solution: '1',
+          hint: 'Cliquer sur 1',
+          tutorials: [tutorial],
+          learningMoreTutorials: [learningMoreTutorial],
+        });
+        server.create('answer', {
+          value: '2',
+          result: 'ko',
+          assessmentId: assessment.id,
+          challengeId: qcuChallenge.id,
+          correction,
+        });
+
+        // when
+        await visit(`/assessments/${assessment.id}/checkpoint`);
+      });
+
+      it('should show the result of previous challenge in checkpoint', async () => {
+        // then
+        expect(find('.result-item__icon').title).to.equal('Réponse incorrecte');
+        expect(find('.result-item__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
+        expect(find('.result-item__correction-button').textContent.trim()).to.equal('Réponses et tutos');
+      });
+
+      it('should show details of challenge result in pop-in, with tutorials and feedbacks', async () => {
+        // when
+        await click('.result-item__correction-button');
+
+        // then
+        expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
+        expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcuChallenge.instruction);
+
+        const goodAnswer = findAll('.qcu-proposal-label__oracle')[0];
+        const badAnswerFromUserResult = findAll('.qcu-proposal-label__oracle')[1];
+        expect(goodAnswer.getAttribute('data-goodness')).to.equal('good');
+        expect(goodAnswer.getAttribute('data-checked')).to.equal('no');
+        expect(badAnswerFromUserResult.getAttribute('data-goodness')).to.equal('bad');
+        expect(badAnswerFromUserResult.getAttribute('data-checked')).to.equal('yes');
+
+        expect(find('.wrong-answer__expected-answer')).to.not.exist;
+
+        expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
+
+        const tutorialToSuccess = findAll('.tutorial-panel__tutorials-container .tutorial-item')[0];
+        const tutorialToLearnMore = findAll('.learning-more-panel__list-container .tutorial-item')[0];
+
+        expect(tutorialToSuccess.textContent).to.contains(tutorial.title);
+        expect(tutorialToLearnMore.textContent).to.contains(learningMoreTutorial.title);
+
+        expect(find('.feedback-panel')).to.exist;
+
+      });
+    });
+  });
+
 });
 

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -18,7 +18,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
   describe('#Component should renders: ', function() {
 
     it('Should renders', async function() {
-      await render(hbs`{{qcm-solution-panel}}`);
+      await render(hbs`<QcmSolutionPanel />`);
 
       expect(find('.qcm-solution-panel')).to.exist;
       expect(findAll('.qcm-proposal-label__oracle')).to.have.lengthOf(0);
@@ -52,7 +52,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
@@ -67,7 +67,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
@@ -83,7 +83,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('no');
@@ -99,7 +99,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('yes');
@@ -113,7 +113,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcm-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         const size = findAll('.comparison-window .qcm-proposal-label__checkbox-picture').length;

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -38,9 +38,8 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
     });
 
     it('Should render', async function() {
-      await render(hbs`{{qcu-solution-panel}}`);
+      await render(hbs`<QcuSolutionPanel/>`);
       expect(find('.qcu-solution-panel')).to.exist;
-      expect(findAll('.qcu-proposal-label__oracle')).to.have.lengthOf(0);
     });
 
     describe('Radio state', function() {
@@ -68,7 +67,8 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('solution', solution);
         this.set('challenge', challenge);
         // When
-        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+
         // Then
         expect(findAll('.radio-on').length).to.equal(1);
       });
@@ -80,7 +80,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         times(findAll('.comparison-window .qcu-panel__proposal-radio').length, function(index) {
@@ -108,7 +108,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(find('.answer-feedback__correct-answer')).to.exist;
@@ -134,7 +134,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         expect(find('.answer-feedback__wrong-answer')).to.exist;
@@ -147,7 +147,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
         this.set('challenge', challenge);
 
         // When
-        await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
         const correctAnswer = find('.wrong-answer__expected-answer');
@@ -172,7 +172,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       });
 
       it('Should render', async function() {
-        await render(hbs`{{qcu-solution-panel}}`);
+        await render(hbs`<QcuSolutionPanel/>`);
         expect(find('.qcu-solution-panel')).to.exist;
         expect(findAll('.qcu-proposal-label__oracle')).to.have.lengthOf(0);
       });
@@ -197,7 +197,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
           this.set('solution', solution);
           this.set('challenge', challenge);
           // When
-          await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
           // Then
           expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
@@ -214,7 +214,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
           this.set('challenge', challenge);
 
           // When
-          await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
           // Then
           expect(findAll('.qcu-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('no');
@@ -229,7 +229,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
           this.set('challenge', challenge);
 
           // When
-          await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
           // Then
           expect(findAll('.qcu-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
@@ -246,7 +246,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
           this.set('challenge', challenge);
 
           // When
-          await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
           // Then
           expect(findAll('.qcu-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('yes');
@@ -261,7 +261,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
           this.set('challenge', challenge);
 
           // When
-          await render(hbs`{{qcu-solution-panel challenge=challenge answer=answer solution=solution}}`);
+          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
           // Then
           times(findAll('.comparison-window .qcu-panel__proposal-radio').length, function(index) {


### PR DESCRIPTION
## :unicorn: Problème
Depuis la version 2.241.0, avec le feature toggle `FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU` activé, l'affichage de la modal de réponse pour les QCU créait une erreur et bloquait l'affichage de la modal.

## :robot: Solution
- Le problème n'était visible que sur les pages Checkpoint (dans les compétences et campagnes), et non dans la pages Result (démo et preview).
- La récupération des données est différentes entre ces deux pages.
- Pour éviter la récupération inutile de toutes les corrections dans la page Checkpoint, il n'y avait pas d'appels à toutes les corrections contrairement à Result.
- **Bug vu** : la valeur de `answer.correction.solution` envoyé à `ComparisonWindow` était undefined dans le cas des QCU. Étrangement, si on affichait cette valeur dans la page Checkpoint, on l'avait bien :s >> conclusion : un problème de récupération de la donnée de correction
- **Solution** : Au moment d'ouvrir une modale, on récupère la correction de l'épreuve via `await answer.correction`
- La solution ne rajoute pas d'appel API par rapport à l'existant
- La solution a été ajouté dans Checkpoint mais aussi dans Result. La route Result n'appelles plus inutilement les challenges et corrections comme avant, ce qui permet de nettoyer cette partie.

## :rainbow: Remarques
- Durant l'analyse du problème, deux composants ont été glimmerizé
- Le paramètre `correction` envoyé au composant `ResultItem` ne semble pas être utilisé et à été retiré
- La page Checkpoint et la page Result affichent toutes les deux les réponses.

## :100: Pour tester
- Vérifier que le feature toogle est activé
- Répondre à des questions dans une compétence, en répondant mal à une question QCU et voir qu'on peut visualiser la bonne réponse
- Faire de même avec une démo
- Possiblement faire de même avec les QCM qui ont été glimmerisé