### PR TITLE
[FEATURE] Permettre au script de création de membres de centre de certification d'ajouter de nouveaux membres (PIX-1948).

### DIFF
--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -50,12 +50,15 @@ function buildCertificationCenterMemberships({ certificationCenterId, membership
 }
 
 async function fetchCertificationCenterMembershipsByExternalId(externalId) {
-  const certificationCenterId = await getCertificationCenterWithoutMembershipIdByExternalId(externalId);
-  if (!certificationCenterId) {
-    return [];
-  }
+  const certificationCenter = await getCertificationCenterIdWithMembershipsUserIdByExternalId(externalId);
   const membershipUserIds = await getAdminMembershipsUserIdByOrganizationExternalId(externalId);
-  return buildCertificationCenterMemberships({ certificationCenterId, membershipUserIds });
+  const missingMemberships = _.filter(membershipUserIds, (userId) => {
+    return !certificationCenter.certificationCenterMemberships.includes(userId);
+  });
+  return buildCertificationCenterMemberships({
+    certificationCenterId: certificationCenter.id,
+    membershipUserIds: missingMemberships,
+  });
 }
 
 async function prepareDataForInsert(rawExternalIds) {

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -29,6 +29,7 @@ async function getAdminMembershipsUserIdByOrganizationExternalId(externalId) {
     .innerJoin('organizations', 'memberships.organizationId', 'organizations.id')
     .innerJoin('users', 'users.id', 'memberships.userId')
     .where('organizationRole', Membership.roles.ADMIN)
+    .whereNull('memberships.disabledAt')
     .where('organizations.externalId', '=', externalId)
     .where('users.firstName', '!~', 'prenom_.*\\d')
     .where('users.lastName', '!~', 'nom_.*\\d');

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -19,6 +19,20 @@ async function getCertificationCenterWithoutMembershipIdByExternalId(externalId)
   return certificationCenter ? certificationCenter.id : null;
 }
 
+async function getCertificationCenterIdWithMembershipsUserIdByExternalId(externalId) {
+  const certificationCenterIdWithMemberships = await knex('certification-centers')
+    .select('certification-centers.id', 'certification-center-memberships.userId')
+    .leftJoin('certification-center-memberships', 'certification-centers.id', 'certification-center-memberships.certificationCenterId')
+    .where('certification-centers.externalId', '=', externalId);
+
+  return { id: certificationCenterIdWithMemberships[0].id,
+    certificationCenterMemberships: _(certificationCenterIdWithMemberships)
+      .map((certificationCenterMembership) => certificationCenterMembership.userId)
+      .compact()
+      .value(),
+  };
+}
+
 async function getAdminMembershipsUserIdByOrganizationExternalId(externalId) {
   const adminMemberships = await knex('memberships')
     .select('memberships.userId')
@@ -93,6 +107,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  getCertificationCenterIdWithMembershipsUserIdByExternalId,
   getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   buildCertificationCenterMemberships,

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -27,8 +27,11 @@ async function getAdminMembershipsUserIdByOrganizationExternalId(externalId) {
   const adminMemberships = await knex('memberships')
     .select('memberships.userId')
     .innerJoin('organizations', 'memberships.organizationId', 'organizations.id')
+    .innerJoin('users', 'users.id', 'memberships.userId')
     .where('organizationRole', Membership.roles.ADMIN)
-    .where('organizations.externalId', '=', externalId);
+    .where('organizations.externalId', '=', externalId)
+    .where('users.firstName', '!~', 'prenom_.*\\d')
+    .where('users.lastName', '!~', 'nom_.*\\d');
 
   return adminMemberships.map((adminMembership) => adminMembership.userId);
 }

--- a/api/scripts/create-certification-center-memberships-from-organization-admins.js
+++ b/api/scripts/create-certification-center-memberships-from-organization-admins.js
@@ -9,16 +9,6 @@ const Membership = require('../lib/domain/models/Membership');
 
 const { knex } = require('../lib/infrastructure/bookshelf');
 
-async function getCertificationCenterWithoutMembershipIdByExternalId(externalId) {
-  const certificationCenter = await knex('certification-centers')
-    .first('certification-centers.id')
-    .leftJoin('certification-center-memberships', 'certification-center-memberships.certificationCenterId', 'certification-centers.id')
-    .whereNull('certification-center-memberships.id')
-    .where('certification-centers.externalId', '=', externalId);
-
-  return certificationCenter ? certificationCenter.id : null;
-}
-
 async function getCertificationCenterIdWithMembershipsUserIdByExternalId(externalId) {
   const certificationCenterIdWithMemberships = await knex('certification-centers')
     .select('certification-centers.id', 'certification-center-memberships.userId')
@@ -111,7 +101,6 @@ if (require.main === module) {
 
 module.exports = {
   getCertificationCenterIdWithMembershipsUserIdByExternalId,
-  getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   buildCertificationCenterMemberships,
   fetchCertificationCenterMembershipsByExternalId,

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -118,12 +118,26 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
     it('should get admin memberships by organization externalId', async () => {
       // given
-      const expectedUserIds = [adminUserId1a, adminUserId1b];
+      const organization = databaseBuilder.factory.buildOrganization();
+      const adminUserId1 = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: adminUserId1,
+        organizationRole: Membership.roles.ADMIN,
+      });
+      const adminUserId2 = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: adminUserId2,
+        organizationRole: Membership.roles.ADMIN,
+      });
+      await databaseBuilder.commit();
 
       // when
-      const userIds = await getAdminMembershipsUserIdByOrganizationExternalId(externalId1);
+      const userIds = await getAdminMembershipsUserIdByOrganizationExternalId(organization.externalId);
 
       // then
+      const expectedUserIds = [adminUserId1, adminUserId2];
       expect(userIds).to.deep.equal(expectedUserIds);
     });
 

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -139,6 +139,38 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       // then
       expect(memberships).to.have.lengthOf(0);
     });
