### PR TITLE
[TECH] Expliciter les routes API réflexives avec /me.

### DIFF
--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -113,17 +113,8 @@ exports.register = async function(server) {
     },
     {
       method: 'GET',
-      path: '/api/users/{id}/memberships',
+      path: '/api/users/me/memberships',
       config: {
-        pre: [{
-          method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
-          assign: 'requestedUserIsAuthenticatedUser',
-        }],
-        validate: {
-          params: Joi.object({
-            id: identifiersType.userId,
-          }),
-        },
         handler: userController.getMemberships,
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +

--- a/api/tests/acceptance/application/security-pre-handlers_test.js
+++ b/api/tests/acceptance/application/security-pre-handlers_test.js
@@ -71,7 +71,7 @@ describe('Acceptance | Application | SecurityPreHandlers', () => {
       // given
       const options = {
         method: 'GET',
-        url: '/api/users/1/memberships',
+        url: '/api/users/1/is-certifiable',
         headers: { authorization: generateValidRequestAuthorizationHeader(2) },
       };
 

--- a/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-memberships_test.js
@@ -16,7 +16,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
     server = await createServer();
   });
 
-  describe('GET /users/:id/memberships', () => {
+  describe('GET /users/me/memberships', () => {
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
@@ -26,7 +26,7 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
 
       options = {
         method: 'GET',
-        url: `/api/users/${userId}/memberships`,
+        url: '/api/users/me/memberships',
         headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
       };
     });
@@ -44,17 +44,6 @@ describe('Acceptance | Controller | users-controller-get-memberships', () => {
         expect(response.statusCode).to.equal(401);
       });
 
-      it('should respond with a 403 - forbidden access - if requested user is not the same as authenticated user', async () => {
-        // given
-        const otherUserId = 9999;
-        options.headers.authorization = generateValidRequestAuthorizationHeader(otherUserId);
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(403);
-      });
     });
 
     describe('Success case', () => {

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -91,7 +91,7 @@ describe('Unit | Router | user-router', () => {
     });
   });
 
-  describe('GET /api/users/{id}/memberships', function() {
+  describe('GET /api/users/me/memberships', function() {
 
     const method = 'GET';
 
@@ -103,7 +103,7 @@ describe('Unit | Router | user-router', () => {
 
     it('should exist', async () => {
       // given
-      const url = '/api/users/12/memberships';
+      const url = '/api/users/me/memberships';
 
       // when
       await httpTestServer.request(method, url);


### PR DESCRIPTION
## :unicorn: Problème
#2523 

## :robot: Solution
Ne pas permettre de contourner la réflexivité, et la rendre explicite, en :
- remplaçant l'identifiant de la ressource par le mot-clef /me 
- extraire le userId du token dans le controller

## :rainbow: Remarques
Cela enlève pas mal de code, dont du code de test
Si cela est une bonne idée, il y a 20 routes concernées dans `users`