### PR TITLE
[FEATURE] Améliorations de la page de finalisation de session (PIX-1996)

### DIFF
--- a/certif/app/components/issue-report-modal/add-issue-report-modal.js
+++ b/certif/app/components/issue-report-modal/add-issue-report-modal.js
@@ -129,7 +129,6 @@ export default class AddIssueReportModal extends Component {
     this.technicalProblemCategory,
   ];
 
-  @tracked reportLength = 0;
   @tracked showCategoryMissingError = false;
   @tracked showIssueReportSubmitError = false;
 
@@ -156,10 +155,5 @@ export default class AddIssueReportModal extends Component {
       issueReportToSave.rollbackAttributes();
       this.showIssueReportSubmitError = true;
     }
-  }
-
-  @action
-  handleTextareaChange(e) {
-    this.reportLength = e.target.value.length;
   }
 }

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.hbs
@@ -18,15 +18,11 @@
         @onChange={{this.onChangeSubcategory}}
       />
       <label for="text-area-for-category-candidate-information-change">{{this.subcategoryTextAreaLabel}}</label>
-      <Textarea
-        id="text-area-for-category-candidate-information-change"
-        @class="session-finalization-reports-informations-step__textarea"
+      <PixTextarea
+        @id="text-area-for-category-candidate-information-change"
         @value={{@candidateInformationChangeCategory.description}}
         @maxlength={{@maxlength}}
-        required
-      />
-      <p class="candidate-information-change-certification-issue-report-fields-details__char-count">{{this.reportLength}}
-        / {{@maxlength}}</p>
+        required="true" />
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/candidate-information-change-certification-issue-report-fields.js
@@ -13,12 +13,6 @@ export default class CandidateInformationChangeCertificationIssueReportFieldsCom
   @tracked
   subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.candidateInformationChangeCategory.subcategory];
 
