### PR TITLE
[BUGFIX] Vérifier l'existence de l'objet fileType avant d'en extraire son contenu (PIX-2017).

### DIFF
--- a/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
+++ b/api/lib/infrastructure/utils/xml/siecle-file-streamer.js
@@ -1,4 +1,4 @@
-const { noop } = require('lodash');
+const { noop, isObject } = require('lodash');
 const { FileValidationError } = require('../../../domain/errors');
 const fs = require('fs');
 const readline = require('readline');
@@ -98,8 +98,9 @@ class SiecleFileStreamer {
   }
 
   async _isFileZipped() {
-    const { mime } = await FileType.fromStream(this._getStreamWithoutBOM());
-    return mime === ZIP;
+    const fileType = await FileType.fromStream(this._getStreamWithoutBOM());
+
+    return isObject(fileType) && fileType.mime === ZIP;
   }
 
   async _readFirstLine() {


### PR DESCRIPTION
## :unicorn: Problème
Remonter d'une erreur sentry sur un destructuration d'un retour 'undefined'. 

## :robot: Solution
Vérifier l'existence de cet objet avant d'en utiliser ses paramètres.