### PR TITLE
[TECH] Installer la même version de node en local que dans la CI.

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -5,7 +5,7 @@
 Vous devez au préalable avoir correctement installé les logiciels suivants :
 
 * [Git](https://git-scm.com/) (2.6.4)
-* [Node.js](https://nodejs.org/) (v14.15.1) et NPM (6.14.8)
+* [Node.js](https://nodejs.org/) (v14.15.0) et NPM (6.14.8)
 * [Docker](https://docs.docker.com/get-started/) (19.03.5) avec [Docker Compose](https://docs.docker.com/compose/install/)
 
 > ⚠️ Les versions indiquées sont celles utilisées et préconisées par l'équipe de développement. Il est possible que l'application fonctionne avec des versions différentes.

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-EXPECTED_NODE_VERSION="v14.15.1"
+EXPECTED_NODE_VERSION="v14.15.0"
 EXPECTED_NPM_VERSION="6.14.8"
 
 function display_banner() {


### PR DESCRIPTION
## :unicorn: Problème
Le script d'installation Pix local `configure.sh` vérifie l'existence d'une version de node différente de celle vérifiée par npm, ce qui empêche l'installation

## :robot: Solution
Mettre ces deux versions en cohérence

## :rainbow: Remarques
La documentation a été mise à jour

## :100: Pour tester
Exécuter le script
