### PR TITLE
[BUGFIX] Éviter de créer deux assessments lors d'un retenter (PIX-2048).

### DIFF
--- a/api/lib/domain/models/Assessment.js
+++ b/api/lib/domain/models/Assessment.js
@@ -66,6 +66,10 @@ class Assessment {
     return this.state === Assessment.states.COMPLETED;
   }
 
+  isStarted() {
+    return this.state === Assessment.states.STARTED;
+  }
+
   setCompleted() {
     this.state = Assessment.states.COMPLETED;
   }

--- a/api/lib/domain/usecases/improve-competence-evaluation.js
+++ b/api/lib/domain/usecases/improve-competence-evaluation.js
@@ -10,11 +10,16 @@ module.exports = async function improveCompetenceEvaluation({
   competenceId,
   domainTransaction,
 }) {
-  const competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({
+  let competenceEvaluation = await competenceEvaluationRepository.getByCompetenceIdAndUserId({
     competenceId,
     userId,
     domainTransaction,
   });
+
+  if (competenceEvaluation.assessment.isStarted() && competenceEvaluation.assessment.isImproving) {
+    return { ...competenceEvaluation, assessmentId: competenceEvaluation.assessmentId };
+  }
+
   const competenceLevel = await getCompetenceLevel({ userId, competenceId });
 
   if (competenceLevel === MAX_REACHABLE_LEVEL) {
@@ -22,9 +27,10 @@ module.exports = async function improveCompetenceEvaluation({
   }
 
   const assessment = Assessment.createImprovingForCompetenceEvaluation({ userId, competenceId });
+
   const { id: assessmentId } = await assessmentRepository.save({ assessment, domainTransaction });
 
-  await competenceEvaluationRepository.updateAssessmentId({
+  competenceEvaluation = await competenceEvaluationRepository.updateAssessmentId({
     currentAssessmentId: competenceEvaluation.assessmentId,
     newAssessmentId: assessmentId,
     domainTransaction,


### PR DESCRIPTION
## :unicorn: Problème
- Lorsqu'on retente une compétence, on ne vérifie pas s'il y a un retenter en cours.
- Exemple fonctionnel : j'ai terminé ma compétence, je peux la retenter. J'ouvre deux onglets avec le bouton retenter. Je lance un premier retenter, ce qui me crée un Assessment. Je répond à une question. Je vais sur l'autre onglet pour cliquer une nouvelle fois sur retenter, ce qui me crée un nouvelle Assessment. Le premier devient obsolète.

## :robot: Solution
- Lorsqu'on retente, si la compétence évaluation a déjà un assessment en cours en improving, c'est celui-ci qu'on renvoit.

## :rainbow: Remarques
- Je ne suis pas sûr que ce bugfix règle les soucis de "No row updated" remonté par Sentry
- Les `competence-evaluation` passent de `started` à `reset` lorsqu'on remet à zéro, mais elle ne passe pas en `completed` : il y a peut être des changements à faire sur notre gestion de cette partie de la BDD

## :100: Pour tester
- Exemple fonctionnel : j'ai terminé ma compétence, je peux la retenter. J'ouvre deux onglets avec le bouton retenter. Je lance un premier retenter, ce qui me crée un Assessment. Je répond à une question. Je vais sur l'autre onglet pour cliquer une nouvelle fois sur retenter, je me retrouve sur le même assessment qu'avant.