### PR TITLE
[BUGFIX] Les filtres sur les paliers dans la liste des participants d'une campagne sur PixOrga ne fonctionnent pas correctement (PIX-2107)

### DIFF
--- a/api/db/seeds/data/campaign-participations-builder.js
+++ b/api/db/seeds/data/campaign-participations-builder.js
@@ -30,20 +30,21 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
     { firstName: 'Brandone', lastName: 'Bro' },
   ]);
 
-  const pixMembersNotCompleted = [users[0], users[1], users[2], users[3]];
+  const pixMembersNotCompleted = [users[1], users[2], users[3]];
   const pixMembersNotShared = [users[4], users[5], users[6], users[7], users[8]];
-  const pixMembersCompletedShared = [users[9], users[10], users[11], users[12]];
+  const pixMembersCompletedShared = [users[0], users[9], users[10], users[11], users[12]];
 
-  const participateToCampaignOfAssessment = (campaignId, user, isShared) => {
+  const participateToCampaignOfAssessment = (campaignId, user, isShared, validatedSkillsCount = null) => {
     const sharedAt = isShared ? new Date() : null;
     const participantExternalId = user.firstName.toLowerCase() + user.lastName.toLowerCase();
-    return databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: user.id, participantExternalId, isShared, sharedAt });
+    return databaseBuilder.factory.buildCampaignParticipation({ campaignId, userId: user.id, participantExternalId, isShared, sharedAt, validatedSkillsCount });
   };
 
   const participateComplexAssessmentCampaign = (campaignId, user, state, isShared) => {
     const { id: userId } = user;
-    const { id: campaignParticipationId } = participateToCampaignOfAssessment(campaignId, user, isShared);
-    if (['Jaune', 'Antoine'].includes(user.firstName)) databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: PRO_BASICS_BADGE_ID });
+    const validatedSkillsCount = isShared ? 3 : null;
+    const { id: campaignParticipationId } = participateToCampaignOfAssessment(campaignId, user, isShared, validatedSkillsCount);
+    if (['Stéphan', 'Antoine'].includes(user.firstName)) databaseBuilder.factory.buildBadgeAcquisition({ userId, badgeId: PRO_BASICS_BADGE_ID });
 
     const { id: assessmentId } = databaseBuilder.factory.buildAssessment({
       userId,
@@ -96,7 +97,6 @@ module.exports = function addCampaignWithParticipations({ databaseBuilder }) {
 
   participateComplexAssessmentCampaign(2, users[0], 'STARTED', false);
   participateComplexAssessmentCampaign(11, users[0], 'COMPLETED', false);
-  participateComplexAssessmentCampaign(12, users[0], 'COMPLETED', true);
 
   [CERTIF_REGULAR_USER1_ID, CERTIF_REGULAR_USER2_ID, CERTIF_REGULAR_USER3_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(userId, true));
   [CERTIF_REGULAR_USER4_ID, CERTIF_REGULAR_USER5_ID].forEach((userId) => participateToCampaignOfTypeProfilesCollection(userId, false));

--- a/api/lib/domain/models/TargetProfileWithLearningContent.js
+++ b/api/lib/domain/models/TargetProfileWithLearningContent.js
@@ -24,7 +24,7 @@ class TargetProfileWithLearningContent {
     this.competences = competences;
     this.areas = areas;
     this.badges = badges;
-    this.stages = stages;
+    this.stages = _.sortBy(stages, 'threshold');
   }
 
   get skillNames() {
@@ -46,7 +46,6 @@ class TargetProfileWithLearningContent {
   get reachableStages() {
     return _(this.stages)
       .filter(({ threshold }) => threshold > 0)
-      .sortBy('threshold')
       .value();
   }
 

--- a/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-with-learning-content-repository.js
@@ -50,13 +50,12 @@ async function _get(whereClauseFnc, locale) {
     throw new NotFoundError('Le profil cible n\'existe pas');
   }
 
-  const targetProfile = await _toDomain(results, locale);
-  targetProfile.badges = await _findBadges(targetProfile.id);
-  targetProfile.stages = await _findStages(targetProfile.id);
-  return targetProfile;
+  const badges = await _findBadges(results[0].id);
+  const stages = await _findStages(results[0].id);
+  return _toDomain(results, badges, stages, locale);
 }
 
-async function _toDomain(results, locale) {
+async function _toDomain(results, badges, stages, locale) {
   const skillIds = _.compact(results.map(({ skillId }) => skillId));
   const {
     skills,
@@ -64,7 +63,6 @@ async function _toDomain(results, locale) {
     competences,
     areas,
   } = await _getTargetedLearningContent(skillIds, locale);
-  const badges = results[0].badges;
 
   return new TargetProfileWithLearningContent({
     id: results[0].id,
@@ -76,7 +74,8 @@ async function _toDomain(results, locale) {
     tubes,
     competences,
     areas,
-    badges: badges && !_.isEmpty(badges[0]) ? badges : [],
+    badges,
+    stages,
   });
 }
 

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -1,6 +1,25 @@
 const { expect, domainBuilder } = require('../../../test-helper');
+const TargetProfileWithLearningContent = require('../../../../lib/domain/models/TargetProfileWithLearningContent');
 
 describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
+
+  describe('constructor', () => {
+
+    it('should order stages by threshold', () => {
+      // given
+      const stage1 = domainBuilder.buildStage({ threshold: 50 });
+      const stage2 = domainBuilder.buildStage({ threshold: 0 });
+      const stage3 = domainBuilder.buildStage({ threshold: 10 });
+
+      // when
+      const targetProfile = new TargetProfileWithLearningContent({
+        stages: [stage1, stage2, stage3],
+      });
+
+      // then
+      expect(targetProfile.stages).to.exactlyContainInOrder([stage2, stage3, stage1]);
+    });
+  });
 
   describe('get#skillNames', () => {
 
@@ -70,11 +89,12 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
     it('should return reachable stages ordered by threshold', () => {
       // given
-      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
       const stage1 = domainBuilder.buildStage({ threshold: 0 });
       const stage2 = domainBuilder.buildStage({ threshold: 50 });
       const stage3 = domainBuilder.buildStage({ threshold: 10 });
-      targetProfile.stages = [stage1, stage2, stage3];
+      const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent({
+        stages: [stage1, stage2, stage3],
+      });
 
       // when
       const reachableStages = targetProfile.reachableStages;


### PR DESCRIPTION
## :unicorn: Problème
Les filtres sur les paliers ne fonctionnent pas correctement -> la liste des résultats filtrés retournés n'est pas correcte.
![probleme](https://user-images.githubusercontent.com/48727874/106880651-e40fa180-66dc-11eb-9c12-0445ce3c5755.png)

## :robot: Solution
Le code supposait que les paliers étaient triés par seuil, or ce n'était pas le cas. On décide de faire ce tri dans le constructeur de 
TargetProfileWithLearningContent.

## :rainbow: Remarques


## :100: Pour tester
Essayer de reproduire le bug en photo et échouer lamentablement.
