### PR TITLE
[TECH] Création d'un script de calcul du résultats pour toutes les participations de campagne d'évaluation (PIX-1993).

### DIFF
--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -5,7 +5,7 @@ const { knex } = require('../../db/knex-database-connection');
 const competenceRepository = require('../../lib/infrastructure/repositories/competence-repository');
 const skillRepository = require('../../lib/infrastructure/repositories/skill-repository');
 const targetProfileRepository = require('../../lib/infrastructure/repositories/target-profile-repository');
-
+const computeValidatedSkillsCount = require('../prod/compute-validated-skills-count-for-assessment-campaign-participation');
 const firstKECreatedAt = new Date('2020-05-01');
 const secondKECreatedAt = new Date('2020-05-02');
 const participationSharedAt = new Date('2020-05-03');
@@ -442,6 +442,8 @@ async function _do({ organizationId, targetProfileId, participantCount, profileT
     await _createParticipants({ count: participantCount, targetProfile, organizationId, campaignId, trx });
   }
   await trx.commit();
+  console.log('calcul des validatedSkillsCount ...');
+  await computeValidatedSkillsCount(10);
   console.log(`Campagne: ${campaignId}\nOrganisation: ${organizationId}\nNombre de participants: ${participantCount}\nProfil Cible: ${targetProfile.id}`);
 }
 

--- a/api/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation.js
+++ b/api/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation.js
@@ -1,0 +1,103 @@
+// Usage: node compute-validated-skills-count-for-assessment-campaign-participation
+/* eslint-disable no-restricted-syntax */
+const targetProfileWithLearningContentRepository = require('../../lib/infrastructure/repositories/target-profile-with-learning-content-repository');
+const knowlegeElementRepository = require('../../lib/infrastructure/repositories/knowledge-element-repository');
+const { knex } = require('../../db/knex-database-connection');
+const _ = require('lodash');
+const bluebird = require('bluebird');
+let count;
+let total;
+
+async function computeValidatedSkillsCount(concurrency) {
+  const campaigns = await knex('campaigns')
+    .distinct('campaigns.id')
+    .select('campaigns.id')
+    .where({ type: 'ASSESSMENT' })
+    .join('campaign-participations', 'campaign-participations.campaignId', 'campaigns.id')
+    .where({
+      type: 'ASSESSMENT',
+      isShared: true,
+      validatedSkillsCount: null,
+    });
+  count = 0;
+  total = campaigns.length;
+  console.log(`Campagnes à traiter ${total}`);
+
+  await bluebird.map(campaigns, _updateCampaignParticipations, { concurrency });
+}
+
+async function _updateCampaignParticipations(campaign) {
+  const validatedSkillsByParticipationId = await _validatedSkillsCountByUser(campaign);
+
+  await knex.raw(`UPDATE "campaign-participations"
+  SET "validatedSkillsCount" = "participationSkillCounts"."validatedSkillsCount"
+  FROM (VALUES ${_toSQLValues(validatedSkillsByParticipationId)}) AS "participationSkillCounts"(id, "validatedSkillsCount")
+  WHERE "campaign-participations".id = "participationSkillCounts".id`);
+
+  count++;
+  console.log(`${count} / ${total}`);
+}
+
+async function _validatedSkillsCountByUser(campaign) {
+  const campaignParticipationInfos = await _getSharingDateByUserId(campaign);
+  const sharingDateByUserId = {};
+
+  campaignParticipationInfos.forEach(({ userId, sharedAt }) => sharingDateByUserId[userId] = sharedAt);
+
+  const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId: campaign.id });
+  const validatedKnowledgeElementByCompetencesByUser = await knowlegeElementRepository.findTargetedGroupedByCompetencesForUsers(sharingDateByUserId, targetProfile);
+
+  const validatedSkillsCountByUser = _.entries(validatedKnowledgeElementByCompetencesByUser).map(_countValidatedSkills);
+  return validatedSkillsCountByUser.map(([ userId, validatedSkillsCount ]) => {
+    const campaignParticipation = campaignParticipationInfos.find((campaignParticipation) => campaignParticipation.userId == userId);
+    return [campaignParticipation.id, validatedSkillsCount];
+  });
+
+}
+
+async function _getSharingDateByUserId(campaign) {
+
+  return knex('campaign-participations')
+    .select(['userId', 'sharedAt', 'id'])
+    .where({
+      campaignId: campaign.id,
+      validatedSkillsCount: null,
+      isShared: true,
+    });
+}
+
+function _countValidatedSkills([userId, validatedKnowledgeElementByCompetence]) {
+  const validatedSkillsCount = _.values(validatedKnowledgeElementByCompetence).flatMap((knowledgeElements) => knowledgeElements.filter(({ status }) => status === 'validated')).length;
+  return [userId, validatedSkillsCount];
+}
+
+function _toSQLValues(validatedSkillsByParticipationId) {
+  return validatedSkillsByParticipationId.map(([id, validatedSkillsCount]) => `(${id}, ${validatedSkillsCount})`).join(', ');
+}
+
+module.exports = computeValidatedSkillsCount;
+let exitCode;
+const SUCCESS = 0;
+const FAILURE = 1;
+const concurrency = parseInt(process.argv[2]);
+
+if (require.main === module) {
+  computeValidatedSkillsCount(concurrency)
+    .then(handleSuccess)
+    .catch(handleError)
+    .finally(exit);
+}
+
+function handleSuccess() {
+  exitCode = SUCCESS;
+}
+
+function handleError(err) {
+  console.error(err);
+  exitCode = FAILURE;
+}
+
+function exit() {
+  console.log('code', exitCode);
+  process.exit(exitCode);
+}

