### PR TITLE
[FEATURE] Enlever le chevron dans Pix Orga au sein de l'onglet analyse quand il n'y a pas de tutoriels (PIX-1811).

### DIFF
--- a/orga/app/components/chevron.hbs
+++ b/orga/app/components/chevron.hbs
@@ -1,4 +1,3 @@
-<div class="table__column--right">
   <button type="button" class="icon-button" {{on 'click' @toggleParent}} aria-expanded="{{@isOpen}}">
     {{#if @isOpen}}
       <FaIcon @icon="chevron-up" />
@@ -6,4 +5,3 @@
       <FaIcon @icon="chevron-down" />
     {{/if}}
   </button>
-</div>

--- a/orga/app/components/chevron.hbs
+++ b/orga/app/components/chevron.hbs
@@ -1,0 +1,9 @@
+<div class="table__column--right">
+  <button type="button" class="icon-button" {{on 'click' @toggleParent}} aria-expanded="{{@isOpen}}">
+    {{#if @isOpen}}
+      <FaIcon @icon="chevron-up" />
+    {{else}}
+      <FaIcon @icon="chevron-down" />
+    {{/if}}
+  </button>
+</div>

--- a/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
@@ -18,13 +18,9 @@
     <TutorialCounter @tutorials={{@tubeRecommendation.tutorials}} />
   </td>
   <td class="table__column--right">
-    <button type="button" class="icon-button" {{on 'click' this.toggleTutorialsSection}} aria-expanded="{{this.isOpen}}">
-      {{#if this.isOpen}}
-        <FaIcon @icon="chevron-up" />
-      {{else}}
-        <FaIcon @icon="chevron-down" />
-      {{/if}}
-    </button>
+    {{#if (gt @tubeRecommendation.tutorials.length 0)}}
+      <Chevron @isOpen={{this.isOpen}} @toggleParent={{this.toggleTutorialsSection}} />
+    {{/if}}
   </td>
 </tr>
 <tr class="tube-recommendation-tutorial {{if this.isOpen " tube-recommendation-tutorial--open"}}"
@@ -33,15 +29,12 @@
     <div class="tube-recommendation-tutorial-wrapper {{if this.isOpen " tube-recommendation-tutorial-wrapper--open"}}">
       <span class="competences-col__border competences-col__border--bottom {{if this.isOpen " competences-col__border--open"}}
         competences-col__border--{{@tubeRecommendation.areaColor}}"></span>
-      {{#if (eq @tubeRecommendation.tutorials.length 0)}}
-      <h3 class="tube-recommendation-tutorial__title">Aucun tuto recommandé pour ce sujet.</h3>
-      {{else}}
       <h3 class="tube-recommendation-tutorial__title">
         {{#if (eq @tubeRecommendation.tutorials.length 1)}}
           1 tuto recommandé par la communauté Pix
         {{else}}
           {{@tubeRecommendation.tutorials.length}} tutos recommandés par la communauté Pix
-      {{/if}}
+        {{/if}}
       </h3>
       <table class="tube-recommendation-tutorial-table">
         <tbody>
@@ -62,7 +55,6 @@
           {{/each}}
         </tbody>
       </table>
-      {{/if}}
     </div>
   </td>
 </tr>

--- a/orga/tests/integration/components/chevron_test.js
+++ b/orga/tests/integration/components/chevron_test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import sinon from 'sinon';
+import { render, click } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | chevron', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    const toggleParent = sinon.stub();
+    this.set('isOpen', false);
+    this.set('click', toggleParent);
+  });
+
+  test('it renders', async function(assert) {
+    // when
+    await render(hbs`<Chevron @isOpen={{isOpen}}  @toggleParent={{click}}/>`);
+
+    // then
+    assert.dom('button[type=button]').exists();
+    assert.dom('[aria-expanded="false"]').exists();
+  });
+
+  test('it should open the accordion when it is closed', async function(assert) {
+    // given
+    await render(hbs`<Chevron @isOpen={{isOpen}}  @toggleParent={{click}}/>`);
+
+    // when
+    await click('[data-icon="chevron-down"]');
+    this.set('isOpen', true);
+
+    // then
+    assert.dom('[aria-expanded="true"]').exists();
+
+  });
+
+  test('it should close the accordion when it already open', async function(assert) {
+    // given
+    await render(hbs`<Chevron @isOpen={{isOpen}}  @toggleParent={{click}}/>`);
+    this.set('isOpen', true);
+
+    // when
+    await click('[data-icon="chevron-up"]');
+    this.set('isOpen', false);
+
+    // then
+    assert.dom('[aria-expanded="false"]').exists();
+
+  });
+});

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
@@ -103,21 +103,6 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tube-re
     assert.dom('[aria-expanded="false"]').exists();
   });
 
-  test('it should display a "no data" message when tutorials are empty', async function(assert) {
-    // given
-    tubeRecommendation.tutorials = [];
-
-    await render(hbs`<Routes::Authenticated::Campaign::Analysis::TubeRecommendationRow
-      @tubeRecommendation={{tubeRecommendation}}
-    />`);
-
-    // when
-    await click('[data-icon="chevron-down"]');
-
-    // then
-    assert.dom('[aria-hidden="false"]').containsText('Aucun tuto recommandé pour ce sujet.');
-  });
-
   module('Testing the number of tutorials', () => {
     test('it should display "1 tuto" when there is only one tutorial', async function(assert) {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Le chevron est visible et peut être étendu même lorsqu'il n'y a pas de tutoriel à proposer.

## :robot: Solution
Enlever le chevron et supprimer le titre 'Aucun tuto recommandé pour ce sujet' quand il n'y a pas de tutoriel à proposer. 

## :rainbow: Remarques
Cette fonctionnalité n'est visible que sur les campagnes d'évaluation et non sur les campagnes de collecte de profils. La campagne d'évaluation sélectionnée doit avoir des participants à fin d'être analysée.

## :100: Pour tester
Connectez-vous sur Pix Orga , Cliquez sur Campagne puis sélectionnez une Campagne , cliquez sur l'onglet "analyse" pour voir tous les sujets de la campagne, Le chevron n'est maintenant plus visible pour les sujets qui n'ont aucun tutoriel proposé.