### PR TITLE
[BUGFIX] Fix les notifications lors de la publication de session dans pix-certif (PIX-2096)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -63,9 +63,8 @@ export default class ListController extends Controller {
       await this.forceRefreshModelFromBackend();
     }
 
-    const isPublished = this.model.isPublished;
     await this.model.juryCertificationSummaries.reload();
-    if (isPublished) {
+    if (this.model.isPublished) {
       this.notifications.success('Les certifications ont été correctement publiées.');
     }
     this.hideConfirmationModal();


### PR DESCRIPTION
## :unicorn: Problème
Une régression a été introduite à l'occasion de #2439 la notification "Les certifications ont été correctement publiées." ne s'affiche plus.

La valeur de `isPublished` est stockée dans une variable locale **_avant_** la mise à jour (`.reload()`) des `juryCertificationSummaries` qui doit avoir pour effet de passer `isPublished` de `false` à `true` : 

```javascript
    const isPublished = this.model.isPublished;
    await this.model.juryCertificationSummaries.reload();
    if (isPublished) {
      this.notifications.success('Les certifications ont été correctement publiées.');
    }
```

## :robot: Solution
Ne pas passer par une variable locale et utiliser directement `this.model.isPublished` :

```javascript
    await this.model.juryCertificationSummaries.reload();
    if (this.model.isPublished) {
      this.notifications.success('Les certifications ont été correctement publiées.');
    }
```

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Publier une session de puis pix-certif, vérifier que la notification "Les certifications ont été correctement publiées." s'affiche.
