### PR TITLE
[TECH] Création d'helpers de tests front respectueux de l'a11y sur PixOrga (PIX-2008)

### DIFF
--- a/orga/app/components/pagination-control.hbs
+++ b/orga/app/components/pagination-control.hbs
@@ -2,7 +2,7 @@
   <div class="page-size">
     <div class="page-size__label">Voir</div>
     <div class="page-size__choice">
-      <select class="content-text content-text--small" {{on "change" this.changePageSize}}>
+      <select aria-label="Sélectionner une pagination" class="content-text content-text--small" {{on "change" this.changePageSize}}>
         <option value="10" selected="{{if (eq this.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq this.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>

--- a/orga/app/components/previous-page-button.hbs
+++ b/orga/app/components/previous-page-button.hbs
@@ -3,7 +3,7 @@
     @route={{@route}}
     @model={{@routeId}}
     class="icon-button previous-page-button__return-button"
-    aria-label={{@aria-label}}
+    aria-label={{@ariaLabel}}
   >
     <FaIcon @icon='arrow-left'></FaIcon>
   </LinkTo>

--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -3,7 +3,7 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.assessments"
      @routeId={{@campaign.id}}
-     @aria-label="Retourner au détail de la campagne"
+     @ariaLabel="Retourner au détail de la campagne"
    >
     {{@campaign.name}}
    </PreviousPageButton>

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -15,14 +15,14 @@
               @field="name"
               @value={{@nameFilter}}
               @placeholder="Rechercher une campagne"
-              @aria-label="Rechercher une campagne"
+              @ariaLabel="Rechercher une campagne"
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::HeaderFilterInput
               @field="creatorName"
               @value={{@creatorNameFilter}}
               @placeholder="Rechercher un créateur"
-              @aria-label="Rechercher un créateur"
+              @ariaLabel="Rechercher un créateur"
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -15,12 +15,14 @@
               @field="name"
               @value={{@nameFilter}}
               @placeholder="Rechercher une campagne"
+              @aria-label="Rechercher une campagne"
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::HeaderFilterInput
               @field="creatorName"
               @value={{@creatorNameFilter}}
               @placeholder="Rechercher un créateur"
+              @aria-label="Rechercher un créateur"
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>

--- a/orga/app/components/routes/authenticated/campaign/new.hbs
+++ b/orga/app/components/routes/authenticated/campaign/new.hbs
@@ -98,10 +98,9 @@
           @type="text"
           @class="input"
           @maxlength="255"
-          @label="Libellé de l’identifiant"
+          aria-label="Libellé de l’identifiant"
           @aria-required="true"
           @placeholder="Libellé de l’identifiant"
