### PR TITLE
[FIX] Corrige le rattachement d'un profil cible à une ou plusieurs organisations

### DIFF
--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -3,7 +3,7 @@
     <h2 class="page-section__title">Rattacher une ou plusieurs organisation(s)</h2>
   </header>
   <div class="organization__forms-section">
-    <form aria-label=">Rattacher une ou plusieurs organisation(s)" class="organization__sub-form form">
+    <form aria-label="Rattacher une ou plusieurs organisation(s)" class="organization__sub-form form">
       <Input aria-label="ID de ou des organisation(s)" @value={{@organizationsToAttach}}
         class="organization-sub-form__input form-field__text form-control" @placeholder="1, 2" />
       <button type="button" {{on "click" @attachOrganizations}}

--- a/admin/app/components/target-profiles/organizations.hbs
+++ b/admin/app/components/target-profiles/organizations.hbs
@@ -3,7 +3,7 @@
     <h2 class="page-section__title">Rattacher une ou plusieurs organisation(s)</h2>
   </header>
   <div class="organization__forms-section">
-    <form aria-label="Rattacher une ou plusieurs organisation(s)" class="organization__sub-form form">
+    <form aria-label="Rattacher une ou plusieurs organisation(s)" class="organization__sub-form form" {{on "submit" @attachOrganizations}}>
       <Input aria-label="ID de ou des organisation(s)" @value={{@organizationsToAttach}}
         class="organization-sub-form__input form-field__text form-control" @placeholder="1, 2" />
       <button type="button" {{on "click" @attachOrganizations}}

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -40,7 +40,8 @@ export default class TargetProfileOrganizationsController extends Controller {
   }
 
   @action
