### PR TITLE
[FEATURE] Afficher la première lettre du prénom et nom de l'utilisateur en majuscule sur le profil dans Pix Orga/App/Certif (PIX-329).

### DIFF
--- a/certif/app/styles/components/user-logged-menu.scss
+++ b/certif/app/styles/components/user-logged-menu.scss
@@ -23,6 +23,7 @@
     font-size: 0.875rem;
     font-weight: bold;
     height: 19px;
+    text-transform: capitalize;
   }
 
   &__certification-center {

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -92,6 +92,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-transform: capitalize;
 }
 
 .logged-user-menu-details__identifier {

--- a/orga/app/styles/components/user-logged-menu.scss
+++ b/orga/app/styles/components/user-logged-menu.scss
@@ -23,6 +23,7 @@
     font-size: 0.875rem;
     font-weight: bold;
     height: 19px;
+    text-transform: capitalize;
   }
 
   &__organization {


### PR DESCRIPTION
## :unicorn: Problème
L'affichage actuel du prénom et nom de l'utilisateur sur Pix App ( dans le menu déroulant sur la page profil ), Pix Orga et Pix Certif ne comporte pas de majuscule sur la première lettre du nom et du prénom

Exemple Pix Orga:
<img width="327" alt="Capture d’écran 2021-01-27 à 11 26 17" src="https://user-images.githubusercontent.com/58915422/105978153-8226ba80-6092-11eb-98c7-5e62feffc87d.png">

## :robot: Solution
Imposer la majuscule coté CSS avec un `text-transform: capitalize`

## :rainbow: Remarques

## :100: Pour tester

- Modifier un seed et passer son nom et prénom en minuscule
- Aller sur Pix App > Connexion > Cliquer sur le menu déroulant et vérifier qu'ils passent en majuscule sur la première lettre
- Pareil pour Pix Orga et Pix Certif
