### PR TITLE
[FEATURE] Ajout des cartes terminées dans mes parcours (PIX-2003)

### DIFF
--- a/api/db/database-builder/factory/build-campaign-participation-elements-for-overview.js
+++ b/api/db/database-builder/factory/build-campaign-participation-elements-for-overview.js
@@ -8,6 +8,7 @@ module.exports = function buildCampaignParticipationElementsForOverview({ userId
   index,
   lastAssessmentState,
   campaignParticipationCreatedAt,
+  campaignParticipationSharedAt,
   campaignArchivedAt,
   isShared,
 } = {}) {
@@ -27,6 +28,7 @@ module.exports = function buildCampaignParticipationElementsForOverview({ userId
     createdAt: campaignParticipationCreatedAt,
     campaignId: campaign.id,
     isShared,
+    sharedAt: campaignParticipationSharedAt,
   });
 
   buildAssessment({

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
@@ -145,19 +145,6 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
           const expectedData = [
             {
               type: 'campaign-participation-overviews',
-              id: startedCampaignParticipationElements.campaignParticipation.id.toString(),
-              attributes: {
-                'is-shared': startedCampaignParticipationElements.campaignParticipation.isShared,
-                'shared-at': startedCampaignParticipationElements.campaignParticipation.sharedAt,
-                'created-at': startedCampaignParticipationElements.campaignParticipation.createdAt,
-                'organization-name': startedCampaignParticipationElements.organization.name,
-                'campaign-code': startedCampaignParticipationElements.campaign.code,
-                'campaign-title': startedCampaignParticipationElements.campaign.title,
-                'assessment-state': Assessment.states.STARTED,
-              },
-            },
-            {
-              type: 'campaign-participation-overviews',
               id: sharableCampaignParticipationElements.campaignParticipation.id.toString(),
               attributes: {
                 'is-shared': sharableCampaignParticipationElements.campaignParticipation.isShared,
@@ -167,6 +154,18 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
                 'campaign-code': sharableCampaignParticipationElements.campaign.code,
                 'campaign-title': sharableCampaignParticipationElements.campaign.title,
                 'assessment-state': Assessment.states.COMPLETED,
+              },
+            }, {
+              type: 'campaign-participation-overviews',
+              id: startedCampaignParticipationElements.campaignParticipation.id.toString(),
+              attributes: {
+                'is-shared': startedCampaignParticipationElements.campaignParticipation.isShared,
+                'shared-at': startedCampaignParticipationElements.campaignParticipation.sharedAt,
+                'created-at': startedCampaignParticipationElements.campaignParticipation.createdAt,
+                'organization-name': startedCampaignParticipationElements.organization.name,
+                'campaign-code': startedCampaignParticipationElements.campaign.code,
+                'campaign-title': startedCampaignParticipationElements.campaign.title,
+                'assessment-state': Assessment.states.STARTED,
               },
             }];
           expect(response.result.data).to.deep.equal(expectedData);

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -125,6 +125,7 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
           isShared: true,
           lastAssessmentState: Assessment.states.COMPLETED,
           campaignParticipationCreatedAt: new Date('2000-07-03T10:00:00Z'),
+          campaignParticipationSharedAt: new Date('2000-07-03T10:00:00Z'),
         });
 
         databaseBuilder.factory.buildCampaignParticipationElementsForOverview({
@@ -143,8 +144,8 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
         const rawCampaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
         const { campaignParticipationOverviews } = rawCampaignParticipationOverviews;
 
-        expect(campaignParticipationOverviews).to.have.lengthOf(4);
-        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['4 - My campaign', '3 - My campaign', '2 - My campaign', '1 - My campaign']);
+        expect(campaignParticipationOverviews).to.have.lengthOf(3);
+        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['2 - My campaign', '1 - My campaign', '3 - My campaign']);
       });
 
       it('should retrieve the campaign participations of the user with filtered assessment where state is TO_SHARE', async () => {
@@ -174,8 +175,8 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
         const rawCampaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
         const { campaignParticipationOverviews } = rawCampaignParticipationOverviews;
 
-        expect(campaignParticipationOverviews).to.have.lengthOf(3);
-        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['4 - My campaign', '3 - My campaign', '2 - My campaign']);
+        expect(campaignParticipationOverviews).to.have.lengthOf(2);
+        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['2 - My campaign', '3 - My campaign']);
       });
 
       it('should retrieve the campaign participations of the user with filtered assessment where state is  ENDED', async () => {
@@ -183,8 +184,8 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
         const rawCampaignParticipationOverviews = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId, states });
         const { campaignParticipationOverviews } = rawCampaignParticipationOverviews;
 
