### PR TITLE
[FEATURE] Obtenir la liste des sessions "sans problème" (PIX-2095)

### DIFF
--- a/api/db/database-builder/factory/build-finalized-session.js
+++ b/api/db/database-builder/factory/build-finalized-session.js
@@ -9,6 +9,7 @@ module.exports = function buildFinalizedSession({
   isPublishable = faker.random.boolean(),
   time = faker.random.number({ min: 0, max: 23 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0') + ':' + faker.random.number({ min: 0, max: 59 }).toString().padStart(2, '0'),
   date = moment(faker.date.recent()).format('YYYY-MM-DD'),
+  publishedAt = null,
 } = {}) {
 
   const values = {
@@ -18,6 +19,7 @@ module.exports = function buildFinalizedSession({
     isPublishable,
     time,
     date,
+    publishedAt,
   };
 
   return databaseBuffer.pushInsertable({

--- a/api/db/database-builder/factory/build-finalized-session.js
+++ b/api/db/database-builder/factory/build-finalized-session.js
@@ -3,7 +3,7 @@ const databaseBuffer = require('../database-buffer');
 const moment = require('moment');
 
 module.exports = function buildFinalizedSession({
-  sessionId = faker.random.number({ min: 0, max: 10 }),
+  sessionId = faker.random.number(),
   certificationCenterName = faker.random.word(),
   finalizedAt = faker.date.recent(),
   isPublishable = faker.random.boolean(),

--- a/api/db/database-builder/factory/build-finalized-session.js
+++ b/api/db/database-builder/factory/build-finalized-session.js
@@ -3,7 +3,7 @@ const databaseBuffer = require('../database-buffer');
 const moment = require('moment');
 
 module.exports = function buildFinalizedSession({
-  sessionId = 1,
+  sessionId = faker.random.number({ min: 0, max: 10 }),
   certificationCenterName = faker.random.word(),
   finalizedAt = faker.date.recent(),
   isPublishable = faker.random.boolean(),

--- a/api/db/migrations/20210203110934_add-publishedAt-in-finalized-session-table.js
+++ b/api/db/migrations/20210203110934_add-publishedAt-in-finalized-session-table.js
@@ -1,0 +1,14 @@
+const TABLE_NAME = 'finalized-sessions';
+const COLUMN_NAME = 'publishedAt';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, function(table) {
+    table.dateTime(COLUMN_NAME);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn(COLUMN_NAME);
+  });
+};

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -1,0 +1,9 @@
+const usecases = require('../../domain/usecases');
+const finalizedSessionSerializer = require('../../infrastructure/serializers/jsonapi/finalized-session-serializer');
+
+module.exports = {
+  async findFinalizedSessionsToPublish() {
+    const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
+    return finalizedSessionSerializer.serialize(finalizedSessionsToPublish);
+  },
+};

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const securityPreHandlers = require('../security-pre-handlers');
 const sessionController = require('./session-controller');
+const finalizedSessionController = require('./finalized-session-controller');
 const sessionAuthorization = require('../preHandlers/session-authorization');
 const featureToggles = require('../preHandlers/feature-toggles');
 const identifiersType = require('../../domain/types/identifiers-type');
@@ -55,6 +56,18 @@ exports.register = async (server) => {
         }],
         handler: sessionController.get,
         tags: ['api', 'sessions'],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/admin/sessions/to-publish',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: finalizedSessionController.findFinalizedSessionsToPublish,
+        tags: ['api', 'finalized-sessions'],
       },
     },
     {

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -1,6 +1,5 @@
 const some = require('lodash/some');
 const every = require('lodash/every');
-const { statuses: juryCertificationSummaryStatuses } = require('../read-models/JuryCertificationSummary');
 
 module.exports = class FinalizedSession {
   constructor({
@@ -36,25 +35,22 @@ module.exports = class FinalizedSession {
       sessionTime,
       isPublishable: !hasExaminerGlobalComment
         && _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries)
-        && _hasNoStartedOrErrorAssessmentResults(juryCertificationSummaries)
+        && _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries)
         && _hasExaminerSeenAllEndScreens(juryCertificationSummaries),
     });
   }
 };
 
 function _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries) {
-  return !some(
-    juryCertificationSummaries.flatMap((summary) => summary.certificationIssueReports),
-    (issueReport) => issueReport.isActionRequired,
-  );
+  return !juryCertificationSummaries.some((summary) => summary.isActionRequired());
 }
 
-function _hasNoStartedOrErrorAssessmentResults(juryCertificationSummaries) {
+function _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries) {
   return !some(
     juryCertificationSummaries,
     (summary) => {
-      return summary.status === juryCertificationSummaryStatuses.ERROR
-        || summary.status === juryCertificationSummaryStatuses.STARTED;
+      return summary.hasScoringError()
+        || !summary.hasCompletedAssessment();
     },
   );
 }

--- a/api/lib/domain/models/FinalizedSession.js
+++ b/api/lib/domain/models/FinalizedSession.js
@@ -9,6 +9,7 @@ module.exports = class FinalizedSession {
     sessionDate,
     sessionTime,
     isPublishable,
+    publishedAt,
   } = {}) {
     this.sessionId = sessionId;
     this.finalizedAt = finalizedAt;
@@ -16,6 +17,7 @@ module.exports = class FinalizedSession {
     this.sessionDate = sessionDate;
     this.sessionTime = sessionTime;
     this.isPublishable = isPublishable;
+    this.publishedAt = publishedAt;
   }
 
   static from({
@@ -37,6 +39,7 @@ module.exports = class FinalizedSession {
         && _hasNoIssueReportsWithRequiredAction(juryCertificationSummaries)
         && _hasNoScoringErrorOrUncompletedAssessmentResults(juryCertificationSummaries)
         && _hasExaminerSeenAllEndScreens(juryCertificationSummaries),
+      publishedAt: null,
     });
   }
 };

--- a/api/lib/domain/read-models/JuryCertificationSummary.js
+++ b/api/lib/domain/read-models/JuryCertificationSummary.js
@@ -41,6 +41,18 @@ class JuryCertificationSummary {
     this.hasSeenEndTestScreen = hasSeenEndTestScreen;
     this.certificationIssueReports = certificationIssueReports;
   }
+
+  isActionRequired() {
+    return this.certificationIssueReports.some((issueReport) => issueReport.isActionRequired);
+  }
+
+  hasScoringError() {
+    return this.status === JuryCertificationSummary.statuses.ERROR;
+  }
+
+  hasCompletedAssessment() {
+    return this.status !== JuryCertificationSummary.statuses.STARTED;
+  }
 }
 
 module.exports = JuryCertificationSummary;

--- a/api/lib/domain/usecases/find-finalized-sessions-to-publish.js
+++ b/api/lib/domain/usecases/find-finalized-sessions-to-publish.js
@@ -1,0 +1,3 @@
+module.exports = function findFinalizedSessionsToPublish({ finalizedSessionRepository }) {
+  return finalizedSessionRepository.findFinalizedSessionsToPublish();
+};

--- a/api/lib/domain/usecases/find-publishable-finalized-sessions.js
+++ b/api/lib/domain/usecases/find-publishable-finalized-sessions.js
@@ -1,0 +1,3 @@
+module.exports = function findPublishableFinalizedSessions({ finalizedSessionRepository }) {
+  return finalizedSessionRepository.findPublishableSessions();
+};

--- a/api/lib/domain/usecases/find-publishable-finalized-sessions.js
+++ b/api/lib/domain/usecases/find-publishable-finalized-sessions.js
@@ -1,3 +1,0 @@
-module.exports = function findPublishableFinalizedSessions({ finalizedSessionRepository }) {
-  return finalizedSessionRepository.findPublishableSessions();
-};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -49,6 +49,7 @@ const dependencies = {
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
   getCompetenceLevel: require('../../domain/services/get-competence-level'),
+  finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
   higherSchoolingRegistrationRepository: require('../../infrastructure/repositories/higher-schooling-registration-repository'),
   improvementService: require('../../domain/services/improvement-service'),
   juryCertificationSummaryRepository: require('../../infrastructure/repositories/jury-certification-summary-repository'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -152,6 +152,7 @@ module.exports = injectDependencies({
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),
+  findPublishableFinalizedSessions: require('./find-publishable-finalized-sessions'),
   findPaginatedCampaignAssessmentParticipationSummaries: require('./find-paginated-campaign-assessment-participation-summaries'),
   findPaginatedFilteredCertificationCenters: require('./find-paginated-filtered-certification-centers'),
   findPaginatedFilteredOrganizationCampaigns: require('./find-paginated-filtered-organization-campaigns'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -152,7 +152,7 @@ module.exports = injectDependencies({
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),
-  findPublishableFinalizedSessions: require('./find-publishable-finalized-sessions'),
+  findFinalizedSessionsToPublish: require('./find-finalized-sessions-to-publish'),
   findPaginatedCampaignAssessmentParticipationSummaries: require('./find-paginated-campaign-assessment-participation-summaries'),
   findPaginatedFilteredCertificationCenters: require('./find-paginated-filtered-certification-centers'),
   findPaginatedFilteredOrganizationCampaigns: require('./find-paginated-filtered-organization-campaigns'),

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -6,6 +6,7 @@ const some = require('lodash/some');
 module.exports = async function publishSession({
   sessionId,
   certificationRepository,
+  finalizedSessionRepository,
   sessionRepository,
   publishedAt = new Date(),
 }) {
@@ -14,6 +15,8 @@ module.exports = async function publishSession({
   await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
 
   let publishedSession = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
+
+  await finalizedSessionRepository.updatePublishedAt(sessionId);
 
   const emailingAttempts = await _sendPrescriberEmails(session);
   if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -16,7 +16,7 @@ module.exports = async function publishSession({
 
   let publishedSession = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
 
-  await finalizedSessionRepository.updatePublishedAt(sessionId);
+  await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
 
   const emailingAttempts = await _sendPrescriberEmails(session);
   if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -17,6 +17,14 @@ module.exports = {
 
     return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, bookshelfFinalizedSession);
   },
+
+  async updatePublishedAt({ sessionId, publishedAt }) {
+    const updatedFinalizedSession = await FinalizedSessionBookshelf
+      .where({ sessionId })
+      .save({ publishedAt }, { method: 'update' });
+
+    return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, updatedFinalizedSession);
+  },
 };
 
 function _toDTO(finalizedSession) {

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -26,7 +26,7 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, updatedFinalizedSession);
   },
 
-  async findPublishableSessions() {
+  async findFinalizedSessionsToPublish() {
     const publishableFinalizedSessions = await FinalizedSessionBookshelf
       .where({ isPublishable: true, publishedAt: null })
       .fetchAll();

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -25,6 +25,14 @@ module.exports = {
 
     return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, updatedFinalizedSession);
   },
+
+  async findPublishableSessions() {
+    const publishableFinalizedSessions = await FinalizedSessionBookshelf
+      .where({ isPublishable: true, publishedAt: null })
+      .fetchAll();
+
+    return bookshelfToDomainConverter.buildDomainObjects(FinalizedSessionBookshelf, publishableFinalizedSessions);
+  },
 };
 
 function _toDTO(finalizedSession) {

--- a/api/lib/infrastructure/serializers/jsonapi/finalized-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/finalized-session-serializer.js
@@ -1,0 +1,17 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(finalizedSessions) {
+    return new Serializer('finalized-sessions', {
+      attributes: [
+        'sessionId',
+        'sessionDate',
+        'sessionTime',
+        'finalizedAt',
+        'certificationCenterName',
+      ],
+    }).serialize(finalizedSessions);
+
+  },
+};

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
@@ -1,0 +1,51 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder, insertUserWithRolePixMaster,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | finalized-session-controller-find-finalized-sessions-to-publish', () => {
+  let server, options;
+
+  beforeEach(async () => {
+    server = await createServer();
+    await insertUserWithRolePixMaster();
+  });
+
+  describe('GET /api/admin/sessions/to-publish', () => {
+    beforeEach(() => {
+      options = {
+        method: 'GET',
+        url: '/api/admin/sessions/to-publish',
+        payload: { },
+      };
+
+      databaseBuilder.factory.buildSession({ id: 121 });
+      databaseBuilder.factory.buildSession({ id: 333 });
+      databaseBuilder.factory.buildSession({ id: 323 });
+      databaseBuilder.factory.buildSession({ id: 423 });
+
+      databaseBuilder.factory.buildFinalizedSession({ sessionId: 121, isPublishable: true, publishedAt: null });
+      databaseBuilder.factory.buildFinalizedSession({ sessionId: 333, isPublishable: true, publishedAt: null });
+      databaseBuilder.factory.buildFinalizedSession({ sessionId: 323, isPublishable: false, publishedAt: null });
+      databaseBuilder.factory.buildFinalizedSession({ sessionId: 423, isPublishable: true, publishedAt: '2021-01-02' });
+
+      return databaseBuilder.commit();
+    });
+    context('When user is authorized', () => {
+
+      beforeEach(() => {
+        options.headers = { authorization: generateValidRequestAuthorizationHeader() };
+      });
+
+      it('should return a 200 status code response with JSON API serialized', async () => {
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.have.lengthOf(2);
+        expect(response.result.data[0].type).to.equal('finalized-sessions');
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -79,6 +79,7 @@ describe('PATCH /api/admin/sessions/:id/publish', () => {
 
         beforeEach(() => {
           sessionId = databaseBuilder.factory.buildSession({ publishedAt: date }).id;
+          databaseBuilder.factory.buildFinalizedSession({ sessionId });
           options.url = `/api/admin/sessions/${sessionId}/publish`;
           certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;
           return databaseBuilder.commit();

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -34,6 +34,7 @@ describe('Integration | Repository | Finalized-session', () => {
         date: '2021-01-01',
         time: '14:00:00',
         isPublishable: true,
+        publishedAt: null,
       });
     });
   });
@@ -60,6 +61,38 @@ describe('Integration | Repository | Finalized-session', () => {
         sessionDate: finalizedSession.date,
         sessionTime: finalizedSession.time,
         isPublishable: finalizedSession.isPublishable,
+        publishedAt: null,
+      });
+    });
+  });
+
+  describe('#updatePublishedAt', () => {
+
+    afterEach(() => {
+      return knex('finalized-sessions').delete();
+    });
+
+    it('should update the publication date of a finalized session', async () => {
+      // given
+      const publishedAt = new Date('2021-01-01');
+      const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await finalizedSessionRepository.updatePublishedAt({
+        sessionId: finalizedSession.sessionId,
+        publishedAt,
+      });
+
+      // then
+      expect(result).to.deep.equal({
+        sessionId: finalizedSession.sessionId,
+        finalizedAt: finalizedSession.finalizedAt,
+        certificationCenterName: finalizedSession.certificationCenterName,
+        sessionDate: finalizedSession.date,
+        sessionTime: finalizedSession.time,
+        isPublishable: finalizedSession.isPublishable,
+        publishedAt,
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -4,13 +4,14 @@ const { knex } = require('../../../../db/knex-database-connection');
 const FinalizedSession = require('../../../../lib/domain/models/FinalizedSession');
 
 describe('Integration | Repository | Finalized-session', () => {
+
   describe('#save', () => {
 
     afterEach(() => {
       return knex('finalized-sessions').delete();
     });
 
-    it('Saves a finalized session', async () => {
+    it('saves a finalized session', async () => {
       // given
       const finalizedSession = new FinalizedSession({
         sessionId: 1234,
@@ -45,7 +46,7 @@ describe('Integration | Repository | Finalized-session', () => {
       return knex('finalized-sessions').delete();
     });
 
-    it('Retrieves a finalized session', async () => {
+    it('retrieves a finalized session', async () => {
       // given
       const finalizedSession = databaseBuilder.factory.buildFinalizedSession({ sessionId: 1234 });
       await databaseBuilder.commit();
@@ -93,6 +94,74 @@ describe('Integration | Repository | Finalized-session', () => {
         sessionTime: finalizedSession.time,
         isPublishable: finalizedSession.isPublishable,
         publishedAt,
+      });
+    });
+  });
+
+  describe('#findPublishableSessions', () => {
+
+    afterEach(() => {
+      return knex('finalized-sessions').delete();
+    });
+
+    context('when there are publishable sessions', () => {
+
+      it('finds a list of publishable finalized session', async () => {
+        // given
+        const publishableFinalizedSession1 = databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null });
+        const publishableFinalizedSession2 = databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null });
+        const publishableFinalizedSession3 = databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: null });
+
+        databaseBuilder.factory.buildFinalizedSession({ isPublishable: false, publishedAt: null }),
+        databaseBuilder.factory.buildFinalizedSession({ isPublishable: true, publishedAt: '2021-01-01' }),
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await finalizedSessionRepository.findPublishableSessions();
+
+        // then
+        expect(result).to.have.lengthOf(3);
+        expect(result).to.deep.equal([
+          {
+            sessionId: publishableFinalizedSession1.sessionId,
+            finalizedAt: publishableFinalizedSession1.finalizedAt,
+            certificationCenterName: publishableFinalizedSession1.certificationCenterName,
+            sessionDate: publishableFinalizedSession1.date,
+            sessionTime: publishableFinalizedSession1.time,
+            isPublishable: publishableFinalizedSession1.isPublishable,
+            publishedAt: null,
+          },
+          {
+            sessionId: publishableFinalizedSession2.sessionId,
+            finalizedAt: publishableFinalizedSession2.finalizedAt,
+            certificationCenterName: publishableFinalizedSession2.certificationCenterName,
+            sessionDate: publishableFinalizedSession2.date,
+            sessionTime: publishableFinalizedSession2.time,
+            isPublishable: publishableFinalizedSession2.isPublishable,
+            publishedAt: null,
+          },
+          {
+            sessionId: publishableFinalizedSession3.sessionId,
+            finalizedAt: publishableFinalizedSession3.finalizedAt,
+            certificationCenterName: publishableFinalizedSession3.certificationCenterName,
+            sessionDate: publishableFinalizedSession3.date,
+            sessionTime: publishableFinalizedSession3.time,
+            isPublishable: publishableFinalizedSession3.isPublishable,
+            publishedAt: null,
+          },
+        ]);
+      });
+    });
+
+    context('when there are no publishable sessions', () => {
+
+      it('returns an empty array', async () => {
+        // given / when
+        const result = await finalizedSessionRepository.findPublishableSessions();
+
+        // then
+        expect(result).to.have.lengthOf(0);
       });
     });
   });

--- a/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/finalized-session-repository_test.js
@@ -98,7 +98,7 @@ describe('Integration | Repository | Finalized-session', () => {
     });
   });
 
-  describe('#findPublishableSessions', () => {
+  describe('#findFinalizedSessionsToPublish', () => {
 
     afterEach(() => {
       return knex('finalized-sessions').delete();
@@ -118,7 +118,7 @@ describe('Integration | Repository | Finalized-session', () => {
         await databaseBuilder.commit();
 
         // when
-        const result = await finalizedSessionRepository.findPublishableSessions();
+        const result = await finalizedSessionRepository.findFinalizedSessionsToPublish();
 
         // then
         expect(result).to.have.lengthOf(3);
@@ -158,7 +158,7 @@ describe('Integration | Repository | Finalized-session', () => {
 
       it('returns an empty array', async () => {
         // given / when
-        const result = await finalizedSessionRepository.findPublishableSessions();
+        const result = await finalizedSessionRepository.findFinalizedSessionsToPublish();
 
         // then
         expect(result).to.have.lengthOf(0);

--- a/api/tests/tooling/domain-builder/factory/build-finalized-session.js
+++ b/api/tests/tooling/domain-builder/factory/build-finalized-session.js
@@ -1,0 +1,22 @@
+const faker = require('faker');
+const Session = require('../../../../lib/domain/models/Session');
+
+module.exports = function buildFinalizedSession({
+  sessionId = faker.random.number(),
+  certificationCenterName = faker.company.companyName(),
+  sessionDate = '2020-12-01',
+  sessionTime = '14:30',
+  finalizedAt = '2021-01-12',
+  publishedAt = null,
+  isPublishable = faker.random.boolean(),
+} = {}) {
+  return new Session({
+    sessionId,
+    certificationCenterName,
+    sessionDate,
+    sessionTime,
+    finalizedAt,
+    publishedAt,
+    isPublishable,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -34,6 +34,7 @@ module.exports = {
   buildCompetenceResult: require('./build-competence-result'),
   buildCompetenceTree: require('./build-competence-tree'),
   buildCourse: require('./build-course'),
+  buildFinalizedSession: require('./build-finalized-session'),
   buildHint: require('./build-hint'),
   buildHigherSchoolingRegistration: require('./build-higher-schooling-registration'),
   buildCertificationResult: require('./build-certification-result'),

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -1,0 +1,44 @@
+const { expect, sinon, hFake } = require('../../../test-helper');
+const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
+const usecases = require('../../../../lib/domain/usecases');
+const finalizedSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/finalized-session-serializer');
+
+describe('Unit | Controller | finalized-session', () => {
+  let request;
+  const userId = 274939274;
+
+  describe('#findFinalizedSessionsToPublish', () => {
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'findFinalizedSessionsToPublish').resolves();
+      sinon.stub(finalizedSessionSerializer, 'serialize');
+
+      request = {
+        payload: { },
+        auth: {
+          credentials: {
+            userId,
+          },
+        },
+      };
+    });
+
+    context('When there are finalized publishable sessions', () => {
+
+      it('should find finalized publishable sessions', async () => {
+        // given
+        const foundFinalizedSessions = Symbol('foundSession');
+        const serializedFinalizedSessions = Symbol('serializedSession');
+        usecases.findFinalizedSessionsToPublish.resolves(foundFinalizedSessions);
+        finalizedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
+
+        // when
+        const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake);
+
+        // then
+        expect(response).to.deep.equal(serializedFinalizedSessions);
+      });
+    });
+
+  });
+});

--- a/api/tests/unit/domain/events/handle-session-finalized_test.js
+++ b/api/tests/unit/domain/events/handle-session-finalized_test.js
@@ -75,6 +75,7 @@ describe('Unit | Domain | Events | handle-session-finalized', () => {
         sessionDate: event.sessionDate,
         sessionTime: event.sessionTime,
         isPublishable: true,
+        publishedAt: null,
       }),
     );
   });

--- a/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
+++ b/api/tests/unit/domain/read-models/JuryCertificationSummary_test.js
@@ -1,11 +1,12 @@
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const JuryCertificationSummary = require('../../../../lib/domain/read-models/JuryCertificationSummary');
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const forIn = require('lodash/forIn');
+const { CertificationIssueReportCategories, CertificationIssueReportSubcategories } = require('../../../../lib/domain/models/CertificationIssueReportCategory');
 
 describe('Unit | Domain | Models | JuryCertificationSummary', () => {
 
-  describe('validate', () => {
+  describe('#validate', () => {
 
     context('when a status is given', () => {
 
@@ -29,6 +30,105 @@ describe('Unit | Domain | Models | JuryCertificationSummary', () => {
         // then
         expect(juryCertificationSummary.status).equal(JuryCertificationSummary.statuses.STARTED);
       });
+    });
+  });
+
+  describe('#isActionRequired', () => {
+    context('when at least one issue report requires action', () => {
+      it('should return true', () => {
+        // given
+        const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
+          domainBuilder.buildCertificationIssueReport({ category: CertificationIssueReportCategories.FRAUD }),
+        ] });
+
+        // when
+        const isRequired = juryCertificationSummary.isActionRequired();
+
+        // then
+        expect(isRequired).to.be.true;
+      });
+
+      context('when no issues require action', () => {
+
+        it('should return false', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ certificationIssueReports: [
+            domainBuilder.buildCertificationIssueReport({
+              category: CertificationIssueReportCategories.LATE_OR_LEAVING,
+              subcategory: CertificationIssueReportSubcategories.SIGNATURE_ISSUE,
+            }),
+          ] });
+
+          // when
+          const isRequired = juryCertificationSummary.isActionRequired();
+
+          // then
+          expect(isRequired).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('#hasScoringError', () => {
+
+    context('when assessment result has a scoring error', () => {
+
+      it('should return true', () => {
+        // given
+        const juryCertificationSummary = new JuryCertificationSummary({ status: AssessmentResult.status.ERROR });
+
+        // when
+        const hasScoringError = juryCertificationSummary.hasScoringError();
+
+        // then
+        expect(hasScoringError).to.be.true;
+      });
+
+      context('when assessment result doesn\'t have a scoring error', () => {
+
+        it('should return false', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ status: AssessmentResult.status.VALIDATED });
+
+          // when
+          const hasScoringError = juryCertificationSummary.hasScoringError();
+
+          // then
+          expect(hasScoringError).to.be.false;
+        });
+      });
+    });
+  });
+
+  describe('#hasCompletedAssessment', () => {
+
+    context('when assessment is completed', () => {
+
+      it('should return true', () => {
+        // given
+        const juryCertificationSummary = new JuryCertificationSummary({ status: AssessmentResult.status.REJECTED });
+
+        // when
+        const hasCompletedAssessment = juryCertificationSummary.hasCompletedAssessment();
+
+        // then
+        expect(hasCompletedAssessment).to.be.true;
+      });
+
+      context('when assessment is not completed', () => {
+
+        it('should return false', () => {
+          // given
+          const juryCertificationSummary = new JuryCertificationSummary({ status: null });
+
+          // when
+          const hasCompletedAssessment = juryCertificationSummary.hasCompletedAssessment();
+
+          // then
+          expect(hasCompletedAssessment).to.be.false;
+        });
+      });
+
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-finalized-sessions-to-publish_test.js
+++ b/api/tests/unit/domain/usecases/find-finalized-sessions-to-publish_test.js
@@ -1,13 +1,13 @@
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
-const findPublishableFinalizedSessions = require('../../../../lib/domain/usecases/find-publishable-finalized-sessions');
+const findFinalizedSessionsToPublish = require('../../../../lib/domain/usecases/find-finalized-sessions-to-publish');
 
-describe('Unit | UseCase | findPublishableFinalizedSessions', () => {
+describe('Unit | UseCase | findFinalizedSessionsToPublish', () => {
 
   let finalizedSessionRepository;
 
   beforeEach(() => {
     finalizedSessionRepository = {
-      findPublishableSessions: sinon.stub(),
+      findFinalizedSessionsToPublish: sinon.stub(),
     };
   });
 
@@ -21,9 +21,9 @@ describe('Unit | UseCase | findPublishableFinalizedSessions', () => {
         domainBuilder.buildFinalizedSession({ isPublishable: true }),
       ];
 
-      finalizedSessionRepository.findPublishableSessions.resolves(publishableSessions);
+      finalizedSessionRepository.findFinalizedSessionsToPublish.resolves(publishableSessions);
       // when
-      const result = await findPublishableFinalizedSessions({ finalizedSessionRepository });
+      const result = await findFinalizedSessionsToPublish({ finalizedSessionRepository });
 
       // then
       expect(result).to.deep.equal(publishableSessions);
@@ -34,9 +34,9 @@ describe('Unit | UseCase | findPublishableFinalizedSessions', () => {
 
     it('should get an empty array', async () => {
       // given
-      finalizedSessionRepository.findPublishableSessions.resolves([]);
+      finalizedSessionRepository.findFinalizedSessionsToPublish.resolves([]);
       // when
-      const result = await findPublishableFinalizedSessions({ finalizedSessionRepository });
+      const result = await findFinalizedSessionsToPublish({ finalizedSessionRepository });
 
       // then
       expect(result).to.deep.equal([]);

--- a/api/tests/unit/domain/usecases/find-publishable-finalized-sessions_test.js
+++ b/api/tests/unit/domain/usecases/find-publishable-finalized-sessions_test.js
@@ -1,0 +1,46 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const findPublishableFinalizedSessions = require('../../../../lib/domain/usecases/find-publishable-finalized-sessions');
+
+describe('Unit | UseCase | findPublishableFinalizedSessions', () => {
+
+  let finalizedSessionRepository;
+
+  beforeEach(() => {
+    finalizedSessionRepository = {
+      findPublishableSessions: sinon.stub(),
+    };
+  });
+
+  context('when there are finalized publishable sessions', () => {
+
+    it('should get a list of publishable sessions', async () => {
+      // given
+      const publishableSessions = [
+        domainBuilder.buildFinalizedSession({ isPublishable: true }),
+        domainBuilder.buildFinalizedSession({ isPublishable: true }),
+        domainBuilder.buildFinalizedSession({ isPublishable: true }),
+      ];
+
+      finalizedSessionRepository.findPublishableSessions.resolves(publishableSessions);
+      // when
+      const result = await findPublishableFinalizedSessions({ finalizedSessionRepository });
+
+      // then
+      expect(result).to.deep.equal(publishableSessions);
+    });
+  });
+
+  context('when there are no finalized publishable sessions', () => {
+
+    it('should get an empty array', async () => {
+      // given
+      finalizedSessionRepository.findPublishableSessions.resolves([]);
+      // when
+      const result = await findPublishableFinalizedSessions({ finalizedSessionRepository });
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/unit/domain/usecases/publish-session_test.js
@@ -14,6 +14,7 @@ describe('Unit | UseCase | publish-session', () => {
   const sessionId = 123;
   let certificationRepository;
   let sessionRepository;
+  let finalizedSessionRepository;
   const now = new Date('2019-01-01T05:06:07Z');
   const sessionDate = '2020-05-08';
   let clock;
@@ -26,6 +27,9 @@ describe('Unit | UseCase | publish-session', () => {
     sessionRepository = {
       updatePublishedAt: sinon.stub(),
       getWithCertificationCandidates: sinon.stub(),
+    };
+    finalizedSessionRepository = {
+      updatePublishedAt: sinon.stub().resolves(),
     };
     sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
     mailService.sendCertificationResultEmail = sinon.stub();
@@ -78,12 +82,14 @@ describe('Unit | UseCase | publish-session', () => {
         const session = await publishSession({
           sessionId,
           certificationRepository,
+          finalizedSessionRepository,
           sessionRepository,
           publishedAt: now,
         });
 
         // then
         expect(session).to.deep.equal(updatedSessionWithResultSent);
+        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId, publishedAt: now });
       });
 
       it('should send result emails', async () => {
@@ -96,6 +102,7 @@ describe('Unit | UseCase | publish-session', () => {
         await publishSession({
           sessionId,
           certificationRepository,
+          finalizedSessionRepository,
           sessionRepository,
         });
 
@@ -127,6 +134,7 @@ describe('Unit | UseCase | publish-session', () => {
         await publishSession({
           sessionId,
           certificationRepository,
+          finalizedSessionRepository,
           sessionRepository,
         });
 
@@ -154,6 +162,7 @@ describe('Unit | UseCase | publish-session', () => {
           await publishSession({
             sessionId,
             certificationRepository,
+            finalizedSessionRepository,
             sessionRepository,
           });
 
@@ -185,6 +194,7 @@ describe('Unit | UseCase | publish-session', () => {
           await publishSession({
             sessionId,
             certificationRepository,
+            finalizedSessionRepository,
             sessionRepository,
             publishedAt: now,
           });
@@ -209,6 +219,7 @@ describe('Unit | UseCase | publish-session', () => {
         const error = await catchErr(publishSession)({
           sessionId,
           certificationRepository,
+          finalizedSessionRepository,
           sessionRepository,
           publishedAt,
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/finalized-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/finalized-session-serializer_test.js
@@ -1,0 +1,43 @@
+const { expect } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/finalized-session-serializer');
+const FinalizedSession = require('../../../../../lib/domain/models/FinalizedSession');
+
+describe('Unit | Serializer | JSONAPI | finalized-session-serializer', function() {
+
+  describe('#serialize()', function() {
+
+    it('should convert a FinalizedSession model object into JSON API data', function() {
+      // given
+      const expectedJsonApi = {
+        data: {
+          type: 'finalized-sessions',
+          attributes: {
+            'session-id': 123,
+            'certification-center-name': 'A certification Center name',
+            'session-date': '2017-01-20',
+            'session-time': '14:30',
+            'finalized-at': new Date('2020-02-17T14:23:56Z'),
+          },
+        },
+      };
+
+      const modelFinalizedSession = new FinalizedSession({
+        sessionId: 123,
+        certificationCenterName: 'A certification Center name',
+        sessionDate: '2017-01-20',
+        sessionTime: '14:30',
+        finalizedAt: new Date('2020-02-17T14:23:56Z'),
+        publishedAt: new Date('2020-02-21T14:23:56Z'),
+        isPublishable: true,
+      });
+
+      // when
+      const json = serializer.serialize(modelFinalizedSession);
+
+      // then
+      expect(json).to.deep.equal(expectedJsonApi);
+    });
+
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Certaines sessions de certification ne nécessitent aucune action du jury avant publication. Aujourd’hui, le pôle certification doit néanmoins ouvrir la page de détails de chaque session pour vérifier s’il s’agit d’une session sans problème afin de la publier. Nous avons la possibilité d’identifier ces sessions, afin d’en permettre la publication en masse.

## :robot: Solution
Outiller l'api afin de faire remonter la liste des sessions finalizées sans problème

## :rainbow: Remarques
suite #2485 

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
