### PR TITLE
[FEATURE] Afficher une documentation spécifique pour les établissements français à l'étranger (ou AEFE) (PIX-1970).

### DIFF
--- a/api/db/seeds/data/organizations-sco-builder.js
+++ b/api/db/seeds/data/organizations-sco-builder.js
@@ -219,21 +219,7 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     provinceCode: '12',
   });
 
-  const agricultureCFA = databaseBuilder.factory.buildOrganization({
-    id: 8,
-    type: 'SCO',
-    name: 'CFA Agricole',
-    isManagingStudents: true,
-    canCollectProfiles: true,
-    email: 'sco4.generic.account@example.net',
-    externalId: '1237457D',
-    provinceCode: '12',
-  });
-
-  databaseBuilder.factory.buildOrganizationTag({ organizationId: 7, tagId: 1 });
-
-  databaseBuilder.factory.buildOrganizationTag({ organizationId: 8, tagId: 1 });
-  databaseBuilder.factory.buildOrganizationTag({ organizationId: 8, tagId: 5 });
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: agriculture.id, tagId: 1 });
 
   databaseBuilder.factory.buildMembership({
     userId: scoUser1.id,
@@ -247,6 +233,21 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
     organizationRole: Membership.roles.MEMBER,
   });
 
+  /* CFA AGRICULTURE */
+  const agricultureCFA = databaseBuilder.factory.buildOrganization({
+    id: 8,
+    type: 'SCO',
+    name: 'CFA Agricole',
+    isManagingStudents: true,
+    canCollectProfiles: true,
+    email: 'sco4.generic.account@example.net',
+    externalId: '1237457D',
+    provinceCode: '12',
+  });
+
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: agricultureCFA.id, tagId: 1 });
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: agricultureCFA.id, tagId: 5 });
+
   databaseBuilder.factory.buildMembership({
     userId: scoUser1.id,
     organizationId: agricultureCFA.id,
@@ -256,6 +257,31 @@ module.exports = function organizationsScoBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildMembership({
     userId: scoUser2.id,
     organizationId: agricultureCFA.id,
+    organizationRole: Membership.roles.MEMBER,
+  });
+
+  /* AEFE */
+  const AEFE = databaseBuilder.factory.buildOrganization({
+    id: 9,
+    type: 'SCO',
+    name: 'AEFE',
+    canCollectProfiles: true,
+    email: 'sco5.generic.account@example.net',
+    externalId: '1237457E',
+    provinceCode: '12',
+  });
+
+  databaseBuilder.factory.buildOrganizationTag({ organizationId: AEFE.id, tagId: 6 });
+
+  databaseBuilder.factory.buildMembership({
+    userId: scoUser1.id,
+    organizationId: AEFE.id,
+    organizationRole: Membership.roles.ADMIN,
+  });
+
+  databaseBuilder.factory.buildMembership({
+    userId: scoUser2.id,
+    organizationId: AEFE.id,
     organizationRole: Membership.roles.MEMBER,
   });
 };

--- a/api/db/seeds/data/tags-builder.js
+++ b/api/db/seeds/data/tags-builder.js
@@ -4,4 +4,5 @@ module.exports = function tagsBuilder({ databaseBuilder }) {
   databaseBuilder.factory.buildTag({ id: 3, name: 'PRIVE' });
   databaseBuilder.factory.buildTag({ id: 4, name: 'POLE EMPLOI' });
   databaseBuilder.factory.buildTag({ id: 5, name: 'CFA' });
+  databaseBuilder.factory.buildTag({ id: 6, name: 'AEFE' });
 };

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -62,6 +62,10 @@ class Organization {
     return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.CFA));
   }
 
+  get isAEFE() {
+    return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AEFE));
+  }
+
   get isPoleEmploi() {
     return Boolean(this.tags.find((tag) => tag.name === Tag.POLE_EMPLOI));
   }

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -11,4 +11,5 @@ class Tag {
 Tag.AGRICULTURE = 'AGRICULTURE';
 Tag.POLE_EMPLOI = 'POLE EMPLOI';
 Tag.CFA = 'CFA';
+Tag.AEFE = 'AEFE';
 module.exports = Tag;

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -16,6 +16,7 @@ module.exports = {
             ...recordWithoutClass.userOrgaSettings.currentOrganization,
             isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization.isAgriculture,
             isCFA: recordWithoutClass.userOrgaSettings.currentOrganization.isCFA,
+            isAEFE: recordWithoutClass.userOrgaSettings.currentOrganization.isAEFE,
           },
         };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
@@ -40,7 +41,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'isAEFE', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -195,4 +195,39 @@ describe('Unit | Domain | Models | Organization', () => {
       });
     });
   });