--- a/api/tests/integration/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation_test.js
+++ b/api/tests/integration/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation_test.js
@@ -1,0 +1,250 @@
+const { expect, mockLearningContent, databaseBuilder, domainBuilder, learningContentBuilder, knex, sinon } = require('../../../test-helper');
+const computeValidatedSkillsCount = require('../../../../scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation');
+const Campaign = require('../../../../lib/domain/models/Campaign');
+
+function setLearningContent(learningContent) {
+  const learningObjects = learningContentBuilder.buildLearningContent(learningContent);
+  mockLearningContent(learningObjects);
+}
+
+describe('computeValidatedSkillsCount', () => {
+  let competence1;
+  let skill1;
+  let skill2;
+  let competence2;
+  let skill3;
+  let skill4;
+  let skill5;
+
+  beforeEach(async () => {
+    skill1 = domainBuilder.buildSkill({ id: 'skill1Id' });
+    skill2 = domainBuilder.buildSkill({ id: 'skill2Id' });
+    skill3 = domainBuilder.buildSkill({ id: 'skill3Id' });
+    skill4 = domainBuilder.buildSkill({ id: 'skill4Id' });
+    skill5 = domainBuilder.buildSkill({ id: 'skill5Id' });
+    competence1 = domainBuilder.buildCompetence({ id: 'competence1Id', skillIds: [skill1.id, skill2.id] });
+    competence2 = domainBuilder.buildCompetence({ id: 'competence2Id', skillIds: [skill3.id, skill4.id] });
+    const learningContent = [{
+      id: 'areaId',
+      competences: [
+        {
+          id: competence1.id,
+          tubes: [{
+            id: 'tube1Id',
+            skills: [
+              { id: skill1.id, nom: '@web1' },
+              { id: skill2.id, nom: '@web2' },
+            ],
+          }],
+        },
+        {
+          id: competence2.id,
+          tubes: [{
+            id: 'tube2Id',
+            skills: [
+              { id: skill3.id, nom: '@file1' },
+              { id: skill4.id, nom: '@file2' },
+              { id: skill5.id, nom: '@file3' },
+            ],
+          }],
+        },
+      ],
+    }];
+    setLearningContent(learningContent);
+    sinon.stub(console, 'log');
+  });
+
+  afterEach(async () => {
+
+    await knex('knowledge-element-snapshots').delete();
+  });
+
+  context('when there are campaign participation on assessment campaign', () => {
+    context('when there is only one campaign participation', () => {
+      it('computes validated skills count for targeted skills', async () => {
+        const user = databaseBuilder.factory.buildUser();
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill1.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill2.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill3.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill4.id });
+        const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user.id,
+          validatedSkillsCount: null,
+          sharedAt: new Date('2020-01-02'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill1.id, status: 'validated' });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill2.id, status: 'invalidated' });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill3.id, status: 'reset' });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2021-01-01'), skillId: skill4.id, status: 'validated' });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill5.id, status: 'validated' });
+
+        await databaseBuilder.commit();
+
+        await computeValidatedSkillsCount(1);
+        const campaignParticipation = await knex('campaign-participations').first();
+
+        expect(campaignParticipation.validatedSkillsCount).to.equals(1);
+      });
+    });
+
+    context('when there are several campaign participation', () => {
+      it('computes validated skills count for each participation', async () => {
+        const user1 = databaseBuilder.factory.buildUser({ id: 1 });
+        const user2 = databaseBuilder.factory.buildUser({ id: 2 });
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill1.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill2.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill3.id });
+        const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user1.id,
+          validatedSkillsCount: null,
+          sharedAt: new Date('2021-01-02'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user2.id,
+          validatedSkillsCount: null,
+          sharedAt: new Date('2021-01-03'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user1.id, createdAt: new Date('2020-01-01'), skillId: skill1.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user2.id, createdAt: new Date('2020-01-01'), skillId: skill2.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user2.id, createdAt: new Date('2020-01-01'), skillId: skill3.id });
+
+        await databaseBuilder.commit();
+
+        await computeValidatedSkillsCount(1);
+        const campaignParticipations = await knex('campaign-participations').select(['userId', 'validatedSkillsCount']).orderBy('sharedAt');
+
+        expect(campaignParticipations).to.deep.equals([{ userId: user1.id, validatedSkillsCount: 1 }, { userId: user2.id, validatedSkillsCount: 2 }]);
+      });
+    });
+
+    context('when there are campaign participation for the several campaigns', () => {
+      it('computes validated skills count for each participation', async () => {
+        const user1 = databaseBuilder.factory.buildUser({ id: 1 });
+        const user2 = databaseBuilder.factory.buildUser({ id: 2 });
+        const targetProfile1 = databaseBuilder.factory.buildTargetProfile();
+        const targetProfile2 = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile1.id, skillId: skill1.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile1.id, skillId: skill2.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile2.id, skillId: skill3.id });
+        const campaign1 = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile1.id });
+        const campaign2 = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile2.id });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign1.id,
+          userId: user1.id,
+          validatedSkillsCount: null,
+          sharedAt: new Date('2021-01-02'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign2.id,
+          userId: user2.id,
+          validatedSkillsCount: null,
+          sharedAt: new Date('2021-01-03'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user1.id, createdAt: new Date('2020-01-01'), skillId: skill1.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user1.id, createdAt: new Date('2020-01-01'), skillId: skill2.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user2.id, createdAt: new Date('2020-01-01'), skillId: skill3.id });
+
+        await databaseBuilder.commit();
+
+        await computeValidatedSkillsCount(1);
+        const campaignParticipations = await knex('campaign-participations').select(['userId', 'validatedSkillsCount']).orderBy('sharedAt');
+
+        expect(campaignParticipations).to.deep.equals([{ userId: user1.id, validatedSkillsCount: 2 }, { userId: user2.id, validatedSkillsCount: 1 }]);
+      });
+    });
+
+    context('when there are campaign participation with already validated skill count computed', () => {
+      it('does not compute validated skills count', async () => {
+        const user = databaseBuilder.factory.buildUser({ id: 1 });
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill1.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill2.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill3.id });
+        const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user.id,
+          validatedSkillsCount: 1,
+          sharedAt: new Date('2021-01-02'),
+          isShared: true,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill1.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill2.id });
+
+        await databaseBuilder.commit();
+
+        await computeValidatedSkillsCount(1);
+        const campaignParticipation = await knex('campaign-participations').select(['userId', 'validatedSkillsCount']).first();
+
+        expect(campaignParticipation).to.deep.equals({ userId: user.id, validatedSkillsCount: 1 });
+      });
+    });
+
+    context('when there are campaign participation not shared', () => {
+      it('does not compute validated skills count', async () => {
+        const user = databaseBuilder.factory.buildUser({ id: 1 });
+        const targetProfile = databaseBuilder.factory.buildTargetProfile();
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill1.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill2.id });
+        databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill3.id });
+        const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.ASSESSMENT, targetProfileId: targetProfile.id });
+        databaseBuilder.factory.buildCampaignParticipation({
+          campaignId: campaign.id,
+          userId: user.id,
+          validatedSkillsCount: null,
+          sharedAt: null,
+          isShared: false,
+        });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill1.id });
+        databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill2.id });
+
+        await databaseBuilder.commit();
+
+        await computeValidatedSkillsCount(1);
+        const campaignParticipation = await knex('campaign-participations').select(['userId', 'validatedSkillsCount']).first();
+
+        expect(campaignParticipation).to.deep.equals({ userId: user.id, validatedSkillsCount: null });
+      });
+    });
+
+  });
+
+  context('when there are campaign participation on profiles collection campaigns', () => {
+    it('does not compute validated skills count', async () => {
+      const user = databaseBuilder.factory.buildUser({ id: 1 });
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill1.id });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill2.id });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId: targetProfile.id, skillId: skill3.id });
+      const campaign = databaseBuilder.factory.buildCampaign({ type: Campaign.types.PROFILES_COLLECTION, targetProfileId: targetProfile.id });
+      databaseBuilder.factory.buildCampaignParticipation({
+        campaignId: campaign.id,
+        userId: user.id,
+        validatedSkillsCount: null,
+        sharedAt: new Date('2021-01-02'),
+        isShared: true,
+      });
+      databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence1.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill1.id });
+      databaseBuilder.factory.buildKnowledgeElement({ competenceId: competence2.id, userId: user.id, createdAt: new Date('2020-01-01'), skillId: skill2.id });
+
+      await databaseBuilder.commit();
+
+      await computeValidatedSkillsCount(1);
+      const campaignParticipation = await knex('campaign-participations').select(['userId', 'validatedSkillsCount']).first();
+
+      expect(campaignParticipation).to.deep.equals({ userId: user.id, validatedSkillsCount: null });
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le calcul du nombre acquis validé au pour une campagne d'évaluation est long à faire pour plusieurs participant à la fois.


## :robot: Solution
Créer un script pour calculer le nombre de acquis validés pour participation partagée des campagnes d'évaluations

## :rainbow: Remarques
RAS

## :100: Pour tester

Tester sur la RA est plus simple

1. Se connecter à la BDD de la RA
2. Effacer les données dans la colonne "validatedSkillsCount" de la table "campaign-participations"
```sql
UPDATE "campaign-participations" SET "validatedSkillsCount" = null;
```  
3. Lancer le script "node scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation" sur la RA
4. Vérifier qu'en BDD toutes les campaign-participations  partagée pour des campagnes d'évaluation on bien valeur dans la colonne "validatedSkillsCount"
```sql
SELECT "campaigns"."type", "isShared", "validatedSkillsCount" FROM "campaign-participations" 
LEFT JOIN "campaigns" ON "campaignId" = "campaigns"."id";


```
