### PR TITLE
[TECH] Calculer le nombre d'acquis obtenus lors du partage des résultats d'une campagne (Pix-1989).

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation.js
+++ b/api/db/database-builder/factory/build-campaign-participation.js
@@ -12,6 +12,7 @@ module.exports = function buildCampaignParticipation({
   sharedAt = faker.date.past(),
   userId,
   participantExternalId = faker.random.word(),
+  validatedSkillsCount,
 } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -26,6 +27,7 @@ module.exports = function buildCampaignParticipation({
     createdAt,
     sharedAt,
     participantExternalId,
+    validatedSkillsCount,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaign-participations',

--- a/api/db/migrations/20210119120015_add-validated-skills-count-to-campaign-participations.js
+++ b/api/db/migrations/20210119120015_add-validated-skills-count-to-campaign-participations.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'campaign-participations';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.integer('validatedSkillsCount');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dropColumn('validatedSkillsCount');
+  });
+};

--- a/api/lib/domain/events/compute-validated-skills-count.js
+++ b/api/lib/domain/events/compute-validated-skills-count.js
@@ -1,0 +1,21 @@
+const _ = require('lodash');
+const CampaignParticipationResultShared = require('./CampaignParticipationResultsShared');
+
+module.exports = async function computeValidatedSkillsCount({ event, campaignParticipationRepository, knowledgeElementRepository, targetProfileWithLearningContentRepository }) {
+  const campaignParticipation = await campaignParticipationRepository.get(event.campaignParticipationId, { include: ['campaign'] });
+  if (campaignParticipation.canComputeValidatedSkillsCount()) {
+
+    campaignParticipation.validatedSkillsCount = await _countValidatedSkills(campaignParticipation, knowledgeElementRepository, targetProfileWithLearningContentRepository);
+
+    await campaignParticipationRepository.update(campaignParticipation);
+  }
+};
+
+async function _countValidatedSkills(campaignParticipation, knowledgeElementRepository, targetProfileWithLearningContentRepository) {
+  const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId: campaignParticipation.campaignId });
+
+  const validatedSkillsCountByCompetence = await knowledgeElementRepository.countValidatedTargetedByCompetencesForOneUser(campaignParticipation.userId, campaignParticipation.sharedAt, targetProfile);
+  return _(validatedSkillsCountByCompetence).values().sum();
+}
+
+module.exports.eventType = CampaignParticipationResultShared;

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -21,6 +21,7 @@ const dependencies = {
   scoringCertificationService: require('../services/scoring/scoring-certification-service'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),
   targetProfileRepository: require('../../infrastructure/repositories/target-profile-repository'),
+  targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
 };
