### PR TITLE
[POC] Calculer le niveau estimé par rapport aux dernières épreuves de l'utilisateur (PIX-1482).

### DIFF
--- a/api/lib/domain/services/smart-random/cat-algorithm.js
+++ b/api/lib/domain/services/smart-random/cat-algorithm.js
@@ -12,8 +12,9 @@ module.exports = {
 };
 
 function getPredictedLevel(knowledgeElements, skills) {
+  const recentKnowledgeElements = _.orderBy(knowledgeElements, 'createdAt', 'desc').slice(0, 10);
   return _.maxBy(_enumerateCatLevels(),
-    (level) => _probabilityThatUserHasSpecificLevel(level, knowledgeElements, skills),
+    (level) => _probabilityThatUserHasSpecificLevel(level, recentKnowledgeElements, skills),
   );
 }
 

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -620,7 +620,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       });
     });
 
-    context('when one challenge has already been answered but its learning content has been updated', function() {
+    context('when one challenge has already been answered but its learning content has been updated', () => {
       it('should not be asked again and ask another challenge from same skill', function() {
         // given
         targetSkills = [web2];
@@ -668,6 +668,103 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
       });
+    });
+
+    context('when users has answered a lot of challenges', () => {
+      it('should has an adapted estimated level', () => {
+        // given
+        targetSkills = [web1, web2, web3, web4, web5, url2, url3, url4, rechInfo5, rechInfo7, cnil1, cnil2, info2];
+        challenges = [];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeWeb_2_3.id, result: AnswerStatus.KO });
+        allAnswers = [lastAnswer];
+        knowledgeElements = [
+          domainBuilder.buildKnowledgeElement({
+            skillId: web1.id,
+            createdAt: '2020-01-01',
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: web2.id,
+            createdAt: '2020-01-02',
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: web3.id,
+            createdAt: '2020-01-03',
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: web4.id,
+            createdAt: '2020-01-04',
+            status: KNOWLEDGE_ELEMENT_STATUS.INVALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url2.id,
+            createdAt: '2020-01-05',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url3.id,
+            createdAt: '2020-01-06',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: url4.id,
+            createdAt: '2020-01-07',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: rechInfo5.id,
+            createdAt: '2020-01-08',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: rechInfo7.id,
+            createdAt: '2020-01-09',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: cnil1.id,
+            createdAt: '2020-01-10',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: cnil2.id,
+            createdAt: '2020-01-11',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+          domainBuilder.buildKnowledgeElement({
+            skillId: info2.id,
+            createdAt: '2020-01-12',
+            status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
+            source: 'direct',
+          }),
+        ];
+
+        // when
+        const { levelEstimated } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          allAnswers,
+          lastAnswer,
+        });
+
+        // then
+        expect(levelEstimated).to.be.equal(5);
+      });
+
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'utilisateur apprends au fur et à mesure de son évaluation, mais les premières épreuves répondues ont toujours un impact sur le calcul du niveau estimé pour le choix des épreuves.

## :robot: Solution
Prendre en considération que les 10 derniers KnowledgeElements pour le calcul du niveau estimé.

## :rainbow: Remarques
Cette PR est un POC qui sera testé et évalué pour savoir si cette modifcation est intéressantes pour nos utilisateurs.

## :100: Pour tester
- Passer des compétences
- Etre mauvais sur les premières épreuves
- Voir si le niveau semble plus réaliste au bout d'une 15zaine d'épreuves.