### PR TITLE
[FEATURE] Choisir l'acquis à jouer dans les acquis qui possèdent une épreuve locale (PIX-1987).

### DIFF
--- a/api/lib/domain/services/smart-random/smart-random.js
+++ b/api/lib/domain/services/smart-random/smart-random.js
@@ -5,7 +5,7 @@ const { computeTubesFromSkills } = require('./../tube-service');
 
 module.exports = { getPossibleSkillsForNextChallenge };
 
-function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers } = {}) {
+function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targetSkills, lastAnswer, allAnswers, locale } = {}) {
 
   const isUserStartingTheTest = !lastAnswer;
   const isLastChallengeTimed = _wasLastChallengeTimed(lastAnswer);
@@ -14,7 +14,7 @@ function getPossibleSkillsForNextChallenge({ knowledgeElements, challenges, targ
     return targetSkills.find((skill) => skill.id === ke.skillId);
   });
   const filteredChallenges = _removeChallengesWithAnswer({ challenges, allAnswers });
-  targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges });
+  targetSkills = _getSkillsWithAddedInformations({ targetSkills, filteredChallenges, locale });
 
   // First challenge has specific rules
   const { possibleSkillsForNextChallenge, levelEstimated } = isUserStartingTheTest
@@ -57,9 +57,9 @@ function _findFirstChallenge({ knowledgeElements, targetSkills, tubes }) {
   return { possibleSkillsForNextChallenge: filteredSkillsForFirstChallenge, levelEstimated: 2 };
 }
 
