### PR TITLE
[FEATURE] Ajout des cartes archivés dans la page 'mes-parcours' (Pix-2005)

### DIFF
--- a/api/db/database-builder/factory/campaign-participation-overview-factory.js
+++ b/api/db/database-builder/factory/campaign-participation-overview-factory.js
@@ -1,0 +1,135 @@
+const buildAssessment = require('./build-assessment');
+const buildCampaign = require('./build-campaign');
+const buildCampaignParticipation = require('./build-campaign-participation');
+const Assessment = require('../../../lib/domain/models/Assessment');
+
+module.exports = {
+  build({
+    userId,
+    createdAt,
+    sharedAt,
+    assessmentCreatedAt,
+    assessmentState,
+    campaignId,
+    id,
+  } = {}) {
+
+    const campaignParticipation = buildCampaignParticipation({
+      userId,
+      campaignId,
+      createdAt: createdAt,
+      sharedAt: sharedAt,
+      isShared: sharedAt ? true : false,
+    });
+
+    buildAssessment({
+      id,
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+      state: assessmentState,
+      createdAt: assessmentCreatedAt,
+    });
+
+    return campaignParticipation;
+  },
+
+  buildOnGoing({
+    userId,
+    createdAt,
+    assessmentCreatedAt,
+  } = {}) {
+
+    const campaignParticipation = buildCampaignParticipation({
+      userId,
+      createdAt: createdAt,
+      sharedAt: null,
+      isShared: false,
+    });
+
+    buildAssessment({
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+      state: Assessment.states.STARTED,
+      createdAt: assessmentCreatedAt,
+    });
+
+    return campaignParticipation;
+  },
+
+  buildToShare({
+    userId,
+    createdAt,
+    assessmentCreatedAt,
+  } = {}) {
+
+    const campaignParticipation = buildCampaignParticipation({
+      userId,
+      createdAt: createdAt,
+      sharedAt: null,
+      isShared: false,
+    });
+
+    buildAssessment({
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+      state: Assessment.states.COMPLETED,
+      createdAt: assessmentCreatedAt,
+    });
+
+    return campaignParticipation;
+  },
+
+  buildEnded({
+    userId,
+    createdAt,
+    sharedAt,
+    assessmentCreatedAt,
+  } = {}) {
+
+    const campaignParticipation = buildCampaignParticipation({
+      userId,
+      createdAt: createdAt,
+      sharedAt: sharedAt || createdAt,
+      isShared: true,
+    });
+
+    buildAssessment({
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+      state: Assessment.states.COMPLETED,
+      createdAt: assessmentCreatedAt,
+    });
+
+    return campaignParticipation;
+  },
+
+  buildArchived({
+    userId,
+    createdAt,
+    sharedAt,
+    assessmentCreatedAt,
+    campaignArchivedAt = new Date('1998-07-01'),
+  } = {}) {
+
+    const campaign = buildCampaign({
+      archivedAt: campaignArchivedAt,
+    });
+
+    const campaignParticipation = buildCampaignParticipation({
+      userId,
+      campaignId: campaign.id,
+      createdAt: createdAt,
+      sharedAt: sharedAt || createdAt,
+      isShared: false,
+    });
+
+    buildAssessment({
+      userId,
+      campaignParticipationId: campaignParticipation.id,
+      createdAt: assessmentCreatedAt,
+    });
+
+    return campaignParticipation;
+  },
+};
+

--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -51,4 +51,5 @@ module.exports = {
   buildUserOrgaSettings: require('./build-user-orga-settings'),
   buildUserPixRole: require('./build-user-pix-role'),
   buildUserTutorial: require('./build-user-tutorial'),
+  campaignParticipationOverviewFactory: require('./campaign-participation-overview-factory'),
 };

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -177,7 +177,7 @@ exports.register = async function(server) {
           '- L’id demandé doit correspondre à celui de l’utilisateur authentifié' +
           '- Les aperçus des participations aux campagnes sont triés par ordre inverse de création' +
           '  (les plus récentes en premier)',
-          '- Cette liste est paginée et filtrée selon des **states** qui peuvent avoir comme valeurs: ONGOING, TO_SHARE et ENDED',
+          '- Cette liste est paginée et filtrée selon des **states** qui peuvent avoir comme valeurs: ONGOING, TO_SHARE, ENDED et ARCHIVED',
         ],
         tags: ['api'],
       },

