### PR TITLE
[TECH]  Utiliser les snapshots pour calculer les resultats d'une participation à une campagne d'évaluation afin de les afficher au participant (PIX-2121).

### DIFF
--- a/api/db/database-builder/factory/index.js
+++ b/api/db/database-builder/factory/index.js
@@ -52,4 +52,5 @@ module.exports = {
   buildUserPixRole: require('./build-user-pix-role'),
   buildUserTutorial: require('./build-user-tutorial'),
   campaignParticipationOverviewFactory: require('./campaign-participation-overview-factory'),
+  knowledgeElementSnapshotFactory: require('./knowledge-elements-snapshot-factory'),
 };

--- a/api/db/database-builder/factory/knowledge-elements-snapshot-factory.js
+++ b/api/db/database-builder/factory/knowledge-elements-snapshot-factory.js
@@ -1,0 +1,27 @@
+const buildKnowledgeElement = require('./build-knowledge-element');
+const databaseBuffer = require('../database-buffer');
+
+function buildSnapshot({
+  id,
+  userId,
+  snappedAt,
+  knowledgeElementsAttributes,
+}) {
+  const knowledgeElements = knowledgeElementsAttributes.map((attributes) => buildKnowledgeElement(attributes));
+
+  const values = {
+    id,
+    userId,
+    snappedAt,
+    snapshot: JSON.stringify(knowledgeElements),
+  };
+
+  return databaseBuffer.pushInsertable({
+    tableName: 'knowledge-element-snapshots',
+    values,
+  });
+}
+
+module.exports = {
+  buildSnapshot,
+};

--- a/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
+++ b/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
@@ -8,8 +8,8 @@ module.exports = {
     const campaignParticipationId = parseInt(request.params.id);
     const userId = request.auth.credentials.userId;
 
-    const report = await usecases.getCampaignParticipationResult({ campaignParticipationId, userId, locale });
+    const participationResult = await usecases.getCampaignParticipationResult({ campaignParticipationId, userId, locale });
 
-    return serializer.serialize(report);
+    return serializer.serialize(participationResult);
   },
 };

