### PR TITLE
[TECH] Génération des snapshots KE pour les données de seeds (dév/local/RA) (PIX-2119)

### DIFF
--- a/api/db/batchTreatment.js
+++ b/api/db/batchTreatment.js
@@ -5,10 +5,7 @@ function batch(knex, elementsToUpdate, treatment) {
   function _innerTreatment(knex, remainingElementsToUpdate, countOfBatches, batchesDone) {
 
     if (remainingElementsToUpdate.length <= 0) {
-      return Promise.resolve()
-        .then(() => {
-          console.log(`-- ENDING - ${numberOfTotalBatches} iterations done\n`);
-        });
+      return Promise.resolve();
     }
 
     const assessments = remainingElementsToUpdate.splice(0, BATCH_SIZE);
@@ -32,9 +29,6 @@ function batch(knex, elementsToUpdate, treatment) {
 
   return Promise
     .resolve()
-    .then(() => {
-      console.log(`\n-- STARTING - Processing the data through ${numberOfTotalBatches} iterations`);
-    })
     .then(() => _innerTreatment(knex, elementsToUpdate, numberOfTotalBatches, 0));
 }
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -58,14 +58,6 @@ async function _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, 
   });
 }
 
-async function _findByUserIdAndLimitDateThenSaveSnapshot({ userId, limitDate }) {
-  const knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({ userId, limitDate });
-  if (limitDate) {
-    await knowledgeElementSnapshotRepository.save({ userId, snappedAt: limitDate, knowledgeElements });
-  }
-  return knowledgeElements;
-}
-
 async function _findSnapshotsForUsers(userIdsAndDates) {
   const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
 
@@ -73,7 +65,7 @@ async function _findSnapshotsForUsers(userIdsAndDates) {
     const userId = parseInt(userIdStr);
     let knowledgeElements = knowledgeElementsFromSnapshot;
     if (!knowledgeElements) {
-      knowledgeElements = await _findByUserIdAndLimitDateThenSaveSnapshot({
+      knowledgeElements = await _findAssessedByUserIdAndLimitDateQuery({
         userId,
         limitDate: userIdsAndDates[userId],
       });

--- a/api/scripts/data-generation/generate-campaign-with-participants.js
+++ b/api/scripts/data-generation/generate-campaign-with-participants.js
@@ -6,6 +6,10 @@ const competenceRepository = require('../../lib/infrastructure/repositories/comp
 const skillRepository = require('../../lib/infrastructure/repositories/skill-repository');
 const targetProfileRepository = require('../../lib/infrastructure/repositories/target-profile-repository');
 const computeValidatedSkillsCount = require('../prod/compute-validated-skills-count-for-assessment-campaign-participation');
+const {
+  getEligibleCampaignParticipations,
+  generateKnowledgeElementSnapshots,
+} = require('../prod/generate-knowledge-element-snapshots-for-campaigns');
 const firstKECreatedAt = new Date('2020-05-01');
 const secondKECreatedAt = new Date('2020-05-02');
 const participationSharedAt = new Date('2020-05-03');
@@ -443,6 +447,9 @@ async function _do({ organizationId, targetProfileId, participantCount, profileT
   await trx.commit();
   console.log('calcul des validatedSkillsCount ...');
   await computeValidatedSkillsCount(10);
+  console.log('génération des snapshots KE ...');
+  const campaignParticipationData = await getEligibleCampaignParticipations(participantCount);
+  await generateKnowledgeElementSnapshots(campaignParticipationData, 3);
   console.log(`Campagne: ${campaignId}\nOrganisation: ${organizationId}\nNombre de participants: ${participantCount}\nProfil Cible: ${targetProfile.id}`);
 }
 

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -49,8 +49,6 @@ async function getEligibleCampaignParticipations(maxSnapshotCount) {
       this.on('knowledge-element-snapshots.userId', 'campaign-participations.userId')
         .andOn('knowledge-element-snapshots.snappedAt', 'campaign-participations.sharedAt');
     })
-    .join('campaigns', 'campaigns.id', 'campaign-participations.campaignId')
-    .whereNull('campaigns.archivedAt')
     .whereNotNull('campaign-participations.sharedAt')
     .where((qb) => {
       qb.whereNull('knowledge-element-snapshots.snappedAt')

--- a/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
+++ b/api/scripts/prod/generate-knowledge-element-snapshots-for-campaigns.js
@@ -65,9 +65,7 @@ async function generateKnowledgeElementSnapshots(campaignParticipationData, conc
     try {
       await knowledgeElementSnapshotRepository.save({ userId, snappedAt: sharedAt, knowledgeElements });
     } catch (err) {
-      if (err instanceof AlreadyExistingEntityError) {
-        console.log(`Un snapshot existe déjà pour l'utilisateur ${userId} à la date ${sharedAt}. Ignoré.`);
-      } else {
+      if (!(err instanceof AlreadyExistingEntityError)) {
         throw err;
       }
     }
@@ -94,13 +92,9 @@ async function main() {
       concurrency,
     } = _validateAndNormalizeArgs(commandLineArgs);
 
-    console.log(`Génération de ${maxSnapshotCount} snapshots avec une concurrence de ${concurrency}`);
-
     const campaignParticipationData = await getEligibleCampaignParticipations(maxSnapshotCount);
-    console.log(`${campaignParticipationData.length} participations récupérées...`);
 
     await generateKnowledgeElementSnapshots(campaignParticipationData, concurrency);
-    console.log('FIN');
   } catch (error) {
     console.error('\x1b[31mErreur : %s\x1b[0m', error.message);
     yargs.showHelp();

--- a/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/knowledge-element-repository_test.js
@@ -813,15 +813,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
             [expectedKnowledgeElement.competenceId]: [expectedKnowledgeElement],
           });
         });
-
-        it('should save a snasphot', async () => {
-          // when
-          await knowledgeElementRepository.findSnapshotGroupedByCompetencesForUsers({ [userId1]: new Date('2018-02-01') });
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId: userId1 });
-          expect(actualUserSnapshots.length).to.equal(1);
-        });
       });
     });
   });