-  get reportLength() {
-    return this.args.candidateInformationChangeCategory.description
-      ? this.args.candidateInformationChangeCategory.description.length
-      : 0;
-  }
-
   @action
   onChangeSubcategory(event) {
     this.args.candidateInformationChangeCategory.subcategory = event.target.value;

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -16,9 +16,11 @@
       <Input
         @id="input-for-category-in-challenge-question-number"
         @name="question-number"
-        @type="text"
+        @type="number"
+        @max="500"
         @required="true"
         @value={{@inChallengeCategory.questionNumber}}
+        placeholder="7"
       />
       <label for="subcategory-for-category-in-challenge">Sélectionnez une sous-catégorie :</label>
       <PixSelect

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -17,7 +17,7 @@
         @id="input-for-category-in-challenge-question-number"
         @name="question-number"
         @type="number"
-        @max="500"
+        @max="48"
         @required="true"
         @value={{@inChallengeCategory.questionNumber}}
         placeholder="7"
@@ -32,15 +32,11 @@
       />
       {{#if this.isOtherSubcategorySelected }}
         <label for="text-area-for-category-in-challenge-subcategory-other">Précisez</label>
-        <Textarea
-          id="text-area-for-category-in-challenge-subcategory-other"
-          @class="session-finalization-reports-informations-step__textarea"
+        <PixTextarea
+          @id="text-area-for-category-in-challenge-subcategory-other"
           @value={{@inChallengeCategory.description}}
           @maxlength={{@maxlength}}
-          required
-        />
-        <p class="candidate-information-change-certification-issue-report-fields-details__char-count">{{this.reportLength}}
-          / {{@maxlength}}</p>
+          required="true" />
       {{/if}}
     </div>
   {{/if}}

--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.js
@@ -3,11 +3,6 @@ import { action } from '@ember/object';
 import { certificationIssueReportSubcategories, subcategoryToLabel, subcategoryToCode } from 'pix-certif/models/certification-issue-report';
 
 export default class InChallengeCertificationIssueReportFields extends Component {
-  get reportLength() {
-    return this.args.inChallengeCategory.description
-      ? this.args.inChallengeCategory.description.length
-      : 0;
-  }
 
   get isOtherSubcategorySelected() {
     return this.args.inChallengeCategory.subcategory === certificationIssueReportSubcategories.OTHER;

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.hbs
@@ -18,14 +18,11 @@
         @onChange={{this.onChangeSubcategory}}
       />
       <label for="text-area-for-category-late-or-leaving">{{this.subcategoryTextAreaLabel}}</label>
-      <Textarea
-        id="text-area-for-category-late-or-leaving"
-        @class="session-finalization-reports-informations-step__textarea"
+      <PixTextarea
+        @id="text-area-for-category-late-or-leaving"
         @value={{@lateOrLeavingCategory.description}}
         @maxlength={{@maxlength}}
-        required
-      />
-      <p class="late-or-leaving-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+        required="true" />
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/late-or-leaving-certification-issue-report-fields.js
@@ -13,12 +13,6 @@ export default class OtherCertificationissueReportFields extends Component {
   @tracked
   subcategoryTextAreaLabel = subcategoryToTextareaLabel[this.args.lateOrLeavingCategory.subcategory];
 
-  get reportLength() {
-    return this.args.lateOrLeavingCategory.description
-      ? this.args.lateOrLeavingCategory.description.length
-      : 0;
-  }
-
   @action
   onChangeSubcategory(event) {
     this.args.lateOrLeavingCategory.subcategory = event.target.value;

--- a/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/other-certification-issue-report-fields.hbs
@@ -11,14 +11,11 @@
   {{#if @otherCategory.isChecked}}
     <div class="other-certification-issue-report-fields__details">
       <label for="text-area-for-category-other">Décrivez l’incident</label>
-      <Textarea
+      <PixTextarea
         id="text-area-for-category-other"
-        @class="session-finalization-reports-informations-step__textarea"
         @value={{@otherCategory.description}}
         @maxlength={{@maxlength}}
-        required
-      />
-      <p class="other-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+        required="true" />
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/other-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/other-certification-issue-report-fields.js
@@ -1,9 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class OtherCertificationIssueReportFields extends Component {
-  get reportLength() {
-    return this.args.otherCategory.description
-      ? this.args.otherCategory.description.length
-      : 0;
-  }
-}

--- a/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.hbs
@@ -11,15 +11,12 @@
   {{#if @technicalProblemCategory.isChecked}}
     <div class="technical-problem-certification-issue-report-fields__details">
       <label for="text-area-for-category-technical-problem">Décrivez l'incident rencontré</label>
-      <Textarea
+      <PixTextarea
         id="text-area-for-category-technical-problem"
-        @class="session-finalization-reports-informations-step__textarea"
         @value={{@technicalProblemCategory.description}}
         @maxlength={{@maxlength}}
         @placeholder="L'ordinateur s'est éteint, lenteur significative du réseau et/ou de l'appareil, etc..."
-        required
-      />
-      <p class="technical-problem-certification-issue-report-fields-details__char-count">{{this.reportLength}} / {{@maxlength}}</p>
+        required="true" />
     </div>
   {{/if}}
 </fieldset>

--- a/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.js
+++ b/certif/app/components/issue-report-modal/technical-problem-certification-issue-report-fields.js
@@ -1,9 +1,0 @@
-import Component from '@glimmer/component';
-
-export default class IssueReportModalTechnicalProblemCertificationIssueReportFieldsComponent extends Component {
-  get reportLength() {
-    return this.args.technicalProblemCategory.description
-      ? this.args.technicalProblemCategory.description.length
-      : 0;
-  }
-}

--- a/certif/app/components/session-finalization-examiner-global-comment-step.hbs
+++ b/certif/app/components/session-finalization-examiner-global-comment-step.hbs
@@ -29,34 +29,24 @@
       </div>
     </div>
     {{#if this.displayExaminerGlobalCommentTextArea}}
-      <div class="session-finalization-examiner-global-comment-step__header-container">
-        <div class="session-finalization-examiner-global-comment-step__characters-information">
-          {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
-        </div>
-      </div>
-      <Textarea
-              @id="examiner-global-comment"
-              class="session-finalization-examiner-global-comment-step__textarea"
-              @value={{@session.examinerGlobalComment}}
+      <PixTextarea
+        @id="examiner-global-comment"
         {{on 'input' @updateExaminerGlobalComment}}
-              @maxlength={{@examinerGlobalCommentMaxLength}}
-      />
+        @value={{@session.examinerGlobalComment}}
+        @maxlength={{@examinerGlobalCommentMaxLength}}
+        class="session-finalization-examiner-global-comment-step__textarea" />
     {{/if}}
   {{else}}
     <div class="session-finalization-examiner-global-comment-step__header-container">
       <label for="examiner-global-comment" class="session-finalization-examiner-global-comment-step__label">
         Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.
       </label>
-      <div class="session-finalization-examiner-global-comment-step__characters-information">
-        {{@session.examinerGlobalComment.length}} / {{@examinerGlobalCommentMaxLength}}
-      </div>
     </div>
-    <Textarea
-            @id="examiner-global-comment"
-            class="session-finalization-examiner-global-comment-step__textarea"
-            @value={{@session.examinerGlobalComment}}
+    <PixTextarea
+      @id="examiner-global-comment"
       {{on 'input' @updateExaminerGlobalComment}}
-            @maxlength={{@examinerGlobalCommentMaxLength}}
-    />
+      @value={{@session.examinerGlobalComment}}
+      @maxlength={{@examinerGlobalCommentMaxLength}}
+      class="session-finalization-examiner-global-comment-step__textarea" />
   {{/if}}
 </div>

--- a/certif/app/components/session-finalization-reports-informations-step.hbs
+++ b/certif/app/components/session-finalization-reports-informations-step.hbs
@@ -47,12 +47,11 @@
                 {{/if}}
               </div>
             {{else}}
-              <Textarea
-                @class="session-finalization-reports-informations-step__textarea"
-                @value={{report.firstIssueReportDescription}}
+              <PixTextarea
                 {{on 'input' (fn @updateCertificationIssueReport report)}}
+                @value={{report.firstIssueReportDescription}}
                 @maxlength={{@issueReportDescriptionMaxLength}}
-              />
+                class="session-finalization-reports-informations-step__textarea--without-indicator" />
             {{/if}}
           </td>
           <td>

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -44,6 +44,10 @@
       }
     }
 
+    input {
+      outline: 2px transparent;
+    }
+
     &--frame {
       max-height: 50vh;
       overflow-y: scroll;
@@ -151,7 +155,7 @@
           &:focus {
             outline: 2px solid $communication-dark;
             -moz-outline-radius: 4px;
-            border: none;
+            border-color: transparent;
           }
 
           &::placeholder {
@@ -180,24 +184,8 @@
         padding-left: 32px;
 
         textarea {
-          box-sizing: border-box;
-          border: 1.2px solid $blue-zodia;
-          border-radius: 4px;
+          box-shadow: none;
           min-height: 82px;
-          padding: 8px;
-
-          &:focus {
-            outline: 2px solid $communication-dark;
-            -moz-outline-radius: 4px;
-            border: none;
-          }
-        }
-
-        p[class$="certification-issue-report-fields-details__char-count"] {
-          margin-top: 6px;
-          font-size: 12px;
-          display: flex;
-          flex-direction: row-reverse;
         }
       }
     }

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -29,6 +29,8 @@
     border-bottom: 1px solid $grey-20;
     padding: 22px 32px;
     background-color: $grey-10;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
 
     h2 {
       font-size: 0.875rem;

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -153,6 +153,16 @@
             -moz-outline-radius: 4px;
             border: none;
           }
+
+          &::placeholder {
+            color: transparent;
+          }
+
+          &:not(:placeholder-shown):invalid {
+            outline: 2px solid $information-dark;
+            -moz-outline-radius: 4px;
+            border: none;
+          }
         }
 
         label[for|="input-radio-for-category"] {

--- a/certif/app/styles/components/add-issue-report-modal.scss
+++ b/certif/app/styles/components/add-issue-report-modal.scss
@@ -58,6 +58,14 @@
       border-radius: 4px;
       padding: 24px;
 
+      button {
+        font-weight: 500;
+
+        svg {
+          margin-right: 8px;
+        }
+      }
+
       .add-issue-report-modal-content__category-label {
         font-family: $roboto;
         padding: 0;
@@ -78,14 +86,6 @@
         color: $grey-50;
         padding: 0 0 0 16px;
         margin: 8px 0 0 0;
-      }
-
-      button {
-        font-weight: 500;
-
-        svg {
-          margin-right: 8px;
-        }
       }
     }
 
@@ -129,11 +129,8 @@
         min-width: 0;
         margin-bottom: 22px;
 
-        label[for^="input-radio-for-category"] {
-
-          span {
-            font-weight: bold;
-          }
+        label[for^="input-radio-for-category"] span {
+          font-weight: bold;
         }
 
         input[id|="input-radio-for-category"] {

--- a/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
+++ b/certif/app/styles/components/session-finalization-examiner-global-comment-step.scss
@@ -17,30 +17,9 @@
     line-height: 22px;
   }
 
-  &__characters-information {
-    flex: 1 0 auto;
-    min-width: max-content;
-    font-size: 0.85rem;
-    align-self: flex-end;
-  }
-
   &__textarea {
     box-sizing: border-box;
     width: 100%;
     height: 116px;
-    resize: none;
-    border-color: $grey-20;
-    border-style: solid;
-    border-radius: 4px;
-    padding: 8px;
-    font-family: $roboto;
-    color: $grey-40;
-    font-size: 1rem;
-
-    &:focus {
-      outline: 2px solid $communication-light;
-      -moz-outline-radius: 4px;
-      border: none;
-    }
   }
 }

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -10,7 +10,7 @@
     align-items: center;
   }
 
-  &__textarea--without-indicator p {
+  &__textarea--without-indicator + p {
     display: none;
   }
 

--- a/certif/app/styles/components/session-finalization-reports-informations-step.scss
+++ b/certif/app/styles/components/session-finalization-reports-informations-step.scss
@@ -10,18 +10,8 @@
     align-items: center;
   }
 
-  &__textarea {
-    box-shadow: none;
-    font-family: $roboto;
-    font-size: 0.8125rem;
-    color: $grey-80;
-    width: 100%;
-    height: 50px;
-    padding: 4px;
-    max-height: 52px;
-    resize: none;
-    border: 1px solid $grey-20;
-    border-radius: 4px;
+  &__textarea--without-indicator p {
+    display: none;
   }
 
   &__checker {

--- a/certif/app/styles/globals/app-modal.scss
+++ b/certif/app/styles/globals/app-modal.scss
@@ -150,7 +150,12 @@ $pix-modal-border-radius: 5px;
 .ember-modal-overlay {
   display: flex;
   justify-content: center;
-  align-items: center;
+  overflow: scroll;
+
+  & > div {
+    height: max-content;
+    margin-top: 10vh;
+  }
 }
 
 .ember-modal-overlay.translucent {

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -19210,8 +19210,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#887ca2307cfba3a946bafd79289af8e70c9e3ff2",
-      "from": "git://github.com/1024pix/pix-ui.git#v1.6.0",
+      "version": "git://github.com/1024pix/pix-ui.git#0c2ba5ff4322455790cb14877fc883123e3735f0",
+      "from": "git://github.com/1024pix/pix-ui.git#v2.0.3",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/certif/package.json
+++ b/certif/package.json
@@ -86,7 +86,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.15",
     "p-queue": "^6.3.0",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v1.6.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.0.3",
     "qunit-dom": "^1.6.0",
     "sass": "^1.26.3",
     "stylelint": "^13.7.2",

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -150,8 +150,7 @@ module('Acceptance | Session Finalization', function(hooks) {
 
           // then
           assert.equal(finalizeController.session.examinerGlobalComment, expectedComment);
-          assert.dom('.session-finalization-examiner-global-comment-step__characters-information').exists();
-          assert.dom('.session-finalization-examiner-global-comment-step__characters-information').hasText(expectedIndicator);
+          assert.dom('#examiner-global-comment + p').hasText(expectedIndicator);
         });
 
         test('it checks the hasSeenEndTestScreen checkbox', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
@@ -1,9 +1,8 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
-import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
 
 module('Integration | Component | candidate-information-change-certification-issue-report-fields', function(hooks) {
@@ -11,7 +10,6 @@ module('Integration | Component | candidate-information-change-certification-iss
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-candidate-information-change';
   const TEXTAREA_SELECTOR = '#text-area-for-category-candidate-information-change';
-  const CHAR_COUNT_SELECTOR = '.candidate-information-change-certification-issue-report-fields-details__char-count';
   const SUBCATEGORY_SELECTOR = '#subcategory-for-category-candidate-information-change';
 
   test('it should call toggle function on click radio button', async function(assert) {
@@ -53,26 +51,6 @@ module('Integration | Component | candidate-information-change-certification-iss
     // then
     assert.dom(SUBCATEGORY_SELECTOR).exists();
     assert.dom(TEXTAREA_SELECTOR).exists();
-  });
-
-  test('it should count textarea characters length', async function(assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const candidateInformationChangeCategory = new RadioButtonCategoryWithDescription({ name: 'CANDIDATE_INFORMATION_CHANGE', isChecked: true });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('candidateInformationChangeCategory', candidateInformationChangeCategory);
-
-    // when
-    await render(hbs`
-      <IssueReportModal::CandidateInformationChangeCertificationIssueReportFields
-        @candidateInformationChangeCategory={{this.candidateInformationChangeCategory}}
-        @toggleOnCategory={{this.toggleOnCategory}}
-        @maxlength={{500}}
-      />`);
-    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
-
-    // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
   });
 
   test('it should show "Précisez les informations à modifier" if subcategory NAME_OR_BIRTHDATE is selected', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import {
@@ -14,7 +14,6 @@ import { RadioButtonCategoryWithSubcategoryWithDescriptionAndQuestionNumber } fr
 
 module('Integration | Component | in-challenge-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
-  const CHAR_COUNT_SELECTOR = '.candidate-information-change-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -62,25 +61,4 @@ module('Integration | Component | in-challenge-certification-issue-report-fields
     assert.contains(`${subcategoryToCode[certificationIssueReportSubcategories.OTHER]} ${subcategoryToLabel[certificationIssueReportSubcategories.OTHER]}`);
   });
 
-  test('it should show a textarea with characters length when selecting subcategory OTHER', async function(assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const inChallengeCategory = new RadioButtonCategoryWithSubcategoryWithDescriptionAndQuestionNumber({ name: 'IN_CHALLENGE', isChecked: true });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('inChallengeCategory', inChallengeCategory);
-
-    // when
-    await render(hbs`
-      <IssueReportModal::InChallengeCertificationIssueReportFields
-        @inChallengeCategory={{this.inChallengeCategory}}
-        @toggleOnCategory={{this.toggleOnCategory}}
-        @maxlength={{500}}
-      />`);
-    await click('[aria-label="Sélectionner la sous-catégorie"]');
-    await fillIn('[aria-label="Sélectionner la sous-catégorie"]', certificationIssueReportSubcategories.OTHER);
-    await fillIn('textarea', 'Coucou');
-
-    // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
-  });
 });

--- a/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
 
 import sinon from 'sinon';
@@ -13,7 +12,6 @@ module('Integration | Component | late-or-leaving-certification-issue-report-fie
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-late-or-leaving';
   const TEXTAREA_SELECTOR = '#text-area-for-category-late-or-leaving';
   const SUBCATEGORY_SELECTOR = '#subcategory-for-category-late-or-leaving';
-  const CHAR_COUNT_SELECTOR = '.late-or-leaving-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -98,25 +96,5 @@ module('Integration | Component | late-or-leaving-certification-issue-report-fie
     assert.dom(SUBCATEGORY_SELECTOR).exists();
     assert.dom(TEXTAREA_SELECTOR).exists();
     assert.contains('Précisez et indiquez l’heure de sortie');
-  });
-
-  test('it should count textarea characters length', async function(assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const lateOrLeavingCategory = new RadioButtonCategoryWithDescription({ name: 'LATE_OR_LEAVING', isChecked: true });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('lateOrLeavingCategory', lateOrLeavingCategory);
-
-    // when
-    await render(hbs`
-      <IssueReportModal::LateOrLeavingCertificationIssueReportFields
-        @lateOrLeavingCategory={{this.lateOrLeavingCategory}}
-        @toggleOnCategory={{this.toggleOnCategory}}
-        @maxlength={{500}}
-      />`);
-    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
-
-    // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
   });
 });

--- a/certif/tests/integration/components/issue-report-modal/other-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/other-certification-issue-report-fields-test.js
@@ -1,16 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 import sinon from 'sinon';
 
 module('Integration | Component | other-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-other';
-  const TEXTAREA_SELECTOR = '#text-area-for-category-other';
-  const CHAR_COUNT_SELECTOR = '.other-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -50,25 +47,5 @@ module('Integration | Component | other-certification-issue-report-fields', func
 
     // then
     assert.dom('.other-certification-issue-report-fields__details').exists();
-  });
-
-  test('it should count textarea characters length', async function(assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const otherCategory = new RadioButtonCategoryWithDescription({ name: 'OTHER', isChecked: true });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('otherCategory', otherCategory);
-
-    // when
-    await render(hbs`
-      <IssueReportModal::OtherCertificationIssueReportFields
-        @otherCategory={{this.otherCategory}}
-        @toggleOnCategory={{this.toggleOnCategory}}
-        @maxlength={{500}}
-      />`);
-    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
-
-    // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
   });
 });

--- a/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
@@ -1,16 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
-import { RadioButtonCategoryWithDescription } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 import sinon from 'sinon';
 
 module('Integration | Component | issue-report-modal/technical-problem-certification-issue-report-fields', function(hooks) {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-technical-problem';
-  const TEXTAREA_SELECTOR = '#text-area-for-category-technical-problem';
-  const CHAR_COUNT_SELECTOR = '.technical-problem-certification-issue-report-fields-details__char-count';
 
   test('it should call toggle function on click radio button', async function(assert) {
     // given
@@ -50,25 +47,5 @@ module('Integration | Component | issue-report-modal/technical-problem-certifica
 
     // then
     assert.dom('.technical-problem-certification-issue-report-fields__details').exists();
-  });
-
-  test('it should count textarea characters length', async function(assert) {
-    // given
-    const toggleOnCategory = sinon.stub();
-    const technicalProblemCategory = new RadioButtonCategoryWithDescription({ name: 'TECHNICAL_PROBLEM', isChecked: true });
-    this.set('toggleOnCategory', toggleOnCategory);
-    this.set('technicalProblemCategory', technicalProblemCategory);
-
-    // when
-    await render(hbs`
-      <IssueReportModal::TechnicalProblemCertificationIssueReportFields
-        @technicalProblemCategory={{this.technicalProblemCategory}}
-        @toggleOnCategory={{this.toggleOnCategory}}
-        @maxlength={{500}}
-      />`);
-    await fillIn(TEXTAREA_SELECTOR, 'Coucou');
-
-    // then
-    assert.dom(CHAR_COUNT_SELECTOR).hasText('6 / 500');
   });
 });

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, find, click } from '@ember/test-helpers';
+import { render, fillIn, click } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -26,31 +26,6 @@ module('Integration | Component | session-finalization-examiner-global-comment-s
 
       // then
       assert.contains('Vous pouvez indiquer un commentaire global sur cette session, par exemple si vous avez rencontré un problème technique qui a impacté le déroulement de la session.');
-    });
-
-    test('it should update the character count accordingly', async function(assert) {
-      // given
-      const updateExaminerGlobalCommentStub = sinon.stub();
-      const firstComment = 'You are a wizard Harry !';
-      this.set('examinerGlobalCommentMaxLength', 500);
-      this.set('session', Object.create({ examinerGlobalComment: '' }));
-      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
-      this.set('isReportsCategorizationFeatureToggleEnabled', false);
-
-      // when
-      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
-              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
-              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
-              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
-      await fillIn('#examiner-global-comment', firstComment);
-
-      // then
-      assert.dom('div.session-finalization-examiner-global-comment-step__characters-information')
-        .hasText(this.session.examinerGlobalComment.length + ' / ' + this.examinerGlobalCommentMaxLength);
-      assert.equal(
-        find('textarea').value.trim(),
-        firstComment,
-      );
     });
 
     test('it should call the appropriate callback function when typing in the text area', async function(assert) {
@@ -111,32 +86,6 @@ module('Integration | Component | session-finalization-examiner-global-comment-s
 
       // then
       assert.dom('textarea').exists();
-    });
-
-    test('it should update the character count accordingly when declaring an incident', async function(assert) {
-      // given
-      const updateExaminerGlobalCommentStub = sinon.stub();
-      const firstComment = 'You are a wizard Harry !';
-      this.set('examinerGlobalCommentMaxLength', 500);
-      this.set('session', Object.create({ examinerGlobalComment: '' }));
-      this.set('updateExaminerGlobalComment', updateExaminerGlobalCommentStub);
-      this.set('isReportsCategorizationFeatureToggleEnabled', true);
-
-      // when
-      await render(hbs`<SessionFinalizationExaminerGlobalCommentStep @session={{this.session}}
-              @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
-              @updateExaminerGlobalComment={{this.updateExaminerGlobalComment}}
-              @examinerGlobalCommentMaxLength={{this.examinerGlobalCommentMaxLength}}  />`);
-      await click('[aria-label="Signaler un incident"]');
-      await fillIn('#examiner-global-comment', firstComment);
-
-      // then
-      assert.dom('div.session-finalization-examiner-global-comment-step__characters-information')
-        .hasText(this.session.examinerGlobalComment.length + ' / ' + this.examinerGlobalCommentMaxLength);
-      assert.equal(
-        find('textarea').value.trim(),
-        firstComment,
-      );
     });
 
     test('it should call the appropriate callback function when typing in the text area when declaring an incident', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de finalisation d’une session, la catégorie “Problème sur une épreuve” nécessite que l’utilisateur précise le numéro d’épreuve pour laquelle le candidat a rencontré un problème. Aujourd’hui, il n’y a pas de message d’erreur clair sur ce champ, alors qu’il n’est pas autorisé d’entrer du texte, ou encore de mettre un nombre > 500 (en réalité, il n’est même pas logique d’avoir un nombre > 48, qui est le nombre max d'épreuves de notre test de certification actuel).

Aussi, lors de l’implémentation de la catégorisation des signalements, le composant “zone de saisie libre” n'était pas encore disponible dans Pix-UI, ce qui est maintenant le cas.

## :robot: Solution
1. Afficher une erreur à l’utilisateur sur le champ “numéro d'épreuve” si la valeur entrée par l’utilisateur ne correspond pas à ce qui est attendu : 

    afficher en rouge la case “numéro d'épreuve” pour signifier à l’utilisateur que le problème se situe à ce niveau

2. Utiliser pour toutes les zones de saisie libre sur cette page le composant Pix-UI

## :rainbow: Remarques
La modale est plus responsive qu'avant pour les écrans pas très grands.

## :100: Pour tester
- Lancer l'api avec `FT_REPORTS_CATEGORISATION=true FT_CERTIF_PRESCRIPTION_SCO=true npm start` 
- Lancer pix certif
- Se connecter avec `certifsco@example.net`
- Aller sur le détail de la session 4
- Cliquer sur "Finaliser la session"
- Ajouter des signalements à certains candidats
- Constater que les Textarea sont redimensionnables
- Constater que la modale s'adapte à la hauteur de l'écran (on peut scroller)
- Ajouter un signalement de type "problème sur une question" + "autre" : essayer de valider sans remplir
- Constater que ce n'est pas possible et que le navigateur indique le champ à remplir
- Constater pour que l'étape 3, le champ commentaire global a un indicateur du nombre de caractères.
