### PR TITLE
[BUGFIX] Correctif pour les Embed Auto (PIX-2038).

### DIFF
--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -8,7 +8,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   @tracked autoReplyAnswer = '';
   postMessageHandler = null;
-  embedOrigin = 'https://epreuves.pix.fr';
+  embedOrigins = ['https://epreuves.pix.fr', 'https://1024pix.github.io'];
 
   constructor() {
     super(...arguments);
@@ -53,18 +53,28 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
 
   _getMessageFromEventData(event) {
     let data = null;
-    if (event.origin === this.embedOrigin) {
-      if (typeof event.data === 'string') {
+    if (this.embedOrigins.includes(event.origin)) {
+      if (this._isNumeric(event.data)) {
+        data = this._transformToObjectMessage(event.data);
+      } else if (typeof event.data === 'string') {
         try {
           data = JSON.parse(event.data);
         } catch {
-          data = { answer: event.data, from: 'pix' };
+          data = this._transformToObjectMessage(event.data);
         }
       } else if (typeof event.data === 'object') {
         data = event.data;
       }
     }
     return data;
+  }
+
+  _isNumeric(x) {
+    return parseFloat(x).toString() === x;
+  }
+
+  _transformToObjectMessage(answer) {
+    return { answer: answer, from: 'pix' };
   }
 
   get showProposal() {

--- a/mon-pix/tests/unit/components/challenge-item-qroc-test.js
+++ b/mon-pix/tests/unit/components/challenge-item-qroc-test.js
@@ -51,12 +51,41 @@ describe('Unit | Component | Challenge item qroc', function() {
         expect(component.autoReplyAnswer).to.deep.equal(answer);
       });
 
+      it('should set the autoreply answer from a string with number', function() {
+        // given
+        const answer = '2';
+        const event = {
+          data: answer,
+          origin: 'https://epreuves.pix.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
       it('should set the autoreply answer from a object', function() {
         // given
         const answer = 'magicWord';
         const event = {
           data: { answer, from: 'pix' },
           origin: 'https://epreuves.pix.fr',
+        };
+
+        // when
+        component._receiveEmbedMessage(event);
+
+        // then
+        expect(component.autoReplyAnswer).to.deep.equal(answer);
+      });
+
+      it('should set the autoreply answer from a object with preview origin', function() {
+        // given
+        const answer = 'magicWord';
+        const event = {
+          data: { answer, from: 'pix' },
+          origin: 'https://1024pix.github.io',
         };
 
         // when


### PR DESCRIPTION
## :unicorn: Problème
- Les Embed ont deux origins : epreuves.pix.fr quand elles sont en prod, mais aussi github quand elles sont en constructions
- Certaines embed envoient un nombre comme valeurs, et le JSON.Parse fonctionne sur elle, ce qui cassait ces épreuves

## :robot: Solution
- Ajouter une origine possible
- Gérer les nombres

## :rainbow: Remarques

## :100: Pour tester
- Epreuve avec un nombre : rec22anu4VgZFqcLJ
- Epreuve sur 1024Pix : rec2e4LoROJxneWLa