@@ -934,26 +925,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           expect(knowledgeElementsCountByCompetenceId).to.deep.equal({
             [targetProfile.competences[0].id]: 1,
           });
-        });
-
-        it('should save a snasphot', async () => {
-          // given
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
-          const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            createdAt: new Date('2018-01-01'),
-            competenceId: targetProfile.competences[0].id,
-            skillId: targetProfile.skills[0].id,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          await knowledgeElementRepository.countValidatedTargetedByCompetencesForOneUser(userId, new Date('2018-02-01'), targetProfile);
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(1);
         });
       });
     });
@@ -1150,26 +1121,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
           expect(knowledgeElementsCountByCompetenceId).to.deep.equal({
             [targetProfile.competences[0].id]: 1,
           });
-        });
-
-        it('should save a snasphot', async () => {
-          // given
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
-          const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            createdAt: new Date('2018-01-01'),
-            competenceId: targetProfile.competences[0].id,
-            skillId: targetProfile.skills[0].id,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          await knowledgeElementRepository.countValidatedTargetedByCompetencesForUsers({ [userId]: new Date('2018-02-01') }, targetProfile);
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(1);
         });
       });
     });
@@ -1397,26 +1348,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
             [targetProfile.competences[0].id]: [expectedKnowledgeElement],
           });
         });
-
-        it('should save a snasphot', async () => {
-          // given
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
-          const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            createdAt: new Date('2018-01-01'),
-            competenceId: targetProfile.competences[0].id,
-            skillId: targetProfile.skills[0].id,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          await knowledgeElementRepository.findTargetedGroupedByCompetencesForUsers({ [userId]: new Date('2018-02-01') }, targetProfile);
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(1);
-        });
       });
     });
 
@@ -1634,25 +1565,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
             [targetProfile.tubes[0].id]: [expectedKnowledgeElement],
           });
         });
