### PR TITLE
[BUGFIX] Corrige l'affichage de la colonne "créé le" dans la liste des campagnes de Pix Orga (PIX-2014).

### DIFF
--- a/orga/app/models/campaign.js
+++ b/orga/app/models/campaign.js
@@ -16,7 +16,7 @@ export default class Campaign extends Model {
   @attr('string') creatorId;
   @attr('string') creatorLastName;
   @attr('string') creatorFirstName;
-  //@attr('date') createdAt;
+  @attr('date') createdAt;
   @attr('string') targetProfileId;
   @attr('string') targetProfileName;
   @attr('string') targetProfileImageUrl;


### PR DESCRIPTION
## :unicorn: Problème
Sans doute dû à un problème de merge suite à des conflits, la colonne "créé le" sur la liste des campagnes sur Pix Orga ne s'affiche plus correctement.

## :robot: Solution
Corriger le bug.

## :rainbow: Remarques
Le composant est testé avec la bonne colonne, mais le test n'a pas échoué puisque le `createRecord` à l'air de prendre tous les arguments même s'ils ne sont pas dans le modèle originel 🤷 Du coup on ne sait pas comment tester ça correctement sans en passer par l'acceptance ou le bout en bout.

## :100: Pour tester
Aller sur Pix Orga, et vérifier que la colonne "créé le" s'affiche correctement.