### PR TITLE
[TECH] Supprimer les colonnes inutilisées dans users (PIX-1711 PIX-1833).

### DIFF
--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -76,7 +76,6 @@ const buildUser = function buildUser({
     hasSeenNewDashboardInfo,
     hasSeenNewLevelInfo, isAnonymous,
     createdAt, updatedAt,
-    shouldChangePassword: false,
   };
 
   return databaseBuffer.pushInsertable({
@@ -110,7 +109,6 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    shouldChangePassword: false,
   };
 
   const user = databaseBuffer.pushInsertable({
@@ -154,7 +152,6 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    shouldChangePassword: false,
   };
 
   const user = databaseBuffer.pushInsertable({
@@ -200,7 +197,6 @@ buildUser.withMembership = function buildUserWithMemberships({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    shouldChangePassword: false,
   };
 
   const user = databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/build-user.js
+++ b/api/db/database-builder/factory/build-user.js
@@ -76,7 +76,6 @@ const buildUser = function buildUser({
     hasSeenNewDashboardInfo,
     hasSeenNewLevelInfo, isAnonymous,
     createdAt, updatedAt,
-    password: '',
     shouldChangePassword: false,
   };
 
@@ -101,7 +100,6 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
   hasSeenAssessmentInstructions = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-
   rawPassword = 'Password123',
   shouldChangePassword = false,
 } = {}) {
@@ -112,7 +110,6 @@ buildUser.withRawPassword = function buildUserWithRawPassword({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    password: '',
     shouldChangePassword: false,
   };
 
@@ -157,7 +154,6 @@ buildUser.withPixRolePixMaster = function buildUserWithPixRolePixMaster({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    password: '',
     shouldChangePassword: false,
   };
 
@@ -192,10 +188,8 @@ buildUser.withMembership = function buildUserWithMemberships({
   hasSeenAssessmentInstructions = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-
   organizationRole = Membership.roles.ADMIN,
   organizationId = null,
-
   rawPassword = 'Password123',
   shouldChangePassword = false,
 } = {}) {
@@ -206,7 +200,6 @@ buildUser.withMembership = function buildUserWithMemberships({
     lang,
     lastTermsOfServiceValidatedAt, mustValidateTermsOfService, pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted, hasSeenAssessmentInstructions,
-    password: '',
     shouldChangePassword: false,
   };
 
@@ -249,7 +242,6 @@ buildUser.withCertificationCenterMembership = function buildUserWithCertificatio
   hasSeenNewLevelInfo = false,
   createdAt = new Date(),
   updatedAt = new Date(),
-
   certificationCenterId = null,
 } = {}) {
 

--- a/api/db/migrations/20210129110252_remove_password_column_from_users_table.js
+++ b/api/db/migrations/20210129110252_remove_password_column_from_users_table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'password';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME);
+  });
+};

--- a/api/db/migrations/20210129124701_remove_shouldChangePassword_column_from_users_table.js
+++ b/api/db/migrations/20210129124701_remove_shouldChangePassword_column_from_users_table.js
@@ -1,0 +1,15 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'shouldChangePassword';
+const DEFAULT_VALUE = false ;
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean(COLUMN_NAME).defaultTo(DEFAULT_VALUE);
+  });
+};

--- a/api/db/migrations/20210129140117_remove_samlId_column_from_users_table.js
+++ b/api/db/migrations/20210129140117_remove_samlId_column_from_users_table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'users';
+const COLUMN_NAME = 'samlId';
+
+exports.up = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.string(COLUMN_NAME)();
+  });
+};

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -557,7 +557,6 @@ function _adaptModelToDb(user) {
 
   return {
     ...userToBeSaved,
-    password: '',
     shouldChangePassword: false,
   };
 }

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -555,8 +555,5 @@ function _adaptModelToDb(user) {
     'authenticationMethods',
   ]);
 
-  return {
-    ...userToBeSaved,
-    shouldChangePassword: false,
-  };
+  return userToBeSaved;
 }

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -6,7 +6,6 @@
     "email": "daenerys.targaryen@pix.fr",
     "cgu": true,
     "pixOrgaTermsOfServiceAccepted": true,
