### PR TITLE
[FEATURE] Afficher le descriptif d'un sujet sur Pix Orga au sein de l'onglet analyse lorsque je le déplie (PIX-1997).

### DIFF
--- a/api/lib/domain/models/TargetedTube.js
+++ b/api/lib/domain/models/TargetedTube.js
@@ -2,11 +2,13 @@ class TargetedTube {
   constructor({
     id,
     practicalTitle,
+    description,
     competenceId,
     skills = [],
   } = {}) {
     this.id = id;
     this.practicalTitle = practicalTitle;
+    this.description = description;
     this.competenceId = competenceId;
     this.skills = skills;
   }

--- a/api/lib/domain/read-models/CampaignAnalysis.js
+++ b/api/lib/domain/read-models/CampaignAnalysis.js
@@ -75,6 +75,10 @@ class CampaignTubeRecommendation {
     return this.tube.practicalTitle;
   }
 
+  get tubeDescription() {
+    return this.tube.description;
+  }
+
   get id() {
     return `${this.campaignId}_${this.tubeId}`;
   }

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -109,9 +109,11 @@ async function _findTargetedTubes(skills, locale) {
   const learningContentTubes = await tubeDatasource.findByRecordIds(Object.keys(skillsByTubeId));
   return learningContentTubes.map((learningContentTube) => {
     const practicalTitle = getTranslatedText(locale, { frenchText: learningContentTube.practicalTitleFrFr, englishText: learningContentTube.practicalTitleEnUs });
+    const description = getTranslatedText(locale, { frenchText: learningContentTube.practicalDescriptionFrFr, englishText: learningContentTube.practicalDescriptionEnUs });
     return new TargetedTube({
       ...learningContentTube,
       practicalTitle,
+      description,
       skills: skillsByTubeId[learningContentTube.id],
     });
   });

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
       campaignTubeRecommendations: {
         ref: 'id',
         includes: true,
-        attributes: ['tubeId', 'competenceId', 'competenceName', 'tubePracticalTitle', 'areaColor', 'averageScore', 'tutorials'],
+        attributes: ['tubeId', 'competenceId', 'competenceName', 'tubePracticalTitle', 'areaColor', 'averageScore', 'tutorials', 'tubeDescription'],
         tutorials: tutorialAttributes,
       },
     }).serialize(results);

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -348,6 +348,7 @@ describe('Acceptance | API | Campaign Controller', () => {
           tubes: [{
             id: 'recTube1',
             practicalTitleFr: 'Monter une étagère FR',
+            practicalDescriptionFr: 'Comment monter une étagère',
             skills: [{
               id: 'recSkillId1',
               nom: '@skill1',
@@ -416,6 +417,7 @@ describe('Acceptance | API | Campaign Controller', () => {
             'competence-name': 'Fabriquer un meuble',
             'tube-practical-title': 'Monter une étagère FR',
             'average-score': 30,
+            'tube-description': 'Comment monter une étagère',
           },
           relationships: {
             tutorials: {

--- a/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
+++ b/api/tests/acceptance/application/campaign-participations/campaign-participations-controller-analyses_test.js
@@ -49,6 +49,7 @@ describe('Acceptance | API | Campaign Participations | Analyses', () => {
           tubes: [{
             id: 'recTube1',
             practicalTitleFr: 'Monter une étagère',
+            practicalDescriptionFr: 'Comment monter une étagère',
             skills: [{
               id: 'recSkillId1',
               nom: '@skill1',
@@ -115,6 +116,7 @@ describe('Acceptance | API | Campaign Participations | Analyses', () => {
             'competence-id': 'recCompetence1',
             'competence-name': 'Fabriquer un meuble',
             'tube-practical-title': 'Monter une étagère',
+            'tube-description': 'Comment monter une étagère',
             'average-score': 30,
           },
           relationships: {

--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -51,12 +51,14 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const tube1_1_1 = domainBuilder.buildTargetedTube({
         id: 'recArea1_Competence1_Tube1',
         practicalTitle: 'tube1_1_1_practicalTitle',
+        description: 'tube1_1_1_practicalDescription',
         competenceId: 'recArea1_Competence1',
         skills: [skill1_1_1_2],
       });
       const tube1_2_1 = domainBuilder.buildTargetedTube({
         id: 'recArea1_Competence2_Tube1',
         practicalTitle: 'tube1_2_1_practicalTitle',
+        description: 'tube1_2_1_practicalDescriptionFrFr',
         competenceId: 'recArea1_Competence2',
         skills: [skill1_2_1_1],
       });
@@ -120,10 +122,14 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
           id: 'recArea1_Competence1_Tube1',
           competenceId: 'recArea1_Competence1',
           practicalTitleFrFr: 'tube1_1_1_practicalTitle',
+          practicalDescriptionFrFr: 'tube1_1_1_practicalDescription',
+
         }, {
           id: 'recArea1_Competence2_Tube1',
           competenceId: 'recArea1_Competence2',
           practicalTitleFrFr: 'tube1_2_1_practicalTitle',
+          practicalDescriptionFrFr: 'tube1_2_1_practicalDescriptionFrFr',
+
         }],
         skills: [{
           id: 'recArea1_Competence1_Tube1_Skill2',
@@ -279,6 +285,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
           id: 'tubeId',
           competenceId: 'competenceId',
           practicalTitleEnUs: 'somePracticalTitle',
+          practicalDescriptionEnUs: 'someDescription',
         }],
         skills: [{
           id: 'skillId',
@@ -369,12 +376,14 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const tube1_1_1 = domainBuilder.buildTargetedTube({
         id: 'recArea1_Competence1_Tube1',
         practicalTitle: 'tube1_1_1_practicalTitle',
+        description: 'tube1_1_1_description',
         competenceId: 'recArea1_Competence1',
         skills: [skill1_1_1_2],
       });
       const tube1_2_1 = domainBuilder.buildTargetedTube({
         id: 'recArea1_Competence2_Tube1',
         practicalTitle: 'tube1_2_1_practicalTitle',
+        description: 'tube1_2_1_description',
         competenceId: 'recArea1_Competence2',
         skills: [skill1_2_1_1],
       });
@@ -438,10 +447,12 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
           id: 'recArea1_Competence1_Tube1',
           competenceId: 'recArea1_Competence1',
           practicalTitleFrFr: 'tube1_1_1_practicalTitle',
+          practicalDescriptionFrFr: 'tube1_1_1_description',
         }, {
           id: 'recArea1_Competence2_Tube1',
           competenceId: 'recArea1_Competence2',
           practicalTitleFrFr: 'tube1_2_1_practicalTitle',
+          practicalDescriptionFrFr: 'tube1_2_1_description',
         }],
         skills: [{
           id: 'recArea1_Competence1_Tube1_Skill2',
@@ -599,6 +610,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
           id: 'tubeId',
           competenceId: 'competenceId',
           practicalTitleEnUs: 'somePracticalTitle',
+          practicalDescriptionEnUs: 'someDescription',
         }],
         skills: [{
           id: 'skillId',

--- a/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
+++ b/api/tests/tooling/domain-builder/factory/build-targeted-tube.js
@@ -4,12 +4,14 @@ const buildTargetedSkill = require('./build-targeted-skill');
 const buildTargetedTube = function buildTargetedTube({
   id = 'someTubeId',
   practicalTitle = 'somePracticalTitle',
+  description = 'someDescription',
   competenceId = 'someCompetenceId',
   skills = [buildTargetedSkill()],
 } = {}) {
   return new TargetedTube({
     id,
     practicalTitle,
+    description,
     competenceId,
     skills,
   });

--- a/api/tests/unit/domain/read-models/CampaignAnalysis_test.js
+++ b/api/tests/unit/domain/read-models/CampaignAnalysis_test.js
@@ -46,6 +46,7 @@ describe('Unit | Domain | Read-Models | CampaignAnalysis', () => {
       expect(campaignAnalysis.campaignTubeRecommendations[0].competenceId).to.equal(targetedCompetence.id);
       expect(campaignAnalysis.campaignTubeRecommendations[0].competenceName).to.equal(targetedCompetence.name);
       expect(campaignAnalysis.campaignTubeRecommendations[0].tubePracticalTitle).to.equal(targetedTube.practicalTitle);
+      expect(campaignAnalysis.campaignTubeRecommendations[0].tubeDescription).to.equal(targetedTube.description);
       expect(campaignAnalysis.campaignTubeRecommendations[0].areaColor).to.equal(targetedArea.color);
       expect(campaignAnalysis.campaignTubeRecommendations[0].maxSkillLevelInTargetProfile).to.equal(targetProfileWithLearningContent.maxSkillDifficulty);
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-analysis-serializer_test.js
@@ -18,6 +18,7 @@ describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
             competenceId: 'rec1',
             competenceName: 'Cuisson des legumes d’automne',
             tubePracticalTitle: 'Savoir cuisiner des legumes d’automne à la perfection',
+            tubeDescription: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
             areaColor: 'jaffa',
             averageScore: 11,
             tutorials: [{
@@ -65,6 +66,7 @@ describe('Unit | Serializer | JSONAPI | campaign-analysis-serializer', () => {
             'tube-id': 'tubeRec1',
             'competence-name': 'Cuisson des legumes d’automne',
             'tube-practical-title': 'Savoir cuisiner des legumes d’automne à la perfection',
+            'tube-description': 'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
             'area-color': 'jaffa',
             'average-score': 11,
           },

--- a/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
@@ -29,6 +29,9 @@
     <div class="tube-recommendation-tutorial-wrapper {{if this.isOpen " tube-recommendation-tutorial-wrapper--open"}}">
       <span class="competences-col__border competences-col__border--bottom {{if this.isOpen " competences-col__border--open"}}
         competences-col__border--{{@tubeRecommendation.areaColor}}"></span>
+      <div class="tube-recommendation-tutorial__description">
+        {{@tubeRecommendation.tubeDescription}}
+      </div>
       <h3 class="tube-recommendation-tutorial__title">
         {{#if (eq @tubeRecommendation.tutorials.length 1)}}
           1 tuto recommandé par la communauté Pix

--- a/orga/app/components/tutorial-counter.hbs
+++ b/orga/app/components/tutorial-counter.hbs
@@ -1,9 +1,7 @@
-<div class="table__column--left">
-    <span class="tutorial-count">
-        {{#if (eq @tutorials.length 1)}}
-            1 tuto
-        {{else if (gt @tutorials.length 1)}}
-            {{@tutorials.length }} tutos
-        {{/if}}
-    </span>
+<div class="table__column--center">
+  {{#if (eq @tutorials.length 1)}}
+    1 tuto
+  {{else if (gt @tutorials.length 1)}}
+    {{@tutorials.length }} tutos
+  {{/if}}
 </div>

--- a/orga/app/models/campaign-tube-recommendation.js
+++ b/orga/app/models/campaign-tube-recommendation.js
@@ -7,6 +7,7 @@ export default class CampaignTubeRecommendation extends Model {
   @attr() competenceId;
   @attr() tubeId;
   @attr() tubePracticalTitle;
+  @attr() tubeDescription;
   @attr() averageScore;
 
   @belongsTo('campaignAnalysis') campaignAnalysis;

--- a/orga/app/styles/app.scss
+++ b/orga/app/styles/app.scss
@@ -41,7 +41,6 @@
 @import "components/manage-authentication-method-modal";
 @import "components/modal";
 @import "components/organization-credit-info";
-@import "components/tube-recommendation-row";
 @import "pages/login";
 @import "pages/join";
 @import "pages/join-request";

--- a/orga/app/styles/components/tube-recommendation-row.scss
+++ b/orga/app/styles/components/tube-recommendation-row.scss
@@ -1,3 +1,0 @@
-.tutorial-count {
-  padding-left: 100px;
-}

--- a/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/analysis/tube-recommendation-row.scss
@@ -13,9 +13,9 @@
 
 .tube-recommendation-subtitle {
   font-family: $open-sans;
-  color: $grey-35;
   font-weight: 400;
   font-size: 0.75rem;
+  color: $grey-35;
 
   &--open {
     color: $grey-60;
@@ -30,9 +30,15 @@
     height: 100%;
   }
 
+  &__description {
+    font-family: $open-sans;
+    color: $grey-60;
+    font-size: 0.875rem;
+  }
+
   &__column {
     position: relative;
-    padding-left: 52px;
+    padding-left: 32px;
     padding-right: 52px;
   }
 
@@ -40,6 +46,7 @@
     font-weight: 400;
     font-family: $open-sans;
     font-size: 1rem;
+    padding-left: 20px;
   }
 }
 
@@ -57,6 +64,7 @@
 
 .tube-recommendation-tutorial-table {
   margin-bottom: 10px;
+  margin-left: 20px;
 
   &__row {
     padding-left: 0;

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
@@ -33,6 +33,7 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tube-re
       competenceId: 'recCompA',
       competenceName: 'Competence A',
       tubePracticalTitle: 'Tube A',
+      tubeDescription: 'Tube Desc A',
       areaColor: 'jaffa',
     });
 
@@ -69,6 +70,8 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tube-re
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('10 minutes');
     assert.dom('[aria-label="Tutoriel"]:first-child').containsText('Par Youtube');
     assert.dom('[aria-expanded="true"]').exists();
+    assert.contains('Tube Desc A');
+
   });
 
   test('it should expand and display 2 tutorials in the list', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
les utilisateurs peuvent pas voire le descriptif d'un sujet au sein de l'onglet analyse dans une campagne d’évaluation
 
## :robot: Solution
Rendre le descriptif d'un sujet visible dans le chevron une fois que il est déplié
 
## :rainbow: Remarques
L’onglet Analyse existe que pour les campagnes dévaluation qui a des participants.  

## :100: Pour tester
Se connecter sur Pix Orga , Sélectionner une campagne d'évaluation puis cliquer sur l'onglet analyse. cliquer sur un sujet qui a des tutorials à fin de voire son descriptif en troisième information après le nom et le titre du sujet.