### PR TITLE
[BUGFIX] Le tooltip est mal positionné et n'est pas lisible sur Pix Orga (PIX-2009)

### DIFF
--- a/orga/app/components/organization-credit-info.hbs
+++ b/orga/app/components/organization-credit-info.hbs
@@ -5,7 +5,7 @@
 		@text={{this.tooltipContent}}
 		@position='bottom'
 		@inline={{false}}
-		@class="pix-orga-tooltip">
+		class="pix-orga-tooltip">
 			<FaIcon @icon="info-circle" class="info-icon"/>
 	</PixTooltip>
 </div>

--- a/orga/app/components/routes/authenticated/sco-students/list-items.hbs
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.hbs
@@ -6,7 +6,7 @@
         <PixTooltip
           @text={{this.textTooltipForAgri}}
           @position='bottom'
-          @class="pix-orga-tooltip list-students-page__tooltip">
+          class="pix-orga-tooltip list-students-page__tooltip">
             <span class="list-students-page__tooltip-title">
               <span>En savoir plus</span>
               <FaIcon @icon="info-circle" class="info-icon"/>


### PR DESCRIPTION
## :unicorn: Problème
L'affichage du hover "en savoir plus" pour les orga AGRI isManagingStudent et l'affichage du hover pour les crédits ne correspondent pas au css.
Le composant PixToolTip recevait  en arguent `@class="..."` ce qui empêchait la classe d'être active et donc d'appliquer le css correspondant à la classe.

## :robot: Solution
Enlever le @ devant e la classe.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- l'affichage du hover "en savoir plus": être connecté avec l'adresse mail `sco.admin@example.net`, sélectionné l'organisation `CFA Agricole` puis aller dans `Élèves` puis voir le `En savoir plus`
- l'affichage du hover des crédits: être connecté avec l'adresse mail `pro.admin@example.net` 