-          aria-label="Libellé de l’identifiant"
           @value={{@campaign.idPixLabel}}
         />
         {{#each @campaign.errors.idPixLabel as |error|}}

--- a/orga/app/components/routes/authenticated/campaign/new.hbs
+++ b/orga/app/components/routes/authenticated/campaign/new.hbs
@@ -101,6 +101,7 @@
           @label="Libellé de l’identifiant"
           @aria-required="true"
           @placeholder="Libellé de l’identifiant"
+          aria-label="Libellé de l’identifiant"
           @value={{@campaign.idPixLabel}}
         />
         {{#each @campaign.errors.idPixLabel as |error|}}

--- a/orga/app/components/routes/authenticated/campaign/new.hbs
+++ b/orga/app/components/routes/authenticated/campaign/new.hbs
@@ -23,14 +23,14 @@
       <label class="label">Quel est l'objectif de votre campagne ?</label>
       <div class="form__sub-label" role="button">
         <label>
-          <input type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" class="radio-button" {{on "change" this.setCampaignGoal}}>
+          <input aria-label="Choisir d'évaluer les participants" type="radio" id="assess-participants" name="campaign-goal" value="assess-participants" class="radio-button" {{on "change" this.setCampaignGoal}}>
           <span class="radio-button-span"></span>Évaluer les participants
         </label>
       </div>
 
       <div class="form__sub-label" role="button">
         <label>
-          <input type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" class="radio-button" {{on "change" this.setCampaignGoal}}>
+          <input aria-label="Choisir de collecter les profils Pix des participants" type="radio" id="collect-participants-profile" name="campaign-goal" value="collect-participants-profile" class="radio-button" {{on "change" this.setCampaignGoal}}>
           <span class="radio-button-span"></span>Collecter les profils Pix des participants
         </label>
       </div>
@@ -75,13 +75,13 @@
       <div class="label">
         <label for="id-pix-wanted-or-not">Souhaitez-vous demander un identifiant externe ?</label>
       </div>
-      <div id="doNotAskLabelIdPix" class="form__sub-label" role="button" {{on 'click' this.doNotAskLabelIdPix}}>
+      <div aria-label="Ne pas demander d'identifiant externe" id="doNotAskLabelIdPix" class="form__sub-label" role="button" {{on 'click' this.doNotAskLabelIdPix}}>
         <label>
           <input type="radio" checked={{@notWantIdPix}} name="radio" class="radio-button">
           <span class="radio-button-span"></span>Non
         </label>
       </div>
-      <div id="askLabelIdPix" class="form__sub-label" role="button" {{on 'click' this.askLabelIdPix}}>
+      <div aria-label="Demander un identifiant externe" id="askLabelIdPix" class="form__sub-label" role="button" {{on 'click' this.askLabelIdPix}}>
         <label>
           <input type="radio" checked={{@wantIdPix}} name="radio" class="radio-button">
           <span class="radio-button-span"></span>Oui

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -3,7 +3,7 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.profiles"
      @routeId={{@campaign.id}}
-     @aria-label="Retourner au détail de la campagne"
+     @ariaLabel="Retourner au détail de la campagne"
    >
     {{@campaign.name}}
    </PreviousPageButton>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -42,12 +42,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
+            @aria-label="Rechercher par nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
+            @aria-label="Rechercher par prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>
@@ -56,6 +58,7 @@
             @options={{@connexionTypesOptions}}
             @selectedOption={{@connexionTypeFilter}}
             @triggerFiltering={{@triggerFiltering}}
+            @aria-label="Rechercher par méthode de connexion"
             @emptyOptionLabel="Tous"
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -42,14 +42,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
-            @aria-label="Rechercher par nom"
+            @aria-label="Entrer un nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
-            @aria-label="Rechercher par prénom"
+            @aria-label="Entrer un prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -42,14 +42,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
-            @aria-label="Entrer un nom"
+            @ariaLabel="Entrer un nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
-            @aria-label="Entrer un prénom"
+            @ariaLabel="Entrer un prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>
@@ -58,7 +58,7 @@
             @options={{@connexionTypesOptions}}
             @selectedOption={{@connexionTypeFilter}}
             @triggerFiltering={{@triggerFiltering}}
-            @aria-label="Rechercher par méthode de connexion"
+            @ariaLabel="Rechercher par méthode de connexion"
             @emptyOptionLabel="Tous"
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -30,12 +30,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
+            @aria-label="Rechercher par nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
+            @aria-label="Rechercher par prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -30,14 +30,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
-            @aria-label="Entrer un nom"
+            @ariaLabel="Entrer un nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
-            @aria-label="Entrer un prénom"
+            @ariaLabel="Entrer un prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/sup-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.hbs
@@ -30,14 +30,14 @@
             @field="lastName"
             @value={{@lastNameFilter}}
             @placeholder="Rechercher par nom"
-            @aria-label="Rechercher par nom"
+            @aria-label="Entrer un nom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::HeaderFilterInput
             @field="firstName"
             @value={{@firstNameFilter}}
             @placeholder="Rechercher par prénom"
-            @aria-label="Rechercher par prénom"
+            @aria-label="Entrer un prénom"
             @triggerFiltering={{@triggerFiltering}}
           />
           <Table::Header/>

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -27,6 +27,7 @@
           @options={{this.organizationRoles}}
           @selectedOption={{@membership.organizationRole}}
           @placeholder="Sélectionner un rôle"
+          @aria-label="Sélectionner un rôle"
         />
       </div>
     </td>

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -27,7 +27,7 @@
           @options={{this.organizationRoles}}
           @selectedOption={{@membership.organizationRole}}
           @placeholder="Sélectionner un rôle"
-          @aria-label="Sélectionner un rôle"
+          @ariaLabel="Sélectionner un rôle"
         />
       </div>
     </td>

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -36,7 +36,7 @@
         <button id='save-organization-role' type="button" class="button button--thin" {{on 'click' (fn this.updateRoleOfMember @membership)}}>
           Enregistrer
         </button>
-        <button id='cancel-update-organization-role' type="button" class="button button--round-with-icon"
+        <button aria-label="Annuler" id='cancel-update-organization-role' type="button" class="button button--round-with-icon"
           {{on 'click' this.cancelUpdateRoleOfMember}}>
           <FaIcon @icon='times'></FaIcon>
         </button>

--- a/orga/app/components/routes/register-form.hbs
+++ b/orga/app/components/routes/register-form.hbs
@@ -84,6 +84,7 @@
           @id="register-cgu"
           @type="checkbox"
           @checked={{this.user.cgu}}
+          aria-label="Accepter les conditions d'utilisation de Pix"
           {{on "focusout" (fn this.validateInput "cgu" this.user.cgu)}}
         />
         <span class="register-form__cgu">

--- a/orga/app/components/search-input.hbs
+++ b/orga/app/components/search-input.hbs
@@ -1,9 +1,10 @@
 <div class="input search-input" ...attributes>
   <FaIcon @icon='search' />
-  <input 
+  <input
     id={{@inputName}}
     name={{@inputName}}
     placeholder={{@placeholder}}
+    aria-label={{@aria-label}}
     value={{@value}}
     oninput={{@filterFunction}}
     class="search-input__invisible-field"

--- a/orga/app/components/search-input.hbs
+++ b/orga/app/components/search-input.hbs
@@ -4,7 +4,7 @@
     id={{@inputName}}
     name={{@inputName}}
     placeholder={{@placeholder}}
-    aria-label={{@aria-label}}
+    aria-label={{@ariaLabel}}
     value={{@value}}
     oninput={{@filterFunction}}
     class="search-input__invisible-field"

--- a/orga/app/components/select-input.hbs
+++ b/orga/app/components/select-input.hbs
@@ -1,5 +1,5 @@
 <div class="select-input" ...attributes>
-  <select {{on 'change' @onChange}} id={{@id}} aria-label={{@aria-label}}>
+  <select {{on 'change' @onChange}} id={{@id}} aria-label={{@ariaLabel}}>
     {{#if (not-eq @emptyOptionLabel undefined)}}
       <option value="">{{@emptyOptionLabel}}</option>
     {{/if}}

--- a/orga/app/components/select-input.hbs
+++ b/orga/app/components/select-input.hbs
@@ -1,5 +1,5 @@
 <div class="select-input" ...attributes>
-  <select {{on 'change' @onChange}} id={{@id}}>
+  <select {{on 'change' @onChange}} id={{@id}} aria-label={{@aria-label}}>
     {{#if (not-eq @emptyOptionLabel undefined)}}
       <option value="">{{@emptyOptionLabel}}</option>
     {{/if}}

--- a/orga/app/components/table/header-filter-input.hbs
+++ b/orga/app/components/table/header-filter-input.hbs
@@ -4,7 +4,7 @@
     @inputName={{@field}}
     @value={{@value}}
     @placeholder={{@placeholder}}
-    @aria-label={{@aria-label}}
+    @ariaLabel={{@ariaLabel}}
     @filterFunction={{fn @triggerFiltering @field true}}
   />
 </Table::Header>

--- a/orga/app/components/table/header-filter-input.hbs
+++ b/orga/app/components/table/header-filter-input.hbs
@@ -4,6 +4,7 @@
     @inputName={{@field}}
     @value={{@value}}
     @placeholder={{@placeholder}}
+    @aria-label={{@aria-label}}
     @filterFunction={{fn @triggerFiltering @field true}}
   />
 </Table::Header>

--- a/orga/app/components/table/header-filter-select.hbs
+++ b/orga/app/components/table/header-filter-select.hbs
@@ -4,7 +4,7 @@
     class="table__input"
     @onChange={{fn @triggerFiltering @field false}}
     @options={{@options}}
-    @aria-label={{@aria-label}}
+    @ariaLabel={{@ariaLabel}}
     @selectedOption={{@selectedOption}}
     @emptyOptionLabel={{@emptyOptionLabel}}
   />

--- a/orga/app/components/table/header-filter-select.hbs
+++ b/orga/app/components/table/header-filter-select.hbs
@@ -4,6 +4,7 @@
     class="table__input"
     @onChange={{fn @triggerFiltering @field false}}
     @options={{@options}}
+    @aria-label={{@aria-label}}
     @selectedOption={{@selectedOption}}
     @emptyOptionLabel={{@emptyOptionLabel}}
   />

--- a/orga/app/components/user-logged-menu.hbs
+++ b/orga/app/components/user-logged-menu.hbs
@@ -1,5 +1,5 @@
-<div class="dropdown logged-user-summary content-text content-text--small" aria-label="Résumé utilisateur">
-  <a href="#" class="link logged-user-summary__link" {{on 'click' this.toggleUserMenu}} aria-haspopup="listbox" aria-expanded="{{this.isMenuOpen}}">
+<div class="dropdown logged-user-summary content-text content-text--small">
+  <a href="#" aria-label="Résumé utilisateur" class="link logged-user-summary__link" {{on 'click' this.toggleUserMenu}} aria-haspopup="listbox" aria-expanded="{{this.isMenuOpen}}">
     <div>
       <div class="logged-user-summary__name">{{this.currentUser.prescriber.firstName}} {{this.currentUser.prescriber.lastName}}</div>
       <div class="logged-user-summary__organization">{{this.organizationNameAndExternalId}}</div>

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   authenticateSession,
@@ -69,8 +70,8 @@ module('Acceptance | authentication', function(hooks) {
     test('it should redirect prescriber to the terms-of-service page', async function(assert) {
       // given
       await visit('/connexion');
-      await fillIn('#login-email', user.email);
-      await fillIn('#login-password', 'secret');
+      await fillInByLabel('Adresse e-mail', user.email);
+      await fillInByLabel('Mot de passe', 'secret');
 
       // when
       await click('button[type=submit]');
@@ -85,8 +86,8 @@ module('Acceptance | authentication', function(hooks) {
       server.create('campaign');
 
       await visit('/connexion');
-      await fillIn('#login-email', user.email);
-      await fillIn('#login-password', 'secret');
+      await fillInByLabel('Adresse e-mail', user.email);
+      await fillInByLabel('Mot de passe', 'secret');
 
       // when
       await click('button[type=submit]');
@@ -112,8 +113,8 @@ module('Acceptance | authentication', function(hooks) {
       server.create('campaign');
 
       await visit('/connexion');
-      await fillIn('#login-email', user.email);
-      await fillIn('#login-password', 'secret');
+      await fillInByLabel('Adresse e-mail', user.email);
+      await fillInByLabel('Mot de passe', 'secret');
 
       // when
       await click('button[type=submit]');
@@ -128,8 +129,8 @@ module('Acceptance | authentication', function(hooks) {
       server.create('campaign');
 
       await visit('/connexion');
-      await fillIn('#login-email', user.email);
-      await fillIn('#login-password', 'secret');
+      await fillInByLabel('Adresse e-mail', user.email);
+      await fillInByLabel('Mot de passe', 'secret');
 
       // when
       await click('button[type=submit]');

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   authenticateSession,
@@ -74,7 +75,7 @@ module('Acceptance | authentication', function(hooks) {
       await fillInByLabel('Mot de passe', 'secret');
 
       // when
-      await click('button[type=submit]');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.equal(currentURL(), '/cgu');
@@ -90,7 +91,7 @@ module('Acceptance | authentication', function(hooks) {
       await fillInByLabel('Mot de passe', 'secret');
 
       // when
-      await click('button[type=submit]');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -117,7 +118,7 @@ module('Acceptance | authentication', function(hooks) {
       await fillInByLabel('Mot de passe', 'secret');
 
       // when
-      await click('button[type=submit]');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.equal(currentURL(), '/campagnes');
@@ -133,7 +134,7 @@ module('Acceptance | authentication', function(hooks) {
       await fillInByLabel('Mot de passe', 'secret');
 
       // when
-      await click('button[type=submit]');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -234,7 +235,7 @@ module('Acceptance | authentication', function(hooks) {
         await visit('/');
 
         // when
-        await click('.sidebar-menu a:nth-child(2)');
+        await clickByLabel('Équipe');
 
         // then
         assert.dom('.sidebar-menu a:first-child').hasText('Campagnes');
@@ -294,13 +295,13 @@ module('Acceptance | authentication', function(hooks) {
           await visit('/');
 
           // when
-          await click('.sidebar-menu a:nth-child(3)');
+          await clickByLabel('Élèves');
 
           // then
           assert.dom('.sidebar-menu').containsText('Campagnes');
           assert.dom('.sidebar-menu').containsText('Équipe');
           assert.dom('.sidebar-menu').containsText('Élèves');
-          assert.dom('.sidebar-menu a:nth-child(3)').hasClass('active');
+          assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
           assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
         });
 

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -58,7 +59,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
 
     test('it should display gdpr footnote', async function(assert) {
       // when
-      await click('#askLabelIdPix');
+      await clickByLabel('Demander un identifiant externe');
 
       // then
       assert.dom('.new-item-form__gdpr-information').isVisible();
@@ -72,13 +73,13 @@ module('Acceptance | Campaign Creation', function(hooks) {
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await click('#askLabelIdPix');
+      await clickByLabel('Demander un identifiant externe');
       await fillInByLabel('Libellé de l’identifiant', 'Mail Pro');
       await fillInByLabel('Titre du parcours', 'Savoir rechercher');
       await fillInByLabel('Texte de la page d\'accueil', 'Texte personnalisé');
 
       // when
-      await click('button[type="submit"]');
+      await clickByLabel('Créer la campagne');
 
       // then
       const firstCampaign = server.db.campaigns[0];
@@ -95,7 +96,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
       server.post('/campaigns', {}, 500);
 
       // when
-      await click('button[type="submit"]');
+      await clickByLabel('Créer la campagne');
 
       // then
       assert.equal(currentURL(), '/campagnes/creation');
@@ -116,13 +117,13 @@ module('Acceptance | Campaign Creation', function(hooks) {
     test('it should allow to create a campaign of type ASSESSMENT and redirect to the newly created campaign', async function(assert) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
-      await click('#assess-participants');
+      await clickByLabel('Choisir d\'évaluer les participants');
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await click('#doNotAskLabelIdPix');
+      await clickByLabel('Ne pas demander d\'identifiant externe');
 
       // when
-      await click('button[type="submit"]');
+      await clickByLabel('Créer la campagne');
 
       // then
       const firstCampaign = server.db.campaigns[0];
@@ -133,12 +134,12 @@ module('Acceptance | Campaign Creation', function(hooks) {
 
     test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function(assert) {
       // given
-      await click('#collect-participants-profile');
+      await clickByLabel('Choisir de collecter les profils Pix des participants');
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
-      await click('#doNotAskLabelIdPix');
+      await clickByLabel('Ne pas demander d\'identifiant externe');
 
       // when
-      await click('button[type="submit"]');
+      await clickByLabel('Créer la campagne');
 
       // then
       assert.equal(server.db.campaigns[0].name, 'Ma Campagne');
@@ -148,15 +149,15 @@ module('Acceptance | Campaign Creation', function(hooks) {
     test('it should create campaign if user changes type after filling the form', async function(assert) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
-      await click('#assess-participants');
+      await clickByLabel('Choisir d\'évaluer les participants');
       await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
       await fillInByLabel('Nom de la campagne', 'Ma Campagne');
       await fillInByLabel('Titre du parcours', 'Savoir rechercher');
-      await click('#doNotAskLabelIdPix');
-      await click('#collect-participants-profile');
+      await clickByLabel('Ne pas demander d\'identifiant externe');
+      await clickByLabel('Choisir de collecter les profils Pix des participants');
 
       // when
-      await click('button[type="submit"]');
+      await clickByLabel('Créer la campagne');
 
       // then
       assert.equal(server.db.campaigns[0].name, 'Ma Campagne');

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -69,12 +70,12 @@ module('Acceptance | Campaign Creation', function(hooks) {
     test('it should allow to create a campaign of type ASSESSMENT by default and redirect to the newly created campaign', async function(assert) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
-      await fillIn('#campaign-target-profile', expectedTargetProfileId);
-      await fillIn('#campaign-name', 'Ma Campagne');
+      await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
+      await fillInByLabel('Nom de la campagne', 'Ma Campagne');
       await click('#askLabelIdPix');
-      await fillIn('#id-pix-label', 'Mail Pro');
-      await fillIn('#campaign-title', 'Savoir rechercher');
-      await fillIn('#custom-landing-page-text', 'Texte personnalisé');
+      await fillInByLabel('Libellé de l’identifiant', 'Mail Pro');
+      await fillInByLabel('Titre du parcours', 'Savoir rechercher');
+      await fillInByLabel('Texte de la page d\'accueil', 'Texte personnalisé');
 
       // when
       await click('button[type="submit"]');
@@ -116,8 +117,8 @@ module('Acceptance | Campaign Creation', function(hooks) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       await click('#assess-participants');
-      await fillIn('#campaign-target-profile', expectedTargetProfileId);
-      await fillIn('#campaign-name', 'Ma Campagne');
+      await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
+      await fillInByLabel('Nom de la campagne', 'Ma Campagne');
       await click('#doNotAskLabelIdPix');
 
       // when
@@ -133,7 +134,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
     test('it should allow to create a campaign of type PROFILES_COLLECTION and redirect to the newly created campaign', async function(assert) {
       // given
       await click('#collect-participants-profile');
-      await fillIn('#campaign-name', 'Ma Campagne');
+      await fillInByLabel('Nom de la campagne', 'Ma Campagne');
       await click('#doNotAskLabelIdPix');
 
       // when
@@ -148,9 +149,9 @@ module('Acceptance | Campaign Creation', function(hooks) {
       // given
       const expectedTargetProfileId = availableTargetProfiles[1].id;
       await click('#assess-participants');
-      await fillIn('#campaign-target-profile', expectedTargetProfileId);
-      await fillIn('#campaign-name', 'Ma Campagne');
-      await fillIn('#campaign-title', 'Savoir rechercher');
+      await fillInByLabel('Que souhaitez-vous tester ?', expectedTargetProfileId);
+      await fillInByLabel('Nom de la campagne', 'Ma Campagne');
+      await fillInByLabel('Titre du parcours', 'Savoir rechercher');
       await click('#doNotAskLabelIdPix');
       await click('#collect-participants-profile');
 

--- a/orga/tests/acceptance/campaign-details-test.js
+++ b/orga/tests/acceptance/campaign-details-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -48,7 +49,7 @@ module('Acceptance | Campaign Details', function(hooks) {
       await visit('/campagnes/1');
 
       // when
-      await click('[aria-label="Retour"]');
+      await clickByLabel('Retour');
 
       // then
       assert.equal(currentURL(), '/campagnes');

--- a/orga/tests/acceptance/campaign-list-test.js
+++ b/orga/tests/acceptance/campaign-list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click, fillIn } from '@ember/test-helpers';
+import { currentURL, visit, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -93,7 +94,7 @@ module('Acceptance | Campaign List', function(hooks) {
         await visit('/campagnes');
 
         // when
-        await fillIn('#creatorName', creator.firstName);
+        await fillInByLabel('Rechercher un créateur', creator.firstName);
 
         // then
         assert.equal(currentURL(), `/campagnes?creatorName=${creator.firstName}`);
@@ -104,7 +105,7 @@ module('Acceptance | Campaign List', function(hooks) {
         await visit(`/campagnes?creatorName=${creator.firstName}`);
 
         // when
-        await fillIn('#creatorName', '');
+        await fillInByLabel('Rechercher un créateur', '');
 
         // then
         assert.equal(currentURL(), '/campagnes');

--- a/orga/tests/acceptance/campaign-list-test.js
+++ b/orga/tests/acceptance/campaign-list-test.js
@@ -90,7 +90,7 @@ module('Acceptance | Campaign List', function(hooks) {
         server.create('campaign', { creator });
       });
 
-      test('t should update URL with creator first name filter', async function(assert) {
+      test('it should update URL with creator first name filter', async function(assert) {
         // given
         await visit('/campagnes');
 

--- a/orga/tests/acceptance/campaign-list-test.js
+++ b/orga/tests/acceptance/campaign-list-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -71,11 +72,11 @@ module('Acceptance | Campaign List', function(hooks) {
 
     test('it should redirect to campaign details on click', async function(assert) {
       // given
-      server.create('campaign', { id: 1 });
+      server.create('campaign', { id: 1, name: 'CampagneEtPrairie' });
       await visit('/campagnes');
 
       // when
-      await click('.campaign-list .table tbody tr:first-child');
+      await clickByLabel('CampagneEtPrairie');
 
       // then
       assert.equal(currentURL(), '/campagnes/1');

--- a/orga/tests/acceptance/campaign-participants-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-results-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click, currentURL } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -20,8 +21,8 @@ module('Acceptance | Campaign Participants Results', function(hooks) {
 
     server.create('campaign', { id: 1 });
     const campaignAssessmentParticipationResult = server.create('campaign-assessment-participation-result', 'withCompetenceResults', { id: 1, campaignId: 1 });
-    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult });
-    server.create('campaign-assessment-participation-summary', { id: 1 });
+    server.create('campaign-assessment-participation', { id: 1, campaignId: 1, campaignAssessmentParticipationResult, lastName: 'Bacri' });
+    server.create('campaign-assessment-participation-summary', { id: 1, lastName: 'Bacri' });
 
     await authenticateSession({
       user_id: user.id,
@@ -36,7 +37,7 @@ module('Acceptance | Campaign Participants Results', function(hooks) {
     test('it could click on user to go to details', async function(assert) {
       // when
       await visit('/campagnes/1/evaluations');
-      await click('[aria-label="Participant"]:first-child');
+      await clickByLabel('Bacri');
 
       // then
       assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');
@@ -45,7 +46,7 @@ module('Acceptance | Campaign Participants Results', function(hooks) {
     test('it could return on list of participants', async function(assert) {
       // when
       await visit('/campagnes/1/evaluations/1');
-      await click('[aria-label="Retourner au détail de la campagne"]');
+      await clickByLabel('Retourner au détail de la campagne');
 
       // then
       assert.equal(currentURL(), '/campagnes/1/evaluations');

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click, currentURL, fillIn } from '@ember/test-helpers';
+import { visit, click, currentURL } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -82,7 +83,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
 
       // when
       await visit('/campagnes/1/evaluations');
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });
@@ -95,7 +96,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
       const changedPageSize = 25;
 
       await visit('/campagnes/1/evaluations');
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
       const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
 
       // when
@@ -113,7 +114,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
 
       // when
       await visit(`/campagnes/1/evaluations?pageNumber=${startPage}`);
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { visit, click, currentURL } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -100,7 +101,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
       const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
 
       // when
-      await click('.page-navigation__arrow--next .icon-button');
+      await clickByLabel('Aller à la page suivante');
 
       // then
       assert.contains('Page 2 / 2');

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { visit, click, currentURL } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
@@ -24,11 +24,13 @@ module('Acceptance | Campaign Participants', function(hooks) {
     createPrescriberByUser(user);
 
     server.create('campaign', { id: 1 });
+    server.create('campaign-assessment-participation', { id: 1, lastName: 'AAAAAAAA_IAM_FIRST', campaignId: 1 });
+    server.create('campaign-assessment-participation-summary', { id: 1, lastName: 'AAAAAAAA_IAM_FIRST' });
     server.createList('campaign-assessment-participation', rowCount, { campaignId: 1 });
     server.createList('campaign-assessment-participation-result', rowCount, { campaignId: 1 });
     server.createList('campaign-assessment-participation-summary', 20, 'completed');
     server.createList('campaign-assessment-participation-summary', 10, 'ongoing');
-    server.createList('campaign-assessment-participation-summary', 20, 'shared');
+    server.createList('campaign-assessment-participation-summary', 19, 'shared');
 
     await authenticateSession({
       user_id: user.id,
@@ -69,7 +71,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
       await visit('/campagnes/1/evaluations');
 
       // when
-      await click('table tbody .tr--clickable');
+      await clickByLabel('AAAAAAAA_IAM_FIRST');
 
       // then
       assert.equal(currentURL(), '/campagnes/1/evaluations/1/resultats');

--- a/orga/tests/acceptance/campaign-profiles-test.js
+++ b/orga/tests/acceptance/campaign-profiles-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click, fillIn } from '@ember/test-helpers';
+import { visit, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
@@ -64,7 +65,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
       // when
       await visit('/campagnes/1/profils');
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });
@@ -77,7 +78,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
       const changedPageSize = 25;
 
       await visit('/campagnes/1/profils');
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
       const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
 
       // when
@@ -95,7 +96,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
       // when
       await visit(`/campagnes/1/profils?pageNumber=${startPage}`);
-      await fillIn('.page-size select', changedPageSize);
+      await fillInByLabel('Sélectionner une pagination', changedPageSize);
 
       // then
       assert.dom('table tbody tr').exists({ count: changedPageSize });

--- a/orga/tests/acceptance/campaign-profiles-test.js
+++ b/orga/tests/acceptance/campaign-profiles-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { visit, click } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUser } from '../helpers/test-init';
@@ -82,7 +83,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
       const someElementFromPage1 = this.element.querySelector('table tbody tr:nth-child(5)').textContent;
 
       // when
-      await click('.page-navigation__arrow--next .icon-button');
+      await clickByLabel('Aller à la page suivante');
 
       // then
       assert.contains('Page 2 / 2');

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -33,8 +34,8 @@ module('Acceptance | Campaign Update', function(hooks) {
     const newText = 'New text';
 
     await visit(`/campagnes/${campaign.id}/modification`);
-    await fillIn('#campaign-name', newName);
-    await fillIn('#campaign-custom-landing-page-text', newText);
+    await fillInByLabel('Nom de la campagne', newName);
+    await fillInByLabel('Texte de la page d\'accueil', newText);
 
     // when
     await click('button[type="submit"]');

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -38,7 +39,7 @@ module('Acceptance | Campaign Update', function(hooks) {
     await fillInByLabel('Texte de la page d\'accueil', newText);
 
     // when
-    await click('button[type="submit"]');
+    await clickByLabel('Modifier');
 
     // then
     assert.equal(server.db.campaigns.find(1).name, newName);

--- a/orga/tests/acceptance/dissociate-student-test.js
+++ b/orga/tests/acceptance/dissociate-student-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -49,9 +50,9 @@ module('Acceptance | Student List', function(hooks) {
       });
       // when
       await visit('/eleves');
-      await click('[aria-label="Afficher les actions"]');
-      await click('.list-students-page__actions [role="button"]:last-child');
-      await click('.dissociate-user-modal__actions button:last-child');
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Dissocier le compte');
+      await clickByLabel('Oui, dissocier le compte');
 
       // then
       assert.dom('[aria-label="Afficher les actions"]').doesNotExist();

--- a/orga/tests/acceptance/information-banner-test.js
+++ b/orga/tests/acceptance/information-banner-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click, currentURL } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -37,7 +38,7 @@ module('Acceptance | Information Banner', function(hooks) {
 
       // when
       await visit('/');
-      await click('.pix-banner a[href="/eleves"]');
+      await clickByLabel('importer ou ré-importer la base élèves');
 
       // then
       assert.equal(currentURL(), '/eleves');

--- a/orga/tests/acceptance/join-request-test.js
+++ b/orga/tests/acceptance/join-request-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { visit, click } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import Response from 'ember-cli-mirage/response';
 
@@ -24,7 +25,7 @@ module('Acceptance | join-request', function(hooks) {
       await fillInByLabel('Votre nom', 'lastName');
 
       // when
-      await click('button.join-request-form__button');
+      await clickByLabel('Envoyer');
 
       // then
       assert.contains('L\'UAI/RNE de l\'établissement n’est pas reconnu. Merci de contacter le support.');
@@ -39,7 +40,7 @@ module('Acceptance | join-request', function(hooks) {
       await fillInByLabel('Votre nom', 'lastName');
 
       // when
-      await click('button.join-request-form__button');
+      await clickByLabel('Envoyer');
 
       // then
       assert.contains('L\'UAI/RNE de l\'établissement n’est pas reconnu. Merci de contacter le support.');
@@ -54,7 +55,7 @@ module('Acceptance | join-request', function(hooks) {
       await fillInByLabel('Votre nom', 'lastName');
 
       // when
-      await click('button.join-request-form__button');
+      await clickByLabel('Envoyer');
 
       // then
       assert.contains('Nous n’avons pas d’adresse e-mail de contact associée à votre établissement, merci de contacter le support pour récupérer votre accès.');
@@ -69,7 +70,7 @@ module('Acceptance | join-request', function(hooks) {
       await fillInByLabel('Votre nom', 'lastName');
 
       // when
-      await click('button.join-request-form__button');
+      await clickByLabel('Envoyer');
 
       // then
       assert.contains('Une erreur est survenue. Merci de contacter le support.');
@@ -84,7 +85,7 @@ module('Acceptance | join-request', function(hooks) {
       await fillInByLabel('Votre nom', 'lastName');
 
       // when
-      await click('button.join-request-form__button');
+      await clickByLabel('Envoyer');
 
       // then
       assert.dom('.join-request__success').exists();

--- a/orga/tests/acceptance/join-request-test.js
+++ b/orga/tests/acceptance/join-request-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, fillIn, click } from '@ember/test-helpers';
+import { visit, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import Response from 'ember-cli-mirage/response';
 
@@ -18,9 +19,9 @@ module('Acceptance | join-request', function(hooks) {
 
     test('it should fail if the uai does not belong to any organization', async function(assert) {
       // given
-      await fillIn('#uai', '1111111A');
-      await fillIn('#firstName', 'firstName');
-      await fillIn('#lastName', 'lastName');
+      await fillInByLabel('UAI/RNE de l\'établissement', '1111111A');
+      await fillInByLabel('Votre prénom', 'firstName');
+      await fillInByLabel('Votre nom', 'lastName');
 
       // when
       await click('button.join-request-form__button');
@@ -33,9 +34,9 @@ module('Acceptance | join-request', function(hooks) {
       // given
       const proOrganization = server.create('organization', { type: 'PRO', externalId: '1234567P' });
 
-      await fillIn('#uai', proOrganization.externalId);
-      await fillIn('#firstName', 'firstName');
-      await fillIn('#lastName', 'lastName');
+      await fillInByLabel('UAI/RNE de l\'établissement', proOrganization.externalId);
+      await fillInByLabel('Votre prénom', 'firstName');
+      await fillInByLabel('Votre nom', 'lastName');
 
       // when
       await click('button.join-request-form__button');
@@ -48,9 +49,9 @@ module('Acceptance | join-request', function(hooks) {
       // given
       const scoOrganization = server.create('organization', { type: 'SCO', externalId: '1234567S' });
 
-      await fillIn('#uai', scoOrganization.externalId);
-      await fillIn('#firstName', 'firstName');
-      await fillIn('#lastName', 'lastName');
+      await fillInByLabel('UAI/RNE de l\'établissement', scoOrganization.externalId);
+      await fillInByLabel('Votre prénom', 'firstName');
+      await fillInByLabel('Votre nom', 'lastName');
 
       // when
       await click('button.join-request-form__button');
@@ -63,9 +64,9 @@ module('Acceptance | join-request', function(hooks) {
       // given
       server.post('/organization-invitations/sco', () => new Response(500, {}, { errors: [{ status: '500', title: 'Internal Server Error' }] }));
 
-      await fillIn('#uai', '1111111A');
-      await fillIn('#firstName', 'firstName');
-      await fillIn('#lastName', 'lastName');
+      await fillInByLabel('UAI/RNE de l\'établissement', '1111111A');
+      await fillInByLabel('Votre prénom', 'firstName');
+      await fillInByLabel('Votre nom', 'lastName');
 
       // when
       await click('button.join-request-form__button');
@@ -78,9 +79,9 @@ module('Acceptance | join-request', function(hooks) {
       // given
       const scoOrganization = server.create('organization', { type: 'SCO', externalId: '1234567S', email: 'sco@example.net' });
 
-      await fillIn('#uai', scoOrganization.externalId);
-      await fillIn('#firstName', 'firstName');
-      await fillIn('#lastName', 'lastName');
+      await fillInByLabel('UAI/RNE de l\'établissement', scoOrganization.externalId);
+      await fillInByLabel('Votre prénom', 'firstName');
+      await fillInByLabel('Votre nom', 'lastName');
 
       // when
       await click('button.join-request-form__button');

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, fillIn, click } from '@ember/test-helpers';
+import { visit, currentURL, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 
 import { currentSession } from 'ember-simple-auth/test-support';
@@ -87,8 +88,8 @@ module('Acceptance | join', function(hooks) {
         // given
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'secret');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'secret');
 
         // when
         await click('button[type=submit]');
@@ -104,8 +105,8 @@ module('Acceptance | join', function(hooks) {
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'secret');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'secret');
 
         // when
         await click('button[type=submit]');
@@ -142,8 +143,8 @@ module('Acceptance | join', function(hooks) {
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'secret');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'secret');
 
         // when
         await click('button[type=submit]');
@@ -159,8 +160,8 @@ module('Acceptance | join', function(hooks) {
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'secret');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'secret');
 
         // when
         await click('button[type=submit]');
@@ -199,8 +200,8 @@ module('Acceptance | join', function(hooks) {
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'fakepassword');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'fakepassword');
 
         // when
         await click('button[type=submit]');
@@ -240,8 +241,8 @@ module('Acceptance | join', function(hooks) {
         }, 412);
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
         await click('#login');
-        await fillIn('#login-email', user.email);
-        await fillIn('#login-password', 'secret');
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', 'secret');
 
         // when
         await click('button[type=submit]');
@@ -273,10 +274,10 @@ module('Acceptance | join', function(hooks) {
           }).id;
 
           await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-          await fillIn('#register-firstName', 'pix');
-          await fillIn('#register-lastName', 'pix');
-          await fillIn('#register-email', 'shi@fu.me');
-          await fillIn('#register-password', 'Password4register');
+          await fillInByLabel('Prénom', 'pix');
+          await fillInByLabel('Nom', 'pix');
+          await fillInByLabel('Adresse e-mail', 'shi@fu.me');
+          await fillInByLabel('Mot de passe', 'Password4register');
           await click('#register-cgu');
 
           // when
@@ -314,10 +315,10 @@ module('Acceptance | join', function(hooks) {
           }, 422);
 
           await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-          await fillIn('#register-firstName', 'pix');
-          await fillIn('#register-lastName', 'pix');
-          await fillIn('#register-email', 'alreadyUser@organization.org');
-          await fillIn('#register-password', 'Password4register');
+          await fillInByLabel('Prénom', 'pix');
+          await fillInByLabel('Nom', 'pix');
+          await fillInByLabel('Adresse e-mail', 'alreadyUser@organization.org');
+          await fillInByLabel('Mot de passe', 'Password4register');
           await click('#register-cgu');
 
           // when

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { visit, currentURL, click } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 
 import { currentSession } from 'ember-simple-auth/test-support';
@@ -87,12 +88,12 @@ module('Acceptance | join', function(hooks) {
       test('it should redirect user to the terms-of-service page', async function(assert) {
         // given
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'secret');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.equal(currentURL(), '/cgu');
@@ -104,12 +105,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'secret');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -142,12 +143,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'secret');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.equal(currentURL(), '/campagnes');
@@ -159,12 +160,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'secret');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -199,12 +200,12 @@ module('Acceptance | join', function(hooks) {
         }, 401);
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'fakepassword');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
@@ -240,12 +241,12 @@ module('Acceptance | join', function(hooks) {
           }],
         }, 412);
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await click('#login');
+        await clickByLabel('Se connecter');
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', 'secret');
 
         // when
-        await click('button[type=submit]');
+        await clickByLabel('Je me connecte');
 
         // then
         assert.equal(currentURL(), '/cgu');
@@ -278,10 +279,10 @@ module('Acceptance | join', function(hooks) {
           await fillInByLabel('Nom', 'pix');
           await fillInByLabel('Adresse e-mail', 'shi@fu.me');
           await fillInByLabel('Mot de passe', 'Password4register');
-          await click('#register-cgu');
+          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
 
           // when
-          await click('button[type=submit]');
+          await clickByLabel('Je m\'inscris');
 
           // then
           assert.equal(currentURL(), '/cgu');
@@ -319,10 +320,10 @@ module('Acceptance | join', function(hooks) {
           await fillInByLabel('Nom', 'pix');
           await fillInByLabel('Adresse e-mail', 'alreadyUser@organization.org');
           await fillInByLabel('Mot de passe', 'Password4register');
-          await click('#register-cgu');
+          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
 
           // when
-          await click('button[type=submit]');
+          await clickByLabel('Je m\'inscris');
 
           // then
           assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);

--- a/orga/tests/acceptance/profile-test.js
+++ b/orga/tests/acceptance/profile-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { visit, click, currentURL } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -32,7 +33,7 @@ module('Acceptance | Campaign Profile', function(hooks) {
 
     // when
     await visit('/campagnes/1/profils/1');
-    await click('[aria-label="Retourner au détail de la campagne"]');
+    await clickByLabel('Retourner au détail de la campagne');
 
     // then
     assert.equal(currentURL(), '/campagnes/1/profils');

--- a/orga/tests/acceptance/sco-student-list-test.js
+++ b/orga/tests/acceptance/sco-student-list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { find, currentURL, triggerEvent, visit, click, fillIn } from '@ember/test-helpers';
+import { find, currentURL, triggerEvent, visit, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -83,7 +84,7 @@ module('Acceptance | Sco Student List', function(hooks) {
       test('it should display the students list filtered by lastname', async function(assert) {
         // when
         await visit('/eleves');
-        await fillIn('[placeholder="Rechercher par nom"]', 'ambo');
+        await fillInByLabel('Rechercher par nom', 'ambo');
         // then
         assert.equal(currentURL(), '/eleves?lastName=ambo');
         assert.contains('Rambo');
@@ -93,7 +94,7 @@ module('Acceptance | Sco Student List', function(hooks) {
       test('it should display the students list filtered by firstname', async function(assert) {
         // when
         await visit('/eleves');
-        await fillIn('[placeholder="Rechercher par prénom"]', 'Jo');
+        await fillInByLabel('Rechercher par prénom', 'Jo');
 
         // then
         assert.equal(currentURL(), '/eleves?firstName=Jo');
@@ -101,10 +102,10 @@ module('Acceptance | Sco Student List', function(hooks) {
         assert.notContains('Norris');
       });
 
-      test('it should display the students list filtered by connexion type', async function(assert) {
+      test('it should display the students list filtered by connection type', async function(assert) {
         // when
         await visit('/eleves');
-        await fillIn('select', 'email');
+        await fillInByLabel('Rechercher par méthode de connexion', 'email');
 
         // then
         assert.equal(currentURL(), '/eleves?connexionType=email');

--- a/orga/tests/acceptance/sco-student-list-test.js
+++ b/orga/tests/acceptance/sco-student-list-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { find, currentURL, triggerEvent, visit, click } from '@ember/test-helpers';
+import { find, currentURL, triggerEvent, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -169,8 +170,8 @@ module('Acceptance | Sco Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // then
           assert.contains('Réinitialiser le mot de passe');
@@ -179,11 +180,11 @@ module('Acceptance | Sco Student List', function(hooks) {
         test('it should display unique password input when reset button is clicked', async function(assert) {
           // given
           await visit('/eleves');
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // when
-          await click('#generate-password');
+          await clickByLabel('Réinitialiser le mot de passe');
 
           // then
           assert.dom('#generate-password').doesNotExist();
@@ -195,8 +196,8 @@ module('Acceptance | Sco Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // then
           assert.dom('#username').hasValue(username);
@@ -218,8 +219,8 @@ module('Acceptance | Sco Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // then
           assert.contains('Médiacentre');
@@ -229,11 +230,11 @@ module('Acceptance | Sco Student List', function(hooks) {
         test('it should display username and unique password when add username button is clicked', async function(assert) {
           // given
           await visit('/eleves');
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // when
-          await click('[aria-label="Ajouter un identifiant"]');
+          await clickByLabel('Ajouter un identifiant');
 
           // then
           assert.contains('Médiacentre');
@@ -260,8 +261,8 @@ module('Acceptance | Sco Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // then
           assert.contains('Médiacentre');
@@ -273,8 +274,8 @@ module('Acceptance | Sco Student List', function(hooks) {
           await visit('/eleves');
 
           // when
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // then
           assert.contains('Réinitialiser le mot de passe');
@@ -283,11 +284,11 @@ module('Acceptance | Sco Student List', function(hooks) {
         test('it should open password modal and display unique password when reset button is clicked', async function(assert) {
           // given
           await visit('/eleves');
-          await click('[aria-label="Afficher les actions"]');
-          await click('li');
+          await clickByLabel('Afficher les actions');
+          await clickByLabel('Gérer le compte');
 
           // when
-          await click('#generate-password');
+          await clickByLabel('Réinitialiser le mot de passe');
 
           // then
           assert.dom('#generate-password').doesNotExist();

--- a/orga/tests/acceptance/sco-student-list-test.js
+++ b/orga/tests/acceptance/sco-student-list-test.js
@@ -85,7 +85,7 @@ module('Acceptance | Sco Student List', function(hooks) {
       test('it should display the students list filtered by lastname', async function(assert) {
         // when
         await visit('/eleves');
-        await fillInByLabel('Rechercher par nom', 'ambo');
+        await fillInByLabel('Entrer un nom', 'ambo');
         // then
         assert.equal(currentURL(), '/eleves?lastName=ambo');
         assert.contains('Rambo');
@@ -95,7 +95,7 @@ module('Acceptance | Sco Student List', function(hooks) {
       test('it should display the students list filtered by firstname', async function(assert) {
         // when
         await visit('/eleves');
-        await fillInByLabel('Rechercher par prénom', 'Jo');
+        await fillInByLabel('Entrer un prénom', 'Jo');
 
         // then
         assert.equal(currentURL(), '/eleves?firstName=Jo');

--- a/orga/tests/acceptance/sup-student-list-test.js
+++ b/orga/tests/acceptance/sup-student-list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { find, triggerEvent, visit, click, typeIn } from '@ember/test-helpers';
+import { find, triggerEvent, visit, typeIn } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -89,10 +90,10 @@ module('Acceptance | Sup Student List', function(hooks) {
         await visit('/etudiants');
 
         // when
-        await click('[aria-label="Afficher les actions"]');
-        await click('[aria-label="Actions"]>*:first-child');
+        await clickByLabel('Afficher les actions');
+        await clickByLabel('Éditer le numéro étudiant');
         await typeIn('#studentNumber', '1234');
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.contains('1234');
@@ -103,10 +104,10 @@ module('Acceptance | Sup Student List', function(hooks) {
         await visit('/etudiants');
 
         // when
-        await click('[aria-label="Afficher les actions"]');
-        await click('[aria-label="Actions"]>*:first-child');
+        await clickByLabel('Afficher les actions');
+        await clickByLabel('Éditer le numéro étudiant');
         await typeIn('#studentNumber', '321');
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.contains('123');

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, visit, currentURL } from '@ember/test-helpers';
+import { visit, currentURL } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import {
@@ -42,7 +43,7 @@ module('Acceptance | Switch Organization', function(hooks) {
       await visit('/');
 
       // when
-      await click('.logged-user-summary__link');
+      await clickByLabel('Résumé utilisateur');
 
       // then
       assert.dom('.logged-user-menu-item__organization-name').doesNotExist();
@@ -67,7 +68,7 @@ module('Acceptance | Switch Organization', function(hooks) {
 
     test('should have an organization in menu', async function(assert) {
       // when
-      await click('.logged-user-summary__link');
+      await clickByLabel('Résumé utilisateur');
 
       // then
       assert.dom('.logged-user-menu-item__organization-name').exists();
@@ -79,8 +80,8 @@ module('Acceptance | Switch Organization', function(hooks) {
 
       test('should change main organization in summary', async function(assert) {
         // when
-        await click('.logged-user-summary__link');
-        await click('.logged-user-menu-item');
+        await clickByLabel('Résumé utilisateur');
+        await clickByLabel('My Heaven Company');
 
         // then
         assert.dom('.logged-user-summary__organization').hasText('My Heaven Company (HEAVEN)');
@@ -88,9 +89,9 @@ module('Acceptance | Switch Organization', function(hooks) {
 
       test('should have the old main organization in the menu', async function(assert) {
         // when
-        await click('.logged-user-summary__link');
-        await click('.logged-user-menu-item');
-        await click('.logged-user-summary__link');
+        await clickByLabel('Résumé utilisateur');
+        await clickByLabel('My Heaven Company');
+        await clickByLabel('Résumé utilisateur');
 
         // then
         assert.dom('.logged-user-menu-item__organization-name').exists();
@@ -105,8 +106,8 @@ module('Acceptance | Switch Organization', function(hooks) {
           await visit('/campagnes?pageNumber=2&pageSize=10&name=test&status=archived');
 
           // when
-          await click('.logged-user-summary__link');
-          await click('.logged-user-menu-item');
+          await clickByLabel('Résumé utilisateur');
+          await clickByLabel('My Heaven Company');
 
           // then
           assert.equal(currentURL(), '/campagnes');
@@ -117,8 +118,8 @@ module('Acceptance | Switch Organization', function(hooks) {
 
         test('it should display student menu item', async function(assert) {
           // when
-          await click('.logged-user-summary__link');
-          await click('.logged-user-menu-item');
+          await clickByLabel('Résumé utilisateur');
+          await clickByLabel('My Heaven Company');
 
           // then
           assert.dom('.sidebar').containsText('Élèves');

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -92,7 +93,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         const organizationInvitation = server.db.organizationInvitations[server.db.organizationInvitations.length - 1];
@@ -109,7 +110,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', '');
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
@@ -121,7 +122,7 @@ module('Acceptance | Team Creation', function(hooks) {
 
         await visit('/equipe/creation');
         await fillInByLabel('Adresse(s) e-mail', email);
-        await click('.button--no-color');
+        await clickByLabel('Annuler');
 
         // when
         await visit('/equipe/creation');
@@ -146,7 +147,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
@@ -170,7 +171,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
@@ -194,7 +195,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
@@ -218,7 +219,7 @@ module('Acceptance | Team Creation', function(hooks) {
         await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
-        await click('button[type="submit"]');
+        await clickByLabel('Inviter');
 
         // then
         assert.equal(currentURL(), '/equipe/creation');

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -88,7 +89,7 @@ module('Acceptance | Team Creation', function(hooks) {
         server.create('user', { firstName: 'Gigi', lastName: 'La Brochette', email, pixOrgaTermsOfServiceAccepted: true });
 
         await visit('/equipe/creation');
-        await fillIn('#email', email);
+        await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
         await click('button[type="submit"]');
@@ -105,7 +106,7 @@ module('Acceptance | Team Creation', function(hooks) {
       test('it should not allow to invite a prescriber when an email is not given', async function(assert) {
         // given
         await visit('/equipe/creation');
-        await fillIn('#email', '');
+        await fillInByLabel('Adresse(s) e-mail', '');
 
         // when
         await click('button[type="submit"]');
@@ -119,7 +120,7 @@ module('Acceptance | Team Creation', function(hooks) {
         const email = 'cancel&cancel.com';
 
         await visit('/equipe/creation');
-        await fillIn('#email', email);
+        await fillInByLabel('Adresse(s) e-mail', email);
         await click('.button--no-color');
 
         // when
@@ -142,7 +143,7 @@ module('Acceptance | Team Creation', function(hooks) {
               },
             ],
           }, 500);
-        await fillIn('#email', 'fake@email');
+        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
         await click('button[type="submit"]');
@@ -166,7 +167,7 @@ module('Acceptance | Team Creation', function(hooks) {
               },
             ],
           }, 412);
-        await fillIn('#email', 'fake@email');
+        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
         await click('button[type="submit"]');
@@ -190,7 +191,7 @@ module('Acceptance | Team Creation', function(hooks) {
               },
             ],
           }, 404);
-        await fillIn('#email', 'fake@email');
+        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
         await click('button[type="submit"]');
@@ -214,7 +215,7 @@ module('Acceptance | Team Creation', function(hooks) {
               },
             ],
           }, 400);
-        await fillIn('#email', 'fake@email');
+        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
 
         // when
         await click('button[type="submit"]');

--- a/orga/tests/acceptance/team-list-items-test.js
+++ b/orga/tests/acceptance/team-list-items-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click, fillIn } from '@ember/test-helpers';
+import { currentURL, visit, click } from '@ember/test-helpers';
+import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -149,7 +150,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child option:checked').hasText('Membre');
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
-        await fillIn('select', 'MEMBER');
+        await fillInByLabel('Sélectionner un rôle', 'MEMBER');
         await click('#save-organization-role');
 
         assert.dom('#table-members tbody tr td').exists({ count: 8 });
@@ -181,7 +182,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child option:checked').hasText('Membre');
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
-        await fillIn('select', 'ADMIN');
+        await fillInByLabel('Sélectionner un rôle', 'ADMIN');
         await click('#save-organization-role');
 
         assert.dom('#table-members tbody tr td').exists({ count: 8 });
@@ -213,11 +214,11 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child option:checked').hasText('Membre');
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
-        await fillIn('select', 'ADMIN');
+        await fillInByLabel('Sélectionner un rôle', 'ADMIN');
         await click('#save-organization-role');
 
         await click('#edit-organization-role');
-        await fillIn('select', 'MEMBER');
+        await fillInByLabel('Sélectionner un rôle', 'MEMBER');
         await click('#cancel-update-organization-role');
 
         assert.dom('#table-members tbody tr:last-child td:nth-child(3)').hasText('Administrateur');

--- a/orga/tests/acceptance/team-list-items-test.js
+++ b/orga/tests/acceptance/team-list-items-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
-import { currentURL, visit, click } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
 import fillInByLabel from '../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -103,7 +104,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         // when
         await visit('/equipe');
 
-        await click('#edit-organization-role');
+        await clickByLabel('Modifier le rôle');
 
         // then
         assert.equal(currentURL(), '/equipe');
@@ -138,7 +139,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         // when
         await visit('/equipe');
 
-        await click('#edit-organization-role');
+        await clickByLabel('Modifier le rôle');
 
         // then
         assert.equal(currentURL(), '/equipe');
@@ -151,7 +152,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
         await fillInByLabel('Sélectionner un rôle', 'MEMBER');
-        await click('#save-organization-role');
+        await clickByLabel('Enregistrer');
 
         assert.dom('#table-members tbody tr td').exists({ count: 8 });
         assert.dom('.zone-edit-role').exists({ count: 1 });
@@ -170,7 +171,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         // when
         await visit('/equipe');
 
-        await click('#edit-organization-role');
+        await clickByLabel('Modifier le rôle');
 
         // then
         assert.equal(currentURL(), '/equipe');
@@ -183,7 +184,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
         await fillInByLabel('Sélectionner un rôle', 'ADMIN');
-        await click('#save-organization-role');
+        await clickByLabel('Enregistrer');
 
         assert.dom('#table-members tbody tr td').exists({ count: 8 });
         assert.dom('.zone-edit-role').exists({ count: 1 });
@@ -202,7 +203,7 @@ module('Acceptance | Team List | Items', function(hooks) {
         // when
         await visit('/equipe');
 
-        await click('#edit-organization-role');
+        await clickByLabel('Modifier le rôle');
 
         // then
         assert.equal(currentURL(), '/equipe');
@@ -215,11 +216,11 @@ module('Acceptance | Team List | Items', function(hooks) {
         assert.dom('#table-members tbody tr:last-child td:nth-child(4)').hasText('Enregistrer');
 
         await fillInByLabel('Sélectionner un rôle', 'ADMIN');
-        await click('#save-organization-role');
+        await clickByLabel('Enregistrer');
 
-        await click('#edit-organization-role');
+        await clickByLabel('Modifier le rôle');
         await fillInByLabel('Sélectionner un rôle', 'MEMBER');
-        await click('#cancel-update-organization-role');
+        await clickByLabel('Annuler');
 
         assert.dom('#table-members tbody tr:last-child td:nth-child(3)').hasText('Administrateur');
 

--- a/orga/tests/acceptance/team-list-test.js
+++ b/orga/tests/acceptance/team-list-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 
@@ -136,7 +137,7 @@ module('Acceptance | Team List', function(hooks) {
       await visit('/campagnes');
 
       // when
-      await click('a[href="/equipe"]');
+      await clickByLabel('Équipe');
 
       // then
       assert.equal(currentURL(), '/equipe');

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
-import { click, currentURL, visit } from '@ember/test-helpers';
+import { currentURL, visit } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
 import { setupApplicationTest } from 'ember-qunit';
 import {
   authenticateSession,
@@ -43,7 +44,7 @@ module('Acceptance | terms-of-service', function(hooks) {
       await visit('/cgu');
 
       // when
-      await click('button[type=submit]');
+      await clickByLabel('J’accepte les conditions d’utilisation');
 
       // then
       assert.equal(currentURL(), '/campagnes');

--- a/orga/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/orga/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,0 +1,35 @@
+import { click, findAll } from '@ember/test-helpers';
+
+export default function clickByLabel(labelText) {
+  const clickableElement = _findClickableElementForLabel(labelText);
+
+  if (!clickableElement) {
+    throw new Error(`Cannot find clickable element labelled "${labelText}".`);
+  }
+
+  return click(clickableElement);
+}
+
+function _findClickableElementForLabel(labelText) {
+  const clickableSelectors = ['button', 'a[href]', '[role="button"]', 'input[type="radio"]', 'input[type="checkbox"]'];
+  return findAll(clickableSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText) ||
+                      _matchesTitle(element, labelText) ||
+                      _matchesAriaLabel(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title && element.title.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel && ariaLabel.includes(labelText);
+}

--- a/orga/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
+++ b/orga/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
@@ -1,0 +1,36 @@
+import { fillIn, findAll, find } from '@ember/test-helpers';
+
+export default function fillInByLabel(labelText, value) {
+  const control = _findControlForLabel(labelText);
+
+  return fillIn(control, value);
+}
+
+function _findControlForLabel(labelText) {
+  const label = _findLabel(labelText);
+  if (label && label.control) return label.control;
+
+  const control = _findControl(labelText);
+  if (control) return control;
+
+  if (label && !label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+  throw new Error(`Cannot find form control labelled "${labelText}".`);
+}
+
+function _findLabel(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _findControl(labelText) {
+  const selectors = [];
+
+  for (const tag of ['input', 'textarea', 'select']) {
+    for (const attr of ['aria-label', 'title']) {
+      selectors.push(`${tag}[${attr}="${labelText}"]`);
+    }
+  }
+
+  return find(selectors.join(','));
+}

--- a/orga/tests/integration/components/dissociate-user-modal-test.js
+++ b/orga/tests/integration/components/dissociate-user-modal-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | dissociate-user-modal', function(hooks) {
@@ -63,8 +64,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     test('it dissociate user form student on click', async function(assert) {
       const student = { id: 12345 };
       this.set('student', student);
-
-      await click('.dissociate-user-modal__actions button:last-child');
+      await clickByLabel('Oui, dissocier le compte');
 
       assert.ok(studentAdapter.dissociateUser.calledWith(student));
     });
@@ -73,7 +73,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
       const student = { id: 12345, lastName: 'Dupont', firstName: 'Jean' };
       this.set('student', student);
 
-      await click('.dissociate-user-modal__actions button:last-child');
+      await clickByLabel('Oui, dissocier le compte');
 
       assert.ok(notifications.sendSuccess.calledWith('La dissociation du compte de l’élève Dupont Jean est réussie.'));
     });
@@ -83,7 +83,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
       const student = { id: 12345, lastName: 'Dupont', firstName: 'Jean' };
       this.set('student', student);
 
-      await click('.dissociate-user-modal__actions button:last-child');
+      await clickByLabel('Oui, dissocier le compte');
 
       assert.ok(notifications.sendError.calledWith('La dissociation du compte de l’élève Dupont Jean a échoué. Veuillez réessayer.'));
     });

--- a/orga/tests/integration/components/dropdown/icon-trigger-test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
@@ -18,7 +19,7 @@ module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
   test('should display actions on click', async function(assert) {
     // when
     await render(hbs`<Dropdown::IconTrigger/>`);
-    await click('[aria-label="Afficher les actions"]');
+    await clickByLabel('Afficher les actions');
 
     // then
     assert.dom('[aria-label="Actions"]').exists();
@@ -27,8 +28,8 @@ module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
   test('should hide actions on click again', async function(assert) {
     // when
     await render(hbs`<Dropdown::IconTrigger/>`);
-    await click('[aria-label="Afficher les actions"]');
-    await click('[aria-label="Afficher les actions"]');
+    await clickByLabel('Afficher les actions');
+    await clickByLabel('Afficher les actions');
 
     // then
     assert.dom('[aria-label="Actions"]').doesNotExist();

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, click, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
+import fillInByLabel from '../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -63,7 +64,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
       test('should have the update button enable', async function(assert) {
         // when
-        await fillIn('#studentNumber', this.student.studentNumber);
+        await fillInByLabel('Nouveau numéro étudiant', this.student.studentNumber);
 
         // then
         assert.dom('button[type=submit]').doesNotHaveAttribute('disabled');
@@ -75,7 +76,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
       test('should have the update button disable', async function(assert) {
         // when
-        await fillIn('#studentNumber', '');
+        await fillInByLabel('Nouveau numéro étudiant', '');
         await click('button[type=submit]');
 
         // then
@@ -90,7 +91,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.withArgs(123456).resolves();
 
         // when
-        await fillIn('#studentNumber', 123456);
+        await fillInByLabel('Nouveau numéro étudiant', 123456);
         await click('button[type=submit]');
 
         // then
@@ -103,7 +104,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
     module('when the update button is clicked and a wrong student number is entered', function() {
       test('it display error message', async function(assert) {
         // when
-        await fillIn('#studentNumber', ' ');
+        await fillInByLabel('Nouveau numéro étudiant', ' ');
         await click('button[type=submit]');
 
         // then
@@ -123,7 +124,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.rejects(error);
 
         // when
-        await fillIn('#studentNumber', 77107);
+        await fillInByLabel('Nouveau numéro étudiant', 77107);
         await click('button[type=submit]');
 
         // then
@@ -143,9 +144,9 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
         onSaveStudentNumberStub.onFirstCall().rejects(error).onSecondCall().resolves();
 
         // when
-        await fillIn('#studentNumber', 77107);
+        await fillInByLabel('Nouveau numéro étudiant', 77107);
         await click('button[type=submit]');
-        await fillIn('#studentNumber', 65432);
+        await fillInByLabel('Nouveau numéro étudiant', 65432);
         await click('button[type=submit]');
 
         // then

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -77,7 +78,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       test('should have the update button disable', async function(assert) {
         // when
         await fillInByLabel('Nouveau numéro étudiant', '');
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.dom('button[type=submit]').exists();
@@ -92,7 +93,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
         // when
         await fillInByLabel('Nouveau numéro étudiant', 123456);
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.dom('.error-message').hasText('');
@@ -105,7 +106,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       test('it display error message', async function(assert) {
         // when
         await fillInByLabel('Nouveau numéro étudiant', ' ');
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.dom('.error-message').hasText('Le numéro étudiant ne doit pas être vide.');
@@ -125,7 +126,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
         // when
         await fillInByLabel('Nouveau numéro étudiant', 77107);
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.contains('Error occured');
@@ -145,9 +146,9 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
         // when
         await fillInByLabel('Nouveau numéro étudiant', 77107);
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
         await fillInByLabel('Nouveau numéro étudiant', 65432);
-        await click('button[type=submit]');
+        await clickByLabel('Mettre à jour');
 
         // then
         assert.notContains('Error occured');
@@ -166,7 +167,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
         // when
         onSaveStudentNumberStub.rejects(error);
-        await click('[aria-label="Fermer la fenêtre"]');
+        await clickByLabel('Fermer la fenêtre');
 
         // then
         assert.dom('button[type=submit]').hasValue('');
@@ -187,7 +188,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
 
         // when
         onSaveStudentNumberStub.rejects(error);
-        await click('.button--light-grey');
+        await clickByLabel('Annuler');
 
         // then
         assert.dom('button[type=submit]').hasValue('');

--- a/orga/tests/integration/components/manage-authentication-method-modal-test.js
+++ b/orga/tests/integration/components/manage-authentication-method-modal-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import { resolve } from 'rsvp';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
@@ -146,7 +147,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
         await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
-        await click('#generate-password');
+        await clickByLabel('Réinitialiser le mot de passe');
 
         // then
         assert.dom('#generated-password').exists();
@@ -157,7 +158,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
         await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
-        await click('#generate-password');
+        await clickByLabel('Réinitialiser le mot de passe');
 
         // then
         assert.dom('button[aria-label="Copier le mot de passe unique"]').hasAttribute('data-clipboard-text', generatedPassword);
@@ -169,7 +170,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
         await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
 
         // when
-        await click('#generate-password');
+        await clickByLabel('Réinitialiser le mot de passe');
         await triggerCopySuccess('button[aria-label="Copier le mot de passe unique"]');
 
         // then
@@ -179,12 +180,12 @@ module('Integration | Component | manage-authentication-method-modal', function(
       test('should generate unique password each time the modal is used', async function(assert) {
         // given
         await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
-        await click('#generate-password');
+        await clickByLabel('Réinitialiser le mot de passe');
         const firstGeneratedPassword = this.element.querySelector('#generated-password').value;
 
         // when
         await render(hbs`<ManageAuthenticationMethodModal @student={{this.studentWithUsernameAndEmail}} @display={{this.display}} />`);
-        await click('#generate-password');
+        await clickByLabel('Réinitialiser le mot de passe');
         const secondGeneratedPassword = this.element.querySelector('#generated-password').value;
 
         // then

--- a/orga/tests/integration/components/modal/dialog-test.js
+++ b/orga/tests/integration/components/modal/dialog-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { getRootElement, render, click, triggerKeyEvent } from '@ember/test-helpers';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -34,7 +35,7 @@ module('Integration | Component | modal', function(hooks) {
     test('should call close method when user clicks on close button', async function(assert) {
       this.set('display', true);
 
-      await click('[aria-label="Fermer la fenêtre"]');
+      await clickByLabel('Fermer la fenêtre');
 
       assert.ok(close.called);
     });

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../../../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/analysis/tab', function(hooks) {
@@ -59,15 +60,14 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tab', f
     });
 
     test('it should order by recommendation asc', async function(assert) {
-      await click('[aria-label="Analyse par sujet"] thead [role="button"]:first-child');
+      await clickByLabel('Pertinence');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube B');
     });
 
     test('it should order by recommendation desc', async function(assert) {
-      const recommendationColumn = '[aria-label="Analyse par sujet"] thead [role="button"]:first-child';
-      await click(recommendationColumn);
-      await click(recommendationColumn);
+      await clickByLabel('Pertinence');
+      await clickByLabel('Pertinence');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
     });

--- a/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -75,7 +76,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await click('#assess-participants');
+      await clickByLabel('Choisir d\'évaluer les participants');
 
       // then
       assert.dom('#campaign-title').exists();
@@ -95,7 +96,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await click('#collect-participants-profile');
+      await clickByLabel('Choisir de collecter les profils Pix des participants');
 
       // then
       assert.dom('#campaign-title').doesNotExist();
@@ -166,7 +167,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     await fillInByLabel('Nom de la campagne', 'Ma campagne');
 
     // when
-    await click('button[type="submit"]');
+    await clickByLabel('Créer la campagne');
 
     // then
     assert.deepEqual(receivedCampaign.name, 'Ma campagne');

--- a/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -162,7 +163,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     // given
     this.campaign = EmberObject.create({});
     await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-    await fillIn('#campaign-name', 'Ma campagne');
+    await fillInByLabel('Nom de la campagne', 'Ma campagne');
 
     // when
     await click('button[type="submit"]');

--- a/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -31,7 +32,7 @@ module('Integration | Component | routes/authenticated/campaign/update', functio
 
     // then
     await fillInByLabel('Titre du parcours', 'New title');
-    await click('button[type="submit"]');
+    await clickByLabel('Modifier');
 
     assert.deepEqual(this.campaign.title, 'New title');
   });

--- a/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -29,7 +30,7 @@ module('Integration | Component | routes/authenticated/campaign/update', functio
     await render(hbs`<Routes::Authenticated::Campaign::Update @campaign={{this.campaign}} @update={{this.updateCampaignSpy}} @cancel={{this.cancelSpy}} />`);
 
     // then
-    await fillIn('#campaign-title', 'New title');
+    await fillInByLabel('Titre du parcours', 'New title');
     await click('button[type="submit"]');
 
     assert.deepEqual(this.campaign.title, 'New title');

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
@@ -169,7 +170,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{noop}}/>`);
 
       // when
-      await click('[aria-label="Afficher les actions"]');
+      await clickByLabel('Afficher les actions');
 
       // then
       assert.contains('Gérer le compte');
@@ -302,7 +303,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
         test('it should display the dissociate action', async function(assert) {
           // when
-          await click('[aria-label="Afficher les actions"]');
+          await clickByLabel('Afficher les actions');
 
           // then
           assert.contains('Dissocier le compte');
@@ -381,7 +382,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
       test('it should not display the dissociate action', async function(assert) {
         // when
-        await click('[aria-label="Afficher les actions"]');
+        await clickByLabel('Afficher les actions');
 
         // then
         assert.notContains('Dissocier le compte');

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, click } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
@@ -76,7 +77,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
       // when
-      await fillIn('[placeholder="Rechercher par nom"]', 'bob');
+      await fillInByLabel('Rechercher par nom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);
@@ -94,7 +95,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
       // when
-      await fillIn('[placeholder="Rechercher par prénom"]', 'bob');
+      await fillInByLabel('Rechercher par prénom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);
@@ -113,7 +114,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}} @connexionTypesOptions={{connexionTypesOptions}} />`);
 
       // when
-      await fillIn('select', 'email');
+      await fillInByLabel('Rechercher par méthode de connexion', 'email');
 
       // then
       const call = triggerFiltering.getCall(0);

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -78,7 +78,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
       // when
-      await fillInByLabel('Rechercher par nom', 'bob');
+      await fillInByLabel('Entrer un nom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);
@@ -96,7 +96,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
       await render(hbs`<Routes::Authenticated::ScoStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
       // when
-      await fillInByLabel('Rechercher par prénom', 'bob');
+      await fillInByLabel('Entrer un prénom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
@@ -125,7 +126,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // when
       await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
-      await fillIn('[placeholder="Rechercher par nom"]', 'bob');
+      await fillInByLabel('Rechercher par nom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);
@@ -142,7 +143,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // when
       await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
-      await fillIn('[placeholder="Rechercher par prénom"]', 'bob');
+      await fillInByLabel('Rechercher par prénom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
@@ -126,7 +126,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // when
       await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
-      await fillInByLabel('Rechercher par nom', 'bob');
+      await fillInByLabel('Entrer un nom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);
@@ -143,7 +143,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       // when
       await render(hbs`<Routes::Authenticated::SupStudents::ListItems @students={{students}} @triggerFiltering={{triggerFiltering}}/>`);
 
-      await fillInByLabel('Rechercher par prénom', 'bob');
+      await fillInByLabel('Entrer un prénom', 'bob');
 
       // then
       const call = triggerFiltering.getCall(0);

--- a/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
@@ -28,7 +29,7 @@ module('Integration | Component | routes/authenticated/team/new-item', function(
     await render(hbs`<Routes::Authenticated::Team::NewItem @organizationInvitation={{organizationInvitation}} @createOrganizationInvitation={{createOrganizationInvitationSpy}} @cancel={{cancelSpy}}/>`);
 
     // when
-    await fillIn('#email', 'dev@example.net');
+    await fillInByLabel('Adresse(s) e-mail', 'dev@example.net');
 
     // then
     assert.deepEqual(this.organizationInvitation.email, 'dev@example.net');

--- a/orga/tests/integration/components/routes/join-request-form-test.js
+++ b/orga/tests/integration/components/routes/join-request-form-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { fillIn, render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
+import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/join-request-form', function(hooks) {
@@ -19,7 +20,7 @@ module('Integration | Component | routes/join-request-form', function(hooks) {
         await render(hbs`<Routes::JoinRequestForm />`);
 
         // when
-        await fillIn('#firstName', stringFilledIn);
+        await fillInByLabel('Votre prénom', stringFilledIn);
         await triggerEvent('#firstName', 'focusout');
 
         // then
@@ -35,7 +36,7 @@ module('Integration | Component | routes/join-request-form', function(hooks) {
         await render(hbs`<Routes::JoinRequestForm />`);
 
         // when
-        await fillIn('#lastName', stringFilledIn);
+        await fillInByLabel('Votre nom', stringFilledIn);
         await triggerEvent('#lastName', 'focusout');
 
         // then

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
-import { click, fillIn, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
+import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject, resolve } from 'rsvp';
@@ -56,8 +57,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
       await render(hbs`<Routes::LoginForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
-      await fillIn('#login-email', 'pix@example.net');
-      await fillIn('#login-password', 'JeMeLoggue1024');
+      await fillInByLabel('Adresse e-mail', 'pix@example.net');
+      await fillInByLabel('Mot de passe', 'JeMeLoggue1024');
 
       // when
       await click('.button');
@@ -94,8 +95,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
       await render(hbs`<Routes::LoginForm @isWithInvitation=true @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
-      await fillIn('#login-email', 'pix@example.net');
-      await fillIn('#login-password', 'JeMeLoggue1024');
+      await fillInByLabel('Adresse e-mail', 'pix@example.net');
+      await fillInByLabel('Mot de passe', 'JeMeLoggue1024');
 
       //  when
       await click('.button');
@@ -119,8 +120,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
     SessionStub.prototype.authenticate = () => reject(msgErrorInvalidCredentiel);
 
     await render(hbs`<Routes::LoginForm/>`);
-    await fillIn('#login-email', 'pix@example.net');
-    await fillIn('#login-password', 'Mauvais mot de passe');
+    await fillInByLabel('Adresse e-mail', 'pix@example.net');
+    await fillInByLabel('Mot de passe', 'Mauvais mot de passe');
 
     //  when
     await click('.button');
@@ -140,8 +141,8 @@ module('Integration | Component | routes/login-form', function(hooks) {
     SessionStub.prototype.authenticate = () => reject(msgErrorNotLinkedOrganization);
 
     await render(hbs`<Routes::LoginForm/>`);
-    await fillIn('#login-email', 'pix@example.net');
-    await fillIn('#login-password', 'pix123');
+    await fillInByLabel('Adresse e-mail', 'pix@example.net');
+    await fillInByLabel('Mot de passe', 'pix123');
 
     //  when
     await click('.button');
@@ -180,11 +181,11 @@ module('Integration | Component | routes/login-form', function(hooks) {
 
     test('it should not change icon when user keeps typing his password', async function(assert) {
       // given
-      await fillIn('#login-password', 'début du mot de passe');
+      await fillInByLabel('Mot de passe', 'début du mot de passe');
 
       // when
       await click('.input-password__icon');
-      await fillIn('#login-password', 'fin du mot de passe');
+      await fillInByLabel('Mot de passe', 'fin du mot de passe');
 
       // then
       assert.dom('.fa-eye').exists();

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import { reject, resolve } from 'rsvp';
@@ -61,7 +62,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
       await fillInByLabel('Mot de passe', 'JeMeLoggue1024');
 
       // when
-      await click('.button');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
@@ -99,7 +100,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
       await fillInByLabel('Mot de passe', 'JeMeLoggue1024');
 
       //  when
-      await click('.button');
+      await clickByLabel('Je me connecte');
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
@@ -124,7 +125,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
     await fillInByLabel('Mot de passe', 'Mauvais mot de passe');
 
     //  when
-    await click('.button');
+    await clickByLabel('Je me connecte');
 
     // then
     assert.dom('#login-form-error-message').exists();
@@ -145,7 +146,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
     await fillInByLabel('Mot de passe', 'pix123');
 
     //  when
-    await click('.button');
+    await clickByLabel('Je me connecte');
 
     // then
     assert.dom('#login-form-error-message').exists();
@@ -165,7 +166,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
 
     test('it should display password when user click', async function(assert) {
       // when
-      await click('.input-password__icon');
+      await clickByLabel('rendre le mot de passe lisible');
 
       // then
       assert.dom('#login-password').hasAttribute('type', 'text');
@@ -173,7 +174,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
 
     test('it should change icon when user click on it', async function(assert) {
       // when
-      await click('.input-password__icon');
+      await clickByLabel('rendre le mot de passe lisible');
 
       // then
       assert.dom('.fa-eye').exists();
@@ -184,7 +185,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
       await fillInByLabel('Mot de passe', 'début du mot de passe');
 
       // when
-      await click('.input-password__icon');
+      await clickByLabel('rendre le mot de passe lisible');
       await fillInByLabel('Mot de passe', 'fin du mot de passe');
 
       // then

--- a/orga/tests/integration/components/routes/login-or-register-test.js
+++ b/orga/tests/integration/components/routes/login-or-register-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/login-or-register', function(hooks) {
@@ -35,7 +36,7 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
     await render(hbs`<Routes::LoginOrRegister/>`);
 
     // when
-    await click('#login');
+    await clickByLabel('Se connecter');
 
     // then
     assert.dom('.login-form').exists();
@@ -46,8 +47,8 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
     await render(hbs`<Routes::LoginOrRegister/>`);
 
     // when
-    await click('#login');
-    await click('#register');
+    await clickByLabel('Se connecter');
+    await clickByLabel('S\'inscrire');
 
     // then
     assert.dom('.register-form').exists();

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
-import { click, fillIn, render, triggerEvent } from '@ember/test-helpers';
+import { click, render, triggerEvent } from '@ember/test-helpers';
+import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
@@ -60,10 +61,10 @@ module('Integration | Component | routes/register-form', function(hooks) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
       await render(hbs`<Routes::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
-      await fillIn('#register-firstName', 'pix');
-      await fillIn('#register-lastName', 'pix');
-      await fillIn('#register-email', 'shi@fu.me');
-      await fillIn('#register-password', 'Mypassword1');
+      await fillInByLabel('Prénom', 'pix');
+      await fillInByLabel('Nom', 'pix');
+      await fillInByLabel('Adresse e-mail', 'shi@fu.me');
+      await fillInByLabel('Mot de passe', 'Mypassword1');
       await click('#register-cgu');
 
       // when
@@ -90,7 +91,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillIn('#register-firstName', stringFilledIn);
+          await fillInByLabel('Prénom', stringFilledIn);
           await triggerEvent('#register-firstName', 'focusout');
 
           // then
@@ -107,7 +108,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillIn('#register-lastName', stringFilledIn);
+          await fillInByLabel('Nom', stringFilledIn);
           await triggerEvent('#register-lastName', 'focusout');
 
           // then
@@ -126,7 +127,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillIn('#register-email', stringFilledIn);
+          await fillInByLabel('Adresse e-mail', stringFilledIn);
           await triggerEvent('#register-email', 'focusout');
 
           // then
@@ -146,7 +147,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillIn('#register-password', stringFilledIn);
+          await fillInByLabel('Mot de passe', stringFilledIn);
           await triggerEvent('#register-password', 'focusout');
 
           // then
@@ -162,10 +163,10 @@ module('Integration | Component | routes/register-form', function(hooks) {
       let validUser;
 
       const fillForm = async function(user) {
-        await fillIn('#register-firstName', user.firstName);
-        await fillIn('#register-lastName', user.lastName);
-        await fillIn('#register-email', user.email);
-        await fillIn('#register-password', user.password);
+        await fillInByLabel('Prénom', user.firstName);
+        await fillInByLabel('Nom', user.lastName);
+        await fillInByLabel('Adresse e-mail', user.email);
+        await fillInByLabel('Mot de passe', user.password);
         if (user.cgu) {
           await click('#register-cgu');
         }

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
-import { click, render, triggerEvent } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
@@ -65,10 +66,10 @@ module('Integration | Component | routes/register-form', function(hooks) {
       await fillInByLabel('Nom', 'pix');
       await fillInByLabel('Adresse e-mail', 'shi@fu.me');
       await fillInByLabel('Mot de passe', 'Mypassword1');
-      await click('#register-cgu');
+      await clickByLabel('Accepter les conditions d\'utilisation de Pix');
 
       // when
-      await click('.button');
+      await clickByLabel('Je m\'inscris');
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
@@ -168,7 +169,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillInByLabel('Adresse e-mail', user.email);
         await fillInByLabel('Mot de passe', user.password);
         if (user.cgu) {
-          await click('#register-cgu');
+          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
         }
       };
 
@@ -199,7 +200,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ firstName: '' } });
 
         // when
-        await click('.button');
+        await clickByLabel('Je m\'inscris');
 
         // then
         assert.equal(spy.callCount, 0);
@@ -210,7 +211,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ lastName: '' } });
 
         // when
-        await click('.button');
+        await clickByLabel('Je m\'inscris');
 
         // then
         assert.equal(spy.callCount, 0);
@@ -221,7 +222,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ email: '' } });
 
         // when
-        await click('.button');
+        await clickByLabel('Je m\'inscris');
 
         // then
         assert.equal(spy.callCount, 0);
@@ -232,7 +233,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ password: '' } });
 
         // when
-        await click('.button');
+        await clickByLabel('Je m\'inscris');
 
         // then
         assert.equal(spy.callCount, 0);
@@ -243,7 +244,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ cgu: false } });
 
         // when
-        await click('.button');
+        await clickByLabel('Je m\'inscris');
 
         // then
         assert.equal(spy.callCount, 0);

--- a/orga/tests/integration/components/tables/header-sort-test.js
+++ b/orga/tests/integration/components/tables/header-sort-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Tables | header-sort', function(hooks) {
@@ -42,7 +43,7 @@ module('Integration | Component | Tables | header-sort', function(hooks) {
     test('should inverse arrow on click', async function(assert) {
       // when
       await render(hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}}>Header</Table::HeaderSort>`);
-      await click('[role="button"]');
+      await clickByLabel('Header');
 
       // then
       assert.ok(onSortStub.calledWith('asc'));

--- a/orga/tests/integration/components/user-logged-menu-test.js
+++ b/orga/tests/integration/components/user-logged-menu-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 import Object from '@ember/object';
 import Service from '@ember/service';
@@ -60,7 +61,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
   test('should display the chevron-up icon when menu is open', async function(assert) {
     // when
     await render(hbs`<UserLoggedMenu/>`);
-    await click('.logged-user-summary__link');
+    await clickByLabel('Résumé utilisateur');
 
     // then
     assert.dom('.fa-chevron-up').exists();
@@ -70,7 +71,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
   test('should display the disconnect link when menu is open', async function(assert) {
     // when
     await render(hbs`<UserLoggedMenu/>`);
-    await click('.logged-user-summary__link');
+    await clickByLabel('Résumé utilisateur');
 
     // then
     assert.contains('Se déconnecter');
@@ -79,7 +80,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
   test('should display the organizations name and externalId when menu is open', async function(assert) {
     // when
     await render(hbs`<UserLoggedMenu />`);
-    await click('.logged-user-summary__link');
+    await clickByLabel('Résumé utilisateur');
 
     // then
     assert.contains(organization2.name);


### PR DESCRIPTION
## :unicorn: Problème
La manière de tester l'UI est un sujet intéressant et riche en propositions.
Il existe une tendance sur les internets qui dit que tester et s'outiller correctement pour tester son UI permet au passage de tester la qualité de l'accessibilité.
On peut rendre un test front très expressif en utilisant les procédés a11y mis en place dans le DOM.

Inspiration : https://www.youtube.com/watch?v=iAyRVPSOpy8&list=PL4eq2DPpyBbnjD5iLp55as9OvIdEDI_Kt&index=11

## :robot: Solution
Je fais donc ici une proposition appliquée à PixOrga sur l'enrichissement de l'outillage de test d'UI.
Ajout du helper suivant :
- fillInByLabel(label, value)
- clickByLabel(label)

L'idée est donc, en plus de disposer d'une manière expressive de remplir un formulaire dans des tests auto, de vérifier la conformité a11y du formulaire. 

### fillInByLabel
Une des règles de l'a11y est de s'assurer que, pour chaque élément de formulaire il existe un label. Voici les deux règles que j'applique ([1](https://www.accede-web.com/en/guidelines/html-css-javascript/forms/label-tag-for-id-attributes-label-form-fields/) et [2](https://www.accede-web.com/en/guidelines/html-css-javascript/forms/use-the-aria-label-or-title-attribute-to-label-form-fields-that-dont-have-a-visible-label/)) qui, en substance préconisent la présence d'un label via :
- Un élément html \<label\> OU
- Un aria-label OU
- Un title

### clickByLabel
On va s'assurer qu'on peut facilement cliquer sur un élément tel qu'il apparaît pour l'utilisateur. On définit la liste des éléments cliquables suivants : `button`, `a[href]`, `[role="button"]`

## :rainbow: Remarques
Cela a donc permis de mettre en évidence des manquements à ces règles a11y sur certains hbs de PixOrga

## :100: Pour tester
Non régression des tests
