### PR TITLE
[TECH] Valider les identifiants dans l'API.

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -1,4 +1,6 @@
+const Joi = require('joi');
 const answerController = require('./answer-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -20,6 +22,11 @@ exports.register = async function(server) {
       path: '/api/answers/{id}',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.answerId,
+          }),
+        },
         handler: answerController.get,
         tags: ['api', 'answers'],
         notes: [
@@ -33,6 +40,11 @@ exports.register = async function(server) {
       path: '/api/answers/{id}',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.answerId,
+          }),
+        },
         handler: answerController.update,
         tags: ['api', 'answers'],
         notes: [
@@ -59,6 +71,11 @@ exports.register = async function(server) {
       path: '/api/answers/{id}/correction',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.answerId,
+          }),
+        },
         handler: answerController.getCorrection,
         tags: ['api', 'answers'],
         notes: [

--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
+const { NotFoundError } = require('../../domain/errors');
 
 exports.register = async function(server) {
   server.route([
@@ -75,6 +76,9 @@ exports.register = async function(server) {
           params: Joi.object({
             id: identifiersType.answerId,
           }),
+          failAction: (request) => {
+            throw new NotFoundError(`Not found correction for answer of ID ${request.params.id}`);
+          },
         },
         handler: answerController.getCorrection,
         tags: ['api', 'answers'],

--- a/api/lib/application/assessments/index.js
+++ b/api/lib/application/assessments/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const assessmentController = require('./assessment-controller');
 const assessmentAuthorization = require('../preHandlers/assessment-authorization');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -28,6 +29,11 @@ exports.register = async function(server) {
       path: '/api/assessments/{id}/next',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.assessmentId,
+          }),
+        },
         handler: assessmentController.getNextChallenge,
         notes: [
           '- Récupération de la question suivante pour l\'évaluation donnée',
@@ -40,6 +46,11 @@ exports.register = async function(server) {
       path: '/api/assessments/{id}',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.assessmentId,
+          }),
+        },
         pre: [{
           method: assessmentAuthorization.verify,
           assign: 'authorizationCheck',
@@ -57,6 +68,11 @@ exports.register = async function(server) {
           method: assessmentAuthorization.verify,
           assign: 'authorizationCheck',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.assessmentId,
+          }),
+        },
         handler: assessmentController.completeAssessment,
         tags: ['api'],
       },
@@ -67,7 +83,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.assessmentId,
           }),
         },
         handler: assessmentController.findCompetenceEvaluations,

--- a/api/lib/application/campaign-participation-results/index.js
+++ b/api/lib/application/campaign-participation-results/index.js
@@ -1,4 +1,6 @@
+const Joi = require('joi');
 const campaignParticipationResultController = require('./campaign-participation-result-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -6,6 +8,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/campaign-participations/{id}/campaign-participation-result',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
         handler: campaignParticipationResultController.get,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/application/campaign-participations/index.js
+++ b/api/lib/application/campaign-participations/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const campaignParticipationController = require('./campaign-participation-controller');
 const { sendJsonApiError, NotFoundError } = require('../http-errors');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -28,6 +29,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/campaign-participations/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
         handler: campaignParticipationController.getById,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -40,6 +46,11 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/campaign-participations/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
         handler: campaignParticipationController.shareCampaignResult,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -64,6 +75,11 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/campaign-participations/{id}/begin-improvement',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.campaignParticipationId,
+          }),
+        },
         handler: campaignParticipationController.beginImprovement,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -79,7 +95,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignParticipationId,
           }),
         },
         handler: campaignParticipationController.getAnalysis,
@@ -97,8 +113,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            campaignId: Joi.number().integer().required(),
-            campaignParticipationId: Joi.number().integer().required(),
+            campaignId: identifiersType.campaignId,
+            campaignParticipationId: identifiersType.campaignParticipationId,
           }),
         },
         handler: campaignParticipationController.getCampaignProfile,
@@ -116,8 +132,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            campaignId: Joi.number().integer().required(),
-            campaignParticipationId: Joi.number().integer().required(),
+            campaignId: identifiersType.campaignId,
+            campaignParticipationId: identifiersType.campaignParticipationId,
           }),
         },
         handler: campaignParticipationController.getCampaignAssessmentParticipation,
@@ -135,8 +151,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            campaignId: Joi.number().integer().required(),
-            campaignParticipationId: Joi.number().integer().required(),
+            campaignId: identifiersType.campaignId,
+            campaignParticipationId: identifiersType.campaignParticipationId,
           }),
         },
         handler: campaignParticipationController.getCampaignAssessmentParticipationResult,

--- a/api/lib/application/campaigns/index.js
+++ b/api/lib/application/campaigns/index.js
@@ -1,5 +1,6 @@
 const Joi = require('joi');
 const campaignController = require('./campaign-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -34,7 +35,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.getById,
@@ -51,7 +52,7 @@ exports.register = async function(server) {
         auth: false,
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.getCsvAssessmentResults,
@@ -70,7 +71,7 @@ exports.register = async function(server) {
         auth: false,
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.getCsvProfilesCollectionResults,
@@ -88,7 +89,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.update,
@@ -106,7 +107,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.getCollectiveResult,
@@ -123,7 +124,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.getAnalysis,
@@ -140,7 +141,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.archiveCampaign,
@@ -156,7 +157,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.unarchiveCampaign,
@@ -172,7 +173,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
@@ -194,7 +195,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
@@ -218,7 +219,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.campaignId,
           }),
         },
         handler: campaignController.division,

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -1,7 +1,7 @@
 const certificationCenterController = require('./certification-center-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 const Joi = require('joi');
-const { idSpecification } = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -68,8 +68,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            certificationCenterId: idSpecification,
-            sessionId: idSpecification,
+            certificationCenterId: identifiersType.certificationCenterId,
+            sessionId: identifiersType.sessionId,
           }),
           query: Joi.object({
             'filter[divisions][]': [Joi.string(), Joi.array().items(Joi.string())],
@@ -91,7 +91,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            certificationCenterId: idSpecification,
+            certificationCenterId: identifiersType.certificationCenterId,
           }),
         },
         handler: certificationCenterController.getDivisions,

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -50,7 +50,7 @@ exports.register = async function(server) {
         }],
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.certificationCenterId,
           }),
         },
         handler: certificationCenterController.getById,
