### PR TITLE
[FEATURE] Permettre de filtrer par classe les profils dans les resultats du campagne de collecte de profils (PIX-1681).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -155,9 +155,11 @@ module.exports = {
   async findProfilesCollectionParticipations(request) {
     const { userId } = request.auth.credentials;
     const campaignId = request.params.id;
-    const { page } = queryParamsUtils.extractParameters(request.query);
-
-    const results = await usecases.findCampaignProfilesCollectionParticipationSummaries({ userId, campaignId, page });
+    const { page, filter: filters } = queryParamsUtils.extractParameters(request.query);
+    if (filters.divisions && !Array.isArray(filters.divisions)) {
+      filters.divisions = [filters.divisions];
+    }
+    const results = await usecases.findCampaignProfilesCollectionParticipationSummaries({ userId, campaignId, page, filters });
     return campaignProfilesCollectionParticipationSummarySerializer.serialize(results);
   },
 

--- a/api/lib/domain/usecases/find-campaign-profiles-collection-participation-summaries.js
+++ b/api/lib/domain/usecases/find-campaign-profiles-collection-participation-summaries.js
@@ -4,11 +4,12 @@ module.exports = async function findCampaignProfilesCollectionParticipationSumma
   userId,
   campaignId,
   page,
+  filters,
   campaignRepository,
   campaignProfilesCollectionParticipationSummaryRepository,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntity('User does not belong to an organization that owns the campaign');
   }
-  return campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId, page);
+  return campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId, page, filters);
 };

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
@@ -123,8 +123,8 @@ async function _getValidatedTargetSkillIds(sharedAtDatesByUsers, targetedSkillId
 
 function _filterQuery(qb, filters) {
   if (filters.divisions) {
-    const divisionsLowerCase = filters.divisions.map((division) => `'${division.toLowerCase()}'`);
-    qb.whereRaw(`LOWER("schooling-registrations"."division") in (${divisionsLowerCase.join(',')})`);
+    const divisionsLowerCase = filters.divisions.map((division) => division.toLowerCase());
+    qb.whereRaw('LOWER("schooling-registrations"."division") = ANY(:divisionsLowerCase)', { divisionsLowerCase });
   }
 }
 

--- a/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profiles-collection-participation-summary-repository_test.js
@@ -130,6 +130,47 @@ describe('Integration | Repository | Campaign Profiles Collection Participation 
         expect(results.data[0].certifiableCompetencesCount).to.equal(1);
       });
     });
+
+    describe('when there is a filter on division', () => {
+
+      beforeEach(async () => {
+        const participation1 = {
+          participantExternalId: 'Can\'t get Enough Of Your Love, Baby',
+          campaignId,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation1, { id: 1 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 1, division: 'Barry' });
+
+        const participation2 = {
+          participantExternalId: 'You\'re The First, The last, My Everything',
+          campaignId,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation2, { id: 2 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 2, division: 'White' });
+
+        const participation3 = {
+          participantExternalId: 'Ain\'t No Mountain High Enough',
+          campaignId,
+        };
+
+        databaseBuilder.factory.buildAssessmentFromParticipation(participation3, { id: 3 });
+        databaseBuilder.factory.buildSchoolingRegistration({ organizationId, userId: 3, division: 'Marvin Gaye' });
+
+        await databaseBuilder.commit();
+      });
+
+      it('returns participations which have the correct division', async () => {
+        // when
+        const divisions = ['Barry', 'White'];
+        const results = await campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId, undefined, { divisions });
+        const participantExternalIds = results.data.map((result) => result.participantExternalId);
+
+        // then
+        expect(participantExternalIds).to.exactlyContain(['Can\'t get Enough Of Your Love, Baby', 'You\'re The First, The last, My Everything']);
+      });
+    });
   });
 });
 