-  async attachOrganizations() {
+  async attachOrganizations(e) {
+    e.preventDefault();
     const targetProfile = this.model.targetProfile;
     try {
       await targetProfile.attachOrganizations({ 'organization-ids': this._getUniqueOrganizations() });

--- a/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile/organizations.js
@@ -41,7 +41,7 @@ export default class TargetProfileOrganizationsController extends Controller {
 
   @action
   async attachOrganizations() {
-    const targetProfile = this.model;
+    const targetProfile = this.model.targetProfile;
     try {
       await targetProfile.attachOrganizations({ 'organization-ids': this._getUniqueOrganizations() });
       this.organizationsToAttach = null;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -26,7 +26,11 @@ export default class TargetProfileOrganizationsRoute extends Route {
         externalId: params.externalId,
       },
     };
-    return await this.store.query('organization', queryParams);
+    const organizations = await this.store.query('organization', queryParams);
+    return {
+      organizations,
+      targetProfile
+    };
   }
 
   resetController(controller, isExiting) {

--- a/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile/organizations.hbs
@@ -1,5 +1,5 @@
 <TargetProfiles::Organizations
-  @organizations={{@model}}
+  @organizations={{@model.organizations}}
   @id={{this.id}}
   @name={{this.name}}
   @type={{this.type}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -1,5 +1,5 @@
 import { createMembership } from './handlers/memberships';
-import { attachTargetProfiles, getOrganizationTargetProfiles, findPaginatedTargetProfileOrganizations, updateTargetProfileName } from './handlers/target-profiles';
+import { attachTargetProfiles, attachTargetProfileToOrganizations, getOrganizationTargetProfiles, findPaginatedTargetProfileOrganizations, updateTargetProfileName } from './handlers/target-profiles';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findPaginatedOrganizationMemberships } from './handlers/organizations';
@@ -48,6 +48,7 @@ export default function() {
   this.get('/admin/target-profiles/:id');
   this.patch('/admin/target-profiles/:id');
   this.get('/admin/target-profiles/:id/organizations', findPaginatedTargetProfileOrganizations);
+  this.post('/admin/target-profiles/:id/attach-organizations', attachTargetProfileToOrganizations);
   this.patch('/admin/target-profiles/:id', updateTargetProfileName);
 
   this.get('/admin/certifications/:id');

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -11,6 +11,15 @@ function attachTargetProfiles(schema, request) {
   return new Response(204);
 }
 
+function attachTargetProfileToOrganizations(schema, request) {
+  const targetProfileId = request.params.id;
+  const params = JSON.parse(request.requestBody);
+  const organizationsToAttach = params['organization-ids'];
+  organizationsToAttach.forEach((organizationId) =>
+    schema.organizations.create({ id: organizationId, name: `Organization ${organizationId}` }));
+  return new Response(204);
+}
+
 async function getOrganizationTargetProfiles(schema, request) {
   const ownerOrganizationId = request.params.id;
   return schema.targetProfiles.where({ ownerOrganizationId });
@@ -61,6 +70,7 @@ function updateTargetProfileName(schema, request) {
 
 export {
   attachTargetProfiles,
+  attachTargetProfileToOrganizations,
   getOrganizationTargetProfiles,
   findPaginatedTargetProfileOrganizations,
   updateTargetProfileName,

--- a/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
@@ -1,0 +1,47 @@
+import { click, fillIn, visit } from '@ember/test-helpers';
+import { module, test, setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { createAuthenticateSession } from '../../../helpers/test-init';
+
+module('Acceptance | authenticated/targets-profile/target-profile/organizations', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let currentUser;
+  let targetProfile;
+
+  hooks.beforeEach(async function() {
+    currentUser = server.create('user');
+    await createAuthenticateSession({ userId: currentUser.id });
+
+    targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
+  });
+
+  module('with multiple organizations', function(hooks) {
+    let myOrganization;
+    let myOtherOrganization;
+
+    hooks.beforeEach(async function() {
+      myOrganization = this.server.create('organization', { name: 'My organization' });
+      myOtherOrganization = this.server.create('organization', { name: 'My other organization' });
+    });
+
+    test('should list organizations', async function(assert) {
+      await visit(`/target-profiles/${targetProfile.id}/organizations`);
+
+      assert.contains('My organization');
+      assert.contains('My other organization');
+    });
+  });
+
+  test('should be able to add new organization to the target profile', async function(assert) {
+    await visit(`/target-profiles/${targetProfile.id}/organizations`);
+
+    await fillIn('[aria-label="ID de ou des organisation(s)"]', '42');
+    await click('[aria-label="Rattacher une ou plusieurs organisation(s)"] button');
+
+    assert.dom('[aria-label="Organisation"]').includesText('42');
+    assert.dom('[aria-label="ID de ou des organisation(s)"]').hasNoValue();
+  });
+});

--- a/admin/tests/integration/components/organizations-test.js
+++ b/admin/tests/integration/components/organizations-test.js
@@ -57,7 +57,7 @@ module('Integration | Component | target-profiles organizations', function(hooks
     // when
     await render(hbs`<TargetProfiles::Organizations @organizations={{this.organizations}} @organizationsToAttach={{this.organizationsToAttach}} @attachOrganizations={{action this.attachOrganizations}} @goToOrganizationPage={{this.goToOrganizationPage}} @triggerFiltering={{this.triggerFiltering}}/>`);
     await fillIn('[aria-label="ID de ou des organisation(s)', '1, 2');
-    await click('[aria-label=">Rattacher une ou plusieurs organisation(s)"] button');
+    await click('[aria-label="Rattacher une ou plusieurs organisation(s)"] button');
 
     sinon.assert.called(attachOrganizations);
     assert.equal(this.organizationsToAttach, '1, 2');

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
@@ -60,13 +60,13 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
     module('when attaching organization works correctly', () => {
       test('it displays a success notifications', async (assert) => {
         controller.notifications = Service.create({ success: sinon.stub() });
-        controller.model = { attachOrganizations: sinon.stub().resolves() };
+        controller.model = { targetProfile: { attachOrganizations: sinon.stub().resolves() } };
         controller.organizationsToAttach = '1,2';
         controller.send = sinon.stub();
 
         await controller.attachOrganizations();
 
-        assert.ok(controller.model.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
+        assert.ok(controller.model.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
         assert.equal(controller.organizationsToAttach, null);
         assert.ok(controller.notifications.success.calledWith('Organisation(s) rattaché(es) avec succès.'));
         assert.ok(controller.send.calledWith('refreshModel'));
@@ -76,13 +76,13 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
     module('when an organization is present several times', () => {
       test('it remove duplicate ids', async (assert) => {
         controller.notifications = Service.create({ success: sinon.stub() });
-        controller.model = { attachOrganizations: sinon.stub().resolves() };
+        controller.model = { targetProfile: { attachOrganizations: sinon.stub().resolves() } };
         controller.organizationsToAttach = '1,1,2,3,3';
         controller.send = sinon.stub();
 
         await controller.attachOrganizations();
 
-        assert.ok(controller.model.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
+        assert.ok(controller.model.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
         assert.equal(controller.organizationsToAttach, null);
         assert.ok(controller.send.calledWith('refreshModel'));
       });
@@ -99,7 +99,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
             ],
           };
           controller.notifications = Service.create({ error: sinon.stub() });
-          controller.model = { attachOrganizations: sinon.stub().rejects(errors) };
+          controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
           await controller.attachOrganizations();
@@ -118,7 +118,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
             ],
           };
           controller.notifications = Service.create({ error: sinon.stub() });
-          controller.model = { attachOrganizations: sinon.stub().rejects(errors) };
+          controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,5,3,3';
 
           await controller.attachOrganizations();
@@ -137,7 +137,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
             ],
           };
           controller.notifications = Service.create({ error: sinon.stub() });
-          controller.model = { attachOrganizations: sinon.stub().rejects(errors) };
+          controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
           await controller.attachOrganizations();
@@ -153,7 +153,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
             ],
           };
           controller.notifications = Service.create({ error: sinon.stub() });
-          controller.model = { attachOrganizations: sinon.stub().rejects(errors) };
+          controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
           await controller.attachOrganizations();
@@ -167,7 +167,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         test('it displays a default notification', async (assert) => {
           const errors = {};
           controller.notifications = Service.create({ error: sinon.stub() });
-          controller.model = { attachOrganizations: sinon.stub().rejects(errors) };
+          controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
           await controller.attachOrganizations();

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
@@ -55,7 +55,13 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
     });
   });
 
-  module('#attachOrganizations', function() {
+  module('#attachOrganizations', function(hooks) {
+
+    let event;
+
+    hooks.beforeEach(function() {
+      event = { preventDefault() {} };
+    });
 
     module('when attaching organization works correctly', () => {
       test('it displays a success notifications', async (assert) => {
@@ -64,7 +70,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         controller.organizationsToAttach = '1,2';
         controller.send = sinon.stub();
 
-        await controller.attachOrganizations();
+        await controller.attachOrganizations(event);
 
         assert.ok(controller.model.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2] }));
         assert.equal(controller.organizationsToAttach, null);
@@ -80,7 +86,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
         controller.organizationsToAttach = '1,1,2,3,3';
         controller.send = sinon.stub();
 
-        await controller.attachOrganizations();
+        await controller.attachOrganizations(event);
 
         assert.ok(controller.model.targetProfile.attachOrganizations.calledWith({ 'organization-ids': [1, 2, 3] }));
         assert.equal(controller.organizationsToAttach, null);
@@ -102,7 +108,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
           controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
-          await controller.attachOrganizations();
+          await controller.attachOrganizations(event);
 
           assert.equal(controller.organizationsToAttach, '1,1,2,3,3');
           assert.ok(controller.notifications.error.calledWith('I am displayed 1'));
@@ -121,7 +127,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
           controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,5,3,3';
 
-          await controller.attachOrganizations();
+          await controller.attachOrganizations(event);
 
           assert.equal(controller.organizationsToAttach, '1,1,5,3,3');
           assert.ok(controller.notifications.error.calledWith('I am displayed too 1'));
@@ -140,7 +146,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
           controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
-          await controller.attachOrganizations();
+          await controller.attachOrganizations(event);
 
           assert.equal(controller.organizationsToAttach, '1,1,2,3,3');
           assert.equal(controller.notifications.error.withArgs('Une erreur est survenue.').callCount, 2);
@@ -156,7 +162,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
           controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
-          await controller.attachOrganizations();
+          await controller.attachOrganizations(event);
 
           assert.equal(controller.organizationsToAttach, '1,1,2,3,3');
           assert.notOk(controller.notifications.error.called);
@@ -170,7 +176,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
           controller.model = { targetProfile: { attachOrganizations: sinon.stub().rejects(errors) } };
           controller.organizationsToAttach = '1,1,2,3,3';
 
-          await controller.attachOrganizations();
+          await controller.attachOrganizations(event);
 
           assert.equal(controller.organizationsToAttach, '1,1,2,3,3');
           assert.ok(controller.notifications.error.calledWith('Une erreur est survenue.'));


### PR DESCRIPTION
## :unicorn: Problème
En refactorant la récupération des organisations dans #2370 nous avons cassé l'action de rattachement d'une organisation a un profil cible. En effet le model était devenu un tableau d'organisations plutôt qu'un profil cible

## :robot: Solution
Renvoyer dans le model le profil cible et les organisations. Et rajouter un test d'application.

## :rainbow: Remarques
_Néant_

## :100: Pour tester

https://user-images.githubusercontent.com/86659/104654581-a3fc6680-56bc-11eb-90f8-f23436c6719a.mp4


