### PR TITLE
[FEATURE] Rediriger vers la page par défaut de Pix App lorsqu'un utilisateur saisis /mes-parcours dans l'url et n'a pas de parcours (PIX-2007).

### DIFF
--- a/mon-pix/app/controllers/terms-of-service.js
+++ b/mon-pix/app/controllers/terms-of-service.js
@@ -24,7 +24,7 @@ export default class TermsOfServiceController extends Controller {
       if (this.session.attemptedTransition) {
         this.session.attemptedTransition.retry();
       } else {
-        this.transitionToRoute('profile');
+        this.transitionToRoute('');
       }
     } else {
       this.showErrorTermsOfServiceNotSelected = true;

--- a/mon-pix/app/routes/terms-of-service.js
+++ b/mon-pix/app/routes/terms-of-service.js
@@ -11,7 +11,7 @@ export default class TermsOfServiceRoute extends Route.extend(AuthenticatedRoute
     const user = users.firstObject;
 
     if (!user.mustValidateTermsOfService) {
-      return this.replaceWith('profile');
+      return this.replaceWith('');
     }
 
     return user;

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -1,8 +1,9 @@
 import { inject as service } from '@ember/service';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
+import { isEmpty } from '@ember/utils';
 
-export default class UserTestsController extends Route.extend(SecuredRouteMixin) {
+export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
   @service store;
 
   model() {
@@ -16,5 +17,11 @@ export default class UserTestsController extends Route.extend(SecuredRouteMixin)
     };
 
     return this.store.query('campaign-participation-overview', queryParams);
+  }
+
+  redirect(model) {
+    if (isEmpty(model)) {
+      this.replaceWith('');
+    }
   }
 }

--- a/mon-pix/tests/acceptance/user-tests-test.js
+++ b/mon-pix/tests/acceptance/user-tests-test.js
@@ -22,6 +22,15 @@ describe('Acceptance | User tests', function() {
     });
 
     it('can visit /mes-parcours', async function() {
+      //given
+      server.create('campaign-participation-overview', {
+        assessmentState: 'started',
+        campaignCode: '123',
+        campaignTitle: 'Campaign 1',
+        createdAt: new Date('2020-04-20T04:05:06Z'),
+        isShared: false,
+      });
+
       // when
       await visit('/mes-parcours');
 

--- a/mon-pix/tests/unit/controllers/terms-of-service-test.js
+++ b/mon-pix/tests/unit/controllers/terms-of-service-test.js
@@ -24,7 +24,7 @@ describe('Unit | Controller | terms-of-service', function() {
 
       // then
       sinon.assert.calledWith(controller.currentUser.user.save, { adapterOptions: { acceptPixTermsOfService: true } });
-      sinon.assert.calledWith(controller.transitionToRoute, 'profile');
+      sinon.assert.calledWith(controller.transitionToRoute, '');
       expect(controller.showErrorTermsOfServiceNotSelected).to.be.false;
 
     });

--- a/mon-pix/tests/unit/routes/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/user-tests-test.js
@@ -34,4 +34,23 @@ describe('Unit | Route | User-Tests', function() {
       expect(model).to.deep.equal(campaignParticipationOverviews);
     });
   });
+
+  describe('redirect', function() {
+    it('should redirect to default page if there is no campaign participation', function() {
+      const route = this.owner.lookup('route:user-tests');
+      sinon.stub(route, 'replaceWith');
+
+      route.redirect([], {});
+      sinon.assert.calledWithExactly(route.replaceWith, '');
+    });
+
+    it('should continue on user-tests if there is some campaign participations', function() {
+      const route = this.owner.lookup('route:user-tests');
+      sinon.stub(route, 'replaceWith');
+      const campaignParticipationOverviews = [EmberObject.create({ id: 10 })];
+
+      route.redirect(campaignParticipationOverviews, {});
+      sinon.assert.notCalled(route.replaceWith);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème
Si un utilisateur qui n'a pas de parcours tape /mes-parcours dans l'url, alors on lui affiche une page vide de tout parcours.

## :robot: Solution
Ne pas lui permettre de voir cette page et faire le même comportement qu'une "404", c'est à dire rediriger sur la page par défaut de Pix App.

## :rainbow: Remarques
Pour l'instant cette page n'est pas accessible depuis le menu de l'utilisateur mais le sera bientôt, lors de l'ouverture de la fonctionnalité. Ce menu ne sera également visible que lorsque l'utilisateur a au moins un parcours.

Petit bonus : refacto à certains endroit d'une redirection directe vers /profil alors que la volonté c'est de rediriger vers la page par défaut.

## :100: Pour tester
- Se connecter avec jaune.attend@example.net, saisir /mes-parcours et vérifier qu'on accède bien à la page "Mes Parcours".
- Se connecter avec userpix1@example.nt, saisir /mes-parcours et vérifier qu'on ne peut pas accéder à la page, et qu'on est redirigé vers la page par défaut (la page profil pour l'instant).
