### PR TITLE
[FEATURE] Filtrer les participations aux campagnes d'évaluation par paliers (PIX-1676).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -144,6 +144,9 @@ module.exports = {
     if (filters.badges && !Array.isArray(filters.badges)) {
       filters.badges = [filters.badges];
     }
+    if (filters.stages && !Array.isArray(filters.stages)) {
+      filters.stages = [filters.stages];
+    }
     const currentUserId = requestResponseUtils.extractUserIdFromRequest(request);
     const campaignAssessmentParticipationSummariesPaginated = await usecases.findPaginatedCampaignAssessmentParticipationSummaries({ userId: currentUserId, campaignId, page, filters });
     return campaignAssessmentParticipationSummarySerializer.serializeForPaginatedList(campaignAssessmentParticipationSummariesPaginated);

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -199,6 +199,7 @@ exports.register = async function(server) {
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
             'filter[badges][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
+            'filter[stages][]': [Joi.number().integer(), Joi.array().items(Joi.number().integer())],
             'page[number]': Joi.number().integer().empty(''),
             'page[size]': Joi.number().integer().empty(''),
           }),

--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -11,6 +11,10 @@ class Stage {
     this.message = message;
     this.threshold = threshold;
   }
+
+  getMinSkillsCountToReachStage(totalSkills) {
+    return Math.ceil(totalSkills * (this.threshold / 100));
+  }
 }
 
 module.exports = Stage;

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -137,6 +137,24 @@ class TargetProfileWithLearningContent {
     const skillMaxDifficulty = _.maxBy(this.skills, 'difficulty');
     return skillMaxDifficulty ? skillMaxDifficulty.difficulty : null;
   }
+
+  getSkillsCountBoundariesFromStages(stageIds) {
+    if (!stageIds || stageIds.length === 0) return null;
+
+    const totalSkills = this.skills.length;
+
+    return stageIds.map((stageId) => {
+      const boundary = {};
+      const stageIndex = this.stages.findIndex((stage) => stage.id == stageId);
+      boundary.from = this.stages[stageIndex].getMinSkillsCountToReachStage(totalSkills);
+      if (stageIndex !== this.stages.length - 1) {
+        boundary.to = this.stages[stageIndex + 1].getMinSkillsCountToReachStage(totalSkills) - 1;
+      } else {
+        boundary.to = totalSkills;
+      }
+      return boundary;
+    });
+  }
 }
 
 module.exports = TargetProfileWithLearningContent;

--- a/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
@@ -8,9 +8,13 @@ module.exports = async function findPaginatedCampaignAssessmentParticipationSumm
   campaignRepository,
   campaignAssessmentParticipationSummaryRepository,
   badgeAcquisitionRepository,