--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -14,6 +14,7 @@ class CampaignParticipationOverview {
     assessmentState,
     campaignCode,
     campaignTitle,
+    campaignArchivedAt,
   } = {}) {
     this.id = id;
     this.createdAt = createdAt;
@@ -26,6 +27,7 @@ class CampaignParticipationOverview {
     this.assessmentState = assessmentState;
     this.campaignCode = campaignCode;
     this.campaignTitle = campaignTitle;
+    this.campaignArchivedAt = campaignArchivedAt;
   }
 
   get masteryPercentage() {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -10,7 +10,7 @@ module.exports = {
   serialize(campaignParticipationOverview, meta) {
     return new Serializer('campaign-participation-overview',
       {
-        attributes: ['isShared', 'sharedAt', 'createdAt', 'organizationName', 'assessmentState', 'campaignCode', 'campaignTitle', 'masteryPercentage'],
+        attributes: ['isShared', 'sharedAt', 'createdAt', 'organizationName', 'assessmentState', 'campaignCode', 'campaignTitle', 'campaignArchivedAt', 'masteryPercentage'],
         meta,
       }).serialize(campaignParticipationOverview);
   },

--- a/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-campaign-participation-overviews_test.js
@@ -59,6 +59,7 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
             'campaign-code': sharableCampaignParticipationElements.campaign.code,
             'campaign-title': sharableCampaignParticipationElements.campaign.title,
             'assessment-state': Assessment.states.COMPLETED,
+            'campaign-archived-at': null,
             'mastery-percentage': null,
           },
         }];
@@ -125,6 +126,7 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
               'campaign-code': startedCampaignParticipationElements.campaign.code,
               'campaign-title': startedCampaignParticipationElements.campaign.title,
               'assessment-state': Assessment.states.STARTED,
+              'campaign-archived-at': null,
               'mastery-percentage': null,
             },
           }];
@@ -156,6 +158,7 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
                 'campaign-code': sharableCampaignParticipationElements.campaign.code,
                 'campaign-title': sharableCampaignParticipationElements.campaign.title,
                 'assessment-state': Assessment.states.COMPLETED,
+                'campaign-archived-at': null,
                 'mastery-percentage': null,
               },
             }, {
@@ -169,6 +172,7 @@ describe('Acceptance | Controller | users-controller-get-campaign-participation-
                 'campaign-code': startedCampaignParticipationElements.campaign.code,
                 'campaign-title': startedCampaignParticipationElements.campaign.title,
                 'assessment-state': Assessment.states.STARTED,
+                'campaign-archived-at': null,
                 'mastery-percentage': null,
               },
             }];

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -16,6 +16,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       assessmentState: 'started',
       campaignCode: '1234',
       campaignTitle: 'My campaign',
+      campaignArchivedAt: new Date('2021-01-01'),
     });
 
     let expectedSerializedCampaignParticipationOverview;
@@ -33,6 +34,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'assessment-state': 'started',
             'campaign-code': '1234',
             'campaign-title': 'My campaign',
+            'campaign-archived-at': new Date('2021-01-01'),
             'mastery-percentage': 50,
           },
         },
@@ -62,6 +64,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           assessmentState: 'started',
           campaignCode: '4567',
           campaignTitle: 'My campaign 1',
+          campaignArchivedAt: null,
         }),
         new CampaignParticipationOverview({
           id: 7,
@@ -72,6 +75,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           assessmentState: 'started',
           campaignCode: '4567',
           campaignTitle: 'My campaign 2',
+          campaignArchivedAt: null,
         }),
       ];
       const pagination = {
@@ -98,6 +102,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'organization-name': 'My organization 1',
               'shared-at': new Date('2018-02-07T17:15:44Z'),
               'mastery-percentage': null,
+              'campaign-archived-at': null,
             },
             id: '6',
             type: 'campaign-participation-overviews',
@@ -112,6 +117,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'organization-name': 'My organization 2',
               'shared-at': new Date('2018-02-10T17:30:44Z'),
               'mastery-percentage': null,
+              'campaign-archived-at': null,
             },
             id: '7',
             type: 'campaign-participation-overviews',

--- a/mon-pix/app/components/campaign-participation-overview/card.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card.hbs
@@ -13,18 +13,24 @@
     </time>
   </header>
   <section class="campaign-participation-overview-card-content">
