### PR TITLE
[BUGFIX] Corriger une faute la bannière SCO de Pix Certif (PIX-2030)

### DIFF
--- a/certif/app/templates/authenticated.hbs
+++ b/certif/app/templates/authenticated.hbs
@@ -38,7 +38,7 @@
         <span class="sco-temporary-banner__informations-text">
           <FaIcon @icon="exclamation-triangle" class="sco-temporary-banner-informations-text__triangle-icon" />
           <p>
-            Il est important de vérifier que les élèves sont certifiables avant de les inscrire en session de certification. <br>
+            Il est important de vérifier que les élèves soient certifiables avant de les inscrire en session de certification. <br>
             Vous pouvez faire une <a href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea " target="_blank" rel="noopener noreferrer">campagne de collecte de profil <FaIcon @icon="external-link-alt"/></a> pour vous en assurer.
           </p>
         </span>


### PR DESCRIPTION
## :unicorn: Problème
Une petite faute de conjugaison s’est malencontreusement glissée dans notre bandeau d’informations affiché dans Pix Certif pour les utilisateurs SCO isScoManagingStudents.

## :robot: Solution
Corriger cette faute : “Il est important de vérifier que les élèves soient certifiables avant de les inscrire en session de certification.”

## :rainbow: Remarques
RAS

## :100: Pour tester
- Lancer l'API et Pix Certif
- Se connecter avec le compte sco sco@example.net
- Se rendre sur la page Sessions
- Constater la correction de la faute dans le bandeau.
