### PR TITLE
[BUGFIX] Pouvoir changer d'avis sur la saisie ou non de l'organisation de référence lors de la création d'un profil cible dans Pix Admin (PIX-2021).

### DIFF
--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -94,8 +94,8 @@ exports.register = async (server) => {
               attributes: {
                 'name': Joi.string().required(),
                 'is-public': Joi.boolean().required(),
-                'organization-id': Joi.string().empty('').allow(null),
-                'image-url': Joi.string().uri().empty('').allow(null),
+                'owner-organization-id': Joi.string().pattern(/^[0-9]+$/, 'numbers').empty('').allow(null).optional(),
+                'image-url': Joi.string().uri().empty('').allow(null).optional(),
                 'skills-id': Joi.array().required(),
               },
             },

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -14,8 +14,81 @@ describe('Integration | Application | Target Profiles | Routes', () => {
     sinon.stub(targetProfileController, 'getTargetProfileDetails').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(targetProfileController, 'updateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
+    sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
+  });
+
+  describe('POST /api/target-profiles', () => {
+    it('should resolve with owner organization id to null', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/target-profiles';
+
+      const payload = {
+        data: {
+          attributes: {
+            'name': 'MyTargetProfile',
+            'owner-organization-id': null,
+            'image-url': null,
+            'is-public': false,
+            'skills-id': ['skill1', 'skill2'],
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should resolve with owner organization id to empty', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/target-profiles';
+
+      const payload = {
+        data: {
+          attributes: {
+            'name': 'MyTargetProfile',
+            'owner-organization-id': '',
+            'image-url': null,
+            'is-public': false,
+            'skills-id': ['skill1', 'skill2'],
+          },
+        },
+      };
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should reject with alphanumeric owner organization id ', async () => {
+      // given
+      const method = 'POST';
+      const url = '/api/admin/target-profiles';
+
+      const payload = {
+        data: {
+          attributes: {
+            'name': 'MyTargetProfile',
+            'owner-organization-id': 'ABC',
+            'image-url': null,
+            'is-public': false,
+            'skills-id': ['skill1', 'skill2'],
+          },
+        },
+      };
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
   });
 
   describe('GET /api/target-profiles', () => {


### PR DESCRIPTION
## :unicorn: Problème
Lors ds tests d'intégration, nous nous somme rendu compte qu'il manquait un contôle pour autoriser le chaîne vide dans un formulaire
## :robot: Solution
Ajouter un contrôle plus fin Joi sur la route en question pour ne pas avoir de souci à la création du profil cible
## :rainbow: Remarques

## :100: Pour tester
