### PR TITLE
[BUGFIX] Arrêter d'intercepter des messages d'autres origines (PIX-2010).

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -8,6 +8,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   @tracked autoReplyAnswer = '';
   postMessageHandler = null;
+  embedOrigin = 'https://epreuves.pix.fr';
 
   constructor() {
     super(...arguments);
@@ -44,9 +45,26 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   _receiveEmbedMessage(event) {
-    if (typeof event.data === 'string') {
-      this.autoReplyAnswer = event.data;
+    const message = this._getMessageFromEventData(event);
+    if (message && message.answer && message.from === 'pix') {
+      this.autoReplyAnswer = message.answer;
     }
+  }
+
+  _getMessageFromEventData(event) {
+    let data = null;
+    if (event.origin === this.embedOrigin) {
+      if (typeof event.data === 'string') {
+        try {
+          data = JSON.parse(event.data);
+        } catch {
+          data = { answer: event.data, from: 'pix' };
+        }
+      } else if (typeof event.data === 'object') {
+        data = event.data;
+      }
+    }
+    return data;
   }
 
   get showProposal() {

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -46,6 +46,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         const event = document.createEvent('Event');
         event.initEvent('message', true, true);
         event.data = 'custom answer from embed';
+        event.origin = 'https://epreuves.pix.fr';
         find('.embed__iframe').dispatchEvent(event);
 
         // then
@@ -68,6 +69,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         const event = document.createEvent('Event');
         event.initEvent('message', true, true);
         event.data = 'custom answer from embed';
+        event.origin = 'https://epreuves.pix.fr';
         find('.embed__iframe').dispatchEvent(event);
 
         // then

--- a/mon-pix/tests/unit/components/challenge-item-qroc-test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc-test.js
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import EmberObject from '@ember/object';
+import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | Challenge item qroc', function() {
+
+  setupTest();
+
+  let component;
+  describe('#_receiveEmbedMessage', function() {
+
+    beforeEach(() => {
+      const challenge = EmberObject.create({
+        autoReply: true,
+        id: 'rec_123',
+      });
+
+      component = createGlimmerComponent('component:challenge-item-qroc', { challenge });
+    });
+
+    context('when the event message is from Pix', function() {
+      it('should set the autoreply answer from a string', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: answer,
+          origin: 'https://epreuves.pix.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
+
+      it('should set the autoreply answer from a string object', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: `{ "answer": "${answer}", "from": "pix"}`,
+          origin: 'https://epreuves.pix.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
+
+      it('should set the autoreply answer from a object', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: { answer, from: 'pix' },
+          origin: 'https://epreuves.pix.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
+    });
+
+    context('when the event message is not from Pix', function() {
+
+      it('should not set the autoreply answer from data in event when origin is not pix', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: { answer, from: 'pix' },
+          origin: 'https://epreuves.fake.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal('');
+      });
+
+      it('should not set the autoreply answer from data in event when data object is not correct', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: { answer },
+          origin: 'https://epreuves.fake.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal('');
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
L'extension WebDragon envoie des messages avec comme origin 'https://epreuves.pix.fr' et ces messages sont pris comme réponse aux embed Auto, ce qui casse l'épreuve

## :robot: Solution
- Vérifier l'origin (au cas où)
- Vérifier le format du message envoyé
- Vérifier que ce n'est que le mot magique (un string simple), ou un autre objet qui pourra être utilisé sur les futures épreuves

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
A faire sur integration puis sur la RA : 
- Avoir l’extension Web Dragon
- Aller sur une épreuvre embed auto : rec15NjJFy22LH3dy
- Bien répondre (ne pas valider)
- Ouvrir la console et envoyer `window.top.postMessage('{"truc":"test"}', "*");`
- Valider
- Voir dans les answers : {"protocol":"nuanria_messaging","type":"request","messageId":3,"action":"ddaloccgjfibfpkalenodgehlhkgoahe:requestSpeechHostStatus","responseRequired":false}
- Et c’est KO comme réponse (sur integ) et OK sur la RA