-        expect(campaignParticipationOverviews).to.have.lengthOf(2);
-        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['4 - My campaign', '3 - My campaign']);
+        expect(campaignParticipationOverviews).to.have.lengthOf(1);
+        expect(_.map(campaignParticipationOverviews, 'campaignTitle')).to.deep.equal(['3 - My campaign']);
       });
     });
 

--- a/mon-pix/app/components/campaign-participation-overview/card.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card.hbs
@@ -8,8 +8,8 @@
     <h3 class="campaign-participation-overview-card-header__title">{{@model.organizationName}}</h3>
     <strong class="campaign-participation-overview-card-header__subtitle">{{@model.campaignTitle}}</strong>
     <time class="campaign-participation-overview-card-header__date"
-          datetime="{{@model.createdAt}}">
-      {{t 'pages.campaign-participation-overview.card.started-at' starteddate=(format-date @model.createdAt)}}
+          datetime="{{this.date}}">
+      {{t this.status.dateText date=(format-date this.date)}}
     </time>
   </header>
 

--- a/mon-pix/app/components/campaign-participation-overview/card.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card.hbs
@@ -13,9 +13,12 @@
     </time>
   </header>
 
-  <LinkTo class="button button--link {{this.status.actionClass}} campaign-participation-overview-card__action"
+  <LinkTo class="{{this.status.actionClass}} campaign-participation-overview-card__action"
           @route="campaigns.start-or-resume"
           @model={{@model.campaignCode}}>
