### PR TITLE
[BUGFIX] Empêcher les suggestions de navigateurs sur les champs de saisie (1834)

### DIFF
--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -1,11 +1,15 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
 export default class QrocProposal extends Component {
 
   get _blocks() {
-    return proposalsAsBlocks(this.args.proposals);
+    return proposalsAsBlocks(this.args.proposals).map((block) => {
+      block.randomName = generateRandomString(block.input);
+      return block;
+    });
   }
 
   get userAnswer() {

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
 
 export default class QrocmProposal extends Component {
@@ -8,6 +9,7 @@ export default class QrocmProposal extends Component {
     return proposalsAsBlocks(this.args.proposals)
       .map((block) => {
         block.showText = block.text && !block.ariaLabel && !block.input;
+        block.randomName = generateRandomString(block.input);
         return block;
       });
   }

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -11,9 +11,9 @@
                   rows="5"
                   id="qroc_input"
                   {{on 'keydown' this.onInputChange}}
-                  name={{block.input}}
+                  name={{block.randomName}}
                   placeholder={{block.placeholder}}
-                  autocomplete="off"
+                  autocomplete="nope"
                   value="{{this.userAnswer}}"
                   data-uid="qroc-proposal-uid"
                   disabled={{if @answer true}}>
@@ -23,9 +23,9 @@
                type="text"
                id="qroc_input"
                {{on 'keydown' this.onInputChange}}
-               name={{block.input}}
+               name={{block.randomName}}
                placeholder={{block.placeholder}}
-               autocomplete="off"
+               autocomplete="nope"
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
@@ -34,9 +34,9 @@
                type="number"
                id="qroc_input"
                {{on 'keydown' this.onInputChange}}
-               name={{block.input}}
+               name={{block.randomName}}
                placeholder={{block.placeholder}}
-               autocomplete="off"
+               autocomplete="nope"
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>
@@ -46,9 +46,9 @@
                type="text"
                id="qroc_input"
                {{on 'keydown' this.onInputChange}}
-               name={{block.input}}
+               name={{block.randomName}}
                placeholder={{block.placeholder}}
-               autocomplete="off"
+               autocomplete="nope"
                value="{{this.userAnswer}}"
                data-uid="qroc-proposal-uid"
                disabled={{if @answer true}}>

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -13,9 +13,9 @@
         {{/if}}
         <Textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
                   rows="5"
-                  name={{block.input}}
+                  name={{block.randomName}}
                   placeholder={{block.placeholder}}
-                  autocomplete="off"
+                  autocomplete="nope"
                   id="{{block.text}}"
                   @value={{mut (get @answersValue block.input)}}
                   disabled={{@answer}}
@@ -28,9 +28,9 @@
 
         <Input class="challenge-response__proposal challenge-response__proposal--sentence"
                @type="text"
-               name={{block.input}}
+               name={{block.randomName}}
                placeholder={{block.placeholder}}
-               autocomplete="off"
+               autocomplete="nope"
                id="{{block.text}}"
                @value={{mut (get @answersValue block.input)}}
                disabled={{@answer}}
@@ -43,9 +43,9 @@
         <Input class="challenge-response__proposal"
                size="{{get-qroc-input-size @format}}"
                @type="text"
-               name={{block.input}}
+               name={{block.randomName}}
                placeholder={{block.placeholder}}
-               autocomplete="off"
+               autocomplete="nope"
                id="{{block.text}}"
                @value={{mut (get @answersValue block.input)}}
                disabled={{@answer}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -7,46 +7,40 @@
     {{/if}}
 
     {{#if block.input}}
+      {{#if block.text}}
+        <label for="{{block.input}}">{{block.text}}</label>
+      {{/if}}
+
       {{#if (eq @format 'paragraphe')}}
-        {{#if block.text}}
-          <label for="{{block.text}}">{{block.text}}</label>
-        {{/if}}
         <Textarea class="challenge-response__proposal challenge-response__proposal--paragraph"
                   rows="5"
                   name={{block.randomName}}
                   placeholder={{block.placeholder}}
                   autocomplete="nope"
-                  id="{{block.text}}"
+                  id="{{block.input}}"
                   @value={{mut (get @answersValue block.input)}}
                   disabled={{@answer}}
                   aria-label={{block.ariaLabel}}
                   onkeydown={{action 'onInputChange'}} />
       {{else if (eq @format 'phrase')}}
-        {{#if block.text}}
-          <label for="{{block.text}}">{{block.text}}</label>
-        {{/if}}
-
         <Input class="challenge-response__proposal challenge-response__proposal--sentence"
                @type="text"
                name={{block.randomName}}
                placeholder={{block.placeholder}}
                autocomplete="nope"
-               id="{{block.text}}"
+               id="{{block.input}}"
                @value={{mut (get @answersValue block.input)}}
                disabled={{@answer}}
                aria-label={{block.ariaLabel}}
                onkeydown={{action 'onInputChange'}} />
       {{else}}
-        {{#if block.text}}
-          <label for="{{block.text}}">{{block.text}}</label>
-        {{/if}}
         <Input class="challenge-response__proposal"
                size="{{get-qroc-input-size @format}}"
                @type="text"
                name={{block.randomName}}
                placeholder={{block.placeholder}}
                autocomplete="nope"
-               id="{{block.text}}"
+               id="{{block.input}}"
                @value={{mut (get @answersValue block.input)}}
                disabled={{@answer}}
                aria-label={{block.ariaLabel}}

--- a/mon-pix/app/utils/generate-random-string.js
+++ b/mon-pix/app/utils/generate-random-string.js
@@ -1,0 +1,4 @@
+export default function generateRandomString(prefix) {
+  const randomString = Math.random().toString().substr(2, 8);
+  return prefix + randomString;
+}

--- a/mon-pix/tests/integration/components/qroc-proposal-test.js
+++ b/mon-pix/tests/integration/components/qroc-proposal-test.js
@@ -102,7 +102,7 @@ describe('Integration | Component | QROC proposal', function() {
           await render(hbs`<QrocProposal @format={{this.format}} @proposals={{this.proposals}} @answerValue={{this.answerValue}} />`);
 
           // then
-          expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('off');
+          expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('nope');
         });
       });
 

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -84,7 +84,7 @@ describe('Integration | Component | QROCm proposal', function() {
           await render(hbs`<QrocmProposal @proposals={{this.proposals}} @format={{this.format}} @answerValue={{this.answerValue}} />`);
 
           // then
-          expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('off');
+          expect(find(`${data.cssClass}`).getAttribute('autocomplete')).to.equal('nope');
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Sur **Chrome**, le navigateur propose des suggestions de valeurs pour les champs input. Il s'agit de valeurs remplis précédemment par l'utilisateur / d'autres utilisateurs.

![Screenshot 2021-01-22 at 18 06 39](https://user-images.githubusercontent.com/11294487/105521757-9c504980-5cdc-11eb-8546-d49dfb33475b.png)

Or, lorsque plusieurs personnes utilisent le même ordinateur, il ne faudrait pas qu'un utilisateur puisse visualiser les réponses données par d'autres.

## :robot: Solution

**Etape 1**

L'attribut `autocomplete` avec la valeur `off` permet de:
> It tells the browser not to save data inputted by the user for later autocompletion on similar forms, though heuristics for complying vary by browser.

> It stops the browser from caching form data in the session history. When form data is cached in session history, the information filled in by the user is shown in the case where the user has submitted the form and clicked the Back button to go back to the original form page.

https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Toutefois Chrome ne tient pas compte de la valeur `off`!
Il nous faut donc attribuer une valeur random, différente de celles proposées par `autocomplete`, pour indiquer au navigateur de ne pas chercher à faire de l'auto-complétion. 
Dans cette PR nous lui attribuons donc la valeur random `nope`.

**Etape 2**

Même après ajouté `autocomplete='nope'`, Chrome continue de suggérer des valeurs à nos champs input.
Nous avons donc modifié l'attribut `name` de nos champs input pour lui attribuer une valeur aléatoire.

## :rainbow: Remarques
Nous avons testé `autocomplete='new-password'`, qui force l'utilisateur à remplir les champs. Mais Chrome continue de suggérer des valeurs à nos champs input...

## :100: Pour tester
- Tester sur Chrome + d'autres navigateurs des épreuves QROC (ex: recs9vPNc01KxEyQb) et QROCM (ex: recUhpELbN9k8kTf)
- Vérifier qu'il n'y a pas d'aide à la saisie sur les champs
- Vérifier que les bonnes et mauvaises réponses sont bien reconnues
