### PR TITLE
[FEATURE] Récuperer les signalements côté pix-admin (PIX-1522)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -1,0 +1,106 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export const certificationIssueReportCategories = {
+  OTHER: 'OTHER',
+  CANDIDATE_INFORMATIONS_CHANGES: 'CANDIDATE_INFORMATIONS_CHANGES',
+  LATE_OR_LEAVING: 'LATE_OR_LEAVING',
+  CONNECTION_OR_END_SCREEN: 'CONNECTION_OR_END_SCREEN',
+  IN_CHALLENGE: 'IN_CHALLENGE',
+  FRAUD: 'FRAUD',
+  TECHNICAL_PROBLEM: 'TECHNICAL_PROBLEM',
+};
+
+export const certificationIssueReportSubcategories = {
+  NAME_OR_BIRTHDATE: 'NAME_OR_BIRTHDATE',
+  EXTRA_TIME_PERCENTAGE: 'EXTRA_TIME_PERCENTAGE',
+  LEFT_EXAM_ROOM: 'LEFT_EXAM_ROOM',
+  SIGNATURE_ISSUE: 'SIGNATURE_ISSUE',
+  IMAGE_NOT_DISPLAYING: 'IMAGE_NOT_DISPLAYING',
+  LINK_NOT_WORKING: 'LINK_NOT_WORKING',
+  EMBED_NOT_WORKING: 'EMBED_NOT_WORKING',
+  FILE_NOT_OPENING: 'FILE_NOT_OPENING',
+  WEBSITE_UNAVAILABLE: 'WEBSITE_UNAVAILABLE',
+  WEBSITE_BLOCKED: 'WEBSITE_BLOCKED',
+  OTHER: 'OTHER',
+};
+
+export const categoryToLabel = {
+  [certificationIssueReportCategories.OTHER]: 'Autre incident',
+  [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'Modification infos candidat',
+  [certificationIssueReportCategories.LATE_OR_LEAVING]: 'Retard, absence ou départ',
+  [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
+  [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'Problème technique',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat n’a pas pu terminer, faute de temps',
+  [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une épreuve',
+};
+
+export const subcategoryToLabel = {
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Prénom/Nom/Date de naissance',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Ajout/modification du temps majoré',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
+  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'L\'image ne s\'affiche pas',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'Le simulateur/l\'application ne s\'affiche pas',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'Le fichier à télécharger ne s\'ouvre pas',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'Le site à visiter est mort/en maintenance/inaccessible',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'Le site à visiter est bloqué par les restrictions réseau de l\'établissement (réseaux sociaux par ex.)',
+  [certificationIssueReportSubcategories.OTHER]: 'Autre',
+};
+
+export const categoryToCode = {
+  [certificationIssueReportCategories.OTHER]: 'A2',
+  [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'C1-C2',
+  [certificationIssueReportCategories.LATE_OR_LEAVING]: 'C3-C4',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
+  [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
+  [certificationIssueReportCategories.FRAUD]: 'C6',
+  [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
+};
+
+export const subcategoryToCode = {
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'C1',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'C2',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'C4',
+  [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E2',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E3',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E4',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
+  [certificationIssueReportSubcategories.OTHER]: 'E7',
+};
+
+export const subcategoryToTextareaLabel = {
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Précisez et indiquez l’heure de sortie',
+  [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Précisez',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Précisez les informations à modifier',
+  [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Précisez le temps majoré',
+};
+
+export default class CertificationIssueReportModel extends Model {
+  @attr('string') category;
+  @attr('string') subcategory;
+  @attr('string') description;
+  @attr('string') questionNumber;
+
+  @belongsTo('certification') certification;
+
+  get categoryLabel() {
+    return categoryToLabel[this.category];
+  }
+
+  get subcategoryLabel() {
+    return this.subcategory ? subcategoryToLabel[this.subcategory] : '';
+  }
+
+  get categoryCode() {
+    return categoryToCode[this.category];
+  }
+
+  get subcategoryCode() {
+    return subcategoryToCode[this.subcategory];
+  }
+}
+

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,5 +1,5 @@
 import { computed } from '@ember/object';
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export const ACQUIRED = 'acquired';
 export const REJECTED = 'rejected';
@@ -33,6 +33,8 @@ export default class Certification extends Model {
   @attr('boolean', { defaultValue: false }) isPublished;
   @attr('boolean', { defaultValue: false }) isV2Certification;
   @attr() cleaCertificationStatus;
+
+  @hasMany('certification-issue-report') certificationIssueReports;
 
   @computed('createdAt')
   get creationDate() {

--- a/admin/app/serializers/certification.js
+++ b/admin/app/serializers/certification.js
@@ -2,11 +2,6 @@ import JSONAPISerializer from '@ember-data/serializer/json-api';
 
 export default class Certification extends JSONAPISerializer {
 
-  normalizeFindRecordResponse(store, primaryModelClass, payload, id) {
-    payload.data.id = id;
-    return this.normalizeSingleResponse(...arguments);
-  }
-
   serialize(snapshot, options) {
     if (options && options.onlyInformation) {
       const data = {};
@@ -26,7 +21,4 @@ export default class Certification extends JSONAPISerializer {
     }
   }
 
-  modelNameFromPayloadKey() {
-    return 'certification';
-  }
 }

--- a/admin/tests/unit/models/certification-issue-report-test.js
+++ b/admin/tests/unit/models/certification-issue-report-test.js
@@ -1,0 +1,84 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+import map from 'lodash/map';
+
+import {
+  certificationIssueReportCategories,
+  certificationIssueReportSubcategories,
+  categoryToLabel,
+  subcategoryToLabel,
+  categoryToCode,
+  subcategoryToCode,
+} from 'pix-admin/models/certification-issue-report';
+
+module('Unit | Model | certification issue report', function(hooks) {
+  setupTest(hooks);
+
+  test('it should return the right label for the category', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportCategories, (category) => {
+      return run(() => store.createRecord('certification-issue-report', { category }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.categoryLabel, categoryToLabel[model.category]);
+    }
+  });
+
+  test('it should return the right label for the subcategory', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportSubcategories, (subcategory) => {
+      return run(() => store.createRecord('certification-issue-report', { subcategory }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.subcategoryLabel, subcategoryToLabel[model.subcategory]);
+    }
+  });
+
+  test('it should return the right code for the category', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportCategories, (category) => {
+      return run(() => store.createRecord('certification-issue-report', { category }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.categoryCode, categoryToCode[model.category]);
+    }
+  });
+
+  test('it should return the right code for the subcategory', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const models = map(certificationIssueReportSubcategories, (subcategory) => {
+      return run(() => store.createRecord('certification-issue-report', { subcategory }));
+    });
+
+    // when / then
+    for (const model of models) {
+      assert.equal(model.subcategoryCode, subcategoryToCode[model.subcategory]);
+    }
+  });
+
+  test('it should return an empty string label when subcategory is null', function(assert) {
+    // given
+    const store = this.owner.lookup('service:store');
+
+    const model = run(() => store.createRecord('certification-issue-report', { subcategory: null }));
+
+    // when / then
+    assert.equal(model.subcategoryLabel, '');
+  });
+
+});

--- a/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
@@ -1,14 +1,13 @@
 const { Serializer } = require('jsonapi-serializer');
-const omit = require('lodash/omit');
 const get = require('lodash/get');
 
 module.exports = {
 
   serialize(certificationResult) {
-    return new Serializer('results', {
+    return new Serializer('certifications', {
       transform(certificationResult) {
         return {
-          ...omit(certificationResult, 'certificationIssueReports'),
+          ...certificationResult,
           examinerComment: get(certificationResult, 'certificationIssueReports[0].description'),
         };
       },
@@ -36,7 +35,17 @@ module.exports = {
         'examinerComment',
         'hasSeenEndTestScreen',
         'cleaCertificationStatus',
+        'certificationIssueReports',
       ],
+      certificationIssueReports: {
+        ref: 'id',
+        attributes: [
+          'category',
+          'description',
+          'subcategory',
+          'questionNumber',
+        ],
+      },
     }).serialize(certificationResult);
   },
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
@@ -41,12 +41,48 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
             category: CertificationIssueReportCategories.OTHER,
             description: 'un commentaire',
           }),
+          new CertificationIssueReport({
+            id: 43,
+            certificationCourseId: certificationCourseId,
+            category: CertificationIssueReportCategories.OTHER,
+            description: 'un autre commentaire',
+          }),
         ],
         hasSeenEndTestScreen: true,
         cleaCertificationStatus: 'acquired',
         sessionId: 22,
         assessmentId: 99,
       });
+      const jsonApiDataRelationship = {
+        data: [{
+          type: 'certificationIssueReports',
+          id: '42',
+        },
+        {
+          type: 'certificationIssueReports',
+          id: '43',
+        }],
+      };
+      const jsonApiDataIncluded = [{
+        type: 'certificationIssueReports',
+        id: '42',
+        attributes: {
+          category: CertificationIssueReportCategories.OTHER,
+          description: 'un commentaire',
+          'question-number': null,
+          subcategory: null,
+        },
+      },
+      {
+        type: 'certificationIssueReports',
+        id: '43',
+        attributes: {
+          category: CertificationIssueReportCategories.OTHER,
+          description: 'un autre commentaire',
+          'question-number': null,
+          subcategory: null,
+        },
+      }];
 
       // when
       const serializedCertificationCourse = serializer.serialize(certificationResult);
@@ -55,20 +91,20 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
       expect(serializedCertificationCourse).to.deep.equal({
         data: {
           id: certificationResult.id.toString(),
-          type: 'results',
+          type: 'certifications',
           attributes: {
             birthdate: certificationResult.birthdate,
             birthplace: certificationResult.birthplace,
             'comment-for-candidate': certificationResult.commentForCandidate,
             'comment-for-jury': certificationResult.commentForJury,
             'comment-for-organization': certificationResult.commentForOrganization,
-            'examiner-comment': 'un commentaire',
             'has-seen-end-test-screen': true,
             'clea-certification-status': certificationResult.cleaCertificationStatus,
             'competences-with-mark': certificationResult.competencesWithMark,
             'completed-at': new Date('2017-02-20T01:02:03Z'),
             'created-at': new Date('2017-02-20T01:02:03Z'),
             emitter: certificationResult.emitter,
+            'examiner-comment': 'un commentaire',
             'external-id': certificationResult.externalId,
             'first-name': certificationResult.firstName,
             'is-published': certificationResult.isPublished,
@@ -81,7 +117,11 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
             'assessment-id': certificationResult.assessmentId,
             status: certificationResult.status,
           },
+          relationships: {
+            'certification-issue-reports': jsonApiDataRelationship,
+          },
         },
+        included: jsonApiDataIncluded,
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix Catégorisation des signalements en certification, nous allons permettre aux utilisateurs Pix Certif de sélectionner une catégorie spécifique de signalement candidat depuis la page de finalisation de la session, dans le but d’aider le pôle certif à savoir si le signalement remonté nécessite une action de leur part ou non. Le pôle certif pourra depuis Pix Admin identifier les certifications concernées par des signalements “impactants” .
Il s’agit maintenant d’afficher le(s) signalement(s) sur la page de détails des certifications concernées afin que le pôle certif puisse en prendre connaissance et effectuer l’action requise. Dans un premier temps, nous allons récuperer les issue reports côté Ember Data de pix-admin.

## :robot: Solution
Ajouter les certification issue reports dans le serializer des certification-results côté api et ajouter un modèle de issue reports côté pix-admin

## :100: Pour tester
- Lancer l'api avec le toggle FT_REPORTS_CATEGORISATION=true
- Finaliser une session de certification en ajoutant des signalements
- Se connecter à pix-admin
- Aller sur le détail de la session finalisée
- Constater dans les Ember-Data que le modèle de certification issue reports contient bien les  signalements 