### PR TITLE
[BUGFIX] L'erreur n'est pas remontée à l'utilisateur lorsque ce dernier importe un fichier CSV d'étudiants comportant une erreur dans la colonne Adresse e-mail dans PixOrga (PIX-2057)

### DIFF
--- a/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/csv-registration-parser.js
@@ -144,6 +144,9 @@ class CsvRegistrationParser {
     if (err.why === 'date_format') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” doit être au format jj/mm/aaaa.`);
     }
+    if (err.why === 'email_format') {
+      throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” doit être une adresse email valide.`);
+    }
     if (err.why === 'required') {
       throw new CsvImportError(`Ligne ${index + 2} : Le champ “${column.label}” est obligatoire.`);
     }

--- a/api/tests/unit/infrastructure/serializers/csv/csv-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/csv-registration-parser_test.js
@@ -184,6 +184,24 @@ describe('Unit | Infrastructure | CsvRegistrationParser', () => {
         });
       });
 
+      context('when error.why is email_format', () => {
+        it('throws a parsing error', async () => {
+          error = new Error();
+          error.key = 'ColumnName';
+          error.why = 'email_format';
+
+          const input = `ColumnLabel;
+          boeuf_bourguignon@chef..com;
+          `;
+          const encodedInput = iconv.encode(input, 'utf8');
+          const parser = new CsvRegistrationParser(encodedInput, organizationId, columns, registrationSet);
+
+          const parsingError = await catchErr(parser.parse, parser)();
+
+          expect(parsingError.message).to.contain('Le champ “ColumnLabel” doit être une adresse email valide.');
+        });
+      });
+
       it('should throw an error including line number', async () => {
         error = new Error();
         error.key = 'ColumnName';


### PR DESCRIPTION
## :unicorn: Problème
Pour inscrire des étudiants à une orga SUP, le prescripteur doit importer les étudiants à l'aide d'un fichier CSV.
Nous avons fait en sorte d'avoir un retour d'erreur précis (n° de ligne, colonne concernée) à l'utilisateur afin qu'il puisse efficacement corriger son erreur dans son CSV. Pour les erreurs non connues/non qualifiées, nous renvoyons un message d'erreur générique très vague. Cela ne devrait jamais arriver pour les erreurs connues.
Or, nous avons oublié de faire remonter le mot d'erreur d'une erreur connue : erreur du format d'adresse e-mail

## :robot: Solution
Ajouter la conversion de cette erreur de validation JOI en erreur API avec le texte approprié.
![nouvelaffichage](https://user-images.githubusercontent.com/48727874/106176662-e2ebeb00-6197-11eb-8c16-da4879188f5f.png)


## :100: Pour tester
Se connecter avec sup.admin@example.net / pix123   sur PixOrga
Se rendre dans l'onglet Etudiants
Télécharger le modèle, remplir une ligne
Importer un CSV comportant une erreur d'adresse mail.
Sur dev -> erreur vague
Sur cette branche -> erreur claire