-function _getSkillsWithAddedInformations({ targetSkills, filteredChallenges }) {
+function _getSkillsWithAddedInformations({ targetSkills, filteredChallenges, locale }) {
   return _.map(targetSkills, (skill) => {
-    const challenges = _.filter(filteredChallenges, (challenge) => challenge.hasSkill(skill));
+    const challenges = _.filter(filteredChallenges, (challenge) => challenge.hasSkill(skill) && challenge.locales.includes(locale));
     const [ firstChallenge ] = challenges;
     const skillCopy = Object.create(skill);
     return Object.assign(skillCopy, {

--- a/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-campaign-assessment.js
@@ -23,7 +23,7 @@ module.exports = async function getNextChallengeForCampaignAssessment({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
+  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -22,7 +22,7 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
   const {
     possibleSkillsForNextChallenge,
     hasAssessmentEnded,
-  } = smartRandom.getPossibleSkillsForNextChallenge(inputValues);
+  } = smartRandom.getPossibleSkillsForNextChallenge({ ...inputValues, locale });
 
   if (hasAssessmentEnded) {
     throw new AssessmentEndedError();

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -22,9 +22,9 @@ function duplicateChallengeOfSameDifficulty(challenge) {
 describe('Integration | Domain | Stategies | SmartRandom', () => {
   let challenges, targetSkills, knowledgeElements, lastAnswer, allAnswers, locale, web1, web2, web3, web4, web5,
     web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
-    challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6,
+    challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6, challengeWeb_7,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
-    challengeRechInfo_7, challengeInfo_2, challengeCnil_1, challengeCnil_2;
+    challengeRechInfo_7, challengeInfo_2_frAndEn, challengeCnil_1, challengeCnil_2;
 
   beforeEach(() => {
     targetSkills = null;
@@ -58,8 +58,9 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     challengeWeb_2_3 = domainBuilder.buildChallenge({ id: 'recweb23', skills: [web2, web3], locales: ['fr'] });
     challengeWeb_3 = domainBuilder.buildChallenge({ id: 'recweb3', skills: [web3], locales: ['fr'] });
     challengeWeb_4 = domainBuilder.buildChallenge({ id: 'recweb4', skills: [web4], locales: ['fr'] });
-    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6], locales: ['fr'] });
-    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7], locales: ['fr'] });
+    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb5', skills: [web5], locales: ['fr'] });
+    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6], locales: ['fr'] });
+    challengeWeb_7 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7], locales: ['fr'] });
     challengeUrl_2 = domainBuilder.buildChallenge({ id: 'recurl2', skills: [url2], locales: ['fr'] });
     challengeUrl_3 = domainBuilder.buildChallenge({ id: 'recurl3', skills: [url3], locales: ['fr'] });
     challengeUrl_4 = domainBuilder.buildChallenge({ id: 'recurl4', skills: [url4], locales: ['fr'] });
@@ -69,7 +70,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     challengeRechInfo_7 = domainBuilder.buildChallenge({ id: 'recinfo7', skills: [rechInfo7], locales: ['fr'] });
     challengeCnil_1 = domainBuilder.buildChallenge({ id: 'reccnil1', skills: [cnil1], locales: ['fr'] });
     challengeCnil_2 = domainBuilder.buildChallenge({ id: 'reccnil2', skills: [cnil2], locales: ['fr'] });
-    challengeInfo_2 = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2], locales: ['fr', 'en'] });
+    challengeInfo_2_frAndEn = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2], locales: ['fr', 'en'] });
   });
 
   describe('#getPossibleSkillsForNextChallenge', function() {
@@ -201,7 +202,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       it('should end the test when the remaining challenges have been inferred to be too hard', function() {
         // given
         targetSkills = [url2, url3, rechInfo5, web7];
-        challenges = [challengeUrl_2, challengeUrl_3, challengeRechInfo_5, challengeWeb_6];
+        challenges = [challengeUrl_2, challengeUrl_3, challengeRechInfo_5, challengeWeb_7];
 
         lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeRechInfo_5.id, result: AnswerStatus.KO });
         allAnswers = [lastAnswer];
@@ -330,7 +331,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
 
       it('should ask a challenge of maximum difficulty when maximum difficulty (minus 1) was correctly answered (edge case test)', function() {
         // given
-        targetSkills = [web1, web2, web4, web6, web7];
+        targetSkills = [web1, web2, web4, web5, web6];
 
         challenges = [challengeWeb_1, challengeWeb_2, challengeWeb_4, challengeWeb_5, challengeWeb_6];
 
@@ -357,7 +358,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
             source: 'indirect',
           }),
           domainBuilder.buildKnowledgeElement({
-            skillId: web6.id,
+            skillId: web5.id,
             status: KNOWLEDGE_ELEMENT_STATUS.VALIDATED,
             source: 'direct',
           }),
@@ -376,7 +377,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         // then
         expect(possibleSkillsForNextChallenge.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
-        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web7.id);
+        expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web6.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_6.id);
       });
 
@@ -416,8 +417,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       it('should prioritize a challenge from an easy tube if given the possibility', function() {
         // given
         targetSkills = [url4, url5, web3, info2];
-        challenges = [challengeUrl_4, challengeUrl_5, challengeInfo_2, challengeWeb_3];
-        lastAnswer = [domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.OK })];
+        challenges = [challengeUrl_4, challengeUrl_5, challengeInfo_2_frAndEn, challengeWeb_3];
+        lastAnswer = [domainBuilder.buildAnswer({ challengeId: challengeInfo_2_frAndEn.id, result: AnswerStatus.OK })];
         allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
