### PR TITLE
[FEATURE] Création d'un profil cible avec ses acquis dans PixAdmin (Pix-1757)

### DIFF
--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -1,0 +1,59 @@
+<form class="form create-target-profile" {{on "submit" @onSubmit}}>
+  
+  <section class="form-section">
+      <span class="form__instructions">
+        Les champs marqués de <abbr title="obligatoire" class="mandatory-mark">*</abbr> sont
+        obligatoires.
+      </span>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="targetProfileName">Nom <abbr title="obligatoire" class="mandatory-mark">*</abbr> : </label>
+      <Input class="form-control"
+             @required="true"
+             @id="targetProfileName"
+             @value={{@targetProfile.name}} />
+    </div>
+
+    <div class="form-field form-group create-target-profile__checkbox">
+      <label class="form-field__label" for="isPublic">Public : </label>
+      <Input class="form-control"
+              @type="checkbox"
+              @checked={{@targetProfile.isPublic}}
+              @id="isPublic" />
+      <p class="form__instructions create-target-profile__instructions">Un profil cible marqué comme public sera affecté à toutes les organisations.</p>
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="skillsList">Fichier JSON Pix Editor <abbr title="obligatoire" class="mandatory-mark">*</abbr> : </label>
+      <Input class={{if @isFileInvalid "form-control is-invalid" "form-control"}}
+              @required="true"
+              {{on "change" @onLoadFile}}
+              @type="file"
+              @id="skillsList" />
+      {{#if @isFileInvalid}}
+        <p class="form-field__error">Le fichier Pix Editor n'est pas au bon format.</p>
+      {{/if}}
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="organizationId">Identifiant de l'organisation de référence : </label>
+      <Input class="form-control"
+              @id="organizationId"
+              @placeholder="7777"
+              @value={{@targetProfile.ownerOrganizationId}} />
+    </div>
+
+    <div class="form-field form-group">
+      <label class="form-field__label" for="imageUrl">Lien de l'image du profil cible :</label>
+      <Input class="form-control"
+              @id="imageUrl"
+              @value={{@targetProfile.imageUrl}} />
+      <p class="form__instructions create-target-profile__instructions">L'url à saisir doit être celle d'OVH. Veuillez vous rapprocher des équipes tech et produit pour la réalisation de celle-ci.</p>
+    </div>
+  </section>
+
+  <section class="form-section form-section--actions">
+    <button class="form-action form-action--cancel btn btn-outline-default btn-thin" type="button" {{on "click" @onCancel}}>Annuler</button>
+    <button class="form-action form-action--submit btn btn-success btn-thin" type="submit" disabled={{@isDisabled}}>Enregistrer</button>
+  </section>
+</form>

--- a/admin/app/controllers/authenticated/target-profiles/new.js
+++ b/admin/app/controllers/authenticated/target-profiles/new.js
@@ -1,0 +1,57 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+
+import { tracked } from '@glimmer/tracking';
+
+export default class NewController extends Controller {
+  @service notifications;
+
+  @tracked isFileInvalid = false;
+  @tracked isSaving = false;
+
+  @action
+  goBackToTargetProfileList() {
+    this.store.deleteRecord(this.model);
+
+    this.transitionToRoute('authenticated.target-profiles.list');
+  }
+
+  @action
+  saveFileObject(event) {
+    const reader = new FileReader();
+
+    reader.readAsText(event.target.files[0]);
+
+    reader.onload = (evt) => {
+      try {
+        const json = JSON.parse(evt.target.result);
+        const skillsId = json.flatMap((tube) => tube.skills);
+        this.isFileInvalid = false;
+        this.model.skillsId = skillsId;
+
+      } catch (e) {
+        this.isFileInvalid = true;
+      }
+    };
+  }
+
+  @action
+  async createTargetProfile(event) {
+    event.preventDefault();
+
+    if (this.isFileInvalid) return;
+
+    try {
+      this.isSaving = true;
+      await this.model.save();
+
+      this.notifications.success('Le profil cible a été créé avec succès.');
+      this.transitionToRoute('authenticated.target-profiles.target-profile', this.model.id);
+    } catch (error) {
+      this.notifications.error('Une erreur est survenue.');
+    }
+
+    this.isSaving = false;
+  }
+}

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -4,8 +4,11 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class TargetProfile extends Model {
   @attr('string') name;
   @attr('boolean') isPublic;
+  @attr('string') imageUrl;
   @attr('boolean') outdated;
   @attr('string') ownerOrganizationId;
+
+  @attr('array') skillsId;
 
   @hasMany('badge') badges;
   @hasMany('skill') skills;

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -61,6 +61,7 @@ Router.map(function() {
 
     this.route('target-profiles', function() {
       this.route('list');
+      this.route('new');
       this.route('target-profile', { path: '/:target_profile_id' }, function() {
         this.route('details', { path: '/' });
         this.route('organizations');

--- a/admin/app/routes/authenticated/target-profiles/new.js
+++ b/admin/app/routes/authenticated/target-profiles/new.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default class NewRoute extends Route.extend(AuthenticatedRouteMixin) {
+  model() {
+    return this.store.createRecord('target-profile');
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -45,3 +45,4 @@
 @import 'components/user-detail-personal-information-section';
 @import 'components/target-profiles/badge-list';
 @import 'components/target-profiles/details';
+@import 'components/target-profiles/create-target-profile-form';

--- a/admin/app/styles/components/target-profiles/create-target-profile-form.scss
+++ b/admin/app/styles/components/target-profiles/create-target-profile-form.scss
@@ -1,0 +1,16 @@
+.create-target-profile {
+  &__checkbox {
+    display: flex;
+    align-items: center;
+
+    & > input[type=checkbox] {
+      margin: 0 8px;
+      width: 16px;
+      height: 16px;
+    }
+  }
+
+  &__instructions {
+    margin: 0;
+  }
+}

--- a/admin/app/templates/authenticated/target-profiles/list.hbs
+++ b/admin/app/templates/authenticated/target-profiles/list.hbs
@@ -1,6 +1,9 @@
 <header class="page-header">
   <div class="page-title">Tous les profils cibles</div>
   <div class="page-actions">
+    <LinkTo @route="authenticated.target-profiles.new" class="btn btn-outline-default btn-thin">
+      <FaIcon @icon="plus"></FaIcon>&nbsp;Nouveau profil cible
+    </LinkTo>
   </div>
 </header>
 

--- a/admin/app/templates/authenticated/target-profiles/new.hbs
+++ b/admin/app/templates/authenticated/target-profiles/new.hbs
@@ -1,0 +1,18 @@
+<header class="page-header">
+  <div class="page-title">
+    Nouveau profil cible
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section">
+    <TargetProfiles::CreateTargetProfileForm
+            @targetProfile={{this.model}}
+            @isFileInvalid={{this.isFileInvalid}}
+            @isDisabled={{this.isSaving}}
+            
+            @onLoadFile={{this.saveFileObject}}
+            @onSubmit={{this.createTargetProfile}}
+            @onCancel={{this.goBackToTargetProfileList}} />
+  </section>
+</main>

--- a/admin/app/transforms/array.js
+++ b/admin/app/transforms/array.js
@@ -1,0 +1,11 @@
+import Transform from '@ember-data/serializer/transform';
+
+export default class Array extends Transform {
+  deserialize(serialized) {
+    return serialized;
+  }
+
+  serialize(deserialized) {
+    return deserialized;
+  }
+}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -44,6 +44,7 @@ export default function() {
   this.get('/organizations/:id/memberships', findPaginatedOrganizationMemberships);
   this.get('/organizations/:id/target-profiles', getOrganizationTargetProfiles);
   this.post('/organizations/:id/target-profiles', attachTargetProfiles);
+  this.post('/admin/target-profiles');
   this.get('/admin/target-profiles');
   this.get('/admin/target-profiles/:id');
   this.patch('/admin/target-profiles/:id');

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { click, fillIn, triggerEvent, render } from '@ember/test-helpers';
+import sinon from 'sinon';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | TargetProfiles::CreateTargetProfileForm', function(hooks) {
+  setupRenderingTest(hooks);
+
+  let targetProfile;
+  let isFileInvalid;
+
+  let onLoadFile;
+  let onSubmit;
+  let onCancel;
+
+  hooks.beforeEach(function() {
+    targetProfile = {
+      name: '',
+      imageUrl: '',
+      ownerOrganizationId: '',
+      isPublic: false,
+    };
+
+    isFileInvalid = false;
+
+    onLoadFile = sinon.stub();
+    onSubmit = sinon.stub();
+    onCancel = sinon.stub();
+
+    this.set('targetProfile', targetProfile);
+    this.set('isFileInvalid', isFileInvalid);
+
+    this.set('onLoadFile', onLoadFile);
+    this.set('onSubmit', onSubmit);
+    this.set('onCancel', onCancel);
+
+  });
+
+  test('it should display the items', async function(assert) {
+    // given
+
+    // when
+    await render(hbs`<TargetProfiles::CreateTargetProfileForm
+                         @targetProfile={{this.targetProfile}}
+                         @isFileInvalid={{this.isFileInvalid}}
+                         
+                         @onLoadFile={{this.onLoadFile}} 
+                         @onSubmit={{this.onSubmit}}
+                         @onCancel={{this.onCancel}}/>`);
+
+    // then
+    assert.contains('Nom * :');
+    assert.contains('Public :');
+    assert.contains('Fichier JSON Pix Editor * :');
+    assert.contains('Identifiant de l\'organisation de référence :');
+    assert.contains('Lien de l\'image du profil cible :');
+    assert.contains('Annuler');
+    assert.contains('Enregistrer');
+  });
+
+  test('it should display json file error text', async function(assert) {
+    // given
+    this.set('isFileInvalid', true);
+
+    // when
+    await render(hbs`<TargetProfiles::CreateTargetProfileForm
+                         @targetProfile={{this.targetProfile}}
+                         @isFileInvalid={{this.isFileInvalid}}
+                         
+                         @onLoadFile={{this.onLoadFile}} 
+                         @onSubmit={{this.onSubmit}}
+                         @onCancel={{this.onCancel}}/>`);
+
+    // then
+    assert.contains('Le fichier Pix Editor n\'est pas au bon format.');
+  });
+
+  test('it should call onSubmit when form is valid', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::CreateTargetProfileForm
+                         @targetProfile={{this.targetProfile}}
+                         @isFileInvalid={{this.isFileInvalid}}
+                         
+                         @onLoadFile={{this.onLoadFile}} 
+                         @onSubmit={{this.onSubmit}}
+                         @onCancel={{this.onCancel}}/>`);
+
+    await triggerEvent(
+      'form',
+      'submit',
+    );
+
+    // then
+    assert.ok(onSubmit.called);
+  });
+
+  test('it should call onCancel when form is cancel', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::CreateTargetProfileForm
+                         @targetProfile={{this.targetProfile}}
+                         @isFileInvalid={{this.isFileInvalid}}
+                         
+                         @onLoadFile={{this.onLoadFile}} 
+                         @onSubmit={{this.onSubmit}}
+                         @onCancel={{this.onCancel}}/>`);
+
+    await click('button[type="button"]');
+
+    // then
+    assert.ok(onCancel.called);
+  });
+
+  test('it should call onLoadFile when file is selected', async function(assert) {
+    // when
+    await render(hbs`<TargetProfiles::CreateTargetProfileForm
+                         @targetProfile={{this.targetProfile}}
+                         @isFileInvalid={{this.isFileInvalid}}
+                         
+                         @onLoadFile={{this.onLoadFile}} 
+                         @onSubmit={{this.onSubmit}}
+                         @onCancel={{this.onCancel}}/>`);
+
+    await triggerEvent(
+      '#skillsList',
+      'change',
+    );
+    // then
+    assert.ok(onLoadFile.called);
+  });
+});

--- a/admin/tests/unit/controllers/authenticated/target-profiles/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/new-test.js
@@ -1,0 +1,145 @@
+import { module, test } from 'qunit';
+import sinon from 'sinon';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | authenticated/target-profiles/new', function(hooks) {
+  setupTest(hooks);
+
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/target-profiles/new');
+  });
+
+  module('#goBackToTargetProfileList', function() {
+    test('should delete record and go back target profile list page', async function(assert) {
+      controller.store.deleteRecord = sinon.stub();
+      controller.transitionToRoute = sinon.stub();
+      controller.model = Symbol('targetProfile');
+
+      controller.goBackToTargetProfileList();
+
+      assert.ok(controller.store.deleteRecord.calledWith(controller.model));
+      assert.ok(controller.transitionToRoute.calledWith('authenticated.target-profiles.list'));
+    });
+  });
+
+  module('#saveFileObject', function(hooks) {
+    hooks.beforeEach(function() {
+      sinon.restore();
+    });
+
+    test('should read the file', async function(assert) {
+      const event = {
+        target: {
+          files: [Symbol('myFile')],
+        },
+      };
+
+      sinon.stub(FileReader.prototype, 'readAsText');
+
+      controller.saveFileObject(event);
+
+      assert.ok(FileReader.prototype.readAsText.calledWith(event.target.files[0]));
+    });
+
+    test('should parse the file', async function(assert) {
+      controller.model = {};
+      const event = {
+        target: {
+          files: [Symbol('myFile')],
+          result: [JSON.stringify([{ skills: ['skill1'] }, { skills: ['skill2'] }])],
+        },
+      };
+
+      let onLoadFunction;
+      sinon.stub(FileReader.prototype, 'readAsText');
+      sinon.stub(FileReader.prototype, 'onload').set(function(onload) {
+        onLoadFunction = onload;
+      });
+
+      controller.saveFileObject(event);
+
+      onLoadFunction(event);
+
+      assert.deepEqual(controller.model.skillsId, ['skill1', 'skill2']);
+      assert.equal(controller.isFileInvalid, false);
+    });
+    test('should cannot parse the file', async function(assert) {
+      controller.model = {};
+      const event = {
+        target: {
+          files: [Symbol('myFile')],
+          result: [JSON.stringify('toto')],
+        },
+      };
+
+      let onLoadFunction;
+      sinon.stub(FileReader.prototype, 'readAsText');
+      sinon.stub(FileReader.prototype, 'onload').set(function(onload) {
+        onLoadFunction = onload;
+      });
+
+      controller.saveFileObject(event);
+
+      onLoadFunction(event);
+
+      assert.equal(controller.isFileInvalid, true);
+    });
+
+  });
+
+  module('#createTargetProfile', function() {
+    test('it should save model', async function(assert) {
+      controller.model = {
+        id: 3,
+        save: sinon.stub(),
+      };
+
+      controller.transitionToRoute = sinon.stub();
+
+      controller.notifications = {
+        success: sinon.stub(),
+      };
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      controller.model.save.resolves();
+
+      // when
+      await controller.createTargetProfile(event);
+
+      // then
+      assert.ok(event.preventDefault.called);
+      assert.ok(controller.model.save.called);
+      assert.ok(controller.notifications.success.calledWith('Le profil cible a été créé avec succès.'));
+      assert.ok(controller.transitionToRoute.calledWith('authenticated.target-profiles.target-profile', controller.model.id));
+    });
+
+    test('it should display notification Error when model cannot be saved', async function(assert) {
+      controller.model = {
+        save: sinon.stub(),
+      };
+
+      controller.notifications = {
+        error: sinon.stub(),
+      };
+
+      const event = {
+        preventDefault: sinon.stub(),
+      };
+
+      controller.model.save.rejects();
+
+      // when
+      await controller.createTargetProfile(event);
+
+      // then
+      assert.ok(event.preventDefault.called);
+      assert.ok(controller.model.save.called);
+      assert.ok(controller.notifications.error.calledWith('Une erreur est survenue.'));
+    });
+  });
+});

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -248,6 +248,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
 
+  if (error instanceof DomainErrors.TargetProfileCannotBeCreated) {
+    return new HttpErrors.UnprocessableEntityError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -82,6 +82,37 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/target-profiles',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+        }],
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                'name': Joi.string().required(),
+                'is-public': Joi.boolean().required(),
+                'organization-id': Joi.string().empty('').allow(null),
+                'image-url': Joi.string().uri().empty('').allow(null),
+                'skills-id': Joi.array().required(),
+              },
+            },
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: targetProfileController.createTargetProfile,
+        tags: ['api', 'target-profiles', 'create'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de créer un profil cible avec ses acquis',
+        ],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/admin/target-profiles/{id}/organizations',
       config: {

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -48,4 +48,11 @@ module.exports = {
     return h.response({}).code(204);
   },
 
+  async createTargetProfile(request) {
+    const targetProfileData = targetProfileSerializer.deserialize(request.payload);
+
+    const targetProfile = await usecases.createTargetProfile({ targetProfileData });
+
+    return targetProfileWithLearningContentSerializer.serialize(targetProfile);
+  },
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -6,6 +6,12 @@ class DomainError extends Error {
   }
 }
 
+class TargetProfileCannotBeCreated extends DomainError {
+  constructor(message = 'Erreur lors de la création du profil cible.') {
+    super(message);
+  }
+}
+
 class AlreadyExistingEntityError extends DomainError {
   constructor(message = 'L’entité existe déjà.') {
     super(message);
@@ -742,6 +748,7 @@ module.exports = {
   SchoolingRegistrationsCouldNotBeSavedError,
   SessionAlreadyFinalizedError,
   TargetProfileInvalidError,
+  TargetProfileCannotBeCreated,
   UnexpectedUserAccount,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,

--- a/api/lib/domain/usecases/create-target-profile.js
+++ b/api/lib/domain/usecases/create-target-profile.js
@@ -1,0 +1,13 @@
+const { TargetProfileInvalidError } = require('../errors');
+const _ = require('lodash');
+
+module.exports = async function createTargetProfile({ targetProfileData, targetProfileRepository, targetProfileWithLearningContentRepository }) {
+
+  if (_.isEmpty(targetProfileData.skillsId)) {
+    throw new TargetProfileInvalidError('Vous ne pouvez pas créer un profil cible sans acquis ciblés.');
+  }
+
+  const targetProfileId = await targetProfileRepository.create(targetProfileData);
+
+  return targetProfileWithLearningContentRepository.get({ id: targetProfileId });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -127,6 +127,7 @@ module.exports = injectDependencies({
   createOrganizationInvitations: require('./create-organization-invitations'),
   createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
   createSession: require('./create-session'),
+  createTargetProfile: require('./create-target-profile'),
   createUser: require('./create-user'),
   createUserFromPoleEmploi: require('./create-user-from-pole-emploi'),
   deleteCertificationIssueReport: require('./delete-certification-issue-report'),

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-serializer.js
@@ -7,4 +7,14 @@ module.exports = {
       meta,
     }).serialize(targetProfiles);
   },
+
+  deserialize(json) {
+    return {
+      name: json.data.attributes['name'],
+      ownerOrganizationId: json.data.attributes['owner-organization-id'],
+      isPublic: json.data.attributes['is-public'],
+      imageUrl: json.data.attributes['image-url'],
+      skillsId: json.data.attributes['skills-id'],
+    };
+  },
 };

--- a/api/scripts/generate-campaign-with-participants.js
+++ b/api/scripts/generate-campaign-with-participants.js
@@ -304,7 +304,7 @@ async function _do({ organizationId, participantCount, profileType, campaignType
   } else {
     await _createParticipants({ count: participantCount, targetProfile, campaignId, trx });
   }
-  trx.commit();
+  await trx.commit();
   console.log(`Campagne: ${campaignId}\nOrganisation: ${organizationId}\nNombre de participants: ${participantCount}\nTargetProfile: ${targetProfile.id}`);
 }
 

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -40,6 +40,50 @@ describe('Acceptance | Controller | target-profile-controller', () => {
     server = await createServer();
   });
 
+  describe('POST /api/admin/target-profiles', () => {
+    let user;
+
+    beforeEach(async () => {
+      mockLearningContent(learningContent);
+
+      user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+
+      await databaseBuilder.commit();
+    });
+
+    afterEach(async () => {
+      await knex('target-profiles_skills').delete();
+      await knex('target-profiles').delete();
+    });
+
+    it('should return 200', async () => {
+      const options = {
+        method: 'POST',
+        url: '/api/admin/target-profiles',
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        payload: {
+          data: {
+            attributes: {
+              'name': 'targetProfileName',
+              'is-public': false,
+              'owner-organization-id': null,
+              'skills-id': [skillId],
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.result.data.relationships.skills.data.length).to.equal(1);
+      expect(response.result.data.relationships.skills.data[0].id).to.equal(skillId);
+    });
+  });
+
   describe('GET /api/admin/target-profiles/{id}', () => {
     let user;
     let targetProfileId;

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -44,7 +44,6 @@ describe('Unit | Controller | target-profile-controller', () => {
         expect(usecases.updateTargetProfileName).to.have.been.calledOnce;
         expect(usecases.updateTargetProfileName).to.have.been.calledWithMatch({ id: 123, name: 'Pixer123' });
       });
-
     });
   });
 });

--- a/api/tests/unit/domain/usecases/create-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/create-target-profile_test.js
@@ -1,0 +1,63 @@
+const { TargetProfileInvalidError } = require('../../../../lib/domain/errors');
+
+const { expect, catchErr, sinon } = require('../../../test-helper');
+const createTargetProfile = require('../../../../lib/domain/usecases/create-target-profile');
+
+describe('Unit | UseCase | create-target-profile', () => {
+  let targetProfileRepositoryStub;
+  let targetProfileWithLearningContentRepositoryStub;
+
+  const targetProfileId = 'targetProfileId';
+  const organizationId = null;
+  const name = 'MyTargetProfile';
+  const isPublic = false;
+  const imageUrl = 'myurlsample';
+
+  beforeEach(() => {
+    targetProfileRepositoryStub = {
+      create: sinon.stub(),
+    };
+
+    targetProfileWithLearningContentRepositoryStub = {
+      get: sinon.stub(),
+    };
+
+  });
+
+  it('should create target profile with skills given data', async () => {
+    const skillsId = ['skill1-tube1', 'skill3-tube1'];
+    const targetProfile = Symbol('ok');
+    //given
+    const targetProfileData = {
+      isPublic,
+      name,
+      imageUrl,
+      organizationId,
+      skillsId,
+    };
+
+    targetProfileRepositoryStub.create.withArgs(targetProfileData).resolves(targetProfileId);
+    targetProfileWithLearningContentRepositoryStub.get.withArgs({ id: targetProfileId }).resolves(targetProfile);
+
+    //when
+    const result = await createTargetProfile({ targetProfileData, targetProfileRepository: targetProfileRepositoryStub, targetProfileWithLearningContentRepository: targetProfileWithLearningContentRepositoryStub });
+
+    expect(result).to.equal(targetProfile);
+  });
+
+  it('should return TargetProfileInvalidError given empty skills', async () => {
+    const skillsId = [];
+    //given
+    const targetProfileData = {
+      isPublic,
+      name,
+      imageUrl,
+      organizationId,
+      skillsId,
+    };
+
+    const result = await catchErr(createTargetProfile)({ targetProfileData, targetProfileRepository: targetProfileRepositoryStub, targetProfileWithLearningContentRepository: targetProfileWithLearningContentRepositoryStub });
+
+    expect(result).to.be.instanceOf(TargetProfileInvalidError);
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, la création de profil cible par les internes Pix est un process long et qui présente bcp de risques d'erreurs/mauvaise manips. Le process existant consiste notamment en l'extraction d'un fichier JSON issu de PixEditor afin d'en créer un profil cible directement en BDD.
On souhaite proposer côté PixAdmin, pour l'ensemble du process et +, une interface + user friendly et moins stressante !

## :robot: Solution
Pour commencer, on décide de conserver dans un premier temps l'usage de ce fichier JSON. On propose donc un formulaire de création de profil cible par PixAdmin lequel nous permet de renseigner les informations de base + inclure le fichier JSON.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Tester la bonne création du nouveau profil cible !
