### PR TITLE
[TECH] Valider les identifiants indépendamment de la route.

### DIFF
--- a/api/lib/domain/validators/id-validator.js
+++ b/api/lib/domain/validators/id-validator.js
@@ -1,0 +1,16 @@
+const { idSpecification } = require('./id-specification');
+
+const validateIds = function(request) {
+
+  const params = Object.getOwnPropertyNames(request.params);
+  const idParams = params.filter((param) => { param === 'id' || param.includes('Id'); });
+  idParams.map((id) => {
+    const { error } = idSpecification.validate(request.params[id]);
+    if (error) {
+      throw new Error(`invalid ID: ${id} - ${request.params[id]}`);
+    }
+  });
+
+};
+
+module.exports = { validateIds };

--- a/api/server.js
+++ b/api/server.js
@@ -12,6 +12,7 @@ const swaggers = require('./lib/swaggers');
 const config = require('./lib/config');
 const security = require('./lib/infrastructure/security');
 const { handleFailAction } = require('./lib/validate');
+const { validateIds } = require('./lib/domain/validators/id-validator');
 
 const createServer = async () => {
 
@@ -35,6 +36,13 @@ const createServer = async () => {
       stripTrailingSlash: true,
     },
   });
+
+  server.ext('onPostAuth',
+    (request, h) =>{
+      validateIds(request);
+      return h.continue;
+    },
+  );
 
   server.ext('onPreResponse', preResponseUtils.handleDomainAndHttpErrors);
 


### PR DESCRIPTION
## :unicorn: Problème
Tous les identifiants possèdent le même type, mais il doit systématiquement être mentioné et testé sur chaque route.
C'est relativement long à implémenter et à tester, voir [cette PR](https://github.com/1024pix/pix/pull/2456)

## :robot: Solution
Utiliser [un hook HAPI](https://livebook.manning.com/book/hapi-js-in-action/chapter-5/v-9/31) pour valider les ID avant même de contrôler le format spécifique de la route.
Comme les paramètres doivent être parsés par HAPI, et les contrôles de sécurité effectus, on peut choisir `onPostAuth`

## :rainbow: Remarques
Cette solution est fragile, elle ne valide que les ID
- en paramètre (pas dans body ou en query-string)
- sur une base textuelle (nom = `id` ou contient `Id`)
- en BDD, et échoue sur les identifiants LCMS qui sont chaînes de caractère (UUID?), ex `competenceId`

Il y a des effets de bord possibles.
De plus, le valideur vient du domaine, mais ici nous ne sommes pas dans le domaine (use-case ou entity) ?
Testons-nous [au bon endroit](https://ikenox.info/blog/where-to-put-validation-in-clean-architecture/) ?

## :100: Pour tester
Envoyer des valeurs incorrectes
- type de base incorrect ` http://localhost:4202/api/admin/users/foo`
- hors du champ: ` http://localhost:4202/api/admin/users/1000000000000000000000000000000`