-    "shouldChangePassword": false,
     "lang": "fr-fr"
   },
   {
@@ -14,8 +13,7 @@
     "firstName": "Samwell",
     "lastName": "Tarly",
     "email": "samwell.tarly@pix.fr",
-    "cgu": true,
-    "shouldChangePassword": false
+    "cgu": true
   },
   {
     "id": 3,
@@ -23,32 +21,28 @@
     "lastName": "Snow",
     "email": "john.snow@pix.fr",
     "cgu": true,
-    "pixOrgaTermsOfServiceAccepted": true,
-    "shouldChangePassword": false
+    "pixOrgaTermsOfServiceAccepted": true
   },
   {
     "id": 4,
     "firstName": "Tyrion",
     "lastName": "Lannister",
     "email": "tyrion.lannister@example.net",
-    "cgu": true,
-    "shouldChangePassword": false
+    "cgu": true
   },
   {
     "id": 5,
     "firstName": "Jaime",
     "lastName": "Lannister",
     "email": "jaime.lannister@example.net",
-    "cgu": true,
-    "shouldChangePassword": false
+    "cgu": true
   },
   {
     "id": 6,
     "firstName": "Cersei",
     "lastName": "Lannister",
     "email": "cersei.lannister@example.net",
-    "cgu": true,
-    "shouldChangePassword": false
+    "cgu": true
   },
   {
     "id": 7,
@@ -56,15 +50,13 @@
     "lastName": "Pro",
     "email": "certif.pro@example.net",
     "cgu": true,
-    "pixCertifTermsOfServiceAccepted": true,
-    "shouldChangePassword": false
+    "pixCertifTermsOfServiceAccepted": true
   },
   {
     "id": 8,
     "firstName": "user",
     "lastName": "name",
-    "username": "user.shouldChangePassword1234",
-    "shouldChangePassword": false
+    "username": "user.shouldChangePassword1234"
   },
   {
     "id": 9,
@@ -72,8 +64,7 @@
     "lastName": "Baratheon",
     "email": "user-who-must-validate-the-last-terms-of-service@example.net",
     "cgu": true,
-    "mustValidateTermsOfService": true,
-    "shouldChangePassword": false
+    "mustValidateTermsOfService": true
   },
   {
     "id": 10,
@@ -81,8 +72,7 @@
     "lastName": "Targaryen",
     "email": "aemon.targaryen@pix.fr",
     "cgu": true,
-    "pixOrgaTermsOfServiceAccepted": true,
-    "shouldChangePassword": false
+    "pixOrgaTermsOfServiceAccepted": true
   },
   {
     "id": 11,
@@ -90,13 +80,11 @@
     "lastName": "Sup",
     "email": "certif.sup@example.net",
     "cgu": true,
-    "pixCertifTermsOfServiceAccepted": true,
-    "shouldChangePassword": false
+    "pixCertifTermsOfServiceAccepted": true
   },
   {
     "id": 12,
     "firstName": "user",
-    "lastName": "gar",
-    "shouldChangePassword": false
+    "lastName": "gar"
   }
 ]

--- a/high-level-tests/e2e/cypress/fixtures/users.json
+++ b/high-level-tests/e2e/cypress/fixtures/users.json
@@ -6,7 +6,6 @@
     "email": "daenerys.targaryen@pix.fr",
     "cgu": true,
     "pixOrgaTermsOfServiceAccepted": true,
-    "password": "",
     "shouldChangePassword": false,
     "lang": "fr-fr"
   },
