### PR TITLE
[FEATURE] Afficher la liste des membres d'un centre de certification dans Pix Admin (PIX-504).

### DIFF
--- a/admin/app/adapters/certification-center-membership.js
+++ b/admin/app/adapters/certification-center-membership.js
@@ -1,0 +1,14 @@
+import ApplicationAdapter from './application';
+
+export default class CertificationCenterMembershipAdapter extends ApplicationAdapter {
+
+  urlForQuery(query) {
+    if (query.filter.certificationCenterId) {
+      const { certificationCenterId } = query.filter;
+      delete query.filter.certificationCenterId;
+
+      return `${this.host}/${this.namespace}/certification-centers/${certificationCenterId}/certification-center-memberships`;
+    }
+    return super.urlForQuery(...arguments);
+  }
+}

--- a/admin/app/components/certification-center-memberships-section.hbs
+++ b/admin/app/components/certification-center-memberships-section.hbs
@@ -1,0 +1,44 @@
+<section class="page-section mb_10">
+
+  <header class="page-section__header">
+    <h2 class="page-section__title">Membres</h2>
+  </header>
+
+  <div class="member-list content-text content-text--small">
+    <div class="table-admin">
+      <table>
+        <thead>
+        <tr>
+          <th class="table__column">ID Membre</th>
+          <th class="table__column">ID Utilisateur</th>
+          <th class="table__column table__column--wide">Prénom</th>
+          <th class="table__column table__column--wide">Nom</th>
+          <th class="table__column table__column--wide">Adresse e-mail</th>
+          <th class="table__column table__column--wide">Date de rattachement</th>
+        </tr>
+        </thead>
+
+        {{#if @certificationCenterMemberships}}
+          <tbody>
+          {{#each @certificationCenterMemberships as |certificationCenterMembership|}}
+            <tr aria-label="Membre">
+              <td data-test-membership-id>{{certificationCenterMembership.id}}</td>
+              <td data-test-user-id>{{certificationCenterMembership.user.id}}</td>
+              <td data-test-user-first-name>{{certificationCenterMembership.user.firstName}}</td>
+              <td data-test-user-last-name>{{certificationCenterMembership.user.lastName}}</td>
+              <td data-test-user-email>{{certificationCenterMembership.user.email}}</td>
+              <td data-test-membership-created-at>
+                {{moment-format certificationCenterMembership.createdAt 'DD-MM-YYYY - HH:mm:ss'}}
+              </td>
+            </tr>
+          {{/each}}
+          </tbody>
+        {{/if}}
+      </table>
+
+      {{#unless @certificationCenterMemberships}}
+        <div class="table__empty content-text" data-test-empty-message>Aucun résultat</div>
+      {{/unless}}
+    </div>
+  </div>
+</section>

--- a/admin/app/models/certification-center-membership.js
+++ b/admin/app/models/certification-center-membership.js
@@ -1,0 +1,10 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class CertificationCenterMembership extends Model {
+
+  @attr('date') createdAt;
+
+  @belongsTo('certification-center') certificationCenter;
+  @belongsTo('user') user;
+
+}

--- a/admin/app/models/certification-center.js
+++ b/admin/app/models/certification-center.js
@@ -5,5 +5,4 @@ export default class CertificationCenter extends Model {
   @attr() name;
   @attr() type;
   @attr() externalId;
-
 }

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -13,6 +13,7 @@ export default class User extends Model {
   @attr('boolean') isAuthenticatedFromGAR;
 
   @hasMany('membership') memberships;
+  @hasMany('certification-center-membership') certificationCenterMemberships;
   @hasMany('schooling-registration') schoolingRegistrations;
 
   @computed('firstName', 'lastName')

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -1,9 +1,20 @@
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import RSVP from 'rsvp';
 
 export default class CertificationCentersGetRoute extends Route.extend(AuthenticatedRouteMixin) {
 
-  model(params) {
-    return this.store.findRecord('certification-center', params.certification_center_id);
+  async model(params) {
+    const certificationCenter = await this.store.findRecord('certification-center', params.certification_center_id);
+    const certificationCenterMemberships = await this.store.query('certification-center-membership', {
+      filter: {
+        certificationCenterId: certificationCenter.id,
+      },
+    });
+
+    return RSVP.hash({
+      certificationCenterMemberships,
+      certificationCenter,
+    });
   }
 }

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -1,8 +1,15 @@
-.certification-center__data {
+#certification-center-get-page {
 
-  .certification-center__name {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: 20px;
+  .page-section__header {
+    justify-content: space-around;
+  }
+
+  .certification-center__data {
+
+    .certification-center__name {
+      font-size: 1.5rem;
+      font-weight: 600;
+      margin-bottom: 20px;
+    }
   }
 }

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -2,18 +2,23 @@
   <div class="page-title">
     <LinkTo @route="authenticated.certification-centers.list"><span id="link-to-certification-centers-page">Tous les centres de certification</span></LinkTo>
     <span class="wire">&nbsp;>&nbsp;</span>
-    {{@model.name}}
+    {{@model.certificationCenter.name}}
   </div>
 </header>
 
-<main class="page-body">
+<main class="page-body" id="certification-center-get-page">
   <section class="page-section mb_10">
     <div class="certification-center__data">
-      <h1 class="certification-center__name">{{@model.name}}</h1>
+      <h1 class="certification-center__name">{{@model.certificationCenter.name}}</h1>
       <p>
-        Type : <span>{{@model.type}}</span><br>
-        Identifiant externe : <span>{{@model.externalId}}</span><br>
+        Type : <span>{{@model.certificationCenter.type}}</span><br>
+        Identifiant externe : <span>{{@model.certificationCenter.externalId}}</span><br>
       </p>
     </div>
   </section>
+
+  <CertificationCenterMembershipsSection
+    @certificationCenterMemberships={{@model.certificationCenterMemberships}}
+  />
+
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -29,6 +29,10 @@ export default function() {
   this.get('/admin/users/:id');
   this.get('/certification-centers');
   this.get('/certification-centers/:id');
+  this.get('/certification-centers/:id/certification-center-memberships', (schema, request) => {
+    const certificationCenterId = request.params.id;
+    return schema.certificationCenterMemberships.where({ certificationCenterId });
+  });
   this.post('/certification-centers', (schema, request) => {
     const params = JSON.parse(request.requestBody);
     const name = params.data.attributes.name;

--- a/admin/mirage/serializers/certification-center-membership.js
+++ b/admin/mirage/serializers/certification-center-membership.js
@@ -1,0 +1,7 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+const relationshipsToInclude = ['certification-center', 'user'];
+
+export default JSONAPISerializer.extend({
+  include: relationshipsToInclude,
+});

--- a/admin/mirage/serializers/certification-center.js
+++ b/admin/mirage/serializers/certification-center.js
@@ -1,0 +1,11 @@
+import { JSONAPISerializer } from 'ember-cli-mirage';
+
+export default JSONAPISerializer.extend({
+  links(certificationCenter) {
+    return {
+      certificationCenterMemberships: {
+        related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+      },
+    };
+  },
+});

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -5528,6 +5528,16 @@
       "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
@@ -16985,6 +16995,49 @@
         }
       }
     },
+    "ember-test-selectors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-5.0.0.tgz",
+      "integrity": "sha512-hqAPqyJLEGBYcQ9phOKvHhSCyvcSbUL8Yj2si8OASsQWxwRqbxrtk5YlkN2aZiZdp9PAd2wErS8uClG0U7tNpA==",
+      "dev": true,
+      "requires": {
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-cli-babel": "^7.22.1",
+        "ember-cli-version-checker": "^5.1.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "ember-test-waiters": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ember-test-waiters/-/ember-test-waiters-1.2.0.tgz",
@@ -18660,6 +18713,13 @@
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
       "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filesize": {
       "version": "4.2.1",
@@ -21515,6 +21575,13 @@
         "lodash.defaultsdeep": "^4.6.0",
         "qs": "^6.2.0"
       }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -26604,7 +26671,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -81,6 +81,7 @@
     "ember-simple-auth": "^3.0.1",
     "ember-sinon": "^5.0.0",
     "ember-source": "~3.23.1",
+    "ember-test-selectors": "^5.0.0",
     "ember-toggle": "^7.0.0",
     "ember-truth-helpers": "^3.0.0",
     "eslint": "^7.15.0",

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { module, test } from 'qunit';
 import { currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
@@ -10,37 +12,45 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  const certificationCenterData = {
+    name: 'Center 1',
+    externalId: 'ABCDEF',
+    type: 'SCO',
+  };
+
+  let certificationCenter;
+  let certificationCenterMembership1;
   let currentUser;
 
   hooks.beforeEach(async function() {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
+
+    certificationCenter = server.create('certification-center', certificationCenterData);
+
+    certificationCenterMembership1 = server.create('certification-center-membership', {
+      createdAt: new Date('2018-02-15T05:06:07Z'),
+      certificationCenter,
+      user: server.create('user'),
+    });
+    server.create('certification-center-membership', {
+      createdAt: new Date('2019-02-15T05:06:07Z'),
+      certificationCenter,
+      user: server.create('user'),
+    });
   });
 
   test('should access Certification center page by URL /certification-centers/:id', async function(assert) {
-    // given
-    server.create('certification-center');
-
     // when
-    await visit('/certification-centers/1');
+    await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
     assert.equal(currentURL(), '/certification-centers/1');
   });
 
   test('should display Certification center detail', async function(assert) {
-    // given
-    const certificationCenter = {
-      name: 'Center 1',
-      externalId: 'ABCDEF',
-      type: 'SCO',
-    };
-    server.create('certification-center', 1, {
-      ...certificationCenter,
-    });
-
     // when
-    await visit('/certification-centers/1');
+    await visit(`/certification-centers/${certificationCenter.id}`);
 
     // then
     assert.contains(certificationCenter.name);
@@ -48,4 +58,22 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
     assert.contains(certificationCenter.type);
   });
 
+  test('should display Certification center memberships', async function(assert) {
+    // given
+    const expectedDate1 = moment(certificationCenterMembership1.createdAt).format('DD-MM-YYYY - HH:mm:ss');
+
+    // when
+    await visit(`/certification-centers/${certificationCenter.id}`);
+
+    // then
+    assert.dom('[aria-label="Membre"]').exists({ count: 2 });
+
+    assert.dom('[aria-label="Membre"]:first-child td:nth-child(2)')
+      .hasText(certificationCenterMembership1.user.id);
+
+    assert.contains(certificationCenterMembership1.user.firstName);
+    assert.contains(certificationCenterMembership1.user.lastName);
+    assert.contains(certificationCenterMembership1.user.email);
+    assert.contains(expectedDate1);
+  });
 });

--- a/admin/tests/integration/components/certification-center-memberships-section-test.js
+++ b/admin/tests/integration/components/certification-center-memberships-section-test.js
@@ -1,0 +1,66 @@
+import moment from 'moment';
+
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import EmberObject from '@ember/object';
+
+module('Integration | Component | certification-center-memberships-section', function(hooks) {
+
+  setupRenderingTest(hooks);
+
+  test('it should display certification center membership details', async function(assert) {
+    // given
+    const user = EmberObject.create({
+      id: 123,
+      firstName: 'Jojo',
+      lastName: 'La Gringue',
+      email: 'jojo@example.net',
+    });
+    const certificationCenterMembership = EmberObject.create({
+      id: 1,
+      user,
+      createdAt: new Date('2018-02-15T05:06:07Z'),
+    });
+    this.set('certificationCenterMemberships', [certificationCenterMembership]);
+
+    const expectedDate = moment(certificationCenterMembership.createdAt).format('DD-MM-YYYY - HH:mm:ss');
+
+    // when
+    await render(hbs `<CertificationCenterMembershipsSection @certificationCenterMemberships={{certificationCenterMemberships}} />`);
+
+    // then
+    assert.dom('[aria-label="Membre"]').exists();
+    assert.dom('[data-test-membership-id]').hasText(certificationCenterMembership.id.toString());
+    assert.dom('[data-test-user-id]').hasText(user.id.toString());
+    assert.dom('[data-test-user-first-name]').hasText(user.firstName);
+    assert.dom('[data-test-user-last-name]').hasText(user.lastName);
+    assert.dom('[data-test-user-email]').hasText(user.email);
+    assert.dom('[data-test-membership-created-at]').hasText(expectedDate);
+  });
+
+  test('it should display a list of certification center memberships', async function(assert) {
+    // given
+    const user1 = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
+    const user2 = EmberObject.create({ firstName: 'Froufrou', lastName: 'Le froussard', email: 'froufrou@lefroussard.fr' });
+    const certificationCenterMembership1 = EmberObject.create({ id: 1, user: user1 });
+    const certificationCenterMembership2 = EmberObject.create({ id: 1, user: user2 });
+    const certificationCenterMemberships = [certificationCenterMembership1, certificationCenterMembership2];
+    this.set('certificationCenterMemberships', certificationCenterMemberships);
+
+    // when
+    await render(hbs `<CertificationCenterMembershipsSection @certificationCenterMemberships={{certificationCenterMemberships}} />`);
+
+    // then
+    assert.dom('[aria-label="Membre"]').exists({ count: 2 });
+  });
+
+  test('it should display a message when there is no membership', async function(assert) {
+    // when
+    await render(hbs `<CertificationCenterMembershipsSection />`);
+
+    // then
+    assert.dom('[data-test-empty-message]').hasText('Aucun résultat');
+  });
+});

--- a/admin/tests/unit/adapters/certification-center-membership-test.js
+++ b/admin/tests/unit/adapters/certification-center-membership-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | certificationCenterMembership', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:certification-center-membership');
+  });
+
+  module('#urlForQuery', () => {
+
+    test('should build query url from certificationCenter id', async function(assert) {
+      const query = { filter: { certificationCenterId: '1' } };
+      const url = await adapter.urlForQuery(query);
+
+      assert.ok(url.endsWith('/api/certification-centers/1/certification-center-memberships'));
+      assert.equal(query.filter.certificationCenterId, undefined);
+    });
+  });
+});

--- a/api/db/database-builder/factory/build-certification-center-membership.js
+++ b/api/db/database-builder/factory/build-certification-center-membership.js
@@ -1,8 +1,10 @@
-const buildCertificationCenter = require('./build-certification-center');
-const buildUser = require('./build-user');
-const databaseBuffer = require('../database-buffer');
 const _ = require('lodash');
 const faker = require('faker');
+
+const buildCertificationCenter = require('./build-certification-center');
+const buildUser = require('./build-user');
+
+const databaseBuffer = require('../database-buffer');
 
 module.exports = function buildCertificationCenterMembership({
   id,

--- a/api/db/seeds/data/certification/certification-center-memberships-builder.js
+++ b/api/db/seeds/data/certification/certification-center-memberships-builder.js
@@ -9,10 +9,19 @@ const {
   PIX_PRO_CERTIF_USER_ID,
   PIX_SUP_CERTIF_USER_ID,
   PIX_NONE_CERTIF_USER_ID,
+  CERTIF_REGULAR_USER1_ID,
 } = require('./users');
 
 module.exports = function certificationCenterMembershipsBuilder({ databaseBuilder }) {
-  databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_SCO_CERTIF_USER_ID, certificationCenterId: SCO_CERTIF_CENTER_ID });
+  databaseBuilder.factory.buildCertificationCenterMembership({
+    certificationCenterId: SCO_CERTIF_CENTER_ID,
+    userId: PIX_SCO_CERTIF_USER_ID,
+  });
+  databaseBuilder.factory.buildCertificationCenterMembership({
+    certificationCenterId: SCO_CERTIF_CENTER_ID,
+    userId: CERTIF_REGULAR_USER1_ID,
+  });
+
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_PRO_CERTIF_USER_ID, certificationCenterId: PRO_CERTIF_CENTER_ID });
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_SUP_CERTIF_USER_ID, certificationCenterId: SUP_CERTIF_CENTER_ID });
   databaseBuilder.factory.buildCertificationCenterMembership({ userId: PIX_NONE_CERTIF_USER_ID, certificationCenterId: NONE_CERTIF_CENTER_ID });

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -1,8 +1,11 @@
 const usecases = require('../../domain/usecases');
+
 const certificationCenterSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-serializer');
+const certificationCenterMembershipSerializer = require('../../infrastructure/serializers/jsonapi/certification-center-membership-serializer');
+const divisionSerializer = require('../../infrastructure/serializers/jsonapi/sco-certification-center-division-serializer');
 const sessionSerializer = require('../../infrastructure/serializers/jsonapi/session-serializer');
 const studentCertificationSerializer = require('../../infrastructure/serializers/jsonapi/student-certification-serializer');
-const divisionSerializer = require('../../infrastructure/serializers/jsonapi/sco-certification-center-division-serializer');
+
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 
 module.exports = {
@@ -59,5 +62,14 @@ module.exports = {
     });
 
     return divisionSerializer.serialize(divisions);
+  },
+
+  async findCertificationCenterMembershipsByCertificationCenter(request) {
+    const certificationCenterId = parseInt(request.params.certificationCenterId);
+    const certificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
+      certificationCenterId,
+    });
+
+    return certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
   },
 };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -119,6 +119,28 @@ exports.register = async function(server) {
         ],
       },
     },
