### PR TITLE
[FEATURE] Améliorer le wording de la page de finalisation d'une session (PIX-1985)

### DIFF
--- a/certif/app/components/session-finalization-examiner-global-comment-step.hbs
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.hbs
@@ -11,7 +11,7 @@
             aria-label="Ne déclarer aucun incident"
             {{on "change" (fn this.toggleDisplayExaminerGlobalCommentTextArea false)}}
           >
-          Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé
+            Aucun problème sur la session, en dehors des signalements individuels renseignés lors de l'étape 1.
         </label>
       </div>
 

--- a/certif/app/components/session-finalization-formbuilder-link-step.hbs
+++ b/certif/app/components/session-finalization-formbuilder-link-step.hbs
@@ -4,7 +4,7 @@
       {{this.text}}
     </span>
       <a href={{this.linkTo}} target="_blank" rel="noopener noreferrer">
-        <FaIcon @icon='arrow-right' /> Formulaire 123formbuilder
+        <FaIcon @icon='arrow-right' /> Formulaire
       </a>
   </div>
   {{#if this.subText.length}}

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
@@ -90,7 +90,7 @@ module('Integration | Component | session-finalization-examiner-global-comment-s
               @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
 
       // then
-      assert.contains('Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé');
+      assert.contains('Aucun problème sur la session, en dehors des signalements individuels renseignés lors de l\'étape 1.');
       assert.contains('Je souhaite signaler un ou plusieurs incident(s) ayant impacté la session dans son ensemble');
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Il est difficile pour les utilisateurs Pix Certif de comprendre ce qu'ils doivent remplir dans le champ commentaire global d'une session. Ils ont tendance à y mettre les signalements concernant des candidats particuliers, alors que ce champ est prévu pour mettre un commentaire global relatif à toute la session de certification.
De plus, à l'étape 2 le lien vers le formulaire mentionne "123formbuilder", cela crée des incompréhensions.

## :robot: Solution
1) Modifier le wording du lien vers 123formbuilder, remplacer “Formulaire 123formbuilder” par “Formulaire”

2) Modifier le wording de la 1ère option de l'étape 3 : remplacer “Aucun problème particulier à signaler, dans l’ensemble tout s’est bien déroulé” par “Aucun problème sur la session, en dehors des signalements individuels renseignés lors de l'étape 1.”

## :rainbow: Remarques
Echange sur le wording à adopter : https://1024pix.slack.com/archives/C66CN9STX/p1610615515004600

## :100: Pour tester
- Lancer Certif et l'api
- Se connecter avec certifsco@example.net
- Aller dans la session 4
- Cliquer sur le bouton finaliser
- Constater les changement de wording