### PR TITLE
[FEATURE] Affichage des paliers dans les résultats individuels d'une campagne d'évaluation (PIX-2053).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -54,8 +54,13 @@
                 {{@campaignAssessmentParticipation.validatedSkillsCount}} / {{@campaignAssessmentParticipation.targetedSkillsCount}} ACQUIS
               </ProgressBar>
             </div>
-            <div class="value-text value-text--highlight">{{@campaignAssessmentParticipation.masteryPercentage}}%
-            </div>
+            {{#if @campaign.hasStages}}
+              <div aria-label="Paliers" class="panel-header-data-content__stages">
+                <StageStars @result={{@campaignAssessmentParticipation.masteryPercentage}} @stages={{@campaign.stages}}/>
+              </div>
+            {{else}}
+              <div class="value-text value-text--highlight">{{@campaignAssessmentParticipation.masteryPercentage}}%</div>
+            {{/if}}
           </li>
         </ul>
       {{/if}}

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -99,8 +99,20 @@
   }
 
   &__progress-bar {
-    margin-top: 14px;
-    margin-right: 20px;
+    margin: 16px 16px 0 16px;
+  }
+
+  &__stages {
+    display: flex;
+    align-items: center;
+    height: 32px;
+    padding-left: 16px;
+    border-left: 1px solid $grey-20;
+
+    .pix-stars svg {
+      width: 26px;
+      height: 26px;
+    }
   }
 }
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
@@ -152,22 +152,6 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
   module('results information', function() {
     module('when the participation is shared', function() {
-      test('it displays campaign participation mastery percentage', async function(assert) {
-        const campaignAssessmentParticipation = {
-          masteryPercentage: 65,
-          isShared: true,
-        };
-
-        const campaign = {};
-
-        this.campaignAssessmentParticipation = campaignAssessmentParticipation;
-        this.campaign = campaign;
-
-        await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
-
-        assert.contains('65%');
-      });
-
       test('it displays campaign participation details of mastery percentage (validated skills over total skills)', async function(assert) {
         const campaignAssessmentParticipation = {
           validatedSkillsCount: 45,
@@ -183,6 +167,44 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
 
         assert.dom('[aria-label="Résultat"]').containsText('45 / 50 ACQUIS');
+      });
+
+      module('when the campaign has stages', function() {
+        test('it displays stages acquired', async function(assert) {
+          const campaign = {
+            hasStages: true,
+            stages: [{ threshold: 20 }, { threshold: 70 }],
+          };
+          const campaignAssessmentParticipation = {
+            masteryPercentage: 65,
+            isShared: true,
+          };
+
+          this.campaignAssessmentParticipation = campaignAssessmentParticipation;
+          this.campaign = campaign;
+
+          await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
+
+          assert.dom('[aria-label="Paliers"]').containsText('1 étoiles sur 2');
+        });
+      });
+
+      module('when the campaign has no stages', function() {
+        test('it displays campaign participation mastery percentage', async function(assert) {
+          const campaignAssessmentParticipation = {
+            masteryPercentage: 65,
+            isShared: true,
+          };
+
+          const campaign = {};
+
+          this.campaignAssessmentParticipation = campaignAssessmentParticipation;
+          this.campaign = campaign;
+
+          await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
+
+          assert.contains('65%');
+        });
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement on voit les paliers sur la page globale des participants, mais pas par participant.

## :robot: Solution
Ajouter les paliers par participant.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix Orga, et vérifier le bon affichage lorsqu'il y a des paliers.
Vérifier la non-régréssion lorsqu'il n'y a pas de paliers.