-    {{#if (eq @model.status "finished")}}
+    {{#if this.cardInfo.hasMasteryPercentage}}
       <p class="campaign-participation-overview-card-content__content">
         {{t 'pages.campaign-participation-overview.card.results' result=@model.masteryPercentage}}
       </p>
+    {{else if (eq @model.status "archived") }}
+      <p class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__archived">
+        {{t 'pages.campaign-participation-overview.card.text-archived' htmlSafe=true}}
+      </p>
     {{/if}}
-    <LinkTo class="{{this.cardInfo.actionClass}} campaign-participation-overview-card-content__action"
-            @route="campaigns.start-or-resume"
-            @model={{@model.campaignCode}}>
-      {{#if (eq @model.status "finished")}}
-        <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
-      {{/if}}
-      {{t this.cardInfo.actionText}}
-    </LinkTo>
+    {{#if (not-eq @model.status "archived")}}
+      <LinkTo class="{{this.cardInfo.actionClass}} campaign-participation-overview-card-content__action"
+              @route="campaigns.start-or-resume"
+              @model={{@model.campaignCode}}>
+        {{#if (eq @model.status "finished")}}
+          <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
+        {{/if}}
+        {{t this.cardInfo.actionText}}
+      </LinkTo>
+    {{/if}}
   </section>
 </article>

--- a/mon-pix/app/components/campaign-participation-overview/card.js
+++ b/mon-pix/app/components/campaign-participation-overview/card.js
@@ -22,11 +22,20 @@ const INFO_BY_STATUSES = {
     actionClass: 'link campaign-participation-overview-card-content__see-more',
     dateText: 'pages.campaign-participation-overview.card.finished-at',
   },
+  archived: {
+    tagText: 'pages.campaign-participation-overview.card.tag.archived',
+    tagColor: 'grey-light',
+    dateText: 'pages.campaign-participation-overview.card.started-at',
+  },
 };
 
 export default class Card extends Component {
   get cardInfo() {
     const status = this.args.model.status;
-    return INFO_BY_STATUSES[status];
+    const infos = INFO_BY_STATUSES[status];
+    const masteryPercentage = this.args.model.masteryPercentage;
+    infos.hasMasteryPercentage = ![null, undefined].includes(masteryPercentage);
+    infos.masteryPercentage = masteryPercentage;
+    return infos;
   }
 }

--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -10,9 +10,11 @@ export default class CampaignParticipationOverviews extends Model {
   @attr('string') assessmentState;
   @attr('string') campaignCode;
   @attr('string') campaignTitle;
+  @attr('date') campaignArchivedAt;
   @attr('number') masteryPercentage;
 
   get status() {
+    if (this.campaignArchivedAt) return 'archived';
     if (this.isShared) return 'finished';
 
     return this.assessmentState;

--- a/mon-pix/app/routes/user-tests.js
+++ b/mon-pix/app/routes/user-tests.js
@@ -13,7 +13,7 @@ export default class UserTestsRoute extends Route.extend(SecuredRouteMixin) {
       'userId': user.id,
       'page[number]': 1,
       'page[size]': maximumDisplayed,
-      'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED'],
+      'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED', 'ARCHIVED'],
     };
 
     return this.store.query('campaign-participation-overview', queryParams);

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -26,12 +26,13 @@
     justify-content: center;
     width: 100%;
     min-height: 50px;
+    max-height: 50px;
     margin-bottom: 12px;
     border-radius: 4px;
     background-color: $grey-10;
     font-size: 1.125rem;
     font-weight: $font-medium;
-    color: $grey-60
+    color: $grey-60;
   }
 
   &__action {
@@ -42,6 +43,14 @@
 
   &__see-more {
     padding: 0;
+  }
+
+  &__archived {
+    font-family: $font-open-sans;
+    font-size: 0.75rem;
+    font-weight: $font-normal;
+    text-align: center;
+    margin-bottom: 32px;
   }
 }
 

--- a/mon-pix/tests/integration/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/integration/components/campaign-participation-overview/card-test.js
@@ -116,4 +116,53 @@ describe('Integration | Component | CampaignParticipationOverview | Card', funct
       expect(contains('20 % de réussite'));
     });
   });
+
+  describe('when card has "archived" status', function() {
+    context('when the participation doesn\'t have a mastery percentage', ()=> {
+      it('should render explanatory text', async function() {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          createdAt: '2020-01-01',
+          campaignArchivedAt: '2020-01-03',
+          assessmentState: 'completed',
+          campaignTitle: 'My campaign',
+          masteryPercentage: null,
+
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
+
+        // then
+        expect(find('.campaign-participation-overview-card-header__tag').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.tag.archived'));
+        expect(find('.campaign-participation-overview-card-header__date').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' }));
+        expect(contains('Parcours archivé par votre organisation. Vos résultats n\'ont pas pu être envoyés.'));
+        expect(contains(this.intl.t('pages.campaign-participation-overview.card.see-more'))).to.not.exist;
+      });
+    });
+
+    context('when the participation has a mastery percentage', ()=> {
+      it('should render the result with percentage', async function() {
+        // given
+        const campaignParticipationOverview = store.createRecord('campaign-participation-overview', {
+          createdAt: '2020-01-01',
+          campaignArchivedAt: '2020-01-03',
+          assessmentState: 'completed',
+          campaignTitle: 'My campaign',
+          masteryPercentage: 56,
+        });
+        this.set('campaignParticipationOverview', campaignParticipationOverview);
+
+        // when
+        await render(hbs`<CampaignParticipationOverview::Card @model={{this.campaignParticipationOverview}} />}`);
+
+        // then
+        expect(find('.campaign-participation-overview-card-header__tag').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.tag.archived'));
+        expect(find('.campaign-participation-overview-card-header__date').textContent.trim()).to.equal(this.intl.t('pages.campaign-participation-overview.card.started-at', { date: '01/01/2020' }));
+        expect(contains(this.intl.t('pages.campaign-participation-overview.card.see-more'))).to.not.exist;
+        expect(contains('56 % de réussite'));
+      });
+    });
+  });
 });

--- a/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
+++ b/mon-pix/tests/unit/components/campaign-participation-overview/card-test.js
@@ -12,17 +12,17 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
   beforeEach(function() {
     // given
     store = this.owner.lookup('service:store');
-    component = createGlimmerComponent('component:campaign-participation-overview/card');
   });
 
   describe('#cardInfo', function() {
 
     it('should return the card info when the status is "completed"', function() {
       // given
-      component.args.model = store.createRecord('campaign-participation-overview', {
+      const model = store.createRecord('campaign-participation-overview', {
         assessmentState: 'completed',
+        masteryPercentage: null,
       });
-
+      component = createGlimmerComponent('component:campaign-participation-overview/card', { model });
       // when
       const result = component.cardInfo;
 
@@ -33,16 +33,19 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         actionText: 'pages.campaign-participation-overview.card.send',
         actionClass: 'button button--link button--yellow',
         dateText: 'pages.campaign-participation-overview.card.started-at',
+        hasMasteryPercentage: false,
+        masteryPercentage: null,
       });
     });
 
     it('should return the card info when the status is "finished"', function() {
       // given
-      component.args.model = store.createRecord('campaign-participation-overview', {
+      const model = store.createRecord('campaign-participation-overview', {
         assessmentState: 'completed',
         isShared: true,
+        masteryPercentage: 67,
       });
-
+      component = createGlimmerComponent('component:campaign-participation-overview/card', { model });
       // when
       const result = component.cardInfo;
 
@@ -53,15 +56,18 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         actionText: 'pages.campaign-participation-overview.card.see-more',
         actionClass: 'link campaign-participation-overview-card-content__see-more',
         dateText: 'pages.campaign-participation-overview.card.finished-at',
+        hasMasteryPercentage: true,
+        masteryPercentage: 67,
       });
     });
 
     it('should return the card info when the status is "started"', function() {
       // given
-      component.args.model = store.createRecord('campaign-participation-overview', {
+      const model = store.createRecord('campaign-participation-overview', {
         assessmentState: 'started',
+        masteryPercentage: null,
       });
-
+      component = createGlimmerComponent('component:campaign-participation-overview/card', { model });
       // when
       const result = component.cardInfo;
 
@@ -72,6 +78,28 @@ describe('Unit | Component | CampaignParticipation | Card', function() {
         actionText: 'pages.campaign-participation-overview.card.resume',
         actionClass: 'button button--link',
         dateText: 'pages.campaign-participation-overview.card.started-at',
+        hasMasteryPercentage: false,
+        masteryPercentage: null,
+      });
+    });
+
+    it('should return the card info when the status is "archived"', function() {
+      // given
+      const model = store.createRecord('campaign-participation-overview', {
+        assessmentState: 'archived',
+        masteryPercentage: null,
+      });
+      component = createGlimmerComponent('component:campaign-participation-overview/card', { model });
+      // when
+      const result = component.cardInfo;
+
+      // then
+      expect(result).to.deep.equal({
+        tagText: 'pages.campaign-participation-overview.card.tag.archived',
+        tagColor: 'grey-light',
+        dateText: 'pages.campaign-participation-overview.card.started-at',
+        hasMasteryPercentage: false,
+        masteryPercentage: null,
       });
     });
   });

--- a/mon-pix/tests/unit/models/campaign-participation-overview-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-overview-test.js
@@ -12,33 +12,56 @@ describe('Unit | Model | Campaign-Participation-Overview', function() {
   });
 
   describe('#status', () => {
-
-    it('should return the status "started"', function() {
-      // given
-      const model = store.createRecord('campaign-participation-overview', {
-        assessmentState: 'started',
+    context('when the campaign is not archived', function() {
+      context('when the assessment state is "started"', () => {
+        it('should return the status "started"', function() {
+          // given
+          const model = store.createRecord('campaign-participation-overview', {
+            assessmentState: 'started',
+          });
+          // when / then
+          expect(model.status).to.equal('started');
+        });
       });
-      // when / then
-      expect(model.status).to.equal('started');
+
+      context('when the assessment state is "completed, the participation is not shared"', () => {
+        it('should return the status "completed"', function() {
+          // given
+          const model = store.createRecord('campaign-participation-overview', {
+            assessmentState: 'completed',
+            isShared: false,
+            campaignArchivedAt: null,
+          });
+          // when / then
+          expect(model.status).to.equal('completed');
+        });
+      });
+
+      context('when the assessment state is "completed and the participation is shared"', () => {
+        it('should return the status "finished"', function() {
+          // given
+          const model = store.createRecord('campaign-participation-overview', {
+            assessmentState: 'completed',
+            campaignArchivedAt: null,
+            isShared: true,
+          });
+          // when / then
+          expect(model.status).to.equal('finished');
+        });
+      });
     });
 
-    it('should return the status "completed"', function() {
-      // given
-      const model = store.createRecord('campaign-participation-overview', {
-        assessmentState: 'completed',
+    context('when the campaign is archived"', () => {
+      it('should return the status "archived"', function() {
+        // given
+        const model = store.createRecord('campaign-participation-overview', {
+          assessmentState: 'completed',
+          isShared: true,
+          campaignArchivedAt: new Date('2021-01-01'),
+        });
+        // when / then
+        expect(model.status).to.equal('archived');
       });
-      // when / then
-      expect(model.status).to.equal('completed');
-    });
-
-    it('should return the status "finished"', function() {
-      // given
-      const model = store.createRecord('campaign-participation-overview', {
-        assessmentState: 'completed',
-        isShared: true,
-      });
-      // when / then
-      expect(model.status).to.equal('finished');
     });
   });
 

--- a/mon-pix/tests/unit/routes/user-tests-test.js
+++ b/mon-pix/tests/unit/routes/user-tests-test.js
@@ -20,7 +20,7 @@ describe('Unit | Route | User-Tests', function() {
         userId: 1,
         'page[number]': 1,
         'page[size]': 100,
-        'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED'],
+        'filter[states]': ['ONGOING', 'TO_SHARE', 'ENDED', 'ARCHIVED'],
       }).returns(campaignParticipationOverviews);
 
       const route = this.owner.lookup('route:user-tests');

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -115,10 +115,12 @@
                 "started-at": "Started the {date}",
                 "finished-at": "Finished the {date}",
                 "results": "Success rate: {result}%",
+                "text-archived": "Your personalised test has been archived by your organisation.'<br>'Your results could not be submitted.",
                 "tag": {
                     "started": "In progress",
                     "completed": "To be submitted",
-                    "finished": "Finished"
+                    "finished": "Finished",
+                    "archived": "Archived"
                 }
             }
         },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -115,10 +115,12 @@
                 "started-at": "Commencé le {date}",
                 "finished-at": "Terminé le {date}",
                 "results": "{result} % de réussite",
+                "text-archived": "Parcours archivé par votre organisation.'<br>'Vos résultats n'ont pas pu être envoyés.",
                 "tag": {
                     "started": "En cours",
                     "completed": "À envoyer",
-                    "finished": "Terminé"
+                    "finished": "Terminé",
+                    "archived": "Archivé"
                 }
             }
         },


### PR DESCRIPTION
## :unicorn: Problème
Les cartes dont les campagnes avaient été archivées n'étaient pas affichées.

## :robot: Solution
Afficher mes parcours "Archivés"

Reprendre le composant déjà utilisé dans la tableau de board.
Réutiliser l'appel de l'API des dashboards (campaign-participation-overview)
De plus dans cette US, ne pas oublier les traductions en anglais.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Aller dans Pix-Orga en se connectant avec `pro.admin@example.net`
- Aller dans la campagne `Pro - Campagne d'évaluation PIC` ou `Parcours Simplifié` et l'archiver.
- Se connecter à mon-pix avec `jaune.attend@example.net`
- Se rendre sur la page /mes-parcours (à écrire directement dans l'url)
- Observer les différentes cartes de participation
