### PR TITLE
[FEATURE] Modifier le niveau max atteignable et le nombre de pix max atteignable sur pix-admin (PIX-1810).

### DIFF
--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -52,7 +52,7 @@ module.exports = function(environment) {
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       ORGANIZATION_DASHBOARD_URL: process.env.ORGANIZATION_DASHBOARD_URL,
       USER_DASHBOARD_URL: process.env.USER_DASHBOARD_URL,
-      MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_REACHABLE_LEVEL', defaultValue: 5, minValue: 5 }),
+      MAX_REACHABLE_LEVEL: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_REACHABLE_LEVEL', defaultValue: 6, minValue: 6 }),
     },
 
     googleFonts: [


### PR DESCRIPTION
## :unicorn: Problème
Sur pix-admin, le sauvegarde de la page de détail d’une certification affiche un message d'erreur car le niveau maximum atteignable est désormais le niveau 6 (et non plus 5) et le nombre de pix max pour une compétence est désormais de 48 (et non plus 40).

## :robot: Solution
Mettre à jour le niveau max atteignable pour une compétence.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur la page de détail d’une certification > onglet “Détails” : lorsqu’un utilisateur Pix Admin clique sur le bouton “Enregistrer” , vérifier qu’aucune des compétences de la certification ne dépasse 48 pix / a un niveau au dessus du niveau 6 :
- si aucune compétence ne déplace le plafond, ALORS ne pas afficher de pop-in 
- sinon si au moins une compétence dépasse 48 pix et/ou dépasse le niveau 6, ALORS afficher la pop-in avec le bon message d’erreur
