### PR TITLE
[FEATURE] Redirige vers le dashboard quand la feature est activée (PIX-1751).

### DIFF
--- a/mon-pix/app/routes/index.js
+++ b/mon-pix/app/routes/index.js
@@ -1,8 +1,13 @@
 import Route from '@ember/routing/route';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
+import ENV from 'mon-pix/config/environment';
 
 export default class IndexRoute extends Route.extend(SecuredRouteMixin) {
   redirect() {
-    this.replaceWith('profile');
+    if (ENV.APP.FT_DASHBOARD) {
+      this.replaceWith('user-dashboard');
+    } else {
+      this.replaceWith('profile');
+    }
   }
 }

--- a/mon-pix/tests/acceptance/authentication-test.js
+++ b/mon-pix/tests/acceptance/authentication-test.js
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from 'mocha';
 import { setupApplicationTest } from 'ember-mocha';
 import { click, fillIn, currentURL } from '@ember/test-helpers';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'mon-pix/config/environment';
 
 import visit from '../helpers/visit';
 import { authenticateByEmail, authenticateByUsername } from '../helpers/authentication';
@@ -13,9 +14,13 @@ describe('Acceptance | Authentication', function() {
   setupMirage();
 
   let user;
+  const CURRENT_FT_DASHBOARD = ENV.APP.FT_DASHBOARD;
 
   beforeEach(function() {
     user = server.create('user', 'withEmail');
+  });
+  afterEach(() => {
+    ENV.APP.FT_DASHBOARD = CURRENT_FT_DASHBOARD;
   });
 
   describe('Success cases', function() {
@@ -39,6 +44,18 @@ describe('Acceptance | Authentication', function() {
 
         // then
         expect(currentURL()).to.equal('/profil');
+      });
+
+      context('when dashboard is on', function() {
+        it('should redirect to the /accueil after connexion', async function() {
+          // given
+          ENV.APP.FT_DASHBOARD = true;
+
+          await authenticateByEmail(user);
+
+          // then
+          expect(currentURL()).to.equal('/accueil');
+        });
       });
     });
   });

--- a/mon-pix/tests/acceptance/terms-of-service-test.js
+++ b/mon-pix/tests/acceptance/terms-of-service-test.js
@@ -4,11 +4,13 @@ import { authenticateByEmail } from '../helpers/authentication';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'mon-pix/config/environment';
 
 describe('Acceptance | terms-of-service', function() {
   setupApplicationTest();
   setupMirage();
   let user;
+  const CURRENT_FT_DASHBOARD = ENV.APP.FT_DASHBOARD;
 
   beforeEach(function() {
     user = server.create('user', {
@@ -17,6 +19,10 @@ describe('Acceptance | terms-of-service', function() {
       mustValidateTermsOfService: true,
       lastTermsOfServiceValidatedAt: null,
     });
+  });
+
+  afterEach(() => {
+    ENV.APP.FT_DASHBOARD = CURRENT_FT_DASHBOARD;
   });
 
   describe('When user log in and must validate Pix latest terms of service', async function() {
@@ -44,6 +50,23 @@ describe('Acceptance | terms-of-service', function() {
       expect(currentURL()).to.equal('/profil');
 
     });
+    context('when dashboard is on', function() {
+      it('should redirect to the dashboard when user validate terms of service', async function() {
+        // given
+        ENV.APP.FT_DASHBOARD = true;
+
+        await authenticateByEmail(user);
+
+        // when
+        await click('#pix-cgu');
+        await click('.terms-of-service-form-actions__submit');
+
+        // then
+        expect(currentURL()).to.equal('/accueil');
+
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
## :unicorn: Problème
- Le dashboard arrive bientôt. Dès qu'il sera activé, il faudra arriver sur la nouvelle page d'accueil.

## :robot: Solution
- Si le feature toogle est activé, redirigé vers /accueil (`user-dashboard`) plutôt que /profil

## :rainbow: Remarques
-

## :100: Pour tester
- Vérifier que la variable d'environnement `FT_DASHBOARD` est à true
- Se connection/s'inscrire et voir le dashboard
- Quitter une évaluation et revenir au dashboard