### PR TITLE
[TECH] Remplacer le package déprécié @hapi/joi par joi.

### DIFF
--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const assessmentController = require('./assessment-controller');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
 

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const AuthenticationController = require('./authentication-controller');
 

--- a/api/lib/application/campaignParticipations/index.js
+++ b/api/lib/application/campaignParticipations/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const campaignParticipationController = require('./campaign-participation-controller');
 const { sendJsonApiError, NotFoundError } = require('../http-errors');
 

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const campaignController = require('./campaign-controller');
 
 exports.register = async function(server) {

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -1,6 +1,6 @@
 const certificationCenterController = require('./certification-center-controller');
 const securityPreHandlers = require('../security-pre-handlers');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');

--- a/api/lib/application/certification-livret-scolaire/index.js
+++ b/api/lib/application/certification-livret-scolaire/index.js
@@ -1,6 +1,6 @@
 const certificationController = require('./certification-controller');
 const { featureToggles } = require('../../config');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const responseErrorObjectDoc = require('../../infrastructure/open-api-doc/livret-scolaire/response-object-error-doc');
 const certificationsResultsResponseDoc = require('../../infrastructure/open-api-doc/livret-scolaire/certifications-results-doc');

--- a/api/lib/application/certification-point-of-contacts/index.js
+++ b/api/lib/application/certification-point-of-contacts/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationPointOfContactController = require('./certification-point-of-contact-controller');

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const organizationInvitationController = require('./organization-invitation-controller');
 
 exports.register = async (server) => {

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { sendJsonApiError, PayloadTooLargeError, NotFoundError, BadRequestError } = require('../http-errors');
 
 const securityPreHandlers = require('../security-pre-handlers');

--- a/api/lib/application/passwords/index.js
+++ b/api/lib/application/passwords/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const XRegExp = require('xregexp');
 
 const { passwordValidationPattern } = require('../../config').account;

--- a/api/lib/application/prescribers/index.js
+++ b/api/lib/application/prescribers/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const prescriberController = require('./prescriber-controller');

--- a/api/lib/application/schooling-registration-dependent-users/index.js
+++ b/api/lib/application/schooling-registration-dependent-users/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const XRegExp = require('xregexp');
 
 const securityPreHandlers = require('../security-pre-handlers');

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { sendJsonApiError, UnprocessableEntityError, NotFoundError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const schoolingRegistrationUserAssociationController = require('./schooling-registration-user-association-controller');

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const targetProfileController = require('./target-profile-controller');

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const userOrgaSettingsController = require('./user-orga-settings-controller');
 
 exports.register = async function(server) {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,6 +1,6 @@
 const securityPreHandlers = require('../security-pre-handlers');
 const userController = require('./user-controller');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;

--- a/api/lib/domain/models/AuthenticationMethod.js
+++ b/api/lib/domain/models/AuthenticationMethod.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 
 const identityProviders = {

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -1,5 +1,5 @@
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 const { states } = require('./Assessment');
 

--- a/api/lib/domain/models/CertificationCandidate.js
+++ b/api/lib/domain/models/CertificationCandidate.js
@@ -1,7 +1,7 @@
 const isNil = require('lodash/isNil');
 const endsWith = require('lodash/endsWith');
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const {
   InvalidCertificationCandidate,
   CertificationCandidatePersonalInfoFieldMissingError,

--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { InvalidCertificationIssueReportForSaving } = require('../errors');
 const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('./CertificationIssueReportCategory');
 

--- a/api/lib/domain/models/CertificationReport.js
+++ b/api/lib/domain/models/CertificationReport.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const { InvalidCertificationReportForFinalization } = require('../errors');
 

--- a/api/lib/domain/models/CleaCertification.js
+++ b/api/lib/domain/models/CleaCertification.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const Badge = require('../models/Badge');
 const PartnerCertification = require('./PartnerCertification');
 const { NotEligibleCandidateError } = require('../errors');
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 
 const MIN_PERCENTAGE = 75;

--- a/api/lib/domain/models/CompetenceMark.js
+++ b/api/lib/domain/models/CompetenceMark.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { validateEntity } = require('../validators/entity-validator');
 
 const schema = Joi.object({

--- a/api/lib/domain/models/PartnerCertification.js
+++ b/api/lib/domain/models/PartnerCertification.js
@@ -1,5 +1,5 @@
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 const { NotImplementedError } = require('../errors');
 

--- a/api/lib/domain/models/SCOCertificationCandidate.js
+++ b/api/lib/domain/models/SCOCertificationCandidate.js
@@ -1,5 +1,5 @@
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { InvalidCertificationCandidate } = require('../errors');
 
 const scoCertificationCandidateValidationJoiSchema = Joi.object({

--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -1,5 +1,5 @@
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 
 const validationSchema = Joi.object({

--- a/api/lib/domain/read-models/SchoolingRegistrationForAdmin.js
+++ b/api/lib/domain/read-models/SchoolingRegistrationForAdmin.js
@@ -1,5 +1,5 @@
-const Joi = require('@hapi/joi')
-  .extend(require('@hapi/joi-date'));
+const Joi = require('joi')
+  .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 
 const validationSchema = Joi.object({

--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { first } = require('lodash');
 const { EntityValidationError } = require('../errors');
 const Campaign = require('../models/Campaign');

--- a/api/lib/domain/validators/certification-center-creation-validator.js
+++ b/api/lib/domain/validators/certification-center-creation-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };

--- a/api/lib/domain/validators/higher-schooling-registration-set-validator.js
+++ b/api/lib/domain/validators/higher-schooling-registration-set-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { allowUnknown: true };

--- a/api/lib/domain/validators/higher-schooling-registration-validator.js
+++ b/api/lib/domain/validators/higher-schooling-registration-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { allowUnknown: true };

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 // Min 32 bits signed integer, our most common id type in Postgres
 const minId = -(2 ** 31);

--- a/api/lib/domain/validators/organization-creation-validator.js
+++ b/api/lib/domain/validators/organization-creation-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };

--- a/api/lib/domain/validators/password-validator.js
+++ b/api/lib/domain/validators/password-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const XRegExp = require('xregexp');
 
 const { passwordValidationPattern } = require('../../config').account;

--- a/api/lib/domain/validators/schooling-registration-set-validator.js
+++ b/api/lib/domain/validators/schooling-registration-set-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { EntityValidationError } = require('../errors');
 
 const validationConfiguration = { allowUnknown: true };

--- a/api/lib/domain/validators/schooling-registration-validator.js
+++ b/api/lib/domain/validators/schooling-registration-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi').extend(require('@hapi/joi-date'));
+const Joi = require('joi').extend(require('@joi/date'));
 const { EntityValidationError } = require('../errors');
 const SchoolingRegistration = require('../models/SchoolingRegistration');
 

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { statuses } = require('../models/Session');
 const { types } = require('../models/CertificationCenter');
 

--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const { EntityValidationError } = require('../errors');
 const validationConfiguration = { abortEarly: false, allowUnknown: true };

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/area-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/area-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 module.exports = Joi.object({
   id: Joi.number().example('1').required().description('ID unique de la compétence (ex : “1”, “4”)'),

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/certification-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/certification-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const certificationStatus = require('../../../../lib/domain/read-models/livret-scolaire/CertificateStatus');
 const competenceResultDoc = require('./competence-result-doc');
 

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/certifications-results-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/certifications-results-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const certificationDoc = require('./certification-doc');
 const competenceDoc = require('./competence-doc');

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/competence-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/competence-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 const areaDoc = require('./area-doc');
 

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/competence-result-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/competence-result-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 module.exports = Joi.object({
   level: Joi.number().example('4').required().description('Niveau obtenu pour la compétence'),

--- a/api/lib/infrastructure/open-api-doc/livret-scolaire/response-object-error-doc.js
+++ b/api/lib/infrastructure/open-api-doc/livret-scolaire/response-object-error-doc.js
@@ -1,4 +1,4 @@
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 
 module.exports = Joi.object({
   code: Joi.string().required().description('An application-specific error code.'),

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1044,6 +1044,31 @@
         "tslib": "^1.9.3"
       }
     },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+        }
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -4582,25 +4607,17 @@
       }
     },
     "joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-fww3Ae9cRyj6yHy90cpxvL2y39V5JCY2KaXV3KfALhoFfFcAuyQBPOq+2q6EZ2QNMn1FhkDy+eRkGVG7J+BvyA==",
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
       "requires": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
         "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
       },
       "dependencies": {
-        "@hapi/address": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        },
         "@hapi/hoek": {
           "version": "9.1.1",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -609,14 +609,6 @@
         }
       }
     },
-    "@hapi/joi-date": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi-date/-/joi-date-2.0.1.tgz",
-      "integrity": "sha512-8be8JUEC8Wm1Do3ryJy+TXmkAL13b2JwXn7gILBoor8LopY/M+hJskodzOOxfJdckkfWnbmbnMEyJW3d/gZMfA==",
-      "requires": {
-        "moment": "2.x.x"
-      }
-    },
     "@hapi/mimos": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-5.0.0.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -905,6 +905,14 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@joi/date": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@joi/date/-/date-2.0.1.tgz",
+      "integrity": "sha512-vAnBxaPmyXRmHlbr5H3zY6x8ToW1a3c3gCo91dsf/HPKP2vS4sz2xzjyCE1up0vmFmSWgfDIyJMpRWVOG2cpZQ==",
+      "requires": {
+        "moment": "2.x.x"
+      }
+    },
     "@pdf-lib/fontkit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@pdf-lib/fontkit/-/fontkit-1.0.0.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3706,6 +3706,18 @@
         "joi": "14.x.x",
         "json-stringify-safe": "5.x.x",
         "moment": "2.x.x"
+      },
+      "dependencies": {
+        "joi": {
+          "version": "14.3.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
+          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+          "requires": {
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        }
       }
     },
     "good-squeeze": {
@@ -4389,13 +4401,6 @@
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
       }
     },
     "isexe": {
@@ -4577,13 +4582,38 @@
       }
     },
     "joi": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-      "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-fww3Ae9cRyj6yHy90cpxvL2y39V5JCY2KaXV3KfALhoFfFcAuyQBPOq+2q6EZ2QNMn1FhkDy+eRkGVG7J+BvyA==",
       "requires": {
-        "hoek": "6.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
       }
     },
     "js-tokens": {
@@ -6522,6 +6552,11 @@
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -47,6 +47,7 @@
     "hapi-swagger": "^13.1.0",
     "hash-int": "^1.0.0",
     "iconv-lite": "^0.6.2",
+    "joi": "^17.1.1",
     "json2csv": "^5.0.3",
     "jsonapi-serializer": "^3.6.6",
     "jsonwebtoken": "^8.5.1",

--- a/api/package.json
+++ b/api/package.json
@@ -22,6 +22,7 @@
     "@hapi/joi": "^17.1.1",
     "@hapi/joi-date": "^2.0.1",
     "@hapi/vision": "^6.0.1",
+    "@joi/date": "^2.0.1",
     "@pdf-lib/fontkit": "^1.0.0",
     "axios": "^0.21.1",
     "bcrypt": "^5.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -19,8 +19,6 @@
     "@hapi/accept": "^5.0.1",
     "@hapi/hapi": "^19.2.0",
     "@hapi/inert": "^6.0.2",
-    "@hapi/joi": "^17.1.1",
-    "@hapi/joi-date": "^2.0.1",
     "@hapi/vision": "^6.0.1",
     "@joi/date": "^2.0.1",
     "@pdf-lib/fontkit": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -46,7 +46,7 @@
     "hapi-swagger": "^13.1.0",
     "hash-int": "^1.0.0",
     "iconv-lite": "^0.6.2",
-    "joi": "^17.1.1",
+    "joi": "^17.3.0",
     "json2csv": "^5.0.3",
     "jsonapi-serializer": "^3.6.6",
     "jsonwebtoken": "^8.5.1",

--- a/api/tests/unit/domain/models/CompetenceMark_test.js
+++ b/api/tests/unit/domain/models/CompetenceMark_test.js
@@ -59,7 +59,7 @@ describe('Unit | Domain | Models | Competence Mark', () => {
 
       // then
       expect(error).to.be.instanceOf(ObjectValidationError);
-      expect(error.message).to.be.equal('ValidationError: "level" must be larger than or equal to -1');
+      expect(error.message).to.be.equal('ValidationError: "level" must be greater than or equal to -1');
     });
 
     it('should return an error if score > 64', async () => {

--- a/api/tests/unit/domain/validators/entity-validator_test.js
+++ b/api/tests/unit/domain/validators/entity-validator_test.js
@@ -1,6 +1,6 @@
 const { expect } = require('../../../test-helper');
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const { validateEntity } = require('../../../../lib/domain/validators/entity-validator');
 
 describe('Unit | Domain | Validators | entity-validator', function() {


### PR DESCRIPTION
## :unicorn: Problème
Voir l'issue #2422 

## :robot: Solution
Remplacer le package hapi-joi par joi
Mettre à jour la version de Joi de 17.1.4 à 17.3.0 - voir le [changelog](https://joi.dev/resources/changelog/) 

## :rainbow: Remarques
Le plugin @hapi/joi-date est remplacé par @joi/date
Suite [à un bugfix](https://github.com/sideway/joi/issues/2318), le libellé` larger than` est remplacé par `greater than `

## :100: Pour tester
Vérifier que la CI passe