-
-        it('should save a snasphot', async () => {
-          // given
-          const targetProfile = domainBuilder.buildTargetProfileWithLearningContent.withSimpleLearningContent();
-          const userId = databaseBuilder.factory.buildUser().id;
-          databaseBuilder.factory.buildKnowledgeElement({
-            userId,
-            createdAt: new Date('2018-01-01'),
-            skillId: targetProfile.skills[0].id,
-          });
-          await databaseBuilder.commit();
-
-          // when
-          await knowledgeElementRepository.findValidatedTargetedGroupedByTubes({ [userId]: new Date('2018-02-01') }, targetProfile);
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId });
-          expect(actualUserSnapshots.length).to.equal(1);
-        });
       });
     });
 
@@ -1826,23 +1738,6 @@ describe('Integration | Repository | knowledgeElementRepository', () => {
 
           // then
           expect(knowledgeElementsByUserIdAndCompetenceId[userId1]).to.deep.include.members([expectedKnowledgeElement]);
-        });
-
-        it('should save a snasphot', async () => {
-          // when
-          await knowledgeElementRepository.findSnapshotForUsers({ [userId1]: new Date('2018-02-01') });
-
-          // then
-          const actualUserSnapshots = await knex.select('*').from('knowledge-element-snapshots').where({ userId: userId1 });
-          expect(actualUserSnapshots.length).to.equal(1);
-          const actualKnowledgeElements = [];
-          for (const knowledgeElementData of actualUserSnapshots[0].snapshot) {
-            actualKnowledgeElements.push(new KnowledgeElement({
-              ...knowledgeElementData,
-              createdAt: new Date(knowledgeElementData.createdAt),
-            }));
-          }
-          expect(actualKnowledgeElements).to.deep.equal([expectedKnowledgeElement]);
         });
       });
     });

--- a/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
+++ b/api/tests/integration/scripts/prod/generate-knowledge-element-snapshots-for-campaigns_test.js
@@ -4,25 +4,12 @@ const knowledgeElementSnapshotRepository = require('../../../../lib/infrastructu
 const {
   getEligibleCampaignParticipations,
   generateKnowledgeElementSnapshots,
-} = require('../../../../scripts/prod/generate-knowledge-element-snapshots-for-active-campaigns');
+} = require('../../../../scripts/prod/generate-knowledge-element-snapshots-for-campaigns');
 
-describe('Integration | Scripts | generate-knowledge-element-snapshots-for-active-campaigns.js', () => {
+describe('Integration | Scripts | generate-knowledge-element-snapshots-for-campaigns.js', () => {
 
   describe('#getEligibleCampaignParticipations', () => {
     const maxParticipationCountToGet = 5;
-
-    it('should avoid returning campaign participations that are not in active campaigns', async () => {
-      // given
-      const campaignId = databaseBuilder.factory.buildCampaign({ archivedAt: new Date('2020-01-01') }).id;
-      databaseBuilder.factory.buildCampaignParticipation({ campaignId });
-      await databaseBuilder.commit();
-
-      // when
-      const campaignParticipationData = await getEligibleCampaignParticipations(maxParticipationCountToGet);
-
-      // then
-      expect(campaignParticipationData.length).to.equal(0);
-    });
 
     it('should avoid returning campaign participations that are not shared', async () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Finalisation du travail sur les snapshots KE.
Pour pouvoir les utiliser partout sans contraintes/complexes et sans avoir à reposer sur le lazy, il faut faire en sorte que chaque participation partagée dans les seeds ait son snapshotKE.

## :robot: Solution
- Modifier légèrement le script de génération de snapshots pour qu'il prenne en compte TOUTES les campagnes (pas seulement les non-archivées)
- Appeler les fonctions de ce script dans la fonction qui seed la DB
- Supprimer le lazy mode de la génération des snapshots.

## :rainbow: Remarques
Au passage, suppression de console.log() vraiment vraiment inutiles lors d'un db:migrate

## :100: Pour tester
Après exécution des seeds, s'assurer que toutes les participations partagées ont leur snapshot KE
