### PR TITLE
[FEATURE] Permettre aux utilisateurs de modifier leur adresse e-mail (PIX-2045).

### DIFF
--- a/mon-pix/app/adapters/user.js
+++ b/mon-pix/app/adapters/user.js
@@ -85,6 +85,11 @@ export default class User extends ApplicationAdapter {
       return url + `/password-update?temporary-key=${encodeURIComponent(temporaryKey)}`;
     }
 
+    if (adapterOptions && adapterOptions.updateEmail) {
+      delete adapterOptions.updatePassword;
+      return url + '/email';
+    }
+
     return url;
   }
 }

--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -1,8 +1,33 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import isEmailValid from '../utils/email-validator';
 
 export default class UserAccountPanel extends Component {
 
+  @tracked isEmailEditionMode = false;
+  @tracked newEmail = '';
+
   get displayUsername() {
     return !!this.args.user.username;
+  }
+
+  @action
+  enableEmailEditionMode() {
+    this.isEmailEditionMode = true;
+  }
+
+  @action
+  disableEmailEditionMode() {
+    this.isEmailEditionMode = false;
+  }
+
+  @action
+  saveNewEmail() {
+    if (isEmailValid(this.newEmail)) {
+      this.args.user.email = this.newEmail;
+      this.args.user.save({ adapterOptions: { updateEmail: true } });
+      this.isEmailEditionMode = false;
+    }
   }
 }

--- a/mon-pix/app/styles/components/_user-account-panel.scss
+++ b/mon-pix/app/styles/components/_user-account-panel.scss
@@ -3,6 +3,7 @@
   &__item {
     margin: 20px 0;
     display: flex;
+    align-items: center;
     align-content: flex-start;
     border-bottom: $grey-15 1px solid;
     padding-bottom: 1rem;
@@ -21,5 +22,13 @@
 
   &__value {
     color: $grey-50;
+  }
+
+  &__button {
+    margin-left: auto;
+  }
+
+  &__actions {
+    margin-left: auto;
   }
 }

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -10,7 +10,28 @@
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</span>
     <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
