### PR TITLE
[FEATURE] Affiche les clés de lecture associées aux profils cible dans l'admin (PIX-1966).

### DIFF
--- a/admin/app/components/target-profiles/badge-list.hbs
+++ b/admin/app/components/target-profiles/badge-list.hbs
@@ -1,0 +1,30 @@
+<div class="content-text content-text--small">
+  {{#if (gt @model.length 0)}}
+    <div class="table-admin badges-table">
+      <table>
+        <thead>
+          <tr>
+            <th class="badges-table__id">ID</th>
+            <th class="badges-table__image">Image</th>
+            <th class="badges-table__key">Key</th>
+            <th class="badges-table__name">Nom</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each @model as |badge|}}
+            <tr>
+              <td>{{badge.id}}</td>
+              <td class="badges-table__image"><img src={{badge.imageUrl}} alt={{badge.altMessage}} /></td>
+              <td>{{badge.key}}</td>
+              <td>{{badge.title}}</td>
+              <td>{{badge.message}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
+    </div>
+  {{else}}
+    <div class="table__empty content-text">Aucune clé de lecture associée</div>
+  {{/if}}
+</div>

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -1,0 +1,8 @@
+<section class="page-section mb_10">
+  <header class="page-section__header">
+    <h2 class="page-section__title">Clés de lecture</h2>
+  </header>
+
+  <TargetProfiles::BadgeList
+    @model={{@model}} />
+</section>

--- a/admin/app/models/badge.js
+++ b/admin/app/models/badge.js
@@ -1,0 +1,9 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class Badge extends Model {
+  @attr() key;
+  @attr() title;
+  @attr() message;
+  @attr() imageUrl;
+  @attr() altMessage;
+}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -7,6 +7,7 @@ export default class TargetProfile extends Model {
   @attr('boolean') outdated;
   @attr('string') organizationId;
 
+  @hasMany('badge') badges;
   @hasMany('skill') skills;
 
   attachOrganizations = memberAction({

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -64,6 +64,7 @@ Router.map(function() {
       this.route('target-profile', { path: '/:target_profile_id' }, function() {
         this.route('details', { path: '/' });
         this.route('organizations');
+        this.route('badges');
       });
     });
 

--- a/admin/app/routes/authenticated/target-profiles/target-profile/badges.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/badges.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class TargetProfileBadgesRoute extends Route {
+  async model(params) {
+    const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
+    return await targetProfile.hasMany('badges').reload();
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -42,3 +42,4 @@
 @import 'components/organization-information-section';
 @import 'components/pagination-control';
 @import 'components/user-detail-personal-information-section';
+@import 'components/target-profiles/badge-list';

--- a/admin/app/styles/components/target-profiles/badge-list.scss
+++ b/admin/app/styles/components/target-profiles/badge-list.scss
@@ -1,0 +1,21 @@
+.badges-table {
+  &__id {
+    width: 75px;
+  }
+
+  &__key {
+    width: 200px;
+  }
+
+  &__name {
+    width: 250px;
+  }
+
+  &__image {
+    width: 126px;
+
+    img {
+      width: 90px;
+    }
+  }
+}

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -36,6 +36,9 @@
     <LinkTo @route="authenticated.target-profiles.target-profile.organizations" @model={{@model}} class="navbar-item">
       Organisations
     </LinkTo>
+    <LinkTo @route="authenticated.target-profiles.target-profile.badges" @model={{@model}} class="navbar-item">
+      Clés de lecture
+    </LinkTo>
   </nav>
 
   {{outlet}}

--- a/admin/app/templates/authenticated/target-profiles/target-profile/badges.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/badges.hbs
@@ -1,0 +1,1 @@
+<TargetProfiles::Badges @model={{this.model}} />

--- a/admin/tests/helpers/contains.js
+++ b/admin/tests/helpers/contains.js
@@ -1,8 +1,8 @@
 import { getRootElement } from '@ember/test-helpers';
 
-function getChildrenThatContainsText(element, text) {
+function getChildrenThatContainsText(element, text, isChild) {
   if (element.textContent.trim() === text) {
-    return element;
+    return isChild ? element : [element];
   }
 
   if (element.children.length === 0) {
@@ -11,7 +11,7 @@ function getChildrenThatContainsText(element, text) {
 
   return [...element.children]
     .map((child) => {
-      return getChildrenThatContainsText(child, text);
+      return getChildrenThatContainsText(child, text, true);
     })
     .filter(Boolean)
     .flatMap((v) => v);

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/badges-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/badges-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | routes/authenticated/target-profiles/target-profile | badges', function(hooks) {
+
+  setupRenderingTest(hooks);
+
+  test('it should display the header and an empty list', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::Badges/>`);
+
+    // then
+    assert.contains('Clés de lecture');
+    assert.contains('Aucune clé de lecture associée');
+  });
+});

--- a/admin/tests/integration/components/target-profiles/badge-list_test.js
+++ b/admin/tests/integration/components/target-profiles/badge-list_test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import EmberObject from '@ember/object';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | TargetProfiles::BadgeList', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it should display the items', async function(assert) {
+    // given
+    const badge = EmberObject.create({
+      id: 1,
+      key: 'My key',
+      title: 'My title',
+      message: 'My message',
+      imageUrl: 'data:,',
+      altMessage: 'My alt message',
+    });
+    this.set('badges', [badge]);
+
+    // when
+    await render(hbs`<TargetProfiles::BadgeList @model={{this.badges}} />`);
+
+    // then
+    assert.dom('table').exists();
+    assert.dom('thead').exists();
+    assert.dom('tbody').exists();
+    assert.contains('ID');
+    assert.contains('Image');
+    assert.contains('Key');
+    assert.contains('Nom');
+    assert.contains('Message');
+    assert.dom('tbody tr').exists({ count: 1 });
+    assert.equal(find('tbody tr td:first-child').textContent, '1');
+    assert.dom('tbody tr td:nth-child(2) img').exists();
+    assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
+    assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('alt'), 'My alt message');
+    assert.equal(find('tbody tr td:nth-child(3)').textContent, 'My key');
+    assert.equal(find('tbody tr td:nth-child(4)').textContent, 'My title');
+    assert.equal(find('tbody tr td:nth-child(5)').textContent, 'My message');
+    assert.notContains('Aucune clé de lecture associée');
+  });
+
+  test('it should display a message when empty', async function(assert) {
+    // given
+    this.set('badges', []);
+
+    // when
+    await render(hbs`<TargetProfiles::BadgeList @model={{this.badges}} />`);
+
+    // then
+    assert.dom('table').doesNotExist();
+    assert.contains('Aucune clé de lecture associée');
+  });
+});

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -138,6 +138,27 @@ exports.register = async (server) => {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/admin/target-profiles/{id}/badges',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: Joi.number().integer().required(),
+          }),
+        },
+        handler: targetProfileController.findTargetProfileBadges,
+        tags: ['api', 'target-profiles', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de récupérer les badges attachés au profil cible',
+        ],
+      },
+    },
   ]);
 };
 

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -3,6 +3,7 @@ const targetProfileSerializer = require('../../infrastructure/serializers/jsonap
 const targetProfileWithLearningContentSerializer = require('../../infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
+const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
 module.exports = {
 
   async findPaginatedFilteredTargetProfiles(request) {
@@ -24,6 +25,13 @@ module.exports = {
 
     const { models: organizations, pagination } = await usecases.findPaginatedFilteredTargetProfileOrganizations({ targetProfileId, filter: options.filter, page: options.page });
     return organizationSerializer.serialize(organizations, pagination);
+  },
+
+  async findTargetProfileBadges(request) {
+    const targetProfileId = parseInt(request.params.id);
+
+    const badges = await usecases.findTargetProfileBadges({ targetProfileId });
+    return badgeSerializer.serialize(badges);
   },
 
   async attachOrganizations(request, h) {

--- a/api/lib/domain/usecases/find-target-profile-badges.js
+++ b/api/lib/domain/usecases/find-target-profile-badges.js
@@ -1,0 +1,3 @@
+module.exports = function findTargetProfileBadges({ targetProfileId, badgeRepository }) {
+  return badgeRepository.findByTargetProfileId(targetProfileId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -158,6 +158,7 @@ module.exports = injectDependencies({
   findPendingOrganizationInvitations: require('./find-pending-organization-invitations'),
   findSessionsForCertificationCenter: require('./find-sessions-for-certification-center'),
   findStudentsForEnrollement: require('./find-students-for-enrollement'),
+  findTargetProfileBadges: require('./find-target-profile-badges'),
   findTutorials: require('./find-tutorials'),
   findUserCampaignParticipationOverviews: require('./find-user-campaign-participation-overviews'),
   findUserTutorials: require('./find-user-tutorials'),

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key'],
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title'],
     }).serialize(badge);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -3,11 +3,21 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(targetProfiles, meta) {
     return new Serializer('target-profile', {
-      attributes: ['name', 'outdated', 'isPublic', 'organizationId', 'skills'],
+      attributes: ['name', 'outdated', 'isPublic', 'organizationId', 'badges', 'skills'],
       skills: {
         ref: 'id',
         included: true,
         attributes: ['name'],
+      },
+      badges: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/admin/target-profiles/${parent.id}/badges`;
+          },
+        },
       },
       meta,
     }).serialize(targetProfiles);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -13,6 +13,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         imageUrl: '/img/banana.svg',
         message: 'Congrats, you won a banana badge',
         key: 'BANANA',
+        title: 'Banana',
         targetProfileId: '1',
       });
 
@@ -22,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
             'alt-message': 'You won a banana badge',
             'image-url': '/img/banana.svg',
             message: 'Congrats, you won a banana badge',
+            title: 'Banana',
             key: 'BANANA',
           },
           id: '1',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -14,10 +14,6 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function() {
         name: 'Les compétences de BRO 2.0',
         outdated: true,
         ispublic: false,
-        organizations: [
-          { id: 1, name: 'Name1' },
-          { id: 2, name: 'Name2' },
-        ],
       });
 
       const meta = { some: 'meta' };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -38,6 +38,11 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
                 type: 'skills',
               }],
             },
+            badges: {
+              links: {
+                related: `/api/admin/target-profiles/${targetProfileWithLearningContent.id}/badges`,
+              },
+            },
           },
         },
         included: [{


### PR DESCRIPTION
## :unicorn: Problème

On ne peut pas voir les clés de lecture associées à un profil cible dans l'admin.

## :robot: Solution

On les affiche avec leur nom, leur image et leur message.

## :rainbow: Remarques

Dans l'API, j'ai renvoyé l'url des many badges avec une URL /admin, ce qui semble différent des organisations associés mais ce point d'API n'existe que dans ce scope.

## :100: Pour tester

https://user-images.githubusercontent.com/86659/104171641-3ffb4900-5403-11eb-9139-134e3cd39b57.mp4