@@ -38,6 +39,7 @@ const handlersToBeInjected = {
   handlePoleEmploiParticipationFinished: require('./handle-pole-emploi-participation-finished'),
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
   handlePoleEmploiParticipationStarted: require('./handle-pole-emploi-participation-started'),
+  computeValidatedSkillsCount: require('./compute-validated-skills-count'),
 };
 
 function buildEventDispatcher(handlersStubs) {

--- a/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
+++ b/api/tests/tooling/domain-builder/factory/build-campaign-participation.js
@@ -14,6 +14,7 @@ module.exports = function buildCampaignParticipation(
     campaignId = campaign.id,
     assessmentId = null,
     userId = faker.random.number(2),
+    validatedSkillsCount,
   } = {}) {
 
   return new CampaignParticipation({
@@ -26,5 +27,6 @@ module.exports = function buildCampaignParticipation(
     campaignId,
     assessmentId,
     userId,
+    validatedSkillsCount,
   });
 };

--- a/api/tests/unit/domain/events/compute-validated-skills-count_test.js
+++ b/api/tests/unit/domain/events/compute-validated-skills-count_test.js
@@ -1,0 +1,77 @@
+const { expect, domainBuilder, sinon } = require('../../../test-helper');
+const computeValidatedSkillsCount = require('../../../../lib/domain/events/compute-validated-skills-count');
+const CampaignParticipationResultsShared = require('./../../../../lib/domain/events/CampaignParticipationResultsShared');
+
+describe('Unit | Domain | Events | compute-validated-skills-count', function() {
+
+  describe('eventType', () => {
+    it('returns the CampaignParticipationResultsShared', () => {
+      const eventType = computeValidatedSkillsCount.eventType;
+
+      expect(eventType).to.equals(CampaignParticipationResultsShared);
+    });
+  });
+
+  describe('.computeValidatedSkillsCount', () => {
+    let knowledgeElementRepository;
+    let campaignParticipationRepository;
+    let targetProfileWithLearningContentRepository;
+
+    beforeEach(() => {
+      campaignParticipationRepository = { get: sinon.stub(), update: sinon.stub() };
+      targetProfileWithLearningContentRepository = { getByCampaignId: sinon.stub() };
+      knowledgeElementRepository = { countValidatedTargetedByCompetencesForOneUser: sinon.stub() };
+    });
+
+    context('when the campaign is of type assessment', () => {
+      it('computes the validated skills count', async () => {
+        const targetProfile = domainBuilder.buildTargetProfile();
+        const campaign = domainBuilder.buildCampaign.ofTypeAssessment();
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: 1, campaignId: 2, userId: 3, campaign });
+        const event = new CampaignParticipationResultsShared({ campaignParticipationId: campaignParticipation.id });
+        const validatedSkillsCountByCompetence = {
+          'competence1': 2,
+          'competence2': 3,
+        };
+        const validatedSkillsCount = 5;
+
+        campaignParticipationRepository.get
+          .withArgs(event.campaignParticipationId, { include: ['campaign'] })
+          .resolves(campaignParticipation);
+
+        targetProfileWithLearningContentRepository.getByCampaignId
+          .withArgs({ campaignId: campaignParticipation.campaignId })
+          .resolves(targetProfile);
+
+        knowledgeElementRepository.countValidatedTargetedByCompetencesForOneUser
+          .withArgs(campaignParticipation.userId, campaignParticipation.sharedAt, targetProfile)
+          .resolves(validatedSkillsCountByCompetence);
+
+        await computeValidatedSkillsCount({ event, campaignParticipationRepository, knowledgeElementRepository, targetProfileWithLearningContentRepository });
+
+        expect(campaignParticipation.validatedSkillsCount).to.equals(validatedSkillsCount);
+        expect(campaignParticipationRepository.update).to.have.been.calledWith(campaignParticipation);
+      });
+    });
+
+    context('when the campaign is of type profile collection', () => {
+      it('does not compute the validated skills count', async () => {
+        const targetProfile = domainBuilder.buildTargetProfile();
+        const campaign = domainBuilder.buildCampaign.ofTypeProfilesCollection();
+        const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: 1, campaignId: 2, userId: 3, campaign });
+        const event = new CampaignParticipationResultsShared({ campaignParticipationId: campaignParticipation.id });
+
+        campaignParticipationRepository.get.resolves(campaignParticipation);
+        targetProfileWithLearningContentRepository.getByCampaignId.resolves(targetProfile);
+        knowledgeElementRepository.countValidatedTargetedByCompetencesForOneUser.resolves({});
+
+        await computeValidatedSkillsCount({ event, campaignParticipationRepository, knowledgeElementRepository, targetProfileWithLearningContentRepository });
+
+        expect(campaignParticipationRepository.update).not.to.have.been.called;
+      });
+    });
+
+  });
+
+});
+

--- a/api/tests/unit/domain/events/event-choregraphy-compute-validated-skills-count_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-compute-validated-skills-count_test.js
@@ -1,0 +1,18 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
+
+describe('Event Choregraphy | Compute Validated Skills Count', function() {
+  it('Should trigger ComputeValidatedSkillsCount on CampaignParticipationResultsShared event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new CampaignParticipationResultsShared();
+    const domainTransaction = Symbol('a transaction');
+
+    // when
+    await eventDispatcher.dispatch(event, domainTransaction);
+
+    // then
+    expect(handlerStubs.computeValidatedSkillsCount).to.have.been.calledWith({ event, domainTransaction });
+  });
+});

--- a/api/tests/unit/domain/models/CampaignParticipation_test.js
+++ b/api/tests/unit/domain/models/CampaignParticipation_test.js
@@ -1,5 +1,8 @@
 const CampaignParticipation = require('../../../../lib/domain/models/CampaignParticipation');
