### PR TITLE
[FEATURE] Rediriger l'utilisateur vers la page des CGU Pôle Emploi sur Pix App(PIX-1695).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -73,6 +73,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.CampaignCodeError) {
     return new HttpErrors.NotFoundError(error.message);
   }
+  if (error instanceof DomainErrors.UserAccountNotFoundForPoleEmploiError) {
+    return new HttpErrors.UnauthorizedError(error.message, error.responseCode, { authenticationKey: error.authenticationKey });
+  }
   if (error instanceof DomainErrors.UserAlreadyExistsWithAuthenticationMethodError) {
     return new HttpErrors.ConflictError(error.message);
   }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -51,10 +51,12 @@ class NotFoundError extends BaseHttpError {
 }
 
 class UnauthorizedError extends BaseHttpError {
-  constructor(message) {
+  constructor(message, code, meta) {
     super(message);
     this.title = 'Unauthorized';
     this.status = 401;
+    this.code = code;
+    this.meta = meta;
   }
 }
 

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -639,6 +639,7 @@ class SchoolingRegistrationNotFound extends NotFoundError {
     super(message);
   }
 }
+
 class UserNotFoundError extends NotFoundError {
   constructor(message = 'Ce compte est introuvable.') {
     super(message);
@@ -653,6 +654,13 @@ class UserNotFoundError extends NotFoundError {
   }
 }
 
+class UserAccountNotFoundForPoleEmploiError extends DomainError {
+  constructor({ message = 'L\'utilisateur n\'a pas de compte Pix', responseCode, authenticationKey }) {
+    super(message);
+    this.responseCode = responseCode;
+    this.authenticationKey = authenticationKey;
+  }
+}
 class WrongDateFormatError extends DomainError {
   constructor(message = 'Format de date invalide.') {
     super(message);
@@ -750,6 +758,7 @@ module.exports = {
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,
   UnexpectedUserAccount,
+  UserAccountNotFoundForPoleEmploiError,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,
   UserCouldNotBeReconciledError,

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -526,7 +526,7 @@ describe('Integration | API | Controller Error', () => {
     });
   });
 
-  context('401 Unauthorized', () => {
+  context('should respond 401 Unauthorized', () => {
     const UNAUTHORIZED_ERROR = 401;
 
     it('responds Unauthorized when a MissingOrInvalidCredentialsError error occurs', async () => {
@@ -551,6 +551,15 @@ describe('Integration | API | Controller Error', () => {
 
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal('Erreur, vous devez changer votre mot de passe.');
+    });
+
+    it('when a UserShouldChangePasswordError error is thrown', async () => {
+      const expectedMessage = 'L\'utilisateur n\'a pas de compte Pix';
+      routeHandler.throws(new DomainErrors.UserAccountNotFoundForPoleEmploiError(expectedMessage));
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
+      expect(responseDetail(response)).to.equal(expectedMessage);
     });
   });
 

--- a/api/tests/unit/domain/errors_test.js
+++ b/api/tests/unit/domain/errors_test.js
@@ -525,4 +525,8 @@ describe('Unit | Domain | Errors', () => {
       });
     });
   });
+
+  it('should export a UserAccountNotFoundForPoleEmploiError', () => {
+    expect(errors.UserAccountNotFoundForPoleEmploiError).to.exist;
+  });
 });

