### PR TITLE
[FEATURE] Ajout de "Mes parcours" dans le menu de Pix App (PIX-2004)

### DIFF
--- a/mon-pix/app/components/navbar-burger-menu.js
+++ b/mon-pix/app/components/navbar-burger-menu.js
@@ -1,6 +1,3 @@
-/* eslint ember/no-classic-components: 0 */
-/* eslint ember/require-tagless-components: 0 */
-
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import ENV from 'mon-pix/config/environment';
@@ -10,5 +7,9 @@ export default class NavbarBurgerMenu extends Component {
 
   get showDashboard() {
     return ENV.APP.FT_DASHBOARD;
+  }
+
+  get showMyTestsLink() {
+    return this.showDashboard && this.currentUser.user.hasAssessmentParticipations;
   }
 }

--- a/mon-pix/app/components/user-logged-menu.js
+++ b/mon-pix/app/components/user-logged-menu.js
@@ -9,6 +9,7 @@ import { on } from '@ember-decorators/object';
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import classic from 'ember-classic-decorator';
+import ENV from 'mon-pix/config/environment';
 import {
   EKMixin as EmberKeyboardMixin,
   keyDown,
@@ -33,6 +34,10 @@ export default class UserLoggedMenu extends Component.extend(EmberKeyboardMixin)
   @computed('currentUser.user.email')
   get displayedIdentifier() {
     return this.currentUser.user.email ? this.currentUser.user.email : this.currentUser.user.username;
+  }
+
+  get showMyTestsLink() {
+    return ENV.APP.FT_DASHBOARD && this.currentUser.user.hasAssessmentParticipations;
   }
 
   @on(keyDown('Escape'))

--- a/mon-pix/app/models/user.js
+++ b/mon-pix/app/models/user.js
@@ -1,5 +1,4 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
-
 export default class User extends Model {
 
   // attributes
@@ -26,7 +25,11 @@ export default class User extends Model {
 
   // methods
   get fullName() {
-    return `${this.firstName} ${ this.lastName}`;
+    return `${this.firstName} ${this.lastName}`;
   }
 
+  get hasAssessmentParticipations() {
+    const participations = this.campaignParticipations.toArray();
+    return participations.some((participation) => participation.campaign.get('isAssessment'));
+  }
 }

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -9,6 +9,13 @@
       </p>
     </div>
   {{/if}}
+  
+  {{#if this.showMyTestsLink}}
+    <LinkTo @route="user-tests" class="navbar-burger-menu-user-info__item">
+      {{t 'navigation.user.tests'}}
+    </LinkTo>
+  {{/if}}
+
   <LinkTo @route="user-certifications" class="navbar-burger-menu-user-info__item">
     {{t 'navigation.user.certifications'}}
   </LinkTo>

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -18,12 +18,19 @@
         </div>
         <ul class="logged-user-menu__actions">
           <li hidden>
-            <LinkTo @route="user-account" data-test-account-link class="logged-user-menu__link" >
+            <LinkTo @route="user-account" class="logged-user-menu__link" >
               {{t 'navigation.user.account'}}
             </LinkTo>
           </li>
+          {{#if this.showMyTestsLink}}
+            <li>
+              <LinkTo @route="user-tests" class="logged-user-menu__link">
+                {{t 'navigation.user.tests'}}
+              </LinkTo>
+            </li>
+          {{/if}}
           <li>
-            <LinkTo @route="user-certifications" data-test-certifications-link class="logged-user-menu__link">
+            <LinkTo @route="user-certifications" class="logged-user-menu__link">
               {{t 'navigation.user.certifications'}}
             </LinkTo>
           </li>

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -183,6 +183,13 @@ export default Factory.extend({
       user.update({ isCertifiable: server.create('is-certifiable', { 'is-certifiable': false }) });
     },
   }),
+  campaignParticipations: trait({
+    afterCreate(user, server) {
+      user.update({ campaignParticipations: [server.create('campaign-participation', {
+        'campaign': server.create('campaign', { type: 'ASSESSMENT' }),
+      }) ] });
+    },
+  }),
   withSomeCertificates: trait({
     afterCreate(user, server) {
       const rejectedCertificate = server.create('certification', {

--- a/mon-pix/tests/acceptance/user-logged-menu-test.js
+++ b/mon-pix/tests/acceptance/user-logged-menu-test.js
@@ -1,9 +1,11 @@
-import { click, currentURL, find } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { beforeEach, describe, it } from 'mocha';
 import { authenticateByEmail } from '../helpers/authentication';
+import { contains } from '../helpers/contains';
 import { expect } from 'chai';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import ENV from 'mon-pix/config/environment';
 
 describe('Acceptance | User account', function() {
   setupApplicationTest();
@@ -12,16 +14,30 @@ describe('Acceptance | User account', function() {
 
   beforeEach(async function() {
     //given
-    user = server.create('user', 'withEmail');
+    ENV.APP.FT_DASHBOARD = true;
+    server.create('campaign-participation-overview', { assessmentState: 'completed' });
+    user = server.create('user', 'withEmail', 'campaignParticipations');
     await authenticateByEmail(user);
   });
 
+  afterEach(function() {
+    ENV.APP.FT_DASHBOARD = false;
+  });
+
   describe('When in profile', function() {
+    it('should open tests page when click on menu', async function() {
+      // when
+      await click('.logged-user-name');
+      await click(contains('Mes parcours'));
+
+      // then
+      expect(currentURL()).to.equal('/mes-parcours');
+    });
 
     it('should open certifications page when click on menu', async function() {
       // when
       await click('.logged-user-name');
-      await click('a[data-test-certifications-link]');
+      await click(contains('Mes certifications'));
 
       // then
       expect(currentURL()).to.equal('/mes-certifications');
@@ -30,7 +46,7 @@ describe('Acceptance | User account', function() {
     it('should contain link to pix.fr/aide', async function() {
       // when
       await click('.logged-user-name');
-      const helplink = find('.logged-user-menu__actions').children[2].children[0].getAttribute('href');
+      const helplink = contains('Aide').getAttribute('href');
 
       // then
       expect(helplink).to.equal('https://pix.fr/aide');

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { beforeEach, describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
+import { contains } from '../../helpers/contains';
 import hbs from 'htmlbars-inline-precompile';
 import ENV from 'mon-pix/config/environment';
 
@@ -71,6 +72,46 @@ describe('Integration | Component | navbar-burger-menu', function() {
       expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Certification');
       expect(findAll('.navbar-burger-menu-navigation__item')[3].textContent.trim()).to.equal('Mes tutos');
       expect(findAll('.navbar-burger-menu-navigation__item')[4].textContent.trim()).to.equal('J\'ai un code');
+    });
+
+    context('when user has participations', function() {
+      beforeEach(async function() {
+        class currentUser extends Service {
+          user = {
+            hasAssessmentParticipations: true,
+          }
+        }
+        this.owner.unregister('service:currentUser');
+        this.owner.register('service:currentUser', currentUser);
+      });
+
+      it('should display "My tests" link', async function() {
+        // when
+        await render(hbs`<NavbarBurgerMenu />`);
+
+        // then
+        expect(contains('Mes parcours')).to.exist;
+      });
+    });
+
+    context('when user has no participations', function() {
+      beforeEach(async function() {
+        class currentUser extends Service {
+          user = {
+            hasAssessmentParticipations: false,
+          }
+        }
+        this.owner.unregister('service:currentUser');
+        this.owner.register('service:currentUser', currentUser);
+      });
+
+      it('should not display "My tests" link', async function() {
+        // when
+        await render(hbs`<NavbarBurgerMenu />`);
+
+        // then
+        expect(contains('Mes parcours')).to.not.exist;
+      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import ENV from 'mon-pix/config/environment';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import {
   click,
@@ -10,6 +11,7 @@ import {
   triggerKeyEvent,
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | user logged menu', function() {
 
@@ -72,8 +74,8 @@ describe('Integration | Component | user logged menu', function() {
       // then
       expect(find('.logged-user-menu')).to.exist;
       expect(findAll('.logged-user-menu__link')).to.have.lengthOf(MENU_ITEMS_COUNT);
-      expect(find('.logged-user-menu-details__fullname').textContent.trim()).to.equal('Hermione Granger');
-      expect(find('.logged-user-menu-details__identifier').textContent.trim()).to.equal('hermione.granger@hogwarts.com');
+      expect(contains('Hermione Granger')).to.exist;
+      expect(contains('hermione.granger@hogwarts.com')).to.exist;
     });
 
     it('should display link to user certifications', async function() {
@@ -82,7 +84,7 @@ describe('Integration | Component | user logged menu', function() {
       await click('.logged-user-name');
 
       // then
-      expect(findAll('.logged-user-menu__link')[1].textContent.trim()).to.equal('Mes certifications');
+      expect(contains('Mes certifications')).to.exist;
     });
 
     it('should display link to help center', async function() {
@@ -91,7 +93,7 @@ describe('Integration | Component | user logged menu', function() {
       await click('.logged-user-name');
 
       // then
-      expect(findAll('.logged-user-menu__link')[2].textContent.trim()).to.equal('Aide');
+      expect(contains('Aide')).to.exist;
     });
 
     it('should hide user menu, when it was previously open and user-name is clicked one more time', async function() {
@@ -122,6 +124,60 @@ describe('Integration | Component | user logged menu', function() {
 
       // then
       expect(find('.logged-user-menu')).to.not.exist;
+    });
+
+    describe('Link to "My tests"', () => {
+      beforeEach(async function() {
+        ENV.APP.FT_DASHBOARD = true;
+      });
+
+      afterEach(function() {
+        ENV.APP.FT_DASHBOARD = false;
+      });
+
+      describe('when user has at least one participation', () => {
+        beforeEach(function() {
+          class currentUserService extends Service {
+            user = {
+              hasAssessmentParticipations: true,
+            }
+          }
+          this.owner.unregister('service:currentUser');
+          this.owner.register('service:currentUser', currentUserService);
+        });
+
+        it('should display link to user tests', async function() {
+          // when
+          await render(hbs`<UserLoggedMenu/>`);
+          await click('.logged-user-name');
+
+          // then
+          expect(contains('Mes parcours')).to.exist;
+        });
+
+        it('should not display link to user tests if feature disabled', async function() {
+          // given
+          ENV.APP.FT_DASHBOARD = false;
+
+          // when
+          await render(hbs`<UserLoggedMenu/>`);
+          await click('.logged-user-name');
+
+          // then
+          expect(contains('Mes parcours')).to.not.exist;
+        });
+      });
+
+      describe('when user has no participation', () => {
+        it('should not display link to user tests', async function() {
+          // when
+          await render(hbs`<UserLoggedMenu/>`);
+          await click('.logged-user-name');
+
+          // then
+          expect(contains('Mes parcours')).to.not.exist;
+        });
+      });
     });
   });
 

--- a/mon-pix/tests/unit/models/user-test.js
+++ b/mon-pix/tests/unit/models/user-test.js
@@ -1,4 +1,3 @@
-import { run } from '@ember/runloop';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
@@ -17,20 +16,61 @@ describe('Unit | Model | user model', function() {
     expect(model).to.be.ok;
   });
 
-  describe('@fullName', () => {
+  describe('#fullName', () => {
     it('should concatenate user first and last name', function() {
-      return run(() => {
-        // given
-        const model = store.createRecord('user');
-        model.set('firstName', 'Manu');
-        model.set('lastName', 'Phillip');
+      // given
+      const model = store.createRecord('user');
+      model.set('firstName', 'Manu');
+      model.set('lastName', 'Phillip');
 
-        // when
-        const fullName = model.get('fullName');
+      // when
+      const fullName = model.get('fullName');
 
-        // then
-        expect(fullName).to.equal('Manu Phillip');
-      });
+      // then
+      expect(fullName).to.equal('Manu Phillip');
+    });
+  });
+
+  describe('#hasAssessmentParticipations', () => {
+    it('should return true if the user has at least one participation', function() {
+      // given
+      const campaign = store.createRecord('campaign', { type: 'ASSESSMENT' });
+      const participation = store.createRecord('campaign-participation');
+      participation.set('campaign', campaign);
+      const model = store.createRecord('user');
+      model.set('campaignParticipations', [participation]);
+
+      // when
+      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+
+      // then
+      expect(hasAssessmentParticipations).to.equal(true);
+    });
+
+    it('should return false if the user has no assessment participation', function() {
+      // given
+      const campaign = store.createRecord('campaign', { type: 'PROFILE_COLLECTION' });
+      const participation = store.createRecord('campaign-participation');
+      participation.set('campaign', campaign);
+      const model = store.createRecord('user');
+      model.set('campaignParticipations', [participation]);
+
+      // when
+      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+
+      // then
+      expect(hasAssessmentParticipations).to.equal(false);
+    });
+
+    it('should return false if the user has no participation', function() {
+      // given
+      const model = store.createRecord('user');
+
+      // when
+      const hasAssessmentParticipations = model.get('hasAssessmentParticipations');
+
+      // then
+      expect(hasAssessmentParticipations).to.equal(false);
     });
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1061,6 +1061,7 @@
         "pix": "Pix",
         "user": {
             "account": "My account",
+            "tests": "My personalised tests",
             "certifications": "My certifications",
             "sign-out": "Log out"
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1064,6 +1064,7 @@
         },
         "user": {
             "account": "Mon compte",
+            "tests": "Mes parcours",
             "certifications": "Mes certifications",
             "sign-out": "Se déconnecter"
         }


### PR DESCRIPTION
## :unicorn: Problème

Actuellement, il n'y a pas d'accès à la page mes parcours.

## :robot: Solution

Ajouter un lien "Mes parcours" dans le menu utilisateur:
- Dans la navbar sur desktop
- Dans le burger menu sur mobile ou tablette

## :rainbow: Remarques

L'affichage est conditionné par:
- Le feature flag `FT_DASHBOARD` est à `true` sur l'environnement de pix-app
- L'utilisateur doit avoir au moins une participation à une campagne d'évaluation

## :100: Pour tester

**Scénario 1, avec des participations:**
1. Se connecter avec `jaune.attend@example.net`
2. Cliquer sur le menu utilisateur et voir le menu "Mes parcours"
3. Cliquer le menu "Mes parcours"
4. Voir la page "Mes parcours"
_(tester également le burger menu en mobile)_

**Scénario 2, sans participation:**
1. Se connecter avec `userpix1@example.net`
2. Cliquer sur le menu utilisateur, il ne devrait pas y avoir de menu "Mes parcours"
_(tester également le burger menu en mobile)_