### PR TITLE
[FEATURE] Afficher mes parcours à envoyer et en cours dans la page Mes parcours (PIX-2002)

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -131,9 +131,27 @@ module.exports = function campaignsBuilder({ databaseBuilder }) {
 
   databaseBuilder.factory.buildCampaign({
     id: 11,
-    code: 'SIMPLIFIE',
     name: 'Parcours simplifié',
+    code: 'SIMPLIFIE',
+    type: 'ASSESSMENT',
+    title: 'Parcours simplifié',
     organizationId: 1,
+    creatorId: 2,
     targetProfileId: 100322,
+    customLandingPageText: '',
+    idPixLabel: null,
+  });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 12,
+    name: 'Pro - Campagne d’évaluation PIC 3',
+    code: 'AZERTY654',
+    type: 'ASSESSMENT',
+    title: 'Parcours recherche avancée 3',
+    customLandingPageText: '',
+    organizationId: 1,
+    creatorId: 2,
+    targetProfileId: 1,
+    idPixLabel: null,
   });
 };

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -1,7 +1,20 @@
+import { inject as service } from '@ember/service';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 export default class UserTestsController extends Route.extend(SecuredRouteMixin) {
+  @service store;
+
   model() {
+    const user = this.currentUser.user;
+    const maximumDisplayed = 100;
+    const queryParams = {
+      'userId': user.id,
+      'page[number]': 1,
+      'page[size]': maximumDisplayed,
+      'filter[states]': ['ONGOING', 'TO_SHARE'],
+    };
+
+    return this.store.query('campaign-participation-overview', queryParams);
   }
 }

--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -6,6 +6,7 @@
   justify-content: space-between;
   max-width: 980px;
   margin: auto;
+  margin-bottom: 16px;
   font-family: $font-roboto;
   font-weight: $font-light;
   padding: 0 20px;
@@ -40,5 +41,18 @@
     width: 100%;
     font-size: 3rem;
     color: $white;
+  }
+}
+
+.user-tests-main {
+  width: 100%;
+  max-width: 980px;
+  margin: auto;
+  font-family: $font-roboto;
+  font-weight: $font-light;
+  padding: 0 20px;
+
+  @include device-is('desktop') {
+    padding: 0;
   }
 }

--- a/mon-pix/app/templates/user-tests.hbs
+++ b/mon-pix/app/templates/user-tests.hbs
@@ -8,6 +8,11 @@
         <h3 class="user-tests-banner__title">{{t 'pages.user-tests.title'}}</h3>
       </div>
     </PixBackgroundHeader>
+    
+    <section class="user-tests-main">
+      <CampaignParticipationOverview::Grid @model={{this.model}}/>
+    </section>
+
     <Footer />
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/tests/acceptance/user-tests-test.js
+++ b/mon-pix/tests/acceptance/user-tests-test.js
@@ -2,6 +2,7 @@ import { currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { expect } from 'chai';
 import { authenticateByEmail } from '../helpers/authentication';
+import { contains } from '../helpers/contains';
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -26,6 +27,31 @@ describe('Acceptance | User tests', function() {
 
       // then
       expect(currentURL()).to.equal('/mes-parcours');
+    });
+
+    it('should display user participation cards', async function() {
+      // given
+      server.create('campaign-participation-overview', {
+        assessmentState: 'started',
+        campaignCode: '123',
+        campaignTitle: 'Campaign 1',
+        createdAt: new Date('2020-04-20T04:05:06Z'),
+        isShared: false,
+      });
+      server.create('campaign-participation-overview', {
+        assessmentState: 'completed',
+        campaignCode: '123',
+        campaignTitle: 'Campaign 2',
+        createdAt: new Date('2020-05-20T04:05:06Z'),
+        isShared: false,
+      });
+
+      // when
+      await visit('/mes-parcours');
+
+      // then
+      expect(contains('Campaign 1')).to.exist;
+      expect(contains('Campaign 2')).to.exist;
     });
   });
 

--- a/mon-pix/tests/unit/routes/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/user-tests-test.js
@@ -9,17 +9,23 @@ describe('Unit | Route | User-Tests', function() {
   setupTest();
 
   describe('#model', function() {
-
     it('should returns the model that contains campaignParticipationOverviews', async function() {
       // given
       const currentUserStub = Service.create({ user: { id: 1 } });
+      const store = this.owner.lookup('service:store');
+      sinon.stub(store, 'query');
 
       const campaignParticipationOverviews = [EmberObject.create({ id: 10 })];
-      const storeStub = { query: sinon.stub().returns(campaignParticipationOverviews) };
+      store.query.withArgs('campaign-participation-overview', {
+        userId: 1,
+        'page[number]': 1,
+        'page[size]': 100,
+        'filter[states]': ['ONGOING', 'TO_SHARE'],
+      }).returns(campaignParticipationOverviews);
 
       const route = this.owner.lookup('route:user-tests');
       route.set('currentUser', currentUserStub);
-      route.set('store', storeStub);
+      route.set('store', store);
 
       // when
       const model = await route.model();
@@ -28,5 +34,4 @@ describe('Unit | Route | User-Tests', function() {
       expect(model).to.deep.equal(campaignParticipationOverviews);
     });
   });
-
 });

--- a/mon-pix/tests/unit/routes/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/user-tests-test.js
@@ -1,0 +1,32 @@
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import sinon from 'sinon';
+
+describe('Unit | Route | User-Tests', function() {
+  setupTest();
+
+  describe('#model', function() {
+
+    it('should returns the model that contains campaignParticipationOverviews', async function() {
+      // given
+      const currentUserStub = Service.create({ user: { id: 1 } });
+
+      const campaignParticipationOverviews = [EmberObject.create({ id: 10 })];
+      const storeStub = { query: sinon.stub().returns(campaignParticipationOverviews) };
+
+      const route = this.owner.lookup('route:user-tests');
+      route.set('currentUser', currentUserStub);
+      route.set('store', storeStub);
+
+      // when
+      const model = await route.model();
+
+      // then
+      expect(model).to.deep.equal(campaignParticipationOverviews);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème

La page Mes Parcours n'affiche pas encore les cartes de participation de l'utilisateur.

## :robot: Solution

Afficher mes parcours à envoyer et en cours dans la page Mes parcours
- Reprendre le composant déjà utilisé dans la tableau de board.
- Réutiliser l'appel de l'API des dashboards (campaign-participation-overview)

De plus dans cette US, ne pas oublier les traductions en anglais.
Bien prévoir l’affichage responsive : mobile + tablette 

![image](https://user-images.githubusercontent.com/516360/105503945-79676a80-5cc7-11eb-942a-b07a0beefa00.png)

## :rainbow: Remarques

Nous avons ajouter à l'utilisateur "Jaune Attend" d'autres participations à des campagnes différentes dans les Seeds (avec l'email `jaune.attend@example.net`). 

## :100: Pour tester

1. Se connecter à mon-pix avec `jaune.attend@example.net`
2. Se rendre sur la page `/mes-parcours` (à écrire directement dans l'url)
3. Observer les différentes cartes de participation (en cours et à envoyer)