--- a/mon-pix/app/authenticators/oidc.js
+++ b/mon-pix/app/authenticators/oidc.js
@@ -67,6 +67,10 @@ export default OIDCAuthenticator.extend({
     const response = await fetch(serverTokenEndpoint, request);
 
     const data = await response.json();
+    if (!response.ok) {
+      return RSVP.reject(data);
+    }
+
     const decodedAccessToken = decodeToken(data.access_token);
 
     return {

--- a/mon-pix/app/controllers/terms-of-service-pe.js
+++ b/mon-pix/app/controllers/terms-of-service-pe.js
@@ -4,10 +4,13 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class TermsOfServicePeController extends Controller {
+  queryParams = ['authenticationKey'];
+
   @service session;
   @service store;
   @service url;
 
+  @tracked authenticationKey = null;
   @tracked isTermsOfServiceValidated = false;
   @tracked showErrorTermsOfServiceNotSelected = false;
 
@@ -20,7 +23,7 @@ export default class TermsOfServicePeController extends Controller {
     if (this.isTermsOfServiceValidated) {
       this.showErrorTermsOfServiceNotSelected = false;
 
-      await this.session.authenticate('authenticator:oidc', { authenticationKey: 'authenticationKey' });
+      await this.session.authenticate('authenticator:oidc', { authenticationKey: this.authenticationKey });
 
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();

--- a/mon-pix/mirage/config.js
+++ b/mon-pix/mirage/config.js
@@ -73,6 +73,19 @@ export default function() {
     return user;
   });
 
+  this.post('/pole-emplois/users', (schema) =>{
+    const createdUser = schema.users.create({
+      firstName: 'Paul',
+      lastName: 'Emploi',
+    });
+
+    return {
+      access_token: 'aaa.' + btoa(`{"user_id":${createdUser.id},"source":"pole_emploi_connect","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      id_token: 'id_token',
+      user_id: createdUser.id,
+    };
+  });
+
   this.get('/feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -419,6 +419,41 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             // then
             expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
           });
+
+          context('When user must validate terms of service Pole Emploi', function() {
+
+            const authenticationKey = 'authenticationKey';
+
+            beforeEach(function() {
+              server.post('/pole-emploi/token', () => {
+
+                const userAccountNotFoundForPoleEmploiError = {
+                  'errors': [{
+                    'status': '401',
+                    'code': 'SHOULD_VALIDATE_CGU',
+                    'title': 'Unauthorized',
+                    'detail': 'L\'utilisateur n\'a pas de compte Pix',
+                    'meta': { authenticationKey },
+                  }],
+                };
+
+                return new Response(401, {}, userAccountNotFoundForPoleEmploiError);
+              });
+            });
+
+            it('should redirect to terms of service Pole Emploi page', async function() {
+              // given
+              const state = 'state';
+              const session = currentSession();
+              session.set('data.state', state);
+
+              // when
+              await visit(`/connexion-pole-emploi?code=test&state=${state}`);
+
+              // then
+              expect(currentURL()).to.equal(`/cgu-pole-emploi?authenticationKey=${authenticationKey}`);
+            });
+          });
         });
       });
 

--- a/mon-pix/tests/unit/controllers/terms-of-service-pe-test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-pe-test.js
@@ -21,7 +21,7 @@ describe('Unit | Controller | terms-of-service-pe', function() {
       // when
       controller.isTermsOfServiceValidated = true ;
       controller.showErrorTermsOfServiceNotSelected = false ;
-
+      controller.authenticationKey = 'authenticationKey';
       await controller.send('submit');
 
       // then


### PR DESCRIPTION
## :unicorn: Problème
La création de la nouvelle route POST `/api/pole-emploi/users` et la création de l'utilisateur et sa méthode d'authentification ont étés gérés dans la PR [2366](https://github.com/1024pix/pix/pull/2366).

Actuellement sur Pix App, l'utilisateur (venant de PE Connect) n'est pas encore redirigé vers la page de validation des CGU Pôle Emploi (s'il n'a aucun compte PIX).

## :robot: Solution

- Retourner une erreur 401, lors de l'appel à POST `/api/pole-emploi/token` si l'utilisateur n'existe pas en base. 
- Renvoyer l'utilisateur sur la page des CGU Pôle Emploi si l'on obtient cette erreur 401.
- Stocker les informations renvoyées par Pôle Emploi dans Redis.
- Renvoyer l'UUID de l'utilisateur dans l'url de redirection, permettant de récupérer les informations précédemment stockées.

## :rainbow: Remarques


## :100: Pour tester

**Utilisateur PE sans compte PIX :**

- Aller sur /campagnes/QWERTY789
- S'authentifier sur PE Connect
- Valider les CGU
- Quitter le parcours et vérifier sur le profil, que l'on est sur le compte de l'utilisateur PE

**Utilisateur PE avec compte PIX :**

Faire le même parcours, vous n'êtes pas redirigés vers la page des CGU

