### PR TITLE
[BUGFIX] Corriger une variable indéfinie dans le service d'envoi de mail

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -11,12 +11,10 @@ const ACCOUNT_CREATION_EMAIL_SUBJECT_EN = 'Your Pix account has been created';
 const RESET_PASSWORD_EMAIL_SUBJECT_FR = 'Demande de réinitialisation de mot de passe PIX';
 const RESET_PASSWORD_EMAIL_SUBJECT_EN = 'Pix password reset request';
 
-let pixName;
-let accountCreationEmailSubject;
-let resetPasswordEmailSubject;
-
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
+  let pixName;
+  let accountCreationEmailSubject;
   let variables;
 
   if (locale === 'fr') {
@@ -72,6 +70,7 @@ function sendCertificationResultEmail({
   certificationCenterName,
   link,
 }) {
+  const pixName = PIX_NAME_FR;
   const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
   const variables = {
     link,
@@ -90,6 +89,8 @@ function sendCertificationResultEmail({
 }
 
 function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
+  let pixName;
+  let resetPasswordEmailSubject;
   let variables;
 
   if (locale === 'fr') {


### PR DESCRIPTION
## :unicorn: Problème
Dans le service d'envoi de mail, il y a une variable `pixName` qui est définie une fois au début du fichier avec un `let`, sans valeur. On lui attribue ensuite une valeur dans chaque fonction selon la locale ("PIX - Ne pas répondre" ou "PIX - Noreply").
MAIS dans la fonction `sendCertificationResultEmail`, on attribue aucune valeur à cette variable. Les tests passent quand on les lance tous ensemble parce que la variable est partagée par toutes les fonctions, et donc il suffit qu'on ait appelé une autre fonction avant pour que `sendCertificationResultEmail` soit définie. Par contre, le test de cette fonction ne passe plus s'il est appelé individuellement (avec `it.only`). Et a priori ça ne devrait pas fonctionner non plus en situation réelle.

## :robot: Solution
J'ai déplacé la définition de la variable `pixName` (et deux autres qui étaient également définie à cet endroit) dans chaque fonction du service pour qu'elles ne soient plus partagée.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer individuellement le test de la fonction `sendCertificationResultEmail` avec `it.only`
