### PR TITLE
[FEATURE] Amélioration du wording des catégories de signalement (PIX-1995)

### DIFF
--- a/admin/app/models/certification-issue-report.js
+++ b/admin/app/models/certification-issue-report.js
@@ -25,37 +25,37 @@ export const certificationIssueReportSubcategories = {
 };
 
 export const categoryToLabel = {
-  [certificationIssueReportCategories.OTHER]: 'Autre incident',
+  [certificationIssueReportCategories.OTHER]: 'Autre (si aucune des catégories ci-dessus ne correspond au signalement)',
   [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'Modification infos candidat',
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'Retard, absence ou départ',
   [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
   [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'Problème technique',
-  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat n’a pas pu terminer, faute de temps',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Le candidat n’a pas pu terminer, faute de temps',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une épreuve',
 };
 
 export const subcategoryToLabel = {
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Prénom/Nom/Date de naissance',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Modification des prénom/nom/date de naissance',
   [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Ajout/modification du temps majoré',
-  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Écran de fin de test non vu',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'L\'image ne s\'affiche pas',
-  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
   [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'Le simulateur/l\'application ne s\'affiche pas',
   [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'Le fichier à télécharger ne s\'ouvre pas',
-  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'Le site à visiter est mort/en maintenance/inaccessible',
-  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'Le site à visiter est bloqué par les restrictions réseau de l\'établissement (réseaux sociaux par ex.)',
-  [certificationIssueReportSubcategories.OTHER]: 'Autre',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'Le site à visiter est indisponible/en maintenance/inaccessible',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'Le site est bloqué par les restrictions réseau de l\'établissement (réseaux sociaux par ex.)',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
+  [certificationIssueReportSubcategories.OTHER]: 'Autre incident lié à une question',
 };
 
 export const categoryToCode = {
-  [certificationIssueReportCategories.OTHER]: 'A2',
   [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'C1-C2',
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'C3-C4',
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
   [certificationIssueReportCategories.FRAUD]: 'C6',
   [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
+  [certificationIssueReportCategories.OTHER]: 'A2',
 };
 
 export const subcategoryToCode = {
@@ -64,11 +64,11 @@ export const subcategoryToCode = {
   [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'C4',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
-  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E2',
-  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E3',
-  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E4',
-  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
-  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E2',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E3',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E6',
   [certificationIssueReportSubcategories.OTHER]: 'E7',
 };
 

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
@@ -92,7 +92,7 @@ module('Integration | Component | routes/authenticated/certifications/certificat
 
           // then
           assert.contains('Signalement(s) impactant(s)');
-          assert.dom('.card-text ul li').hasText('Autre incident - Un signalement impactant');
+          assert.dom('.card-text ul li').hasText('Autre (si aucune des catégories ci-dessus ne correspond au signalement) - Un signalement impactant');
           assert.notContains('Signalement(s) non impactant(s)');
         });
       });

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -93,11 +93,11 @@ const subcategoryCodeRequiredAction = {
   [CertificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'C1',
   [CertificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
   [CertificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
-  [CertificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E2',
-  [CertificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E3',
-  [CertificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E4',
-  [CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
-  [CertificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
+  [CertificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E2',
+  [CertificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E3',
+  [CertificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
+  [CertificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
+  [CertificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E6',
   [CertificationIssueReportSubcategories.OTHER]: 'E7',
 };
 

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -13,33 +13,33 @@
   {{#if @inChallengeCategory.isChecked}}
     <div class="candidate-information-change-certification-issue-report-fields__details">
       <label for="input-for-category-in-challenge-question-number">Numéro d'épreuve :</label>
-       <Input
-              @id="input-for-category-in-challenge-question-number"
-              @name="question-number"
-              @type="text"
-              @required="true"
-              @value={{@inChallengeCategory.questionNumber}}
-       />
-       <label for="subcategory-for-category-in-challenge">Sélectionnez une sous-catégorie :</label>
-       <PixSelect
-               aria-label="Sélectionner la sous-catégorie"
-               id="subcategory-for-category-in-challenge"
-               @options={{this.options}}
-               @selectedOption={{@inChallengeCategory.subcategory}}
-               @onChange={{this.onChangeSubcategory}}
-       />
+      <Input
+        @id="input-for-category-in-challenge-question-number"
+        @name="question-number"
+        @type="text"
+        @required="true"
+        @value={{@inChallengeCategory.questionNumber}}
+      />
+      <label for="subcategory-for-category-in-challenge">Sélectionnez une sous-catégorie :</label>
+      <PixSelect
+        aria-label="Sélectionner la sous-catégorie"
+        id="subcategory-for-category-in-challenge"
+        @options={{this.options}}
+        @selectedOption={{@inChallengeCategory.subcategory}}
+        @onChange={{this.onChangeSubcategory}}
+      />
       {{#if this.isOtherSubcategorySelected }}
         <label for="text-area-for-category-in-challenge-subcategory-other">Précisez</label>
         <Textarea
-                id="text-area-for-category-in-challenge-subcategory-other"
-                @class="session-finalization-reports-informations-step__textarea"
-                @value={{@inChallengeCategory.description}}
-                @maxlength={{@maxlength}}
-                required
+          id="text-area-for-category-in-challenge-subcategory-other"
+          @class="session-finalization-reports-informations-step__textarea"
+          @value={{@inChallengeCategory.description}}
+          @maxlength={{@maxlength}}
+          required
         />
         <p class="candidate-information-change-certification-issue-report-fields-details__char-count">{{this.reportLength}}
           / {{@maxlength}}</p>
       {{/if}}
-     </div>
-   {{/if}}
- </fieldset>
+    </div>
+  {{/if}}
+</fieldset>

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -19,8 +19,8 @@ export default class InChallengeCertificationIssueReportFields extends Component
     this.args.inChallengeCategory.description = null;
   }
 
-  options = ['IMAGE_NOT_DISPLAYING', 'LINK_NOT_WORKING', 'EMBED_NOT_WORKING',
-    'FILE_NOT_OPENING', 'WEBSITE_UNAVAILABLE', 'WEBSITE_BLOCKED', 'OTHER'].map((subcategoryKey) => {
+  options = ['IMAGE_NOT_DISPLAYING', 'EMBED_NOT_WORKING', 'FILE_NOT_OPENING',
+    'WEBSITE_UNAVAILABLE', 'WEBSITE_BLOCKED', 'LINK_NOT_WORKING', 'OTHER'].map((subcategoryKey) => {
     const subcategory = certificationIssueReportSubcategories[subcategoryKey];
     return {
       value: certificationIssueReportSubcategories[subcategory],

--- a/certif/app/models/certification-issue-report.js
+++ b/certif/app/models/certification-issue-report.js
@@ -25,37 +25,37 @@ export const certificationIssueReportSubcategories = {
 };
 
 export const categoryToLabel = {
-  [certificationIssueReportCategories.OTHER]: 'Autre incident',
+  [certificationIssueReportCategories.OTHER]: 'Autre (si aucune des catégories ci-dessus ne correspond au signalement)',
   [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'Modification infos candidat',
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'Retard, absence ou départ',
   [certificationIssueReportCategories.FRAUD]: 'Suspicion de fraude',
   [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'Problème technique',
-  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Connexion et fin de test : le candidat n’a pas pu terminer, faute de temps',
+  [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'Le candidat n’a pas pu terminer, faute de temps',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'Problème sur une épreuve',
 };
 
 export const subcategoryToLabel = {
-  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Prénom/Nom/Date de naissance',
+  [certificationIssueReportSubcategories.NAME_OR_BIRTHDATE]: 'Modification des prénom/nom/date de naissance',
   [certificationIssueReportSubcategories.EXTRA_TIME_PERCENTAGE]: 'Ajout/modification du temps majoré',
-  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Ecran de fin de test non vu',
+  [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'Écran de fin de test non vu',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'Était présent(e) mais a oublié de signer, ou a signé sur la mauvaise ligne',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'L\'image ne s\'affiche pas',
-  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
   [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'Le simulateur/l\'application ne s\'affiche pas',
   [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'Le fichier à télécharger ne s\'ouvre pas',
-  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'Le site à visiter est mort/en maintenance/inaccessible',
-  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'Le site à visiter est bloqué par les restrictions réseau de l\'établissement (réseaux sociaux par ex.)',
-  [certificationIssueReportSubcategories.OTHER]: 'Autre',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'Le site à visiter est indisponible/en maintenance/inaccessible',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'Le site est bloqué par les restrictions réseau de l\'établissement (réseaux sociaux par ex.)',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'Le lien ne fonctionne pas',
+  [certificationIssueReportSubcategories.OTHER]: 'Autre incident lié à une question',
 };
 
 export const categoryToCode = {
-  [certificationIssueReportCategories.OTHER]: 'A2',
   [certificationIssueReportCategories.CANDIDATE_INFORMATIONS_CHANGES]: 'C1-C2',
   [certificationIssueReportCategories.LATE_OR_LEAVING]: 'C3-C4',
   [certificationIssueReportCategories.CONNECTION_OR_END_SCREEN]: 'C5',
   [certificationIssueReportCategories.IN_CHALLENGE]: 'E1-E7',
   [certificationIssueReportCategories.FRAUD]: 'C6',
   [certificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
+  [certificationIssueReportCategories.OTHER]: 'A2',
 };
 
 export const subcategoryToCode = {
@@ -64,11 +64,11 @@ export const subcategoryToCode = {
   [certificationIssueReportSubcategories.LEFT_EXAM_ROOM]: 'C3',
   [certificationIssueReportSubcategories.SIGNATURE_ISSUE]: 'C4',
   [certificationIssueReportSubcategories.IMAGE_NOT_DISPLAYING]: 'E1',
-  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E2',
-  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E3',
-  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E4',
-  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E5',
-  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E6',
+  [certificationIssueReportSubcategories.EMBED_NOT_WORKING]: 'E2',
+  [certificationIssueReportSubcategories.FILE_NOT_OPENING]: 'E3',
+  [certificationIssueReportSubcategories.WEBSITE_UNAVAILABLE]: 'E4',
+  [certificationIssueReportSubcategories.WEBSITE_BLOCKED]: 'E5',
+  [certificationIssueReportSubcategories.LINK_NOT_WORKING]: 'E6',
   [certificationIssueReportSubcategories.OTHER]: 'E7',
 };
 


### PR DESCRIPTION
## :unicorn: Problème
Il y a quelques différences notamment de wording mais aussi de code de signalement entre le PV d’incident utilisé par les surveillants de session, et la page de finalisation de session dans Pix Certif.

## :robot: Solution
Apporter les modifications suivantes aux catégories/sous-catégories de signalement sur la page de finalisation de session : 
C1 - Modification des prénom/nom/date de naissance
C3 - Écran de fin de test non vu
C5 - Le candidat n’a pas pu terminer, faute de temps
E1-E7 Problème sur une épreuve
E2 - Le simulateur/l’application ne s’affiche pas
E3 - Le fichier à télécharger ne s’ouvre pas
E4 - Le site à visiter est indisponible/en maintenance/inaccessible
E5 - Le site est bloqué par les restrictions réseau de l’établissement
E6 - Le lien ne fonctionne pas
E7 - Autre incident lié à une question
A2 - Autre (si aucune des catégories ci-dessus ne correspond au signalement)

## :rainbow: Remarques
RAS

## :100: Pour tester
- Lancer l'API avec le flag FT_REPORTS_CATEGORISATION
- Lancer Certif
- Aller dans la session 4 et finaliser
- Constater les corrections des libellés des catégories
- Ajouter quelques signalements des catégories modifiées
- Lancer Admin
- Aller dans la session 4
- Constater les corrections des libellés des catégories