+  targetProfileWithLearningContentRepository,
 }) {
 
   await _checkUserAccessToCampaign(campaignId, userId, campaignRepository);
+
+  const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
+  filters.validatedSkillBoundaries = targetProfile.getSkillsCountBoundariesFromStages(filters.stages);
 
   const paginatedParticipations = await campaignAssessmentParticipationSummaryRepository.findPaginatedByCampaignId({ page, campaignId, filters });
 

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-summary-repository.js
@@ -56,7 +56,8 @@ function _campaignParticipationByParticipantSortedByDate(qb, campaignId, filters
     .where('campaign-participations.campaignId', '=', campaignId)
     .modify(_filterMostRecentAssessments)
     .modify(_filterByDivisions, filters)
-    .modify(_filterByBadgeAcquisitionsIn, filters);
+    .modify(_filterByBadgeAcquisitionsIn, filters)
+    .modify(_filterBySkillBoundaries, filters);
 }
 
 async function _buildCampaignAssessmentParticipationSummaries(results, targetedSkillIds) {
@@ -140,6 +141,16 @@ function _filterByBadgeAcquisitionsOut(qb, filters) {
   if (filters.badges) {
     qb.whereRaw(':badgeIds <@ "badges_acquired"', { badgeIds: filters.badges });
   }
+}
+
+function _filterBySkillBoundaries(qb, filters) {
+  if (!filters.validatedSkillBoundaries) return;
+
+  qb.where((builder) => {
+    filters.validatedSkillBoundaries.forEach((boundary) => {
+      builder.orWhereBetween('campaign-participations.validatedSkillsCount', [boundary.from, boundary.to]);
+    });
+  });
 }
 
 module.exports = campaignAssessmentParticipationRepository;

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -700,16 +700,14 @@ describe('Acceptance | API | Campaign Controller', () => {
 
       databaseBuilder.factory.buildMembership({ userId, organizationId: organization.id });
 
+      const skill = { id: 'Skill1', name: '@Acquis1', challenges: [] };
       const learningContent = [{
         id: 'recArea1',
         competences: [{
           id: 'recCompetence1',
           tubes: [{
             id: 'recTube1',
-            skills: [{
-              id: 'skill1',
-              challenges: [],
-            }],
+            skills: [skill],
           }],
         }],
       }];
@@ -717,7 +715,7 @@ describe('Acceptance | API | Campaign Controller', () => {
       const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
       mockLearningContent(learningContentObjects);
 
-      campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId: organization.id }, [learningContent]);
+      campaign = databaseBuilder.factory.buildAssessmentCampaignForSkills({ organizationId: organization.id }, [skill]);
 
       const campaignParticipation = {
         participantExternalId: 'Die Hard',

--- a/api/tests/unit/application/campaign/index_test.js
+++ b/api/tests/unit/application/campaign/index_test.js
@@ -344,6 +344,22 @@ describe('Unit | Application | Router | campaign-router ', function() {
       expect(result.statusCode).to.equal(200);
     });
 
+    it('should return 200 with a string array of one element as stage filter', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]=114');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should return 200 with a string array of several elements as stage filter', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]=114&filter[stages][]=115');
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
     it('should return 400 with unexpected filters', async () => {
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[unexpected][]=5');
@@ -371,6 +387,22 @@ describe('Unit | Application | Router | campaign-router ', function() {
     it('should return 400 with a badge filter which is not a number', async () => {
       // when
       const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[badges][]="truc"');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return 400 with a stage filter which is not an array', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages]=114');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return 400 with a stage filter which is not a number', async () => {
+      // when
+      const result = await httpTestServer.request('GET', '/api/campaigns/1/assessment-participations?filter[stages][]="truc"');
 
       // then
       expect(result.statusCode).to.equal(400);

--- a/api/tests/unit/domain/models/Stage_test.js
+++ b/api/tests/unit/domain/models/Stage_test.js
@@ -1,0 +1,28 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+
+describe('Unit | Domain | Models | Stage', () => {
+
+  describe('getMinSkillsCountToReachStage', () => {
+    it('should returns the number of skills in order to reach the stage', () => {
+      // given
+      const stage = domainBuilder.buildStage({ threshold: 20 });
+
+      // when
+      const skillsToReach = stage.getMinSkillsCountToReachStage(50);
+
+      // then
+      expect(skillsToReach).to.be.equal(10);
+    });
+
+    it('should always return an integer', () => {
+      // given
+      const stage = domainBuilder.buildStage({ threshold: 33 });
+
+      // when
+      const skillsToReach = stage.getMinSkillsCountToReachStage(25);
+
+      // then
+      expect(skillsToReach).to.be.equal(9);
+    });
+  });
+});

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -661,4 +661,90 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
       expect(maxDifficulty).to.be.null;
     });
   });
+
+  describe('getSkillsCountBoundariesFromStages()', () => {
+
+    it('should return skill count boundary for the given stage id', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill();
+      const skill2 = domainBuilder.buildTargetedSkill();
+      const skill3 = domainBuilder.buildTargetedSkill();
+      const skill4 = domainBuilder.buildTargetedSkill();
+      const skill5 = domainBuilder.buildTargetedSkill();
+      const skill6 = domainBuilder.buildTargetedSkill();
+
+      const stage1 = domainBuilder.buildStage({ id: 'stage1', threshold: 0 });
+      const stage2 = domainBuilder.buildStage({ id: 'stage2', threshold: 40 });
+      const stage3 = domainBuilder.buildStage({ id: 'stage3', threshold: 80 });
+
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3, skill4, skill5, skill6],
+        stages: [stage1, stage2, stage3],
+      });
+
+      // when
+      const skillCountBoundaries = targetProfile.getSkillsCountBoundariesFromStages(['stage2']);
+
+      // then
+      expect(skillCountBoundaries).to.deep.equal([
+        { from: 3, to: 4 },
+      ]);
+    });
+
+    it('should return skill count boundaries for the given stage id list', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill();
+      const skill2 = domainBuilder.buildTargetedSkill();
+      const skill3 = domainBuilder.buildTargetedSkill();
+      const skill4 = domainBuilder.buildTargetedSkill();
+      const skill5 = domainBuilder.buildTargetedSkill();
+      const skill6 = domainBuilder.buildTargetedSkill();
+
+      const stage1 = domainBuilder.buildStage({ id: 'stage1', threshold: 0 });
+      const stage2 = domainBuilder.buildStage({ id: 'stage2', threshold: 40 });
+      const stage3 = domainBuilder.buildStage({ id: 'stage3', threshold: 80 });
+
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3, skill4, skill5, skill6],
+        stages: [stage1, stage2, stage3],
+      });
+
+      // when
+      const skillCountBoundaries = targetProfile.getSkillsCountBoundariesFromStages(['stage1', 'stage2']);
+
+      // then
+      expect(skillCountBoundaries).to.deep.equal([
+        { from: 0, to: 2 },
+        { from: 3, to: 4 },
+      ]);
+    });
+
+    it('should return total skills count in "to" if it’s the last stage', () => {
+      // given
+      const skill1 = domainBuilder.buildTargetedSkill();
+      const skill2 = domainBuilder.buildTargetedSkill();
+      const skill3 = domainBuilder.buildTargetedSkill();
+      const skill4 = domainBuilder.buildTargetedSkill();
+      const skill5 = domainBuilder.buildTargetedSkill();
+      const skill6 = domainBuilder.buildTargetedSkill();
+
+      const stage1 = domainBuilder.buildStage({ id: 'stage1', threshold: 0 });
+      const stage2 = domainBuilder.buildStage({ id: 'stage2', threshold: 40 });
+      const stage3 = domainBuilder.buildStage({ id: 'stage3', threshold: 80 });
+
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent({
+        skills: [skill1, skill2, skill3, skill4, skill5, skill6],
+        stages: [stage1, stage2, stage3],
+      });
+
+      // when
+      const skillCountBoundaries = targetProfile.getSkillsCountBoundariesFromStages(['stage3']);
+
+      // then
+      expect(skillCountBoundaries).to.deep.equal([
+        { from: 5, to: 6 },
+      ]);
+    });
+
+  });
 });

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -2,6 +2,7 @@
   @campaign={{@campaign}}
   @selectedDivisions={{@selectedDivisions}}
   @selectedBadges={{@selectedBadges}}