+    {{#unless this.isEmailEditionMode}}
+      <PixButton class="user-account-panel-item__button button" @triggerAction={{this.enableEmailEditionMode}} data-test-edit-email>
+        {{t 'pages.user-account.account-panel.edit-button'}}
+      </PixButton>
+    {{/unless}}
   </div>
+  {{#if this.isEmailEditionMode}}
+    <div class="user-account-panel__item">
+      <label class="form-textfield__label user-account-panel-item__label" for="new-email">
+        {{t 'pages.user-account.account-panel.new-email'}}
+      </label>
+      <Input id="new-email" @type="email" @value={{this.newEmail}} data-test-new-email />
+      <div class="user-account-panel-item__actions">
+        <PixButton class="user-account-panel-item__button button" type="button" @triggerAction={{this.disableEmailEditionMode}} data-test-cancel-email>
+          {{t 'common.actions.cancel'}}
+        </PixButton>
+        <PixButton class="user-account-panel-item__button button" type="submit" @triggerAction={{this.saveNewEmail}} data-test-submit-email>
+          {{t 'pages.user-account.account-panel.save-button'}}
+        </PixButton>
+      </div>
+    </div>
+  {{/if}}
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</span>

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -1,19 +1,19 @@
 <PixBlock>
   <div class="user-account-panel__item">
-    <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.first-name'}}</label>
+    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.first-name'}}</span>
     <span class="user-account-panel-item__value" data-test-firstName>{{@user.firstName}}</span>
   </div>
   <div class="user-account-panel__item">
-    <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.last-name'}}</label>
+    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.last-name'}}</span>
     <span class="user-account-panel-item__value" data-test-lastName>{{@user.lastName}}</span>
   </div>
   <div class="user-account-panel__item">
-    <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.email'}}</label>
+    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</span>
     <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
   </div>
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">
-    <label class="form-textfield__label user-account-panel-item__label">{{t 'navigation.user.account-panel.username'}}</label>
+    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</span>
     <span class="user-account-panel-item__value" data-test-username>{{@user.username}}</span>
   </div>
   {{/if}}

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -23,6 +23,13 @@ export default function index(config) {
   config.get('/users/:id/campaign-participations', getUserCampaignParticipations);
   config.get('/users/:id/campaign-participation-overviews', getUserCampaignParticipationOverviews);
 
+  config.patch('/users/:id/email', (schema, request) => {
+    const body = JSON.parse(request.requestBody);
+    const user = schema.users.find(request.params.id);
+    user.update({ email: body.data.attributes.email });
+    return new Response(204);
+  });
+
   config.patch('/users/:id/password-update', (schema, request) => {
     const body = JSON.parse(request.requestBody);
     const user = schema.users.find(request.params.id);

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -1,4 +1,4 @@
-import { currentURL } from '@ember/test-helpers';
+import { click, currentURL, fillIn } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
@@ -34,6 +34,21 @@ describe('Acceptance | User account page', function() {
 
       // then
       expect(currentURL()).to.equal('/mon-compte');
+    });
+
+    it('should edit e-mail', async function() {
+      // given
+      const newEmail = 'new-email@example.net';
+      await authenticateByEmail(user);
+      await visit('/mon-compte');
+
+      // when
+      await click('button[data-test-edit-email]');
+      await fillIn('input[data-test-new-email]', newEmail);
+      await click('button[data-test-submit-email]');
+
+      // then
+      expect(user.email).to.equal(newEmail);
     });
   });
 });

--- a/mon-pix/tests/unit/adapters/user-test.js
+++ b/mon-pix/tests/unit/adapters/user-test.js
@@ -90,6 +90,14 @@ describe('Unit | Adapters | user', function() {
       expect(url.endsWith('/users/123/lang/en')).to.be.true;
     });
 
+    it('should redirect to email when updateEmail adapter option is include', async function() {
+      // when
+      const options = { adapterOptions: { updateEmail: true, newPassword: 'NeWPa$$word' } };
+      const url = await adapter.urlForUpdateRecord(123, 'user', options);
+
+      // then
+      expect(url.endsWith('/users/123/email')).to.be.true;
+    });
   });
 
   describe('#createRecord', () => {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -927,7 +927,14 @@
             "title": "My personalised tests"
         },
         "user-account": {
-            "title": "My account"
+            "title": "My account",
+            "account-panel": {
+                "first-name": "First name",
+                "last-name": "Last name",
+                "email": "Email address",
+                "new-email": "New email address",
+                "username": "Username",
+            }
         },
         "user-tutorials": {
             "title": "My tutorials",
@@ -1047,12 +1054,6 @@
         "pix": "Pix",
         "user": {
             "account": "My account",
-            "account-panel": {
-                "first-name": "First name",
-                "last-name": "Last name",
-                "email": "Email address",
-                "username": "Username"
-            },
             "certifications": "My certifications",
             "sign-out": "Log out"
         },

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -934,6 +934,8 @@
                 "email": "Email address",
                 "new-email": "New email address",
                 "username": "Username",
+                "edit-button": "Edit",
+                "save-button": "Save"
             }
         },
         "user-tutorials": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -927,7 +927,14 @@
             "title": "Mes parcours"
         },
         "user-account": {
-            "title": "Mon compte"
+            "title": "Mon compte",
+            "account-panel": {
+                "first-name": "Prénom",
+                "last-name": "Nom",
+                "email": "Adresse e-mail",
+                "new-email": "Nouvelle adresse e-mail",
+                "username": "Identifiant",
+            }
         },
         "user-tutorials": {
             "title": "Mes tutos",
@@ -1050,12 +1057,6 @@
         },
         "user": {
             "account": "Mon compte",
-            "account-panel": {
-                "first-name": "Prénom",
-                "last-name": "Nom",
-                "email": "Adresse e-mail",
-                "username": "Identifiant"
-            },
             "certifications": "Mes certifications",
             "sign-out": "Se déconnecter"
         }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -934,6 +934,8 @@
                 "email": "Adresse e-mail",
                 "new-email": "Nouvelle adresse e-mail",
                 "username": "Identifiant",
+                "edit-button": "Modifier",
+                "save-button": "Enregistrer"
             }
         },
         "user-tutorials": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous ne proposons pas à nos utilisateurs de changer d'adresse e-mail. Comme à l'inscription, nous ne vérifions pas l'adresse e-mail, les utilisateurs peuvent se retrouver bloqués et dès lors contactent le support.

## :robot: Solution
Proposer à l'utilisateur de modifier son e-mail dans la page `/mon-compte` en utilisant la route existante `/users/:id/email/`

## :rainbow: Remarques
Dans cette première solution (étant couvert par un feature toggle), nous proposons simplement de modifier l'adresse e-mail et d'enregistrer la modification, sans :
- demander une confirmation
- demander le mot de passe
- gérer les éventuelles erreurs. 

## :100: Pour tester
Aller sur la page : `/mon-compte` et modifier l'e-mail de l'utilisateur. 
(Ajout `FT_MY_ACCOUNT= true` en RA, à ajouter en local si test local)