### PR TITLE
[FEATURE] Ajouter un bandeau Pix Certif pour la fonctionnalité d'envoi automatique des résultats (PIX-2087)

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -124,7 +124,9 @@
         @icon='times'
         class="certification-candidates-row-actions__close"
         @triggerAction={{this.cancel}}
-        data-test-id="panel-candidate__action__cancel" />
+        data-test-id="panel-candidate__action__cancel"
+        @withBackground={{true}}
+      />
     </div>
   </td>
 </tr>

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -15,7 +15,7 @@
         <div id="add-candidate" class="certification-candidates-add-button__text">
           Ajouter un candidat
         </div>
-        <PixActionButton aria-describedby="add-candidate" @icon='plus'/>
+        <PixActionButton aria-describedby="add-candidate" @icon='plus' @withBackground={{true}} />
       </div>
     {{/if}}
   </div>
@@ -110,19 +110,23 @@
                 <div class="certification-candidates-actions__delete">
                   {{#if candidate.isLinked}}
                     <PixActionButton
-                            @icon="trash-alt"
-                            class="certification-candidates-actions__delete-button--disabled"
-                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
+                      @icon="trash-alt"
+                      class="certification-candidates-actions__delete-button--disabled"
+                      data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
+                      @withBackground={{true}}
+                    />
                     <div class="certification-candidates-actions__delete-tooltip">
                       Ce candidat a déjà rejoint la session. Vous ne pouvez pas le supprimer.
                     </div>
                   {{else}}
                     <PixActionButton
-                            @icon="trash-alt"
+                      @icon="trash-alt"
                       {{on 'click' (fn this.deleteCertificationCandidate candidate)}}
-                            aria-label="Supprimer un élève"
-                            class="certification-candidates-actions__delete-button"
-                            data-test-id="panel-candidate__actions__delete__{{candidate.id}}" />
+                      aria-label="Supprimer un élève"
+                      class="certification-candidates-actions__delete-button"
+                      data-test-id="panel-candidate__actions__delete__{{candidate.id}}"
+                      @withBackground={{true}}
+                    />
                   {{/if}}
                 </div>
               </div>

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -30,4 +30,9 @@ export default class SessionsDetailsController extends Controller {
   get shouldDisplayDownloadButton() {
     return this.hasOneOrMoreCandidates && (this.shouldDisplayPrescriptionScoStudentRegistrationFeature || this.isResultRecipientEmailVisible);
   }
+
+  @computed('isResultRecipientEmailVisible')
+  get shouldDisplayResultRecipientInfoMessage() {
+    return this.isResultRecipientEmailVisible === true;
+  }
 }

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -1,11 +1,13 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import config from 'pix-certif/config/environment';
 
 export default class SessionsDetailsController extends Controller {
+  @service currentUser;
 
   isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
@@ -31,8 +33,8 @@ export default class SessionsDetailsController extends Controller {
     return this.hasOneOrMoreCandidates && (this.shouldDisplayPrescriptionScoStudentRegistrationFeature || this.isResultRecipientEmailVisible);
   }
 
-  @computed('isResultRecipientEmailVisible')
+  @computed('isResultRecipientEmailVisible', 'currentUser.currentCertificationCenter.isScoManagingStudents')
   get shouldDisplayResultRecipientInfoMessage() {
-    return this.isResultRecipientEmailVisible === true;
+    return this.isResultRecipientEmailVisible === true && this.currentUser.currentCertificationCenter.isScoManagingStudents === false;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -1,6 +1,7 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
 import { notEmpty, sort } from '@ember/object/computed';
 import config from 'pix-certif/config/environment';
@@ -8,6 +9,8 @@ import config from 'pix-certif/config/environment';
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
 export default class SessionsListController extends Controller {
+  @service currentUser;
+
   isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   sortingOrder = SORTING_ORDER;
@@ -21,8 +24,8 @@ export default class SessionsListController extends Controller {
     this.transitionToRoute('authenticated.sessions.details', session.id);
   }
 
-  @computed('isResultRecipientEmailVisible')
+  @computed('isResultRecipientEmailVisible', 'currentUser.currentCertificationCenter.isScoManagingStudents')
   get shouldDisplayResultRecipientInfoMessage() {
-    return this.isResultRecipientEmailVisible === true;
+    return this.isResultRecipientEmailVisible === true && this.currentUser.currentCertificationCenter.isScoManagingStudents === false;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -1,12 +1,15 @@
 /* eslint-disable ember/no-computed-properties-in-native-classes*/
 
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { notEmpty, sort } from '@ember/object/computed';
+import config from 'pix-certif/config/environment';
 
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
 export default class SessionsListController extends Controller {
+  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
+
   sortingOrder = SORTING_ORDER;
 
   @notEmpty('model') hasSession;
@@ -16,5 +19,10 @@ export default class SessionsListController extends Controller {
   @action
   goToDetails(session) {
     this.transitionToRoute('authenticated.sessions.details', session.id);
+  }
+
+  @computed('isResultRecipientEmailVisible')
+  get shouldDisplayResultRecipientInfoMessage() {
+    return this.isResultRecipientEmailVisible === true;
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/add-student.scss
+++ b/certif/app/styles/pages/authenticated/sessions/add-student.scss
@@ -14,9 +14,5 @@
   &__info-message {
     align-items: center;
     display: flex;
-
-    span {
-      margin-left: 6px;
-    }
   }
 }

--- a/certif/app/styles/pages/authenticated/sessions/list-items.scss
+++ b/certif/app/styles/pages/authenticated/sessions/list-items.scss
@@ -2,10 +2,6 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-
-  &__header {
-    margin-bottom: 44px;
-  }
 }
 
 .session-list {

--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -8,12 +8,10 @@
   <h1 class="add-student__title">Ajouter des candidats</h1>
 
   <PixMessage @type='info' @withIcon={{true}} class="add-student__info-message">
-    <span>
-      Si certain(e)s élèves n’apparaissent pas dans cette liste, 
-      merci de ré-importer le fichier SIECLE dans Pix Orga.<br>
-      Si malgré tout des élèves ne sont pas visibles, merci de contacter 
-      <a href="https://support.pix.fr" target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
-    </span>
+    Si certain(e)s élèves n’apparaissent pas dans cette liste,
+    merci de ré-importer le fichier SIECLE dans Pix Orga.<br>
+    Si malgré tout des élèves ne sont pas visibles, merci de contacter
+    <a href="https://support.pix.fr" target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
   </PixMessage>
 
   <AddStudentList

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -37,6 +37,14 @@
     </div>
   </div>
 
+  <PixMessage @withIcon={{true}}>
+    Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
+    Pensez à bien renseigner ce champ lors de l'inscription des candidats.
+    <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
+      Plus d'informations ici.
+    </a>
+  </PixMessage>
+
   <div class="panel session-details__controls">
     <nav class="navbar session-details-controls__navbar-tabs">
       <LinkTo @route="authenticated.sessions.details.parameters" class="navbar-item">

--- a/certif/app/templates/authenticated/sessions/details.hbs
+++ b/certif/app/templates/authenticated/sessions/details.hbs
@@ -37,13 +37,15 @@
     </div>
   </div>
 
-  <PixMessage @withIcon={{true}}>
-    Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
-    Pensez à bien renseigner ce champ lors de l'inscription des candidats.
-    <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
-      Plus d'informations ici.
-    </a>
-  </PixMessage>
+  {{#if this.shouldDisplayResultRecipientInfoMessage}}
+    <PixMessage @withIcon={{true}}>
+      Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
+      Pensez à bien renseigner ce champ lors de l'inscription des candidats.
+      <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
+        Plus d'informations ici.
+      </a>
+    </PixMessage>
+  {{/if}}
 
   <div class="panel session-details__controls">
     <nav class="navbar session-details-controls__navbar-tabs">

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -4,6 +4,14 @@
       <h1 class="page__title page-title">Sessions de certification</h1>
     </div>
 
+    <PixMessage @withIcon={{true}}>
+      Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
+      Pensez à bien renseigner ce champ lors de l'inscription des candidats.
+      <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
+        Plus d'informations ici.
+      </a>
+    </PixMessage>
+
     <div class="panel">
       <div class="session-list__header">
           <LinkTo @route="authenticated.sessions.new" class="button button--link button--with-icon">

--- a/certif/app/templates/authenticated/sessions/list.hbs
+++ b/certif/app/templates/authenticated/sessions/list.hbs
@@ -4,13 +4,15 @@
       <h1 class="page__title page-title">Sessions de certification</h1>
     </div>
 
-    <PixMessage @withIcon={{true}}>
-      Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
-      Pensez à bien renseigner ce champ lors de l'inscription des candidats.
-      <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
-        Plus d'informations ici.
-      </a>
-    </PixMessage>
+    {{#if this.shouldDisplayResultRecipientInfoMessage}}
+      <PixMessage @withIcon={{true}}>
+        Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur).<br>
+        Pensez à bien renseigner ce champ lors de l'inscription des candidats.
+        <a href="https://cloud.pix.fr/s/gTwmp4GKWNJtdn5" target="_blank" rel="noreferrer noopener">
+          Plus d'informations ici.
+        </a>
+      </PixMessage>
+    {{/if}}
 
     <div class="panel">
       <div class="session-list__header">

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -117,34 +117,57 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
         });
       });
     });
+  });
 
-    module('#shouldDisplayResultRecipientInfoMessage', function() {
-      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
-        test('should return false', function(assert) {
-          // given
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
-          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+  module('#shouldDisplayResultRecipientInfoMessage', function() {
+    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
+      test('should return false', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
+        const controller = this.owner.lookup('controller:authenticated/sessions/details');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: false },
+        };
 
-          // when
-          const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
 
-          // then
-          assert.notOk(shouldDisplayResultRecipientInfoMessage);
-        });
+        // then
+        assert.notOk(shouldDisplayResultRecipientInfoMessage);
       });
+    });
 
-      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
-        test('should return true', function(assert) {
-          // given
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
-          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+    module('when the current user certification center does manage students', function() {
+      test('should also return false', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+        const controller = this.owner.lookup('controller:authenticated/sessions/details');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: true },
+        };
 
-          // when
-          const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
 
-          // then
-          assert.ok(shouldDisplayResultRecipientInfoMessage);
-        });
+        // then
+        assert.notOk(shouldDisplayResultRecipientInfoMessage);
+      });
+    });
+
+    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled and current user is if of type Sco and does not managing students', function() {
+      test('should return true', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+        const controller = this.owner.lookup('controller:authenticated/sessions/details');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: false },
+        };
+
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+        // then
+        assert.ok(shouldDisplayResultRecipientInfoMessage);
       });
     });
   });

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -117,6 +117,36 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
         });
       });
     });