+
+    it('should not return anonymize user', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const anonymmizeUser = databaseBuilder.factory.buildUser({
+        firstName: 'prenom_1234',
+        lastName: 'nom_1234',
+      });
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: anonymmizeUser.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      const notAnonymizeUserId = databaseBuilder.factory.buildUser({
+        firstName: 'pre_1234',
+        lastName: 'no_1234',
+      }).id;
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: notAnonymizeUserId,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const memberships = await getAdminMembershipsUserIdByOrganizationExternalId(organization.externalId);
+
+      // then
+      expect(memberships).to.deep.equal([notAnonymizeUserId]);
+    });
   });
 
   describe('#fetchCertificationCenterMembershipsByExternalId', () => {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -7,7 +7,6 @@ const BookshelfCertificationCenterMembership = require('../../../lib/infrastruct
 
 const {
   getCertificationCenterIdWithMembershipsUserIdByExternalId,
-  getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   fetchCertificationCenterMembershipsByExternalId,
   prepareDataForInsert,
@@ -73,25 +72,6 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
     });
 
     await databaseBuilder.commit();
-  });
-
-  describe('#getCertificationCenterIdByExternalId', () => {
-
-    it('should get certification center by externalId', async () => {
-      // when
-      const certificationCenterId = await getCertificationCenterWithoutMembershipIdByExternalId(externalId1);
-
-      // then
-      expect(certificationCenterId).to.equal(certificationCenterId1);
-    });
-
-    it('should return null when certification center has a membership', async () => {
-      // when
-      const result = await getCertificationCenterWithoutMembershipIdByExternalId(externalIdForCertificationCenterWithMembership);
-
-      // then
-      expect(result).to.be.null;
-    });
   });
 
   describe('#getCertificationCenterIdWithMembershipsUserIdByExternalId', () => {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -171,6 +171,25 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
       // then
       expect(memberships).to.deep.equal([notAnonymizeUserId]);
     });
