### PR TITLE
[BUGFIX] Corriger certains bugs lors du changement de centre de certification dans Pix Certif (PIX-1980).

### DIFF
--- a/certif/app/controllers/authenticated.js
+++ b/certif/app/controllers/authenticated.js
@@ -10,14 +10,15 @@ export default class AuthenticatedController extends Controller {
 
   @tracked isBannerVisible = true;
   @service router;
+  @service currentUser;
 
   get showBanner() {
     const isOnFinalizationPage = this.router.currentRouteName === 'authenticated.sessions.finalize';
-    return this.model.isScoManagingStudents && this.isBannerVisible && !isOnFinalizationPage;
+    return this.currentUser.currentCertificationCenter.isScoManagingStudents && this.isBannerVisible && !isOnFinalizationPage;
   }
 
   get documentationLink() {
-    if (this.model.isScoManagingStudents) {
+    if (this.currentUser.currentCertificationCenter.isScoManagingStudents) {
       return LINK_SCO;
     }
     return LINK_OTHER;

--- a/certif/app/routes/authenticated/sessions/add-student.js
+++ b/certif/app/routes/authenticated/sessions/add-student.js
@@ -1,7 +1,11 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
+
+  @service currentUser;
+
   queryParams = {
     pageNumber: { refreshModel: true },
     pageSize: { refreshModel: true },
@@ -10,8 +14,7 @@ export default class AuthenticatedSessionsDetailsAddStudentRoute extends Route {
 
   async model(params) {
     const session = await this.store.findRecord('session', params.session_id);
-    const { id: certificationCenterId } = this.modelFor('authenticated');
-
+    const certificationCenterId = this.currentUser.currentCertificationCenter.id;
     const certificationCandidates = await this.store.query('certification-candidate', { sessionId: params.session_id });
     const divisions = await this.store.query('division', { certificationCenterId });
 

--- a/certif/tests/unit/controllers/authenticated-test.js
+++ b/certif/tests/unit/controllers/authenticated-test.js
@@ -10,9 +10,11 @@ module('Unit | Controller | authenticated', function(hooks) {
       const controller = this.owner.lookup('controller:authenticated');
 
       // when
-      controller.model = { isScoManagingStudents: true };
+      controller.currentUser = {
+        currentCertificationCenter: { isScoManagingStudents: true },
+      };
       const actualScoLink = controller.documentationLink;
-      controller.model = { isScoManagingStudents: false };
+      controller.currentUser.currentCertificationCenter.isScoManagingStudents = false;
       const actualOtherLink = controller.documentationLink;
 
       // then

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -33,11 +33,13 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       const findRecordStub = sinon.stub();
       findRecordStub.withArgs('session', session_id).resolves(session);
       route.store.findRecord = findRecordStub;
-      route.modelFor = sinon.stub().returns({ id: certificationCenterId });
       route.store.query = sinon.stub();
       route.store.query.onCall(0).resolves([Symbol('a candidate')]);
       route.store.query.onCall(1).resolves(divisions);
       route.store.query.onCall(2).resolves(paginatedStudents);
+      route.currentUser = {
+        currentCertificationCenter: { id: certificationCenterId },
+      };
 
       const expectedModel = {
         certificationCenterDivisions: [
@@ -60,7 +62,6 @@ module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
       const actualModel = await route.model({ session_id, pageNumber: 1, pageSize: 1 });
 
       // then
-      sinon.assert.calledWith(route.modelFor, 'authenticated');
       sinon.assert.calledWith(route.store.query, 'student', {
         filter: {
           certificationCenterId,


### PR DESCRIPTION
## :unicorn: Problème
Suite à la mise en place du multi certif dans Pix Certif, certaines parties de l'application n'étaient pas mise à jour lors deu changement de centre de certif:
- La liste des candidats à ajouter à une session de certification.
- Le lien de documentation qui diffère selon le type du centre de certification.
- L'affichage ou non de la bannière qui est dépendant du type de certification.  

## :robot: Solution
Utiliser les informations issues du service current-user plutôt que se baser sur l'état du model de la route authenticated.

## :rainbow: Remarques
Il apparaît que lorsque nous redirigeons l'utilisateur sur la route `authenticated`, le model de cette dernière n'est pas réactualiser bien que la valeur du `currentCertificationCenter` du service `currentUser soit bien mise à jour

## :100: Pour tester

- Se connecter à Pix Certif avec l'utilisateur `sco.admin@example.net`.
- Vérifier que le lien de documentation pour une centre de certif SUP est "http://cloud.pix.fr/s/fLSG4mYCcX7GDRF",
- Changer pour un des centre de certif SCO et vérifier que le lien de documentation est "http://cloud.pix.fr/s/GqwW6dFDDrHezfS" et que la bannière verte "Il est important de vérifier que les élèves..." est affichée.
- Sélectionner le centre de certif ayant l'UAI `123457A`, cliquer sur l'une des sessions, cliquer sur `Candidats` puis "Ajouter des candidats". Vérifier que les élèves de la liste correspondent bien à ceux présent dans Pix Orga pour l'organisation ayant le même UAI (se connecter avec le même compte utilisateur sur Pix Orga).
- Sélectionner le centre de certif ayant l'UAI `123457B`, cliquer sur l'une des sessions, cliquer sur `Candidats` puis "Ajouter des candidats". Vérifier que les élèves de la liste correspondent bien à ceux présent dans Pix Orga pour l'organisation ayant le même UAI