### PR TITLE
[FEATURE] Passage du header, footer et TDB en 1280px (PIX-1994). 

### DIFF
--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -10,7 +10,7 @@
 
     @include device-is('desktop') {
       flex-direction: row;
-      padding: 18px 0 48px;
+      padding: 18px 20px 48px 20px;
     }
   }
 }

--- a/mon-pix/app/styles/components/_footer.scss
+++ b/mon-pix/app/styles/components/_footer.scss
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     margin: 0 auto;
-    max-width: 980px;
+    max-width: 1280px;
     padding: 18px 16px;
     width: 100%;
 

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -2,7 +2,7 @@
 
   &__container {
     margin: 0 auto;
-    max-width: 980px;
+    max-width: 1280px;
     display: flex;
     flex-direction: row;
     padding: 20px 0;

--- a/mon-pix/app/styles/components/_navbar-desktop-header.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-header.scss
@@ -9,6 +9,10 @@
     align-items: center;
     position: relative;
   }
+
+  @include device-is('desktop') {
+    margin-left: 20px;
+  }
 }
 
 .navbar-desktop-header-container {

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -1,10 +1,6 @@
 .dashboard-content {
   padding: 40px 20px;
 
-  @include device-is('desktop') {
-    padding: 40px 0;
-  }
-
   &__section {
     border-bottom: 1px solid $grey-20;
     padding: 20px 0 40px;

--- a/mon-pix/app/styles/globals/_layout.scss
+++ b/mon-pix/app/styles/globals/_layout.scss
@@ -1,4 +1,4 @@
 .page-container {
-  max-width: 980px;
+  max-width: 1280px;
   margin: 0 auto;
 }


### PR DESCRIPTION
## :unicorn: Problème

Nous souhaitons augmenter la largeur des éléments visuels de Pix-app pour passer de 980px de largeur max à 1280px.
🛑 Nous changeons dans cette PR uniquement les valeurs du footer, header et tableau de bord.

## :robot: Solution

Augmentation de la max-width des éléments mentionnés précédemment en 1280px.

## :rainbow: Remarques

Sur le tableau de bord de Pix-App, lorsque l'on arrive au breakpoint de 981px de largeur, on rencontre un problème avec un manque de margin gauche et droite sur l'ensemble de la page (Header / Contenu / Footer). 

<img width="980" alt="Capture d’écran 2021-02-01 à 14 38 32" src="https://user-images.githubusercontent.com/36371437/106480763-05d61200-64ac-11eb-9a52-cbce2b75a2c0.png">

Nous corrigeons ce problème avec un ajout de margin sur le header et de padding sur le footer. 

## :100: Pour tester

Vérifier que les différents éléments redimensionnés aient bien la bonne largeur.
Vérifier qu'il n'y ait plus de problème de marge au rétrécissement de la fenêtre.