-const { expect, domainBuilder } = require('../../../test-helper');
+const { expect, domainBuilder, sinon, catchErr } = require('../../../test-helper');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+const Assessment = require('../../../../lib/domain/models/Assessment');
+const { ArchivedCampaignError, AssessmentNotCompletedError, AlreadySharedCampaignParticipationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | CampaignParticipation', () => {
 
@@ -54,4 +57,124 @@ describe('Unit | Domain | Models | CampaignParticipation', () => {
 
   });
 
+  describe('share', () => {
+
+    context('when the campaign is not archived', () => {
+      let clock;
+      const now = new Date('2021-09-25');
+
+      beforeEach(() => {
+        clock = sinon.useFakeTimers(now.getTime());
+      });
+
+      afterEach(() => {
+        clock.restore();
+      });
+
+      context('when the campaign is already shared', () => {
+        it('throws an AlreadySharedCampaignParticipationError error', async () => {
+          const campaign = domainBuilder.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
+          const campaignParticipation = new CampaignParticipation({ campaign, isShared: true });
+
+          const error = await catchErr(campaignParticipation.share, campaignParticipation)();
+
+          expect(error).to.be.an.instanceOf(AlreadySharedCampaignParticipationError);
+        });
+      });
+
+      context('when the campaign as the type PROFILES_COLLECTION', () => {
+        it('share the CampaignParticipation', () => {
+          const campaign = domainBuilder.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
+          const campaignParticipation = new CampaignParticipation({ campaign });
+
+          campaignParticipation.share();
+
+          expect(campaignParticipation.isShared).to.be.true;
+          expect(campaignParticipation.sharedAt).to.deep.equals(now);
+        });
+      });
+
+      context('when the campaign as the type ASSESSMENT', () => {
+        context('when there is no assessment', () => {
+          it('throws an AssessmentNotCompletedError', async () => {
+            const campaign = domainBuilder.buildCampaign({ type: Campaign.types.ASSESSMENT });
+            const campaignParticipation = new CampaignParticipation({ campaign, assessments: [] });
+
+            const error = await catchErr(campaignParticipation.share, campaignParticipation)();
+
+            expect(error).to.be.an.instanceOf(AssessmentNotCompletedError);
+          });
+        });
+
+        context('when the last assessment is not completed', () => {
+
+          it('throws an AssessmentNotCompletedError', async () => {
+            const campaign = domainBuilder.buildCampaign({ type: Campaign.types.ASSESSMENT });
+            const assessments = [
+              domainBuilder.buildAssessment({ createdAt: new Date('2020-01-01'), state: Assessment.states.COMPLETED }),
+              domainBuilder.buildAssessment({ createdAt: new Date('2020-01-02'), state: Assessment.states.STARTED }),
+            ];
+            const campaignParticipation = new CampaignParticipation({ campaign, assessments });
+
+            const error = await catchErr(campaignParticipation.share, campaignParticipation)();
+
+            expect(error).to.be.an.instanceOf(AssessmentNotCompletedError);
+          });
+        });
+
+        context('when the last assessment is completed', () => {
+
+          it('share the CampaignParticipation', () => {
+            const campaign = domainBuilder.buildCampaign({ type: Campaign.types.ASSESSMENT });
+            const assessments = [
+              domainBuilder.buildAssessment({ createdAt: new Date('2020-03-01'), state: Assessment.states.COMPLETED }),
+              domainBuilder.buildAssessment({ createdAt: new Date('2020-01-01'), state: Assessment.states.STARTED }),
+            ];
+            const campaignParticipation = new CampaignParticipation({ campaign, assessments });
+
+            campaignParticipation.share();
+
+            expect(campaignParticipation.isShared).to.be.true;
+            expect(campaignParticipation.sharedAt).to.deep.equals(now);
+          });
+        });
+      });
+    });
+
+    context('when the campaign is archived', () => {
+      it('throws an ArchivedCampaignError error', async () => {
+        const campaign = domainBuilder.buildCampaign({ archivedAt: new Date() });
+        const campaignParticipation = new CampaignParticipation({ campaign });
+
+        const error = await catchErr(campaignParticipation.share, campaignParticipation)();
+
+        expect(error).to.be.an.instanceOf(ArchivedCampaignError);
+        expect(error.message).to.equals('Cannot share results on an archived campaign.');
+      });
+    });
+  });
+
+  describe('canComputeValidatedSkillsCount', () => {
+    context('when the campaign as the type PROFILES_COLLECTION', () => {
+      it('returns false', () => {
+        const campaign = domainBuilder.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION });
+        const campaignParticipation = new CampaignParticipation({ campaign });
+
+        const canComputeValidatedSkillsCount = campaignParticipation.canComputeValidatedSkillsCount();
+
+        expect(canComputeValidatedSkillsCount).to.be.false;
+      });
+    });
+
+    context('when the campaign as the type ASSESSMENT', () => {
+      it('returns true', () => {
+        const campaign = domainBuilder.buildCampaign({ type: Campaign.types.ASSESSMENT });
+        const campaignParticipation = new CampaignParticipation({ campaign });
+
+        const canComputeValidatedSkillsCount = campaignParticipation.canComputeValidatedSkillsCount();
+
+        expect(canComputeValidatedSkillsCount).to.be.true;
+      });
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -1,111 +1,53 @@
 const { sinon, expect, domainBuilder, catchErr } = require('../../../test-helper');
-const { AssessmentNotCompletedError, UserNotAuthorizedToAccessEntity, ArchivedCampaignError } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
-const usecases = require('../../../../lib/domain/usecases');
+const shareCampaignResult = require('../../../../lib/domain/usecases/share-campaign-result');
 
 describe('Unit | UseCase | share-campaign-result', () => {
   const campaignParticipationRepository = {
     get: sinon.stub(),
-    share: sinon.stub(),
+    updateWithSnapshot: sinon.stub(),
     isAssessmentCompleted: sinon.stub(),
-  };
-  const campaignRepository = {
-    get: sinon.stub(),
   };
   const userId = 123;
   const campaignParticipationId = 456;
-  const campaignId = 789;
-  const organizationId = 159;
 
-  it('should throw a UserNotAuthorizedToAccessEntity error when user is not the owner of the campaign participation', async () => {
-    // given
-    campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId: userId + 1 });
-
-    // when
-    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
-
-    // then
-    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
-  });
-
-  it('should throw a ArchivedCampaignError error when campaign is archived', async () => {
-    // given
-    campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId, campaignId });
-    campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ id: campaignId, archivedAt: new Date('1990-11-04') }));
-
-    // when
-    const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
-
-    // then
-    expect(error).to.be.instanceOf(ArchivedCampaignError);
-  });
-
-  context('when the campaign is of type assessment', () => {
-    it('should throw a AssessmentNotCompletedError error when latest assessment of participation is not completed', async () => {
+  context('when user is not the owner of the campaign participation', () => {
+    it('throws a UserNotAuthorizedToAccessEntity error ', async () => {
       // given
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves({ userId, campaignId });
-      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(false);
+      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves({ userId: userId + 1 });
 
       // when
-      const error = await catchErr(usecases.shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      const error = await catchErr(shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository });
 
       // then
-      expect(error).to.be.instanceOf(AssessmentNotCompletedError);
-    });
-
-    it('should share successfully the participation when latest assessment is completed', async () => {
-      // given
-      const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(true);
-
-      // when
-      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
-
-      // then
-      expect(campaignParticipationRepository.share).to.have.been.calledWith(campaignParticipation);
-    });
-
-    it('should return the CampaignParticipationResultsShared event', async () => {
-      // given
-      const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeAssessment({ id: campaignId, archivedAt: null, organizationId }));
-      campaignParticipationRepository.isAssessmentCompleted.withArgs(campaignParticipationId).resolves(true);
-
-      // when
-      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
-
-      // then
-      expect(actualEvent).to.deep.equal({ campaignParticipationId });
-      expect(actualEvent).to.be.instanceOf(CampaignParticipationResultsShared);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
     });
   });
-
-  context('when the campaign is of type profiles collection', () => {
-    it('should share successfully the participation', async () => {
+  context('when user is the owner of the campaign participation', () => {
+    it('updates the campaign participation', async () => {
       // given
-      const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeProfilesCollection({ id: campaignId, archivedAt: null }));
+      const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
+      sinon.stub(campaignParticipation, 'share');
+      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
 
       // when
-      await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });
 
       // then
-      expect(campaignParticipationRepository.share).to.have.been.calledWith(campaignParticipation);
+      expect(campaignParticipation.share).to.have.been.called;
+      expect(campaignParticipationRepository.updateWithSnapshot).to.have.been.calledWith(campaignParticipation);
     });
 
-    it('should return the CampaignParticipationResultsShared event', async () => {
+    it('returns the CampaignParticipationResultsShared event', async () => {
       // given
-      const campaignParticipation = { id: campaignParticipationId, userId, campaignId };
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
-      campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign.ofTypeProfilesCollection({ id: campaignId, archivedAt: null, organizationId }));
+      const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
+      sinon.stub(campaignParticipation, 'share');
+
+      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
 
       // when
-      const actualEvent = await usecases.shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository, campaignRepository });
+      const actualEvent = await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });
 
       // then
       expect(actualEvent).to.deep.equal({ campaignParticipationId });


### PR DESCRIPTION
## :unicorn: Problème
Avoir le nombre d'acquis validés pour plusieurs personnes et une tâche coûteuse en terme de temps d’exécution.


## :robot: Solution
Lorsqu'un prescrit partage ses résultats, déclencher l'enregistrement du nombre d'acquis validés en BDD.

## :rainbow: Remarques
RAS, petit refacto pour sortir la logique présente dans l'infra et la mettre dans le domaine.

Il y a un truc qui me chagrine un peu, les `repositories` on une connaissance très fine des structure internes des modèles. C'est "pratique", mais pas très propre. À cause de ça j'ai du trier les champs que je veux mettre en base dans le `repository`.
Ça risque de poser des problèmes si jamais on rajoute des attributs dans les modèle qui n'ont pas vocation à être en BDD.
Par exemple, j'ai besoin d'une campagne dans le modèle campagne participation, donc je lui ajoute un attribut campagne, mais Bookshelf essaye de le persister donc ça marche pas.

## :100: Pour tester
Participer à une campagne, puis partager ses résultats.
Constater qu'en BDD la colonne `validatedSkillsCount` est bien remplie.
