### PR TITLE
[FEATURE] Mise à jour de la bannière de campagnes dans Pix Orga (PIX-1776).

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -1,20 +1,15 @@
 {{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
-  <PixBanner>
-    <FaIcon @icon="exclamation-triangle" class="warning-icon" />
+  <PixBanner class="information-banner">
+    <FaIcon @icon="exclamation-triangle" class="icon--warning icon--margin"/>
     Rentrée 2020 : l’<strong>administrateur</strong> doit
-    <LinkTo @route="authenticated.sco-students" class="link link-dark">
-      importer ou ré-importer la base élèves
-    </LinkTo>
+    <LinkTo @route="authenticated.sco-students" class="link link--white link--bold link--underlined">
+      importer ou ré-importer la base élèves</LinkTo>
     pour initialiser Pix Orga. Plus d’info
-    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link-dark" target="_blank" rel="noopener noreferrer">
-      collège
-      <FaIcon @icon="external-link-alt" />
-    </a>
+    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
+      collège <FaIcon @icon="external-link-alt" /></a>
     et
-    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link-dark" target="_blank" rel="noopener noreferrer">
-      lycée (GT et Pro)
-      <FaIcon @icon="external-link-alt" />
-    </a>
+    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
+      lycée (GT et Pro) <FaIcon @icon="external-link-alt" /></a>
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner>

--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -12,16 +12,12 @@
       lycée (GT et Pro) <FaIcon @icon="external-link-alt" /></a>
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
-  <PixBanner>
-    <strong>Parcours de rentrée 2020</strong> : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant les vacances de Noël. Plus d’info
-    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" class="link link-dark" target="_blank" rel="noopener noreferrer">
-      collège
-      <FaIcon @icon="external-link-alt" />
-    </a>
-    et
-    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba" class="link link-dark" target="_blank" rel="noopener noreferrer">
-      lycée (GT et Pro)
-      <FaIcon @icon="external-link-alt" />
-    </a>
+  <PixBanner class="information-banner">
+    <FaIcon @icon="bullhorn" class="icon--margin"/>
+    Il est important de vérifier que les élèves soient <strong>certifiables</strong> avant de les inscrire en session de certification. Vous pouvez faire une
+    <a href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
+      campagne de collecte de profils
+      <FaIcon @icon="external-link-alt"/></a>
+    pour vous en assurer.
   </PixBanner>
 {{/if}}

--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-const bannerDeadLine = '2020-11-02';
 export default class InformationBanner extends Component {
   @service currentUser;
   get displayNewYearSchoolingRegistrationsImportBanner() {
@@ -11,9 +10,7 @@ export default class InformationBanner extends Component {
   }
 
   get displayNewYearCampaignsBanner() {
-    const isBeforeBannerDeadLine = new Date() < new Date(bannerDeadLine);
-    return isBeforeBannerDeadLine &&
-      this.currentUser.isSCOManagingStudents &&
+    return this.currentUser.isSCOManagingStudents &&
       !this.currentUser.isAgriculture;
   }
 }

--- a/orga/app/components/manage-authentication-method-modal.hbs
+++ b/orga/app/components/manage-authentication-method-modal.hbs
@@ -140,7 +140,7 @@
             <button id="generate-password" type="button" class="button" {{on 'click' this.resetPassword}}>Réinitialiser le mot de passe</button>
 
             <div class="manage-authentication-window__warning">
-              <FaIcon @icon="exclamation-triangle" class="warning-icon" />
+              <FaIcon @icon="exclamation-triangle" class="icon--warning" />
               <span>Réinitialiser supprime le mot de passe actuel de l’élève</span>
             </div>
           </div>

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -24,6 +24,7 @@
 @import "components/dissociate-user-modal";
 @import "components/edit-student-number-modal";
 @import "components/dropdown";
+@import "components/information-banner";
 @import "components/join-request-form";
 @import "components/pagination-control";
 @import "components/previous-page-button";

--- a/orga/app/styles/components/information-banner.scss
+++ b/orga/app/styles/components/information-banner.scss
@@ -1,0 +1,3 @@
+.information-banner {
+  background-color: darken($dark-orga, 10%);
+}

--- a/orga/app/styles/components/manage-authentication-method-modal.scss
+++ b/orga/app/styles/components/manage-authentication-method-modal.scss
@@ -54,10 +54,6 @@
     color: $white;
     font-size: .875rem;
 
-    .warning-icon {
-      color: $information-light;
-    }
-
     span {
       margin-left: 10px;
     }

--- a/orga/app/styles/globals/icons.scss
+++ b/orga/app/styles/globals/icons.scss
@@ -1,3 +1,10 @@
-.warning-icon {
-  color: $warning;
+.icon {
+
+  &--margin {
+    margin: 0 8px;
+  }
+
+  &--warning {
+    color: $warning;
+  }
 }

--- a/orga/app/styles/globals/texts.scss
+++ b/orga/app/styles/globals/texts.scss
@@ -87,13 +87,26 @@
     color: $blue-hover;
   }
 
-  &-dark {
-    color: darken($blue, 20%);
+  &--bold {
+    font-weight: 600;
+  }
 
-    &:hover,
+  &--underlined {
+    text-decoration: underline;
+  }
+
+  &--white {
+    color: $white;
+
+    &:hover {
+      color: $white;
+      opacity: 0.85;
+    }
+
     &:focus,
-    &:active {
-      color:  darken($blue-hover, 10%);
+    &:active{
+      color: $black;
+      background-color: $yellow;
     }
   }
 }

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -6,6 +6,7 @@ module.exports = function() {
       'arrow-left',
       'arrow-right',
       'arrow-up',
+      'bullhorn',
       'chevron-down',
       'chevron-up',
       'ellipsis-v',

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -101,62 +101,20 @@ module('Integration | Component | information-banner', function(hooks) {
 
   module('Campaign Banner', () => {
     module('when prescriber’s organization is of type SCO that manages students', function() {
-      module('when banner dead line has passed', function(hooks) {
-        const now = new Date('2020-11-03T00:00:00Z');
-        let clock;
+      test('should render the campaign banner', async function(assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: true }
+          isSCOManagingStudents = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
 
-        hooks.beforeEach(() => {
-          clock = sinon.useFakeTimers(now);
-        });
+        // when
+        await render(hbs`<InformationBanner/>`);
 
-        hooks.afterEach(() => {
-          clock.restore();
-        });
-
-        test('should not render the campaign banner', async function(assert) {
-          // given
-          class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true }
-            isSCOManagingStudents = true;
-          }
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          await render(hbs`<InformationBanner/>`);
-
-          // then
-          assert.dom('.pix-banner').doesNotExist();
-        });
-      });
-
-      module('when banner dead line has not passed', function(hooks) {
-        const now = new Date('2019-01-01T05:06:07Z');
-        let clock;
-
-        hooks.beforeEach(() => {
-          clock = sinon.useFakeTimers(now);
-        });
-
-        hooks.afterEach(() => {
-          clock.restore();
-        });
-
-        test('should render the campaign banner', async function(assert) {
-          // given
-          class CurrentUserStub extends Service {
-            prescriber = { areNewYearSchoolingRegistrationsImported: true }
-            isSCOManagingStudents = true;
-          }
-          this.owner.register('service:current-user', CurrentUserStub);
-
-          // when
-          await render(hbs`<InformationBanner/>`);
-
-          // then
-          assert.dom('a[href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
-          assert.dom('a[href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=e11f61b2-3047-4be3-9a4d-dd9e7cc698ba"]').exists();
-          assert.dom('.pix-banner').includesText('Parcours de rentrée 2020 : les codes sont disponibles dans l’onglet Campagnes. N’oubliez pas de les diffuser aux élèves avant les vacances de Noël. Plus d’info collège et lycée (GT et Pro)');
-        });
+        // then
+        assert.dom('a[href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea"]').exists();
+        assert.dom('.pix-banner').includesText('Il est important de vérifier que les élèves soient certifiables avant de les inscrire en session de certification. Vous pouvez faire une campagne de collecte de profils pour vous en assurer.');
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
La bannière n'était plus à jour et désormais on veut pousser les organisations à partager le code des campagnes de collecte de profils afin de vérifier que les élèves sont tous certifiables avant d'être inscrit en session de certification.

## :robot: Solution
Modifier la bannière.

## :rainbow: Remarques
Modification de l'apparence pour plus d'accessibilité.

## :100: Pour tester
- Se connecter à Pix Orga en tant que sco.admin@example.net
- Aller sur "Collège The Night Watch" et regarder le bon affichage de la bannière de campagnes de collecte ainsi que le bon fonctionnement du lien
- Aller sur "Lycée The Night Watch" et regarder le bon affichage de la bannière d'import ainsi que le bon fonctionnement des liens