### PR TITLE
[FEATURE] Mettre le filtre classe recherchable pour les campagnes (PIX-1981)

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -1,14 +1,17 @@
 {{#if this.displayDivisionFilter }}
   <PixFilterBanner @title="Filtres" class="participant-filter-banner" aria-label="Filtres sur les participations">
     <PixMultiSelect
-            class="division-filter"
-            @emptyMessage={{"Pas de classes"}}
-            @title={{'Classes'}}
-            @id={{'division'}}
-            @isSearchable={{false}}
-            @onSelect={{ this.onSelectDivision }}
-            @selected={{ @selectedDivisions }}
-            @options={{ this.divisionOptions }} as |option|>
+      class="division-filter"
+      @id="division"
+      @title="Classes"
+      @placeholder="Classes"
+      @isSearchable={{true}}
+      @showOptionsOnInput={{true}}
+      @emptyMessage="Pas de classe"
+      @onSelect={{this.onSelectDivision}}
+      @selected={{@selectedDivisions}}
+      @options={{this.divisionOptions}} as |option|
+    >
       {{option.value}}
     </PixMultiSelect>
   </PixFilterBanner>

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.js
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.js
@@ -10,7 +10,7 @@ export default class List extends Component {
   }
 
   get divisionOptions() {
-    return this.args.campaign.divisions.map(({ name }) => ({ value: name }));
+    return this.args.campaign.divisions.map(({ name }) => ({ value: name, label: name }));
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -1,14 +1,17 @@
 {{#if this.displayDivisionFilter }}
   <PixFilterBanner @title="Filtres" class="participant-filter-banner" aria-label="Filtres sur les profiles">
     <PixMultiSelect
-            class="division-filter"
-            @emptyMessage={{"Pas de classes"}}
-            @title={{"Classes"}}
-            @id={{"division"}}
-            @isSearchable={{false}}
-            @onSelect={{ @selectDivisions }}
-            @selected={{ @selectedDivisions }}
-            @options={{ this.divisionOptions }} as |option|>
+      class="division-filter"
+      @id="division"
+      @title="Classes"
+      @placeholder="Classes"
+      @isSearchable={{true}}
+      @showOptionsOnInput={{true}}
+      @emptyMessage="Pas de classe"
+      @onSelect={{@selectDivisions}}
+      @selected={{@selectedDivisions}}
+      @options={{this.divisionOptions}} as |option|
+    >
       {{option.value}}
     </PixMultiSelect>
   </PixFilterBanner>

--- a/orga/app/components/routes/authenticated/campaign/profile/list.js
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.js
@@ -9,6 +9,6 @@ export default class List extends Component {
   }
 
   get divisionOptions() {
-    return this.args.campaign.divisions.map(({ name }) => ({ value: name }));
+    return this.args.campaign.divisions.map(({ name }) => ({ value: name, label: name }));
   }
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -25044,8 +25044,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#70c0c562d0f56cd8ecc678dbc63724c361f986cf",
-      "from": "git://github.com/1024pix/pix-ui.git#v1.3.0",
+      "version": "git://github.com/1024pix/pix-ui.git#ff17d437face0099bc673ad4cba0bebecf9fcb75",
+      "from": "git://github.com/1024pix/pix-ui.git#v1.4.1",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -84,7 +84,7 @@
     "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.3.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.4.1",
     "query-string": "^6.13.6",
     "qunit-dom": "^1.5.0",
     "sass": "^1.27.0"


### PR DESCRIPTION
## :unicorn: Problème

Dans la liste des participations à des campagnes, il n'est pas possible de rechercher des classes dans le filtre multiple.

## :robot: Solution

Utiliser la propriété `isSearchable` de `<PixMultiSelect>` afin de rendre possible la recherche dans le filtre des classes.
La modification a été appliquée sur le filtre des classes dans les écrans :
- de participations à des campagnes d'évaluation.
- de participation à des campagnes de collectes de profils.

## :rainbow: Remarques

A nécessité la montée de version de pix-ui en v1.4.1

## :100: Pour tester

1. Se connecter à pix-orga avec le compte sco
2. Vérifier le filtre des classes sur les écrans:
- de participations à des campagnes d'évaluation.
- de participation à des campagnes de collectes de profils.
