### PR TITLE
[FEATURE] Afficher la page de detail d'un centre de certification dans Pix Admin (PIX-500).

### DIFF
--- a/admin/app/adapters/organization.js
+++ b/admin/app/adapters/organization.js
@@ -2,11 +2,12 @@ import ApplicationAdapter from './application';
 import queryString from 'query-string';
 
 export default class OrganizationAdapter extends ApplicationAdapter {
-  urlForQuery (query, modelName) {
+
+  urlForQuery(query) {
     if (query.targetProfileId) {
       const { targetProfileId } = query;
       delete query.targetProfileId;
-      return  `${this.host}/api/admin/target-profiles/${targetProfileId}/organizations`;
+      return `${this.host}/api/admin/target-profiles/${targetProfileId}/organizations`;
     }
     return super.urlForQuery(...arguments);
   }

--- a/admin/app/adapters/target-profile.js
+++ b/admin/app/adapters/target-profile.js
@@ -1,5 +1,4 @@
 import ApplicationAdapter from './application';
-import queryString from 'query-string';
 
 export default class TargetProfileAdapter extends ApplicationAdapter {
   namespace = 'api/admin';

--- a/admin/app/components/certification-centers/list-items.hbs
+++ b/admin/app/components/certification-centers/list-items.hbs
@@ -42,7 +42,12 @@
     {{#if @certificationCenters}}
       <tbody>
       {{#each @certificationCenters as |certificationCenter|}}
-        <tr>
+        <tr
+          aria-label="Centre de certification"
+          role="button"
+          class="tr--clickable"
+          {{on "click" (fn @goToCertificationCenterPage certificationCenter.id)}}
+        >
           <td>{{certificationCenter.id}}</td>
           <td>{{certificationCenter.name}}</td>
           <td>{{certificationCenter.type}}</td>

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import config from 'pix-admin/config/environment';
 
@@ -26,4 +27,9 @@ export default class ListController extends Controller {
     this.pendingFilters = {};
     this.pageNumber = DEFAULT_PAGE_NUMBER;
   }).restartable()) triggerFiltering;
+
+  @action
+  goToCertificationCenterPage(certificationCenterId) {
+    this.transitionToRoute('authenticated.certification-centers.get', certificationCenterId);
+  }
 }

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -40,8 +40,9 @@ Router.map(function() {
     });
 
     this.route('certification-centers', function() {
-      this.route('new');
+      this.route('get', { path: '/:certification_center_id' });
       this.route('list');
+      this.route('new');
     });
 
     this.route('sessions', function() {

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -1,0 +1,9 @@
+import Route from '@ember/routing/route';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+
+export default class CertificationCentersGetRoute extends Route.extend(AuthenticatedRouteMixin) {
+
+  model(params) {
+    return this.store.findRecord('certification-center', params.certification_center_id);
+  }
+}

--- a/admin/app/routes/authenticated/target-profiles/target-profile/badges.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/badges.js
@@ -1,7 +1,8 @@
 import Route from '@ember/routing/route';
 
 export default class TargetProfileBadgesRoute extends Route {
-  async model(params) {
+
+  async model() {
     const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
     return await targetProfile.hasMany('badges').reload();
   }

--- a/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/organizations.js
@@ -13,7 +13,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
 
   async model(params) {
     const targetProfile = this.modelFor('authenticated.target-profiles.target-profile');
-    const queryParams  = {
+    const queryParams = {
       targetProfileId: targetProfile.id,
       page: {
         size: params.pageSize,
@@ -29,7 +29,7 @@ export default class TargetProfileOrganizationsRoute extends Route {
     const organizations = await this.store.query('organization', queryParams);
     return {
       organizations,
-      targetProfile
+      targetProfile,
     };
   }
 

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -21,13 +21,14 @@
 /* pages */
 @import 'login';
 @import 'authenticated';
-@import 'authenticated/organizations/get';
 @import 'authenticated/certifications/index';
-@import 'authenticated/certifications/certification/informations';
 @import 'authenticated/certifications/certification/details';
+@import 'authenticated/certifications/certification/informations';
+@import 'authenticated/certification-center/index';
+@import 'authenticated/organizations/get';
 @import 'authenticated/sessions/list';
-@import 'authenticated/sessions/session/informations';
 @import 'authenticated/sessions/session/certifications';
+@import 'authenticated/sessions/session/informations';
 @import 'authenticated/tools';
 
 /* components */

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -1,0 +1,8 @@
+.certification-center__data {
+
+  .certification-center__name {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-bottom: 20px;
+  }
+}

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -1,0 +1,19 @@
+<header class="page-header">
+  <div class="page-title">
+    <LinkTo @route="authenticated.certification-centers.list"><span id="link-to-certification-centers-page">Tous les centres de certification</span></LinkTo>
+    <span class="wire">&nbsp;>&nbsp;</span>
+    {{@model.name}}
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section mb_10">
+    <div class="certification-center__data">
+      <h1 class="certification-center__name">{{@model.name}}</h1>
+      <p>
+        Type : <span>{{@model.type}}</span><br>
+        Identifiant externe : <span>{{@model.externalId}}</span><br>
+      </p>
+    </div>
+  </section>
+</main>

--- a/admin/app/templates/authenticated/certification-centers/list.hbs
+++ b/admin/app/templates/authenticated/certification-centers/list.hbs
@@ -15,6 +15,7 @@
       @name={{this.name}}
       @type={{this.type}}
       @externalId={{this.externalId}}
-      @triggerFiltering={{this.triggerFiltering}} />
+      @triggerFiltering={{this.triggerFiltering}}
+      @goToCertificationCenterPage={{this.goToCertificationCenterPage}} />
   </section>
 </main>

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -12,7 +12,6 @@ function attachTargetProfiles(schema, request) {
 }
 
 function attachTargetProfileToOrganizations(schema, request) {
-  const targetProfileId = request.params.id;
   const params = JSON.parse(request.requestBody);
   const organizationsToAttach = params['organization-ids'];
   organizationsToAttach.forEach((organizationId) =>

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { createAuthenticateSession } from '../../../helpers/test-init';
+
+module('Acceptance | authenticated/certification-centers/get', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let currentUser;
+
+  hooks.beforeEach(async function() {
+    currentUser = server.create('user');
+    await createAuthenticateSession({ userId: currentUser.id });
+  });
+
+  test('should access Certification center page by URL /certification-centers/:id', async function(assert) {
+    // given
+    server.create('certification-center');
+
+    // when
+    await visit('/certification-centers/1');
+
+    // then
+    assert.equal(currentURL(), '/certification-centers/1');
+  });
+
+  test('should display Certification center detail', async function(assert) {
+    // given
+    const certificationCenter = {
+      name: 'Center 1',
+      externalId: 'ABCDEF',
+      type: 'SCO',
+    };
+    server.create('certification-center', 1, {
+      ...certificationCenter,
+    });
+
+    // when
+    await visit('/certification-centers/1');
+
+    // then
+    assert.contains(certificationCenter.name);
+    assert.contains(certificationCenter.externalId);
+    assert.contains(certificationCenter.type);
+  });
+
+});

--- a/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
@@ -19,12 +19,10 @@ module('Acceptance | authenticated/targets-profile/target-profile/organizations'
   });
 
   module('with multiple organizations', function(hooks) {
-    let myOrganization;
-    let myOtherOrganization;
 
     hooks.beforeEach(async function() {
-      myOrganization = this.server.create('organization', { name: 'My organization' });
-      myOtherOrganization = this.server.create('organization', { name: 'My other organization' });
+      this.server.create('organization', { name: 'My organization' });
+      this.server.create('organization', { name: 'My other organization' });
     });
 
     test('should list organizations', async function(assert) {

--- a/admin/tests/acceptance/certification-centers-list-test.js
+++ b/admin/tests/acceptance/certification-centers-list-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { currentURL, visit } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -57,6 +57,18 @@ module('Acceptance | Certification-centers List', function(hooks) {
 
       // then
       assert.dom('#type').hasValue('sup');
+    });
+
+    test('should go to certification center page when line is clicked', async function(assert) {
+      // given
+      server.createList('certification-center', 1);
+      await visit('/certification-centers/list');
+
+      // when
+      await click('tr[aria-label="Centre de certification"]:first-child');
+
+      // then
+      assert.equal(currentURL(), '/certification-centers/1');
     });
   });
 });

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.js
@@ -1,35 +1,46 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
 
 module('Integration | Component | routes/authenticated/certification-centers | list-items', function(hooks) {
 
   setupRenderingTest(hooks);
 
-  test('it should display certification-centers list', async function(assert) {
-    // given
-    const certificationCenters = [
-      { id: 1, name: 'John', type: 'SCO', externalId: '123' },
-      { id: 2, name: 'Jane', type: 'SUP', externalId: '456' },
-      { id: 3, name: 'Lola', type: 'PRO', externalId: '789' },
-    ];
-    certificationCenters.meta = {
-      rowCount: 3,
-    };
-    const triggerFiltering = function() {};
+  const certificationCenters = [
+    { id: 1, name: 'John', type: 'SCO', externalId: '123' },
+    { id: 2, name: 'Jane', type: 'SUP', externalId: '456' },
+    { id: 3, name: 'Lola', type: 'PRO', externalId: '789' },
+  ];
+  certificationCenters.meta = {
+    rowCount: 3,
+  };
+  const triggerFiltering = function() {};
 
+  hooks.beforeEach(async function() {
     this.set('certificationCenters', certificationCenters);
     this.set('triggerFiltering', triggerFiltering);
+    this.goToCertificationCenterPage = sinon.spy();
 
-    // when
-    await render(hbs`{{certification-centers/list-items certificationCenters=certificationCenters triggerFiltering=triggerFiltering}}`);
+    await render(hbs `<CertificationCenters::ListItems @certificationCenters={{this.certificationCenters}} @triggerFiltering={{this.triggerFiltering}} @goToCertificationCenterPage={{this.goToCertificationCenterPage}} />`);
+  });
 
+  test('it should display certification-centers list', async function(assert) {
     // then
     assert.dom('table tbody tr:first-child td:first-child').hasText('1');
     assert.dom('table tbody tr:first-child td:nth-child(2)').hasText('John');
     assert.dom('table tbody tr:first-child td:nth-child(3)').hasText('SCO');
     assert.dom('table tbody tr:first-child td:nth-child(4)').hasText('123');
     assert.dom('table tbody tr').exists({ count: 3 });
+    assert.dom('tr[aria-label="Centre de certification"]').hasAttribute('role', 'button');
+  });
+
+  test('should call goToCertificationCenterPage function when a line is clicked', async function(assert) {
+    // when
+    await click('tr[aria-label="Centre de certification"]:first-child');
+
+    // then
+    assert.ok(this.goToCertificationCenterPage.calledWith(1));
   });
 });

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, fillIn, triggerEvent, render } from '@ember/test-helpers';
+import { click, triggerEvent, render } from '@ember/test-helpers';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -44,8 +44,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
                          @targetProfile={{this.targetProfile}}
                          @isFileInvalid={{this.isFileInvalid}}
-                         
-                         @onLoadFile={{this.onLoadFile}} 
+
+                         @onLoadFile={{this.onLoadFile}}
                          @onSubmit={{this.onSubmit}}
                          @onCancel={{this.onCancel}}/>`);
 
@@ -67,8 +67,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
                          @targetProfile={{this.targetProfile}}
                          @isFileInvalid={{this.isFileInvalid}}
-                         
-                         @onLoadFile={{this.onLoadFile}} 
+
+                         @onLoadFile={{this.onLoadFile}}
                          @onSubmit={{this.onSubmit}}
                          @onCancel={{this.onCancel}}/>`);
 
@@ -81,8 +81,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
                          @targetProfile={{this.targetProfile}}
                          @isFileInvalid={{this.isFileInvalid}}
-                         
-                         @onLoadFile={{this.onLoadFile}} 
+
+                         @onLoadFile={{this.onLoadFile}}
                          @onSubmit={{this.onSubmit}}
                          @onCancel={{this.onCancel}}/>`);
 
@@ -100,8 +100,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
                          @targetProfile={{this.targetProfile}}
                          @isFileInvalid={{this.isFileInvalid}}
-                         
-                         @onLoadFile={{this.onLoadFile}} 
+
+                         @onLoadFile={{this.onLoadFile}}
                          @onSubmit={{this.onSubmit}}
                          @onCancel={{this.onCancel}}/>`);
 
@@ -116,8 +116,8 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
                          @targetProfile={{this.targetProfile}}
                          @isFileInvalid={{this.isFileInvalid}}
-                         
-                         @onLoadFile={{this.onLoadFile}} 
+
+                         @onLoadFile={{this.onLoadFile}}
                          @onSubmit={{this.onSubmit}}
                          @onCancel={{this.onCancel}}/>`);
 

--- a/admin/tests/unit/routes/authenticated/certification-centers/get-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | authenticated/certification-centers/get', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    const route = this.owner.lookup('route:authenticated/certification-centers/get');
+    assert.ok(route);
+  });
+});

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -44,11 +44,16 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/certification-centers/{id}',
       config: {
-        handler: certificationCenterController.getById,
         pre: [{
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+        validate: {
+          params: Joi.object({
+            id: idSpecification,
+          }),
+        },
+        handler: certificationCenterController.getById,
         notes: [
           '- **Cette route est restreinte aux utilisateurs Pix Master authentifiés**\n' +
           '- Récupération d\'un centre de certification\n' +


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, à partir de la page listant les Centres de certifications, il n'est pas possible de voir le détail d'un centre en particulier.

## :robot: Solution
* Créer une nouvelle page affichant les noms, type et identifiant externe d'un centre de certification
* A partir de la page des Centres de certification, permettre de basculer vers la nouvelle page crée, en cliquant sur une ligne (du tableau des Centres)
<img src= "https://user-images.githubusercontent.com/88607/106017325-a1d4d780-60c0-11eb-870b-f9fb0d30dbfc.png" width="500" />


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Dans Pix Admin, aller sur la page `/certification-centers/list`
* Sélectionner un Centre de certification, en cliquant sur une ligne du tableau affiché
* Vérifier que la page contient les nom, type et Identifiant externe du centre de certification choisi
