### PR TITLE
[FEATURE] Ajout du Pix-score sur le tableau de bord (PIX-1660).

### DIFF
--- a/mon-pix/app/components/competence-card/list.hbs
+++ b/mon-pix/app/components/competence-card/list.hbs
@@ -1,6 +1,6 @@
 <section class="competence-card-list">
-  {{#each @scorecards as |scorecard|}}
-    <div class="competence-card-list__competence-card">
+  {{#each @scorecards as |scorecard index|}}
+    <div class="competence-card-list__competence-card competence-card-list__competence-card--{{index}}">
       <CompetenceCard @scorecard={{scorecard}} @interactive={{true}}/>
     </div>
   {{/each}}

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -11,8 +11,11 @@
       {{/unless}}
   </section>
 
-  <section class="dashboard-content__section--score dashboard-content__score">
-    SCORE PIX
+  <section class="dashboard-content__score">
+    <div class="dashboard-content-score__wrapper">
+      <HexagonScore @pixScore={{this.userScore}} />
+      <LinkTo @route="profile" class="dashboard-content-score-wrapper__button">{{t 'pages.dashboard.score.profile-link'}}</LinkTo>
+    </div>
   </section>
 
   <section class="dashboard-content__cards">

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -1,17 +1,24 @@
 <section class="page-container dashboard-content">
   <h1 class="sr-only">{{t 'pages.dashboard.title'}}</h1>
 
-  {{#unless this.hasUserSeenNewDashboardInfo}}
+  <div class="dashboard-content__banner">
     <section class="dashboard-content__section" data-test-new-dashboard-info>
-      <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
-                      @image="/images/discovery_TDB_pix.svg"
-                      @backgroundColorClass="new-information--blue-gradient-background"
-                      @textColorClass="new-information--white-text"
-                      @closeaction={{this.closeInformationAboutNewDashboard}}/>
+      {{#unless this.hasUserSeenNewDashboardInfo}}
+          <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
+                          @image="/images/discovery_TDB_pix.svg"
+                          @backgroundColorClass="new-information--blue-gradient-background"
+                          @textColorClass="new-information--white-text"
+                          @closeaction={{this.closeInformationAboutNewDashboard}}/>
+      {{/unless}}
     </section>
-  {{/unless}}
+  </div>
 
-  {{#if this.hasNothingToShow}}
+  <div class="dashboard-content__score">
+    SCORE PIX
+  </div>
+
+  <div class="dashboard-content__cards">
+    {{#if this.hasNothingToShow}}
     <section class="dashboard-content__section" data-test-empty-dashboard>
       <div class="dashboard-content-section--with-button">
         <NewInformation @information="{{t 'pages.dashboard.empty-dashboard.message'}}"
@@ -25,34 +32,41 @@
   {{/if}}
 
   {{#if this.hasCampaignParticipationOverviews}}
-    <section class="dashboard-content__section" data-test-campaign-participation-overviews>
-      <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
-      <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
+      <section class="dashboard-content__section" data-test-campaign-participation-overviews>
+        <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
+        <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
 
-      <CampaignParticipationOverview::Grid @model={{@model.campaignParticipationOverviews}}/>
-    </section>
-  {{/if}}
+        <CampaignParticipationOverview::Grid @model={{@model.campaignParticipationOverviews}}/>
+      </section>
+    {{/if}}
 
-  {{#if this.hasStartedCompetences}}
-    <section class="dashboard-content__section" data-test-started-competences>
-      <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
-      <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
+    {{#if this.hasStartedCompetences}}
+      <section class="dashboard-content__section" data-test-started-competences>
+        <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
+        <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
 
-      <CompetenceCard::List @scorecards={{this.startedCompetences}} />
-    </section>
-  {{/if}}
+        <CompetenceCard::List @scorecards={{this.startedCompetences}} />
+      </section>
+    {{/if}}
 
-  {{#if this.hasRecommendedCompetences}}
-    <section class="dashboard-content__section" data-test-recommended-competences>
-      <div class="dashboard-content-section--with-button">
-        <div>
-          <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
-          <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
+    {{#if this.hasRecommendedCompetences}}
+      <section class="dashboard-content__section" data-test-recommended-competences>
+        <div class="dashboard-content-section--with-button">
+          <div>
+            <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
+            <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
+          </div>
+          <LinkTo @route="profile" class="dashboard-content-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
         </div>
-        <LinkTo @route="profile" class="dashboard-content-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
-      </div>
 
-      <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />
-    </section>
-  {{/if}}
+        <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />
+      </section>
+    {{/if}}
+  </div>
+
+  <div class="dashboard-content__certif">
+    <!-- Rajout du bloc certif ultérieurement -->
+    <!-- Div ajoutée afin de créer le layout Grid CSS -->
+  </div>
+
 </section>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -1,8 +1,7 @@
 <section class="page-container dashboard-content">
   <h1 class="sr-only">{{t 'pages.dashboard.title'}}</h1>
 
-  <div class="dashboard-content__banner">
-    <section class="dashboard-content__section" data-test-new-dashboard-info>
+  <section class="dashboard-content__section--banner dashboard-content__banner" data-test-new-dashboard-info>
       {{#unless this.hasUserSeenNewDashboardInfo}}
           <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
                           @image="/images/discovery_TDB_pix.svg"
@@ -10,14 +9,13 @@
                           @textColorClass="new-information--white-text"
                           @closeaction={{this.closeInformationAboutNewDashboard}}/>
       {{/unless}}
-    </section>
-  </div>
+  </section>
 
-  <div class="dashboard-content__score">
+  <section class="dashboard-content__section--score dashboard-content__score">
     SCORE PIX
-  </div>
+  </section>
 
-  <div class="dashboard-content__cards">
+  <section class="dashboard-content__cards">
     {{#if this.hasNothingToShow}}
     <section class="dashboard-content__section" data-test-empty-dashboard>
       <div class="dashboard-content-section--with-button">
@@ -32,41 +30,41 @@
   {{/if}}
 
   {{#if this.hasCampaignParticipationOverviews}}
-      <section class="dashboard-content__section" data-test-campaign-participation-overviews>
-        <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
-        <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
+      <section class="dashboard-content-cards__section" data-test-campaign-participation-overviews>
+        <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
+        <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
 
         <CampaignParticipationOverview::Grid @model={{@model.campaignParticipationOverviews}}/>
       </section>
     {{/if}}
 
     {{#if this.hasStartedCompetences}}
-      <section class="dashboard-content__section" data-test-started-competences>
-        <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
-        <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
+      <section class="dashboard-content-cards__section" data-test-started-competences>
+        <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
+        <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
 
         <CompetenceCard::List @scorecards={{this.startedCompetences}} />
       </section>
     {{/if}}
 
     {{#if this.hasRecommendedCompetences}}
-      <section class="dashboard-content__section" data-test-recommended-competences>
-        <div class="dashboard-content-section--with-button">
+      <section class="dashboard-content-cards__section" data-test-recommended-competences>
+        <div class="dashboard-content-cards-section--with-button">
           <div>
-            <h2 class="dashboard-content-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
-            <p class="dashboard-content-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
+            <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
+            <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
           </div>
-          <LinkTo @route="profile" class="dashboard-content-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
+          <LinkTo @route="profile" class="dashboard-content-cards-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
         </div>
 
         <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />
       </section>
     {{/if}}
-  </div>
+  </section>
 
-  <div class="dashboard-content__certif">
+  <section class="dashboard-content__section dashboard-content__certif">
     <!-- Rajout du bloc certif ultérieurement -->
     <!-- Div ajoutée afin de créer le layout Grid CSS -->
-  </div>
+  </section>
 
 </section>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -1,15 +1,16 @@
 <section class="page-container dashboard-content">
   <h1 class="sr-only">{{t 'pages.dashboard.title'}}</h1>
 
-  <section class="dashboard-content__section--banner dashboard-content__banner" data-test-new-dashboard-info>
-      {{#unless this.hasUserSeenNewDashboardInfo}}
-          <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
-                          @image="/images/discovery_TDB_pix.svg"
-                          @backgroundColorClass="new-information--blue-gradient-background"
-                          @textColorClass="new-information--white-text"
-                          @closeaction={{this.closeInformationAboutNewDashboard}}/>
-      {{/unless}}
-  </section>
+  {{#unless this.hasUserSeenNewDashboardInfo}}
+    <section class="dashboard-content__banner" data-test-new-dashboard-info>
+      <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
+                      @image="/images/discovery_TDB_pix.svg"
+                      @backgroundColorClass="new-information--blue-gradient-background"
+                      @textColorClass="new-information--white-text"
+                      @closeaction={{this.closeInformationAboutNewDashboard}}
+      />
+    </section>
+  {{/unless}}
 
   <section class="dashboard-content__score">
     <div class="dashboard-content-score__wrapper">
@@ -18,7 +19,18 @@
     </div>
   </section>
 
-  <section class="dashboard-content__cards">
+  <section class="dashboard-content__main">
+    {{#unless this.hasUserSeenNewDashboardInfo}}
+      <section class="dashboard-content-main__banner">
+        <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
+                        @image="/images/discovery_TDB_pix.svg"
+                        @backgroundColorClass="new-information--blue-gradient-background"
+                        @textColorClass="new-information--white-text"
+                        @closeaction={{this.closeInformationAboutNewDashboard}}
+        />
+      </section>
+    {{/unless}}
+
     {{#if this.hasNothingToShow}}
     <section class="dashboard-content__section" data-test-empty-dashboard>
       <div class="dashboard-content-section--with-button">
@@ -33,31 +45,31 @@
   {{/if}}
 
   {{#if this.hasCampaignParticipationOverviews}}
-      <section class="dashboard-content-cards__section" data-test-campaign-participation-overviews>
-        <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
-        <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
+      <section class="dashboard-content-main__section" data-test-campaign-participation-overviews>
+        <h2 class="dashboard-content-main-section__title">{{t 'pages.dashboard.campaigns.title'}}</h2>
+        <p class="dashboard-content-main-section__subtitle">{{t 'pages.dashboard.campaigns.subtitle'}}</p>
 
         <CampaignParticipationOverview::Grid @model={{@model.campaignParticipationOverviews}}/>
       </section>
     {{/if}}
 
     {{#if this.hasStartedCompetences}}
-      <section class="dashboard-content-cards__section" data-test-started-competences>
-        <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
-        <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
+      <section class="dashboard-content-main__section" data-test-started-competences>
+        <h2 class="dashboard-content-main-section__title">{{t 'pages.dashboard.started-competences.title'}}</h2>
+        <p class="dashboard-content-main-section__subtitle">{{t 'pages.dashboard.started-competences.subtitle'}}</p>
 
         <CompetenceCard::List @scorecards={{this.startedCompetences}} />
       </section>
     {{/if}}
 
     {{#if this.hasRecommendedCompetences}}
-      <section class="dashboard-content-cards__section" data-test-recommended-competences>
-        <div class="dashboard-content-cards-section--with-button">
+      <section class="dashboard-content-main__section" data-test-recommended-competences>
+        <div class="dashboard-content-main-section--with-button">
           <div>
-            <h2 class="dashboard-content-cards-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
-            <p class="dashboard-content-cards-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
+            <h2 class="dashboard-content-main-section__title">{{t 'pages.dashboard.recommended-competences.title'}}</h2>
+            <p class="dashboard-content-main-section__subtitle">{{t 'pages.dashboard.recommended-competences.subtitle'}}</p>
           </div>
-          <LinkTo @route="profile" class="dashboard-content-cards-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
+          <LinkTo @route="profile" class="dashboard-content-main-section__button">{{t 'pages.dashboard.recommended-competences.profile-link'}}</LinkTo>
         </div>
 
         <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -50,6 +50,10 @@ export default class Content extends Component {
     return this.currentUser.user.hasSeenNewDashboardInfo;
   }
 
+  get userScore() {
+    return this.currentUser.user.profile.pixScore;
+  }
+
   @action
   async closeInformationAboutNewDashboard() {
     await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenNewDashboardInfo: true } });

--- a/mon-pix/app/styles/components/_badge-acquired-card.scss
+++ b/mon-pix/app/styles/components/_badge-acquired-card.scss
@@ -1,12 +1,14 @@
 .badge-acquired-container {
   display: grid;
   grid-template-columns: 1fr;
+  grid-template-rows: auto;
   grid-column-gap: 32px;
   grid-row-gap: 24px;
   padding: 0 14px 48px;
 
   @include device-is('tablet') {
     grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto;
     grid-gap: 32px;
     padding: 0 0 48px;
   }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -66,7 +66,6 @@
 
   &__img {
     display: block;
-    height: 100%;
     margin: 12px 48px 12px 30px;
   }
 

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -34,6 +34,10 @@
 
   &--yellow-background {
     background: linear-gradient(-225deg, rgba(254, 220, 65, 0.55) 0%, rgba(255, 159, 0, 0.55) 100%);
+
+    @include device-is('tablet') {
+      margin-top: 40px;
+    }
   }
 
   &--blue-gradient-background {

--- a/mon-pix/app/styles/components/campaign-participation-overview/_grid.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_grid.scss
@@ -1,19 +1,28 @@
 .campaign-participation-overview-grid {
-  display: grid;
-  grid-gap: 20px;
-  padding-left: 0;
-  min-width: 0;
-  grid-template-columns: minmax(200px, 1fr);
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0;
 
   @include device-is('tablet') {
-    grid-template-columns: repeat(2, minmax(200px, 1fr));
-  }
-
-  @include device-is('desktop') {
-    grid-template-columns: repeat(3, minmax(200px, 1fr));
+    flex-direction: row;
   }
 
   &__item {
     list-style-type: none;
+    margin-bottom: 16px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @include device-is('tablet') {
+      width: calc(50% - 10px);
+    }
+
+    @include device-is('desktop') {
+      width: calc(33% - 10px);
+    }
   }
 }

--- a/mon-pix/app/styles/components/competence-card/_list.scss
+++ b/mon-pix/app/styles/components/competence-card/_list.scss
@@ -10,7 +10,6 @@
 
   .competence-card-list {
     grid-template-columns: repeat(3, 1fr);
-    grid-gap: 37px;
 
     &__competence-card {
       margin: 0;

--- a/mon-pix/app/styles/components/competence-card/_list.scss
+++ b/mon-pix/app/styles/components/competence-card/_list.scss
@@ -1,25 +1,40 @@
+$scorecard-width: 212px;
+
 .competence-card-list {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
 
   &__competence-card {
-    margin: 12px 0;
-  }
-}
+    margin-bottom: 37px;
 
-@include device-is('tablet') {
-
-  .competence-card-list {
-    grid-template-columns: repeat(3, 1fr);
-
-    &__competence-card {
-      margin: 0;
+    &:last-child {
+      margin-bottom: 0;
     }
   }
-}
 
-@include device-is('desktop') {
+  @include device-is('tablet') {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-start;
 
-  .competence-card-list {
-    grid-template-columns: repeat(4, 1fr);
+    &__competence-card {
+      margin-right: calc((100% - #{$scorecard-width} * 3) / 2);
+
+      &:nth-child(3n) {
+        margin-right: 0;
+      }
+    }
+  }
+
+  @include device-is('middle-desktop') {
+
+    &__competence-card, &__competence-card:nth-child(3n)  {
+      margin-right: calc((100% - #{$scorecard-width} * 4) / 3);
+
+      &:nth-child(4n) {
+        margin-right: 0;
+      }
+    }
   }
 }

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -41,6 +41,7 @@
 
     &__certif {
       @include add-dashboard-content-separator();
+
       grid-area: 2 / 4 / 3 / 7;
       margin-bottom: 24px;
       height: 100%;
@@ -53,10 +54,11 @@
 
   @include device-is('large-screen') {
     grid-template-columns: repeat(4, 1fr);
-    padding: 0;
+    padding: 0 20px;
 
     &__banner {
       @include add-dashboard-content-separator();
+
       grid-area: 1 / 1 / 2 / 4;
     }
 
@@ -82,11 +84,37 @@
 
   &__section {
     @include add-dashboard-content-separator();
+
     padding: 24px 0;
 
     &:last-child {
       border-bottom: none;
     }
+  }
+}
+
+.dashboard-content-score {
+
+  &__wrapper {
+    display: flex;
+    background-color: $white;
+    border-radius: 10px;
+    padding: 19px 0;
+    box-shadow: 0 1px 0 0 rgba(23, 43, 77, 0.12);
+    flex-direction: column;
+    align-items: center;
+
+    @include device-is('large-screen') {
+      margin-left: 34px;
+      font-size: 0.8125rem;
+    }
+  }
+}
+
+.dashboard-content-score-wrapper {
+
+  &__button {
+    padding-top: 10px;
   }
 }
 

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -1,14 +1,22 @@
+@mixin add-dashboard-content-separator() {
+  border-bottom: 1px solid $grey-20;
+  padding: 24px 0;
+}
+
 .dashboard-content {
   display: grid;
   grid: "autoplace";
   grid-template-columns: 1fr;
+  padding: 40px 20px;
 
   &__banner {
     grid-area: 1 / 1 / 2 / 2;
   }
 
   &__score {
+    @include add-dashboard-content-separator();
     grid-area: 2 / 1 / 3 / 2;
+    margin-bottom: 20px;
   }
 
   &__cards {
@@ -19,8 +27,6 @@
     grid-area: 7 / 1 / 8 / 2;
   }
 
-  padding: 40px 20px;
-
   @include device-is('tablet') {
     grid-template-columns: repeat(6, 1fr);
 
@@ -30,10 +36,14 @@
 
     &__score {
       grid-area: 2 / 1 / 3 / 4;
+      height: 100%;
     }
 
     &__certif {
+      @include add-dashboard-content-separator();
       grid-area: 2 / 4 / 3 / 7;
+      margin-bottom: 24px;
+      height: 100%;
     }
 
     &__cards {
@@ -43,17 +53,23 @@
 
   @include device-is('large-screen') {
     grid-template-columns: repeat(4, 1fr);
+    padding: 0;
 
     &__banner {
+      @include add-dashboard-content-separator();
       grid-area: 1 / 1 / 2 / 4;
     }
 
     &__score {
       grid-area: 1 / 4 / 2 / 5;
+      border-bottom: none;
+      margin: 0;
     }
 
     &__certif {
       grid-area: 2 / 4 / 13 / 5;
+      border-bottom: none;
+      margin: 0;
     }
 
     &__cards {
@@ -65,12 +81,8 @@
 .dashboard-content-cards {
 
   &__section {
-    border-bottom: 1px solid $grey-20;
-    padding: 20px 0 40px;
-
-    &:first-of-type {
-      padding-top: 0;
-    }
+    @include add-dashboard-content-separator();
+    padding: 24px 0;
 
     &:last-child {
       border-bottom: none;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -6,6 +6,7 @@
 .dashboard-content {
   display: grid;
   grid-template-columns: 100%;
+  grid-template-rows: auto;
   padding: 40px 20px;
   grid-template-areas:
     'banner'
@@ -42,6 +43,7 @@
 
   @include device-is('tablet') {
     grid-template-columns: repeat(6, 1fr);
+    grid-template-rows: auto;
     grid-template-areas:
       'banner banner banner banner banner banner'
       'score score score certif certif certif'
@@ -73,11 +75,12 @@
 
   @include device-is('large-screen') {
     grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: auto;
     grid-template-areas:
       'main main main score'
       'main main main certif'
-      'main main main empty'
-      'main main main empty';
+      'main main main certif'
+      'main main main certif';
     padding: 0 20px;
 
     &__banner {

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -15,11 +15,20 @@
 
   &__score {
     @include add-dashboard-content-separator();
+
     grid-area: 2 / 1 / 3 / 2;
     margin-bottom: 20px;
+
+    &:first-of-type {
+      padding-top: 0;
+
+      .dashboard-content-score__wrapper {
+        margin-top: 0;
+      }
+    }
   }
 
-  &__cards {
+  &__main {
     grid-area: 3 / 1 / 7 / 2;
   }
 
@@ -47,7 +56,7 @@
       height: 100%;
     }
 
-    &__cards {
+    &__main {
       grid-area: 3 / 1 / 13 / 7;
     }
   }
@@ -57,30 +66,37 @@
     padding: 0 20px;
 
     &__banner {
-      @include add-dashboard-content-separator();
+      display: none;
+    }
 
-      grid-area: 1 / 1 / 2 / 4;
+    &__main {
+      grid-area: 1 / 1 / 6 / 4;
     }
 
     &__score {
       grid-area: 1 / 4 / 2 / 5;
       border-bottom: none;
       margin: 0;
+      padding-top: 40px;
+
+      &:first-of-type {
+        padding-top: 40px;
+      }
     }
 
     &__certif {
-      grid-area: 2 / 4 / 13 / 5;
+      grid-area: 2 / 4 / 3 / 5;
       border-bottom: none;
       margin: 0;
-    }
-
-    &__cards {
-      grid-area: 2 / 1 / 13 / 4;
     }
   }
 }
 
-.dashboard-content-cards {
+.dashboard-content-main {
+
+  &__banner {
+    display: none;
+  }
 
   &__section {
     @include add-dashboard-content-separator();
@@ -89,6 +105,20 @@
 
     &:last-child {
       border-bottom: none;
+    }
+  }
+
+  @include device-is('large-screen') {
+
+    &__banner {
+      @include add-dashboard-content-separator();
+
+      display: block;
+      padding: 40px 0 47px 0;
+
+      & > .new-information {
+        padding: 20px 5px 20px 0;
+      }
     }
   }
 }
@@ -118,7 +148,7 @@
   }
 }
 
-.dashboard-content-cards-section {
+.dashboard-content-main-section {
 
   &__title {
     color: $grey-80;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -5,18 +5,22 @@
 
 .dashboard-content {
   display: grid;
-  grid: "autoplace";
-  grid-template-columns: 1fr;
+  grid-template-columns: 100%;
   padding: 40px 20px;
+  grid-template-areas:
+    'banner'
+    'score'
+    'main'
+    'certif';
 
   &__banner {
-    grid-area: 1 / 1 / 2 / 2;
+    grid-area: banner;
   }
 
   &__score {
     @include add-dashboard-content-separator();
 
-    grid-area: 2 / 1 / 3 / 2;
+    grid-area: score;
     margin-bottom: 20px;
 
     &:first-of-type {
@@ -29,40 +33,51 @@
   }
 
   &__main {
-    grid-area: 3 / 1 / 7 / 2;
+    grid-area: main;
   }
 
   &__certif {
-    grid-area: 7 / 1 / 8 / 2;
+    grid-area: certif;
   }
 
   @include device-is('tablet') {
     grid-template-columns: repeat(6, 1fr);
+    grid-template-areas:
+      'banner banner banner banner banner banner'
+      'score score score certif certif certif'
+      'main main main main main main'
+      'main main main main main main'
+      'main main main main main main';
 
     &__banner {
-      grid-area: 1 / 1 / 2 / 7;
+      grid-area: banner;
     }
 
     &__score {
-      grid-area: 2 / 1 / 3 / 4;
+      grid-area: score;
       height: 100%;
     }
 
     &__certif {
       @include add-dashboard-content-separator();
 
-      grid-area: 2 / 4 / 3 / 7;
+      grid-area: certif;
       margin-bottom: 24px;
       height: 100%;
     }
 
     &__main {
-      grid-area: 3 / 1 / 13 / 7;
+      grid-area: main;
     }
   }
 
   @include device-is('large-screen') {
     grid-template-columns: repeat(4, 1fr);
+    grid-template-areas:
+      'main main main score'
+      'main main main certif'
+      'main main main empty'
+      'main main main empty';
     padding: 0 20px;
 
     &__banner {
@@ -70,11 +85,11 @@
     }
 
     &__main {
-      grid-area: 1 / 1 / 6 / 4;
+      grid-area: main;
     }
 
     &__score {
-      grid-area: 1 / 4 / 2 / 5;
+      grid-area: score;
       border-bottom: none;
       margin: 0;
       padding-top: 40px;
@@ -85,7 +100,7 @@
     }
 
     &__certif {
-      grid-area: 2 / 4 / 3 / 5;
+      grid-area: certif;
       border-bottom: none;
       margin: 0;
     }

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -21,19 +21,6 @@
 
   padding: 40px 20px;
 
-  &__section {
-    border-bottom: 1px solid $grey-20;
-    padding: 20px 0 40px;
-
-    &:first-of-type {
-      padding-top: 0;
-    }
-
-    &:last-child {
-      border-bottom: none;
-    }
-  }
-
   @include device-is('tablet') {
     grid-template-columns: repeat(6, 1fr);
 
@@ -75,7 +62,23 @@
   }
 }
 
-.dashboard-content-section {
+.dashboard-content-cards {
+
+  &__section {
+    border-bottom: 1px solid $grey-20;
+    padding: 20px 0 40px;
+
+    &:first-of-type {
+      padding-top: 0;
+    }
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.dashboard-content-cards-section {
 
   &__title {
     color: $grey-80;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -1,4 +1,24 @@
 .dashboard-content {
+  display: grid;
+  grid: "autoplace";
+  grid-template-columns: 1fr;
+
+  &__banner {
+    grid-area: 1 / 1 / 2 / 2;
+  }
+
+  &__score {
+    grid-area: 2 / 1 / 3 / 2;
+  }
+
+  &__cards {
+    grid-area: 3 / 1 / 7 / 2;
+  }
+
+  &__certif {
+    grid-area: 7 / 1 / 8 / 2;
+  }
+
   padding: 40px 20px;
 
   &__section {
@@ -11,6 +31,46 @@
 
     &:last-child {
       border-bottom: none;
+    }
+  }
+
+  @include device-is('tablet') {
+    grid-template-columns: repeat(6, 1fr);
+
+    &__banner {
+      grid-area: 1 / 1 / 2 / 7;
+    }
+
+    &__score {
+      grid-area: 2 / 1 / 3 / 4;
+    }
+
+    &__certif {
+      grid-area: 2 / 4 / 3 / 7;
+    }
+
+    &__cards {
+      grid-area: 3 / 1 / 13 / 7;
+    }
+  }
+
+  @include device-is('large-screen') {
+    grid-template-columns: repeat(4, 1fr);
+
+    &__banner {
+      grid-area: 1 / 1 / 2 / 4;
+    }
+
+    &__score {
+      grid-area: 1 / 4 / 2 / 5;
+    }
+
+    &__certif {
+      grid-area: 2 / 4 / 13 / 5;
+    }
+
+    &__cards {
+      grid-area: 2 / 1 / 13 / 4;
     }
   }
 }

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -25,6 +25,4 @@
 abbr.mandatory-mark {
   cursor: help;
   color: $dark-error;
-  display: contents;
-  margin: 1.25rem;
 }

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -15,6 +15,9 @@ module.exports = function(defaults) {
       exclude: ['png', 'svg'],
       extensions: ['js', 'css', 'jpg', 'gif', 'map'],
     },
+    autoprefixer: {
+      grid: 'autoplace',
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/mon-pix/tests/acceptance/user-dashboard-test.js
+++ b/mon-pix/tests/acceptance/user-dashboard-test.js
@@ -147,7 +147,7 @@ describe('Acceptance | User dashboard page', function() {
     });
 
     it('should display the link to profile', function() {
-      expect(find('.dashboard-content-section__button')).to.exist;
+      expect(find('.dashboard-content-cards-section__button')).to.exist;
     });
 
   });

--- a/mon-pix/tests/acceptance/user-dashboard-test.js
+++ b/mon-pix/tests/acceptance/user-dashboard-test.js
@@ -147,7 +147,7 @@ describe('Acceptance | User dashboard page', function() {
     });
 
     it('should display the link to profile', function() {
-      expect(find('.dashboard-content-cards-section__button')).to.exist;
+      expect(find('.dashboard-content-main-section__button')).to.exist;
     });
 
   });

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -9,11 +9,15 @@ import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 describe('Integration | Component | Dashboard | Content', function() {
   setupIntlRenderingTest();
 
+  const pixScore = 105;
   class CurrentUserStub extends Service {
     user = {
       firstName: 'Banana',
       email: 'banana.split@example.net',
       fullName: 'Banana Split',
+      profile: {
+        pixScore,
+      },
     }
   }
 
@@ -265,5 +269,23 @@ describe('Integration | Component | Dashboard | Content', function() {
       expect(find('section[data-test-empty-dashboard]')).not.to.exist;
     });
 
+  });
+
+  describe('user pix score rendering', function() {
+    it('should display user score', async function() {
+      // given
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        scorecards: [],
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+
+      // then
+      expect(find('.dashboard-content__score')).to.exist;
+      expect(find('.hexagon-score-content__pix-score').textContent).to.contains(pixScore);
+    });
   });
 });

--- a/mon-pix/tests/unit/components/dashboard/content-test.js
+++ b/mon-pix/tests/unit/components/dashboard/content-test.js
@@ -266,4 +266,18 @@ describe('Unit | Component | Dashboard | Content', function() {
     });
 
   });
+
+  describe('#userScore', function() {
+    it('should return user score', function() {
+      // given
+      const pixScore = '68';
+      component.currentUser = EmberObject.create({ user: { profile: { pixScore } } });
+
+      // when
+      const result = component.userScore;
+
+      // then
+      expect(result).to.equal(pixScore);
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -532,6 +532,9 @@
                 "subtitle": "Discover the skills recommended for you.",
                 "title": "Recommended skills"
             },
+            "score": {
+                "profile-link": "See my skills"
+            },
             "started-competences": {
                 "subtitle": "Continue your tests, find the most recent ones here.",
                 "title": "Resume testing a skill"

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -532,6 +532,9 @@
                 "subtitle": "Explorez les compétences recommandées pour vous.",
                 "title": "Compétences recommandées"
             },
+            "score": {
+                "profile-link": "Voir mes compétences"
+            },
             "started-competences": {
                 "subtitle": "Continuez vos tests de compétences, retrouvez les plus récents ici.",
                 "title": "Reprendre une compétence"


### PR DESCRIPTION
## :unicorn: Problème

Nos souhaitons ajouter le Pix-Score sur le tableau de bord en vue de la sortie prochaine de ce dernier.

## :robot: Solution

Ajout d'un sytème de grid sur le TDB :

- Format mobile : 

<img width="186" alt="Capture d’écran 2021-02-05 à 16 57 04" src="https://user-images.githubusercontent.com/36371437/107057818-21a32600-67d4-11eb-9dda-7e3dd4dc5fbd.png">

- Format tablette : 

<img width="1198" alt="Capture d’écran 2021-02-05 à 16 59 42" src="https://user-images.githubusercontent.com/36371437/107057834-27007080-67d4-11eb-85bb-a0dfb347c789.png">

- Format large-screen :

<img width="1199" alt="Capture d’écran 2021-02-05 à 17 01 53" src="https://user-images.githubusercontent.com/36371437/107057855-2c5dbb00-67d4-11eb-89d5-edb85bfbacef.png">


## :rainbow: Remarques

Comme nous pouvons le remarquer sur les screens ci-dessus, nous avons inclus la bannière dans la `div` contenant les cards au format large-screen, afin de pouvoir remonter les `cards` une fois la suppression de la bannière effectuée par l'utilisateur.

🛑   Pour réaliser cela nous avons dû dupliquer la bannière dans `content.hbs`.

🛑  2 : La `div` contenant le futur bloc `certif` a été créé dans cette PR afin de faciliter l'intégration de l'ensemble mais n'est pas visible à l'écran. 

🛑 3 : Des commits ont été ajoutés à cette PR afin de se débarrasser des `warning` générés en console lors du build de l'application et liés à l'utilisation de grid nouvellement implémentée.
En particulier le dernier commit pour lequel nous avons dû modifier l'élément `abbr` de page d'inscription mais pour lequel il ne semble pas y avoir de répercussion niveau accessibilité.

## :100: Pour tester

Aller sur `/accueil` et constater de l'incorporation du score de l'utilisateur dans les différents formats d'écran.
Il est également possible de tester avec la bannière de `compétences complétées` si plus aucune carte ne reste à faire.