+  @selectedStages={{@selectedStages}}
   @triggerFiltering={{@triggerFiltering}}
 />
 

--- a/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
@@ -15,6 +15,17 @@
         {{option.label}}
       </PixMultiSelect>
     {{/if}}
+    {{#if this.displayStagesFilter }}
+      <PixMultiSelect
+        @id="stage"
+        @title="Paliers"
+        @onSelect={{this.onSelectStage}}
+        @selected={{@selectedStages}}
+        @options={{this.stageOptions}} as |stage|
+      >
+        <StageStars @result={{stage.threshold}} @stages={{@campaign.stages}} />
+      </PixMultiSelect>
+    {{/if}}
     {{#if this.displayBadgesFilter }}
       <PixMultiSelect
         @id="badge"

--- a/orga/app/components/routes/authenticated/campaign/participation-filters.js
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.js
@@ -6,12 +6,26 @@ export default class ParticipationFilters extends Component {
   @service currentUser;
 
   get displayFilters() {
-    return this.displayBadgesFilter || this.displayDivisionFilter;
+    return this.displayStagesFilter || this.displayBadgesFilter || this.displayDivisionFilter;
+  }
+
+  get displayStagesFilter() {
+    const { isTypeAssessment, hasStages } = this.args.campaign;
+    return isTypeAssessment && hasStages;
+  }
+
+  get stageOptions() {
+    return this.args.campaign.stages.map(({ id, threshold }) => ({ value: id, threshold }));
+  }
+
+  @action
+  onSelectStage(stages) {
+    this.args.triggerFiltering({ stages });
   }
 
   get displayBadgesFilter() {
-    const { badges, isTypeAssessment } = this.args.campaign;
-    return isTypeAssessment && Boolean(badges) && badges.length > 0;
+    const { isTypeAssessment, hasBadges } = this.args.campaign;
+    return isTypeAssessment && hasBadges;
   }
 
   get badgeOptions() {

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
@@ -3,12 +3,13 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
 export default class AssessmentsController extends Controller {
-  queryParams = ['pageNumber', 'pageSize', 'divisions', 'badges'];
+  queryParams = ['pageNumber', 'pageSize', 'divisions', 'badges', 'stages'];
 
   @tracked pageNumber = 1;
   @tracked pageSize = 10;
   @tracked divisions = [];
   @tracked badges = [];
+  @tracked stages = [];
 
   @action
   goToAssessmentPage(campaignId, participantId) {
@@ -20,5 +21,6 @@ export default class AssessmentsController extends Controller {
     this.pageNumber = null;
     this.divisions = filters.divisions || this.divisions;
     this.badges = filters.badges || this.badges;
+    this.stages = filters.stages || this.stages;
   }
 }

--- a/orga/app/routes/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessments.js
@@ -16,6 +16,9 @@ export default class AssessmentsRoute extends Route {
     badges: {
       refreshModel: true,
     },
+    stages: {
+      refreshModel: true,
+    },
   };
 
   @action
@@ -42,6 +45,7 @@ export default class AssessmentsRoute extends Route {
       filter: {
         divisions: params.divisions,
         badges: params.badges,
+        stages: params.stages,
       },
       campaignId: params.campaignId,
     });
@@ -53,6 +57,7 @@ export default class AssessmentsRoute extends Route {
       controller.pageSize = 10;
       controller.divisions = [];
       controller.badges = [];
+      controller.stages = [];
     }
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
@@ -1,8 +1,9 @@
 <Routes::Authenticated::Campaign::Assessment::List
-        @campaign={{@model.campaign}}
-        @participations={{@model.campaignAssessmentParticipationSummaries}}
-        @goToAssessmentPage={{this.goToAssessmentPage}}
-        @triggerFiltering={{this.triggerFiltering}}
-        @selectedDivisions={{this.divisions}}
-        @selectedBadges={{this.badges}}
+  @campaign={{@model.campaign}}
+  @participations={{@model.campaignAssessmentParticipationSummaries}}
+  @goToAssessmentPage={{this.goToAssessmentPage}}
+  @triggerFiltering={{this.triggerFiltering}}
+  @selectedDivisions={{this.divisions}}
+  @selectedBadges={{this.badges}}
+  @selectedStages={{this.stages}}
 />

--- a/orga/tests/integration/components/routes/authenticated/campaign/participation-filters-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/participation-filters-test.js
@@ -190,5 +190,81 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         assert.notContains('Thématiques');
       });
     });
+
+    module('when campaign has no stages', function() {
+      test('should not displays the stage filter', async function(assert) {
+        // given
+        const campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+          stages: [],
+        });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+
+        // then
+        assert.notContains('Paliers');
+      });
+    });
+
+    module('when the campaign has stage but is not assessment type', function() {
+      test('it should not displays the stage filter', async function(assert) {
+        // given
+        const stage = store.createRecord('stage', { id: 'stage1' });
+        const campaign = store.createRecord('campaign', {
+          type: 'PROFILES_COLLECTION',
+          stages: [stage],
+        });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} />`);
+
+        // then
+        assert.notContains('Paliers');
+      });
+    });
+
+    module('when campaign has stages and has type ASSESSMENT', function() {
+      test('it displays the stage filter', async function(assert) {
+        // given
+        const stage = store.createRecord('stage', { id: 'stage1', threshold: 40 });
+        const campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+          stages: [stage],
+        });
+
+        this.set('campaign', campaign);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}}/>`);
+
+        // then
+        assert.contains('Paliers');
+      });
+
+      test('it triggers the filter when a stage is selected', async function(assert) {
+        // given
+        const stage = store.createRecord('stage', { id: 'stage1', threshold: 40 });
+        const campaign = store.createRecord('campaign', {
+          type: 'ASSESSMENT',
+          stages: [stage],
+        });
+
+        const triggerFiltering = sinon.stub();
+        this.set('campaign', campaign);
+        this.set('triggerFiltering', triggerFiltering);
+
+        // when
+        await render(hbs`<Routes::Authenticated::Campaign::ParticipationFilters @campaign={{campaign}} @triggerFiltering={{triggerFiltering}} />`);
+        await click('[for="stage-stage1"]');
+
+        // then
+        assert.ok(triggerFiltering.calledWith({ stages: ['stage1'] }));
+      });
+    });
   });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