+
+    module('#shouldDisplayResultRecipientInfoMessage', function() {
+      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
+        test('should return false', function(assert) {
+          // given
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
+          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+
+          // when
+          const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+          // then
+          assert.notOk(shouldDisplayResultRecipientInfoMessage);
+        });
+      });
+
+      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
+        test('should return true', function(assert) {
+          // given
+          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+          const controller = this.owner.lookup('controller:authenticated/sessions/details');
+
+          // when
+          const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+          // then
+          assert.ok(shouldDisplayResultRecipientInfoMessage);
+        });
+      });
+    });
   });
 
   module('when there is no enrolled candidate', function() {

--- a/certif/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
 
+import config from 'pix-certif/config/environment';
+
 module('Unit | Controller | authenticated/sessions/list', function(hooks) {
   setupTest(hooks);
 
@@ -36,6 +38,36 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
 
       // then
       assert.equal(hasSession, true);
+    });
+  });
+
+  module('#shouldDisplayResultRecipientInfoMessage', function() {
+    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
+      test('should return false', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
+        const controller = this.owner.lookup('controller:authenticated/sessions/list');
+
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+        // then
+        assert.notOk(shouldDisplayResultRecipientInfoMessage);
+      });
+    });
+
+    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
+      test('should return true', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+        const controller = this.owner.lookup('controller:authenticated/sessions/list');
+
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+        // then
+        assert.ok(shouldDisplayResultRecipientInfoMessage);
+      });
     });
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -47,6 +47,9 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
         // given
         config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
         const controller = this.owner.lookup('controller:authenticated/sessions/list');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: false },
