### PR TITLE
[BUGFIX] Erreur lors de la sauvegarde d'une réponse avec null à la fin (PIX-2015).

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -1,4 +1,3 @@
-const Answer = require('../../domain/models/Answer');
 const answerSerializer = require('../../infrastructure/serializers/jsonapi/answer-serializer');
 const correctionSerializer = require('../../infrastructure/serializers/jsonapi/correction-serializer');
 const usecases = require('../../domain/usecases');
@@ -7,7 +6,7 @@ const requestResponseUtils = require('../../infrastructure/utils/request-respons
 module.exports = {
 
   async save(request, h) {
-    const answer = partialDeserialize(request.payload);
+    const answer = answerSerializer.deserialize(request.payload);
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
     const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId });
 
@@ -59,16 +58,3 @@ module.exports = {
     return correctionSerializer.serialize(correction);
   },
 };
-
-function partialDeserialize(payload) {
-  // XXX missing AnswerStatus adapter for result serialisation
-  return new Answer({
-    value: payload.data.attributes.value,
-    result: null,
-    resultDetails: null,
-    timeout: payload.data.attributes.timeout,
-    elapsedTime: payload.data.attributes['elapsed-time'],
-    assessmentId: payload.data.relationships.assessment.data.id,
-    challengeId: payload.data.relationships.challenge.data.id,
-  });
-}

--- a/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/answer-serializer.js
@@ -1,3 +1,4 @@
+const Answer = require('../../../domain/models/Answer');
 const { Serializer } = require('jsonapi-serializer');
 const answerStatusJSONAPIAdapter = require('../../adapters/answer-status-json-api-adapter');
 
@@ -41,4 +42,20 @@ module.exports = {
     }).serialize(answer);
   },
 
+  deserialize(payload) {
+    return new Answer({
+      value: _cleanValue(payload.data.attributes.value),
+      result: null,
+      resultDetails: null,
+      timeout: payload.data.attributes.timeout,
+      elapsedTime: payload.data.attributes['elapsed-time'],
+      assessmentId: payload.data.relationships.assessment.data.id,
+      challengeId: payload.data.relationships.challenge.data.id,
+    });
+  },
+
 };
+
+function _cleanValue(value) {
+  return value.replace('\u0000', '');
+}

--- a/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/answer-serializer_test.js
@@ -1,4 +1,5 @@
 const { expect, domainBuilder } = require('../../../../test-helper');
+const Answer = require('../../../../../lib/domain/models/Answer');
 const AnswerStatus = require('../../../../../lib/domain/models/AnswerStatus');
 const answerStatusJSONAPIAdapter = require('../../../../../lib/infrastructure/adapters/answer-status-json-api-adapter');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/answer-serializer');
@@ -71,4 +72,54 @@ describe('Unit | Serializer | JSONAPI | answer-serializer', () => {
       expect(json).to.deep.equal(expectedJSON);
     });
   });
+
+  describe('#deserialize()', () => {
+
+    let jsonAnswer;
+    const assessmentId = 'assessmentId', challengeId = 'recChallengeId';
+
+    beforeEach(() => {
+      jsonAnswer = {
+        data: {
+          type: 'answers',
+          attributes: {
+            value: 'test\u0000',
+            result: null,
+            'result-details': null,
+            timeout: null,
+            'elapsed-time': 34,
+          },
+          relationships: {
+            assessment: {
+              data: {
+                type: 'assessments',
+                id: assessmentId,
+              },
+            },
+            challenge: {
+              data: {
+                type: 'challenges',
+                id: challengeId,
+              },
+            },
+          },
+        },
+      };
+    });
+    it('should convert JSON API data into an Answer model object', () => {
+      // when
+      const answer = serializer.deserialize(jsonAnswer);
+
+      // then
+      expect(answer).to.be.an.instanceOf(Answer);
+      expect(answer.value).to.equal('test');
+      expect(answer.result).to.deep.equal(AnswerStatus.from(null));
+      expect(answer.resultDetails).to.equal(null);
+      expect(answer.timeout).to.equal(null);
+      expect(answer.elapsedTime).to.equal(34);
+      expect(answer.assessmentId).to.equal(assessmentId);
+      expect(answer.challengeId).to.equal(challengeId);
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
- Des erreurs sentry remontent des erreurs : `invalid byte sequence for encoding "UTF8": 0x00`
- PostgreSQL ne supporte pas d'enregistrer le char NULL (\0x00) dans des champs textes.

## :robot: Solution
- Au moment de deserialiser la réponse, retirer le char unicode NULL (\u0000) de la valeur.

## :rainbow: Remarques
- BSR : remettre le deserializer au bon endroit

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