@@ -44,5 +44,23 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessments', funct
         assert.deepEqual(controller.divisions, ['division1']);
       });
     });
+
+    module('stage filter', function() {
+      test('update the stage filter', function(assert) {
+        // given
+        controller.triggerFiltering({ stages: ['stage1'] });
+        // then
+        assert.deepEqual(controller.stages, ['stage1']);
+      });
+
+      test('should keep other filters when is stage updated', function(assert) {
+        // when
+        controller.set('divisions', ['division1']);
+        // given
+        controller.triggerFiltering({ stages: ['stage1'] });
+        // then
+        assert.deepEqual(controller.divisions, ['division1']);
+      });
+    });
   });
 });

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessments-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessments-test.js
@@ -33,6 +33,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessments', function(h
         pageSize: 2,
         divisions: ['4eme'],
         badges: [],
+        stages: [],
         campaignId: 3,
       };
       const expectedSummaries = [{
@@ -50,6 +51,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessments', function(h
             filter: {
               divisions: params.divisions,
               badges: params.badges,
+              stages: params.stages,
             },
             campaignId: params.campaignId,
           })


### PR DESCRIPTION
## :unicorn: Problème

Pour les campagnes d'évaluation, il n'est pas possible de filtrer par palier.

## :robot: Solution

Pour les campagnes d'évaluation, ajouter la possibilité de filtrer par palier (si le profil cible de la campagne en a défini)
- On doit pouvoir visualiser la liste des paliers sous forme d'étoiles dans le filtre
- On doit pouvoir sélectionner plusieurs paliers.

