### PR TITLE
[FEATURE] Voir le nombre de "signalements impactants" dans la liste des certification dans Pix Admin (PIX-1519)

### DIFF
--- a/admin/app/components/certification/certification-list.js
+++ b/admin/app/components/certification/certification-list.js
@@ -22,6 +22,10 @@ export default class CertificationList extends Component {
       title: 'Statut',
     },
     {
+      propertyName: 'numberOfCertificationIssueReportsWithActionRequired',
+      title: 'Signalements impactants',
+    },
+    {
       propertyName: 'cleaStatus',
       title: 'Certification CléA numérique',
     },

--- a/admin/tests/integration/components/certification/certification-list-test.js
+++ b/admin/tests/integration/components/certification/certification-list-test.js
@@ -8,7 +8,7 @@ module('Integration | Component | <Certification::CertificationList/>', function
 
   setupRenderingTest(hooks);
 
-  test('sould display many certifications', async function(assert) {
+  test('should display many certifications', async function(assert) {
     // given
     this.certifications = [
       EmberObject.create({ id: 1 }),
@@ -21,5 +21,18 @@ module('Integration | Component | <Certification::CertificationList/>', function
 
     const $tableRows = this.element.querySelectorAll('tbody > tr');
     assert.equal($tableRows.length, 3);
+  });
+
+  test('should display number of certification issue reports with required action', async function(assert) {
+    // given
+    this.certifications = [
+      EmberObject.create({ id: 1, numberOfCertificationIssueReportsWithActionRequired: 2 }),
+    ];
+
+    // when
+    await render(hbs`<Certification::CertificationList @certifications={{certifications}} />`);
+
+    const numberOfCertificationIssueReportsWithRequiredAction = this.element.querySelector('tbody > tr td:nth-child(5)');
+    assert.dom(numberOfCertificationIssueReportsWithRequiredAction).hasText('2');
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix Catégorisation des signalements en certification, nous allons permettre aux utilisateurs Pix Certif de sélectionner une catégorie spécifique de signalement candidat depuis la page de finalisation de la session, dans le but d’aider le pôle certif à savoir si le signalement remonté nécessite une action de leur part ou non. Le nombre de “signalements impactants” va être affiché sur la page de détails de la session, ce qui permet au pôle certif dans un premier temps de savoir si au moins une certification dans cette session est concernée. Il s’agit maintenant de permettre au pôle certif de savoir quelle(s) certification(s) sont impactées.

## :robot: Solution
Dans la liste des certifications d’une session dans Pix Admin, ajouter une colonne “Signalements impactants” : 

- Afficher le nombre de “signalements impactants” (= qui nécessitent une action de la part du pôle certif) pour chaque certification de la session

- A placer après entre la colonne “Statut” et “Certification CléA numérique”

## :100: Pour tester
- Lancer pix-api avec FT_REPORTS_CATEGORISATION=true
- Finaliser une session en ajoutant un signalement impactant ( catégorie autre par ex)
- Se connecter à pix-admin
- Aller sur la page de détail de la session
- Constater que la colonne "Signalements impactants" est présente et affiche le nb de signalements impactants correspondant