+    {{#if @model.isShared}}
+      <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
+    {{/if}}
     {{t this.status.actionText}}
   </LinkTo>
 </article>

--- a/mon-pix/app/components/campaign-participation-overview/card.js
+++ b/mon-pix/app/components/campaign-participation-overview/card.js
@@ -5,21 +5,21 @@ const STATUSES = {
     tagText: 'pages.campaign-participation-overview.card.tag.completed',
     tagColor: 'yellow-light',
     actionText: 'pages.campaign-participation-overview.card.send',
-    actionClass: 'button--yellow',
+    actionClass: 'button button--link button--yellow',
     dateText: 'pages.campaign-participation-overview.card.started-at',
   },
   started: {
     tagText: 'pages.campaign-participation-overview.card.tag.started',
     tagColor: 'green-light',
     actionText: 'pages.campaign-participation-overview.card.resume',
-    actionClass: '',
+    actionClass: 'button button--link',
     dateText: 'pages.campaign-participation-overview.card.started-at',
   },
   finished: {
     tagText: 'pages.campaign-participation-overview.card.tag.finished',
     tagColor: 'grey-light',
     actionText: 'pages.campaign-participation-overview.card.see-more',
-    actionClass: '',
+    actionClass: 'link campaign-participation-overview-card__see-more',
     dateText: 'pages.campaign-participation-overview.card.finished-at',
   },
 };
@@ -36,10 +36,9 @@ export default class Card extends Component {
 
   get date() {
     const isShared = this.args.model.get('isShared');
+    const sharedAt = this.args.model.get('sharedAt');
+    const createdAt = this.args.model.get('createdAt');
 
-    if (isShared) return this.args.model.get('sharedAt');
-
-    return this.args.model.get('createdAt');
-
+    return isShared ? sharedAt : createdAt;
   }
 }

--- a/mon-pix/app/components/campaign-participation-overview/card.js
+++ b/mon-pix/app/components/campaign-participation-overview/card.js
@@ -6,18 +6,21 @@ const STATUSES = {
     tagColor: 'yellow-light',
     actionText: 'pages.campaign-participation-overview.card.send',
     actionClass: 'button--yellow',
+    dateText: 'pages.campaign-participation-overview.card.started-at',
   },
   started: {
     tagText: 'pages.campaign-participation-overview.card.tag.started',
     tagColor: 'green-light',
     actionText: 'pages.campaign-participation-overview.card.resume',
     actionClass: '',
+    dateText: 'pages.campaign-participation-overview.card.started-at',
   },
-  shared: {
+  finished: {
     tagText: 'pages.campaign-participation-overview.card.tag.finished',
     tagColor: 'grey-light',
     actionText: 'pages.campaign-participation-overview.card.see-more',
     actionClass: '',
+    dateText: 'pages.campaign-participation-overview.card.finished-at',
   },
 };
 
@@ -26,8 +29,17 @@ export default class Card extends Component {
     const currentState = this.args.model.get('assessmentState');
     const isShared = this.args.model.get('isShared');
 
-    if (isShared) return STATUSES.shared;
+    if (isShared) return STATUSES.finished;
 
     return STATUSES[currentState];
+  }
+
+  get date() {
+    const isShared = this.args.model.get('isShared');
+
+    if (isShared) return this.args.model.get('sharedAt');
+
+    return this.args.model.get('createdAt');
+
   }
 }

--- a/mon-pix/app/components/campaign-participation-overview/card.js
+++ b/mon-pix/app/components/campaign-participation-overview/card.js
@@ -13,11 +13,21 @@ const STATUSES = {
     actionText: 'pages.campaign-participation-overview.card.resume',
     actionClass: '',
   },
+  shared: {
+    tagText: 'pages.campaign-participation-overview.card.tag.finished',
+    tagColor: 'grey-light',
+    actionText: 'pages.campaign-participation-overview.card.see-more',
+    actionClass: '',
+  },
 };
 
 export default class Card extends Component {
   get status() {
     const currentState = this.args.model.get('assessmentState');
+    const isShared = this.args.model.get('isShared');
+
+    if (isShared) return STATUSES.shared;
+
     return STATUSES[currentState];
   }
 }

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -12,7 +12,7 @@ export default class UserTestsController extends Route.extend(SecuredRouteMixin)
       'userId': user.id,
       'page[number]': 1,
       'page[size]': maximumDisplayed,
-      'filter[states]': ['ONGOING', 'TO_SHARE'],
+      'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED'],
     };
 
     return this.store.query('campaign-participation-overview', queryParams);

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -21,6 +21,10 @@
     font-size: 0.825rem;
     font-weight: $font-medium;
   }