+        };
 
         // when
         const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
@@ -56,11 +59,31 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
       });
     });
 
-    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
+    module('when the current user certification center does manage students', function() {
+      test('should also return false', function(assert) {
+        // given
+        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
+        const controller = this.owner.lookup('controller:authenticated/sessions/list');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: true },
+        };
+
+        // when
+        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
+
+        // then
+        assert.notOk(shouldDisplayResultRecipientInfoMessage);
+      });
+    });
+
+    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled and current user is not sco managing students', function() {
       test('should return true', function(assert) {
         // given
         config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/list');
+        controller.currentUser = {
+          currentCertificationCenter: { isScoManagingStudents: false },
+        };
 
         // when
         const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;


### PR DESCRIPTION
## :unicorn: Problème

La fonctionnalité d’envoi automatique des résultats de certification aux prescripteurs va bientôt être activée en production. Si une communication est prévue auprès des référents de centre de certification, il y a une crainte que cette information (envoyée par courriel) passe à la trappe, et que les référents de centre/utilisateurs Pix Certif oublie de renseigner le champ “Adresse email du destinataire des résultats”, et donc ne reçoivent pas les résultats de leur(s) candidat(s) alors qu’ils souhaitaient les recevoir (donc risque de support…). Nous souhaitons donc renforcer l’information quant à l’existence de cette nouvelle fonctionnalité et la nécessité de renseigner le champ pour recevoir les résultats de certification.

## :robot: Solution

Pour tous les centres de certification de type SUP, PRO, SCO is NOT ManagingStudent : afficher le bandeau d’informations Pix Certif avec le texte suivant : “Vous pouvez maintenant renseigner l'adresse email du destinataire des résultats (exemple : formateur). Pensez à bien renseigner ce champ lors de l'inscription des candidats. Plus d'informations ici.”
- le texte “Plus d’informations ici” est cliquable et renvoi vers la doc correspondante : https://cloud.pix.fr/s/gTwmp4GKWNJtdn5
- afficher ce bandeau sur les pages suivantes : liste des sessions, page de détails d’une session

TODO

- [x] Mettre à jour Pix UI
- [x] Ajouter les bannières
- [x] Affcher uniquement avec le flag FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS
- [x] Affcher uniquement pour les centres de certification de type SUP, PRO, SCO is NOT ManagingStudent 

## :rainbow: Remarques
- Pix UI a du être mis à jour dans Pix Certif pour gérer les bannières d'informations avec une icône et plusieurs lignes
- Pix UI 2.0 a introduit des _breakings changes_ qui ont nécessité de revoir les paramètres passés à `PixActionButton`
- Le lien Pix Cloud vers lequel on renvoie pour plus d'information est pour l'instant un dossier vide

## :100: Pour tester
- Lancer l'API et Certif avec le flag FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS
- Se connecter avec un compte non-sco (ex: certifsup@example.net)
- Afficher la liste des sessions et constater l'apparition de la bannière
- Ouvrir le détail d'une session et constater l'apparition de la bannière