--- a/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-result-repository.js
@@ -9,22 +9,19 @@ const campaignParticipationResultRepository = {
   async getByParticipationId(campaignParticipationId, campaignBadges, acquiredBadgeIds, locale) {
     const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
 
-    const [targetProfile, competences, assessment, knowledgeElements] = await Promise.all([
+    const [targetProfile, competences, assessment] = await Promise.all([
       targetProfileRepository.getByCampaignId(campaignParticipation.campaignId),
       competenceRepository.list({ locale }),
       assessmentRepository.get(campaignParticipation.assessmentId),
-      knowledgeElementRepository.findUniqByUserId({
-        userId: campaignParticipation.userId,
-        limitDate: campaignParticipation.sharedAt,
-      }),
     ]);
 
+    const snapshots = await knowledgeElementRepository.findSnapshotForUsers({ [campaignParticipation.userId]: campaignParticipation.sharedAt });
     return CampaignParticipationResult.buildFrom({
       campaignParticipationId,
       assessment,
       competences,
       targetProfile,
-      knowledgeElements,
+      knowledgeElements: snapshots[campaignParticipation.userId],
       campaignBadges,
       acquiredBadgeIds,
     });

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-result-repository_test.js
@@ -1,0 +1,65 @@
+const { expect, databaseBuilder, mockLearningContent } = require('../../../test-helper');
+const campaignParticipationResultRepository = require('../../../../lib/infrastructure/repositories/campaign-participation-result-repository');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+
+describe('Integration | Repository | Campaign Participation Result', () => {
+
+  describe('#getByParticipationId', () => {
+
+    let targetProfileId;
+
+    beforeEach(() => {
+      targetProfileId = databaseBuilder.factory.buildTargetProfile().id;
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill1' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill2' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill3' });
+      databaseBuilder.factory.buildTargetProfileSkill({ targetProfileId, skillId: 'skill4' });
+
+      const learningContent = {
+        areas: [
+          { id: 'recArea1', name: 'area1', competenceIds: ['rec1'], color: 'colorArea1' },
+          { id: 'recArea2', name: 'area2', competenceIds: ['rec2'], color: 'colorArea2' },
+        ],
+        competences: [
+          { id: 'rec1', nameFrFr: 'comp1Fr', nameEnUs: 'comp1En', index: '1.1', areaId: 'recArea1', color: 'rec1Color', skillIds: ['skill1', 'skill2'] },
+          { id: 'rec2', nameFrFr: 'comp2Fr', nameEnUs: 'comp2En', index: '2.1', areaId: 'recArea2', color: 'rec2Color', skillIds: ['skill3', 'skill4', 'skill5'] },
+        ],
+        tubes: [
+          { id: 'recTube1', competenceId: 'rec1' },
+          { id: 'recTube2', competenceId: 'rec2' },
+        ],
+        skills: [
+          { id: 'skill1', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' },
+          { id: 'skill2', status: 'actif', tubeId: 'recTube1', competenceId: 'rec1' },
+          { id: 'skill3', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
+          { id: 'skill4', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
+          { id: 'skill5', status: 'actif', tubeId: 'recTube2', competenceId: 'rec2' },
+        ],
+      };
+
+      mockLearningContent(learningContent);
+      return databaseBuilder.commit();
+    });
+
+    it('use the most recent assessment to define if the participation is completed', async () => {
+      const { id: userId } = databaseBuilder.factory.buildUser();
+      const { id: campaignId } = databaseBuilder.factory.buildCampaign({ targetProfileId });
+      const { id: campaignParticipationId } = databaseBuilder.factory.buildCampaignParticipation({
+        userId,
+        campaignId,
+        sharedAt: new Date('2020-01-02'),
+      });
+
+      databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'started', createdAt: new Date('2021-01-01') });
+      databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId, state: 'completed', createdAt: new Date('2021-01-02') });
+      await databaseBuilder.commit();
+
+      const campaignAssessmentParticipationResult = await campaignParticipationResultRepository.getByParticipationId(campaignParticipationId, [], [], 'FR');
+
+      expect(campaignAssessmentParticipationResult).to.deep.include({
+        isCompleted: true,
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on calcule les résultats d'un participant à une campagne, on doit trier tous les éléments de connaissance obtenus en fonction de la date de partage de la participation. 

## :robot: Solution
Utiliser les snapshots pour obtenir tous les éléments de connaissance obtenus avant la date de partage.

## :rainbow: Remarques
Le `campaign-participation-result-repository` est utilisé pour l'obtention des badges et pour le calcule des résultats donc je l'ai dupliqué pour ne pas casser le code de l'obtention des badges en changeant le design du repository.

Le model CampaignParticipationResult est à re-travailler. On y utilise dans deux cas l'objet `CompetenceResults`:
- 1 fois pour les compétences 
- 1 fois pour les compétences des badges.

Le problème c'est que les compétences de badges et les compétences n'ont pas les mêmes "attributs".
La compétence a un `areaName`, `areaColor`, et un index, mais la compétence de badge n'a ni 'index, ni domaine et donc pas de couleur de domaine ni de nom de domaine.
On se retrouve à stocker la couleur de la compétence de badge dans un attribut areaColor. La factorisation dans ce cas gomme les différences entre ces deux concepts et rend difficile à suivre et comprendre le code.

Une des autres problématique est l'affinité forte entre le back et le front. Par exemple on peut trouver un attribut `starCount` dans les résultats de la campagne pour connaître le palier atteint. Comme la notion d'étoile n'est qu'une représentation graphique du concept de palier on ne devrait pas la trouver dans le back.

Il y a deux autres PR pour faire toutes les modifications nécessaires

## :100: Pour tester
Test de non régressions sur les résultats d'un participant à une campagne d'évaluation (APP).
On doit les résultats par compétences les badges obtenus et le palier atteint.
Il faut tester sur le badge CléaNumérique 
