### PR TITLE
[BUGFIX] Revert de l'option timezone du format-date dans le certificat

### DIFF
--- a/mon-pix/app/templates/components/user-certifications-detail-header.hbs
+++ b/mon-pix/app/templates/components/user-certifications-detail-header.hbs
@@ -6,7 +6,7 @@
       <h1>{{t "pages.certificate.title"}}</h1>
 
       <p class="user-certifications-detail-header__info-certificate--grey">
-        {{t "pages.certificate.issued-on"}} {{format-date @certification.deliveredAt format="LL" timeZone="Europe/Paris"}}
+        {{t "pages.certificate.issued-on"}} {{format-date @certification.deliveredAt format="LL"}}
       </p>
       <p class="user-certifications-detail-header__info-certificate--grey">
         {{t "pages.certificate.validity"}}
@@ -25,7 +25,7 @@
         <p>{{t "pages.certificate.certification-center"}} {{@certification.certificationCenter}}</p>
       {{/if}}
 
-      <p>{{t "pages.certificate.exam-date"}} {{format-date @certification.date format="LL" timeZone="Europe/Paris"}}</p>
+      <p>{{t "pages.certificate.exam-date"}} {{format-date @certification.date format="LL"}}</p>
 
     </div>
   </div>


### PR DESCRIPTION
## :unicorn: Problème
Afin de corriger un problème d'affichage de date sur le certificat dans mon-pix en fonction des fuseaux horaires, la timezone de destination a été forcée à "Europe/Paris" pour ne pas que celle-ci soit convertie dans la timezone du navigateur. Or cette option n'est pas supportée par IE pour lequel l'affichage du certificat ne fonctionne plus. 

## :robot: Solution
Solution intermédiaire et dégradée : revert l'option timezone le temps d'explorer d'autres solutions pour IE.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Afficher le certificat sous IE constater qu'il s'afficher entièrement.
