### PR TITLE
[BUGFIX] Récupérer correctement l'erreur provenant de l'API (Sentry)

### DIFF
--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -14,8 +14,9 @@ export default class ErrorRoute extends Route {
     super.setupController(...arguments);
     controller.errorMessage = error;
 
-    if (error.errors && error.errors[0]) {
-      const apiError = error.errors[0];
+    const apiError = get(error, 'errors[0]');
+
+    if (apiError) {
       controller.errorDetail = apiError.detail;
       controller.errorStatus = apiError.status;
       controller.errorTitle = apiError.title;


### PR DESCRIPTION
## :unicorn: Problème
Une erreur Sentry remonte régulièrement. https://sentry.io/organizations/pix/issues/2081047934/?project=5476250
On tente d'accéder directement à `errors `sans vérifier que son parent existe.
## :robot: Solution
Vérifier que le parent de `errors` existe avant de l'utiliser.

## :rainbow: Remarques

## :100: Pour tester
