### PR TITLE
[BUGFIX] Le script dév/local de génération de campagnes avec participants ne fonctionne plus (PIX-2108)

### DIFF
--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -205,7 +205,6 @@ async function _createUsers({ count, uniqId, trx }) {
       firstName: `firstName${identifier}`,
       lastName: `lastName${identifier}`,
       email: `email${identifier}@example.net`,
-      password: 'salut',
     });
   }
   const chunkSize = _getChunkSize(userData[0]);


### PR DESCRIPTION
## :unicorn: Problème
Le script ne fonctionne plus.

## :robot: Solution
Dû au retrait de la colonne password dans la table users. Retirer l'ajout de la donnée lors de l'insertion.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Le script re-fonctionne !