@@ -106,6 +106,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/certification-centers/{id}/sessions',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCenterId,
+          }),
+        },
         handler: certificationCenterController.getSessions,
         tags: ['api', 'certification-center'],
         notes: [

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -1,7 +1,7 @@
 const certificationCenterController = require('./certification-center-controller');
 const securityPreHandlers = require('../security-pre-handlers');
 const Joi = require('joi');
-const identifiersType = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -15,6 +15,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
         handler: certificationCourseController.computeResult,
         tags: ['api'],
         notes: [
@@ -45,6 +50,11 @@ exports.register = async function(server) {
       method: 'PATCH',
       path: '/api/certification-courses/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
         handler: certificationCourseController.update,
         tags: ['api'],
       },
@@ -65,6 +75,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/certification-courses/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
         handler: certificationCourseController.get,
         tags: ['api'],
       },

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');
 
-const { idSpecification } = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -30,7 +30,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.certificationCourseId,
           }),
         },
         pre: [{

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');
 
-const identifiersType = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([

--- a/api/lib/application/certification-issue-reports/index.js
+++ b/api/lib/application/certification-issue-reports/index.js
@@ -1,4 +1,6 @@
+const Joi = require('joi');
 const certificationIssueReportController = require('./certification-issue-report-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -6,6 +8,11 @@ exports.register = async (server) => {
       method: 'DELETE',
       path: '/api/certification-issue-reports/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationIssueReportId,
+          }),
+        },
         handler: certificationIssueReportController.deleteCertificationIssueReport,
         tags: ['api', 'certification-issue-reports'],
         notes: [

--- a/api/lib/application/certification-point-of-contacts/index.js
+++ b/api/lib/application/certification-point-of-contacts/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const certificationPointOfContactController = require('./certification-point-of-contact-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -11,7 +12,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            userId: Joi.number().required(),
+            userId: identifiersType.certificationCenterMembershipId,
           }),
         },
         pre: [{

--- a/api/lib/application/certification-reports/index.js
+++ b/api/lib/application/certification-reports/index.js
@@ -1,4 +1,6 @@
+const Joi = require('joi');
 const certificationReportController = require('./certification-report-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -6,6 +8,11 @@ exports.register = async (server) => {
       method: 'POST',
       path: '/api/certification-reports/{id}/certification-issue-reports',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationIssueReportId,
+          }),
+        },
         handler: certificationReportController.saveCertificationIssueReport,
         tags: ['api', 'certification-reports'],
         notes: [

--- a/api/lib/application/certifications/index.js
+++ b/api/lib/application/certifications/index.js
@@ -1,4 +1,7 @@
+const Joi = require('joi');
+
 const certificationController = require('./certification-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -18,6 +21,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/certifications/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
         handler: certificationController.getCertification,
         notes: [
           '- **Route nécessitant une authentification**\n' +
@@ -45,6 +53,11 @@ exports.register = async function(server) {
       method: 'GET',
       path: '/api/attestation/{id}',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.certificationCourseId,
+          }),
+        },
         handler: certificationController.getPDFAttestation,
         notes: [
           '- **Route accessible par un user authentifié**\n' +

--- a/api/lib/application/challenges/index.js
+++ b/api/lib/application/challenges/index.js
@@ -1,4 +1,7 @@
-const ChallengeController = require('./challenge-controller');
+const Joi = require('joi');
+
+const challengeController = require('./challenge-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -7,7 +10,12 @@ exports.register = async function(server) {
       path: '/api/challenges/{id}',
       config: {
         auth: false,
-        handler: ChallengeController.get,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.challengeId,
+          }),
+        },
+        handler: challengeController.get,
         tags: ['api'],
       },
     },

--- a/api/lib/application/courses/index.js
+++ b/api/lib/application/courses/index.js
@@ -1,4 +1,7 @@
+const Joi = require('joi');
+
 const courseController = require('./course-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -7,6 +10,11 @@ exports.register = async function(server) {
       path: '/api/courses/{id}',
       config: {
         auth: false,
+        validate: {
+          params: Joi.object({
+            id: identifiersType.courseId,
+          }),
+        },
         handler: courseController.get,
         tags: ['api'],
       },

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');
-const identifiersType = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const membershipController = require('./membership-controller');
-const { idSpecification } = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -66,7 +66,7 @@ exports.register = async function(server) {
         }],
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.membershipId,
           }),
         },
         handler: membershipController.disable,

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -38,7 +38,7 @@ exports.register = async function(server) {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.membershipId,
           }),
         },
         handler: membershipController.update,

--- a/api/lib/application/organization-invitations/index.js
+++ b/api/lib/application/organization-invitations/index.js
@@ -1,5 +1,7 @@
 const Joi = require('joi');