+    {
+      method: 'GET',
+      path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+        },
+        handler: certificationCenterController.findCertificationCenterMembershipsByCertificationCenter,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs Pix Master authentifiés**\n' +
+          '- Récupération de tous les membres d\'un centre de certification.\n' +
+          '- L‘utilisateur doit avoir les droits d‘accès en tant que Pix Master',
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/models/CertificationCenterMembership.js
+++ b/api/lib/domain/models/CertificationCenterMembership.js
@@ -3,9 +3,13 @@ class CertificationCenterMembership {
   constructor({
     id,
     certificationCenter,
+    user,
+    createdAt,
   } = {}) {
     this.id = id;
     this.certificationCenter = certificationCenter;
+    this.user = user;
+    this.createdAt = createdAt;
   }
 }
 

--- a/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
+++ b/api/lib/domain/usecases/find-certification-center-memberships-by-certification-center.js
@@ -1,0 +1,6 @@
+module.exports = function findCertificationCenterMembershipsByCertificationCenter({
+  certificationCenterId,
+  certificationCenterMembershipRepository,
+}) {
+  return certificationCenterMembershipRepository.findByCertificationCenterId(certificationCenterId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -148,6 +148,7 @@ module.exports = injectDependencies({
   findCampaignAssessments: require('./find-campaign-assessments'),
   findCampaignParticipationsRelatedToAssessment: require('./find-campaign-participations-related-to-assessment'),
   findCampaignProfilesCollectionParticipationSummaries: require('./find-campaign-profiles-collection-participation-summaries'),
+  findCertificationCenterMembershipsByCertificationCenter: require('./find-certification-center-memberships-by-certification-center'),
   findCompetenceEvaluationsByAssessment: require('./find-competence-evaluations-by-assessment'),
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -7,10 +7,24 @@ module.exports = {
 
   async findByUserId(userId) {
     const certificationCenterMemberships = await BookshelfCertificationCenterMembership
-      .where({ userId: userId })
+      .where({ userId })
       .fetchAll({
         withRelated: [
           'certificationCenter',
+        ],
+      });
+
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfCertificationCenterMembership, certificationCenterMemberships);
+  },
+
+  async findByCertificationCenterId(certificationCenterId) {
+    const certificationCenterMemberships = await BookshelfCertificationCenterMembership
+      .where({ certificationCenterId })
+      .orderBy('id', 'ASC')
+      .fetchAll({
+        withRelated: [
+          'certificationCenter',
+          'user',
         ],
       });
 

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer.js
@@ -8,7 +8,7 @@ module.exports = {
         record.certificationCenter.sessions = [];
         return record;
       },
-      attributes: ['certificationCenter'],
+      attributes: ['createdAt', 'certificationCenter', 'user'],
       certificationCenter: {
         ref: 'id',
         included: true,
@@ -22,6 +22,11 @@ module.exports = {
             },
           },
         },
+      },
+      user: {
+        ref: 'id',
+        included: true,
+        attributes: ['firstName', 'lastName', 'email'],
       },
     }).serialize(certificationCenterMemberships);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-center-serializer.js
@@ -6,7 +6,19 @@ module.exports = {
 
   serialize(certificationCenters, meta) {
     return new Serializer('certification-center', {
-      attributes: ['id', 'name', 'type', 'externalId', 'createdAt'],
+      attributes: [
+        'id', 'name', 'type', 'externalId', 'createdAt', 'certificationCenterMemberships',
+      ],
+      certificationCenterMemberships: {
+        ref: 'id',
+        ignoreRelationshipData: true,
+        nullIfMissing: true,
+        relationshipLinks: {
+          related(record, current, parent) {
+            return `/api/certification-centers/${parent.id}/certification-center-memberships`;
+          },
+        },
+      },
       meta,
     }).serialize(certificationCenters);
   },

--- a/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
+++ b/api/tests/acceptance/application/users/users-controller-get-certification-center-memberships_test.js
@@ -19,7 +19,10 @@ describe('Acceptance | Controller | users-controller-get-certification-center-me
     beforeEach(() => {
       certificationCenter = databaseBuilder.factory.buildCertificationCenter({ name: 'certifCenter' });
       user = databaseBuilder.factory.buildUser();
-      certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({ certificationCenterId: certificationCenter.id, userId: user.id });
+      certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+        certificationCenterId: certificationCenter.id,
+        userId: user.id,
+      });
       options = {
         method: 'GET',
         url: `/api/users/${user.id}/certification-center-memberships`,
@@ -68,11 +71,16 @@ describe('Acceptance | Controller | users-controller-get-certification-center-me
             {
               type: 'certificationCenterMemberships',
               id: certificationCenterMembership.id.toString(),
-              attributes: {},
+              attributes: {
+                'created-at': certificationCenterMembership.createdAt,
+              },
               relationships: {
                 'certification-center': {
                   data:
                     { type: 'certificationCenters', id: certificationCenter.id.toString() },
+                },
+                user: {
+                  data: null,
                 },
               },
             },

--- a/api/tests/integration/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/integration/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -1,0 +1,37 @@
+const { databaseBuilder, expect } = require('../../../test-helper');
+
+const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
+const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
+
+const { findCertificationCenterMembershipsByCertificationCenter } = require('../../../../lib/domain/usecases/index');
+
+describe('Integration | UseCase | find-certification-center-memberships-by-certification-center', () => {
+
+  it('should return certification center memberships', async () => {
+    // given
+    const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+    const user = databaseBuilder.factory.buildUser();
+    const certificationCenterMembership = databaseBuilder.factory.buildCertificationCenterMembership({
+      certificationCenterId: certificationCenter.id,
+      userId: user.id,
+    });
+
+    await databaseBuilder.commit();
+
+    // when
+    const foundCertificationCenterMemberships = await findCertificationCenterMembershipsByCertificationCenter({
+      certificationCenterId: certificationCenter.id,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    const foundCertificationCenterMembership = foundCertificationCenterMemberships[0];
+    expect(foundCertificationCenterMembership).to.be.instanceOf(CertificationCenterMembership);
+    expect(foundCertificationCenterMembership.id)
+      .to.equal(certificationCenterMembership.id);
+    expect(foundCertificationCenterMembership.certificationCenter.id)
+      .to.equal(certificationCenter.id);
+    expect(foundCertificationCenterMembership.user.id)
+      .to.equal(user.id);
+  });
+});

--- a/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-center-membership.js
@@ -1,14 +1,29 @@
+const faker = require('faker');
+
+const User = require('../../../../lib/domain/models/User');
 const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
 const buildCertificationCenter = require('./build-certification-center');
 
-module.exports = function buildCertificationCenterMembership(
-  {
-    id = 1,
-    certificationCenter = buildCertificationCenter(),
-  } = {}) {
+function _buildUser() {
+  return new User({
+    id: faker.random.number(),
+    firstName: faker.name.firstName(),
+    lastName: faker.name.lastName(),
+    email: faker.internet.exampleEmail().toLowerCase(),
+  });
+}
+
+module.exports = function buildCertificationCenterMembership({
+  id = 1,
+  certificationCenter = buildCertificationCenter(),
+  user = _buildUser(),
+  createdAt = faker.date.recent(),
+} = {}) {
 
   return new CertificationCenterMembership({
     id,
     certificationCenter,
+    user,
+    createdAt,
   });
 };

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -1,7 +1,9 @@
 const { expect, sinon, domainBuilder, hFake } = require('../../../test-helper');
 
-const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
 const usecases = require('../../../../lib/domain/usecases');
+const certificationCenterMembershipSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/certification-center-membership-serializer');
+
+const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
 
 describe('Unit | Controller | certifications-center-controller', () => {
 
@@ -54,6 +56,7 @@ describe('Unit | Controller | certifications-center-controller', () => {
   });
 
   describe('#getDivisions', () => {
+
     it('Should return a serialized list of divisions', async () => {
       // given
       const request = {
@@ -114,4 +117,35 @@ describe('Unit | Controller | certifications-center-controller', () => {
       );
     });
   });
+
+  describe('#findCertificationCenterMembershipsByCertificationCenter', () => {
+
+    const certificationCenterId = 1;
+
+    const request = {
+      params: {
+        certificationCenterId,
+      },
+    };
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'findCertificationCenterMembershipsByCertificationCenter');
+      sinon.stub(certificationCenterMembershipSerializer, 'serialize');
+    });
+
+    it('should call usecase and serializer and return ok', async () => {
+      // given
+      usecases.findCertificationCenterMembershipsByCertificationCenter.withArgs({
+        certificationCenterId,
+      }).resolves({});
+      certificationCenterMembershipSerializer.serialize.withArgs({}).returns('ok');
+
+      // when
+      const response = await certificationCenterController.findCertificationCenterMembershipsByCertificationCenter(request);
+
+      // then
+      expect(response).to.equal('ok');
+    });
+  });
+
 });

--- a/api/tests/unit/application/certification-centers/index_test.js
+++ b/api/tests/unit/application/certification-centers/index_test.js
@@ -4,21 +4,25 @@ const {
   sinon,
 } = require('../../../test-helper');
 
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const moduleUnderTest = require('../../../../lib/application/certification-centers');
 
-const CertificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
+const certificationCenterController = require('../../../../lib/application/certification-centers/certification-center-controller');
 
 describe('Unit | Router | certification-center-router', function() {
 
   let httpTestServer;
 
   beforeEach(function() {
-    sinon.stub(CertificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+    sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').returns(true);
+    sinon.stub(certificationCenterController, 'getStudents').callsFake((request, h) => h.response().code(200));
+    sinon.stub(certificationCenterController, 'findCertificationCenterMembershipsByCertificationCenter').returns('ok');
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('GET /api/certification-centers/{certificationCenterId}/divisions', function() {
+
     it('should reject an invalid certification center id', async () => {
       // when
       const result = await httpTestServer.request('GET', '/api/certification-centers/invalid/divisions');
@@ -109,7 +113,28 @@ describe('Unit | Router | certification-center-router', function() {
       // then
       expect(result.statusCode).to.equal(400);
     });
+  });
 
+  describe('GET /api/certification-centers/{certificationCenterId}/certification-center-memberships', () => {
+
+    const method = 'GET';
+    const url = '/api/certification-centers/1/certification-center-memberships';
+
+    it('should exist', async () => {
+      // when
+      const result = await httpTestServer.request(method, url);
+
+      // then
+      expect(result.statusCode).to.equal(200);
+    });
+
+    it('should reject an invalid certification-centers id', async () => {
+      // when
+      const result = await httpTestServer.request(method, '/api/certification-centers/invalid/certification-center-memberships');
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
   });
 
 });

--- a/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
+++ b/api/tests/unit/domain/usecases/find-certification-center-memberships-by-certification-center_test.js
@@ -1,0 +1,34 @@
+const { domainBuilder, expect, sinon } = require('../../../test-helper');
+
+const usecases = require('../../../../lib/domain/usecases');
+
+describe('Unit | UseCase | find-certification-center-memberships-by-certification-center', () => {
+
+  const certificationCenterId = 1;
+  const certificationCenterMemberships = [domainBuilder.buildCertificationCenterMembership()];
+
+  let certificationCenterMembershipRepository;
+
+  beforeEach(() => {
+    certificationCenterMembershipRepository = {
+      findByCertificationCenterId: sinon.stub(),
+    };
+    certificationCenterMembershipRepository.findByCertificationCenterId.resolves(certificationCenterMemberships);
+  });
+
+  it('should result certification-center-memberships by certification center id', async () => {
+    // given
+
+    // when
+    const foundCertificationCenterMemberships = await usecases.findCertificationCenterMembershipsByCertificationCenter({
+      certificationCenterId,
+      certificationCenterMembershipRepository,
+    });
+
+    // then
+    expect(certificationCenterMembershipRepository.findByCertificationCenterId)
+      .to.have.been.calledWith(certificationCenterId);
+    expect(foundCertificationCenterMemberships).to.deep.equal(certificationCenterMemberships);
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-membership-serializer_test.js
@@ -8,13 +8,20 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
     it('should convert a Certification Center Membership model object into JSON API data', function() {
       // given
       const certificationCenter = domainBuilder.buildCertificationCenter();
-      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({ certificationCenter });
+      const user = domainBuilder.buildUser();
+      const certificationCenterMembership = domainBuilder.buildCertificationCenterMembership({
+        certificationCenter,
+        user,
+      });
 
       const expectedSerializedCertificationCenter = {
         data: [
           {
-            attributes: {},
             id: certificationCenterMembership.id.toString(),
+            type: 'certificationCenterMemberships',
+            attributes: {
+              'created-at': certificationCenterMembership.createdAt,
+            },
             relationships: {
               'certification-center': {
                 data: {
@@ -22,17 +29,23 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
                   type: 'certificationCenters',
                 },
               },
+              user: {
+                data: {
+                  id: user.id.toString(),
+                  type: 'users',
+                },
+              },
             },
-            type: 'certificationCenterMemberships',
           },
         ],
         included: [
           {
+            id: certificationCenter.id.toString(),
+            type: 'certificationCenters',
             attributes: {
               name: certificationCenter.name,
               type: certificationCenter.type,
             },
-            id: certificationCenter.id.toString(),
             relationships: {
               sessions: {
                 links: {
@@ -40,7 +53,15 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
                 },
               },
             },
-            type: 'certificationCenters',
+          },
+          {
+            id: user.id.toString(),
+            type: 'users',
+            attributes: {
+              'first-name': user.firstName,
+              'last-name': user.lastName,
+              email: user.email,
+            },
           },
         ],
       };
@@ -51,7 +72,6 @@ describe('Unit | Serializer | JSONAPI | certification-center-membership-serializ
       // then
       expect(serializedCertificationCenter).to.deep.equal(expectedSerializedCertificationCenter);
     });
-
   });
 
 });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-center-serializer_test.js
@@ -2,7 +2,7 @@ const { expect } = require('../../../../test-helper');
 const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-center-serializer');
 const CertificationCenter = require('../../../../../lib/domain/models/CertificationCenter');
 
-describe('Unit | Serializer | JSONAPI | certification-center-serializer', function() {
+describe('Unit | Serializer | JSONAPI | certification-center-serializer', () => {
 
   let certificationCenterId;
   let certificationCenterName;
@@ -18,9 +18,9 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
     certificationCenterDate = 'Some date';
   });
 
-  describe('#serialize', function() {
+  describe('#serialize', () => {
 
-    it('should convert a Certification Center model object into JSON API data', function() {
+    it('should convert a Certification Center model object into JSON API data', () => {
       // given
       const certificationCenter = new CertificationCenter({
         id: certificationCenterId.toString(),
@@ -40,6 +40,13 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
             'external-id': undefined,
             'created-at': certificationCenterDate,
           },
+          relationships: {
+            'certification-center-memberships': {
+              links: {
+                related: `/api/certification-centers/${certificationCenter.id}/certification-center-memberships`,
+              },
+            },
+          },
         },
       };
 
@@ -49,12 +56,11 @@ describe('Unit | Serializer | JSONAPI | certification-center-serializer', functi
       // then
       expect(serializedCertificationCenter).to.deep.equal(expectedSerializedCertificationCenter);
     });
-
   });
 
-  describe('#deserialize', function() {
+  describe('#deserialize', () => {
 
-    it('should convert JSON API certification center data into a Certification Center model object', function() {
+    it('should convert JSON API certification center data into a Certification Center model object', () => {
       // given
       const jsonApi = {
         data: {


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, Il n'est pas possible de voir les membres qui sont rattachés à un centre de certification.

## :robot: Solution
Depuis la page de détail d'un centre de certification, afficher la liste des membres rattachés à ce centre de certification.

Avec les colonnes suivantes : 
* ID Membre
* ID Utilisateur
* Prénom
* Nom
* Adresse e-mail
* Date de rattachement

Trier la liste selon la colonne ID Membre
Afficher les dates sous le format : 'JJ-MM-AAAA - 00:00:00'

## :rainbow: Remarques
Après le lancement du linter, on peut constater qu'il y a une quarantaine d'erreurs.
Leur correction sera effectuée dans un prochain ticket.

## :100: Pour tester
* Dans Pix Admin aller sur la page listant tous les centres de certification
* Dans la liste, [sélectionner le centre](https://admin-pr2507.review.pix.fr/certification-centers/1) "Centre SCO des Anne-Étoiles", en cliquant sur la ligne.
* Vérifier que la liste des membres rattachés au centre s'affichent correctement ( 2 membres, [seeds ici](http://github.com/1024pix/pix/blob/dev/api/db/seeds/data/certification/certification-center-memberships-builder.js))