### PR TITLE
[FEATURE] Ajouter les liens de téléchargements des résultats de certification aux mails (PIX-1998)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -282,7 +282,7 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
-      path: '/api/sessions/results-by-recipient-email/{token}',
+      path: '/api/sessions/download-results/{token}',
       config: {
         auth: false,
         handler: sessionController.getSessionResultsByRecipientEmail,

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,6 +1,7 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 const moment = require('moment');
+const tokenService = require('./token-service');
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
@@ -68,10 +69,14 @@ function sendCertificationResultEmail({
   sessionId,
   sessionDate,
   certificationCenterName,
-  link,
+  resultRecipientEmail,
+  daysBeforeExpiration,
 }) {
   const pixName = PIX_NAME_FR;
   const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
+  const token = tokenService.createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
+  const link = `/api/sessions/results-by-recipient-email/${token}`;
+
   const variables = {
     link,
     sessionId,

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -75,7 +75,7 @@ function sendCertificationResultEmail({
   const pixName = PIX_NAME_FR;
   const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
   const token = tokenService.createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
-  const link = `/api/sessions/results-by-recipient-email/${token}`;
+  const link = `${settings.domain.pixApp + settings.domain.tldOrg}/api/sessions/download-results/${token}`;
 
   const variables = {
     link,

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -23,6 +23,15 @@ function createIdTokenForUserReconciliation(externalUser) {
   }, settings.authentication.secret, { expiresIn: settings.authentication.tokenForStudentReconciliationLifespan });
 }
 
+function createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration }) {
+  return jsonwebtoken.sign({
+    session_id: sessionId,
+    result_recipient_email: resultRecipientEmail,
+  }, settings.authentication.secret, {
+    expiresIn: `${daysBeforeExpiration}d`,
+  });
+}
+
 function extractTokenFromAuthChain(authChain) {
   if (!authChain) {
     return authChain;
@@ -100,6 +109,7 @@ module.exports = {
   createAccessTokenFromUser,
   createTokenForCampaignResults,
   createIdTokenForUserReconciliation,
+  createCertificationResultLinkToken,
   decodeIfValid,
   extractExternalUserFromIdToken,
   extractPayloadFromPoleEmploiIdToken,

--- a/api/lib/domain/usecases/update-publication-session.js
+++ b/api/lib/domain/usecases/update-publication-session.js
@@ -33,12 +33,14 @@ async function _sendPrescriberEmails(session) {
     .filter(Boolean);
 
   const promises = recipientEmails.map((recipientEmail) => {
+    const link = `api/${recipientEmail}/${session.id}/results`;
+
     return mailService.sendCertificationResultEmail({
       email: recipientEmail,
       sessionId: session.id,
       sessionDate: session.date,
       certificationCenterName: session.certificationCenter,
-      link: 'EMPTY LINK',
+      link,
     });
   });
   return Promise.all(promises);

--- a/api/lib/domain/usecases/update-publication-session.js
+++ b/api/lib/domain/usecases/update-publication-session.js
@@ -33,14 +33,13 @@ async function _sendPrescriberEmails(session) {
     .filter(Boolean);
 
   const promises = recipientEmails.map((recipientEmail) => {
-    const link = `api/${recipientEmail}/${session.id}/results`;
-
     return mailService.sendCertificationResultEmail({
       email: recipientEmail,
       sessionId: session.id,
       sessionDate: session.date,
       certificationCenterName: session.certificationCenter,
-      link,
+      resultRecipientEmail: recipientEmail,
+      daysBeforeExpiration: 30,
     });
   });
   return Promise.all(promises);

--- a/api/tests/acceptance/application/session/session-controller-get-session-results-by-result-recipient-email_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results-by-result-recipient-email_test.js
@@ -5,7 +5,7 @@ const settings = require('../../../../lib/config');
 
 describe('Acceptance | Controller | session-controller-get-session-results-by-result-recipient-email', () => {
 
-  describe('GET /api/sessions/results-by-recipient-email/{token}', function() {
+  describe('GET /api/sessions/download-results/{token}', function() {
 
     context('when a valid token is given', () => {
 
@@ -36,7 +36,7 @@ describe('Acceptance | Controller | session-controller-get-session-results-by-re
 
         const request = {
           method: 'GET',
-          url: `/api/sessions/results-by-recipient-email/${token}`,
+          url: `/api/sessions/download-results/${token}`,
           payload: {},
         };
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -2,6 +2,7 @@ const { sinon, expect } = require('../../../test-helper');
 
 const mailService = require('../../../../lib/domain/services/mail-service');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
+const tokenService = require('../../../../lib/domain/services/token-service');
 
 describe('Unit | Service | MailService', () => {
 
@@ -70,10 +71,14 @@ describe('Unit | Service | MailService', () => {
 
     it('should use mailer to send an email with given options', async () => {
       // given
-      const link = 'pix.fr';
       const sessionDate = '2020-10-03';
       const sessionId = '3';
       const certificationCenterName = 'Vincennes';
+      const resultRecipientEmail = 'email1@example.net';
+      const daysBeforeExpiration = 30;
+      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultLinkToken');
+      tokenServiceStub.withArgs({ sessionId, resultRecipientEmail, daysBeforeExpiration }).returns('token-1');
+      const link = '/api/sessions/results-by-recipient-email/token-1';
       const expectedOptions = {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',
@@ -93,7 +98,8 @@ describe('Unit | Service | MailService', () => {
         sessionId,
         sessionDate,
         certificationCenterName,
-        link,
+        resultRecipientEmail,
+        daysBeforeExpiration,
       });
 
       // then

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -3,6 +3,7 @@ const { sinon, expect } = require('../../../test-helper');
 const mailService = require('../../../../lib/domain/services/mail-service');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const tokenService = require('../../../../lib/domain/services/token-service');
+const settings = require('../../../../lib/config');
 
 describe('Unit | Service | MailService', () => {
 
@@ -71,6 +72,7 @@ describe('Unit | Service | MailService', () => {
 
     it('should use mailer to send an email with given options', async () => {
       // given
+      sinon.stub(settings.domain, 'pixApp').value('https://pix.app');
       const sessionDate = '2020-10-03';
       const sessionId = '3';
       const certificationCenterName = 'Vincennes';
@@ -78,7 +80,7 @@ describe('Unit | Service | MailService', () => {
       const daysBeforeExpiration = 30;
       const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultLinkToken');
       tokenServiceStub.withArgs({ sessionId, resultRecipientEmail, daysBeforeExpiration }).returns('token-1');
-      const link = '/api/sessions/results-by-recipient-email/token-1';
+      const link = 'https://pix.app.org/api/sessions/download-results/token-1';
       const expectedOptions = {
         from: senderEmailAddress,
         fromName: 'PIX - Ne pas répondre',

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -248,4 +248,24 @@ describe('Unit | Domain | Service | Token Service', () => {
 
   });
 
+  describe('#createCertificationResultLinkToken', () => {
+    it('should return a valid token with sessionId and resultRecipientEmail', () => {
+      // given
+      const sessionId = 'abcd1234';
+      const resultRecipientEmail = 'results@college-romain-rolland.edu';
+      const daysBeforeExpiration = 30;
+      const expectedTokenAttributes = {
+        'session_id': 'abcd1234',
+        'result_recipient_email': 'results@college-romain-rolland.edu',
+      };
+
+      // when
+      const linkToken = tokenService.createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
+
+      // then
+      const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);
+      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
+    });
+  });
+
 });

--- a/api/tests/unit/domain/usecases/update-publication-session_test.js
+++ b/api/tests/unit/domain/usecases/update-publication-session_test.js
@@ -140,6 +140,8 @@ describe('Unit | UseCase | update-publication-session', () => {
         toPublish = true;
         certificationRepository.updatePublicationStatusesBySessionId.withArgs(sessionId, toPublish).resolves();
         sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSession);
+        mailService.sendCertificationResultEmail.withArgs({ sessionId, resultRecipientEmail: 'email1@example.net', daysBeforeExpiration: 30 }).returns('token-1');
+        mailService.sendCertificationResultEmail.withArgs({ sessionId, resultRecipientEmail: 'email2@example.net', daysBeforeExpiration: 30 }).returns('token-2');
 
         // when
         await updatePublicationSession({
@@ -150,8 +152,12 @@ describe('Unit | UseCase | update-publication-session', () => {
         });
 
         // then
-        expect(mailService.sendCertificationResultEmail.firstCall).to.have.been.calledWithMatch({ link: `api/email1@example.net/${sessionId}/results` });
-        expect(mailService.sendCertificationResultEmail.secondCall).to.have.been.calledWithMatch({ link: `api/email2@example.net/${sessionId}/results` });
+        expect(mailService.sendCertificationResultEmail.firstCall).to.have.been.calledWithMatch(
+          { sessionId, resultRecipientEmail: 'email1@example.net', daysBeforeExpiration: 30 },
+        );
+        expect(mailService.sendCertificationResultEmail.secondCall).to.have.been.calledWithMatch(
+          { sessionId, resultRecipientEmail: 'email2@example.net', daysBeforeExpiration: 30 },
+        );
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Au vu du nombre croissant de certification, il est nécessaire d'automatiser au maximum les tâches du pôle certification.
Aujourd'hui, après avoir publié une session, le pôle certification doit lui même écrire un email dans lequel ils ajoutent en pièce jointe le fichiers des résultats (téléchargeable depuis Pix Admin).
Cette tâche manuelle peut être automatisée.

Actuellement, soumis à feature toggle (donc non activé en production), nous avons déjà créer un service permettant d'envoyer un mail automatique à chaque destinataire des résultats. De plus, il est prévu dans une autre PR (en cours), de permettre via une url particulière de pouvoir télécharger les fichiers des résultats (sans être connecté, à la différence du fichier téléchargeable depuis Pix Admin). 

## :robot: Solution
Le but de cette PR là est donc de faire le pont entre les features précédentes : à savoir générer et ajouter un lien dans les emails lors de la publication de la session.

## :rainbow: Remarques
Cette PR dépend du ticket https://1024pix.atlassian.net/browse/PIX-973.

## :100: Pour tester

1. Lancer l'API
2. Lancer Certif avec le flag `FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS=true`
3. Créer une nouvelle session de certification et ajouter un candidat (avec une vraie adresse e-mail)
4. Lancer Mon Pix
5. Passer la certification
6. Lancer Admin
7. Aller dans **Sessions de certifications**
8. Ouvrir la session créée en 3.
9. Aller dans l'onglet **Candidats**
10. Cliquer sur **Publier la session**
11. Constater la réception de l'email avec le lien à l'adresse spécifiée en 3.
12. Cliquer sur le lien et constater le téléchargement du fichier de résultats