### PR TITLE
[FEATURE] Masquer les élèves des années précédentes dans Pix Certif (PIX-2022)

### DIFF
--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -35,7 +35,6 @@ module.exports = {
   },
 
   async getStudents(request) {
-    const userId = parseInt(request.auth.credentials.userId);
     const certificationCenterId = parseInt(request.params.certificationCenterId);
     const sessionId = parseInt(request.params.sessionId);
 
@@ -44,14 +43,12 @@ module.exports = {
       filter.divisions = [filter.divisions];
     }
 
-    const { data, pagination } = await usecases.findStudentsForEnrollement(
-      {
-        userId,
-        certificationCenterId,
-        sessionId,
-        page,
-        filter,
-      });
+    const { data, pagination } = await usecases.findStudentsForEnrollement({
+      certificationCenterId,
+      sessionId,
+      page,
+      filter,
+    });
     return studentCertificationSerializer.serialize(data, pagination);
   },
 

--- a/api/lib/domain/usecases/find-students-for-enrollement.js
+++ b/api/lib/domain/usecases/find-students-for-enrollement.js
@@ -12,7 +12,7 @@ module.exports = async function findStudentsForEnrollement({
 }) {
   try {
     const organizationId = await organizationRepository.getIdByCertificationCenterId(certificationCenterId);
-    const paginatedStudents = await schoolingRegistrationRepository.findByOrganizationIdOrderByDivision({
+    const paginatedStudents = await schoolingRegistrationRepository.findByOrganizationIdAndUpdatedAtOrderByDivision({
       page,
       filter,
       organizationId,

--- a/api/lib/infrastructure/repositories/schooling-registration-repository.js
+++ b/api/lib/infrastructure/repositories/schooling-registration-repository.js
@@ -77,9 +77,13 @@ module.exports = {
       .then((schoolingRegistrations) => bookshelfToDomainConverter.buildDomainObjects(BookshelfSchoolingRegistration, schoolingRegistrations));
   },
 
-  async findByOrganizationIdOrderByDivision({ organizationId, page, filter }) {
+  async findByOrganizationIdAndUpdatedAtOrderByDivision({ organizationId, page, filter }) {
+    const BEGINNING_OF_THE_2020_SCHOOL_YEAR = '2020-08-15';
     const query = BookshelfSchoolingRegistration
-      .where({ organizationId })
+      .where((qb) => {
+        qb.where({ organizationId });
+        qb.where('updatedAt', '>', BEGINNING_OF_THE_2020_SCHOOL_YEAR);
+      })
       .query((qb) => {
         qb.orderByRaw('LOWER("division") ASC, LOWER("lastName") ASC, LOWER("firstName") ASC');
         if (filter.divisions) {

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -24,7 +24,7 @@ describe('Unit | Controller | certifications-center-controller', () => {
 
       sinon
         .stub(usecases, 'findStudentsForEnrollement')
-        .withArgs({ userId: 111, certificationCenterId: 99, sessionId: 88, page: { size: 10, number: 1 }, filter: { divisions: [ '3A' ] } })
+        .withArgs({ certificationCenterId: 99, sessionId: 88, page: { size: 10, number: 1 }, filter: { divisions: [ '3A' ] } })
         .resolves({
           data: [student],
           pagination: { page: 1, pageSize: 10, rowCount: 1, pageCount: 1 },

--- a/api/tests/unit/domain/usecases/find-students-for-enrollement_test.js
+++ b/api/tests/unit/domain/usecases/find-students-for-enrollement_test.js
@@ -15,7 +15,7 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
     getIdByCertificationCenterId: sinon.stub(),
   };
   const schoolingRegistrationRepository = {
-    findByOrganizationIdOrderByDivision: sinon.stub(),
+    findByOrganizationIdAndUpdatedAtOrderByDivision: sinon.stub(),
   };
 
   const certificationCandidateRepository = {
@@ -61,7 +61,7 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
       const enrolledStudent = domainBuilder.buildSchoolingRegistration({ organization, division: '3A' });
       const enrollableStudents = _.times(5, () => domainBuilder.buildSchoolingRegistration({ organization }));
       const certificationCandidates = [ domainBuilder.buildCertificationCandidate({ sessionId, schoolingRegistrationId: enrolledStudent.id }) ];
-      schoolingRegistrationRepository.findByOrganizationIdOrderByDivision
+      schoolingRegistrationRepository.findByOrganizationIdAndUpdatedAtOrderByDivision
         .withArgs({ page: { number: 1, size: 10 }, filter: { divisions: ['3A'] }, organizationId: organization.id })
         .resolves({
           data: [ enrolledStudent, ...enrollableStudents ],
@@ -95,7 +95,7 @@ describe('Unit | UseCase | find-students-for-enrollement', () => {
 
       it('should return empty array', async () => {
         // given
-        schoolingRegistrationRepository.findByOrganizationIdOrderByDivision
+        schoolingRegistrationRepository.findByOrganizationIdAndUpdatedAtOrderByDivision
           .withArgs({ page: { number: 1, size: 10 }, filter: {}, organizationId: organization.id }).resolves({
             data: [],
             pagination: { page: 1, pageSize: 10, rowCount: 0, pageCount: 0 },

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -1,5 +1,5 @@
 .add-student {
-margin-bottom: 68px;
+  margin-bottom: 68px;
   &__return-to span {
     color: $blue-zodia;
   }
@@ -9,5 +9,14 @@ margin-bottom: 68px;
     font-family: $open-sans;
     font-size: 2.25rem;
     font-weight: 300;
+  }
+
+  &__info-message {
+    align-items: center;
+    display: flex;
+
+    span {
+      margin-left: 6px;
+    }
   }
 }

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -7,6 +7,15 @@
 
   <h1 class="add-student__title">Ajouter des candidats</h1>
 
+  <PixMessage @type='info' @withIcon={{true}} class="add-student__info-message">
+    <span>
+      Si certain(e)s élèves n’apparaissent pas dans cette liste, 
+      merci de ré-importer le fichier SIECLE dans Pix Orga.<br>
+      Si malgré tout des élèves ne sont pas visibles, merci de contacter 
+      <a href="https://support.pix.fr" target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
+    </span>
+  </PixMessage>
+
   <AddStudentList
     @studentList={{@model.students}}
     @session={{@model.session}}
@@ -14,5 +23,5 @@
     @certificationCenterDivisions={{@model.certificationCenterDivisions}}
     @returnToSessionCandidates={{this.returnToSessionCandidates}}
     @selectedDivisions={{@model.selectedDivisions}}
-    />
+  />
 </div>

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -19183,8 +19183,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#fe0716c996a705eeba6f7ba047668d708e490993",
-      "from": "git://github.com/1024pix/pix-ui.git#v1.2.1",
+      "version": "git://github.com/1024pix/pix-ui.git#887ca2307cfba3a946bafd79289af8e70c9e3ff2",
+      "from": "git://github.com/1024pix/pix-ui.git#v1.6.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -86,7 +86,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.2.1",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.6.0",
     "qunit-dom": "^1.4.0",
     "sass": "^1.26.3",
     "stylelint": "^13.7.2",


### PR DESCRIPTION
## :unicorn: Problème
Certains établissements avaient accès à Pix Orga l’année scolaire dernière pour faire leur import, et ont donc une liste d'élèves comprenant les élèves de l’année scolaire 2020-21 ET 2019-20. Ces derniers, qui ne sont plus présents dans l’établissement, viennent donc “polluer” la liste des élèves affichée dans Pix Certif, rendant plus compliqué l’ajout des élèves à une session en utilisant notamment le filtre sur la classe (obligation de décocher manuellement les élèves ayant quitté l'établissement).

Un épix côté équipe prescription prévoit de gérer correctement la désactivation des élèves d’une année scolaire à l’autre pour la rentrée sco prochaine, mais il y a besoin de contourner le problème en attendant.

## :robot: Solution
Dans Pix Certif > page “Ajouter des candidats” (accessible depuis l’onglet “Candidats” quand il n’y a aucun candidat inscrit, puis depuis la liste des candidats quand des candidats sont déjà inscrits), 
- n’afficher QUE les élèves ayant été mis à jour APRES le 15/08/2020.
- afficher un message l’information suivante : “Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier SIECLE dans Pix Orga. Si malgré tout des élèves ne sont pas visibles, merci de contacter support.pix.fr” => cliquer sur “support.pix.fr” ouvre un nouvel onglet avec la page https://support.pix.fr/

![Affichage du message dans Pix Certif](https://user-images.githubusercontent.com/5627688/106106593-0dad5380-6146-11eb-982a-04ab7803ea82.png)


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer l'API avec le flag FT_CERTIF_PRESCRIPTION_SCO
- Lancer Certif
- Se connecter avec le compte certifsco@example.net
- Cliquer une session
- Cliquer sur l'onglet **Candidats** puis **Ajouter des candidats**
- Noter le nom d'un des candidats
- Accéder à la base de données et modifier le champ `updatedAt` du candidat pour mettre une date antérieure au 15/08/2020 (Comment ?)
- Recharger la page *Ajouter des candidats* et constater la disparition du candidat