@@ -447,8 +448,8 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       it('should nevertheless target a challenge from any tubes when there is no easy tube', function() {
         // given
         targetSkills = [url4, url6, info2];
-        challenges = [challengeUrl_4, challengeUrl_6, challengeInfo_2];
-        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeInfo_2.id, result: AnswerStatus.OK });
+        challenges = [challengeUrl_4, challengeUrl_6, challengeInfo_2_frAndEn];
+        lastAnswer = domainBuilder.buildAnswer({ challengeId: challengeInfo_2_frAndEn.id, result: AnswerStatus.OK });
         allAnswers = [lastAnswer];
         knowledgeElements = [
           domainBuilder.buildKnowledgeElement({
@@ -694,7 +695,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       it('should propose only skill with asked locale', function() {
         // given
         targetSkills = [info2, cnil2];
-        challenges = [challengeInfo_2, challengeCnil_2];
+        challenges = [challengeInfo_2_frAndEn, challengeCnil_2];
         lastAnswer = null;
         allAnswers = [];
         knowledgeElements = [];

--- a/api/tests/integration/domain/services/smart-random/smart-random_test.js
+++ b/api/tests/integration/domain/services/smart-random/smart-random_test.js
@@ -20,7 +20,7 @@ function duplicateChallengeOfSameDifficulty(challenge) {
 }
 
 describe('Integration | Domain | Stategies | SmartRandom', () => {
-  let challenges, targetSkills, knowledgeElements, lastAnswer, allAnswers, web1, web2, web3, web4, web5,
+  let challenges, targetSkills, knowledgeElements, lastAnswer, allAnswers, locale, web1, web2, web3, web4, web5,
     web6, web7, url2, url3, url4, url5, url6, rechInfo5, rechInfo7, info2, cnil1, cnil2, challengeWeb_1,
     challengeWeb_2, challengeWeb_2_3, challengeWeb_3, challengeWeb_4, challengeWeb_5, challengeWeb_6,
     challengeUrl_2, challengeUrl_3, challengeUrl_4, challengeUrl_5, challengeUrl_6, challengeRechInfo_5,
@@ -31,6 +31,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     knowledgeElements = null;
     lastAnswer = null;
     allAnswers = [];
+    locale = 'fr';
 
     // Acquis (skills)
     web1 = domainBuilder.buildSkill({ name: '@web1' });
@@ -52,23 +53,23 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
     cnil2 = domainBuilder.buildSkill({ name: '@cnil2' });
 
     // Challenges
-    challengeWeb_1 = domainBuilder.buildChallenge({ id: 'recweb1', skills: [web1] });
-    challengeWeb_2 = domainBuilder.buildChallenge({ id: 'recweb2', skills: [web2] });
-    challengeWeb_2_3 = domainBuilder.buildChallenge({ id: 'recweb23', skills: [web2, web3] });
-    challengeWeb_3 = domainBuilder.buildChallenge({ id: 'recweb3', skills: [web3] });
-    challengeWeb_4 = domainBuilder.buildChallenge({ id: 'recweb4', skills: [web4] });
-    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6] });
-    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7] });
-    challengeUrl_2 = domainBuilder.buildChallenge({ id: 'recurl2', skills: [url2] });
-    challengeUrl_3 = domainBuilder.buildChallenge({ id: 'recurl3', skills: [url3] });
-    challengeUrl_4 = domainBuilder.buildChallenge({ id: 'recurl4', skills: [url4] });
-    challengeUrl_5 = domainBuilder.buildChallenge({ id: 'recurl5', skills: [url5] });
-    challengeUrl_6 = domainBuilder.buildChallenge({ id: 'recurl6', skills: [url6] });
-    challengeRechInfo_5 = domainBuilder.buildChallenge({ id: 'recinfo5', skills: [rechInfo5] });
-    challengeRechInfo_7 = domainBuilder.buildChallenge({ id: 'recinfo7', skills: [rechInfo7] });
-    challengeCnil_1 = domainBuilder.buildChallenge({ id: 'reccnil1', skills: [cnil1] });
-    challengeCnil_2 = domainBuilder.buildChallenge({ id: 'reccnil2', skills: [cnil2] });
-    challengeInfo_2 = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2] });
+    challengeWeb_1 = domainBuilder.buildChallenge({ id: 'recweb1', skills: [web1], locales: ['fr'] });
+    challengeWeb_2 = domainBuilder.buildChallenge({ id: 'recweb2', skills: [web2], locales: ['fr'] });
+    challengeWeb_2_3 = domainBuilder.buildChallenge({ id: 'recweb23', skills: [web2, web3], locales: ['fr'] });
+    challengeWeb_3 = domainBuilder.buildChallenge({ id: 'recweb3', skills: [web3], locales: ['fr'] });
+    challengeWeb_4 = domainBuilder.buildChallenge({ id: 'recweb4', skills: [web4], locales: ['fr'] });
+    challengeWeb_5 = domainBuilder.buildChallenge({ id: 'recweb6', skills: [web6], locales: ['fr'] });
+    challengeWeb_6 = domainBuilder.buildChallenge({ id: 'recweb7', skills: [web7], locales: ['fr'] });
+    challengeUrl_2 = domainBuilder.buildChallenge({ id: 'recurl2', skills: [url2], locales: ['fr'] });
+    challengeUrl_3 = domainBuilder.buildChallenge({ id: 'recurl3', skills: [url3], locales: ['fr'] });
+    challengeUrl_4 = domainBuilder.buildChallenge({ id: 'recurl4', skills: [url4], locales: ['fr'] });
+    challengeUrl_5 = domainBuilder.buildChallenge({ id: 'recurl5', skills: [url5], locales: ['fr'] });
+    challengeUrl_6 = domainBuilder.buildChallenge({ id: 'recurl6', skills: [url6], locales: ['fr'] });
+    challengeRechInfo_5 = domainBuilder.buildChallenge({ id: 'recinfo5', skills: [rechInfo5], locales: ['fr'] });
+    challengeRechInfo_7 = domainBuilder.buildChallenge({ id: 'recinfo7', skills: [rechInfo7], locales: ['fr'] });
+    challengeCnil_1 = domainBuilder.buildChallenge({ id: 'reccnil1', skills: [cnil1], locales: ['fr'] });
+    challengeCnil_2 = domainBuilder.buildChallenge({ id: 'reccnil2', skills: [cnil2], locales: ['fr'] });
+    challengeInfo_2 = domainBuilder.buildChallenge({ id: 'recinfo2', skills: [info2], locales: ['fr', 'en'] });
   });
 
   describe('#getPossibleSkillsForNextChallenge', function() {
@@ -86,6 +87,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements: [],
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -111,6 +113,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements: [],
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -133,6 +136,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements: [],
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -155,6 +159,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements: [],
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -178,6 +183,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements: [],
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -224,6 +230,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -256,6 +263,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -310,6 +318,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -361,6 +370,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -396,6 +406,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -423,6 +434,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -453,6 +465,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -493,6 +506,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -526,6 +540,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -573,6 +588,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -607,6 +623,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           lastAnswer,
           allAnswers,
+          locale,
         });
 
         // then