+
+  &__see-more {
+    padding: 0;
+  }
 }
 
 .campaign-participation-overview-card-header {

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card-test.js
@@ -45,6 +45,7 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
     expect(find('.campaign-participation-overview-card-header__tag')).to.exist;
     expect(find('.campaign-participation-overview-card-header__tag').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.tag.started'));
     expect(find('.campaign-participation-overview-card__action').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.resume'));
+    expect(find('.campaign-participation-overview-card-header__date').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '10/12/2020' }));
   });
 
   it('should render component with a completed state but not shared', async function() {
@@ -63,5 +64,26 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
     // then
     expect(find('.campaign-participation-overview-card-header__tag').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.tag.completed'));
     expect(find('.campaign-participation-overview-card__action').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.send'));
+    expect(find('.campaign-participation-overview-card-header__date').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '10/12/2020' }));
+  });
+
+  it('should render component with a completed state and shared', async function() {
+    // given
+    const campaignParticipationOverview = EmberObject.create({
+      isShared: true,
+      createdAt: '2020-12-10T15:16:20.109Z',
+      sharedAt: '2020-12-18T15:16:20.109Z',
+      assessmentState: 'completed',
+      campaignTitle: 'My campaign',
+    });
+    this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+    // when
+    await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
+
+    // then
+    expect(find('.campaign-participation-overview-card-header__tag').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.tag.finished'));
+    expect(find('.campaign-participation-overview-card__action').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.see-more'));
+    expect(find('.campaign-participation-overview-card-header__date').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.finished-at', { date: '18/12/2020' }));
   });
 });

--- a/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
@@ -24,11 +24,11 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
       const result = component.status;
 
       // then
-      expect(result).to.eql({
+      expect(result).to.deep.equal({
         tagText: 'pages.campaign-participation-overview.card.tag.completed',
         tagColor: 'yellow-light',
         actionText: 'pages.campaign-participation-overview.card.send',
-        actionClass: 'button--yellow',
+        actionClass: 'button button--link button--yellow',
         dateText: 'pages.campaign-participation-overview.card.started-at',
       });
     });
@@ -41,11 +41,11 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
       const result = component.status;
 
       // then
-      expect(result).to.eql({
+      expect(result).to.deep.equal({
         tagText: 'pages.campaign-participation-overview.card.tag.finished',
         tagColor: 'grey-light',
         actionText: 'pages.campaign-participation-overview.card.see-more',
-        actionClass: '',
+        actionClass: 'link campaign-participation-overview-card__see-more',
         dateText: 'pages.campaign-participation-overview.card.finished-at',
       });
     });
@@ -58,11 +58,11 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
       const result = component.status;
 
       // then
-      expect(result).to.eql({
+      expect(result).to.deep.equal({
         tagText: 'pages.campaign-participation-overview.card.tag.started',
         tagColor: 'green-light',
         actionText: 'pages.campaign-participation-overview.card.resume',
-        actionClass: '',
+        actionClass: 'button button--link',
         dateText: 'pages.campaign-participation-overview.card.started-at',
       });
     });

--- a/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
@@ -16,7 +16,7 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
 
   describe('#status', function() {
 
-    it('should return the status when the campaign is completed', function() {
+    it('should return the status when the participation is completed', function() {
       // given
       component.args.model = EmberObject.create({ assessmentState: 'completed' });
 
@@ -29,10 +29,11 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         tagColor: 'yellow-light',
         actionText: 'pages.campaign-participation-overview.card.send',
         actionClass: 'button--yellow',
+        dateText: 'pages.campaign-participation-overview.card.started-at',
       });
     });
 
-    it('should return the status when the campaign is completed and shared', function() {
+    it('should return the status when the participation is completed and shared', function() {
       // given
       component.args.model = EmberObject.create({ assessmentState: 'completed', isShared: true });
 
@@ -45,10 +46,11 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         tagColor: 'grey-light',
         actionText: 'pages.campaign-participation-overview.card.see-more',
         actionClass: '',
+        dateText: 'pages.campaign-participation-overview.card.finished-at',
       });
     });
 
-    it('should return the status when the campaign is not completed', function() {
+    it('should return the status when the participation is not completed', function() {
       // given
       component.args.model = EmberObject.create({ assessmentState: 'started' });
 
@@ -61,7 +63,31 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         tagColor: 'green-light',
         actionText: 'pages.campaign-participation-overview.card.resume',
         actionClass: '',
+        dateText: 'pages.campaign-participation-overview.card.started-at',
       });
+    });
+  });
+
+  describe('#date', function() {
+    it('should return the sharing date when the participation is shared', function() {
+      // given
+      component.args.model = EmberObject.create({ isShared: true, sharedAt: '2020-12-18T15:16:20.109Z' });
+
+      // when
+      const result = component.date;
+
+      // then
+      expect(result).to.equal('2020-12-18T15:16:20.109Z');
+    });
+    it('should return the starting date when the participation is not shared', function() {
+      // given
+      component.args.model = EmberObject.create({ isShared: false, createdAt: '2020-12-10T15:16:20.109Z' });
+
+      // when
+      const result = component.date;
+
+      // then
+      expect(result).to.equal('2020-12-10T15:16:20.109Z');
     });
   });
 });

