### PR TITLE
[TECH] Faire émerger un nouveau read-model CampaignReport dans l'API.

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -40,12 +40,11 @@ module.exports = {
     return campaignToJoinSerializer.serialize(campaignToJoin);
   },
 
-  getById(request) {
+  async getById(request) {
     const campaignId = request.params.id;
-    const options = queryParamsUtils.extractParameters(request.query);
     const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
-    return usecases.getCampaign({ campaignId, options })
-      .then((campaign) => campaignSerializer.serialize(campaign, {}, { tokenForCampaignResults }));
+    const campaign = await usecases.getCampaign({ campaignId });
+    return campaignReportSerializer.serialize(campaign, {}, { tokenForCampaignResults });
   },
 
   async getCsvAssessmentResults(request) {

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -2,7 +2,7 @@ const organizationService = require('../../domain/services/organization-service'
 const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
 
-const campaignSerializer = require('../../infrastructure/serializers/jsonapi/campaign-serializer');
+const campaignReportSerializer = require('../../infrastructure/serializers/jsonapi/campaign-report-serializer');
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
 const organizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/organization-invitation-serializer');
@@ -69,7 +69,7 @@ module.exports = {
       delete options.filter.status;
     }
     const { models: campaigns, meta } = await usecases.findPaginatedFilteredOrganizationCampaigns({ organizationId, filter: options.filter, page: options.page });
-    return campaignSerializer.serialize(campaigns, meta, { ignoreCampaignReportRelationshipData: false });
+    return campaignReportSerializer.serialize(campaigns, meta);
   },
 
   async findPaginatedFilteredMemberships(request) {

--- a/api/lib/domain/read-models/CampaignReport.js
+++ b/api/lib/domain/read-models/CampaignReport.js
@@ -1,0 +1,60 @@
+const { types } = require('../models/Campaign');
+
+class CampaignReport {
+  constructor({
+    id,
+    name,
+    code,
+    title,
+    idPixLabel,
+    createdAt,
+    customLandingPageText,
+    archivedAt,
+    type,
+    creatorId,
+    creatorLastName,
+    creatorFirstName,
+    targetProfileId,
+    targetProfileName,
+    targetProfileImageUrl,
+    participationsCount,
+    sharedParticipationsCount,
+    badges = [],
+    stages = [],
+  } = {}) {
+    this.id = id;
+    this.name = name;
+    this.code = code;
+    this.title = title;
+    this.type = type;
+    this.idPixLabel = idPixLabel;
+    this.customLandingPageText = customLandingPageText;
+    this.createdAt = createdAt;
+    this.archivedAt = archivedAt;
+    this.creatorId = creatorId;
+    this.creatorLastName = creatorLastName;
+    this.creatorFirstName = creatorFirstName;
+    this.targetProfileId = targetProfileId;
+    this.targetProfileName = targetProfileName;
+    this.targetProfileImageUrl = targetProfileImageUrl;
+    this.participationsCount = participationsCount;
+    this.sharedParticipationsCount = sharedParticipationsCount;
+    this.badges = badges;
+    this.stages = stages;
+  }
+
+  get isAssessment() {
+    return this.type === types.ASSESSMENT;
+  }
+
+  get isProfilesCollection() {
+    return this.type === types.PROFILES_COLLECTION;
+  }
+
+  get isArchived() {
+    return Boolean(this.archivedAt);
+  }
+}
+
+CampaignReport.types = types;
+module.exports = CampaignReport;

--- a/api/lib/domain/usecases/find-paginated-filtered-organization-campaigns.js
+++ b/api/lib/domain/usecases/find-paginated-filtered-organization-campaigns.js
@@ -1,3 +1,3 @@
-module.exports = function findPaginatedFilteredOrganizationCampaigns({ organizationId, filter, page, campaignRepository }) {
-  return campaignRepository.findPaginatedFilteredByOrganizationIdWithCampaignReports({ organizationId, filter, page });
+module.exports = function findPaginatedFilteredOrganizationCampaigns({ organizationId, filter, page, campaignReportRepository }) {
+  return campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
 };

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,16 +1,18 @@
 const { NotFoundError } = require('../../domain/errors');
 
-module.exports = async function getCampaign({ campaignId, campaignReportRepository, stageRepository }) {
+module.exports = async function getCampaign({ campaignId, badgeRepository, campaignReportRepository, stageRepository }) {
   const integerCampaignId = parseInt(campaignId);
   if (!Number.isFinite(integerCampaignId)) {
     throw new NotFoundError(`Campaign not found for ID ${campaignId}`);
   }
 
-  const [campaignReport, stages] = await Promise.all([
+  const [campaignReport, badges, stages] = await Promise.all([
     campaignReportRepository.get(integerCampaignId),
+    badgeRepository.findByCampaignId(integerCampaignId),
     stageRepository.findByCampaignId(integerCampaignId),
   ]);
 
+  campaignReport.badges = badges;
   campaignReport.stages = stages;
   return campaignReport;
 };

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,10 +1,16 @@
 const { NotFoundError } = require('../../domain/errors');
 
-module.exports = function getCampaign({ campaignId, options, campaignRepository }) {
+module.exports = async function getCampaign({ campaignId, campaignReportRepository, stageRepository }) {
   const integerCampaignId = parseInt(campaignId);
   if (!Number.isFinite(integerCampaignId)) {
     throw new NotFoundError(`Campaign not found for ID ${campaignId}`);
   }
 
-  return campaignRepository.get(integerCampaignId, options);
+  const [campaignReport, stages] = await Promise.all([
+    campaignReportRepository.get(integerCampaignId),
+    stageRepository.findByCampaignId(integerCampaignId),
+  ]);
+
+  campaignReport.stages = stages;
+  return campaignReport;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -17,6 +17,7 @@ const dependencies = {
   campaignParticipationResultRepository: require('../../infrastructure/repositories/campaign-participation-result-repository'),
   campaignProfilesCollectionParticipationSummaryRepository: require('../../infrastructure/repositories/campaign-profiles-collection-participation-summary-repository'),
   campaignProfileRepository: require('../../infrastructure/repositories/campaign-profile-repository'),
+  campaignReportRepository: require('../../infrastructure/repositories/campaign-report-repository'),
   campaignRepository: require('../../infrastructure/repositories/campaign-repository'),
   campaignToJoinRepository: require('../../infrastructure/repositories/campaign-to-join-repository'),
   campaignCsvExportService: require('../../domain/services/campaign-csv-export-service'),

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -10,9 +10,21 @@ module.exports = {
         require: false,
         withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
       })
-      .then((results) =>
-        results.map((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, result)),
-      );
+      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
+  },
+
+  findByCampaignId(campaignId) {
+    return BookshelfBadge
+      .query((qb) => {
+        qb.join('target-profiles', 'target-profiles.id', 'badges.targetProfileId');
+        qb.join('campaigns', 'campaigns.targetProfileId', 'target-profiles.id');
+      })
+      .where('campaigns.id', campaignId)
+      .fetchAll({
+        require: false,
+        withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
+      })
+      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },
 
   findByCampaignParticipationId(campaignParticipationId) {
@@ -27,9 +39,7 @@ module.exports = {
         require: false,
         withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
       })
-      .then((results) =>
-        results.map((result) => bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, result)),
-      );
+      .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },
 
 };

--- a/api/lib/infrastructure/repositories/campaign-report-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-report-repository.js
@@ -1,0 +1,75 @@
+const { knex } = require('../bookshelf');
+
+const CampaignReport = require('../../domain/read-models/CampaignReport');
+const { fetchPage } = require('../utils/knex-utils');
+const { NotFoundError } = require('../../domain/errors');
+
+function _setSearchFiltersForQueryBuilder(qb, { name, ongoing = true, creatorName }) {
+  if (name) {
+    qb.whereRaw('LOWER("name") LIKE ?', `%${name.toLowerCase()}%`);
+  }
+  if (ongoing) {
+    qb.whereNull('campaigns.archivedAt');
+  } else {
+    qb.whereNotNull('campaigns.archivedAt');
+  }
+  if (creatorName) {
+    qb.whereRaw('(LOWER("users"."firstName") LIKE ? OR LOWER("users"."lastName") LIKE ?)', [`%${creatorName.toLowerCase()}%`, `%${creatorName.toLowerCase()}%`]);
+  }
+}
+
+module.exports = {
+
+  async get(id) {
+    const result = await knex('campaigns')
+      .select('campaigns.*')
+      .select({
+        'creatorId': 'users.id',
+        'creatorLastName': 'users.lastName',
+        'creatorFirstName': 'users.firstName',
+        'targetProfileId': 'target-profiles.id',
+        'targetProfileName': 'target-profiles.name',
+        'targetProfileImageUrl': 'target-profiles.imageUrl',
+      })
+      .select(
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
+      )
+      .join('users', 'users.id', 'campaigns.creatorId')
+      .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
+      .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where('campaigns.id', id)
+      .first();
+
+    if (!result) {
+      throw new NotFoundError(`La campagne d'id ${id} n'existe pas ou son accès est restreint`);
+    }
+
+    return new CampaignReport({ ...result, id });
+  },
+
+  async findPaginatedFilteredByOrganizationId({ organizationId, filter, page }) {
+    const query = knex('campaigns')
+      .distinct('campaigns.id')
+      .select(
+        'campaigns.*',
+        'users.id AS "creatorId"',
+        'users.firstName AS creatorFirstName',
+        'users.lastName AS creatorLastName',
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL) OVER (partition by "campaigns"."id") AS "participationsCount"'),
+        knex.raw('COUNT(*) FILTER (WHERE "campaign-participations"."id" IS NOT NULL AND "campaign-participations"."isShared" IS TRUE) OVER (partition by "campaigns"."id") AS "sharedParticipationsCount"'),
+      )
+      .join('users', 'users.id', 'campaigns.creatorId')
+      .leftJoin('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+      .where('campaigns.organizationId', organizationId)
+      .modify(_setSearchFiltersForQueryBuilder, filter)
+      .orderBy('campaigns.createdAt', 'DESC');
+
+    const { results, pagination } = await fetchPage(query, page);
+    const atLeastOneCampaign = await knex('campaigns').select('id').where({ organizationId }).first(1);
+    const hasCampaigns = Boolean(atLeastOneCampaign);
+
+    const campaignReports = results.map((result) => new CampaignReport(result));
+    return { models: campaignReports, meta: { ...pagination, hasCampaigns } };
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -12,11 +12,16 @@ module.exports = {
       attributes: ['name', 'code', 'title', 'type', 'createdAt', 'customLandingPageText', 'isArchived',
         'tokenForCampaignResults', 'idPixLabel', 'targetProfileId', 'targetProfileName', 'targetProfileImageUrl',
         'creatorId', 'creatorLastName', 'creatorFirstName', 'participationsCount', 'sharedParticipationsCount',
-        'campaignCollectiveResult', 'campaignAnalysis', 'divisions', 'stages'],
+        'campaignCollectiveResult', 'campaignAnalysis', 'divisions', 'stages', 'badges'],
       stages: {
         ref: 'id',
         included: true,
         attributes: ['title', 'message', 'threshold'],
+      },
+      badges: {
+        ref: 'id',
+        included: true,
+        attributes: ['title'],
       },
       campaignCollectiveResult: {
         ref: 'id',

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -1,14 +1,54 @@
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(reports) {
-    return new Serializer('campaign-report', {
-      attributes: ['participationsCount', 'sharedParticipationsCount', 'stages'],
+  serialize(campaignReports, meta, { tokenForCampaignResults } = {}) {
+    return new Serializer('campaign', {
+      transform: (record) => {
+        const campaign = Object.assign({}, record);
+        campaign.tokenForCampaignResults = tokenForCampaignResults;
+        campaign.isArchived = record.isArchived;
+        return campaign;
+      },
+      attributes: ['name', 'code', 'title', 'type', 'createdAt', 'customLandingPageText', 'isArchived',
+        'tokenForCampaignResults', 'idPixLabel', 'targetProfileId', 'targetProfileName', 'targetProfileImageUrl',
+        'creatorId', 'creatorLastName', 'creatorFirstName', 'participationsCount', 'sharedParticipationsCount',
+        'campaignCollectiveResult', 'campaignAnalysis', 'divisions', 'stages'],
       stages: {
         ref: 'id',
         included: true,
         attributes: ['title', 'message', 'threshold'],
       },
-    }).serialize(reports);
+      campaignCollectiveResult: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/campaigns/${parent.id}/collective-results`;
+          },
+        },
+      },
+      campaignAnalysis: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/campaigns/${parent.id}/analyses`;
+          },
+        },
+      },
+      divisions: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/campaigns/${parent.id}/divisions`;
+          },
+        },
+      },
+      meta,
+    }).serialize(campaignReports);
   },
 };

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -367,7 +367,6 @@ describe('Acceptance | Application | organization-controller', () => {
       ], (camp) => {
         const builtCampaign = databaseBuilder.factory.buildCampaign(camp);
         return { name: camp.name, code: camp.code, id: builtCampaign.id };
-
       });
       databaseBuilder.factory.buildCampaignParticipation({ campaignId: campaignsData[4].id, isShared: true });
       await databaseBuilder.commit();
@@ -397,7 +396,7 @@ describe('Acceptance | Application | organization-controller', () => {
       });
     });
 
-    context('Retrieve campaigns with campaignReports', () => {
+    context('Retrieve campaigns', () => {
 
       it('should return 200 status code the organization campaigns', async () => {
         // when
@@ -424,8 +423,8 @@ describe('Acceptance | Application | organization-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(200);
-        expect(response.result.included[1].attributes['first-name']).to.equal('Daenerys');
-        expect(response.result.included[1].attributes['last-name']).to.equal('Targaryen');
+        expect(response.result.data[0].attributes['creator-first-name']).to.equal('Daenerys');
+        expect(response.result.data[0].attributes['creator-last-name']).to.equal('Targaryen');
       });
 
       it('should return archived campaigns', async () => {
@@ -443,7 +442,7 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.result.data[0].type).to.equal('campaigns');
       });
 
-      it('should return 200 status code with the campaignReports with the campaigns', async () => {
+      it('should return report with the campaigns', async () => {
         // given
         options.url = `/api/organizations/${otherOrganizationId}/campaigns`;
 
@@ -454,9 +453,8 @@ describe('Acceptance | Application | organization-controller', () => {
         expect(response.statusCode).to.equal(200);
         const campaigns = response.result.data;
         expect(campaigns).to.have.lengthOf(1);
-        const campaignReport = response.result.included[0].attributes;
-        expect(campaignReport['participations-count']).to.equal(1);
-        expect(campaignReport['shared-participations-count']).to.equal(1);
+        expect(response.result.data[0].attributes['participations-count']).to.equal(1);
+        expect(response.result.data[0].attributes['shared-participations-count']).to.equal(1);
       });
 
       it('should return default pagination meta data', async () => {

--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -1,0 +1,313 @@
+const { expect, databaseBuilder, catchErr } = require('../../../test-helper');
+const campaignReportRepository = require('../../../../lib/infrastructure/repositories/campaign-report-repository');
+const CampaignReport = require('../../../../lib/domain/read-models/CampaignReport');
+const { NotFoundError } = require('../../../../lib/domain/errors');
+const _ = require('lodash');
+
+describe('Integration | Repository | Campaign-Report', () => {
+
+  describe('#get', () => {
+    let campaign;
+    let targetProfileId;
+
+    beforeEach(() => {
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      campaign = databaseBuilder.factory.buildCampaign({ targetProfileId, archivedAt: new Date() });
+      return databaseBuilder.commit();
+    });
+
+    it('should return a CampaignReport by its id', async () => {
+      // when
+      const result = await campaignReportRepository.get(campaign.id);
+
+      // then
+      expect(result).to.be.an.instanceof(CampaignReport);
+      expect(result).to.deep.include(_.pick(campaign, ['id', 'name', 'code', 'createdAt', 'archivedAt', 'targetProfileId', 'idPixLabel', 'title', 'type', 'customLandingPageText', 'creatorId', 'creatorLastName', 'creatorFirstName', 'targetProfileId', 'targetProfileName', 'targetProfileImageUrl', 'participationsCount', 'sharedParticipationsCount']));
+    });
+
+    it('should throw a NotFoundError if campaign can not be found', async () => {
+      // given
+      const nonExistentId = 666;
+
+      // when
+      const error = await catchErr(campaignReportRepository.get)(nonExistentId);
+
+      // then
+      expect(error).to.be.instanceOf(NotFoundError);
+    });
+  });
+
+  describe('#findPaginatedFilteredByOrganizationId', () => {
+    let filter, page;
+    let organizationId, targetProfileId, creatorId;
+    let campaign;
+
+    beforeEach(async () => {
+      organizationId = databaseBuilder.factory.buildOrganization({}).id;
+      targetProfileId = databaseBuilder.factory.buildTargetProfile({ organizationId }).id;
+      creatorId = databaseBuilder.factory.buildUser({}).id;
+      await databaseBuilder.commit();
+
+      filter = {};
+      page = { number: 1, size: 3 };
+    });
+
+    context('when the given organization has no campaign', () => {
+
+      it('should return an empty array', async () => {
+        // given
+        databaseBuilder.factory.buildCampaign({ organizationId });
+        const otherOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        await databaseBuilder.commit();
+
+        // when
+        const { models: campaignsWithReports, meta } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId: otherOrganizationId, filter, page });
+
+        // then
+        expect(campaignsWithReports).to.deep.equal([]);
+        expect(meta.hasCampaigns).to.equal(false);
+      });
+    });
+
+    context('when the given organization has campaigns', () => {
+
+      it('should return campaign with all attributes', async () => {
+        // given
+        campaign = databaseBuilder.factory.buildCampaign({
+          name: 'campaign name',
+          code: 'AZERTY789',
+          organizationId,
+          targetProfileId,
+          creatorId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { models: campaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+        // then
+        expect(campaignsWithReports[0]).to.be.instanceof(CampaignReport);
+        expect(campaignsWithReports[0]).to.deep.include(_.pick(campaign, ['id', 'name', 'code', 'createdAt', 'archivedAt', 'targetProfileId', 'idPixLabel', 'title', 'type', 'customLandingPageText', 'creatorId', 'creatorLastName', 'creatorFirstName', 'targetProfileId', 'targetProfileName', 'targetProfileImageUrl', 'participationsCount', 'sharedParticipationsCount']));
+      });
+
+      it('should return hasCampaign to true if the organization has one campaign at least', async () => {
+        // given
+        const organizationId2 = databaseBuilder.factory.buildOrganization({}).id;
+        databaseBuilder.factory.buildCampaign({
+          organizationId: organizationId2,
+          targetProfileId,
+          creatorId,
+        });
+        databaseBuilder.factory.buildCampaign({
+          organizationId,
+          targetProfileId,
+          creatorId,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const { meta } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+        // then
+        expect(meta.hasCampaigns).to.equal(true);
+      });
+
+      it('should sort campaigns by descending creation date', async () => {
+        // given
+        const createdAtInThePast = new Date('2010-07-30T09:35:45Z');
+        const createdAtInThePresent = new Date('2020-07-30T09:35:45Z');
+        const createdAtInTheFuture = new Date('2030-07-30T09:35:45Z');
+
+        const campaignBInThePastId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'B', createdAt: createdAtInThePast }).id;
+        const campaignAInThePresentId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'A', createdAt: createdAtInThePresent }).id;
+        const campaignBInTheFutureId = databaseBuilder.factory.buildCampaign({ organizationId, name: 'B', createdAt: createdAtInTheFuture }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const { models: campaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+        // then
+        expect(campaignsWithReports).to.have.lengthOf(3);
+        expect(_.map(campaignsWithReports, 'id')).to.deep.equal([campaignBInTheFutureId, campaignAInThePresentId, campaignBInThePastId]);
+      });
+
+      context('when campaigns have participants', async () => {
+
+        it('should return correct participations count and shared participations count', async () => {
+          // given
+          const campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+          _.each([
+            { campaignId: campaign.id, isShared: true },
+            { campaignId: campaign.id, isShared: false },
+            { campaignId: campaign.id, isShared: false },
+          ], (campaignParticipation) => {
+            databaseBuilder.factory.buildCampaignParticipation(campaignParticipation);
+          });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: campaignReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(campaignReports[0]).to.be.instanceOf(CampaignReport);
+          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 3, sharedParticipationsCount: 1 });
+        });
+      });
+
+      context('when campaigns do not have participants', async () => {
+
+        it('should return 0 as participations count and as shared participations count', async () => {
+          // given
+          campaign = databaseBuilder.factory.buildCampaign({ organizationId, targetProfileId });
+          await databaseBuilder.commit();
+
+          // when
+          const { models: campaignReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(campaignReports[0]).to.include({ id: campaign.id, participationsCount: 0, sharedParticipationsCount: 0 });
+        });
+      });
+
+      context('when some campaigns matched the archived filter', async () => {
+
+        it('should be able to retrieve only campaigns that are archived', async () => {
+          // given
+          organizationId = databaseBuilder.factory.buildOrganization().id;
+          const archivedCampaign = databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: new Date('2010-07-30T09:35:45Z') });
+          databaseBuilder.factory.buildCampaign({ organizationId, archivedAt: null });
+          filter.ongoing = false;
+
+          await databaseBuilder.commit();
+          // when
+          const { models: archivedCampaigns } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(archivedCampaigns).to.have.lengthOf(1);
+          expect(archivedCampaigns[0].id).to.equal(archivedCampaign.id);
+          expect(archivedCampaigns[0].archivedAt).to.deep.equal(archivedCampaign.archivedAt);
+        });
+      });
+
+      context('when some campaigns names match the "name" search pattern', () => {
+        // given
+        const filter = { name: 'matH' };
+
+        beforeEach(() => {
+          _.each([
+            { name: 'Maths L1' },
+            { name: 'Maths L2' },
+            { name: 'Chimie' },
+          ], (campaign) => {
+            databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+          });
+
+          return databaseBuilder.commit();
+        });
+
+        it('should return these campaigns only', async () => {
+          // when
+          const { models: actualCampaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Maths L2']);
+        });
+      });
+
+      context('when some campaigns creator firstName match the given creatorName searched', () => {
+
+        let filter;
+
+        beforeEach(() => {
+          const creator1 = databaseBuilder.factory.buildUser({});
+          const creator2 = databaseBuilder.factory.buildUser({});
+
+          filter = { creatorName: creator1.firstName.toUpperCase() };
+
+          _.each([
+            { name: 'Maths L1', creatorId: creator1.id },
+            { name: 'Maths L2', creatorId: creator2.id },
+            { name: 'Chimie', creatorId: creator1.id },
+          ], (campaign) => {
+            databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+          });
+
+          return databaseBuilder.commit();
+        });
+
+        it('should return the matching campaigns', async () => {
+          const { models: actualCampaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Chimie']);
+        });
+      });
+
+      context('when some campaigns creator lastName match the given creatorName searched', () => {
+
+        let filter;
+
+        beforeEach(() => {
+          const creator1 = databaseBuilder.factory.buildUser({});
+          const creator2 = databaseBuilder.factory.buildUser({});
+
+          filter = { creatorName: creator1.lastName.toUpperCase() };
+
+          _.each([
+            { name: 'Maths L1', creatorId: creator1.id },
+            { name: 'Maths L2', creatorId: creator2.id },
+            { name: 'Chimie', creatorId: creator1.id },
+          ], (campaign) => {
+            databaseBuilder.factory.buildCampaign({ ...campaign, organizationId });
+          });
+
+          return databaseBuilder.commit();
+        });
+
+        it('should return the matching campaigns', async () => {
+          const { models: actualCampaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          expect(_.map(actualCampaignsWithReports, 'name')).to.have.members(['Maths L1', 'Chimie']);
+        });
+      });
+
+      context('when the given filter search property is not searchable', () => {
+        // given
+        const filter = { code: 'FAKECODE' };
+        const page = { number: 1, size: 10 };
+
+        beforeEach(() => {
+          databaseBuilder.factory.buildCampaign({ organizationId });
+          return databaseBuilder.commit();
+        });
+
+        it('should ignore the filter and return all campaigns', async () => {
+          // when
+          const { models: actualCampaignsWithReports } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(actualCampaignsWithReports).to.have.lengthOf(1);
+        });
+      });
+
+      context('when campaigns amount exceed page size', () => {
+        // given
+        let expectedPagination;
+
+        beforeEach(() => {
+          _.times(4, () => databaseBuilder.factory.buildCampaign({ organizationId }));
+          expectedPagination = { page: page.number, pageSize: page.size, pageCount: 2, rowCount: 4 };
+          return databaseBuilder.commit();
+        });
+
+        it('should return page size number of campaigns', async () => {
+          // when
+          const { models: campaignsWithReports, meta: pagination } = await campaignReportRepository.findPaginatedFilteredByOrganizationId({ organizationId, filter, page });
+
+          // then
+          expect(campaignsWithReports).to.have.lengthOf(3);
+          expect(pagination).to.include(expectedPagination);
+        });
+      });
+    });
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-campaign-report.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-report.js
@@ -1,12 +1,45 @@
-const CampaignReport = require('../../../../lib/domain/models/CampaignReport');
-const faker = require('faker');
+const CampaignReport = require('../../../../lib/domain/read-models/CampaignReport');
 
-module.exports = function buildCampaignReport(
-  {
-    id = 1,
-    participationsCount = faker.random.number(50),
-    sharedParticipationsCount = faker.random.number({ max: participationsCount }),
-    stages = [],
-  } = {}) {
-  return new CampaignReport({ id, participationsCount, sharedParticipationsCount, stages });
+module.exports = function buildCampaignReport({
+  id = 1,
+  name = 'Un nom de campagne',
+  code = 'AZERTY123',
+  title = 'Un titre de campagne',
+  idPixLabel = 'Un id pix label',
+  createdAt = new Date(),
+  customLandingPageText = 'Une custom landing page',
+  archivedAt = null,
+  type = CampaignReport.types.ASSESSMENT,
+  creatorId = 2,
+  creatorFirstName = 'Un prénom',
+  creatorLastName = 'Un nom',
+  targetProfileId = 3,
+  targetProfileName = 'Le profil cible',
+  targetProfileImageUrl = 'url.org',
+  participationsCount = 5,
+  sharedParticipationsCount = 2,
+  badges = [],
+  stages = [],
+} = {}) {
+  return new CampaignReport({
+    id,
+    name,
+    code,
+    title,
+    idPixLabel,
+    createdAt,
+    customLandingPageText,
+    archivedAt,
+    type,
+    creatorId,
+    creatorFirstName,
+    creatorLastName,
+    targetProfileId,
+    targetProfileName,
+    targetProfileImageUrl,
+    participationsCount,
+    sharedParticipationsCount,
+    badges,
+    stages,
+  });
 };

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -179,7 +179,7 @@ describe('Unit | Application | Controller | Campaign', () => {
     });
   });
 
-  describe('#getByCode ', () => {
+  describe('#getByCode', () => {
 
     it('should return the serialized campaign', async () => {
       // given
@@ -219,7 +219,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
   });
 
-  describe('#getById ', () => {
+  describe('#getById', () => {
     let request, campaign;
 
     beforeEach(() => {
@@ -240,7 +240,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       };
 
       sinon.stub(usecases, 'getCampaign');
-      sinon.stub(campaignSerializer, 'serialize');
+      sinon.stub(campaignReportSerializer, 'serialize');
       sinon.stub(queryParamsUtils, 'extractParameters');
       sinon.stub(tokenService, 'createTokenForCampaignResults');
 
@@ -250,16 +250,16 @@ describe('Unit | Application | Controller | Campaign', () => {
 
     it('should return the campaign', async () => {
       // given
+      const expectedResult = Symbol('ok');
       const tokenForCampaignResults = 'token';
-      const expectedCampaign = { ...campaign, tokenForCampaignResults };
-      usecases.getCampaign.withArgs({ campaignId: campaign.id, options: {} }).resolves(campaign);
-      campaignSerializer.serialize.withArgs(campaign, {}, { tokenForCampaignResults }).returns(expectedCampaign);
+      usecases.getCampaign.withArgs({ campaignId: campaign.id }).resolves(campaign);
+      campaignReportSerializer.serialize.withArgs(campaign, {}, { tokenForCampaignResults }).returns(expectedResult);
 
       // when
       const response = await campaignController.getById(request, hFake);
 
       // then
-      expect(response).to.deep.equal(expectedCampaign);
+      expect(response).to.deep.equal(expectedResult);
     });
   });
 

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -8,7 +8,7 @@ const usecases = require('../../../../lib/domain/usecases');
 const organizationService = require('../../../../lib/domain/services/organization-service');
 const tokenService = require('../../../../lib/domain/services/token-service');
 
-const campaignSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-serializer');
+const campaignReportSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-report-serializer');
 const organizationInvitationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-invitation-serializer');
 const organizationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/organization-serializer');
 const targetProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/target-profile-serializer');
@@ -288,7 +288,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
       sinon.stub(queryParamsUtils, 'extractParameters');
       sinon.stub(usecases, 'findPaginatedFilteredOrganizationCampaigns');
-      sinon.stub(campaignSerializer, 'serialize');
+      sinon.stub(campaignReportSerializer, 'serialize');
     });
 
     it('should call the usecase to get the campaigns and associated campaignReports', async () => {
@@ -302,7 +302,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       const expectedResults = [campaign];
       const expectedPagination = { page: expectedPage, pageSize: 25, itemsCount: 100, pagesCount: 4 };
       usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: expectedResults, pagination: expectedPagination });
-      campaignSerializer.serialize.returns({ data: serializedCampaigns, meta: {} });
+      campaignReportSerializer.serialize.returns({ data: serializedCampaigns, meta: {} });
 
       // when
       await organizationController.findPaginatedFilteredCampaigns(request, hFake);
@@ -317,7 +317,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       const expectedResponse = { data: serializedCampaigns, meta: {} };
       queryParamsUtils.extractParameters.withArgs({}).returns({ filter: {} });
       usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: {}, pagination: {} });
-      campaignSerializer.serialize.returns(expectedResponse);
+      campaignReportSerializer.serialize.returns(expectedResponse);
 
       // when
       const response = await organizationController.findPaginatedFilteredCampaigns(request, hFake);
@@ -331,7 +331,6 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       request.query = {};
       const expectedResults = [campaign];
       const expectedPagination = { page: 2, pageSize: 25, itemsCount: 100, pagesCount: 4, hasCampaigns: true };
-      const expectedConfig = { ignoreCampaignReportRelationshipData: false };
       queryParamsUtils.extractParameters.withArgs({}).returns({ filter: {} });
       usecases.findPaginatedFilteredOrganizationCampaigns.resolves({ models: expectedResults, meta: expectedPagination });
 
@@ -339,7 +338,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       await organizationController.findPaginatedFilteredCampaigns(request, hFake);
 
       // then
-      expect(campaignSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination, expectedConfig);
+      expect(campaignReportSerializer.serialize).to.have.been.calledWithExactly(expectedResults, expectedPagination);
     });
   });
 

--- a/api/tests/unit/domain/read-models/CampaignReport_test.js
+++ b/api/tests/unit/domain/read-models/CampaignReport_test.js
@@ -1,0 +1,59 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const { types } = require('../../../../lib/domain/read-models/CampaignReport');
+
+describe('Unit | Domain | Models | CampaignReport', () => {
+
+  describe('#isAssessment', () => {
+    it('should return true if the campaign is of type ASSESSMENT', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ type: types.ASSESSMENT });
+
+      // when / then
+      expect(campaignReport.isAssessment).to.be.true;
+    });
+
+    it('should return false if the campaign is not of type ASSESSMENT', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ type: types.PROFILES_COLLECTION });
+
+      // when / then
+      expect(campaignReport.isAssessment).to.be.false;
+    });
+  });
+
+  describe('#isProfilesCollection', () => {
+    it('should return true if the campaign is of type PROFILES_COLLECTION', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ type: types.PROFILES_COLLECTION });
+
+      // when / then
+      expect(campaignReport.isProfilesCollection).to.be.true;
+    });
+
+    it('should return false if the campaign is not of type PROFILES_COLLECTION', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ type: types.ASSESSMENT });
+
+      // when / then
+      expect(campaignReport.isProfilesCollection).to.be.false;
+    });
+  });
+
+  describe('#isArchived', () => {
+    it('should return true if the campaign is archived', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ archivedAt: new Date('2020-02-02') });
+
+      // when / then
+      expect(campaignReport.isArchived).to.be.true;
+    });
+
+    it('should return false if the campaign is not archived', () => {
+      // given
+      const campaignReport = domainBuilder.buildCampaignReport({ archivedAt: null });
+
+      // when / then
+      expect(campaignReport.isArchived).to.be.false;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
+++ b/api/tests/unit/domain/usecases/find-paginated-filtered-organization-campaigns_test.js
@@ -4,10 +4,10 @@ const findPaginatedFilteredOrganizationCampaigns = require('../../../../lib/doma
 
 describe('Unit | Domain | Use Cases | find-paginated-filtered-organization-campaigns', () => {
 
-  const campaignRepository = { findPaginatedFilteredByOrganizationIdWithCampaignReports: () => undefined };
+  const campaignReportRepository = { findPaginatedFilteredByOrganizationId: () => undefined };
 
   beforeEach(() => {
-    campaignRepository.findPaginatedFilteredByOrganizationIdWithCampaignReports = sinon.stub();
+    campaignReportRepository.findPaginatedFilteredByOrganizationId = sinon.stub();
   });
 
   describe('#findPaginatedFilteredOrganizationCampaigns', () => {
@@ -17,11 +17,11 @@ describe('Unit | Domain | Use Cases | find-paginated-filtered-organization-camp
       const organizationId = 251;
       const foundCampaign = domainBuilder.buildCampaign({ organizationId });
       const foundCampaigns = [foundCampaign];
-      campaignRepository.findPaginatedFilteredByOrganizationIdWithCampaignReports.resolves(foundCampaigns);
+      campaignReportRepository.findPaginatedFilteredByOrganizationId.resolves(foundCampaigns);
       const page = { number: 1, size: 3 };
 
       // when
-      const promise = findPaginatedFilteredOrganizationCampaigns({ organizationId, page, campaignRepository });
+      const promise = findPaginatedFilteredOrganizationCampaigns({ organizationId, page, campaignReportRepository });
 
       // then
       return promise.then((campaigns) => {

--- a/api/tests/unit/domain/usecases/get-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign_test.js
@@ -7,6 +7,7 @@ describe('Unit | UseCase | get-campaign', () => {
   let campaign;
   let campaignReportRepository;
   let stageRepository;
+  let badgeRepository;
 
   beforeEach(() => {
     campaign = {
@@ -19,6 +20,9 @@ describe('Unit | UseCase | get-campaign', () => {
     stageRepository = {
       findByCampaignId: sinon.stub(),
     };
+    badgeRepository = {
+      findByCampaignId: sinon.stub(),
+    };
   });
 
   it('should get the campaign', async () => {
@@ -27,7 +31,7 @@ describe('Unit | UseCase | get-campaign', () => {
     stageRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves();
 
     // when
-    const resultCampaign = await getCampaign({ campaignId: campaign.id, campaignReportRepository, stageRepository });
+    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
 
     // then
     expect(resultCampaign.name).to.equal(campaign.name);
@@ -40,10 +44,23 @@ describe('Unit | UseCase | get-campaign', () => {
     stageRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves(stages);
 
     // when
-    const resultCampaign = await getCampaign({ campaignId: campaign.id, campaignReportRepository, stageRepository });
+    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
 
     // then
     expect(resultCampaign.stages).to.equal(stages);
+  });
+
+  it('should get campaign badges', async () => {
+    // given
+    const badges = Symbol('badges');
+    campaignReportRepository.get.withArgs(parseInt(campaign.id)).resolves(campaign);
+    badgeRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves(badges);
+
+    // when
+    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
+
+    // then
+    expect(resultCampaign.badges).to.equal(badges);
   });
 
   it('should throw a Not found error when the campaign is searched with a not valid ID', async () => {

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -25,31 +25,61 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
       // then
       expect(json).to.deep.equal({
         data: {
-          type: 'campaign-reports',
-          id: report.id,
+          type: 'campaigns',
+          id: report.id.toString(),
           relationships: {
             stages: {
               data: [
                 {
-                  id: '1',
+                  id: report.stages[0].id.toString(),
                   type: 'stages',
                 },
               ],
             },
+            'campaign-analysis': {
+              links: {
+                related: '/api/campaigns/campaign_report_id/analyses',
+              },
+            },
+            'campaign-collective-result': {
+              links: {
+                related: '/api/campaigns/campaign_report_id/collective-results',
+              },
+            },
+            divisions: {
+              links: {
+                related: '/api/campaigns/campaign_report_id/divisions',
+              },
+            },
           },
           attributes: {
-            'participations-count': 4,
-            'shared-participations-count': 2,
+            code: report.code,
+            name: report.name,
+            type: report.type,
+            title: report.title,
+            'created-at': report.createdAt,
+            'creator-id': report.creatorId,
+            'creator-first-name': report.creatorFirstName,
+            'creator-last-name': report.creatorLastName,
+            'custom-landing-page-text': report.customLandingPageText,
+            'id-pix-label': report.idPixLabel,
+            'is-archived': report.isArchived,
+            'target-profile-id': report.targetProfileId,
+            'target-profile-name': report.targetProfileName,
+            'target-profile-image-url': report.targetProfileImageUrl,
+            'token-for-campaign-results': report.tokenForCampaignResults,
+            'participations-count': report.participationsCount,
+            'shared-participations-count': report.sharedParticipationsCount,
           },
         },
         included: [
           {
             attributes: {
-              message: 'stageMessage',
-              threshold: 30,
-              title: 'stage1',
+              message: report.stages[0].message,
+              threshold: report.stages[0].threshold,
+              title: report.stages[0].title,
             },
-            id: '1',
+            id: report.stages[0].id.toString(),
             type: 'stages',
           },
         ],

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -17,6 +17,10 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
           message: 'stageMessage',
           threshold: 30,
         }],
+        badges: [{
+          id: 123,
+          title: 'badge123',
+        }],
       });
 
       // when
@@ -33,6 +37,14 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
                 {
                   id: report.stages[0].id.toString(),
                   type: 'stages',
+                },
+              ],
+            },
+            badges: {
+              data: [
+                {
+                  id: report.badges[0].id.toString(),
+                  type: 'badges',
                 },
               ],
             },
@@ -81,6 +93,13 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
             },
             id: report.stages[0].id.toString(),
             type: 'stages',
+          },
+          {
+            attributes: {
+              title: report.badges[0].title,
+            },
+            id: report.badges[0].id.toString(),
+            type: 'badges',
           },
         ],
       });

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -23,7 +23,7 @@
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}
           <th>Résultats</th>
-          {{#if @campaign.targetProfile.hasBadges}}
+          {{#if @campaign.hasBadges}}
             <th>Résultats Thématiques</th>
           {{/if}}
         </tr>
@@ -40,10 +40,10 @@
             {{/if}}
             <td>
               {{#if participation.isShared}}
-                {{#if @campaign.campaignReport.hasStages}}
+                {{#if @campaign.hasStages}}
                   <StageStars
                     @result={{participation.masteryPercentage}}
-                    @stages={{@campaign.campaignReport.stages}}
+                    @stages={{@campaign.stages}}
                   />
                 {{else}}
                   <span class="participant-list__mastery-percentage">
@@ -64,7 +64,7 @@
                 {{/if}}
               {{/if}}
             </td>
-            {{#if @campaign.targetProfile.hasBadges}}
+            {{#if @campaign.hasBadges}}
               <td>
                 {{#if participation.isShared}}
                   {{#each participation.badges as |badge|}}

--- a/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
@@ -32,10 +32,10 @@
 <div class="panel panel--light-shadow participant-results__details content-text content-text--small">
 
 
-  <table>
+  <table aria-label="Résultats collectifs par compétence">
     <thead>
     <tr>
-      <th class="table__column--wide">Compétences ({{ @campaignCollectiveResult.campaignCompetenceCollectiveResults.length }})</th>
+      <th class="table__column--wide">Compétences ({{if @sharedParticipationsCount @campaignCollectiveResult.campaignCompetenceCollectiveResults.length '-' }})</th>
       <th class="table__column--wide">Résultats</th>
       <th class="table__column--small">Acquis validés</th>
       <th class="table__column--small">Acquis évalués</th>
@@ -46,7 +46,7 @@
 
       <tbody>
       {{#each @campaignCollectiveResult.campaignCompetenceCollectiveResults as |competenceResult|}}
-        <tr>
+        <tr aria-label="Compétence">
           <td class="competences-col__name">
             <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
             <span>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.hbs
@@ -3,7 +3,7 @@
     {{#if @campaign.isTypeAssessment}}
       <div class="campaign-details-content">
         <h4 class="label-text campaign-details-content__label">Profil cible</h4>
-        <p class="content-text campaign-details-content__text">{{@campaign.targetProfile.name}}</p>
+        <p class="content-text campaign-details-content__text">{{@campaign.targetProfileName}}</p>
       </div>
     {{/if}}
     {{#if @campaign.idPixLabel}}

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -33,10 +33,10 @@
         {{#each @campaigns as |campaign|}}
           <tr aria-label="Campagne" role="button" {{on 'click' (fn @goToCampaignPage campaign.id)}} class="tr--clickable">
             <td>{{campaign.name}}</td>
-            <td class="table__column--truncated">{{campaign.creator.fullName}}</td>
+            <td class="table__column--truncated">{{campaign.creatorFullName}}</td>
             <td>{{moment-format campaign.createdAt 'DD/MM/YYYY' allow-empty=true}}</td>
-            <td>{{campaign.campaignReport.participationsCount}}</td>
-            <td>{{campaign.campaignReport.sharedParticipationsCount}}</td>
+            <td>{{campaign.participationsCount}}</td>
+            <td>{{campaign.sharedParticipationsCount}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -58,7 +58,7 @@
         @model={{@campaign}}
         class="navbar-item"
       >
-        Participants ({{@campaign.campaignReport.participationsCount}})
+        Participants ({{@campaign.participationsCount}})
       </LinkTo>
       {{#if @campaign.isTypeAssessment}}
         <LinkTo @route="authenticated.campaigns.campaign.collective-results" @model={{@campaign}} class="navbar-item">

--- a/orga/app/components/routes/authenticated/campaign/report.js
+++ b/orga/app/components/routes/authenticated/campaign/report.js
@@ -8,13 +8,13 @@ export default class Report extends Component {
   @service notifications;
 
   get participationsCount() {
-    const participationsCount = this.args.campaign.campaignReport.get('participationsCount');
+    const participationsCount = this.args.campaign.participationsCount;
 
     return participationsCount > 0 ? participationsCount : '-';
   }
 
   get sharedParticipationsCount() {
-    const sharedParticipationsCount = this.args.campaign.campaignReport.get('sharedParticipationsCount');
+    const sharedParticipationsCount = this.args.campaign.sharedParticipationsCount;
 
     return sharedParticipationsCount > 0 ? sharedParticipationsCount : '-';
   }

--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -5,58 +5,44 @@ const PROFILES_COLLECTION_TEXT = 'Collecte de profils';
 const ASSESSMENT_TEXT = 'Évaluation';
 
 export default class Campaign extends Model {
-  @attr('string')
-  name;
+  @attr('string') name;
+  @attr('string') code;
+  @attr('string') type;
+  @attr('string') title;
+  @attr('boolean') isArchived;
+  @attr('string') idPixLabel;
+  @attr('string') customLandingPageText;
+  @attr('string') tokenForCampaignResults;
+  @attr('string') creatorId;
+  @attr('string') creatorLastName;
+  @attr('string') creatorFirstName;
+  @attr('string') targetProfileId;
+  @attr('string') targetProfileName;
+  @attr('string') targetProfileImageUrl;
+  @attr('number') participationsCount;
+  @attr('number') sharedParticipationsCount;
 
-  @attr('string')
-  code;
+  @belongsTo('user') creator;
+  @belongsTo('organization') organization;
+  @belongsTo('target-profile') targetProfile;
+  @belongsTo('campaign-collective-result') campaignCollectiveResult;
+  @belongsTo('campaign-analysis') campaignAnalysis;
 
-  @attr('string')
-  type;
+  @hasMany('badge') badges;
+  @hasMany('stage') stages;
+  @hasMany('divisions') divisions;
 
-  @attr('string')
-  title;
+  get hasBadges() {
+    return Boolean(this.badges) && this.badges.length > 0;
+  }
 
-  @attr('date')
-  createdAt;
+  get hasStages() {
+    return Boolean(this.stages) && this.stages.length > 0;
+  }
 
-  @belongsTo('user')
-  creator;
-
-  @attr('date')
-  archivedAt;
-
-  @attr('string')
-  idPixLabel;
-
-  @attr('string')
-  customLandingPageText;
-
-  // TODO remove organizationId and work only with the relationship
-
-  @attr('number')
-  organizationId;
-
-  @belongsTo('organization')
-  organization;
-
-  @attr('string')
-  tokenForCampaignResults;
-
-  @belongsTo('target-profile')
-  targetProfile;
-
-  @belongsTo('campaign-report')
-  campaignReport;
-
-  @belongsTo('campaign-collective-result')
-  campaignCollectiveResult;
-
-  @belongsTo('campaign-analysis')
-  campaignAnalysis;
-
-  @hasMany('divisions')
-  divisions;
+  get creatorFullName() {
+    return `${this.creatorFirstName} ${this.creatorLastName}`;
+  }
 
   get isTypeProfilesCollection() {
     return this.type === 'PROFILES_COLLECTION';
@@ -77,17 +63,13 @@ export default class Campaign extends Model {
     return `${ENV.APP.API_HOST}/api/campaigns/${this.id}/csv-profiles-collection-results?accessToken=${this.tokenForCampaignResults}`;
   }
 
-  get isArchived() {
-    return Boolean(this.archivedAt);
-  }
-
   async archive() {
     await this.store.adapterFor('campaign').archive(this);
-    return this.store.findRecord('campaign', this.id, { include: 'targetProfile' });
+    return this.store.findRecord('campaign', this.id);
   }
 
   async unarchive() {
     await this.store.adapterFor('campaign').unarchive(this);
-    return this.store.findRecord('campaign', this.id, { include: 'targetProfile' });
+    return this.store.findRecord('campaign', this.id);
   }
 }

--- a/orga/app/models/prescriber.js
+++ b/orga/app/models/prescriber.js
@@ -7,8 +7,4 @@ export default class Prescriber extends Model {
   @attr('boolean') areNewYearSchoolingRegistrationsImported;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
-
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
-  }
 }

--- a/orga/app/models/target-profile.js
+++ b/orga/app/models/target-profile.js
@@ -2,5 +2,4 @@ import Model, { attr } from '@ember-data/model';
 
 export default class TargetProfile extends Model {
   @attr('string') name;
-  @attr('boolean') hasBadges;
 }

--- a/orga/app/models/user.js
+++ b/orga/app/models/user.js
@@ -9,8 +9,4 @@ export default class User extends Model {
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
   @hasMany('membership') memberships;
   @belongsTo('user-orga-setting') userOrgaSettings;
-
-  get fullName() {
-    return `${this.firstName} ${this.lastName}`;
-  }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign.js
+++ b/orga/app/routes/authenticated/campaigns/campaign.js
@@ -3,13 +3,9 @@ import Route from '@ember/routing/route';
 export default class CampaignRoute extends Route {
 
   model(params) {
-    return this.store.findRecord('campaign', params.campaign_id, { include: 'targetProfile,targetProfile.badges' })
+    return this.store.findRecord('campaign', params.campaign_id)
       .catch((error) => {
         return this.send('error', error, this.replaceWith('not-found', params.campaign_id));
       });
-  }
-
-  afterModel(model) {
-    return model.belongsTo('campaignReport').reload();
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/analysis.hbs
@@ -1,4 +1,4 @@
 <Routes::Authenticated::Campaign::Analysis::Tab
   @campaignTubeRecommendations={{@model.campaignAnalysis.campaignTubeRecommendations}}
-  @displayAnalysis={{gt @model.campaignReport.sharedParticipationsCount 0}}
+  @displayAnalysis={{gt @model.sharedParticipationsCount 0}}
 />

--- a/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/collective-results.hbs
@@ -1,1 +1,1 @@
-<Routes::Authenticated::Campaign::CollectiveResults::Tab @campaignCollectiveResult={{@model.campaignCollectiveResult}} @sharedParticipationsCount={{@model.campaignReport.sharedParticipationsCount}} />
+<Routes::Authenticated::Campaign::CollectiveResults::Tab @campaignCollectiveResult={{@model.campaignCollectiveResult}} @sharedParticipationsCount={{@model.sharedParticipationsCount}} />

--- a/orga/mirage/factories/campaign.js
+++ b/orga/mirage/factories/campaign.js
@@ -1,4 +1,4 @@
-import { association, Factory } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
 import faker from 'faker';
 
 export default Factory.extend({
@@ -14,8 +14,6 @@ export default Factory.extend({
   createdAt() {
     return faker.date.recent();
   },
-
-  campaignReport: association(),
 
 });
 

--- a/orga/tests/acceptance/campaign-analysis-test.js
+++ b/orga/tests/acceptance/campaign-analysis-test.js
@@ -19,7 +19,7 @@ module('Acceptance | Campaign Analysis', function(hooks) {
     createPrescriberByUser(user);
 
     const campaignAnalysis = server.create('campaign-analysis', 'withTubeRecommendations');
-    server.create('campaign', { id: 1, campaignAnalysis });
+    server.create('campaign', { campaignAnalysis, sharedParticipationsCount: 2 });
 
     await authenticateSession({
       user_id: user.id,

--- a/orga/tests/acceptance/campaign-collective-result-test.js
+++ b/orga/tests/acceptance/campaign-collective-result-test.js
@@ -18,9 +18,8 @@ module('Acceptance | Campaign Collective Result', function(hooks) {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
     createPrescriberByUser(user);
 
-    const campaignReport = server.create('campaign-report', { sharedParticipationCount: 3 });
     const campaignCollectiveResult = server.create('campaign-collective-result', 'withCompetenceCollectiveResults');
-    server.create('campaign', { id: 1, campaignCollectiveResult, campaignReport });
+    server.create('campaign', { campaignCollectiveResult, sharedParticipationsCount: 2 });
 
     await authenticateSession({
       user_id: user.id,
@@ -32,15 +31,10 @@ module('Acceptance | Campaign Collective Result', function(hooks) {
 
   test('it should display campaign collective result', async function(assert) {
     // when
+    server.logging = true;
     await visit('/campagnes/1/resultats-collectifs');
 
     // then
-    assert.dom('.table__empty').doesNotExist();
-
-    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('competences-col__border--jaffa');
-    assert.dom('table tbody tr:first-child td:first-child span:nth-child(2)').hasText('Competence A');
-    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('50%');
-    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('5');
-    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('10');
+    assert.dom('[aria-label="Résultats collectifs par compétence"]').containsText('Compétences (2)');
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -48,46 +48,14 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       assert.contains('80%');
     });
 
-    test('it should display badge column when participant shared result', async function(assert) {
+    test('it should display badge and tooltip', async function(assert) {
       // given
-      const badge = store.createRecord('badge', { id: 'b1', imageUrl: 'url-badge' });
-      const targetProfile = store.createRecord('targetProfile', {
-        id: 't1',
-        hasBadges: true,
-      });
+      const badge = store.createRecord('badge', { imageUrl: 'url-badge' });
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        targetProfile,
+        badges: [badge],
       });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe', badges: [badge], isShared: true }];
-      participations.meta = { rowCount: 1 };
-
-      this.set('campaign', campaign);
-      this.set('participations', participations);
-      this.set('goToAssessmentPage', () => {});
-      // when
-      await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
-
-      // then
-      assert.contains('Résultats Thématiques');
-    });
-
-    test('it should display badge and tooltip when pariticipant shared his results', async function(assert) {
-      // given
-      const badge = store.createRecord('badge', { id: 'b1', imageUrl: 'url-badge' });
-      const targetProfile = store.createRecord('targetProfile', {
-        id: 't1',
-        hasBadges: true,
-      });
-      const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        targetProfile,
-      });
-
-      const participations = [{ firstName: 'John', lastName: 'Doe', badges: [badge], isShared: true }];
+      const participations = [{ badges: [badge], isShared: true }];
       participations.meta = { rowCount: 1 };
 
       this.set('campaign', campaign);
@@ -107,7 +75,6 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     test('it should display that participant\'s results are pending', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
         name: 'campagne 1',
       });
 
@@ -137,21 +104,14 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       assert.contains('En attente');
     });
 
-    test('it should not display badge neither tooltip when participant not shared result', async function(assert) {
+    test('it should not display badge neither tooltip', async function(assert) {
       // given
-      const badge = store.createRecord('badge', { id: 'b1', imageUrl: 'url-badge' });
-      const targetProfile = store.createRecord('targetProfile', {
-        id: 't1',
-        hasBadges: true,
-      });
-
+      const badge = store.createRecord('badge', { imageUrl: 'url-badge' });
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        targetProfile,
+        badges: [badge],
       });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe', badges: [badge], isShared: false }];
+      const participations = [{ badges: [badge], isShared: false }];
       participations.meta = { rowCount: 1 };
 
       this.set('campaign', campaign);
@@ -171,7 +131,6 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     test('it should display that participant\'s results are still ongoing', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
         name: 'campagne 1',
       });
 
@@ -206,12 +165,10 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     test('it should display participant\'s results with external id', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
         idPixLabel: 'identifiant externe',
       });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe', participantExternalId: '123' }];
+      const participations = [{ participantExternalId: '123' }];
       participations.meta = {
         rowCount: 1,
       };
@@ -233,7 +190,6 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     test('it should display "waiting for participants"', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
         name: 'campagne 1',
       });
 
@@ -257,11 +213,10 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     test('it should not display badge column', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
+        badges: [],
       });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe' }];
+      const participations = [{}];
       participations.meta = { rowCount: 1 };
 
       this.set('campaign', campaign);
@@ -279,18 +234,12 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
   module('when the campaign has badges', function() {
     test('it should display badge column', async function(assert) {
       // given
-      const targetProfile = store.createRecord('targetProfile', {
-        id: 't1',
-        hasBadges: true,
-      });
-
+      const badge = store.createRecord('badge');
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        targetProfile,
+        badges: [badge],
       });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe' }];
+      const participations = [{ }];
       participations.meta = { rowCount: 1 };
 
       this.set('campaign', campaign);
@@ -308,18 +257,12 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
   module('when the campaign has stages', function() {
     test('it should display stars instead of mastery percentage in result column', async function(assert) {
       // given
-      const stage = store.createRecord('stage', { id: 's1', threshold: 50 });
-      const campaignReport = store.createRecord('campaign-report', {
-        id: 'c1',
+      const stage = store.createRecord('stage', { threshold: 50 });
+      const campaign = store.createRecord('campaign', {
         stages: [stage],
       });
-      const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        campaignReport,
-      });
 
-      const participations = [{ firstName: 'John', lastName: 'Doe', masteryPercentage: 60, isShared: true }];
+      const participations = [{ masteryPercentage: 60, isShared: true }];
       participations.meta = { rowCount: 1 };
 
       this.set('campaign', campaign);

--- a/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
@@ -26,15 +26,12 @@ module('Integration | Component | routes/authenticated/campaign/collective-resul
     await render(hbs`<Routes::Authenticated::Campaign::CollectiveResults::Tab @campaignCollectiveResult={{campaignCollectiveResult}}/>`);
 
     // then
-    assert.dom('table tbody').doesNotExist();
-    assert.dom('.table__empty').hasText('En attente de résultats');
+    assert.contains('En attente de résultats');
   });
 
   test('it should display the collective result list of the campaign', async function(assert) {
     // given
-    const campaignReport = store.createRecord('campaign-report', { id: 1, participationsCount: 5, sharedParticipationsCount: 4 });
-
-    const campaignCompetenceCollectiveResult_1 = store.createRecord('campaign-competence-collective-result', {
+    const campaignCompetenceCollectiveResult = store.createRecord('campaign-competence-collective-result', {
       id: '1_recCompA',
       areaCode: '1',
       areaColor: 'jaffa',
@@ -44,23 +41,13 @@ module('Integration | Component | routes/authenticated/campaign/collective-resul
       targetedSkillsCount: 30,
     });
 
-    const campaignCompetenceCollectiveResult_2 = store.createRecord('campaign-competence-collective-result', {
-      id: '2_recCompB',
-      areaCode: '2',
-      areaColor: 'emerald',
-      competenceId: 'recCompB',
-      competenceName: 'Competence B',
-      averageValidatedSkills: 12.5,
-      targetedSkillsCount: 50,
-    });
-
     const campaignCollectiveResult = store.createRecord('campaign-collective-result', {
       id: 1,
-      campaignCompetenceCollectiveResults: [campaignCompetenceCollectiveResult_1, campaignCompetenceCollectiveResult_2],
+      campaignCompetenceCollectiveResults: [campaignCompetenceCollectiveResult],
     });
 
     this.set('campaignCollectiveResult', campaignCollectiveResult);
-    this.set('sharedParticipationsCount', campaignReport.sharedParticipationsCount);
+    this.set('sharedParticipationsCount', 4);
 
     // when
     await render(hbs`<Routes::Authenticated::Campaign::CollectiveResults::Tab
@@ -69,18 +56,11 @@ module('Integration | Component | routes/authenticated/campaign/collective-resul
     );
 
     // then
-    assert.dom('.table__empty').doesNotExist();
-    assert.dom('table tbody tr:first-child td:first-child span:first-child').hasClass('competences-col__border--jaffa');
-    assert.dom('table tbody tr:first-child td:first-child span:nth-child(2)').hasText('Competence A');
-    assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('33%');
-    assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('10');
-    assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('30');
-
-    assert.dom('table tbody tr:nth-child(2) td:first-child span:first-child').hasClass('competences-col__border--emerald');
-    assert.dom('table tbody tr:nth-child(2) td:first-child span:nth-child(2)').hasText('Competence B');
-    assert.dom('table tbody tr:nth-child(2) td:nth-child(2)').hasText('25%');
-    assert.dom('table tbody tr:nth-child(2) td:nth-child(3)').hasText('12.5');
-    assert.dom('table tbody tr:nth-child(2) td:nth-child(4)').hasText('50');
+    assert.notContains('En attente de résultats');
+    const firstCompetence = '[aria-label="Compétence"]:first-child';
+    assert.dom(firstCompetence).containsText('Competence A');
+    assert.dom(firstCompetence).containsText('33%');
+    assert.dom(firstCompetence).containsText('10');
+    assert.dom(firstCompetence).containsText('30');
   });
-
 });

--- a/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
@@ -19,12 +19,9 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     module('when type is ASSESSMENT', function() {
       test('it should display target profile related to campaign', async function(assert) {
         // given
-        const targetProfile = store.createRecord('targetProfile', {
-          name: 'profil cible de la campagne 1',
-        });
         const campaign = store.createRecord('campaign', {
           type: 'ASSESSMENT',
-          targetProfile,
+          targetProfileName: 'profil cible de la campagne 1',
         });
 
         this.set('campaign', campaign);
@@ -145,9 +142,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
   module('on Archived action display', function() {
     test('it should display the button archived', async function(assert) {
       // given
-      const campaign = store.createRecord('campaign', {
-        archivedAt: null,
-      });
+      const campaign = store.createRecord('campaign', { isArchived: false });
 
       this.set('campaign', campaign);
 
@@ -163,7 +158,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     module('when the campaign is not archived', function() {
       test('it should display the button modify', async function(assert) {
         // given
-        const campaign = store.createRecord('campaign', { archivedAt: null });
+        const campaign = store.createRecord('campaign', { isArchived: false });
 
         this.set('campaign', campaign);
 
@@ -178,7 +173,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     module('when the campaign is archived', function() {
       test('it should not display the button modify', async function(assert) {
         // given
-        const campaign = store.createRecord('campaign', { archivedAt: new Date() });
+        const campaign = store.createRecord('campaign', { isArchived: true });
 
         this.set('campaign', campaign);
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -84,27 +84,13 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
     test('it should display the creator of the campaigns', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const user1 = store.createRecord('user', {
-        id: 1,
-        firstName: 'Jean-Michel',
-        lastName: 'Jarre',
-      });
-      const user2 = store.createRecord('user', {
-        id: 2,
-        firstName: 'Mathilde',
-        lastName: 'Bonnin de La Bonninière de Beaumont',
-      });
       const campaign1 = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        creator: user1,
-        code: 'AAAAAA111',
+        creatorFirstName: 'Jean-Michel',
+        creatorLastName: 'Jarre',
       });
       const campaign2 = store.createRecord('campaign', {
-        id: 2,
-        name: 'campagne 1',
-        creator: user2,
-        code: 'BBBBBB222',
+        creatorFirstName: 'Mathilde',
+        creatorLastName: 'Bonnin de La Bonninière de Beaumont',
       });
       const campaigns = [campaign1, campaign2];
       campaigns.meta = {
@@ -157,17 +143,8 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
     test('it should display the participations count', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaignReport = store.createRecord('campaignReport', {
-        id: 1,
-        participationsCount: 10,
-        sharedParticipationsCount: 4,
-      });
-
       const campaign1 = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        code: 'AAAAAA111',
-        campaignReport,
+        participationsCount: 10,
       });
 
       const campaigns = [campaign1];
@@ -189,17 +166,8 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
     test('it should display the shared participations count', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const campaignReport = store.createRecord('campaignReport', {
-        id: 1,
-        participationsCount: 10,
-        sharedParticipationsCount: 4,
-      });
-
       const campaign1 = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        code: 'AAAAAA111',
-        campaignReport,
+        sharedParticipationsCount: 4,
       });
 
       const campaigns = [campaign1];

--- a/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
@@ -12,69 +12,94 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     store = this.owner.lookup('service:store');
   });
 
-  test('it should display campaign details', async function(assert) {
+  test('it should display campaign name', async function(assert) {
     // given
     const campaign = store.createRecord('campaign', {
-      id: 1,
       name: 'campagne 1',
     });
-
     this.set('campaign', campaign);
 
     // when
     await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
 
     // then
-    assert.dom('.campaign-details-header__title').hasText('campagne 1');
+    assert.contains('campagne 1');
   });
 
-  module('Campaign details header', function() {
-    test('it should display the campaign report', async function(assert) {
+  test('it should display campaign code', async function(assert) {
+    // given
+    const campaign = store.createRecord('campaign', {
+      code: '1234PixTest',
+    });
+    this.set('campaign', campaign);
+
+    // when
+    await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
+    // then
+    assert.contains('1234PixTest');
+  });
+
+  module('When there is some results', function() {
+    test('it should display campaign participants number', async function(assert) {
       // given
-      const campaignReport = store.createRecord('campaignReport', {
-        id: 1,
-        participationsCount: 10,
-        sharedParticipationsCount: 4,
-      });
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        campaignReport,
-        code: '1234PixTest',
-        type: 'ASSESSMENT',
+        participationsCount: 10,
       });
 
       this.set('campaign', campaign);
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
       // then
-      assert.dom('.campaign-details-header-report__info:nth-child(1) .campaign-details-content__text').hasText('1234PixTest');
-      assert.dom('.campaign-details-header-report__info:nth-child(2) .campaign-details-content__text').hasText('10');
-      assert.dom('.campaign-details-header-report__shared .campaign-details-content__text').hasText('4');
+      assert.contains('10');
     });
 
-    test('it should display - instead of 0 for the campaign report', async function(assert) {
+    test('it should display campaign shared participations number', async function(assert) {
       // given
-      const campaignReport = store.createRecord('campaignReport', {
-        id: 1,
-        participationsCount: 0,
-        sharedParticipationsCount: 0,
-      });
       const campaign = store.createRecord('campaign', {
-        id: 1,
-        name: 'campagne 1',
-        campaignReport,
+        sharedParticipationsCount: 4,
       });
-
       this.set('campaign', campaign);
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
 
       // then
-      assert.dom('.campaign-details-header-report__info:nth-child(2) .campaign-details-content__text').hasText('-');
-      assert.dom('.campaign-details-header-report__shared .campaign-details-content__text').hasText('-');
+      assert.contains('4');
+    });
+  });
+
+  module('When there is no results', function() {
+    test('it should display "-" when no one participated', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        participationsCount: 0,
+        sharedParticipationsCount: 2,
+      });
+      this.set('campaign', campaign);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
+      // then
+      assert.contains('-');
+    });
+
+    test('it should display "-" when no one shared his participation', async function(assert) {
+      // given
+      const campaign = store.createRecord('campaign', {
+        participationsCount: 4,
+        sharedParticipationsCount: 0,
+      });
+      this.set('campaign', campaign);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Report @campaign={{campaign}}/>`);
+
+      // then
+      assert.contains('-');
     });
   });
 
@@ -98,12 +123,9 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
 
     module('When campaign type is ASSESSMENT', function(hooks) {
       hooks.beforeEach(async function() {
-        const campaignReport = store.createRecord('campaignReport', {
-          participationsCount: 10,
-        });
         const campaign = store.createRecord('campaign', {
           id: 13,
-          campaignReport,
+          participationsCount: 10,
           type: 'ASSESSMENT',
         });
 

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -1,59 +1,43 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { run } from '@ember/runloop';
 
 module('Unit | Model | campaign', function(hooks) {
   setupTest(hooks);
 
   test('it should return the right data in the campaign model', function(assert) {
     const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {
+    const model = store.createRecord('campaign', {
       name: 'Fake name',
       code: 'ABC123',
-    }));
+    });
     assert.equal(model.name, 'Fake name');
     assert.equal(model.code, 'ABC123');
   });
 
-  test('it should construct the url to result of the campaign with type assessment', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'Fake name',
-      code: 'ABC123',
-      tokenForCampaignResults: 'token',
-      type: 'ASSESSMENT',
-    }));
-    assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token');
-  });
+  module('#urlToResult', function() {
+    test('it should construct the url to result of the campaign with type assessment', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        id: 1,
+        name: 'Fake name',
+        code: 'ABC123',
+        tokenForCampaignResults: 'token',
+        type: 'ASSESSMENT',
+      });
+      assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-assessment-results?accessToken=token');
+    });
 
-  test('it should construct the url to result of the campaign with type profiles collection', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {
-      id: 1,
-      name: 'Fake name',
-      code: 'ABC123',
-      tokenForCampaignResults: 'token',
-      type: 'PROFILES_COLLECTION',
-    }));
-    assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results?accessToken=token');
-  });
-
-  test('it should compute the isArchived property from the archivation date at creation', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {
-      archivedAt: new Date('2010-10-10'),
-    }));
-    assert.equal(model.isArchived, true);
-  });
-
-  test('it should compute the isArchived property from the archivation date when set to null', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('campaign', {
-      archivedAt: new Date('2010-10-10'),
-    }));
-    model.set('archivedAt', null);
-    assert.equal(model.isArchived, false);
+    test('it should construct the url to result of the campaign with type profiles collection', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        id: 1,
+        name: 'Fake name',
+        code: 'ABC123',
+        tokenForCampaignResults: 'token',
+        type: 'PROFILES_COLLECTION',
+      });
+      assert.equal(model.urlToResult, 'http://localhost:3000/api/campaigns/1/csv-profiles-collection-results?accessToken=token');
+    });
   });
 
   module('#readableType', function(hooks) {
@@ -80,30 +64,54 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('isArchived', function() {
-    let store;
+  module('#hasStages', function() {
+    test('returns true while campaign contains stages', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const stage = store.createRecord('stage', { threshold: 45 });
+      const model = store.createRecord('campaign', {
+        stages: [stage],
+      });
 
-    hooks.beforeEach(function() {
-      store = this.owner.lookup('service:store');
+      assert.equal(model.hasStages, true);
     });
 
-    module('when campaign does not have an archived date', function() {
-      test('it should return false', function(assert) {
-        const campaign = store.createRecord('campaign', {
-          archivedAt: null,
-        });
-
-        assert.equal(campaign.isArchived, false);
+    test('returns false while campaign does not contain stages', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        stages: [],
       });
+
+      assert.equal(model.hasStages, false);
     });
-    module('when campaign has an archived date', function() {
-      test('it should return true', function(assert) {
-        const campaign = store.createRecord('campaign', {
-          archivedAt: new Date('2020-01-01'),
-        });
+  });
 
-        assert.equal(campaign.isArchived, true);
+  module('#hasBadges', function() {
+    test('returns true while campaign contains badges', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const badge = store.createRecord('badge', { threshold: 45 });
+      const model = store.createRecord('campaign', {
+        badges: [badge],
       });
+
+      assert.equal(model.hasBadges, true);
+    });
+
+    test('returns false while campaign does not contain badges', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', {
+        badges: [],
+      });
+
+      assert.equal(model.hasBadges, false);
+    });
+  });
+
+  module('#creatorFullName', function() {
+    test('it should return the fullname, combination of last and first name', function(assert) {
+      const store = this.owner.lookup('service:store');
+      const model = store.createRecord('campaign', { creatorFirstName: 'Jean-Baptiste', creatorLastName: 'Poquelin' });
+
+      assert.equal(model.creatorFullName, 'Jean-Baptiste Poquelin');
     });
   });
 });


### PR DESCRIPTION
## 🦄 Problème
Le modèle de Campaign côté API est un modèle fourre-tout actuellement. Il comprends dans attributs ayant leur place, mais également d'autres attributs n'y ayant pas leur place. D'autres attributs y sont en doublon (exemple : avoir le creatorId et le creator).

## 🤖 Solution
Mettre un coup de balai 🧹 dans tout ça et faire émerger un read modèle pour les besoin de Pix Orga : CampaignReport. Il symbolise la vision qu'a Pix Orga de la campagne avec des participants, leurs résultats, etc.

## 🌈 Remarques
Un autre read-model a déjà émergé pour les besoins de Pix App : CampaignToJoin (#2321).

## :100: Pour tester
Les tests fonctionnels seront faits sur #2352.