@@ -620,7 +637,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
       });
     });
 
-    context('when one challenge has already been answered but its learning content has been updated', function() {
+    context('when one challenge has already been answered but its learning content has been updated', () => {
       it('should not be asked again and ask another challenge from same skill', function() {
         // given
         targetSkills = [web2];
@@ -636,6 +653,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           allAnswers,
           lastAnswer,
+          locale,
         });
 
         // then
@@ -660,6 +678,7 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
           knowledgeElements,
           allAnswers,
           lastAnswer,
+          locale,
         });
 
         // then
@@ -667,6 +686,44 @@ describe('Integration | Domain | Stategies | SmartRandom', () => {
         expect(possibleSkillsForNextChallenge[0].challenges.length).to.be.equal(1);
         expect(possibleSkillsForNextChallenge[0].id).to.be.equal(web1.id);
         expect(possibleSkillsForNextChallenge[0].challenges[0].id).to.be.equal(challengeWeb_1.id);
+      });
+    });
+
+    context('when one skill does not have challenge in the asked locale', () => {
+
+      it('should propose only skill with asked locale', function() {
+        // given
+        targetSkills = [info2, cnil2];
+        challenges = [challengeInfo_2, challengeCnil_2];
+        lastAnswer = null;
+        allAnswers = [];
+        knowledgeElements = [];
+
+        // when
+        const { possibleSkillsForNextChallenge: possibleSkillsForNextChallengeInEnglish } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          lastAnswer,
+          allAnswers,
+          locale: 'en',
+        });
+        const { possibleSkillsForNextChallenge: possibleSkillsForNextChallengeInFrench } = SmartRandom.getPossibleSkillsForNextChallenge({
+          targetSkills,
+          challenges,
+          knowledgeElements,
+          lastAnswer,
+          allAnswers,
+          locale: 'fr',
+        });
+
+        // then
+        expect(possibleSkillsForNextChallengeInFrench.length).to.be.equal(2);
+        expect(possibleSkillsForNextChallengeInFrench[0].name).to.be.equal('@info2');
+        expect(possibleSkillsForNextChallengeInFrench[1].name).to.be.equal('@cnil2');
+
+        expect(possibleSkillsForNextChallengeInEnglish.length).to.be.equal(1);
+        expect(possibleSkillsForNextChallengeInEnglish[0].name).to.be.equal('@info2');
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-campaign-assessment_test.js
@@ -100,6 +100,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-campaign-assessmen
         challenges,
         targetSkills: targetProfile.skills,
         knowledgeElements: recentKnowledgeElements,
+        locale,
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -8,7 +8,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
   describe('#getNextChallengeForCompetenceEvaluation', () => {
 
     let userId, assessmentId, competenceId,
-      assessment, lastAnswer, challenges, targetSkills,
+      assessment, lastAnswer, challenges, targetSkills, locale,
       answerRepository, challengeRepository, skillRepository,
       knowledgeElementRepository, pickChallengeService,
       recentKnowledgeElements, actualComputedChallenge,
@@ -24,6 +24,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
       challenges = [];
       targetSkills = [];
       lastAnswer = null;
+      locale = 'fr';
 
       answerRepository = { findByAssessment: sinon.stub().resolves([lastAnswer]) };
       challengeRepository = { findValidatedByCompetenceId: sinon.stub().resolves(challenges) };
@@ -61,6 +62,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           skillRepository,
           pickChallengeService,
           improvementService,
+          locale,
         });
       });
       it('should throw a UserNotAuthorizedToAccessEntity error', () => {
@@ -79,6 +81,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           skillRepository,
           pickChallengeService,
           improvementService,
+          locale,
         });
       });
       it('should have fetched the answers', () => {
@@ -101,6 +104,7 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           challenges,
           targetSkills,
           knowledgeElements: recentKnowledgeElements,
+          locale,
         });
       });
 


### PR DESCRIPTION
## :unicorn: Problème
- L'algorithme choisit un acquis à jouer dans les acquis disponibles d'après le statut et s'il possède une épreuve.
- Si l'acquis n'a pas d'épreuve dans la locale (par exemple, l'utilisateur est en anglais et l'acquis est dans un PIX+Français et n'a pas d'épreuve en français), l'algorithme pourrait le choisir mais nous ne pouvons pas proposer d'épreuve : par conséquent le test est fini

## :robot: Solution
- Passer la locale à l'algo
- Au moment d'ajouter l'info `isPlayable` à l'acquis, on vérifie si l'acquis a au moins une épreuve avec la bonne langue

## :rainbow: Remarques
- Clean dans cette PR sur un décalage entre les noms de challenges et d'acquis dans les tests (un challenge web6 attaché à l'acquis web7)

## :100: Pour tester
- Rejoindre la campagne KVTPFJ772 qui contient des acquis de 1.1 et d'acquis du Pix+ uniquement français. 
- Rejoindre cette campagne en Anglais et pouvoir faire toutes les questions 1.1 avant de finir (et ne pas voir les question FR).
- Rejoindre cette campagne en Français/FR et pouvoir faire tous les acquis