### PR TITLE
[FEATURE] Amélioration de la phrase sur le consentement dans la landing page pour un parcours (PIX-2109).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -77,7 +77,7 @@
                 "action": "Begin",
                 "announcement": "Start your personalised test.'<br>' Sign up or log in to the Pix platform and start your test.",
                 "details": "During this personalised test, you will be able to:",
-                "legal": "Information about your progress will be sent to the organiser so they can provide support. Your test results will only be shared with your permission.",
+                "legal": "By clicking on “Begin“, information about your progress will be shared with the organiser so they can assist you if necessary. At the end of your personalised test, your results will be shared with your organisation when clicking on “Submit my results“.",
                 "evaluate": {
                     "title": "Assess your digital skills with fun tests on different subjects, such as:",
                     "complement": "The Pix public service for the assessment and certification of digital skills enables assessment of your level in 5 major skill areas covering current uses of digital technology.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -77,7 +77,7 @@
                 "action": "Je commence",
                 "announcement": "Démarrez votre parcours d'évaluation personnalisé.'<br>' Inscrivez-vous ou connectez-vous sur la plateforme Pix et lancez votre test.",
                 "details": "Durant ce parcours, vous aurez l’opportunité de :",
-                "legal": "Les informations relatives à votre avancée seront transmises à l'organisateur du parcours pour lui permettre de vous accompagner. Les résultats des tests ne seront transmis qu’avec votre consentement.",
+                "legal": "En cliquant sur “Je commence”, les informations relatives à votre avancée dans le parcours seront transmises à l’organisateur du parcours pour lui permettre de vous accompagner. A la fin du parcours, en cliquant sur le bouton “J’envoie mes résultats” vos résultats seront transmis à l’organisateur.",
                 "evaluate": {
                     "title": "Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :",
                     "complement": "Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.",


### PR DESCRIPTION
## :unicorn: Problème
Mise à jour de la phrase de consentement avant que le prescrit commence un parcours d'évaluation personnalisé.

## :robot: Solution
Remplacer l'ancienne phrase de consentement par la nouvelle

## :rainbow: Remarques
N/A

## :100: Pour tester
connectez-vous à pix app puis saisissez un code dans la section " j'ai un code ".
vous serez dirigé vers une page de présentation avant de commencer un parcours. Sous le bouton " J commence " , vous trouverez la nouvelle phrase de consentement.