### PR TITLE
[FEATURE] Dans Pix App, déconnecter un utilisateur après qu'il a envoyé ses résultats d'un parcours simplifié (PIX-2011).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -128,4 +128,12 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
     title: null,
     customLandingPageText: null,
   });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 11,
+    code: 'SIMPLIFIE',
+    name: 'Parcours simplifié',
+    organizationId: 1,
+    targetProfileId: 100322,
+  });
 };

--- a/api/db/seeds/data/target-profiles-builder.js
+++ b/api/db/seeds/data/target-profiles-builder.js
@@ -107,4 +107,25 @@ module.exports = function targetProfilesBuilder({ databaseBuilder }) {
       skillId,
     });
   });
+
+  const simplifiedAccesTargetProfile = databaseBuilder.factory.buildTargetProfile({
+    id: 100322,
+    name: 'Accès simplifié',
+    isPublic: true,
+    organizationId: 1,
+    isSimplifiedAccess: true,
+  });
+
+  [
+    'recGd7oJ2wVEyKmPS', 'recHvlTH8v706UYvc', 'recl2o6fA6oyMGPkb', 'recVgnoo6RjCxjCQp', 'recUQEnFmSvPBA807',
+    'recINVk1gM5DHCbs7', 'recpyHTeNkGnFnqhZ', 'rec9iiMaoi1GLzWVn', 'rec336WB21z6wKR6q', 'recVywppdS4hGEekR',
+    'recIcL3GuLDaDgGAt', 'recOyQOjUhDKTO7UN', 'recO6p9wxUDweUysu', 'recrxbonOSuEvsuor', 'recDZTKszXX02aXD1',
+    'rec8b2zEqznu1VdSu', 'rectZKS13rdkqxHer', 'recW4iZCujkyyfCve', 'recxij74P8pBL3pdq', 'recmB2623CruGvA1b',
+    'recIOtIleMBECQayX', 'recEPgGwP6P3nZBbK', 'recbZ44oYHqlOGJ2C', 'recU78yTsZnxIghHA', 'recDkqabsU2X5a4Z5',
+    'recVv1eoSLW7yFgXv', 'recvBiIG0dvHJOe7i', 'reca2TivtMI9QRWBY', 'recSF5OuzyBOfg97L', 'recUdMS2pRSF4sgnk',
+    'recr9No0p5zGhq2bg', 'recWalmeLbapvhX3K', 'recKTybfk95zVWBDM', 'recKFUQ2CzcYHrxPR',
+  ]
+    .forEach((skillId) => {
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: simplifiedAccesTargetProfile.id, skillId });
+    });
 };

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -7,8 +7,10 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 describe('Acceptance | Campaigns | Campaigns Result', function() {
+
   setupApplicationTest();
   setupMirage();
+
   let user;
   let campaign;
   let campaignParticipation;
@@ -36,8 +38,10 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
     });
 
     describe('When user is logged in', async function() {
+
       const competenceResultName = 'Competence Nom';
       const partnerCompetenceResultName = 'badge partner competence nom';
+
       let campaignParticipationResult;
 
       beforeEach(async function() {

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -22,6 +22,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
           masteryPercentage: 50,
         }),
         campaign: EmberObject.create({
+          isSimplifiedAccess: false,
           targetProfile: {
             name: 'Cléa Numérique',
           },
@@ -41,15 +42,28 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     });
 
     component.router.transitionTo = sinon.stub();
+    component.disconnectUser = sinon.stub();
   });
 
   describe('#shareCampaignParticipation', function() {
+
     it('should set isShared to true', async function() {
       // when
       await component.actions.shareCampaignParticipation.call(component);
 
       // then
       expect(component.args.model.campaignParticipation.isShared).to.equal(true);
+    });
+
+    it('should disconnect user if campaign has simplified access', async function() {
+      // given
+      component.args.model.campaignParticipation.campaign.isSimplifiedAccess = true;
+
+      // when
+      await component.actions.shareCampaignParticipation.call(component);
+
+      // then
+      sinon.assert.called(component.disconnectUser);
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix App, à l'issue d'un parcours simplifié, et après avoir envoyé ses résultats, l'utilisateur reste connecté.

## :robot: Solution
* Si c'est un parcours simplifié, après l'envoie des résultats, forcer la déconnexion,
et rediriger vers la page du site vitrine pix.fr.

## :rainbow: Remarques
*Si l'environnement n'est pas PROD, alors la redirection sera faite vers la page de connexion.

## :100: Pour tester
* Se connecter à Pix App
* Commencer un parcours avec accès simplifié (avec le code campagne SIMPLIFIE en RA)
* A l'issue de ce parcours, envoyer les résultats
* Constater que la redirection vers le site vitrine* est bien faite (la session est bien supprimée).

_Relancer les seeds si besoin  :_
```shell
scalingo --region osc-fr1 --app pix-api-review-pr2427 run bash
npm run db:seed
```