### PR TITLE
[FEATURE] Afficher le détail des signalements dans Pix Admin (PIX-1522)

### DIFF
--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -47,6 +47,31 @@ export default class CertificationInformationsController extends Controller {
     return '';
   }
 
+  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  get certificationIssueReportsWithRequiredAction() {
+    return this.certification.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired);
+  }
+
+  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  get certificationIssueReportsWithoutRequiredAction() {
+    return this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isActionRequired);
+  }
+
+  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  get hasIssueReports() {
+    return Boolean(this.certification.certificationIssueReports.length);
+  }
+
+  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  get hasIssueReportsWithRequiredAction() {
+    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => issueReport.isActionRequired).length);
+  }
+
+  @computed('certification.certificationIssueReports.@each.isActionRequired')
+  get hasIssueReportsWithoutRequiredAction() {
+    return Boolean(this.certification.certificationIssueReports.filter((issueReport) => !issueReport.isActionRequired).length);
+  }
+
   @action
   onEdit() {
     this.edition = true;

--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -84,6 +84,7 @@ export default class CertificationIssueReportModel extends Model {
   @attr('string') subcategory;
   @attr('string') description;
   @attr('string') questionNumber;
+  @attr('boolean') isActionRequired;
 
   @belongsTo('certification') certification;
 

--- a/admin/app/styles/authenticated/certifications/certification/informations.scss
+++ b/admin/app/styles/authenticated/certifications/certification/informations.scss
@@ -32,4 +32,9 @@
   .certification-info-label {
     margin-right: 5px;
   }
+
+  &__certification-issue-report-title--with-required-action {
+    font-weight: bold;
+    color: $information-dark;
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -56,6 +56,7 @@
                       {{issueReport.categoryLabel}}
                       {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
                       {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
+                      {{#if issueReport.questionNumber}}- Épreuve {{issueReport.questionNumber}}{{/if}}
                     </li>
                   {{/each}}
                 </ul>

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -49,7 +49,7 @@
 
             {{#if this.hasIssueReportsWithRequiredAction}}
               <div class="card-text">
-                <h6>Signalement(s) impactant(s)</h6>
+                <h6 class="certification-informations__certification-issue-report-title--with-required-action">Signalement(s) impactant(s)</h6>
                 <ul>
                   {{#each this.certificationIssueReportsWithRequiredAction as |issueReport| }}
                     <li>

--- a/admin/app/templates/authenticated/certifications/certification/informations.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/informations.hbs
@@ -39,6 +39,50 @@
       </div>
     </div>
   </div>
+
+  {{#if this.hasIssueReports}}
+    <div class="row">
+      <div class="col">
+        <div class="card {{if this.edition 'border-primary'}}">
+          <div class="card-body">
+            <h5 class="card-title">Signalements</h5>
+
+            {{#if this.hasIssueReportsWithRequiredAction}}
+              <div class="card-text">
+                <h6>Signalement(s) impactant(s)</h6>
+                <ul>
+                  {{#each this.certificationIssueReportsWithRequiredAction as |issueReport| }}
+                    <li>
+                      {{issueReport.categoryLabel}}
+                      {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
+                      {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </div>
+            {{/if}}
+
+            {{#if this.hasIssueReportsWithoutRequiredAction}}
+              <div class="card-text">
+                <h6>Signalement(s) non impactant(s)</h6>
+                <ul>
+                  {{#each this.certificationIssueReportsWithoutRequiredAction as |issueReport| }}
+                    <li>
+                      {{issueReport.categoryLabel}}
+                      {{#if issueReport.subcategoryLabel}}: {{issueReport.subcategoryLabel}}{{/if}}
+                      {{#if issueReport.description}}- {{issueReport.description}}{{/if}}
+                    </li>
+                  {{/each}}
+                </ul>
+              </div>
+            {{/if}}
+
+          </div>
+        </div>
+      </div>
+    </div>
+  {{/if}}
+
   <div class="row">
     <div class="col">
       <div class="card {{if this.edition 'border-primary'}}">

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -71,7 +71,7 @@
     </div>
     <div class="row">
       <div class="col">Nombre de signalements :</div>
-      <div class="col" data-test-id="session-info__number-of-report">{{this.sessionModel.countCertificationIssueReports}}</div>
+      <div class="col" data-test-id="session-info__number-of-issue-report">{{this.sessionModel.countCertificationIssueReports}}</div>
     </div>
     <div class="row">
       <div class="col">Nombre d'écrans de fin de test non renseignés :</div>

--- a/admin/mirage/serializers/certification.js
+++ b/admin/mirage/serializers/certification.js
@@ -1,0 +1,8 @@
+import ApplicationSerializer from './application';
+
+const include = ['certification-issue-reports'];
+
+export default ApplicationSerializer.extend({
+  include,
+  alwaysIncludeLinkageData: true,
+});

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
@@ -141,6 +141,46 @@ module('Integration | Component | routes/authenticated/certifications/certificat
         });
       });
 
+      test('it renders a "in challenge" issue report with its challenge number', async function(assert) {
+        // given
+        const certificationIssueReport = this.server.create('certification-issue-report', {
+          category: 'IN_CHALLENGE',
+          subcategory: 'IMAGE_NOT_DISPLAYING',
+          description: 'image disparue',
+          questionNumber: 666,
+          isActionRequired: true,
+        });
+        const certification = this.server.create('certification', {
+          competencesWithMark: [
+            {
+              'id': 104637,
+              'area_code': '5',
+              'competence_code': '5.1',
+              'competenceId': 'recIhdrmCuEmCDAzj',
+              'level': -1,
+              'score': 0,
+              'assessmentResultId': 104635,
+            },
+            {
+              'id': 104650,
+              'area_code': '1',
+              'competence_code': '1.3',
+              'competenceId': 'recIkYm646lrGvLNT',
+              'level': -1,
+              'score': 0,
+              'assessmentResultId': 104635,
+            },
+          ],
+        });
+        certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+        // when
+        await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.dom('.card-text ul li').hasText('Problème sur une épreuve : L\'image ne s\'affiche pas - image disparue - Épreuve 666');
+      });
+
     });
 
   });

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
@@ -1,0 +1,147 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+module('Integration | Component | routes/authenticated/certifications/certification | informations', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const user = server.create('user');
+    await createAuthenticateSession({ userId: user.id });
+  });
+
+  module('certification issue report container', function() {
+
+    module('when there is no certification issue report', function() {
+      test('it renders nothing', async function(assert) {
+        // given
+        const certificationIssueReports = [];
+        const certification = this.server.create('certification', {
+          certificationIssueReports,
+          competencesWithMark: [
+            {
+              'id': 104637,
+              'area_code': '5',
+              'competence_code': '5.1',
+              'competenceId': 'recIhdrmCuEmCDAzj',
+              'level': -1,
+              'score': 0,
+              'assessmentResultId': 104635,
+            },
+            {
+              'id': 104650,
+              'area_code': '1',
+              'competence_code': '1.3',
+              'competenceId': 'recIkYm646lrGvLNT',
+              'level': -1,
+              'score': 0,
+              'assessmentResultId': 104635,
+            },
+          ],
+        });
+
+        // when
+        await visit(`/certifications/${certification.id}`);
+
+        // then
+        assert.notContains('Signalements');
+      });
+    });
+
+    module('when there are certification issue reports', function() {
+
+      module('when there are only certification issue reports with required action', function() {
+
+        test('it renders only certifications issue reports with required action', async function(assert) {
+          // given
+          const certificationIssueReport = this.server.create('certification-issue-report', {
+            category: 'OTHER',
+            description: 'Un signalement impactant',
+            isActionRequired: true,
+          });
+          const certification = this.server.create('certification', {
+            competencesWithMark: [
+              {
+                'id': 104637,
+                'area_code': '5',
+                'competence_code': '5.1',
+                'competenceId': 'recIhdrmCuEmCDAzj',
+                'level': -1,
+                'score': 0,
+                'assessmentResultId': 104635,
+              },
+              {
+                'id': 104650,
+                'area_code': '1',
+                'competence_code': '1.3',
+                'competenceId': 'recIkYm646lrGvLNT',
+                'level': -1,
+                'score': 0,
+                'assessmentResultId': 104635,
+              },
+            ],
+          });
+          certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+          // when
+          await visit(`/certifications/${certification.id}`);
+
+          // then
+          assert.contains('Signalement(s) impactant(s)');
+          assert.dom('.card-text ul li').hasText('Autre incident - Un signalement impactant');
+          assert.notContains('Signalement(s) non impactant(s)');
+        });
+      });
+
+      module('when there are only certification issue reports without required action', function() {
+
+        test('it renders only certifications issue reports without required action', async function(assert) {
+          // given
+          const certificationIssueReport = this.server.create('certification-issue-report', {
+            category: 'CANDIDATE_INFORMATIONS_CHANGES',
+            subcategory: 'EXTRA_TIME_PERCENTAGE',
+            description: 'Un signalement non impactant',
+            isActionRequired: false,
+          });
+          const certification = this.server.create('certification', {
+            competencesWithMark: [
+              {
+                'id': 104637,
+                'area_code': '5',
+                'competence_code': '5.1',
+                'competenceId': 'recIhdrmCuEmCDAzj',
+                'level': -1,
+                'score': 0,
+                'assessmentResultId': 104635,
+              },
+              {
+                'id': 104650,
+                'area_code': '1',
+                'competence_code': '1.3',
+                'competenceId': 'recIkYm646lrGvLNT',
+                'level': -1,
+                'score': 0,
+                'assessmentResultId': 104635,
+              },
+            ],
+          });
+          certification.update({ certificationIssueReports: [certificationIssueReport] });
+
+          // when
+          await visit(`/certifications/${certification.id}`);
+
+          // then
+          assert.contains('Signalement(s) non impactant(s)');
+          assert.dom('.card-text ul li').hasText('Modification infos candidat : Ajout/modification du temps majoré - Un signalement non impactant');
+          assert.notContains('Signalement(s) impactant(s)');
+        });
+      });
+
+    });
+
+  });
+});

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
@@ -87,7 +87,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       await visit(`/sessions/${session.id}`);
 
       // when
-      assert.dom('[data-test-id="session-info__number-of-report"]').hasText('1');
+      assert.dom('[data-test-id="session-info__number-of-issue-report"]').hasText('1');
       assert.dom('[data-test-id="session-info__number-of-not-checked-end-screen"]').hasText('1');
       assert.dom('[data-test-id="session-info__number-of-not-ended-certifications"]').hasText('0');
     });

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -74,6 +74,140 @@ module('Unit | Controller | authenticated/certifications/certification/informati
     });
   });
 
+  module('#hasIssueReportsWithRequiredAction', () => {
+    test('it should return true when there are some issue reports with required action', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReportsWithRequiredAction, true);
+    });
+
+    test('it should return false when there are no issue reports with required action', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReportsWithRequiredAction, false);
+    });
+  });
+
+  module('#hasIssueReportsWithoutRequiredAction', () => {
+    test('it should return true when there are some issue reports without required action', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: true }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReportsWithoutRequiredAction, true);
+    });
+
+    test('it should return false when there are no issue reports without required action', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: true }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReportsWithoutRequiredAction, false);
+    });
+  });
+
+  module('#hasIssueReports', () => {
+    test('it should return true when there are some issue reports', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReports, true);
+    });
+
+    test('it should return false when there are no issue reports', async function(assert) {
+      // given
+      const certificationIssueReports = [];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.hasIssueReports, false);
+    });
+  });
+
+  module('#certificationIssueReportsWithRequiredAction', () => {
+    test('it should return certification issue reports with action required', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.certificationIssueReportsWithRequiredAction.length, 2);
+    });
+  });
+
+  module('#certificationIssueReportsWithoutRequiredAction', () => {
+    test('it should return certification issue reports without action required', async function(assert) {
+      // given
+      const certificationIssueReports = [
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: true }),
+        EmberObject.create({ isActionRequired: false }),
+        EmberObject.create({ isActionRequired: false }),
+      ];
+      controller.certification = EmberObject.create({
+        certificationIssueReports,
+      });
+
+      // when/then
+      assert.equal(controller.certificationIssueReportsWithoutRequiredAction.length, 3);
+    });
+  });
+
   module('#onUpdateScore', () => {
 
     module('when there is a given score', function() {

--- a/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-result-serializer.js
@@ -44,6 +44,7 @@ module.exports = {
           'description',
           'subcategory',
           'questionNumber',
+          'isActionRequired',
         ],
       },
     }).serialize(certificationResult);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-result-serializer_test.js
@@ -69,6 +69,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
         attributes: {
           category: CertificationIssueReportCategories.OTHER,
           description: 'un commentaire',
+          'is-action-required': true,
           'question-number': null,
           subcategory: null,
         },
@@ -79,6 +80,7 @@ describe('Unit | Serializer | JSONAPI | certification-result-serializer', functi
         attributes: {
           category: CertificationIssueReportCategories.OTHER,
           description: 'un autre commentaire',
+          'is-action-required': true,
           'question-number': null,
           subcategory: null,
         },


### PR DESCRIPTION
## :unicorn: Problème
Les utilistateurs de Pix Certif peuvent d'ores et déjà ajouter des signalements triés par catégories et sous catégories.

Cependant, notre pôle certif, traitant les certifications (publications, création de jury en cas de soucis...), ne peut toujours pas consulter le nouveau détail de ces signalements.
De plus, **certaines** de ces catégories de signalements, nécessiterons toujours une action de la part du pôle certif. Il serait donc important de pouvoir identifier clairement quel signalement est "impactant" ou non.


## :robot: Solution
Sur la page de détails d’une certification, ajouter une section “Signalement(s) surveillant” :
- afficher une liste des signalements "impactants", précédée d'un titre "Signalement(s) impactant"
Ce titre sera mis en rouge pour être facilement repérable d'un simple coup d'oeil et ne s'affichera UNIQUEMENT s'il y a des signalements impactant pour cette certification.

- afficher une liste des signalements "non impactants", précédée d'un titre "Signalement(s) non impactant".

Ensuite le détail des signalements suivra la convention suivante : 
<catégorie> : <sous-catégorie> - <description> - Epreuve <numéro_d'epreuve>

![image](https://user-images.githubusercontent.com/38167520/104040372-dcd99e80-51d7-11eb-87e0-e2a8997473d3.png)


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer l'API avec : `FT_REPORTS_CATEGORISATION=true FT_CERTIF_PRESCRIPTION_SCO=true npm start`
- Lancer Pix Certif
- Ajouter des signalements dans la page de finalisation d'une session (en local la session 4 : cliquer sur le bouton "Finaliser")

- Lancer Pix Admin
- Aller sur la page de détail de la session 4 (soit par le tableau soit par la recherche de l'onglet "Session")
- Cliquer sur l'onglet "Certifications"
- Retrouver la certification sur laquelle on a ajouté des signalements
- Cliquer sur l'id de la certification
- Constater qu'il y a un encadré "Signalements" et que nos signalements et leur détail apparaît correctement.
Exemple de rendu : 
![image](https://user-images.githubusercontent.com/38167520/104325613-1d436000-54e9-11eb-9ec4-6968f27bb699.png)
