### PR TITLE
[TECH] Mettre à jour la BDD de la version 12.4 à la version 12.5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
   api_build_and_test:
     docker:
       - image: circleci/node:14.15.0
-      - image: postgres:12.4-alpine
+      - image: postgres:12.5-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -214,7 +214,7 @@ jobs:
   e2e_test:
     docker:
       - image: cypress/browsers:node14.15.0-chrome86-ff82
-      - image: postgres:12.4-alpine
+      - image: postgres:12.5-alpine
         environment:
           POSTGRES_USER: circleci
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:12.4-alpine
+    image: postgres:12.5-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## :unicorn: Problème
La version 12.5.1 est disponible sur Scalingo et installée en intrégration et recette
[Release note](https://www.postgresql.org/docs/12/release-12-5.html)

## :robot: Solution
L'utiliser en local et dans la CI

## :rainbow: Remarques
Le faire en production lorsque la PR est MEP

## :100: Pour tester
Exécuter les tests en local et dans la CI