--- a/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
@@ -32,6 +32,22 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
       });
     });
 
+    it('should return the status when the campaign is completed and shared', function() {
+      // given
+      component.args.model = EmberObject.create({ assessmentState: 'completed', isShared: true });
+
+      // when
+      const result = component.status;
+
+      // then
+      expect(result).to.eql({
+        tagText: 'pages.campaign-participation-overview.card.tag.finished',
+        tagColor: 'grey-light',
+        actionText: 'pages.campaign-participation-overview.card.see-more',
+        actionClass: '',
+      });
+    });
+
     it('should return the status when the campaign is not completed', function() {
       // given
       component.args.model = EmberObject.create({ assessmentState: 'started' });

--- a/mon-pix/tests/unit/routes/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/user-tests-test.js
@@ -20,7 +20,7 @@ describe('Unit | Route | User-Tests', function() {
         userId: 1,
         'page[number]': 1,
         'page[size]': 100,
-        'filter[states]': ['ONGOING', 'TO_SHARE'],
+        'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED'],
       }).returns(campaignParticipationOverviews);
 
       const route = this.owner.lookup('route:user-tests');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -112,7 +112,8 @@
                 "resume": "Resume",
                 "send": "Submit my results",
                 "see-more": "See more",
-                "started-at": "Started the {starteddate}",
+                "started-at": "Started the {date}",
+                "finished-at": "Finished the {date}",
                 "tag": {
                     "started": "In progress",
                     "completed": "To be submitted",

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -111,10 +111,12 @@
             "card": {
                 "resume": "Resume",
                 "send": "Submit my results",
+                "see-more": "See more",
                 "started-at": "Started the {starteddate}",
                 "tag": {
                     "started": "In progress",
-                    "completed": "To be submitted"
+                    "completed": "To be submitted",
+                    "finished": "Finished"
                 }
             }
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -112,7 +112,8 @@
                 "resume": "Reprendre",
                 "send": "Envoyer mes résultats",
                 "see-more": "Voir le détail",
-                "started-at": "Commencé le {starteddate}",
+                "started-at": "Commencé le {date}",
+                "finished-at": "Terminé le {date}",
                 "tag": {
                     "started": "En cours",
                     "completed": "À envoyer",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -111,10 +111,12 @@
             "card": {
                 "resume": "Reprendre",
                 "send": "Envoyer mes résultats",
+                "see-more": "Voir le détail",
                 "started-at": "Commencé le {starteddate}",
                 "tag": {
                     "started": "En cours",
-                    "completed": "À envoyer"
+                    "completed": "À envoyer",
+                    "finished": "Terminé"
                 }
             }
         },


### PR DESCRIPTION
## :unicorn: Problème
Afficher les parcours terminés dans la page "Mes-parcours" et les organiser dans l'ordre "À Envoyer", "En Cours" et "Terminé"

## :robot: Solution
Afficher mes parcours "Terminé"

Reprendre le composant déjà utilisé dans la tableau de board.
Réutiliser l'appel de l'API des dashboards (campaign-participation-overview)
De plus dans cette US, ne pas oublier les traductions en anglais.

## :rainbow: Remarques
Le résultat en pourcentage va être ajouter dans une autre US 

## :100: Pour tester
Se connecter à mon-pix avec jaune.attend@example.net
Se rendre sur la page /mes-parcours (à écrire directement dans l'url)
Observer les différentes cartes de participation