--- a/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -22,15 +22,19 @@ describe('Unit | UseCase | find-campaign-profiles-collection-participation-summa
     });
 
     it('should retrieve the campaign participations datas', async () => {
+      const page = { number: 1 };
+      const filters = { divisions: ['Barry White Classics'] };
       // given
       campaignProfilesCollectionParticipationSummaryRepository
         .findPaginatedByCampaignId
-        .withArgs(campaignId)
+        .withArgs(campaignId, page, filters)
         .resolves(campaignProfilesCollectionParticipationSummaries);
 
       participationSummaries = await findCampaignProfilesCollectionParticipationSummaries({
         userId,
         campaignId,
+        page,
+        filters,
         campaignRepository,
         campaignProfilesCollectionParticipationSummaryRepository,
       });

--- a/api/tests/unit/domain/usecases/siecle.csv
+++ b/api/tests/unit/domain/usecases/siecle.csv
@@ -1,0 +1,4 @@
+Identifiant unique*;Premier prénom*;Deuxième prénom;Troisième prénom;Nom de famille*;Nom d'usage;Date de naissance (jj/mm/aaaa)*;Code commune naissance**;Libellé commune naissance**;Code département naissance*;Code pays naissance*;Statut*;Code MEF*;Division*
+        123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;97422;;974;99100;ST;MEF1;Division 1;
+        0123456789F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;AP;MEF1;Division 2;
+        

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -2,6 +2,7 @@
   <PixFilterBanner @title="Filtres" class="participant-filter-banner" aria-label="Filtres sur les participations">
     <PixMultiSelect
             class="division-filter"
+            @emptyMessage={{"Pas de classes"}}
             @title={{'Classes'}}
             @id={{'division'}}
             @isSearchable={{false}}

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -1,3 +1,18 @@
+{{#if this.displayDivisionFilter }}
+  <PixFilterBanner @title="Filtres" class="participant-filter-banner" aria-label="Filtres sur les profiles">
+    <PixMultiSelect
+            class="division-filter"
+            @emptyMessage={{"Pas de classes"}}
+            @title={{"Classes"}}
+            @id={{"division"}}
+            @isSearchable={{false}}
+            @onSelect={{ @selectDivisions }}
+            @selected={{ @selectedDivisions }}
+            @options={{ this.divisionOptions }} as |option|>
+      {{option.value}}
+    </PixMultiSelect>
+  </PixFilterBanner>
+{{/if}}
 <div class="panel">
   <div class="table content-text content-text--small">
     <table>
@@ -53,7 +68,7 @@
     </table>
 
     {{#unless @profiles}}
-      <div class="table__empty content-text">En attente de profiles</div>
+      <div class="table__empty content-text">En attente de profils</div>
     {{/unless}}
   </div>
 </div>

--- a/orga/app/components/routes/authenticated/campaign/profile/list.js
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class List extends Component {
+  @service currentUser;
+
+  get displayDivisionFilter() {
+    return this.currentUser.isSCOManagingStudents;
+  }
+
+  get divisionOptions() {
+    return this.args.campaign.divisions.map(({ name }) => ({ value: name }));
+  }
+}

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
@@ -1,8 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
-import debounce from 'lodash/debounce';
-import config from 'pix-orga/config/environment';
 
 export default class AssessmentsController extends Controller {
   queryParams = ['pageNumber', 'pageSize', 'divisions'];
@@ -18,12 +16,6 @@ export default class AssessmentsController extends Controller {
 
   @action
   triggerFiltering(filters) {
-    this.debouncedUpdateFilters(filters);
-  }
-
-  debouncedUpdateFilters = debounce(this._updateFilters, config.pagination.debounce);
-
-  _updateFilters(filters) {
     this.pageNumber = null;
     this.divisions = filters.divisions;
   }

--- a/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
@@ -3,12 +3,19 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 export default class ProfilesController extends Controller {
-  queryParams = ['pageNumber', 'pageSize'];
+  queryParams = ['pageNumber', 'pageSize', 'divisions'];
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
+  @tracked divisions = [];
 
   @action
   goToProfilePage(campaignId, campaignParticipationId) {
     this.transitionToRoute('authenticated.campaigns.profile', campaignId, campaignParticipationId);
+  }
+
+ @action
+  selectDivisions(divisions) {
+    this.pageNumber = null;
+    this.divisions = divisions;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profiles.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { action } from '@ember/object';
 
 export default class ProfilesRoute extends Route {
   queryParams = {
@@ -9,21 +10,36 @@ export default class ProfilesRoute extends Route {
     pageSize: {
       refreshModel: true,
     },
+    divisions: {
+      refreshModel: true,
+    },
   };
+
+  @action
+  loading(transition) {
+    if (transition.from && transition.from.name === 'authenticated.campaigns.campaign.profiles') {
+      return false;
+    }
+  }
 
   model(params) {
     const campaign = this.modelFor('authenticated.campaigns.campaign');
     return RSVP.hash({
       campaign,
-      profiles: this.store.query('CampaignProfilesCollectionParticipationSummary', {
-        filter: {
-          campaignId: campaign.id,
-        },
-        page: {
-          number: params.pageNumber,
-          size: params.pageSize,
-        },
-      }),
+      profiles: this.fetchProfileSummaries({ campaignId: campaign.id, ...params }),
+    });
+  }
+
+  fetchProfileSummaries(params) {
+    return this.store.query('CampaignProfilesCollectionParticipationSummary', {
+      filter: {
+        campaignId: params.campaignId,
+        divisions: params.divisions,
+      },
+      page: {
+        number: params.pageNumber,
+        size: params.pageSize,
+      },
     });
   }
 
@@ -31,6 +47,7 @@ export default class ProfilesRoute extends Route {
     if (isExiting) {
       controller.pageNumber = 1;
       controller.pageSize = 10;
+      controller.divisions = [];
     }
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
@@ -2,5 +2,7 @@
   @campaign={{@model.campaign}}
   @profiles={{@model.profiles}}
   @goToProfilePage={{this.goToProfilePage}}
+  @selectDivisions={{this.selectDivisions}}
+  @selectedDivisions={{this.divisions}}
 />
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -448,7 +448,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       await render(hbs`<Routes::Authenticated::Campaign::Assessment::List @campaign={{campaign}} @participations={{participations}} @goToAssessmentPage={{goToAssessmentPage}}/>`);
 
       // then
-      assert.notContains('Classe');
+      assert.notContains('Classes');
       assert.notContains('d2');
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
@@ -1,7 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+import sinon from 'sinon';
 
 module('Integration | Component | routes/authenticated/campaign/profile/list', function(hooks) {
   setupRenderingTest(hooks);
@@ -51,7 +53,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
         />`);
 
       // then
-      assert.notContains('En attente de profiles');
+      assert.notContains('En attente de profils');
       assert.contains('Doe');
       assert.contains('Doe2');
       assert.contains('John');
@@ -147,7 +149,124 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
       await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}}/>}}`);
 
       // then
-      assert.contains('En attente de profiles');
+      assert.contains('En attente de profils');
+    });
+  });
+
+  module('when user works for a SCO organization which manages students', function() {
+    class CurrentUserStub extends Service {
+      prescriber = { areNewYearSchoolingRegistrationsImported: false }
+      isSCOManagingStudents = true;
+    }
+
+    test('it displays the division filter', async function(assert) {
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // given
+      const division = store.createRecord('division', {
+        id: 'd1',
+        name: 'd1',
+      });
+      const campaignReport = store.createRecord('campaign-report', {
+        id: 'c1',
+        stages: [],
+      });
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        campaignReport,
+        divisions: [division],
+      });
+
+      const profiles = [{ firstName: 'John', lastName: 'Doe', isShared: true }];
+      profiles.meta = { rowCount: 1 };
+
+      this.set('campaign', campaign);
+      this.set('profiles', profiles);
+      this.set('goToProfilePage', () => {});
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}}/>}}`);
+
+      // then
+      assert.contains('Classes');
+      assert.contains('d1');
+    });
+
+    test('it filters the profiles when a division is selected', async function(assert) {
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // given
+      const division = store.createRecord('division', {
+        id: 'd1',
+        name: 'd1',
+      });
+      const campaignReport = store.createRecord('campaign-report', {
+        id: 'c1',
+        stages: [],
+      });
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        campaignReport,
+        divisions: [division],
+      });
+
+      const profiles = [{ firstName: 'John', lastName: 'Doe', isShared: true }];
+      profiles.meta = { rowCount: 1 };
+      const selectDivisions = sinon.stub();
+      this.set('campaign', campaign);
+      this.set('profiles', profiles);
+      this.set('goToProfilePage', () => {});
+      this.set('selectDivisions', selectDivisions);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}} @selectDivisions={{selectDivisions}}/>`);
+      await click('[for="division-d1"]');
+
+      // then
+      assert.ok(selectDivisions.calledWith(['d1']));
+    });
+  });
+
+  module('when user does not work for a SCO organization which manages students', function() {
+    class CurrentUserStub extends Service {
+      prescriber = { areNewYearSchoolingRegistrationsImported: false }
+      isSCOManagingStudents = false;
+    }
+
+    test('it does not display the division filter', async function(assert) {
+      this.owner.register('service:current-user', CurrentUserStub);
+
+      // given
+      const division = store.createRecord('division', {
+        id: 'd2',
+        name: 'd2',
+      });
+      const campaignReport = store.createRecord('campaign-report', {
+        id: 'c1',
+        stages: [],
+      });
+      const campaign = store.createRecord('campaign', {
+        id: 1,
+        name: 'campagne 1',
+        campaignReport,
+        divisions: [division],
+      });
+
+      const profiles = [{ firstName: 'John', lastName: 'Doe', isShared: true }];
+      profiles.meta = { rowCount: 1 };
+
+      this.set('campaign', campaign);
+      this.set('profiles', profiles);
+      this.set('goToProfilePage', () => {});
+
+      // when
+      await render(hbs`<Routes::Authenticated::Campaign::Profile::List @campaign={{campaign}} @profiles={{profiles}} @goToProfilePage={{goToProfilePage}}/>`);
+
+      // then
+      assert.notContains('Classes');
+      assert.notContains('d2');
     });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
@@ -2,23 +2,24 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/campaigns/campaign/assessments', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/campaign/profiles', function(hooks) {
   setupTest(hooks);
   let controller;
   hooks.beforeEach(function() {
-    controller = this.owner.lookup('controller:authenticated/campaigns/campaign/assessments');
+    controller = this.owner.lookup('controller:authenticated/campaigns/campaign/profiles');
   });
 
-  module('triggerFiltering', function() {
-    test('update the filters', function(assert) {
+  module('selectDivisions', function() {
+    test('update the divisions', function(assert) {
       const fetchCampaign = sinon.stub();
       controller.set('fetchCampaign', fetchCampaign);
       controller.set('model', { id: 12 });
       controller.set('pageNumber', 11);
 
-      controller.triggerFiltering({ divisions: ['6eme'] });
+      controller.selectDivisions(['6eme']);
 
       assert.deepEqual(controller.divisions, ['6eme']);
+      assert.deepEqual(controller.pageNumber, null);
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles-test.js
@@ -1,0 +1,100 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hooks) {
+  setupTest(hooks);
+
+  let route;
+
+  hooks.beforeEach(function() {
+    route = this.owner.lookup('route:authenticated/campaigns/campaign/profiles');
+  });
+
+  module('fetchProfileSummaries', function(hooks) {
+    let store;
+    let storeStub;
+
+    hooks.beforeEach(function() {
+      storeStub = {
+        query: sinon.stub(),
+      };
+      store = route.store;
+      route.store = storeStub;
+    });
+
+    hooks.afterEach(function() {
+      route.store = store;
+    });
+
+    test('if finds profile summaries from stores', function(assert) {
+      const params = {
+        pageNumber: 1,
+        pageSize: 2,
+        divisions: ['4eme'],
+        campaignId: 3,
+      };
+      const expectedSummaries = [{
+        id: 12,
+      }];
+
+      storeStub.query
+        .withArgs(
+          'CampaignProfilesCollectionParticipationSummary',
+          {
+            page: {
+              number: params.pageNumber,
+              size: params.pageSize,
+            },
+            filter: {
+              divisions: params.divisions,
+              campaignId: params.campaignId,
+            },
+          })
+        .returns(expectedSummaries);
+
+      const summaries = route.fetchProfileSummaries(params);
+
+      assert.equal(summaries, expectedSummaries);
+    });
+  });
+
+  module('loading', function(hooks) {
+    let store;
+    let storeStub;
+
+    hooks.beforeEach(function() {
+      storeStub = {
+        query: sinon.stub(),
+      };
+      store = route.store;
+      route.store = storeStub;
+    });
+
+    hooks.afterEach(function() {
+      route.store = store;
+    });
+
+    module('when the transition comes from "authenticated.campaigns.campaign.profiles"', function() {
+      test('if returns false', function(assert) {
+        const transition = { from: { name: 'authenticated.campaigns.campaign.profiles' } };
+        assert.equal(route.loading(transition), false);
+      });
+    });
+
+    module('when the transition comes from somewhere else', function() {
+      test('if returns undefined', function(assert) {
+        const transition = { from: { name: 'authenticated.campaigns.campaign' } };
+        assert.equal(route.loading(transition), undefined);
+      });
+    });
+
+    module('when the transition has no from attribute', function() {
+      test('if keeps loading page', function(assert) {
+        const transition = {};
+        assert.equal(route.loading(transition), undefined);
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un prescripteur consulte les profiles qui ont été partagés pendant une campagne il ne peut pas les consulter par classe.

## :robot: Solution

Ajout du filtre de la classe dans l'affichage de la liste des profiles pour toutes les campagnes de collecte de profils des organisations SCO qui gèrent des étudiants.

## :rainbow: Remarques
RAS

## :100: Pour tester
Participer à une campagne de collecte de profils avec des étudiants avec des classe différentes.
Dans Pix-Orga quand on consulte les résultats de cette campagne on doit pouvoir filtrer en fonction des classes participants.