+
 const organizationInvitationController = require('./organization-invitation-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -10,6 +12,9 @@ exports.register = async (server) => {
         auth: false,
         handler: organizationInvitationController.acceptOrganizationInvitation,
         validate: {
+          params: Joi.object({
+            id: identifiersType.organizationInvitationId,
+          }),
           payload: Joi.object({
             data: {
               id: Joi.string().required(),
@@ -60,7 +65,7 @@ exports.register = async (server) => {
         handler: organizationInvitationController.getOrganizationInvitation,
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.organizationInvitationId,
           }),
           query: Joi.object({
             code: Joi.string().required(),

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -1,8 +1,9 @@
 const Joi = require('joi');
-const { sendJsonApiError, PayloadTooLargeError, NotFoundError, BadRequestError } = require('../http-errors');
 
+const { sendJsonApiError, PayloadTooLargeError, NotFoundError, BadRequestError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const organizationController = require('./organization-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -57,6 +58,11 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.getOrganizationDetails,
         tags: ['api', 'organizations'],
         notes: [
@@ -73,6 +79,11 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserHasRolePixMaster,
           assign: 'hasRolePixMaster',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.updateOrganizationInformation,
         tags: ['api', 'organizations'],
         notes: [
@@ -85,6 +96,11 @@ exports.register = async (server) => {
       method: 'GET',
       path: '/api/organizations/{id}/campaigns',
       config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.findPaginatedFilteredCampaigns,
         tags: ['api', 'organizations'],
         notes: [
@@ -101,6 +117,11 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserBelongsToOrganizationOrHasRolePixMaster,
           assign: 'belongsToOrganization',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.findPaginatedFilteredMemberships,
         tags: ['api', 'organizations'],
         notes: [
@@ -131,6 +152,9 @@ exports.register = async (server) => {
         }],
         handler: organizationController.attachTargetProfiles,
         validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
           payload: Joi.object({
             data: {
               attributes: {
@@ -155,7 +179,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.organizationId,
           }),
           query: Joi.object({
             'page[size]': Joi.number().integer().empty(''),
@@ -180,7 +204,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.organizationId,
           }),
           query: Joi.object({
             format: Joi.string().default('xml'),
@@ -209,7 +233,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.organizationId,
           }),
         },
         payload: {
@@ -238,6 +262,9 @@ exports.register = async (server) => {
         }],
         handler: organizationController.sendInvitations,
         validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
           options: {
             allowUnknown: true,
           },
@@ -264,6 +291,11 @@ exports.register = async (server) => {
           method: securityPreHandlers.checkUserIsAdminInOrganization,
           assign: 'isAdminInOrganization',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
         handler: organizationController.findPendingInvitations,
         tags: ['api', 'invitations'],
         notes: [
@@ -279,7 +311,7 @@ exports.register = async (server) => {
         auth: false,
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.organizationId,
           }),
           query: Joi.object({
             accessToken: Joi.string().required(),

--- a/api/lib/application/prescribers/index.js
+++ b/api/lib/application/prescribers/index.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 
 const securityPreHandlers = require('../security-pre-handlers');
 const prescriberController = require('./prescriber-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -11,7 +12,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            userId: Joi.number().required(),
+            userId: identifiersType.userId,
           }),
         },
         pre: [{

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -1,7 +1,9 @@
 const Joi = require('joi').extend(require('@joi/date'));
+
 const { sendJsonApiError, UnprocessableEntityError, NotFoundError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const schoolingRegistrationUserAssociationController = require('./schooling-registration-user-association-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -156,8 +158,8 @@ exports.register = async function(server) {
           },
           params:
             Joi.object({
-              id: Joi.number().required(),
-              schoolingRegistrationId: Joi.number().required(),
+              id: identifiersType.organizationId,
+              schoolingRegistrationId: identifiersType.schoolingRegistrationId,
             }),
           payload: Joi.object({
             data: {
@@ -191,7 +193,7 @@ exports.register = async function(server) {
           payload: Joi.object({
             data: {
               attributes: {
-                'schooling-registration-id': Joi.number(),
+                'schooling-registration-id': identifiersType.schoolingRegistrationId,
               },
             },
           }),

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -359,7 +359,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -3,7 +3,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
 const featureToggles = require('../preHandlers/feature-toggles');
-const identifiersType = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -3,7 +3,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
 const featureToggles = require('../preHandlers/feature-toggles');
-const { idSpecification } = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async (server) => {
   server.route([
@@ -29,7 +29,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -46,7 +46,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -64,7 +64,7 @@ exports.register = async (server) => {
         auth: false,
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         handler: sessionController.getAttendanceSheet,
@@ -82,7 +82,7 @@ exports.register = async (server) => {
         auth: false,
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         handler: sessionController.getCandidatesImportSheet,
@@ -111,7 +111,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -132,7 +132,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         payload: {
@@ -158,7 +158,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -180,7 +180,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -201,7 +201,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -222,8 +222,8 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
-            certificationCandidateId: idSpecification,
+            id: identifiersType.sessionId,
+            certificationCandidateId: identifiersType.certificationCandidateId,
           }),
         },
         pre: [{
@@ -244,7 +244,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -265,7 +265,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -298,7 +298,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -320,7 +320,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         handler: sessionController.createCandidateParticipation,
@@ -338,7 +338,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -380,7 +380,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -403,7 +403,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [{
@@ -424,7 +424,7 @@ exports.register = async (server) => {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.sessionId,
           }),
         },
         pre: [

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -1,7 +1,9 @@
 const Joi = require('joi');
+
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const securityPreHandlers = require('../security-pre-handlers');
 const targetProfileController = require('./target-profile-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -46,7 +48,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.targetProfileId,
           }),
         },
         handler: targetProfileController.getTargetProfileDetails,
@@ -70,7 +72,7 @@ exports.register = async (server) => {
             'organization-ids': Joi.array().items(Joi.number().integer()).required(),
           }),
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.targetProfileId,
           }),
         },
         handler: targetProfileController.attachOrganizations,
@@ -122,7 +124,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.targetProfileId,
           }),
           query: Joi.object({
             'filter[id]': Joi.number().integer().empty('').allow(null).optional(),
@@ -151,7 +153,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.targetProfileId,
           }),
           payload: Joi.object({
             data: {
@@ -179,7 +181,7 @@ exports.register = async (server) => {
         }],
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.targetProfileId,
           }),
         },
         handler: targetProfileController.findTargetProfileBadges,

--- a/api/lib/application/tutorial-evaluations/index.js
+++ b/api/lib/application/tutorial-evaluations/index.js
@@ -1,4 +1,7 @@
+const Joi = require('joi');
+
 const tutorialEvaluationsController = require('./tutorial-evaluations-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -7,6 +10,14 @@ exports.register = async (server) => {
       path: '/api/users/tutorials/{tutorialId}/evaluate',
       config: {
         handler: tutorialEvaluationsController.evaluate,
+        validate: {
+          params: Joi.object({
+            tutorialId: identifiersType.tutorialId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
         tags: ['api', 'tutorials'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/application/user-orga-settings/index.js
+++ b/api/lib/application/user-orga-settings/index.js
@@ -1,5 +1,7 @@
 const Joi = require('joi');
+
 const userOrgaSettingsController = require('./user-orga-settings-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([
@@ -12,6 +14,9 @@ exports.register = async function(server) {
           options: {
             allowUnknown: true,
           },
+          params: Joi.object({
+            id: identifiersType.userOrgaSettingsId,
+          }),
           payload: Joi.object({
             data: {
               relationships: {

--- a/api/lib/application/user-tutorials/index.js
+++ b/api/lib/application/user-tutorials/index.js
@@ -1,4 +1,7 @@
+const Joi = require('joi');
+
 const userTutorialsController = require('./user-tutorials-controller');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async (server) => {
   server.route([
@@ -7,6 +10,14 @@ exports.register = async (server) => {
       path: '/api/users/tutorials/{tutorialId}',
       config: {
         handler: userTutorialsController.add,
+        validate: {
+          params: Joi.object({
+            tutorialId: identifiersType.tutorialId,
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
         tags: ['api', 'tutorials'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -31,6 +42,11 @@ exports.register = async (server) => {
       method: 'DELETE',
       path: '/api/users/tutorials/{tutorialId}',
       config: {
+        validate: {
+          params: Joi.object({
+            tutorialId: identifiersType.tutorialId,
+          }),
+        },
         handler: userTutorialsController.removeFromUser,
         tags: ['api', 'tutorials'],
         notes: [

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -8,6 +8,7 @@ const XRegExp = require('xregexp');
 const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
 const { idSpecification } = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -55,7 +56,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: idSpecification,
+            id: identifiersType.userId,
           }),
           failAction: (request, h) => {
             return sendJsonApiError(new BadRequestError('L\'identifiant de l\'utilisateur n\'est pas au bon format.'), h);

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -423,6 +423,12 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate : {
+          params: Joi.object({
+            userId: identifiersType.userId,
+            competenceId: identifiersType.competenceId,
+          }),
+        },
         handler: userController.resetScorecard,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -7,7 +7,6 @@ const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
 const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
-const { idSpecification } = require('../../domain/validators/id-specification');
 const identifiersType = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -7,7 +7,7 @@ const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
 const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
-const identifiersType = require('../../domain/validators/id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 exports.register = async function(server) {
   server.route([

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -7,6 +7,7 @@ const { passwordValidationPattern } = require('../../config').account;
 const XRegExp = require('xregexp');
 const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
+const { idSpecification } = require('../../domain/validators/id-specification');
 
 exports.register = async function(server) {
   server.route([
@@ -54,7 +55,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: idSpecification,
           }),
           failAction: (request, h) => {
             return sendJsonApiError(new BadRequestError('L\'identifiant de l\'utilisateur n\'est pas au bon format.'), h);

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -1,10 +1,11 @@
+const Joi = require('joi');
+const XRegExp = require('xregexp');
+
 const securityPreHandlers = require('../security-pre-handlers');
 const userController = require('./user-controller');
-const Joi = require('joi');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;
-const XRegExp = require('xregexp');
 const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
 const identifiersType = require('../../domain/types/identifiers-type');
@@ -88,7 +89,7 @@ exports.register = async function(server) {
         },
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().required(),
+            id: identifiersType.userId,
           }),
           payload: Joi.object({
             data: {
@@ -118,6 +119,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.getMemberships,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -135,6 +141,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.getCertificationCenterMemberships,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -152,6 +163,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.getCampaignParticipations,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -171,6 +187,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.getCampaignParticipationOverviews,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -199,6 +220,9 @@ exports.register = async function(server) {
         ],
         handler: userController.updateEmail,
         validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
           options: {
             allowUnknown: true,
           },
@@ -234,6 +258,9 @@ exports.register = async function(server) {
           options: {
             allowUnknown: true,
           },
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
           payload: Joi.object({
             data: {
               attributes: {
@@ -257,6 +284,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.accepPixLastTermsOfService,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -275,6 +307,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.acceptPixOrgaTermsOfService,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -291,7 +328,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().positive().required(),
+            id: identifiersType.userId,
             lang: Joi.string().valid('fr', 'en'),
           }),
         },
@@ -317,6 +354,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.acceptPixCertifTermsOfService,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -335,6 +377,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.rememberUserHasSeenAssessmentInstructions,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -353,6 +400,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.rememberUserHasSeenNewLevelInfo,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -371,6 +423,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.rememberUserHasSeenNewDashboardInfo,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -389,6 +446,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.isCertifiable,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -406,6 +468,11 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+        },
         handler: userController.getProfile,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
@@ -423,7 +490,7 @@ exports.register = async function(server) {
           method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
           assign: 'requestedUserIsAuthenticatedUser',
         }],
-        validate : {
+        validate: {
           params: Joi.object({
             userId: identifiersType.userId,
             competenceId: identifiersType.competenceId,
@@ -445,8 +512,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            userId: Joi.number().required(),
-            campaignId: Joi.number().required(),
+            userId: identifiersType.userId,
+            campaignId: identifiersType.campaignId,
           }),
         },
         pre: [{
@@ -468,8 +535,8 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            userId: Joi.number().required(),
-            campaignId: Joi.number().required(),
+            userId: identifiersType.userId,
+            campaignId: identifiersType.campaignId,
           }),
         },
         pre: [{
@@ -491,7 +558,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().positive().required(),
+            id: identifiersType.userId,
           }),
         },
         pre: [{
@@ -511,7 +578,7 @@ exports.register = async function(server) {
       config: {
         validate: {
           params: Joi.object({
-            id: Joi.number().integer().positive().required(),
+            id: identifiersType.userId,
           }),
         },
         pre: [{

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -1,21 +1,27 @@
 const Joi = require('joi');
 
-const sequenceStartAt = 1;
-const sequencesEndsAt = 2 ** 31 - 1;
-const positive32bitIntegerType = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
+const postgreSQLSequenceDefaultStart = 1;
+const postgreSQLSequenceEnd = 2 ** 31 - 1;
 
-const userId = positive32bitIntegerType;
-const sessionId = positive32bitIntegerType;
-const certificationCandidateId = positive32bitIntegerType;
-const certificationCenterId = positive32bitIntegerType;
-const certificationCourseId = positive32bitIntegerType;
-const membershipId = positive32bitIntegerType;
+const implementationType = {
+  positiveInteger32bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceEnd).required(),
+  alphanumeric255: Joi.string().max(255).required(),
+};
+
+const competenceId = implementationType.alphanumeric255;
+const certificationCandidateId = implementationType.positiveInteger32bits;
+const certificationCenterId = implementationType.positiveInteger32bits;
+const certificationCourseId = implementationType.positiveInteger32bits;
+const membershipId = implementationType.positiveInteger32bits;
+const userId = implementationType.positiveInteger32bits;
+const sessionId = implementationType.positiveInteger32bits;
 
 module.exports = {
-  userId,
-  sessionId,
   certificationCandidateId,
   certificationCenterId,
   certificationCourseId,
+  competenceId,
   membershipId,
+  userId,
+  sessionId,
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -6,22 +6,51 @@ const postgreSQLSequenceEnd = 2 ** 31 - 1;
 const implementationType = {
   positiveInteger32bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceEnd).required(),
   alphanumeric255: Joi.string().max(255).required(),
+  alphanumeric: Joi.string().required(),
 };
 
-const competenceId = implementationType.alphanumeric255;
+const answerId = implementationType.positiveInteger32bits;
+const assessmentId = implementationType.positiveInteger32bits;
+const campaignId = implementationType.positiveInteger32bits;
+const campaignParticipationId = implementationType.positiveInteger32bits;
 const certificationCandidateId = implementationType.positiveInteger32bits;
 const certificationCenterId = implementationType.positiveInteger32bits;
+const certificationCenterMembershipId = implementationType.positiveInteger32bits;
 const certificationCourseId = implementationType.positiveInteger32bits;
+const certificationIssueReportId = implementationType.positiveInteger32bits;
+const challengeId = implementationType.alphanumeric255;
+const courseId = implementationType.alphanumeric;
+const competenceId = implementationType.alphanumeric255;
 const membershipId = implementationType.positiveInteger32bits;
-const userId = implementationType.positiveInteger32bits;
+const organizationId = implementationType.positiveInteger32bits;
+const organizationInvitationId = implementationType.positiveInteger32bits;
+const schoolingRegistrationId = implementationType.positiveInteger32bits;
 const sessionId = implementationType.positiveInteger32bits;
+const targetProfileId = implementationType.positiveInteger32bits;
+const tutorialId = implementationType.alphanumeric;
+const userId = implementationType.positiveInteger32bits;
+const userOrgaSettingsId = implementationType.positiveInteger32bits;
 
 module.exports = {
+  answerId,
+  assessmentId,
+  campaignId,
+  campaignParticipationId,
   certificationCandidateId,
   certificationCenterId,
+  certificationCenterMembershipId,
   certificationCourseId,
+  certificationIssueReportId,
+  challengeId,
   competenceId,
+  courseId,
   membershipId,
-  userId,
+  organizationId,
+  organizationInvitationId,
+  schoolingRegistrationId,
   sessionId,
+  targetProfileId,
+  tutorialId,
+  userId,
+  userOrgaSettingsId,
 };

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const sequenceStartAt = 1;
 const sequencesEndsAt = 2 ** 31 - 1;
-const positive32bitIntegerType = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();;
+const positive32bitIntegerType = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
 
 const userId = positive32bitIntegerType;
 const sessionId = positive32bitIntegerType;

--- a/api/lib/domain/usecases/get-correction-for-answer.js
+++ b/api/lib/domain/usecases/get-correction-for-answer.js
@@ -9,9 +9,7 @@ module.exports = async function getCorrectionForAnswer({
   locale,
 } = {}) {
   const integerAnswerId = parseInt(answerId);
-  if (!Number.isFinite(integerAnswerId)) {
-    throw new NotFoundError(`Not found correction for answer of ID ${answerId}`);
-  }
+
   const answer = await answerRepository.get(integerAnswerId);
   const assessment = await assessmentRepository.get(answer.assessmentId);
 

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -1,10 +1,10 @@
 const Joi = require('joi');
 
-// Min 32 bits signed integer, our most common id type in Postgres
-const minId = -(2 ** 31);
+const sequenceStartAt = 1;
 // Max 32 bits signed integer, our most common id type in Postgres
-const maxId = 2 ** 31 - 1;
+const sequencesEndsAt = 2 ** 31 - 1;
+const idSpecification = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
 
 module.exports = {
-  idSpecification: Joi.number().integer().min(minId).max(maxId).required(),
+  idSpecification,
 };

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -1,14 +1,21 @@
 const Joi = require('joi');
 
 const sequenceStartAt = 1;
-// Max 32 bits signed integer, our most common id type in Postgres
 const sequencesEndsAt = 2 ** 31 - 1;
-const idSpecification = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
+const positive32bitIntegerType = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();;
 
-const positive32bitIntegerType = idSpecification;
 const userId = positive32bitIntegerType;
+const sessionId = positive32bitIntegerType;
+const certificationCandidateId = positive32bitIntegerType;
+const certificationCenterId = positive32bitIntegerType;
+const certificationCourseId = positive32bitIntegerType;
+const membershipId = positive32bitIntegerType;
 
 module.exports = {
-  idSpecification,
   userId,
+  sessionId,
+  certificationCandidateId,
+  certificationCenterId,
+  certificationCourseId,
+  membershipId,
 };

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -4,7 +4,9 @@ const sequenceStartAt = 1;
 // Max 32 bits signed integer, our most common id type in Postgres
 const sequencesEndsAt = 2 ** 31 - 1;
 const idSpecification = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
-const userId = idSpecification;
+
+const positive32bitIntegerType = idSpecification;
+const userId = positive32bitIntegerType;
 
 module.exports = {
   idSpecification,

--- a/api/lib/domain/validators/id-specification.js
+++ b/api/lib/domain/validators/id-specification.js
@@ -4,7 +4,9 @@ const sequenceStartAt = 1;
 // Max 32 bits signed integer, our most common id type in Postgres
 const sequencesEndsAt = 2 ** 31 - 1;
 const idSpecification = Joi.number().integer().min(sequenceStartAt).max(sequencesEndsAt).required();
+const userId = idSpecification;
 
 module.exports = {
   idSpecification,
+  userId,
 };

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -3,7 +3,7 @@ const { statuses } = require('../models/Session');
 const { types } = require('../models/CertificationCenter');
 
 const { EntityValidationError } = require('../errors');
-const { idSpecification } = require('./id-specification');
+const identifiersType = require('./id-specification');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 
@@ -45,7 +45,7 @@ const sessionValidationJoiSchema = Joi.object({
 });
 
 const sessionFiltersValidationSchema = Joi.object({
-  id: idSpecification.optional(),
+  id: identifiersType.sessionId.optional(),
   status: Joi.string().trim()
     .valid(statuses.CREATED, statuses.FINALIZED, statuses.IN_PROCESS, statuses.PROCESSED).optional(),
   resultsSentToPrescriberAt: Joi.boolean().optional(),

--- a/api/lib/domain/validators/session-validator.js
+++ b/api/lib/domain/validators/session-validator.js
@@ -3,7 +3,7 @@ const { statuses } = require('../models/Session');
 const { types } = require('../models/CertificationCenter');
 
 const { EntityValidationError } = require('../errors');
-const identifiersType = require('./id-specification');
+const identifiersType = require('../../domain/types/identifiers-type');
 
 const validationConfiguration = { abortEarly: false, allowUnknown: true };
 

--- a/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get-correction_test.js
@@ -147,7 +147,7 @@ describe('Acceptance | Controller | answer-controller-get-correction', () => {
       // given
       const options = {
         method: 'GET',
-        url: '/api/answers/coucou/correction',
+        url: '/api/answers/1/correction',
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
 

--- a/api/tests/acceptance/application/answers/answer-controller-get_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-get_test.js
@@ -67,12 +67,12 @@ describe('Acceptance | Controller | answer-controller-get', () => {
         };
       });
 
-      it('should return 404 HTTP status code', async () => {
+      it('should return 400 HTTP status code', async () => {
         // when
         const response = await server.inject(options);
 
         // given
-        expect(response.statusCode).to.equal(404);
+        expect(response.statusCode).to.equal(400);
       });
     });
 

--- a/api/tests/integration/application/campaignParticipations/index_test.js
+++ b/api/tests/integration/application/campaignParticipations/index_test.js
@@ -47,7 +47,7 @@ describe('Integration | Application | Route | campaignParticipationRouter', () =
       };
 
       // when
-      const response = await httpTestServer.request('PATCH', '/api/campaign-participations/FAKE_ID', payload);
+      const response = await httpTestServer.request('PATCH', '/api/campaign-participations/1', payload);
 
       // then
       expect(response.statusCode).to.equal(201);

--- a/api/tests/integration/application/campaigns/index_test.js
+++ b/api/tests/integration/application/campaigns/index_test.js
@@ -1,0 +1,105 @@
+const {
+  expect,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
+
+const moduleUnderTest = require('../../../../lib/application/campaigns');
+
+const campaignController = require('../../../../lib/application/campaigns/campaign-controller');
+
+describe('Integration | Application | Route | campaignRouter', () => {
+
+  let httpTestServer;
+
+  beforeEach(() => {
+    sinon.stub(campaignController, 'save').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignController, 'getCsvAssessmentResults').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(campaignController, 'getCsvProfilesCollectionResults').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(campaignController, 'getById').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(campaignController, 'update').callsFake((request, h) => h.response('ok').code(201));
+    sinon.stub(campaignController, 'getAnalysis').callsFake((request, h) => h.response('ok').code(200));
+
+    httpTestServer = new HttpTestServer(moduleUnderTest);
+  });
+
+  describe('POST /api/campaigns', () => {
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('POST', '/api/campaigns');
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/csv-assessment-results', () => {
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-assessment-results');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/csv-profiles-collection-results', () => {
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1/csv-profiles-collection-results');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}', () => {
+
+    it('should return a 200', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/campaigns/1');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('GET /api/campaigns/{id}/analyses', () => {
+
+    it('should return 200', async () => {
+      // given
+      const campaignId = 1;
+
+      // when
+      const response = await httpTestServer.request('GET', `/api/campaigns/${campaignId}/analyses`);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return 400', async () => {
+      // given
+      const campaignId = 'wrongId';
+
+      // when
+      const response = await httpTestServer.request('GET', `/api/campaigns/${campaignId}/analyses`);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+  });
+
+  describe('PATCH /api/campaigns/{id}', () => {
+
+    it('should exist', async () => {
+      // when
+      const response = await httpTestServer.request('PATCH', '/api/campaigns/1');
+
+      // then
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+});

--- a/api/tests/integration/application/organizations/index_test.js
+++ b/api/tests/integration/application/organizations/index_test.js
@@ -63,7 +63,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should call the organization controller to get the campaigns', async () => {
       // given
       const method = 'GET';
-      const url = '/api/organizations/:id/campaigns';
+      const url = '/api/organizations/1/campaigns';
 
       // when
       const response = await httpTestServer.request(method, url);
@@ -109,7 +109,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should call the organization controller to send invitations', async () => {
       // given
       const method = 'POST';
-      const url = '/api/organizations/:id/invitations';
+      const url = '/api/organizations/1/invitations';
       const payload = {
         data: {
           type: 'organization-invitations',
@@ -133,7 +133,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should exist', async () => {
       // given
       const method = 'GET';
-      const url = '/api/organizations/:id/invitations';
+      const url = '/api/organizations/1/invitations';
 
       // when
       const response = await httpTestServer.request(method, url);
@@ -204,7 +204,7 @@ describe('Integration | Application | Organizations | Routes', () => {
     it('should resolve with a 204 status code', async () => {
       // given
       const method = 'POST';
-      const url = '/api/organizations/:id/target-profiles';
+      const url = '/api/organizations/1/target-profiles';
       const payload = {
         data: {
           type: 'target-profile-shares',

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -3,6 +3,7 @@ const { expect, sinon, HttpTestServer } = require('../../../test-helper');
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const userController = require('../../../../lib/application/users/user-controller');
 const moduleUnderTest = require('../../../../lib/application/users');
+const faker = require('faker');
 
 describe('Integration | Application | Users | Routes', () => {
 
@@ -20,6 +21,7 @@ describe('Integration | Application | Users | Routes', () => {
     sinon.stub(userController, 'getUserDetailsForAdmin').returns('ok');
     sinon.stub(userController, 'updateUserDetailsForAdministration').returns('updated');
     sinon.stub(userController, 'dissociateSchoolingRegistrations').returns('ok');
+    sinon.stub(userController, 'resetScorecard').returns('ok');
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -57,6 +59,36 @@ describe('Integration | Application | Users | Routes', () => {
 
       // when
       const response = await httpTestServer.request(methodGET, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+  });
+
+  describe('POST /api/users/{userId}/competences/{competenceId}/reset', () => {
+
+    it('should return OK (200) when params are valid', async () => {
+      // given
+      securityPreHandlers.checkRequestedUserIsAuthenticatedUser.callsFake((request, h) => h.response(true));
+      const url = '/api/users/123/competences/abcdefghijklmnop/reset';
+
+      // when
+      const response = await httpTestServer.request('POST', url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return BAD_REQUEST (400) when competenceId parameter is invalid', async () => {
+
+      // given
+      const invalidCompetenceId = faker.random.alphaNumeric(256);
+      securityPreHandlers.checkRequestedUserIsAuthenticatedUser.callsFake((request, h) => h.response(true));
+      const url = `/api/users/123/competences/${invalidCompetenceId}/reset`;
+
+      // when
+      const response = await httpTestServer.request('POST', url);
 
       // then
       expect(response.statusCode).to.equal(400);

--- a/api/tests/integration/application/users/index_test.js
+++ b/api/tests/integration/application/users/index_test.js
@@ -38,10 +38,22 @@ describe('Integration | Application | Users | Routes', () => {
       expect(response.statusCode).to.equal(200);
     });
 
-    it('should return a 400 when id in param is not a number"', async () => {
+    it('should return BAD_REQUEST (400) when id in param is not a number"', async () => {
 
       // given
       const url = '/api/admin/users/NOT_A_NUMBER';
+
+      // when
+      const response = await httpTestServer.request(methodGET, url);
+
+      // then
+      expect(response.statusCode).to.equal(400);
+    });
+
+    it('should return BAD_REQUEST (400) when id in param is out of range"', async () => {
+
+      // given
+      const url = '/api/admin/users/0';
 
       // when
       const response = await httpTestServer.request(methodGET, url);

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -36,7 +36,7 @@ describe('Unit | Router | answer-router', function() {
 
     it('should exist', async () => {
       // when
-      const result = await httpTestServer.request('GET', '/api/answers/answer_id');
+      const result = await httpTestServer.request('GET', '/api/answers/1');
 
       // then
       expect(result.statusCode).to.equal(200);
@@ -58,7 +58,7 @@ describe('Unit | Router | answer-router', function() {
 
     it('should exist', async () => {
       // when
-      const result = await httpTestServer.request('PATCH', '/api/answers/answer_id');
+      const result = await httpTestServer.request('PATCH', '/api/answers/1');
 
       // then
       expect(result.statusCode).to.equal(204);

--- a/api/tests/unit/application/assessments/index_test.js
+++ b/api/tests/unit/application/assessments/index_test.js
@@ -42,7 +42,7 @@ describe('Integration | Route | AssessmentRoute', () => {
 
     it('should exist', async () => {
       // when
-      const response = await httpTestServer.request('GET', '/api/assessments/assessment_id/next');
+      const response = await httpTestServer.request('GET', '/api/assessments/1/next');
 
       // then
       expect(response.statusCode).to.equal(200);
@@ -63,7 +63,7 @@ describe('Integration | Route | AssessmentRoute', () => {
   describe('GET /api/assessments/{id}', () => {
 
     const method = 'GET';
-    const url = '/api/assessments/assessment_id';
+    const url = '/api/assessments/1';
 
     it('should exist', async () => {
       // when

--- a/api/tests/unit/domain/types/identifiers-type_test.js
+++ b/api/tests/unit/domain/types/identifiers-type_test.js
@@ -1,9 +1,9 @@
 const { expect } = require('../../../test-helper');
-const { userId } = require('../../../../lib/domain/validators/id-specification');
+const { userId } = require('../../../../lib/domain/types/identifiers-type');
 
-describe('Unit | Domain | Validators | id-specification', () => {
+describe('Unit | Domain | Type | identifier-types', () => {
 
-  describe('#idSpecification', () => {
+  describe('#userId', () => {
 
     context('when id is valid', () => {
 

--- a/api/tests/unit/domain/types/identifiers-type_test.js
+++ b/api/tests/unit/domain/types/identifiers-type_test.js
@@ -1,5 +1,6 @@
 const { expect } = require('../../../test-helper');
-const { userId } = require('../../../../lib/domain/types/identifiers-type');
+const { userId, competenceId } = require('../../../../lib/domain/types/identifiers-type');
+const faker = require('faker');
 
 describe('Unit | Domain | Type | identifier-types', () => {
 
@@ -41,6 +42,49 @@ describe('Unit | Domain | Type | identifier-types', () => {
 
         // then
         expect(error.message).to.equal('"value" must be less than or equal to 2147483647');
+      });
+
+    });
+  });
+
+  describe('#competenceId', () => {
+
+    context('when id is valid', () => {
+
+      it('should not reject', () => {
+        // given
+        const validId = '1234567890123456';
+
+        // when then
+        const { error } = competenceId.validate(validId);
+
+        // then
+        expect(error).to.be.undefined;
+      });
+    });
+
+    context('when id is invalid', () => {
+
+      it('should reject when empty', async () => {
+        // given
+        const emptyString = '';
+
+        // when
+        const { error } = competenceId.validate(emptyString);
+
+        // then
+        expect(error.message).to.equal('"value" is not allowed to be empty');
+      });
+
+      it('should reject when too large', async () => {
+        // given
+        const tooLargeString = faker.random.alphaNumeric(256);
+
+        // when
+        const { error } = competenceId.validate(tooLargeString);
+
+        // then
+        expect(error.message).to.equal('"value" length must be less than or equal to 255 characters long');
       });
 
     });

--- a/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
+++ b/api/tests/unit/domain/usecases/get-correction-for-answer_test.js
@@ -151,25 +151,4 @@ describe('Unit | UseCase | getCorrectionForAnswer', () => {
     });
   });
 
-  context('when provided answer id is not an integer', () => {
-
-    it('should throw a NotFound error', async () => {
-      // given
-      const assessment = domainBuilder.buildAssessment({ state: 'completed' });
-      assessmentRepository.get.withArgs(assessmentId).resolves(assessment);
-
-      // when
-      const error = await catchErr(getCorrectionForAnswer)({
-        assessmentRepository,
-        answerRepository,
-        correctionRepository,
-        answerId: 'not an integer id',
-        userId: assessment.userId,
-      });
-
-      // then
-      return expect(error).to.be.instanceOf(NotFoundError);
-    });
-  });
-
 });

--- a/api/tests/unit/domain/validators/id-specification_test.js
+++ b/api/tests/unit/domain/validators/id-specification_test.js
@@ -1,5 +1,5 @@
 const { expect } = require('../../../test-helper');
-const { idSpecification } = require('../../../../lib/domain/validators/id-specification');
+const { userId } = require('../../../../lib/domain/validators/id-specification');
 
 describe('Unit | Domain | Validators | id-specification', () => {
 
@@ -12,7 +12,7 @@ describe('Unit | Domain | Validators | id-specification', () => {
         const validId = 1;
 
         // when
-        const { error } = idSpecification.validate(validId);
+        const { error } = userId.validate(validId);
 
         // then
         expect(error).to.be.undefined;
@@ -26,7 +26,7 @@ describe('Unit | Domain | Validators | id-specification', () => {
         const lowerBoundOutOfRangeId = 0;
 
         // when
-        const { error } = idSpecification.validate(lowerBoundOutOfRangeId);
+        const { error } = userId.validate(lowerBoundOutOfRangeId);
 
         // then
         expect(error.message).to.equal('"value" must be greater than or equal to 1');
@@ -37,7 +37,7 @@ describe('Unit | Domain | Validators | id-specification', () => {
         const upperBoundOutOfRangeId = 2147483648;
 
         // when
-        const { error } = idSpecification.validate(upperBoundOutOfRangeId);
+        const { error } = userId.validate(upperBoundOutOfRangeId);
 
         // then
         expect(error.message).to.equal('"value" must be less than or equal to 2147483647');

--- a/api/tests/unit/domain/validators/id-specification_test.js
+++ b/api/tests/unit/domain/validators/id-specification_test.js
@@ -1,0 +1,48 @@
+const { expect } = require('../../../test-helper');
+const { idSpecification } = require('../../../../lib/domain/validators/id-specification');
+
+describe('Unit | Domain | Validators | id-specification', () => {
+
+  describe('#idSpecification', () => {
+
+    context('when id is valid', () => {
+
+      it('should not reject', () => {
+        // given
+        const validId = 1;
+
+        // when
+        const { error } = idSpecification.validate(validId);
+
+        // then
+        expect(error).to.be.undefined;
+      });
+    });
+
+    context('when id is invalid', () => {
+
+      it('should reject outside of lower bound', async () => {
+        // given
+        const lowerBoundOutOfRangeId = 0;
+
+        // when
+        const { error } = idSpecification.validate(lowerBoundOutOfRangeId);
+
+        // then
+        expect(error.message).to.equal('"value" must be greater than or equal to 1');
+      });
+
+      it('should reject outside of upper bound', async () => {
+        // given
+        const upperBoundOutOfRangeId = 2147483648;
+
+        // when
+        const { error } = idSpecification.validate(upperBoundOutOfRangeId);
+
+        // then
+        expect(error.message).to.equal('"value" must be less than or equal to 2147483647');
+      });
+
+    });
+  });
+});

--- a/docs/adr/00019-typer-les-identifiants.md
+++ b/docs/adr/00019-typer-les-identifiants.md
@@ -1,0 +1,98 @@
+# 19. Typer les identifiants
+
+Date : 2020-27-01
+
+## État
+
+Accepté
+
+## Contexte
+
+Sur ce projet, nous avons besoin de :
+- éviter les incohérences en contrôlant la validité des données, notamment des identifiants
+- pouvoir consulter les types de données (ex: lors des phases de design) dans un seul endroit  
+- isoler le domaine, notamment de l'implémentation des identifiants dans les data-provider
+  - cache
+  - BDD propre ou distante (LCMS)
+- permettre le changement de type
+- disposer de plusieurs types, suivant les exigences d'implémentation
+
+Cela ne veut pas dire que :
+- le domaine fixe arbitrairement le type, car il risque de ne pas pouvoir être implémenté dans les data-provider
+- le domaine impose un format de sérialisation à l'interface REST entre un front et l'API
+
+Nous souhaitons plutôt que : 
+- le domaine contienne la description des types d'identifiant
+- les données manipulées puissent être contrôlées par rapport à cette description 
+
+### Solution n°1 : contrôler le type côté domaine
+Il est possible de contrôler la validité des données fournies lors de l'instanciation des objets du domaine.
+Ce contrôle peut être effectué par une libraire dédiée, par exemple [Joi](https://github.com/sideway/joi).
+
+Il est aussi possible de le faire en utilisant au lieu du langage Javascript le language TypeScript.
+Dans ce cas, la vérification de type (type checking) est déléguée au langage.
+
+Avantages :
+- met le domaine au centre
+- si un langage typé est choisi, prévient les erreurs d'inattention
+
+Inconvénients :
+- performance moindre, car un identifiant incorrect traversera toutes les couches avant d'être rejeté
+- si un langage typé est choisi, coût d'implémentation élevé (réécriture et formation des développeurs)
+
+### Solution n°2 : contrôler le type côté application
+Il est également possible de contrôler la validité des données fournies en entrée de l'API avec une librairie dédiée.
+Cela n'est pas strictement de la responsabilité de la couche application.
+Néanmoins, sous l'hypothèse que toutes les données déjà persistées sont conformes au modèle, et
+en l'absence d'erreur dans le code, cela suffit à garantir que le type des données (ici, des identifiants) est conforme.
+
+Bien que la vérification ne soit pas effectuée dans le domaine, la définition du type peut appartenir au domaine. 
+
+Avantages :
+- coût d'implémentation moins élevé (librairie Joi déjà connue, et solution déjà partiellement en place)
+- performance plus élevée, car un identifiant incorrect sera rejeté avant d'être passé au controller
+
+Inconvénients :
+- le controller effectue une opération qui n'est pas de sa responsabilité première
+
+## Décision
+Au vu des coûts d'implémentation, le solution n° 2 est retenue.
+
+## Conséquences
+
+Dans le domaine, décrire les types d'identifiants du domaine en fonction de leur implémentation 
+```javascript
+  const implementationType = {
+    positiveInteger32bits: Joi.number().integer().min(postgreSQLSequenceDefaultStart).max(postgreSQLSequenceEnd).required(),
+    alphanumeric255: Joi.string().max(255).required(),
+  };
+  
+  const campaignId = implementationType.positiveInteger32bits;
+  const userId = implementationType.positiveInteger32bits;
+```
+
+N'exposer que les types du domaine
+```javascript
+module.exports = {
+  campaignId,
+  userId,
+};
+```
+
+En entrée de la route, contrôler la conformité de la donnée reçue par rapport au type du domaine
+```javascript
+
+  const identifiersType = require('../../domain/types/identifiers-type');  
+
+  method: 'GET',
+  path: '/api/users/{userId}/campaigns/{campaignId}/profile',
+  config: {
+    validate: {
+      params: Joi.object({
+        userId: identifiersType.userId,
+        campaignId: identifiersType.campaignId,
+      }),
+    },
+```
+
+Ne pas écrire de test d'intégration sur ce contrôle


### PR DESCRIPTION
## :unicorn: Problème
Les contrôles effectués en entrée de l'API ne sont pas complets, voir PR #2456 
La méthode elle-même n'est pas optimale et une solution a été envisagée #2457 du type Convention Over Configuration, mais elle n'est pas satisfaisante

Dans l'avenir, les types d'identifiant peuvent varier par table, notamment un passage du 32 bits au 64 bits pour les `answers`

## :robot: Solution
Remise à plat des besoins,
Discussion des soluitions possibles
Décision et documentation de ce choix
Implémentation

## :rainbow: Remarques

La solution peut être complétée sur les routes suivantes qui emploient des ID composites
- cache
- progression
- scorecard

Un contrôle ayant lieu dans le use-case (et renvoyant 404 au lieu de  400 )  a été déplacé dans la route
`GET /api/answers/{id}/correction`

## :100: Pour tester
Aucun test n'a été créé, sauf le TU du type lui-même.
Les raisons à cela sont exposées dans un ADR en cours par @jonathanperret

Appeler l'API avec une valeur hors de l'intervalle, exemple sur PixAdmin
https://admin-pr2464.review.pix.fr/users/20057120057

Vérifier que l'erreur remontée est une erreur 400 

```
{
	"errors": [
		{
			"status": "400",
			"title": "Bad Request",
			"detail": "L'identifiant de l'utilisateur n'est pas au bon format."
		}
	]
}
```

