### PR TITLE
[TECH] Supprime la relation hasMany organization sur les target profile

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -2,6 +2,14 @@ import ApplicationAdapter from './application';
 import queryString from 'query-string';
 
 export default class OrganizationAdapter extends ApplicationAdapter {
+  urlForQuery (query, modelName) {
+    if (query.targetProfileId) {
+      const { targetProfileId } = query;
+      delete query.targetProfileId;
+      return  `${this.host}/api/admin/target-profiles/${targetProfileId}/organizations`;
+    }
+    return super.urlForQuery(...arguments);
+  }
 
   findHasMany(store, snapshot, url, relationship) {
     url = this.urlPrefix(url, this.buildURL(snapshot.modelName, snapshot.id, null, 'findHasMany'));

--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -3,12 +3,4 @@ import queryString from 'query-string';
 
 export default class TargetProfileAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
-
-  findHasMany(store, snapshot, url, relationship) {
-    if (relationship.type === 'organization' && snapshot.adapterOptions) {
-      const options = queryString.stringify(snapshot.adapterOptions);
-      url += '?' + options;
-      return this.ajax(url, 'GET');
-    }
-  }
 }

--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -6,7 +6,6 @@ export default class TargetProfileAdapter extends ApplicationAdapter {
 
   findHasMany(store, snapshot, url, relationship) {
     if (relationship.type === 'organization' && snapshot.adapterOptions) {
-      url = `${this.host}/${this.namespace}/target-profiles/${snapshot.id}/organizations`;
       const options = queryString.stringify(snapshot.adapterOptions);
       url += '?' + options;
       return this.ajax(url, 'GET');

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -7,7 +7,6 @@ export default class TargetProfile extends Model {
   @attr('boolean') outdated;
   @attr('string') organizationId;
 
-  @hasMany('organization') organizations;
   @hasMany('skill') skills;
 
   attachOrganizations = memberAction({

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -13,15 +13,20 @@ export default class TargetProfileOrganizationsRoute extends Route {
 
   async model(params) {
     const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
-    await targetProfile.hasMany('organizations').reload({ adapterOptions: {
-      'page[size]': params.pageSize,
-      'page[number]': params.pageNumber,
-      'filter[id]': params.id,
-      'filter[name]': params.name,
-      'filter[type]': params.type,
-      'filter[externalId]': params.externalId,
-    } });
-    return targetProfile;
+    const queryParams  = {
+      targetProfileId: targetProfile.id,
+      page: {
+        size: params.pageSize,
+        number: params.pageNumber,
+      },
+      filter: {
+        id: params.id,
+        name: params.name,
+        type: params.type,
+        externalId: params.externalId,
+      },
+    };
+    return await this.store.query('organization', queryParams);
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -1,5 +1,5 @@
 <TargetProfiles::Organizations
-  @organizations={{@model.organizations}}
+  @organizations={{@model}}
   @id={{this.id}}
   @name={{this.name}}
   @type={{this.type}}

--- a/admin/mirage/serializers/target-profile.js
+++ b/admin/mirage/serializers/target-profile.js
@@ -4,11 +4,4 @@ const _includes = ['skills'];
 
 export default ApplicationSerializer.extend({
   include: _includes,
-  links(targetProfile) {
-    return {
-      organizations: {
-        related: `/api/target-profiles/${targetProfile.id}/organizations`,
-      },
-    };
-  },
 });

--- a/admin/tests/acceptance/target-profiles-details-test.js
+++ b/admin/tests/acceptance/target-profiles-details-test.js
@@ -84,8 +84,8 @@ module('Acceptance | Target Profile Details', function(hooks) {
 
     test('it should display target profile organizations', async function(assert) {
       // given
-      const organization = server.create('organization', { id: 1, name: 'Fantastix', type: 'PRO', externalId: '123' });
-      server.create('target-profile', { id: 1, name: 'Profil Cible', organizations: [organization] });
+      server.create('organization', { id: 1, name: 'Fantastix', type: 'PRO', externalId: '123' });
+      server.create('target-profile', { id: 1, name: 'Profil Cible' });
 
       // when
       await visit('/target-profiles/1/organizations');

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -10,7 +10,7 @@ module.exports = {
         nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/api/target-profiles/${parent.id}/organizations`;
+            return `/api/admin/target-profiles/${parent.id}/organizations`;
           },
         },
       },

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -3,17 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(targetProfiles, meta) {
     return new Serializer('target-profile', {
-      attributes: ['name', 'outdated', 'isPublic', 'organizationId', 'organizations'],
-      organizations: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        nullIfMissing: true,
-        relationshipLinks: {
-          related(record, current, parent) {
-            return `/api/admin/target-profiles/${parent.id}/organizations`;
-          },
-        },
-      },
+      attributes: ['name', 'outdated', 'isPublic', 'organizationId'],
       meta,
     }).serialize(targetProfiles);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -3,21 +3,11 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
   serialize(targetProfiles, meta) {
     return new Serializer('target-profile', {
-      attributes: ['name', 'outdated', 'isPublic', 'organizationId', 'skills', 'organizations'],
+      attributes: ['name', 'outdated', 'isPublic', 'organizationId', 'skills'],
       skills: {
         ref: 'id',
         included: true,
         attributes: ['name'],
-      },
-      organizations: {
-        ref: 'id',
-        ignoreRelationshipData: true,
-        nullIfMissing: true,
-        relationshipLinks: {
-          related(record, current, parent) {
-            return `/api/admin/target-profiles/${parent.id}/organizations`;
-          },
-        },
       },
       meta,
     }).serialize(targetProfiles);

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -15,7 +15,7 @@ module.exports = {
         nullIfMissing: true,
         relationshipLinks: {
           related(record, current, parent) {
-            return `/api/target-profiles/${parent.id}/organizations`;
+            return `/api/admin/target-profiles/${parent.id}/organizations`;
           },
         },
       },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -35,7 +35,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function() {
           relationships: {
             organizations: {
               links: {
-                related: `/api/target-profiles/${targetProfile.id}/organizations`,
+                related: `/api/admin/target-profiles/${targetProfile.id}/organizations`,
               },
             },
           },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-serializer_test.js
@@ -32,13 +32,6 @@ describe('Unit | Serializer | JSONAPI | target-profile-serializer', function() {
             'is-public': targetProfile.isPublic,
             'organization-id': targetProfile.organizationId,
           },
-          relationships: {
-            organizations: {
-              links: {
-                related: `/api/admin/target-profiles/${targetProfile.id}/organizations`,
-              },
-            },
-          },
         },
         meta,
       };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -32,11 +32,6 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             'organization-id': targetProfileWithLearningContent.organizationId,
           },
           relationships: {
-            organizations: {
-              links: {
-                related: `/api/admin/target-profiles/${targetProfileWithLearningContent.id}/organizations`,
-              },
-            },
             skills: {
               data: [{
                 id: targetProfileWithLearningContent.skills[0].id.toString(),

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -34,7 +34,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
           relationships: {
             organizations: {
               links: {
-                related: `/api/target-profiles/${targetProfileWithLearningContent.id}/organizations`,
+                related: `/api/admin/target-profiles/${targetProfileWithLearningContent.id}/organizations`,
               },
             },
             skills: {


### PR DESCRIPTION
## :unicorn: Problème
Dans l'admin, on filtre affiche et filtre les organizations associés a un profil cible. On utilise une relation hasMany ce qui n'est pas recommandé car le backend ne renvoit pas un contenu complet. 
De plus l'url de relation renvoyé coté API était fausse car il manquait le `/admin`.

## :robot: Solution
Nous avons supprimé la liaison has many entre target profile et organization coté front et API.

## :rainbow: Remarques
Un peu de contexte sur les hasMany et les collections non complètes dans ember data:

@jonathanperret:
> @lisequesnel le problème des hasMany filtrés/paginés c'est toujours que ça amène le type de bug introduit dans #1527 et corrigé par #1858 : la collection associée se retrouve à ne pas contenir un reflet fiable de ce que contient la base mais une vue arbitrairement limitée en fonction des paginations/filtres qui viennent d'être faits. Et du coup du code qui fait une hypothèse différente se retrouve induit en erreur.

## :100: Pour tester

https://user-images.githubusercontent.com/86659/104196666-55cd3600-5424-11eb-9cd8-90453eb6d235.mp4


