### PR TITLE
[BUGFIX] Les résultats d'une campagne participation s'affichent pas de temps en temps (PIX-1984).

### DIFF
--- a/api/lib/domain/read-models/CampaignAssessmentParticipationCompetenceResult.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipationCompetenceResult.js
@@ -1,11 +1,12 @@
 class CampaignAssessmentParticipationCompetenceResult {
   constructor({
+    campaignParticipationId,
     targetedArea,
     targetedCompetence,
     targetedSkillsCount,
     validatedTargetedKnowledgeElementsCount,
   } = {}) {
-    this.id = targetedCompetence.id;
+    this.id = `${campaignParticipationId}-${targetedCompetence.id}`;
     this.name = targetedCompetence.name;
     this.index = targetedCompetence.index;
     this.areaColor = targetedArea.color;

--- a/api/lib/domain/read-models/CampaignAssessmentParticipationResult.js
+++ b/api/lib/domain/read-models/CampaignAssessmentParticipationResult.js
@@ -19,6 +19,7 @@ class CampaignAssessmentParticipationResult {
         .map((targetedCompetence) => {
           const targetedArea = targetProfile.getAreaOfCompetence(targetedCompetence.id);
           return new CampaignAssessmentParticipationCompetenceResult({
+            campaignParticipationId,
             targetedArea,
             targetedCompetence,
             targetedSkillsCount: targetedCompetence.skillCount,

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -104,14 +104,14 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
       it('fills competenceResults', async () => {
         const expectedResult = [{
           areaColor: 'orange',
-          id: 'rec1',
+          id: `${campaignParticipationId}-rec1`,
           index: '1.1',
           name: 'Compétence 1',
           targetedSkillsCount: 1,
           validatedSkillsCount: 1,
         }, {
           areaColor: 'orange',
-          id: 'rec2',
+          id: `${campaignParticipationId}-rec2`,
           index: '1.2',
           name: 'Compétence 2',
           targetedSkillsCount: 1,

--- a/api/tests/unit/domain/read-models/CampaignAssessmentParticipationCompetenceResult_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentParticipationCompetenceResult_test.js
@@ -14,11 +14,12 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationCompetenceResu
       const targetedArea = domainBuilder.buildTargetedArea({ id: 'area1' });
 
       const campaignAssessmentParticipationCompetenceResult = new CampaignAssessmentParticipationCompetenceResult({
+        campaignParticipationId: '1',
         targetedArea,
         targetedCompetence,
       });
 
-      expect(campaignAssessmentParticipationCompetenceResult.id).equal('rec123');
+      expect(campaignAssessmentParticipationCompetenceResult.id).equal('1-rec123');
       expect(campaignAssessmentParticipationCompetenceResult.name).equal('competence1');
       expect(campaignAssessmentParticipationCompetenceResult.index).equal('1.1');
     });

--- a/api/tests/unit/domain/read-models/CampaignAssessmentParticipationResult_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAssessmentParticipationResult_test.js
@@ -53,7 +53,7 @@ describe('Unit | Domain | Models | CampaignAssessmentParticipationResult', () =>
 
         expect(campaignAssessmentParticipationResult.isShared).equal(true);
         expect(campaignAssessmentParticipationResult.competenceResults.length).equal(1);
-        expect(campaignAssessmentParticipationResult.competenceResults[0].id).equal('competence1');
+        expect(campaignAssessmentParticipationResult.competenceResults[0].id).equal('1-competence1');
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer_test.js
@@ -24,7 +24,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
           relationships: {
             'competence-results': {
               data: [{
-                id: targetedCompetence.id,
+                id: `1-${targetedCompetence.id}`,
                 type: 'campaign-assessment-participation-competence-results',
               }],
             },
@@ -32,7 +32,7 @@ describe('Unit | Serializer | JSONAPI | campaign-assessment-participation-result
         },
         included: [{
           type: 'campaign-assessment-participation-competence-results',
-          id: targetedCompetence.id,
+          id: `1-${targetedCompetence.id}`,
           attributes: {
             name: targetedCompetence.name,
             'index': targetedCompetence.index,


### PR DESCRIPTION
## :unicorn: Problème

Quand on clique sur une participation, que l'on revient en arrière et que l'on clique à nouveau sur une participation, la liste des compétences n'est pas affichée.

Problème sur les campagnes d'évaluation et pour les participation partagée.

Reproduction aléatoire.

## :robot: Solution

Le modèle de la route n'est pas correctement récupéré. Corriger la récupération du modèle.

## :rainbow: Remarques

N/A

## :100: Pour tester

Se connecter sur pix-orga dans une campagne d'évaluation avec des participation
(ex: en PRO avec la campagne "Pro - Campagne d’évaluation 5.1")

Puis naviguer plusieurs fois entre les participations partagées et la liste des participations

> La liste des compétences doit toujours être affichée