## :rainbow: Remarques

Voici le principe "général" du filtrage par palier en considérant un profil cible avec 10 acquis et les 3 paliers suivants:
- **stage1** atteint dès 0%
- **stage2** atteint dès 50%
- **stage3** atteint dès 90%

1. Si l'utilisateur sélectionne 2 paliers dans le filtres, ils sont reçus au niveau du backend par le controleur sous la forme:
```js
{ stages: ['stage1', 'stage2'] } // id des paliers sélectionnés dans le filtre
```

2. Afin de déterminer les participations à retourner, il faut convertir le seuil de chaque palier sélectionné en nombre d'acquis à avoir pour atteindre le palier. Par exemple:
```js
[
  { from: 0, to: 5 }, // il faut entre 0 et 5 acquis validés pour atteindre le palier 'stage1'
  { from: 5, to: 9 }, // il faut entre 5 et 9 acquis validés pour atteindre le palier 'stage2'
]
```

3. Requêter les campagnes participations en prenant en compte ces bornes:
```sql
SELECT ... FROM campagne-participations
WHERE
   ...
  AND
  (       validatedSkillsCount BETWEEN 0 AND 4
    OR validatedSkillsCount BETWEEN 5 AND 8)
```

## :100: Pour tester

1. Se connecter en sco
2. Aller sur la campagne https://orga-pr2463.review.pix.fr/campagnes/10000000
3. Jouer avec les filtres