### PR TITLE
[FEATURE] Préparer l'affichage de la liste des sessions publiables (a.k.a "Sans problèmes") (PIX-2094)

### DIFF
--- a/api/db/database-builder/database-buffer.js
+++ b/api/db/database-builder/database-buffer.js
@@ -4,9 +4,14 @@ module.exports = {
   objectsToInsert: [],
   nextId: INITIAL_ID,
 
-  pushInsertable({ tableName, values }) {
-    if (!values.id) {
-      values = { ...values, id: this.nextId++ };
+  pushInsertable({ tableName, values, customIdKey }) {
+    let idKey = 'id';
+    if (customIdKey) {
+      idKey = customIdKey;
+    }
+    if (!values[idKey]) {
+      values = { ...values };
+      values[idKey] = this.nextId++;
     }
     this.objectsToInsert.push({ tableName, values });
 

--- a/api/db/database-builder/factory/build-finalized-session.js
+++ b/api/db/database-builder/factory/build-finalized-session.js
@@ -1,0 +1,28 @@
+const faker = require('faker');
+const databaseBuffer = require('../database-buffer');
+const moment = require('moment');
+
+module.exports = function buildFinalizedSession({
+  sessionId = 1,
+  certificationCenterName = faker.random.word(),
+  finalizedAt = faker.date.recent(),
+  isPublishable = faker.random.boolean(),
+  time = faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0'),
+  date = moment(faker.date.recent()).format('YYYY-MM-DD'),
+} = {}) {
+
+  const values = {
+    sessionId,
+    certificationCenterName,
+    finalizedAt,
+    isPublishable,
+    time,
+    date,
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'finalized-sessions',
+    values,
+    customIdKey: 'sessionId',
+  });
+};

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -29,6 +29,7 @@ module.exports = {
   buildCompetenceMark: require('./build-competence-mark'),
   buildCorrectAnswersAndKnowledgeElementsForLearningContent: require('./build-correct-answers-and-knowledge-elements-for-learning-content'),
   buildCorrectAnswerAndKnowledgeElement: require('./build-correct-answer-and-knowledge-element'),
+  buildFinalizedSession: require('./build-finalized-session'),
   buildKnowledgeElement: require('./build-knowledge-element'),
   buildKnowledgeElementSnapshot: require('./build-knowledge-element-snapshot'),
   buildOrganization: require('./build-organization'),

--- a/api/db/migrations/20210201101653_create-finalized-session-table.js
+++ b/api/db/migrations/20210201101653_create-finalized-session-table.js
@@ -1,0 +1,16 @@
+const TABLE_NAME = 'finalized-sessions';
+
+exports.up = async (knex) => {
+  await knex.schema.createTable(TABLE_NAME, (t) => {
+    t.integer('sessionId').primary();
+    t.boolean('isPublishable').notNullable();
+    t.text('certificationCenterName').notNullable();
+    t.dateTime('finalizedAt').notNullable();
+    t.date('date').notNullable();
+    t.time('time').notNullable();
+  });
+};
+
+exports.down = (knex) => {
+  return knex.schema.dropTable(TABLE_NAME);
+};

--- a/api/lib/domain/events/SessionFinalized.js
+++ b/api/lib/domain/events/SessionFinalized.js
@@ -1,0 +1,7 @@
+module.exports = class SessionFinalized {
+  constructor({
+    sessionId,
+  }) {
+    this.sessionId = sessionId;
+  }
+};

--- a/api/lib/domain/events/SessionFinalized.js
+++ b/api/lib/domain/events/SessionFinalized.js
@@ -3,9 +3,15 @@ module.exports = class SessionFinalized {
     sessionId,
     finalizedAt,
     hasExaminerGlobalComment,
+    sessionDate,
+    sessionTime,
+    certificationCenterName,
   }) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
     this.hasExaminerGlobalComment = hasExaminerGlobalComment;
+    this.sessionDate = sessionDate;
+    this.sessionTime = sessionTime;
+    this.certificationCenterName = certificationCenterName;
   }
 };

--- a/api/lib/domain/events/SessionFinalized.js
+++ b/api/lib/domain/events/SessionFinalized.js
@@ -1,7 +1,11 @@
 module.exports = class SessionFinalized {
   constructor({
     sessionId,
+    finalizedAt,
+    hasExaminerGlobalComment,
   }) {
     this.sessionId = sessionId;
+    this.finalizedAt = finalizedAt;
+    this.hasExaminerGlobalComment = hasExaminerGlobalComment;
   }
 };

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -1,4 +1,3 @@
-const { save } = require('../../infrastructure/repositories/assessment-repository');
 const FinalizedSession = require('../models/FinalizedSession');
 const { checkEventType } = require('./check-event-type');
 const SessionFinalized = require('./SessionFinalized');
@@ -17,8 +16,8 @@ async function handleSessionFinalized({
     sessionId: event.sessionId,
     finalizedAt: event.finalizedAt,
     certificationCenterName: event.certificationCenterName,
-    sessionDate: event.date,
-    sessionTime: event.time,
+    sessionDate: event.sessionDate,
+    sessionTime: event.sessionTime,
     hasExaminerGlobalComment: event.hasExaminerGlobalComment,
     juryCertificationSummaries,
   });

--- a/api/lib/domain/events/handle-session-finalized.js
+++ b/api/lib/domain/events/handle-session-finalized.js
@@ -1,0 +1,31 @@
+const { save } = require('../../infrastructure/repositories/assessment-repository');
+const FinalizedSession = require('../models/FinalizedSession');
+const { checkEventType } = require('./check-event-type');
+const SessionFinalized = require('./SessionFinalized');
+
+const eventType = SessionFinalized;
+
+async function handleSessionFinalized({
+  event,
+  juryCertificationSummaryRepository,
+  finalizedSessionRepository,
+}) {
+  checkEventType(event, eventType);
+  const juryCertificationSummaries = await juryCertificationSummaryRepository.findBySessionId(event.sessionId);
+
+  const finalizedSession = FinalizedSession.from({
+    sessionId: event.sessionId,
+    finalizedAt: event.finalizedAt,
+    certificationCenterName: event.certificationCenterName,
+    sessionDate: event.date,
+    sessionTime: event.time,
+    hasExaminerGlobalComment: event.hasExaminerGlobalComment,
+    juryCertificationSummaries,
+  });
+
+  await finalizedSessionRepository.save(finalizedSession);
+}
+
+handleSessionFinalized.eventType = eventType;
+module.exports = handleSessionFinalized;
+

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -24,6 +24,7 @@ const dependencies = {
   targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
+  // TODO : ajouter les dependences du handler ici
 };
 
 const partnerCertificationRepository = injectDependencies(
@@ -40,6 +41,7 @@ const handlersToBeInjected = {
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
   handlePoleEmploiParticipationStarted: require('./handle-pole-emploi-participation-started'),
   computeValidatedSkillsCount: require('./compute-validated-skills-count'),
+  // TODO : ajouter le handler ici
 };
 
 function buildEventDispatcher(handlersStubs) {

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -24,7 +24,8 @@ const dependencies = {
   targetProfileWithLearningContentRepository: require('../../infrastructure/repositories/target-profile-with-learning-content-repository'),
   userRepository: require('../../infrastructure/repositories/user-repository'),
   poleEmploiNotifier: require('../../infrastructure/externals/pole-emploi/pole-emploi-notifier'),
-  // TODO : ajouter les dependences du handler ici
+  juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),
+  finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
 };
 
 const partnerCertificationRepository = injectDependencies(
@@ -41,7 +42,7 @@ const handlersToBeInjected = {
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),
   handlePoleEmploiParticipationStarted: require('./handle-pole-emploi-participation-started'),
   computeValidatedSkillsCount: require('./compute-validated-skills-count'),
-  // TODO : ajouter le handler ici
+  handleSessionFinalized: require('./handle-session-finalized'),
 };
 
 function buildEventDispatcher(handlersStubs) {

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -1,0 +1,65 @@
+const some = require('lodash/some');
+const every = require('lodash/every');
+const { statuses: juryCertificationSummaryStatuses } = require('../read-models/JuryCertificationSummary');
+
+module.exports = class FinalizedSession {
+  constructor({
+    sessionId,
+    finalizedAt,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    isPublishable,
+  }) {
+    this.sessionId = sessionId;
+    this.finalizedAt = finalizedAt;
+    this.certificationCenterName = certificationCenterName;
+    this.sessionDate = sessionDate;
+    this.sessionTime = sessionTime;
+    this.isPublishable = isPublishable;
+  }
+
+  static from({
+    sessionId,
+    finalizedAt,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    hasExaminerGlobalComment,
+    juryCertificationSummaries,
+  }) {
+    return new FinalizedSession({
+      sessionId,
+      finalizedAt,
+      certificationCenterName,
+      sessionDate,
+      sessionTime,
+
+      isPublishable: !hasExaminerGlobalComment
+        && _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries)
+        && _hasNoStartedOrErrorAssessmentResults(juryCertificationSummaries)
+        && _hasExaminerSeenAllEndScreens(juryCertificationSummaries),
+    });
+  }
+};
+
+function _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries) {
+  return !some(
+    juryCertificationSummaries.flatMap((summary) => summary.certificationIssueReports),
+    (issueReport) => issueReport.isActionRequired,
+  );
+}
+
+function _hasNoStartedOrErrorAssessmentResults(juryCertificationSummaries) {
+  return !some(
+    juryCertificationSummaries,
+    (summary) => {
+      return summary.status === juryCertificationSummaryStatuses.ERROR
+        || summary.status === juryCertificationSummaryStatuses.STARTED;
+    },
+  );
+}
+
+function _hasExaminerSeenAllEndScreens(juryCertificationSummaries) {
+  return every(juryCertificationSummaries.map((summary) => summary.hasSeenEndTestScreen));
+}

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -34,7 +34,6 @@ module.exports = class FinalizedSession {
       certificationCenterName,
       sessionDate,
       sessionTime,
-
       isPublishable: !hasExaminerGlobalComment
         && _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries)
         && _hasNoStartedOrErrorAssessmentResults(juryCertificationSummaries)

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -10,7 +10,7 @@ module.exports = class FinalizedSession {
     sessionDate,
     sessionTime,
     isPublishable,
-  }) {
+  } = {}) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
     this.certificationCenterName = certificationCenterName;

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -19,11 +19,18 @@ module.exports = async function finalizeSession({
 
   await certificationReportRepository.finalizeAll(certificationReports);
 
-  await sessionRepository.finalize({
+  const finalizedSession = await sessionRepository.finalize({
     id: sessionId,
     examinerGlobalComment,
     finalizedAt: new Date(),
   });
 
-  return new SessionFinalized(sessionId);
+  return new SessionFinalized({
+    sessionId,
+    finalizedAt: finalizedSession.finalizedAt,
+    hasExaminerGlobalComment: Boolean(examinerGlobalComment),
+    certificationCenterName: finalizedSession.certificationCenterName,
+    sessionDate: finalizedSession.date,
+    sessionTime: finalizedSession.time,
+  });
 };

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -1,4 +1,5 @@
 const { SessionAlreadyFinalizedError } = require('../errors');
+const SessionFinalized = require('../events/SessionFinalized');
 
 module.exports = async function finalizeSession({
   sessionId,
@@ -18,9 +19,11 @@ module.exports = async function finalizeSession({
 
   await certificationReportRepository.finalizeAll(certificationReports);
 
-  return sessionRepository.finalize({
+  await sessionRepository.finalize({
     id: sessionId,
     examinerGlobalComment,
     finalizedAt: new Date(),
   });
+
+  return new SessionFinalized(sessionId);
 };

--- a/api/lib/domain/usecases/finalize-session.js
+++ b/api/lib/domain/usecases/finalize-session.js
@@ -29,7 +29,7 @@ module.exports = async function finalizeSession({
     sessionId,
     finalizedAt: finalizedSession.finalizedAt,
     hasExaminerGlobalComment: Boolean(examinerGlobalComment),
-    certificationCenterName: finalizedSession.certificationCenterName,
+    certificationCenterName: finalizedSession.certificationCenter,
     sessionDate: finalizedSession.date,
     sessionTime: finalizedSession.time,
   });

--- a/api/lib/infrastructure/data/finalized-session.js
+++ b/api/lib/infrastructure/data/finalized-session.js
@@ -6,6 +6,7 @@ module.exports = Bookshelf.model(modelName, {
 
   tableName: 'finalized-sessions',
   requireFetch: true,
+
   parse(rawAttributes) {
     rawAttributes.sessionDate = rawAttributes.date;
     rawAttributes.sessionTime = rawAttributes.time;

--- a/api/lib/infrastructure/data/finalized-session.js
+++ b/api/lib/infrastructure/data/finalized-session.js
@@ -1,0 +1,18 @@
+const Bookshelf = require('../bookshelf');
+
+const modelName = 'FinalizedSession';
+
+module.exports = Bookshelf.model(modelName, {
+
+  tableName: 'finalized-sessions',
+  requireFetch: true,
+  parse(rawAttributes) {
+    rawAttributes.sessionDate = rawAttributes.date;
+    rawAttributes.sessionTime = rawAttributes.time;
+
+    return rawAttributes;
+  },
+
+}, {
+  modelName,
+});

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -1,0 +1,22 @@
+const _ = require('lodash');
+
+const FinalizedSessionBookshelf = require('../data/finalized-session');
+
+module.exports = {
+
+  async save(finalizedSession) {
+    return await new FinalizedSessionBookshelf(_toDTO(finalizedSession)).save();
+  },
+
+};
+
+function _toDTO(finalizedSession) {
+  return _.omit(
+    {
+      ...finalizedSession,
+      date: finalizedSession.sessionDate,
+      time: finalizedSession.sessionTime,
+    },
+    ['sessionDate', 'sessionTime'],
+  );
+}

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -2,12 +2,21 @@ const _ = require('lodash');
 
 const FinalizedSessionBookshelf = require('../data/finalized-session');
 
+const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+
 module.exports = {
 
   async save(finalizedSession) {
     return await new FinalizedSessionBookshelf(_toDTO(finalizedSession)).save();
   },
 
+  async get({ sessionId }) {
+    const bookshelfFinalizedSession = await FinalizedSessionBookshelf
+      .where({ sessionId })
+      .fetch({ require: true });
+
+    return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, bookshelfFinalizedSession);
+  },
 };
 
 function _toDTO(finalizedSession) {

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -37,4 +37,30 @@ describe('Integration | Repository | Finalized-session', () => {
       });
     });
   });
+
+  describe('#get', () => {
+
+    afterEach(() => {
+      return knex('finalized-sessions').delete();
+    });
+
+    it('Retrieves a finalized session', async () => {
+      // given
+      const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await finalizedSessionRepository.get({ sessionId: finalizedSession.sessionId });
+
+      // then
+      expect(result).to.deep.equal({
+        sessionId: finalizedSession.sessionId,
+        finalizedAt: finalizedSession.finalizedAt,
+        certificationCenterName: finalizedSession.certificationCenterName,
+        sessionDate: finalizedSession.date,
+        sessionTime: finalizedSession.time,
+        isPublishable: finalizedSession.isPublishable,
+      });
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -1,0 +1,40 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const finalizedSessionRepository = require('../../../../lib/infrastructure/repositories/finalized-session-repository');
+const { knex } = require('../../../../db/knex-database-connection');
+const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
+
+describe('Integration | Repository | Finalized-session', () => {
+  describe('#save', () => {
+
+    afterEach(() => {
+      return knex('finalized-sessions').delete();
+    });
+
+    it('Saves a finalized session', async () => {
+      // given
+      const finalizedSession = new FinalizedSession({
+        sessionId: 1234,
+        finalizedAt: new Date('2021-02-01T11:48:00Z'),
+        certificationCenterName: 'A certification center name',
+        sessionDate: '2021-01-01',
+        sessionTime: '14:00:00',
+        isPublishable: true,
+      });
+
+      // when
+      await finalizedSessionRepository.save(finalizedSession);
+
+      // then
+      const result = await knex('finalized-sessions');
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.deep.equal({
+        sessionId: 1234,
+        finalizedAt: new Date('2021-02-01T11:48:00Z'),
+        certificationCenterName: 'A certification center name',
+        date: '2021-01-01',
+        time: '14:00:00',
+        isPublishable: true,
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -625,6 +625,7 @@ describe('Unit | Controller | sessionController', () => {
 
       sinon.stub(certificationReportSerializer, 'deserialize').resolves(aCertificationReport);
       sinon.stub(usecases, 'finalizeSession').resolves(updatedSession);
+      sinon.stub(usecases, 'getSession').resolves(updatedSession);
       sinon.stub(sessionSerializer, 'serializeForFinalization').withArgs(updatedSession);
     });
 

--- a/api/tests/unit/domain/events/event-choregraphy-finalized-session_test.js
+++ b/api/tests/unit/domain/events/event-choregraphy-finalized-session_test.js
@@ -1,0 +1,17 @@
+const { expect } = require('../../../test-helper');
+const buildEventDispatcherAndHandlersForTest = require('../../../tooling/events/event-dispatcher-builder');
+const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
+
+describe('Event Choregraphy | Finalized session', function() {
+  it('Should trigger persiting a finalized session on Finalized Session event', async () => {
+    // given
+    const { handlerStubs, eventDispatcher } = buildEventDispatcherAndHandlersForTest();
+    const event = new SessionFinalized({});
+
+    // when
+    await eventDispatcher.dispatch(event);
+
+    // then
+    expect(handlerStubs.handleSessionFinalized).to.have.been.calledWith({ event, domainTransaction: undefined });
+  });
+});

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -1,0 +1,81 @@
+const { catchErr, expect, domainBuilder, sinon } = require('../../../test-helper');
+const handleFinalizedSession = require('../../../../lib/domain/events/handle-session-finalized');
+const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
+const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
+const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+const SessionFinalized = require('../../../../lib/domain/events/SessionFinalized');
+const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
+
+describe('Unit | Domain | Events | handle-session-finalized', () => {
+
+  const juryCertificationSummaryRepository = { findBySessionId: sinon.stub() };
+  const finalizedSessionRepository = { save: sinon.stub() };
+
+  const dependencies = {
+    juryCertificationSummaryRepository,
+    finalizedSessionRepository,
+  };
+
+  it('fails when event is not of correct type', async () => {
+    // given
+    const event = 'not an event of the correct type';
+
+    // when
+    const error = await catchErr(handleFinalizedSession)(
+      { event, ...dependencies },
+    );
+
+    // then
+    expect(error).not.to.be.null;
+  });
+
+  it('saves a finalized session', async () => {
+    // given
+    const event = new SessionFinalized({
+      sessionId: 1234,
+      finalizedAt: new Date(),
+      hasExaminerGlobalComment: false,
+      certificationCenterName: 'A certification center name',
+      sessionDate: '2021-01-29',
+      sessionTime: '14:00',
+    });
+    juryCertificationSummaryRepository.findBySessionId.withArgs(1234).resolves(
+      [
+        new JuryCertificationSummary({
+          id: 1,
+          firstName: 'firstName',
+          lastName: 'lastName',
+          status: assessmentResultStatuses.VALIDATED,
+          pixScore: 120,
+          createdAt: new Date(),
+          completedAt: new Date(),
+          isPublished: false,
+          hasSeenEndTestScreen: true,
+          cleaCertificationStatus: 'not_passed',
+          certificationIssueReports: [
+            domainBuilder.buildCertificationIssueReport({
+              category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+              subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+            }),
+          ],
+        }),
+      ],
+    );
+    finalizedSessionRepository.save.resolves();
+
+    // when
+    await handleFinalizedSession({ event, ...dependencies });
+
+    // then
+    expect(finalizedSessionRepository.save).to.have.been.calledWithExactly(
+      new FinalizedSession({
+        sessionId: event.sessionId,
+        finalizedAt: event.finalizedAt,
+        certificationCenterName: event.certificationCenterName,
+        sessionDate: event.sessionDate,
+        sessionTime: event.sessionTime,
+        isPublishable: true,
+      }),
+    );
+  });
+});

--- a/api/tests/unit/domain/models/FinalizedSession_test.js
+++ b/api/tests/unit/domain/models/FinalizedSession_test.js
@@ -1,0 +1,235 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
+const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
+const { status: assessmentResultStatuses } = require('../../../../lib/domain/models/AssessmentResult');
+const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
+
+describe('Unit | Domain | Models | FinalizedSession', () => {
+
+  context('#isPublishable', () => {
+    it('is not publishable when session has an examiner global comment', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: true,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    it('is not publishable when at least one test end screen has not been seen', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatusButEndScreenNotSeen(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    it('is not publishable when at least one issue report require action', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _someWithRequiredActionButNoErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    it('is not publishable when at least one scoring error occurred', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionButSomeErrorStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    it('is not publishable when at least one assessment has not been completed', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionButSomeStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+
+      // then
+      expect(finalizedSession.isPublishable).to.be.false;
+    });
+
+    it('is publishable when session has no global comment, no started or error status, no issue report requiring action and all end screen seen', () => {
+      // given / when
+      const finalizedSession = FinalizedSession.from({
+        sessionId: 1234,
+        certificationCenterName: 'a certification center',
+        sessionDate: '2021-01-29',
+        sessionTime: '16:00',
+        hasExaminerGlobalComment: false,
+        juryCertificationSummaries: _noneWithRequiredActionNorErrorOrStartedStatus(),
+        finalizedAt: new Date('2020-01-01T00:00:00Z'),
+      });
+
+      // then
+      expect(finalizedSession.isPublishable).to.be.true;
+    });
+  });
+});
+
+function _noneWithRequiredActionNorErrorOrStartedStatus() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: assessmentResultStatuses.VALIDATED,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    }),
+  ];
+}
+
+function _noneWithRequiredActionNorErrorOrStartedStatusButEndScreenNotSeen() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: assessmentResultStatuses.VALIDATED,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: false,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    }),
+    new JuryCertificationSummary({
+      id: 2,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: assessmentResultStatuses.VALIDATED,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    }),
+  ];
+}
+
+function _noneWithRequiredActionButSomeErrorStatus() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: assessmentResultStatuses.ERROR,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    }),
+  ];
+}
+
+function _noneWithRequiredActionButSomeStartedStatus() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: null,
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+          subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+        }),
+      ],
+    }),
+  ];
+}
+
+function _someWithRequiredActionButNoErrorOrStartedStatus() {
+  return [
+    new JuryCertificationSummary({
+      id: 1,
+      firstName: 'firstName',
+      lastName: 'lastName',
+      status: 'validated',
+      pixScore: 120,
+      createdAt: new Date(),
+      completedAt: new Date(),
+      isPublished: false,
+      hasSeenEndTestScreen: true,
+      cleaCertificationStatus: 'not_passed',
+      certificationIssueReports: [
+        domainBuilder.buildCertificationIssueReport({
+          category: CertificationIssueReportCategories.FRAUD,
+        }),
+      ],
+    }),
+  ];
+}

--- a/api/tests/unit/domain/usecases/finalize-session_test.js
+++ b/api/tests/unit/domain/usecases/finalize-session_test.js
@@ -139,6 +139,13 @@ describe('Unit | UseCase | finalize-session', () => {
 
       it('raises a session finalized event', async () => {
         // given
+        const updatedSession = domainBuilder.buildSession({
+          finalizedAt: new Date('2020-01-01T14:00:00Z'),
+          examinerGlobalComment: 'an examiner comment',
+          certificationCenter: 'a certification center name',
+          date: '2019-12-12',
+          time: '16:00:00',
+        });
         clock = sinon.useFakeTimers(now);
         const validReportForFinalization = domainBuilder.buildCertificationReport({
           examinerComment: 'signalement sur le candidat',
@@ -166,11 +173,11 @@ describe('Unit | UseCase | finalize-session', () => {
         expect(event).to.be.an.instanceof(SessionFinalized);
         expect(event).to.deep.equal(new SessionFinalized({
           sessionId,
-          finalizedAt: updatedSession.finalizedAt,
-          hasExaminerGlobalComment: Boolean(examinerGlobalComment),
-          certificationCenterName: updatedSession.certificationCenterName,
-          sessionDate: updatedSession.date,
-          sessionTime: updatedSession.time,
+          finalizedAt: new Date('2020-01-01T14:00:00Z'),
+          hasExaminerGlobalComment: true,
+          certificationCenterName: 'a certification center name',
+          sessionDate: '2019-12-12',
+          sessionTime: '16:00:00',
         }));
       });
     });

--- a/api/tests/unit/tooling/database-builder/database-buffer_test.js
+++ b/api/tests/unit/tooling/database-builder/database-buffer_test.js
@@ -22,6 +22,20 @@ describe('Unit | Tooling | DatabaseBuilder | database-buffer', () => {
       ]);
     });
 
+    it('should add an object to insert with a custom id property', () => {
+      // given
+      const tableName = 'someTableName';
+      const values = { sessionId: 123, a: 'aVal', b: 'bVal' };
+
+      // when
+      databaseBuffer.pushInsertable({ tableName, values, customIdKey: 'sessionId' });
+
+      // then
+      expect(databaseBuffer.objectsToInsert).to.deep.equal([
+        { tableName, values },
+      ]);
+    });
+
     it('should return inserted values', () => {
       // given
       const tableName = 'someTableName';
@@ -32,6 +46,24 @@ describe('Unit | Tooling | DatabaseBuilder | database-buffer', () => {
 
       // then
       expect(expectedValues).to.deep.equal(values);
+    });
+
+    context('when no id is provided but there is a custom id key', () => {
+
+      it('should add an object to insert with a custom id property', () => {
+        // given
+        const tableName = 'someTableName';
+        const values = { a: 'aVal', b: 'bVal' };
+        const expectedId = databaseBuffer.nextId;
+
+        // when
+        databaseBuffer.pushInsertable({ tableName, values, customIdKey: 'sessionId' });
+
+        // then
+        expect(databaseBuffer.objectsToInsert).to.deep.equal([
+          { tableName, values: { ...values, sessionId: expectedId } },
+        ]);
+      });
     });
 
     context('when no id is provided along with the object', () => {


### PR DESCRIPTION
## :unicorn: Problème
Certaines sessions de certification ne nécessitent aucune action du jury avant publication. Aujourd’hui, le pôle certification doit néanmoins ouvrir la page de détails de chaque session pour vérifier s’il s’agit d’une session sans problème afin de la publier. Nous avons la possibilité d’identifier ces sessions, afin d’en permettre la publication en masse.

Une session est dite "sans problème" si : 
- Elle ne fait l'objet d'aucun signalement impactant
- Elle ne fait pas l'objet d'un commentaire global
- Elle ne comporte aucun test qui n'est pas complété ou en erreur de scoring
- Tous les écrans de fin de tests ont été vus par le surveillant

Actuellement pour avoir ces informations sur une session demande de remonter :
- La `Session`
- Le `CertificationCourse`, ses `CertificationIssueReport`, son dernier `AssessmentResult`

Ce qui est assez volumineux. Le remonter pour _**une liste**_ de session l'est encore plus ! 

## :robot: Solution
Modéliser une session finalisée aussi bien dans le code (`FinalizedSession`) que dans le modèle de donnée (`finalized-sessions`). Cette table est alimenté au moment de la validation. Techniquement, un _Domain Event_ `SessionFinalzed` est dispatché en sortie du usecase `finalize-session`, cet évènement est écouté par un handler peuplant la table "`finalized-session`".

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer l'API avec `FT_CERTIF_PRESCRIPTION_SCO=true npm start`
- Lancer Pix Certif
- Finaliser une session (test de non-regression)
- Vérifier qu'elle figure bien dans la table `finalized-sessions`.
- Pour aller plus loin finaliser une session avec problème (+ combinatoire)
