### PR TITLE
[FEATURE] Afficher une documentation spécifique pour les missions laïques françaises (ou MLF) (PIX-1976).

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -66,6 +66,10 @@ class Organization {
     return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.AEFE));
   }
 
+  get isMLF() {
+    return Boolean(this.tags.find((tag) => this.isSco && tag.name === Tag.MLF));
+  }
+
   get isPoleEmploi() {
     return Boolean(this.tags.find((tag) => tag.name === Tag.POLE_EMPLOI));
   }

--- a/api/lib/domain/models/Tag.js
+++ b/api/lib/domain/models/Tag.js
@@ -12,4 +12,5 @@ Tag.AGRICULTURE = 'AGRICULTURE';
 Tag.POLE_EMPLOI = 'POLE EMPLOI';
 Tag.CFA = 'CFA';
 Tag.AEFE = 'AEFE';
+Tag.MLF = 'MLF';
 module.exports = Tag;

--- a/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/prescriber-serializer.js
@@ -17,6 +17,7 @@ module.exports = {
             isAgriculture: recordWithoutClass.userOrgaSettings.currentOrganization.isAgriculture,
             isCFA: recordWithoutClass.userOrgaSettings.currentOrganization.isCFA,
             isAEFE: recordWithoutClass.userOrgaSettings.currentOrganization.isAEFE,
+            isMLF: recordWithoutClass.userOrgaSettings.currentOrganization.isMLF,
           },
         };
         delete recordWithoutClass.userOrgaSettings.currentOrganization;
@@ -41,7 +42,7 @@ module.exports = {
         attributes: ['organization', 'user'],
         organization: {
           ref: 'id',
-          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'isAEFE', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
+          attributes: ['name', 'type', 'credit', 'isManagingStudents', 'canCollectProfiles', 'isAgriculture', 'isCFA', 'isAEFE', 'isMLF', 'targetProfiles', 'memberships', 'students', 'organizationInvitations'],
           memberships: {
             ref: 'id',
             ignoreRelationshipData: true,

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -230,4 +230,39 @@ describe('Unit | Domain | Models | Organization', () => {
       });
     });
   });
+
+  describe('get#isMLF', () => {
+    context('when organization is not SCO', () => {
+      it('should return false when the organization has the "MLF" tag', () => {
+        // given
+        const tag = domainBuilder.buildTag({ name: Tag.MLF });
+        const organization = domainBuilder.buildOrganization({ type: 'SUP', tags: [tag] });
+
+        // when / then
+        expect(organization.isMLF).is.false;
+      });
+    });
+
+    context('when organization is SCO', () => {
+      it('should return true when organization is of type SCO and has the "MLF" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: Tag.MLF });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isMLF).is.true;
+      });
+
+      it('should return false when when organization is of type SCO and has not the "MLF" tag', () => {
+        // given
+        const tag1 = domainBuilder.buildTag({ name: 'To infinity…and beyond!' });
+        const tag2 = domainBuilder.buildTag({ name: 'OTHER' });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', tags: [tag1, tag2] });
+
+        // when / then
+        expect(organization.isMLF).is.false;
+      });
+    });
+  });
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/prescriber-serializer_test.js
@@ -422,6 +422,52 @@ describe('Unit | Serializer | JSONAPI | prescriber-serializer', () => {
       });
     });
 
+    context('when isMLF is true', () => {
+      it('should serialize prescriber with isMLF', () => {
+        // given
+        const user = domainBuilder.buildUser({
+          pixOrgaTermsOfServiceAccepted: true,
+          memberships: [],
+          certificationCenterMemberships: [],
+        });
+
+        const tags = [domainBuilder.buildTag({ name: 'MLF' })];
+        const organization = domainBuilder.buildOrganization({ tags });
+
+        const membership = domainBuilder.buildMembership({
+          organization,
+          organizationRole: Membership.roles.MEMBER,
+          user,
+        });
+
+        user.memberships.push(membership);
+
+        organization.memberships.push(membership);
+
+        const userOrgaSettings = domainBuilder.buildUserOrgaSettings({
+          currentOrganization: organization,
+        });
+        userOrgaSettings.user = null;
+
+        const prescriber = domainBuilder.buildPrescriber({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          areNewYearSchoolingRegistrationsImported: false,
+          pixOrgaTermsOfServiceAccepted: user.pixOrgaTermsOfServiceAccepted,
+          memberships: [membership],
+          userOrgaSettings,
+        });
+
+        const expectedPrescriberSerialized = createExpectedPrescriberSerializedWithOneMoreField({ prescriber, membership, userOrgaSettings, organization, serializedField: 'is-mlf', field: 'isMLF' });
+
+        // when
+        const result = serializer.serialize(prescriber);
+
+        // then
+        expect(result).to.be.deep.equal(expectedPrescriberSerialized);
+      });
+    });
+
     context('when all booleans are false', () => {
       it('should serialize prescriber without these booleans', () => {
         // given

--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -13,7 +13,7 @@ export default class SidebarMenu extends Component {
       return 'https://view.genial.ly/5f3e7a5ba8ffb90d11ac034f';
     }
 
-    if (this.currentUser.isAEFE) {
+    if (this.currentUser.isAEFE || this.currentUser.isMLF) {
       return 'https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8';
     }
 

--- a/orga/app/models/organization.js
+++ b/orga/app/models/organization.js
@@ -10,6 +10,7 @@ export default class Organization extends Model {
   @attr('boolean') isAgriculture;
   @attr('boolean') isCFA;
   @attr('boolean') isAEFE;
+  @attr('boolean') isMLF;
 
   @hasMany('campaign') campaigns;
   @hasMany('target-profile') targetProfiles;

--- a/orga/app/services/current-user.js
+++ b/orga/app/services/current-user.js
@@ -15,6 +15,7 @@ export default class CurrentUserService extends Service {
   @tracked isAgriculture;
   @tracked isCFA;
   @tracked isAEFE;
+  @tracked isMLF;
 
   async load() {
     if (this.session.isAuthenticated) {
@@ -60,6 +61,7 @@ export default class CurrentUserService extends Service {
     this.isAgriculture = organization.isAgriculture;
     this.isCFA = organization.isCFA;
     this.isAEFE = organization.isAEFE;
+    this.isMLF = organization.isMLF;
 
     this.organization = organization;
   }

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -63,6 +63,20 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
   });
 
+  test('it should display documentation for a sco MLF organization', async function(assert) {
+    class CurrentUserStub extends Service {
+      organization = Object.create({ id: 1, type: 'SCO' });
+      isMLF = true;
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+
+    // then
+    assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
+  });
+
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });


### PR DESCRIPTION
## 🦄 Problème
Nous allons ouvrir Pix aux missions laïques françaises (MLF). Cependant, les élèves n'ont pas d'INE (ni aucun identifiant unique), et donc on ne peut pas les gérer comme des élèves "classiques", à savoir avec un import.

La manière de les gérer sera donc la manière non restreinte. Cependant, ils ont besoin d'une documentation relative à leur usage.

## 🤖 Solution
Rendre disponible une documentation spécifique.

## 🌈 Remarques
NA

## 💯 Pour tester
Se connecter à Pix Orga avec sco.admin@pix.fr
Aller sur l'organisation "AEFE"
Vérifier que le lien de documentation à gauche existe et redirige vers la bonne documentation