### PR TITLE
[BUGFIX] Corriger l'apparition furtive de la page d'erreur suite à l'acceptation des CGU Pôle Emploi (PIX-2036).

### DIFF
--- a/mon-pix/app/controllers/terms-of-service-pe.js
+++ b/mon-pix/app/controllers/terms-of-service-pe.js
@@ -25,11 +25,6 @@ export default class TermsOfServicePeController extends Controller {
 
       await this.session.authenticate('authenticator:oidc', { authenticationKey: this.authenticationKey });
 
-      if (this.session.attemptedTransition) {
-        this.session.attemptedTransition.retry();
-      } else {
-        this.transitionToRoute('profile');
-      }
     } else {
       this.showErrorTermsOfServiceNotSelected = true;
     }

--- a/mon-pix/tests/unit/controllers/terms-of-service-pe-test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-pe-test.js
@@ -11,7 +11,6 @@ describe('Unit | Controller | terms-of-service-pe', function() {
 
     beforeEach(function() {
       controller = this.owner.lookup('controller:terms-of-service-pe');
-      controller.transitionToRoute = sinon.stub();
       controller.session = {
         authenticate: sinon.stub().resolves(),
       };
@@ -26,7 +25,6 @@ describe('Unit | Controller | terms-of-service-pe', function() {
 
       // then
       sinon.assert.calledWith(controller.session.authenticate, 'authenticator:oidc', { authenticationKey: 'authenticationKey' });
-      sinon.assert.calledWith(controller.transitionToRoute, 'profile');
       expect(controller.showErrorTermsOfServiceNotSelected).to.be.false;
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à l'acceptation des CGU pour un utilisateur venant du formulaire de connexion Pôle Emploi, on perçoit l'apparition de la page d'erreur de Pix pendant un cours instant avant d'être redirigé vers la campagne. Cette erreur est dû à une gestion à manuelle des transition dans le controller de la route des CGU qui n'est pas nécessaire. En effet, suite à l'acceptation des CGU, nous redirigions vers le profile alors que l'utilisateur n'était pas encore authentifié, ce qui causait l'erreur. Par ailleurs, la redirection de l'utilisateur vers sa campagne est déjà correctement gérée dans la route `application.js` et l'usage dans la sessions de l'attribut `nextUrl`.

## :robot: Solution
Supprimer la gestion manuelle des transition dans le controller de la route des CGU Pôle Emploi.

## :100: Pour tester
- Récupérer la branche en local et rejoindre la campagne Pôle Emploi `QWERTY789`. 
- Accepter les CGU et configurer Chrome en `Slow 3G`.
- Vérifier que la page d'erreur n'apparaît plus et que l'on est bien redirigé vers la page de présentation de la campagne. 
