### PR TITLE
[BUGFIX] Eviter les erreurs de casse sur les e-mails (PIX-2052).

### DIFF
--- a/api/lib/infrastructure/repositories/membership-repository.js
+++ b/api/lib/infrastructure/repositories/membership-repository.js
@@ -88,17 +88,6 @@ module.exports = {
       .then((memberships) => bookshelfToDomainConverter.buildDomainObjects(BookshelfMembership, memberships));
   },
 
-  isMembershipExistingByOrganizationIdAndEmail(organizationId, email) {
-    return BookshelfMembership
-      .where({ 'memberships.organizationId': organizationId, 'users.email': email })
-      .query((qb) => {
-        qb.innerJoin('users', 'users.id', 'memberships.userId');
-      })
-      .fetch({ require: true })
-      .then(() => true)
-      .catch(() => false);
-  },
-
   updateById({ id, membershipAttributes }) {
     return new BookshelfMembership({ id })
       .save(membershipAttributes, { patch: true, method: 'update', require: true })

--- a/api/lib/infrastructure/repositories/reset-password-demands-repository.js
+++ b/api/lib/infrastructure/repositories/reset-password-demands-repository.js
@@ -7,10 +7,12 @@ module.exports = {
   },
 
   markAsBeingUsed(email) {
-    return ResetPasswordDemand.where({ email }).save({ used: true }, {
-      patch: true,
-      require: false,
-    });
+    return ResetPasswordDemand
+      .query((qb) => qb.where('email', 'ILIKE', email))
+      .save({ used: true }, {
+        patch: true,
+        require: false,
+      });
   },
 
   findByTemporaryKey(temporaryKey) {

--- a/api/lib/infrastructure/repositories/reset-password-demands-repository.js
+++ b/api/lib/infrastructure/repositories/reset-password-demands-repository.js
@@ -25,7 +25,11 @@ module.exports = {
   },
 
   findByUserEmail(email, temporaryKey) {
-    return ResetPasswordDemand.where({ email, used: false, temporaryKey })
+    return ResetPasswordDemand.query((qb) => {
+      qb.where('email', 'ILIKE', email);
+      qb.where({ 'used': false });
+      qb.where({ temporaryKey });
+    })
       .fetch({ require: true })
       .catch((err) => {
         if (err instanceof ResetPasswordDemand.NotFoundError) {

--- a/api/tests/integration/infrastructure/repositories/membership-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/membership-repository_test.js
@@ -486,41 +486,6 @@ describe('Integration | Infrastructure | Repository | membership-repository', ()
     });
   });
 
-  describe('#isMembershipExistingByOrganizationIdAndEmail', () => {
-
-    it('should return true when the membership exists by organizationId and email', async () => {
-      // given
-      const user = databaseBuilder.factory.buildUser();
-      const email = user.email;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ organizationId, userId: user.id });
-
-      await databaseBuilder.commit();
-
-      // when
-      const membershipExists = await membershipRepository.isMembershipExistingByOrganizationIdAndEmail(organizationId, email);
-
-      // then
-      expect(membershipExists).to.be.true;
-    });
-
-    it('should throw an error when the membership does not exist by organizationId and email', async () => {
-      // given
-      const userId = databaseBuilder.factory.buildUser().id;
-      const organizationId = databaseBuilder.factory.buildOrganization().id;
-      databaseBuilder.factory.buildMembership({ organizationId, userId });
-
-      await databaseBuilder.commit();
-
-      // when
-      const membershipExists = await membershipRepository.isMembershipExistingByOrganizationIdAndEmail(organizationId, 'wrongEmail@organization.org');
-
-      // then
-      expect(membershipExists).to.be.false;
-    });
-
-  });
-
   describe('#updateById', () => {
 
     let existingMembershipId;

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -27,7 +27,7 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
   });
 
   describe('#markAsBeingUsed', () => {
-    const email = 'someEmail';
+    const email = 'someEmail@example.net';
 
     beforeEach(() => {
       databaseBuilder.factory.buildResetPasswordDemand({ email, used: false });
@@ -44,6 +44,23 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
         .where({ email })
         .first();
       expect(demand.used).to.be.true;
+    });
+
+    context('when case is not identical', () => {
+      it('should mark demand as used', async () => {
+        // given
+        const sameEmailWithAnotherCase = 'SomeEmaIL@example.net';
+
+        // when
+        await resetPasswordDemandsRepository.markAsBeingUsed(sameEmailWithAnotherCase);
+
+        // then
+        const demand = await knex('reset-password-demands')
+          .select('used')
+          .where({ email })
+          .first();
+        expect(demand.used).to.be.true;
+      });
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -12,7 +12,7 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
 
     it('should create a password reset demand', async () => {
       // when
-      const email = 'someMail';
+      const email = 'someMail@example.net';
       const temporaryKey = 'someKey';
       await resetPasswordDemandsRepository.create({ email, temporaryKey });
 
@@ -98,7 +98,7 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
       });
 
       context('when demand is still up', () => {
-        const email = 'someMail';
+        const email = 'someMail@example.net';
         let demandId;
 
         beforeEach(() => {

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -120,7 +120,7 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
 
     context('when demand exists', () => {
       const temporaryKey = 'someTemporaryKey';
-      const email = 'someMail';
+      const email = 'someMail@example.net';
 
       context('when demand has been used already', () => {
 
@@ -160,6 +160,21 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
           expect(demand.attributes.used).to.equal(false);
         });
 
+        context('when case is not identical', () => {
+          it('should return the bookshelf demand', async () => {
+            // given
+            const sameEmailWithAnotherCase = 'SomeMaIL@example.net';
+
+            // when
+            const demand = await resetPasswordDemandsRepository.findByUserEmail(sameEmailWithAnotherCase, temporaryKey);
+
+            // then
+            expect(demand.attributes.id).to.equal(demandId);
+            expect(demand.attributes.email).to.equal(email);
+            expect(demand.attributes.temporaryKey).to.equal(temporaryKey);
+            expect(demand.attributes.used).to.equal(false);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, un utilisateur peut créer une demande de réinitialisation de mot de passe grâce à son adresse e-mail même si ce dernier a une casse différente. 

Il pourra alors bien recevoir son e-mail comportant un lien lui permettant de réinitialiser son mot de passe. Seulement, au moment de changer son mot de passe on lui affichera un message d'erreur non explicite

En cherchant dans Datadog, nous pouvons voir que nous retournons une 404, car pour l'API il n'existe pas de tuple dans la table `reset-password-demands` avec l'e-mail sans la faute de casse. Cette erreur est créé par la méthode  `findByUserEmail` du `reset-password-demands` repository. 

## :robot: Solution
Laisser la possibilité de créer une demande même si la casse n'est pas bonne, mais gérer ce cas en ajoutant des ILIKE au moment de la vérification dans le repository.

## :rainbow: Remarques
- D'autres endroit avec le même problème ont été repérés et corigés

- Nous considérons les e-mails étant insensibles à la casse

- Les e-mails des users sont stockés en lowercase grâce au modèle du domain qui fait un `.toLowerCase()`.

## :100: Pour tester
- Créer un compte avec e-mail
- Faire une demande de réinitialisation de mot de passe avec le même e-mail mais une casse différente
- Vérifier que le changement de mot de passe est possible