+
+    it('should not return disabled member', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+      const disabledUser = databaseBuilder.factory.buildUser();
+      databaseBuilder.factory.buildMembership({
+        organizationId: organization.id,
+        userId: disabledUser.id,
+        organizationRole: Membership.roles.ADMIN,
+        disabledAt: '2020-02-04',
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const memberships = await getAdminMembershipsUserIdByOrganizationExternalId(organization.externalId);
+
+      // then
+      expect(memberships).to.have.length(0);
+    });
   });
 
   describe('#fetchCertificationCenterMembershipsByExternalId', () => {

--- a/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
+++ b/api/tests/integration/scripts/create-certification-center-memberships-from-organization-admins_test.js
@@ -6,6 +6,7 @@ const Membership = require('../../../lib/domain/models/Membership');
 const BookshelfCertificationCenterMembership = require('../../../lib/infrastructure/data/certification-center-membership');
 
 const {
+  getCertificationCenterIdWithMembershipsUserIdByExternalId,
   getCertificationCenterWithoutMembershipIdByExternalId,
   getAdminMembershipsUserIdByOrganizationExternalId,
   fetchCertificationCenterMembershipsByExternalId,
@@ -90,6 +91,46 @@ describe('Integration | Scripts | create-certification-center-memberships-from-o
 
       // then
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#getCertificationCenterIdWithMembershipsUserIdByExternalId', () => {
+
+    context('when certification center has memberships', () => {
+      it('should get certification center id with memberships user id by externalId', async () => {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+        const userId = databaseBuilder.factory.buildUser().id;
+        databaseBuilder.factory.buildCertificationCenterMembership({
+          certificationCenterId: certificationCenter.id,
+          userId,
+        });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await getCertificationCenterIdWithMembershipsUserIdByExternalId(certificationCenter.externalId);
+
+        // then
+        expect(result.id).to.equal(certificationCenter.id);
+        expect(result.certificationCenterMemberships).to.deep.equal([userId]);
+      });
+    });
+
+    context('when certification center does not have memberships', () => {
+      it('should get certification center id with memberships user id by externalId', async () => {
+        // given
+        const certificationCenter = databaseBuilder.factory.buildCertificationCenter();
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await getCertificationCenterIdWithMembershipsUserIdByExternalId(certificationCenter.externalId);
+
+        // then
+        expect(result.id).to.equal(certificationCenter.id);
+        expect(result.certificationCenterMemberships).to.deep.equal([]);
+      });
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Le script de création des membres de centre de certification:
- détermine l'organisation associée au centre de certification
- sur cette organisation, recherche les memberships de type `administrateur `
- crée les certification-centermemberships correspondant à ces utilisateurs.

Seulement 
- quand le centre de certification a déjà des membres 
- alors le script ne permet pas d'en ajouter des nouveaux. 

De plus, le script peut aussi ajouter des membres d'une organisation qui ont été anonymisés ou désactivé, ce qui n'est pas souhaités

## :robot: Solution
Permettre  d'ajouter les nouveaux membres d'une organisation dans le centre de certification associé
Pour cela, créer une méthode qui retourne l'id du centre de certification pour un `externalId` ainsi que ces membres associés  
https://github.com/1024pix/pix/blob/9b2008a4c94247649b8e189ee2ba0f48897cadac/api/scripts/create-certification-center-memberships-from-organization-admins.js#L22-L34

Ne pas ajouter les membres admin anonymisés et désactivés : 
Pour cela, ajouter des conditions dans la requête knex de la méthode qui va chercher les admin d'une organisation.
https://github.com/1024pix/pix/blob/6fa4b67c1dcb42cc0692242f8b8c4752d014b8f1/api/scripts/create-certification-center-memberships-from-organization-admins.js#L26-L38

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

### Ajouter de nouveaux membres

Sur une organisation avec un `externalId`
- localiser un centre de certification avec des membres, ex `Centre SCO des Anne-Étoiles`
- ajouter un administrateur à une organisation, ex modifier rôle de `Targaryen`
- lancer le script
- vérifier que l'administrateur est membre du centre de certification


### Ne pas rattacher des membres désactivés

Sur une organisation avec un `externalId`
- [anonymiser](https://admin-pr2511.review.pix.fr/users/5) un membre administrateur, ex  `Targaryen`
- vérifier qu'il n'est pas déjà membre du centre de certification (ou alors, le supprimer)
- lancer le script
- vérifier que l'administrateur n'est pas membre du centre de certification

### Helper de test
Relancer les seeds
`scalingo --app pix-api-review-pr2511 run "npm run db:seed" `

Créer un fichier `centre-certif-membre-existant.csv`
```
externalId
1237457A
```
Exécution
`scalingo --app pix-api-review-pr2511 run --file centre-certif-membre-existant.csv node scripts/create-certification-center-memberships-from-organization-admins.js /tmp/uploads/centre-certif-membre-existant.csv`

Message
```
Starting creating Certification Center memberships with a list of ExternalIds.
Check csv extension file...  ok
Reading and parsing csv data file...  ok
Data preparation before insertion into the database... ok
Creating Certification Center Memberships into database... Done.
```