### PR TITLE
[TECH] Mise à jour de la description du repository.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -2,7 +2,7 @@
   "name": "pix-api",
   "version": "3.9.0",
   "private": false,
-  "description": "Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones",
+  "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -15,7 +15,7 @@ describe('Unit | Controller | healthcheckController', () => {
       // then
       expect(response).to.include.keys('name', 'version', 'description');
       expect(response['name']).to.equal('pix-api');
-      expect(response['description']).to.equal('Plateforme d\'évaluation et de certification des compétences numériques à l\'usage de tous les citoyens francophones');
+      expect(response['description']).to.equal('Plateforme d\'évaluation et de certification des compétences numériques');
       expect(response['environment']).to.equal('test');
     });
   });

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -2,7 +2,7 @@
   "name": "mon-pix",
   "version": "3.9.0",
   "private": false,
-  "description": "Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones.",
+  "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pix",
   "version": "3.9.0",
   "private": false,
-  "description": "Plateforme d'évaluation et de certification des compétences numériques des citoyens francophones.",
+  "description": "Plateforme d'évaluation et de certification des compétences numériques",
   "license": "AGPL-3.0",
   "author": "GIP Pix",
   "engines": {


### PR DESCRIPTION
## :unicorn: Problème
La description actuelle (package.json) mentionne
> Plateforme d'évaluation et de certification des compétences numériques à l'usage de tous les citoyens francophones

Or la plateforme est disponible
- en anglais, plus seulement en français
- aux salariés, plus seulement aux citoyens

## :robot: Solution
Modifier la description vers
> Plateforme d'évaluation et de certification des compétences numériques

## :rainbow: Remarques
C'est l'occasion de décider si
- on met la même description partout (root + sous-dossiers)
- on met cette description à la racine, et un description de l'application dans le sous-dossier

Actuellement, les sous-dossiers n'ont pas le même type de contenu