@@ -16,7 +15,6 @@
     "lastName": "Tarly",
     "email": "samwell.tarly@pix.fr",
     "cgu": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -26,7 +24,6 @@
     "email": "john.snow@pix.fr",
     "cgu": true,
     "pixOrgaTermsOfServiceAccepted": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -35,7 +32,6 @@
     "lastName": "Lannister",
     "email": "tyrion.lannister@example.net",
     "cgu": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -44,7 +40,6 @@
     "lastName": "Lannister",
     "email": "jaime.lannister@example.net",
     "cgu": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -53,7 +48,6 @@
     "lastName": "Lannister",
     "email": "cersei.lannister@example.net",
     "cgu": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -63,7 +57,6 @@
     "email": "certif.pro@example.net",
     "cgu": true,
     "pixCertifTermsOfServiceAccepted": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -71,7 +64,6 @@
     "firstName": "user",
     "lastName": "name",
     "username": "user.shouldChangePassword1234",
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -81,7 +73,6 @@
     "email": "user-who-must-validate-the-last-terms-of-service@example.net",
     "cgu": true,
     "mustValidateTermsOfService": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -91,7 +82,6 @@
     "email": "aemon.targaryen@pix.fr",
     "cgu": true,
     "pixOrgaTermsOfServiceAccepted": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
@@ -101,14 +91,12 @@
     "email": "certif.sup@example.net",
     "cgu": true,
     "pixCertifTermsOfServiceAccepted": true,
-    "password": "",
     "shouldChangePassword": false
   },
   {
     "id": 12,
     "firstName": "user",
     "lastName": "gar",
-    "password": "",
     "shouldChangePassword": false
   }
 ]


### PR DESCRIPTION
## :unicorn: Problème
Depuis les PR #2200 et #2125 , les colonnes suivantes de la table `users` ne sont plus utilisées :
- password 
- shouldChangePassword
- samlId

## :robot: Solution
Supprimer 
- les références éventuelles
- les colonnes en BDD

## :rainbow: Remarques

### Contraintes
Les contraintes relatives à une colonne (ici, le NOT NULL) sont [automatiquement supprimées](https://www.postgresql.org/docs/current/ddl-alter.html)

### Restauration de la version précédente
La partie `down` des scripts de migration peut être invoquée si la version précédente doit être restaurée:
- lors du déploiement, car une version du front impossible à déployer
- après le déploiement, si découverte d'un bug dans la version actuelle (API ou front)

Ici, elle a été implémentée en
- recréant la colonne
- de manière compatible avec les données existantes (ex: `password` est à l'origine NOT NULL, mais sans valeur par défaut, la contrainte NOT NULL a donc été omise ici)

Note: si l'une des migrations échoue, c'est le `ROLLBACK` qui est invoqué, pas le `down`

### Gestion des locks
Les 3 migrations affectant la table users, et seulement celle-ci, il n'y a aucun risque de deadlock.
L'instruction DROP COLUMN va chercher à acquérir un verrou ACCESS EXCLUSIVE qui mettra en file d'attente certaines requêtes, comme la création de compte. Cela n'est pas un problème car l'opération est rapide, [ne nécessitant pas](https://fluca1978.github.io/2020/02/09/PostgreSQLDROPCOlumn.html) la réécriture intégrale et immédiate de la table sur le FS

### Metabase
Vérifier que les rapports mentionnant ces champs soient mis à jour

## :100: Pour tester
Créer les conditions de production:
- créer table avec les colonnes à supprimer et données
- exécution de la migration introduite par la branche

En local:
- `git checkout HEAD~`
- `npm run db:reset`
- `git checkout HEAD@{1}`
- `npm run db:migrate`
- vérifier que le script est sorti sans erreur
- vérifier que la colonne n'est plus présente

Sur la RA:
- supprimer les tables créés par le déploiement initial
  - `scalingo --app pix-api-review-pr2472 pgsql-console` 
  - `DROP OWNED BY CURRENT_USER CASCADE;`
- créer les tables et les alimenter 
  - déployer la dernière relase de `dev`, ex: `scalingo --app pix-api-review-pr2472 deploy https://github.com/1024pix/pix/archive/v3.9.0.tar.gz`
  - `scalingo -app pix-api-review-pr2472 run 'npm run db:seed'`
- déployer la version de `tech-remove-unused-users-password-column` avec un manual deploy 
- vérifier que le déploiement est sorti sans erreur
- vérifier que les colonnes ne sont plus présentes
  - `scalingo --app pix-api-review-pr2472 pgsql-console` 
  - `select id, password, "samdId", "shouldChangePasssword" from users limit 1;`