### PR TITLE
[BUGFIX] Pouvoir se réconcilier après avoir eu une erreur et corrigé ses infos lors de la réconciliation SCO.

### DIFF
--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco.js
@@ -85,6 +85,9 @@ export default class JoinSco extends Component {
     event.preventDefault();
     this.isLoading = true;
     this.errorMessage = null;
+    this.displayInformationModal = false;
+    this.reconciliationError = null;
+    this.reconciliationWarning = null;
 
     this._validateForm();
     if (this.isFormNotValid) {

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -339,66 +339,6 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       sinon.assert.called(eventStub.preventDefault);
     });
 
-    it('should display an error on firstName', async function() {
-      // given
-      component.firstName = ' ';
-
-      // when
-      await component.actions.submit.call(component, eventStub);
-
-      // then
-      sinon.assert.notCalled(onSubmitToReconcileStub);
-      expect(component.validation.firstName).to.equal('Votre prénom n’est pas renseigné.');
-    });
-
-    it('should display an error on lastName', async function() {
-      // given
-      component.lastName = '';
-
-      // when
-      await component.actions.submit.call(component, eventStub);
-
-      // then
-      sinon.assert.notCalled(onSubmitToReconcileStub);
-      expect(component.validation.lastName).to.equal('Votre nom n’est pas renseigné.');
-    });
-
-    it('should display an error on dayOfBirth', async function() {
-      // given
-      component.dayOfBirth = '99';
-
-      // when
-      await component.actions.submit.call(component, eventStub);
-
-      // then
-      sinon.assert.notCalled(onSubmitToReconcileStub);
-      expect(component.validation.dayOfBirth).to.equal('Votre jour de naissance n’est pas valide.');
-    });
-
-    it('should display an error on monthOfBirth', async function() {
-      // given
-      component.monthOfBirth = '99';
-
-      // when
-      await component.actions.submit.call(component, eventStub);
-
-      // then
-      sinon.assert.notCalled(onSubmitToReconcileStub);
-      expect(component.validation.monthOfBirth).to.equal('Votre mois de naissance n’est pas valide.');
-    });
-
-    it('should display an error on yearOfBirth', async function() {
-      // given
-      component.yearOfBirth = '99';
-
-      // when
-      await component.actions.submit.call(component, eventStub);
-
-      // then
-      sinon.assert.notCalled(onSubmitToReconcileStub);
-      expect(component.validation.yearOfBirth).to.equal('Votre année de naissance n’est pas valide.');
-    });
-
     context('When user does not come from external identity provider', function() {
 
       beforeEach(function() {
@@ -557,6 +497,66 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         // then
         sinon.assert.calledOnce(record.unloadRecord);
         expect(component.errorMessage).to.be.null;
+      });
+
+      it('should display an error on firstName', async function() {
+        // given
+        component.firstName = ' ';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.notCalled(onSubmitToReconcileStub);
+        expect(component.validation.firstName).to.equal('Votre prénom n’est pas renseigné.');
+      });
+
+      it('should display an error on lastName', async function() {
+        // given
+        component.lastName = '';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.notCalled(onSubmitToReconcileStub);
+        expect(component.validation.lastName).to.equal('Votre nom n’est pas renseigné.');
+      });
+
+      it('should display an error on dayOfBirth', async function() {
+        // given
+        component.dayOfBirth = '99';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.notCalled(onSubmitToReconcileStub);
+        expect(component.validation.dayOfBirth).to.equal('Votre jour de naissance n’est pas valide.');
+      });
+
+      it('should display an error on monthOfBirth', async function() {
+        // given
+        component.monthOfBirth = '99';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.notCalled(onSubmitToReconcileStub);
+        expect(component.validation.monthOfBirth).to.equal('Votre mois de naissance n’est pas valide.');
+      });
+
+      it('should display an error on yearOfBirth', async function() {
+        // given
+        component.yearOfBirth = '99';
+
+        // when
+        await component.actions.submit.call(component, eventStub);
+
+        // then
+        sinon.assert.notCalled(onSubmitToReconcileStub);
+        expect(component.validation.yearOfBirth).to.equal('Votre année de naissance n’est pas valide.');
       });
 
       it('should display a not found error', async function() {

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -621,6 +621,26 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
 
       });
 
+      describe('When student mistyped its information, has an error, and correct it', () => {
+
+        it('should reconcile', async function() {
+          // given
+          const error = { status: '409', meta: { userId: 1 } };
+
+          onSubmitToReconcileStub
+            .onFirstCall().rejects({ errors: [error] })
+            .onSecondCall().resolves();
+
+          // when
+          await component.actions.submit.call(component, eventStub);
+          await component.actions.submit.call(component, eventStub);
+
+          // then
+          expect(component.displayInformationModal).to.be.true;
+          expect(component.reconciliationError).to.be.null;
+          expect(component.isLoading).to.be.false;
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur SCO saisissait des infos incorrectes, ne pouvait pas se réconcilier, puis se rendait compte de sa bêtise et corrigeait ses infos, Pix ne permettait pas la réconciliation, même si cela était possible.

En effet, les variables d'erreurs n'étant pas réinitialisées, lors de la seconde fois, on affichait la pop-up avec les anciennes valeurs d'erreur.

## :robot: Solution
Réinitialiser les variables d'erreurs.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix App, échouer à se réconcilier avec une 409, puis se réconcilier avec les bonnes infos.
