### PR TITLE
[FEATURE] Permettre à un utilisateur de passer un parcours Accès Simplifié sans inscription sur Pix App (PIX-1040).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -61,6 +61,7 @@ const buildUser = function buildUser({
   hasSeenAssessmentInstructions = false,
   hasSeenNewLevelInfo = false,
   hasSeenNewDashboardInfo = false,
+  isAnonymous = false,
   createdAt = new Date(),
   updatedAt = new Date(),
 } = {}) {
@@ -72,8 +73,8 @@ const buildUser = function buildUser({
     cgu, lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    hasSeenNewLevelInfo,
     hasSeenNewDashboardInfo,
+    hasSeenNewLevelInfo, isAnonymous,
     createdAt, updatedAt,
     password: '',
     shouldChangePassword: false,

--- a/api/db/migrations/20210119141645_add-column-is-anonymous-to-users.js
+++ b/api/db/migrations/20210119141645_add-column-is-anonymous-to-users.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'isAnonymous';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.boolean(COLUMN_NAME).defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -62,4 +62,17 @@ module.exports = {
 
     return h.response(response).code(200);
   },
+
+  async authenticateAnonymousUser(request, h) {
+
+    const { 'campaign_code': campaignCode } = request.payload;
+    const accessToken = await usecases.authenticateAnonymousUser({ campaignCode });
+
+    const response = {
+      token_type: 'bearer',
+      access_token: accessToken,
+    };
+
+    return h.response(response).code(200);
+  },
 };

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -25,6 +25,28 @@ exports.register = async (server) => {
       },
     },
 
+    {
+      method: 'POST',
+      path: '/api/token/anonymous',
+      config: {
+        auth: false,
+        payload: {
+          allow: 'application/x-www-form-urlencoded',
+        },
+        validate: {
+          payload: Joi.object().required().keys({
+            campaign_code: Joi.string().required(),
+          }),
+        },
+        handler: AuthenticationController.authenticateAnonymousUser,
+        notes: [
+          '- Cette route permet de créer un utilisateur à partir d\'un code parcours Accès Simplifié\n' +
+          '- Elle retournera un access token Pix correspondant à l\'utilisateur.',
+        ],
+        tags: ['api'],
+      },
+    },
+
     /**
      * This endpoint does nothing and exists only because it is required by
      * Ember Simpl Auth addon, for OAuth 2 "Password Grant" strategy.

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -145,6 +145,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.AlreadySharedCampaignParticipationError) {
     return new HttpErrors.PreconditionFailedError(error.message);
   }
+  if (error instanceof DomainErrors.UserCantBeCreatedError) {
+    return new HttpErrors.UnauthorizedError(error.message);
+  }
   if (error instanceof DomainErrors.ForbiddenAccess) {
     return new HttpErrors.ForbiddenError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -646,6 +646,12 @@ class SchoolingRegistrationNotFound extends NotFoundError {
   }
 }
 
+class UserCantBeCreatedError extends DomainError {
+  constructor(message = 'L\'utilisateur ne peut pas être créé') {
+    super(message);
+  }
+}
+
 class UserNotFoundError extends NotFoundError {
   constructor(message = 'Ce compte est introuvable.') {
     super(message);
@@ -768,6 +774,7 @@ module.exports = {
   UserAccountNotFoundForPoleEmploiError,
   UserAlreadyExistsWithAuthenticationMethodError,
   UserAlreadyLinkedToCandidateInSessionError,
+  UserCantBeCreatedError,
   UserCouldNotBeReconciledError,
   UserNotAuthorizedToAccessEntity,
   UserNotAuthorizedToCertifyError,

--- a/api/lib/domain/models/User.js
+++ b/api/lib/domain/models/User.js
@@ -18,6 +18,7 @@ class User {
     hasSeenNewDashboardInfo,
     mustValidateTermsOfService,
     lang,
+    isAnonymous,
     memberships = [],
     certificationCenterMemberships = [],
     pixRoles = [],
@@ -41,6 +42,7 @@ class User {
     this.hasSeenNewDashboardInfo = hasSeenNewDashboardInfo;
     this.knowledgeElements = knowledgeElements;
     this.lang = lang;
+    this.isAnonymous = isAnonymous;
     this.pixRoles = pixRoles;
     this.pixScore = pixScore;
     this.memberships = memberships;

--- a/api/lib/domain/usecases/authenticate-anonymous-user.js
+++ b/api/lib/domain/usecases/authenticate-anonymous-user.js
@@ -1,0 +1,28 @@
+const User = require('../models/User');
+const { UserCantBeCreatedError } = require('../errors');
+
+module.exports = async function authenticateAnonymousUser({
+  campaignCode,
+  campaignToJoinRepository,
+  userRepository,
+  tokenService,
+}) {
+
+  const campaign = await campaignToJoinRepository.getByCode(campaignCode);
+  if (!campaign.isSimplifiedAccess) {
+    throw new UserCantBeCreatedError();
+  }
+
+  const newUser = await userRepository.create({
+    user: new User({
+      firstName: '',
+      lastName: '',
+      cgu: false,
+      mustValidateTermsOfService: false,
+      isAnonymous: true,
+    }),
+  });
+
+  const accessToken = tokenService.createAccessTokenFromUser(newUser.id, 'pix');
+  return accessToken;
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -111,6 +111,7 @@ module.exports = injectDependencies({
   attachOrganizationsToTargetProfile: require('./attach-organizations-to-target-profile'),
   archiveCampaign: require('./archive-campaign'),
   assignCertificationOfficerToJurySession: require('./assign-certification-officer-to-jury-session'),
+  authenticateAnonymousUser: require('./authenticate-anonymous-user'),
   authenticatePoleEmploiUser: require('./authenticate-pole-emploi-user'),
   authenticateUser: require('./authenticate-user'),
   beginCampaignParticipationImprovement: require('./begin-campaign-participation-improvement'),

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -21,6 +21,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       user_id: 'the-user-id',
     }));
     sinon.stub(authenticationController, 'authenticatePoleEmploiUser').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(authenticationController, 'authenticateAnonymousUser').callsFake((request, h) => h.response('ok').code(200));
 
     httpTestServer = new HttpTestServer(moduleUnderTest, true);
   });
@@ -227,7 +228,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       };
     });
 
-    it('should return a 400 BAd Request if username is missing', async () => {
+    it('should return a 400 Bad Request if username is missing', async () => {
       // given
       payload.data.attributes.username = undefined;
 
@@ -238,7 +239,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 BAd Request if password is missing', async () => {
+    it('should return a 400 Bad Request if password is missing', async () => {
       // given
       payload.data.attributes.password = undefined;
 
@@ -249,7 +250,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 BAd Request if external-user-token is missing', async () => {
+    it('should return a 400 Bad Request if external-user-token is missing', async () => {
       // given
       payload.data.attributes['external-user-token'] = undefined;
 
@@ -260,7 +261,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
       expect(response.statusCode).to.equal(400);
     });
 
-    it('should return a 400 BAd Request if expected-user-id is missing', async () => {
+    it('should return a 400 Bad Request if expected-user-id is missing', async () => {
       // given
       payload.data.attributes['expected-user-id'] = undefined;
 
@@ -358,6 +359,43 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
         code,
         client_id,
       });
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('POST /api/token/anonymous', () => {
+
+    const method = 'POST';
+    const url = '/api/token/anonymous';
+    const headers = {
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    const code = 'SIMPLIFIE';
+
+    let payload;
+
+    beforeEach(() => {
+      payload = querystring.stringify({
+        campaign_code: code,
+      });
+    });
+
+    it('should return a response with HTTP status code 200', async () => {
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400 when campaignCode is missing', async () => {
+      // given
+      payload = querystring.stringify({});
 
       // when
       const response = await httpTestServer.request(method, url, payload, null, headers);

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -569,6 +569,14 @@ describe('Integration | API | Controller Error', () => {
       expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
       expect(responseDetail(response)).to.equal(expectedMessage);
     });
+
+    it('responds Unauthorized when a UserCantBeCreatedError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.UserCantBeCreatedError('L\'utilisateur ne peut pas être créé'));
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(UNAUTHORIZED_ERROR);
+      expect(responseDetail(response)).to.equal('L\'utilisateur ne peut pas être créé');
+    });
   });
 
   context('500 Internal Server Error', () => {

--- a/api/tests/tooling/domain-builder/factory/build-user.js
+++ b/api/tests/tooling/domain-builder/factory/build-user.js
@@ -21,6 +21,7 @@ module.exports = function buildUser({
   pixCertifTermsOfServiceAccepted = false,
   hasSeenAssessmentInstructions = false,
   hasSeenNewLevelInfo = false,
+  isAnonymous = false,
   pixRoles = [buildPixRole()],
   memberships = [buildMembership()],
   certificationCenterMemberships = [buildCertificationCenterMembership()],
@@ -33,7 +34,7 @@ module.exports = function buildUser({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService,
     pixOrgaTermsOfServiceAccepted, pixCertifTermsOfServiceAccepted,
-    hasSeenAssessmentInstructions, hasSeenNewLevelInfo,
+    hasSeenAssessmentInstructions, hasSeenNewLevelInfo, isAnonymous,
     pixRoles, memberships, certificationCenterMemberships,
     authenticationMethods,
   });

--- a/api/tests/unit/domain/models/User_test.js
+++ b/api/tests/unit/domain/models/User_test.js
@@ -16,6 +16,7 @@ describe('Unit | Domain | Models | User', () => {
         cgu: true,
         lastTermsOfServiceValidatedAt: '2020-05-04T13:40:00.000Z',
         mustValidateTermsOfService: true,
+        isAnonymous: false,
       };
 
       // when
@@ -29,6 +30,7 @@ describe('Unit | Domain | Models | User', () => {
       expect(user.cgu).to.equal(rawData.cgu);
       expect(user.lastTermsOfServiceValidatedAt).to.equal(rawData.lastTermsOfServiceValidatedAt);
       expect(user.mustValidateTermsOfService).to.equal(rawData.mustValidateTermsOfService);
+      expect(user.isAnonymous).to.equal(rawData.isAnonymous);
     });
   });
 

--- a/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
@@ -1,0 +1,78 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+const User = require('../../../../lib/domain/models/User');
+const { UserCantBeCreatedError } = require('../../../../lib/domain/errors');
+
+const authenticateAnonymousUser = require('../../../../lib/domain/usecases/authenticate-anonymous-user');
+
+describe('Unit | UseCase | authenticate-anonymous-user', () => {
+  let campaignCode;
+  let campaignToJoinRepository;
+  let userRepository;
+  let tokenService;
+
+  beforeEach(() => {
+    campaignCode = 'SIMPLIFIE';
+    campaignToJoinRepository = {
+      getByCode: sinon.stub(),
+    };
+    userRepository = {
+      create: sinon.stub(),
+    };
+    tokenService = {
+      createAccessTokenFromUser: sinon.stub(),
+    };
+    campaignToJoinRepository.getByCode
+      .withArgs(campaignCode)
+      .resolves({ isSimplifiedAccess: true });
+  });
+
+  it('should create an anonymous user', async () => {
+    // given
+    const expectedUser = new User({
+      firstName: '',
+      lastName: '',
+      cgu: false,
+      mustValidateTermsOfService: false,
+      isAnonymous: true,
+    });
+    userRepository.create.resolves({ id: 1 });
+
+    // when
+    await authenticateAnonymousUser({ campaignCode, campaignToJoinRepository, userRepository, tokenService });
+
+    // then
+    expect(campaignToJoinRepository.getByCode).to.have.been.calledWith(campaignCode);
+    expect(userRepository.create).to.have.been.calledWith({ user: expectedUser });
+  });
+
+  it('should create an access token', async () => {
+    // given
+    const userId = 1;
+
+    userRepository.create.resolves({ id: userId });
+
+    // when
+    await authenticateAnonymousUser({ campaignCode, campaignToJoinRepository, userRepository, tokenService });
+
+    // then
+    expect(tokenService.createAccessTokenFromUser).to.have.been.calledWith(userId, 'pix');
+  });
+
+  it('should throw a UserCantBeCreatedError', async () => {
+    // given
+    const userId = 1;
+    campaignCode = 'RANDOM123';
+
+    userRepository.create.resolves({ id: userId });
+    campaignToJoinRepository.getByCode
+      .withArgs(campaignCode)
+      .resolves({ isSimplifiedAccess: false });
+
+    // when
+    const actualError = await catchErr(authenticateAnonymousUser)({ campaignCode, campaignToJoinRepository, userRepository, tokenService });
+
+    // then
+    expect(actualError).to.be.an.instanceOf(UserCantBeCreatedError);
+  });
+
+});

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -1,0 +1,51 @@
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+import ENV from 'mon-pix/config/environment';
+import fetch from 'fetch';
+import RSVP from 'rsvp';
+import { decodeToken } from 'mon-pix/helpers/jwt';
+import { isEmpty } from '@ember/utils';
+
+export default BaseAuthenticator.extend({
+
+  serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token/anonymous`,
+
+  async authenticate({ campaignCode }) {
+    const bodyObject = { campaign_code: campaignCode };
+
+    const body = Object.keys(bodyObject)
+      .map((k) => `${k}=${encodeURIComponent(bodyObject[k])}`)
+      .join('&');
+
+    const options = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+    };
+
+    const response = await fetch(this.serverTokenEndpoint, options);
+
+    const data = await response.json();
+    if (!response.ok) {
+      return RSVP.reject(data);
+    }
+
+    const decodedAccessToken = decodeToken(data.access_token);
+
+    return {
+      access_token: data.access_token,
+      user_id: decodedAccessToken.user_id,
+    };
+  },
+
+  restore(data) {
+    return new RSVP.Promise((resolve, reject) => {
+      if (!isEmpty(data['access_token'])) {
+        resolve(data);
+      }
+      reject();
+    });
+  },
+});

--- a/mon-pix/app/routes/campaigns/restricted/join.js
+++ b/mon-pix/app/routes/campaigns/restricted/join.js
@@ -14,7 +14,7 @@ export default class JoinRoute extends Route {
     return this.modelFor('campaigns');
   }
 
-  async redirect(campaign) {
+  async afterModel(campaign) {
     if (!this.session.get('data.externalUser')) {
       let schoolingRegistration = await this.store.queryRecord('schooling-registration-user-association', { userId: this.currentUser.user.id, campaignCode: campaign.code });
 

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -40,4 +40,16 @@ export default function index(config) {
       user_id: createdUser.id,
     };
   });
+
+  config.post('/token/anonymous', (schema) => {
+    const createdUser = schema.users.create({
+      firstName: '',
+      lastName: '',
+    });
+
+    return {
+      access_token: 'aaa.' + btoa(`{"user_id":${createdUser.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      user_id: createdUser.id,
+    };
+  });
 }

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -455,6 +455,32 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
             });
           });
         });
+
+        context('When is a simplified access campaign', function() {
+
+          beforeEach(function() {
+            campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+          });
+
+          it('should redirect to landing page', async function() {
+            // when
+            await visit(`/campagnes/${campaign.code}`);
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to tutorial page after starting campaign', async function() {
+            // when
+            await visit(`/campagnes/${campaign.code}`);
+            await click('button[type="submit"]');
+            await fillIn('#id-pix-label', 'vu');
+            await click('button[type="submit"]');
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+          });
+        });
       });
 
       context('When campaign code does not exist', function() {
@@ -831,6 +857,31 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
         });
       });
 
+      context('When is a simplified access campaign', function() {
+
+        beforeEach(function() {
+          campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+        });
+
+        it('should redirect to landing page', async function() {
+          // when
+          await visit(`/campagnes/${campaign.code}`);
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+        });
+
+        it('should redirect to tutorial page after starting campaign', async function() {
+          // when
+          await visit(`/campagnes/${campaign.code}`);
+          await click('button[type="submit"]');
+          await fillIn('#id-pix-label', 'vu');
+          await click('button[type="submit"]');
+
+          // then
+          expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+        });
+      });
     });
 
     context('When user is logged in an external platform', function() {

--- a/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
+++ b/mon-pix/tests/unit/routes/campaigns/restricted/join-test.js
@@ -11,7 +11,7 @@ const AUTHENTICATED_SOURCE_FROM_MEDIACENTRE = ENV.APP.AUTHENTICATED_SOURCE_FROM_
 describe('Unit | Route | campaigns/restricted/join', function() {
   setupTest();
 
-  describe('#redirect', function() {
+  describe('#afterModel', function() {
 
     it('should redirect to campaigns.start-or-resume when an association already exists', async function() {
       // given
@@ -28,7 +28,7 @@ describe('Unit | Route | campaigns/restricted/join', function() {
       const transition = { to: { queryParams: {} } };
 
       // when
-      await route.redirect(campaign, transition);
+      await route.afterModel(campaign, transition);
 
       // then
       sinon.assert.calledWith(route.replaceWith, 'campaigns.start-or-resume', campaign.code, { queryParams: { associationDone: true } });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'Accès Simplifié, nous devons permettre à un utilisateur de pouvoir participer à un parcours "Accès Simplifié", sans avoir à s'inscrire.

## :robot: Solution
 
- Ajout d'une colonne sur le user permettant de le distinguer comme étant anonyme : `isAnonymous`
- Création de la route POST `/api/token/anonymous`
- Création automatique d'un user avec les champs prénom et nom vides ( ⚠️ pas de création si un utilisateur est déjà connecté sur Pix)
- Création d'un nouveau authenticator `anonymous`

## :rainbow: Remarques


## :100: Pour tester

- Rentrer le parcours suivant : "SIMPLIFIE"
- Commencer et finir le parcours
- Vérifier que les résultats sont présents sur Pix Orga ( avec pro.admin@example.net)

Tester également avec utilisateur déjà connecté sur Pix
