### PR TITLE
[BUG] Correction de flacky test sur les campaign report repository (PIX-1988)

### DIFF
--- a/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-report-repository_test.js
@@ -219,8 +219,8 @@ describe('Integration | Repository | Campaign-Report', () => {
         let filter;
 
         beforeEach(() => {
-          const creator1 = databaseBuilder.factory.buildUser({});
-          const creator2 = databaseBuilder.factory.buildUser({});
+          const creator1 = databaseBuilder.factory.buildUser({ firstName: 'Robert' });
+          const creator2 = databaseBuilder.factory.buildUser({ firstName: 'Bernard' });
 
           filter = { creatorName: creator1.firstName.toUpperCase() };
 
@@ -247,8 +247,8 @@ describe('Integration | Repository | Campaign-Report', () => {
         let filter;
 
         beforeEach(() => {
-          const creator1 = databaseBuilder.factory.buildUser({});
-          const creator2 = databaseBuilder.factory.buildUser({});
+          const creator1 = databaseBuilder.factory.buildUser({ lastName: 'Redford' });
+          const creator2 = databaseBuilder.factory.buildUser({ lastName: 'Menez' });
 
           filter = { creatorName: creator1.lastName.toUpperCase() };
 


### PR DESCRIPTION
## :unicorn: Problème

```
 1) Integration | Repository | Campaign-Report
       #findPaginatedFilteredByOrganizationId
         when the given organization has campaigns
           when some campaigns creator firstName match the given creatorName searched
             should return the matching campaigns:
      AssertionError: expected [ 'Maths L1', 'Chimie', 'Maths L2' ] to have the same members as [ 'Maths L1', 'Chimie' ]
      + expected - actual
       [
         "Maths L1"
         "Chimie"
      -  "Maths L2"
       ]
      at Context.<anonymous> (tests/integration/infrastructure/repositories/campaign-report-repository_test.js:241:69)
      at runMicrotasks (<anonymous>)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

Faker génère des `firstName` et `lastName` sur 2 utilisateurs différents pour tester les filtres. Parfois les 2 utilisateurs avaient les mêmes noms, donc les filtres ne retournaient pas les même résultats

## :robot: Solution

Mettre en dur les `firstName` et `lastName` pour qu'ils soient consistants à chaque exécution.

## :rainbow: Remarques

N/A

## :100: Pour tester

Exécution des tests