+
+  describe('get#isAEFE', () => {
+    context('when organization is not SCO', () => {
+      it('should return false when the organization has the "AEFE" tag', () => {
+        // given
+        const tag = domainBuilder.buildTag({ name: Tag.AEFE });
+        const organization = domainBuilder.buildOrganization({ type: 'SUP', tags: [tag] });
+
+        // when / then
+        expect(organization.isAEFE).is.false;
+      });
+    });
+
+    context('when organization is SCO', () => {
+      it('should return true when organization is of type SCO and has the "AEFE" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: Tag.AEFE });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isAEFE).is.true;
+      });
+
+      it('should return false when when organization is of type SCO and has not the "AEFE" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: 'To infinity…and beyond!' });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isAEFE).is.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -239,51 +239,6 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       });
     });
 
-    context('when canCollectProfiles is false', () => {
-      it('should serialize prescriber without canCollectProfiles', () => {
-        // given
-        const user = domainBuilder.buildUser({
-          pixOrgaTermsOfServiceAccepted: true,
-          memberships: [],
-          certificationCenterMemberships: [],
-        });
-
-        const organization = domainBuilder.buildOrganization({ canCollectProfiles: false });
-
-        const membership = domainBuilder.buildMembership({
-          organization,
-          organizationRole: Membership.roles.MEMBER,
-          user,
-        });
-
-        user.memberships.push(membership);
-
-        organization.memberships.push(membership);
-
-        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
-          currentOrganization: organization,
-        });
-        userOrgaSettings.user = null;
-
-        const prescriber = domainBuilder.buildPrescriber({
-          firstName: user.firstName,
-          lastName: user.lastName,
-          areNewYearSchoolingRegistrationsImported: false,
-          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-          memberships: [membership],
-          userOrgaSettings,
-        });
-
-        const expectedPrescriberSerialized = createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSettings, organization });
-
-        // when
-        const result = serializer.serialize(prescriber);
-
-        // then
-        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
-      });
-    });
-
     context('when isManagingStudents is true', () => {
       it('should serialize prescriber with isManagingStudents', () => {
         // given
@@ -320,51 +275,6 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
         });
 
         const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-managing-students', field: 'isManagingStudents' });
-
-        // when
-        const result = serializer.serialize(prescriber);
-
-        // then
-        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
-      });
-    });
-
-    context('when isManagingStudents is false', () => {
-      it('should serialize prescriber without isManagingStudents', () => {
-        // given
-        const user = domainBuilder.buildUser({
-          pixOrgaTermsOfServiceAccepted: true,
-          memberships: [],
-          certificationCenterMemberships: [],
-        });
-
-        const organization = domainBuilder.buildOrganization({ isManagingStudents: false });
-
-        const membership = domainBuilder.buildMembership({
-          organization,
-          organizationRole: Membership.roles.MEMBER,
-          user,
-        });
-
-        user.memberships.push(membership);
-
-        organization.memberships.push(membership);
-
-        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
-          currentOrganization: organization,
-        });
-        userOrgaSettings.user = null;
-
-        const prescriber = domainBuilder.buildPrescriber({
-          firstName: user.firstName,
-          lastName: user.lastName,
-          areNewYearSchoolingRegistrationsImported: false,
-          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
-          memberships: [membership],
-          userOrgaSettings,
-        });
-
-        const expectedPrescriberSerialized = createExpectedPrescriberSerialized({ prescriber, membership, userOrgaSettings, organization });
 
         // when
         const result = serializer.serialize(prescriber);
@@ -420,8 +330,100 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       });
     });
 
-    context('when isAgriculture is false', () => {
-      it('should serialize prescriber without isAgriculture', () => {
+    context('when isCFA is true', () => {
+      it('should serialize prescriber with isCFA', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const tags = [domainBuilder.buildTag({ name: 'CFA' })];
+        const organization = domainBuilder.buildOrganization({ tags });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-cfa', field: 'isCFA' });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when isAEFE is true', () => {
+      it('should serialize prescriber with isAEFE', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const tags = [domainBuilder.buildTag({ name: 'AEFE' })];
+        const organization = domainBuilder.buildOrganization({ tags });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-aefe', field: 'isAEFE' });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
+    context('when all booleans are false', () => {
+      it('should serialize prescriber without these booleans', () => {
         // given
         const user = domainBuilder.buildUser({
           pixOrgaTermsOfServiceAccepted: true,
@@ -430,7 +432,7 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
         });
 
         const tags = [domainBuilder.buildTag({ name: 'OTHER' })];
-        const organization = domainBuilder.buildOrganization({ tags });
+        const organization = domainBuilder.buildOrganization({ tags, isManagingStudents: false, canCollectProfiles: false });
 
         const membership = domainBuilder.buildMembership({
           organization,

--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -13,6 +13,10 @@ export default class SidebarMenu extends Component {
       return 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f';
     }
 
+    if (this.currentUser.isAEFE) {
+      return 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8';
+    }
+
     if (this.currentUser.organization.isPro) {
       return 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4';
     }

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -9,6 +9,7 @@ export default class Organization extends Model {
   @attr('boolean') canCollectProfiles;
   @attr('boolean') isAgriculture;
   @attr('boolean') isCFA;
+  @attr('boolean') isAEFE;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -14,6 +14,7 @@ export default class CurrentUserService extends Service {
   @tracked isSUPManagingStudents;
   @tracked isAgriculture;
   @tracked isCFA;
+  @tracked isAEFE;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -58,6 +59,7 @@ export default class CurrentUserService extends Service {
 
     this.isAgriculture = organization.isAgriculture;
     this.isCFA = organization.isCFA;
+    this.isAEFE = organization.isAEFE;
 
     this.organization = organization;
   }

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -49,6 +49,20 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     assert.dom('a[href="https://view.genial.ly/5f85a0b87812e90d12b7b593"]').exists();
   });
 
+  test('it should display documentation for a sco AEFE organization', async function(assert) {
+    class CurrentUserStub extends Service {
+      organization = Object.create({ id: 1, type: 'SCO' });
+      isAEFE = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
+  });
+
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });


### PR DESCRIPTION
## :unicorn: Problème
Nous allons ouvrir Pix aux établissements français à l'étranger (AEFE). Cependant, les élèves n'ont pas d'INE (ni aucun identifiant unique), et donc on ne peut pas les gérer comme des élèves "classiques", à savoir avec un import.

La manière de les gérer sera donc la manière non restreinte. Cependant, ils ont besoin d'une documentation relative à leur usage.

## :robot: Solution
Rendre disponible une documentation spécifique.

## :rainbow: Remarques
NA

## :100: Pour tester
- Se connecter à Pix Orga avec sco.admin@pix.fr
- Aller sur l'organisation "AEFE"
- Vérifier que le lien de documentation à gauche existe et redirige vers la bonne documentation
