### PR TITLE
[BUGFIX] Rendre l'affichage de la date de naissance du certificat insensible aux fuseaux horaires (PIX-1824)

### DIFF
--- a/mon-pix/app/components/user-certifications-detail-header.js
+++ b/mon-pix/app/components/user-certifications-detail-header.js
@@ -5,13 +5,14 @@ import { tracked } from '@glimmer/tracking';
 
 export default class UserCertificationsDetailHeader extends Component {
   @service intl;
+  @service intlDateFormatter;
   @service fileSaver;
   @service session;
 
   @tracked tooltipText = this.intl.t('pages.certificate.verification-code.copy');
 
   get birthdate() {
-    return this.intl.formatDate(this.args.certification.birthdate, { format: 'LL' });
+    return this.intlDateFormatter.formatDateStringToString(this.args.certification.birthdate);
   }
 
   @action

--- a/mon-pix/app/models/certification.js
+++ b/mon-pix/app/models/certification.js
@@ -22,7 +22,7 @@ export default class Certification extends Model {
   @attr('string') status;
   @attr('string') verificationCode;
   @attr() cleaCertificationStatus;
-  @attr() deliveredAt;
+  @attr('date') deliveredAt;
   @attr('number') maxReachableLevelOnCertificationDate;
 
   // includes

--- a/mon-pix/app/services/intl-date-formatter.js
+++ b/mon-pix/app/services/intl-date-formatter.js
@@ -1,0 +1,27 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+
+export default class IntlDateFormatter extends Service {
+  @service intl;
+
+  formatDateStringToString(dateString) {
+    if (!isDateStringValid(dateString)) {
+      throw new Error(`Date "${dateString}" does not comply with the "YYYY-MM-DD" format`);
+    }
+    return this.intl.formatDate(
+      toDateAtMidnightUTC(dateString),
+      { format: 'LL', timeZone: 'UTC' },
+    );
+  }
+}
+
+function isDateStringValid(dateString) {
+  const yearFormat = '\\d\\d\\d\\d'; // 4 digits
+  const monthFormat = '(0[1-9]|1[0-2])'; // 2 digits between 01 and 12
+  const dayFormat = '(0[1-9]|[12][0-9]|3[01])'; // 2 digits between 01 and 31
+  return new RegExp(`${yearFormat}-${monthFormat}-${dayFormat}`).test(dateString);
+}
+
+function toDateAtMidnightUTC(dateString) {
+  return new Date(dateString + 'T00:00:00Z');
+}

--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -6,7 +6,7 @@
       <h1>{{t "pages.certificate.title"}}</h1>
 
       <p class="user-certifications-detail-header__info-certificate--grey">
-        {{t "pages.certificate.issued-on"}} {{format-date @certification.deliveredAt format="LL"}}
+        {{t "pages.certificate.issued-on"}} {{format-date @certification.deliveredAt format="LL" timeZone="Europe/Paris"}}
       </p>
       <p class="user-certifications-detail-header__info-certificate--grey">
         {{t "pages.certificate.validity"}}
@@ -25,7 +25,7 @@
         <p>{{t "pages.certificate.certification-center"}} {{@certification.certificationCenter}}</p>
       {{/if}}
 
-      <p>{{t "pages.certificate.exam-date"}} {{format-date @certification.date format="LL"}}</p>
+      <p>{{t "pages.certificate.exam-date"}} {{format-date @certification.date format="LL" timeZone="Europe/Paris"}}</p>
 
     </div>
   </div>

--- a/mon-pix/tests/unit/services/intl-date-formatter-test.js
+++ b/mon-pix/tests/unit/services/intl-date-formatter-test.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
+
+describe('Unit | Service | intl-date-formatter', function() {
+
+  setupTest();
+  setupIntl();
+
+  let intlDateFormatter;
+
+  beforeEach(function() {
+    intlDateFormatter = this.owner.lookup('service:intl-date-formatter');
+  });
+
+  it('format "2020-01-01" date string to human-readable "1 janvier 2020"', function() {
+    // given
+    const dateString = '2020-01-01';
+
+    // when
+    const formattedHumanReadableString = intlDateFormatter.formatDateStringToString(dateString);
+
+    // then
+    expect(formattedHumanReadableString).to.equal('1 janvier 2020');
+  });
+
+  it('format "2020-12-31" date string to human-readable "31 décembre 2020"', function() {
+    // given
+    const dateString = '2020-12-31';
+
+    // when
+    const formattedHumanReadableString = intlDateFormatter.formatDateStringToString(dateString);
+
+    // then
+    expect(formattedHumanReadableString).to.equal('31 décembre 2020');
+  });
+
+  it('throws when the input date does not comply with the "YYYY-MM-DD" format', function() {
+    // given
+    const dateStringWithInvertedDayAndMonth = '2020-31-12';
+
+    // when / then
+    expect(() => intlDateFormatter.formatDateStringToString(dateStringWithInvertedDayAndMonth))
+      .to.throw();
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le formatage de la date de naissance sur le certificat (front `mon-pix`) dépend du fuseau horaire dans lequel se trouve l'utilisateur. Par exemple la date "brute" `2020-01-01` sera affichée "1 janvier 2020" en France et "31 décembre 1999" à Tahiti. 
Le problème réside dans le fait que le `formatDate` du service `ember-intl` convertit à la volée une string en date à l'aide d'un `new Date(laDate)` sans spécifier de timezone. Le comportement par défaut utilise la timezone du navigateur. 

## :robot: Solution
Convertir explicitement la string en date avant d'appeler `formatDate` et spécifier également la timezone du formatage attendu.

## :rainbow: Remarques
RAS

## :100: Pour tester
En local :
- se connecter avec certif-success@example.net
- consulter le certificat
- constater l'affichage de la date de naissance "1 janvier 2000"
- modifier la timezone du navigateur (sous chrome : console de dev > trois petit points > more tools > sensors > location)
- recharger la page 
- constater que l'affichage de la date de naissance est toujours "1 janvier 2000" (avec cette PR, il aurait été "31 décembre 1999")

