### PR TITLE
[FIX] Réintroduit le logging système sur l'API

### DIFF
--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -41,6 +41,14 @@ const plugins = [
   Inert,
   Vision,
   Blipp,
+  {
+    plugin: require('good'),
+    options: {
+      reporters: {
+        console: consoleReporters,
+      },
+    },
+  },
   ...(settings.sentry.enabled ? [
     {
       plugin: require('hapi-sentry'),


### PR DESCRIPTION
## :unicorn: Problème

Nous n'avons plus de retours sur les stats système en production depuis d638f8485036a0dd526cab92e334372fe7f8de8a

## :robot: Solution

Remettre le logger `good`

## Remarques

Le logger good est déprécié

## :100: Pour tester

1. Sur la review app de l'api
2. Vérifier que des infos systèmes sont loggé a interval régulier
