### PR TITLE
[FEATURE] Demander 2 fois la saisie de l’adresse e-mail pour la modifier dans la page "Mon compte" sur Pix App (PIX-2082).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -48,12 +48,14 @@ module.exports = {
   },
 
   async updateEmail(request, h) {
-    const { email } = request.payload.data.attributes;
     const userId = parseInt(request.params.id);
+    const authenticatedUserId = request.auth.credentials.userId;
+    const { email } = request.payload.data.attributes;
 
     await usecases.updateUserEmail({
       email,
       userId,
+      authenticatedUserId,
     });
 
     return h.response({}).code(204);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -67,7 +67,7 @@ class AssessmentResultNotCreatedError extends DomainError {
 }
 
 class AlreadyRegisteredEmailError extends DomainError {
-  constructor(message = 'Cet email est déjà utilisé.') {
+  constructor(message = 'Cette adresse e-mail est déjà utilisée.') {
     super(message);
   }
 }

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -1,12 +1,10 @@
 const { UserNotAuthorizedToUpdateEmailError } = require('../errors');
-const isEmpty = require('lodash/isEmpty');
 
 module.exports = async function updateUserEmail({
   email,
   userId,
   authenticatedUserId,
   userRepository,
-  schoolingRegistrationRepository,
 }) {
   if (userId !== authenticatedUserId) {
     throw new UserNotAuthorizedToUpdateEmailError();
@@ -14,11 +12,6 @@ module.exports = async function updateUserEmail({
 
   const user = await userRepository.get(userId);
   if (!user.email) {
-    throw new UserNotAuthorizedToUpdateEmailError();
-  }
-
-  const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
-  if (!isEmpty(schoolingRegistrations)) {
     throw new UserNotAuthorizedToUpdateEmailError();
   }
 

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -18,5 +18,5 @@ module.exports = async function updateUserEmail({
   }
 
   await userRepository.isEmailAvailable(email);
-  await userRepository.updateEmail({ id: userId, email });
+  await userRepository.updateEmail({ id: userId, email: email.toLowerCase() });
 };

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -4,9 +4,14 @@ const isEmpty = require('lodash/isEmpty');
 module.exports = async function updateUserEmail({
   email,
   userId,
+  authenticatedUserId,
   userRepository,
   schoolingRegistrationRepository,
 }) {
+  if (userId !== authenticatedUserId) {
+    throw new UserNotAuthorizedToUpdateEmailError();
+  }
+
   const user = await userRepository.get(userId);
   if (!user.email) {
     throw new UserNotAuthorizedToUpdateEmailError();

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -180,7 +180,7 @@ module.exports = {
 
   isEmailAvailable(email) {
     return BookshelfUser
-      .where({ email: email.toLowerCase() })
+      .query((qb) => qb.where('email', 'ILIKE', email))
       .fetch()
       .then((user) => {
         if (user) {

--- a/api/tests/integration/domain/usecases/update-user-details-for-administration_test.js
+++ b/api/tests/integration/domain/usecases/update-user-details-for-administration_test.js
@@ -92,7 +92,7 @@ describe('Integration | UseCases | updateUserDetailsForAdministration', () => {
 
     // then
     expect(error).to.be.instanceOf(AlreadyRegisteredEmailError);
-    expect(error.message).to.equal('Cet email est déjà utilisé.');
+    expect(error.message).to.equal('Cette adresse e-mail est déjà utilisée.');
   });
 
 });

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -739,10 +739,13 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
     it('should reject an AlreadyRegisteredEmailError when email case insensitive already exists', async () => {
       // given
-      const uppercaseEmailAlreadyInDb = userInDb.email.toUpperCase();
+      const upperCaseEmail = 'TEST@example.net';
+      const lowerCaseEmail = 'test@example.net';
+      databaseBuilder.factory.buildUser({ email: upperCaseEmail });
+      await databaseBuilder.commit();
 
       // when
-      const result = await catchErr(userRepository.isEmailAvailable)(uppercaseEmailAlreadyInDb);
+      const result = await catchErr(userRepository.isEmailAvailable)(lowerCaseEmail);
 
       // then
       expect(result).to.be.instanceOf(AlreadyRegisteredEmailError);

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -1,7 +1,7 @@
 const updateUserEmail = require('../../../../lib/domain/usecases/update-user-email');
 const { AlreadyRegisteredEmailError, UserNotAuthorizedToUpdateEmailError } = require('../../../../lib/domain/errors');
 
-const { sinon, expect, catchErr, domainBuilder } = require('../../../test-helper');
+const { sinon, expect, catchErr } = require('../../../test-helper');
 
 describe('Unit | UseCase | update-user-email', () => {
 
@@ -110,26 +110,6 @@ describe('Unit | UseCase | update-user-email', () => {
     const userId = 1;
     const authenticatedUserId = 1;
     const newEmail = 'new_email@example.net';
-
-    // when
-    const error = await catchErr(updateUserEmail)({
-      userId,
-      authenticatedUserId,
-      email: newEmail,
-      userRepository,
-      schoolingRegistrationRepository,
-    });
-
-    // then
-    expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
-  });
-
-  it('throw UserNotAuthorizedToUpdateEmailError if user is reconciled', async () => {
-    // given
-    const userId = 1;
-    const authenticatedUserId = 1;
-    const newEmail = 'new_email@example.net';
-    schoolingRegistrationRepository.findByUserId.resolves([domainBuilder.buildSchoolingRegistration()]);
 
     // when
     const error = await catchErr(updateUserEmail)({

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -23,11 +23,13 @@ describe('Unit | UseCase | update-user-email', () => {
   it('should call updateEmail', async () => {
     // given
     const userId = 1;
+    const authenticatedUserId = 1;
     const newEmail = 'new_email@example.net';
 
     // when
     await updateUserEmail({
       userId,
+      authenticatedUserId,
       email: newEmail,
       userRepository,
       schoolingRegistrationRepository,
@@ -43,12 +45,14 @@ describe('Unit | UseCase | update-user-email', () => {
   it('should save email in lower case', async () => {
     // given
     const userId = 1;
+    const authenticatedUserId = 1;
     const newEmail = 'EMAIl_IN_UPPER_CASE@example.net';
     const newEmailInLowerCase = newEmail.toLowerCase();
 
     // when
     await updateUserEmail({
       userId,
+      authenticatedUserId,
       email: newEmail,
       userRepository,
       schoolingRegistrationRepository,
@@ -65,11 +69,13 @@ describe('Unit | UseCase | update-user-email', () => {
     // given
     userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
     const userId = 1;
+    const authenticatedUserId = 1;
     const newEmail = 'new_email@example.net';
 
     // when
     const error = await catchErr(updateUserEmail)({
       userId,
+      authenticatedUserId,
       email: newEmail,
       userRepository,
       schoolingRegistrationRepository,
@@ -79,15 +85,36 @@ describe('Unit | UseCase | update-user-email', () => {
     expect(error).to.be.an.instanceOf(AlreadyRegisteredEmailError);
   });
 
-  it('throw UserNotAuthorizedToUpdateEmailError if user has not email', async () => {
+  it('throw UserNotAuthorizedToUpdateEmailError if the authenticated user try to change the email of an other user', async () => {
     // given
-    userRepository.get.resolves({});
     const userId = 1;
+    const authenticatedUserId = 2;
     const newEmail = 'new_email@example.net';
 
     // when
     const error = await catchErr(updateUserEmail)({
       userId,
+      authenticatedUserId,
+      email: newEmail,
+      userRepository,
+      schoolingRegistrationRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
+  });
+
+  it('throw UserNotAuthorizedToUpdateEmailError if user has not email', async () => {
+    // given
+    userRepository.get.resolves({});
+    const userId = 1;
+    const authenticatedUserId = 1;
+    const newEmail = 'new_email@example.net';
+
+    // when
+    const error = await catchErr(updateUserEmail)({
+      userId,
+      authenticatedUserId,
       email: newEmail,
       userRepository,
       schoolingRegistrationRepository,
@@ -100,12 +127,14 @@ describe('Unit | UseCase | update-user-email', () => {
   it('throw UserNotAuthorizedToUpdateEmailError if user is reconciled', async () => {
     // given
     const userId = 1;
+    const authenticatedUserId = 1;
     const newEmail = 'new_email@example.net';
     schoolingRegistrationRepository.findByUserId.resolves([domainBuilder.buildSchoolingRegistration()]);
 
     // when
     const error = await catchErr(updateUserEmail)({
       userId,
+      authenticatedUserId,
       email: newEmail,
       userRepository,
       schoolingRegistrationRepository,

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -40,6 +40,27 @@ describe('Unit | UseCase | update-user-email', () => {
     });
   });
 
+  it('should save email in lower case', async () => {
+    // given
+    const userId = 1;
+    const newEmail = 'EMAIl_IN_UPPER_CASE@example.net';
+    const newEmailInLowerCase = newEmail.toLowerCase();
+
+    // when
+    await updateUserEmail({
+      userId,
+      email: newEmail,
+      userRepository,
+      schoolingRegistrationRepository,
+    });
+
+    // then
+    expect(userRepository.updateEmail).to.have.been.calledWith({
+      id: userId,
+      email: newEmailInLowerCase,
+    });
+  });
+
   it('throw AlreadyRegisteredEmailError if email already exists', async () => {
     // given
     userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());

--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -1,33 +1,8 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import isEmailValid from '../utils/email-validator';
 
 export default class UserAccountPanel extends Component {
 
-  @tracked isEmailEditionMode = false;
-  @tracked newEmail = '';
-
   get displayUsername() {
     return !!this.args.user.username;
-  }
-
-  @action
-  enableEmailEditionMode() {
-    this.isEmailEditionMode = true;
-  }
-
-  @action
-  disableEmailEditionMode() {
-    this.isEmailEditionMode = false;
-  }
-
-  @action
-  saveNewEmail() {
-    if (isEmailValid(this.newEmail)) {
-      this.args.user.email = this.newEmail;
-      this.args.user.save({ adapterOptions: { updateEmail: true } });
-      this.isEmailEditionMode = false;
-    }
   }
 }

--- a/mon-pix/app/components/user-account-update-email.js
+++ b/mon-pix/app/components/user-account-update-email.js
@@ -1,0 +1,89 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import isEmailValid from '../utils/email-validator';
+import get from 'lodash/get';
+
+const STATUS_MAP = {
+  defaultStatus: 'default',
+  errorStatus: 'error',
+  successStatus: 'success',
+};
+
+const ERROR_INPUT_MESSAGE_MAP = {
+  wrongFormat: 'pages.user-account.account-update-email.fields.errors.wrong-format',
+  mismatching: 'pages.user-account.account-update-email.fields.errors.mismatching',
+  unknown: 'pages.user-account.account-update-email.fields.errors.unknown',
+};
+
+class NewEmailValidation {
+  @tracked status = STATUS_MAP['defaultStatus'];
+  @tracked message = null;
+}
+
+class NewEmailConfirmationValidation {
+  @tracked status = STATUS_MAP['defaultStatus'];
+  @tracked message = null;
+}
+
+export default class UserAccountUpdateEmail extends Component {
+
+  @service intl;
+  @tracked newEmail = '';
+  @tracked newEmailConfirmation = '';
+  @tracked errorMessage = null;
+
+  @tracked newEmailValidation = new NewEmailValidation();
+  @tracked newEmailConfirmationValidation = new NewEmailConfirmationValidation();
+
+  @action
+  validateNewEmail() {
+    const isInvalidInput = !isEmailValid(this.newEmail);
+
+    this.newEmailValidation.status = STATUS_MAP['successStatus'];
+    this.newEmailValidation.message = null;
+
+    if (isInvalidInput) {
+      this.newEmailValidation.status = STATUS_MAP['errorStatus'];
+      this.newEmailValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+    }
+  }
+
+  @action
+  validateNewEmailConfirmation() {
+    const isInvalidInput = !isEmailValid(this.newEmailConfirmation);
+
+    this.newEmailConfirmationValidation.status = STATUS_MAP['successStatus'];
+    this.newEmailConfirmationValidation.message = null;
+
+    if (isInvalidInput) {
+      this.newEmailConfirmationValidation.status = STATUS_MAP['errorStatus'];
+      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+    } else if (this.newEmail !== this.newEmailConfirmation) {
+      this.newEmailConfirmationValidation.status = STATUS_MAP['errorStatus'];
+      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['mismatching']);
+    }
+  }
+
+  @action
+  async onSubmit(event) {
+    event && event.preventDefault();
+    this.errorMessage = null;
+
+    if (this.newEmail === this.newEmailConfirmation && isEmailValid(this.newEmail)) {
+      try {
+        await this.args.saveNewEmail(this.newEmail);
+      } catch (response) {
+        const status = get(response, 'errors[0].status');
+        if (status === '422') {
+          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+        } else if (status === '400' || status === '403') {
+          this.errorMessage = get(response, 'errors[0].detail');
+        } else {
+          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknown']);
+        }
+      }
+    }
+  }
+}

--- a/mon-pix/app/controllers/user-account.js
+++ b/mon-pix/app/controllers/user-account.js
@@ -1,0 +1,25 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class UserAccountController extends Controller {
+
+  @tracked isEmailEditionMode = false;
+
+  @action
+  enableEmailEditionMode() {
+    this.isEmailEditionMode = true;
+  }
+
+  @action
+  disableEmailEditionMode() {
+    this.isEmailEditionMode = false;
+  }
+
+  @action
+  async saveNewEmail(newEmail) {
+    this.model.email = newEmail.trim().toLowerCase();
+    await this.model.save({ adapterOptions: { updateEmail: true } });
+    this.disableEmailEditionMode();
+  }
+}

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -91,6 +91,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/tutorial-panel';
 @import 'components/user-account';
 @import 'components/user-account-panel';
+@import 'components/user-account-update-email';
 @import 'components/user-certifications-detail-competences-list';
 @import 'components/user-certifications-detail-competence';
 @import 'components/user-certifications-detail-header';

--- a/mon-pix/app/styles/components/_user-account-panel.scss
+++ b/mon-pix/app/styles/components/_user-account-panel.scss
@@ -3,13 +3,13 @@
   &__item {
     margin: 20px 0;
     display: flex;
-    align-items: center;
     align-content: flex-start;
     border-bottom: $grey-15 1px solid;
     padding-bottom: 1rem;
 
     &:last-child {
       border-bottom: none;
+      padding-bottom: 0;
     }
   }
 }
@@ -26,9 +26,12 @@
 
   &__button {
     margin-left: auto;
-  }
+    background-color: transparent;
+    color: $blue;
+    padding: 0 20px;
 
-  &__actions {
-    margin-left: auto;
+    &:hover {
+      background-color: transparent;
+    }
   }
 }

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -1,0 +1,42 @@
+.user-account-update-email {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 50px 0 60px 0;
+
+  &__informations {
+    padding-top: 12px;
+    text-align: center;
+    color: $grey-90;
+    font-family: $font-open-sans;
+    line-height: 1.75rem;
+  }
+
+  &__form {
+    padding-top: 30px;
+  }
+
+  &__actions {
+    padding-top: 30px;
+    width: 100%;
+    max-width: 449px;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__error {
+    padding-top: 30px;
+    color: $red;
+  }
+}
+
+.user-account-update-email-actions {
+
+  &__button {
+    min-width: 120px;
+  }
+}
+
+abbr.mandatory-mark {
+  text-decoration: none;
+}

--- a/mon-pix/app/styles/components/_user-account.scss
+++ b/mon-pix/app/styles/components/_user-account.scss
@@ -30,7 +30,8 @@
     }
   }
 
-  &__panel {
+  &__panel,
+  &__update-email {
     margin: 0 auto;
     max-width: 980px;
     position: relative;

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -10,28 +10,13 @@
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</span>
     <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
-    {{#unless this.isEmailEditionMode}}
-      <PixButton class="user-account-panel-item__button button" @triggerAction={{this.enableEmailEditionMode}} data-test-edit-email>
+      <PixButton
+              class="user-account-panel-item__button"
+              @triggerAction={{@enableEmailEditionMode}}
+              data-test-edit-email>
         {{t 'pages.user-account.account-panel.edit-button'}}
       </PixButton>
-    {{/unless}}
   </div>
-  {{#if this.isEmailEditionMode}}
-    <div class="user-account-panel__item">
-      <label class="form-textfield__label user-account-panel-item__label" for="new-email">
-        {{t 'pages.user-account.account-panel.new-email'}}
-      </label>
-      <Input id="new-email" @type="email" @value={{this.newEmail}} data-test-new-email />
-      <div class="user-account-panel-item__actions">
-        <PixButton class="user-account-panel-item__button button" type="button" @triggerAction={{this.disableEmailEditionMode}} data-test-cancel-email>
-          {{t 'common.actions.cancel'}}
-        </PixButton>
-        <PixButton class="user-account-panel-item__button button" type="submit" @triggerAction={{this.saveNewEmail}} data-test-submit-email>
-          {{t 'pages.user-account.account-panel.save-button'}}
-        </PixButton>
-      </div>
-    </div>
-  {{/if}}
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</span>

--- a/mon-pix/app/templates/components/user-account-update-email.hbs
+++ b/mon-pix/app/templates/components/user-account-update-email.hbs
@@ -1,0 +1,53 @@
+<PixBlock>
+    <div class="user-account-update-email">
+      <h3>{{t 'pages.user-account.account-update-email.title'}}</h3>
+      <div class="user-account-update-email__informations">
+        <span>{{t 'pages.user-account.account-update-email.informations' htmlSafe=true}}</span>
+      </div>
+      <form class="sign-form__body user-account-update-email__form">
+        <div class="sign-form-body__input" data-test-new-email>
+          <FormTextfield @label="{{t 'pages.user-account.account-update-email.fields.new-email.label'}}"
+                       @textfieldName="newEmail"
+                       @inputBindingValue={{this.newEmail}}
+                       @onValidate={{this.validateNewEmail}}
+                       @validationMessage={{this.newEmailValidation.message}}
+                       @validationStatus={{this.newEmailValidation.status}}
+                       @autocomplete="off"
+                       @require={{true}}/>
+        </div>
+
+        <div class="sign-form-body__input" data-test-new-email-confirmation>
+          <FormTextfield @label="{{t 'pages.user-account.account-update-email.fields.new-email-confirmation.label'}}"
+                       @textfieldName="newEmailConfirmation"
+                       @inputBindingValue={{this.newEmailConfirmation}}
+                       @onValidate={{this.validateNewEmailConfirmation}}
+                       @validationMessage={{this.newEmailConfirmationValidation.message}}
+                       @validationStatus={{this.newEmailConfirmationValidation.status}}
+                       @autocomplete="off"
+                       @require={{true}}/>
+        </div>
+        {{#if this.errorMessage}}
+        <div class="user-account-update-email__error">
+          <span data-test-error-message>{{this.errorMessage}}</span>
+        </div>
+        {{/if}}
+        <div class="user-account-update-email__actions">
+          <PixButton
+                  class="user-account-update-email-actions__button"
+                  @type="button"
+                  @triggerAction={{@disableEmailEditionMode}}
+                  @backgroundColor="transparent"
+                  data-test-cancel-email>
+          {{t 'common.actions.cancel'}}
+          </PixButton>
+          <PixButton
+                  class="user-account-update-email-actions__button"
+                  @type="submit"
+                  @triggerAction={{this.onSubmit}}
+                  data-test-submit-email>
+          {{t 'pages.user-account.account-update-email.save-button'}}
+          </PixButton>
+        </div>
+      </form>
+    </div>
+</PixBlock>

--- a/mon-pix/app/templates/user-account.hbs
+++ b/mon-pix/app/templates/user-account.hbs
@@ -8,14 +8,23 @@
     <main>
       <div class="background-banner">
         <div class="user-account__banner">
-          <img src="{{rootURL}}/images/user-account/banner-icon.svg" class="user-tutorials-banner__icon" role="none" alt=""/>
           <h1 class="user-account-banner__title">{{t 'pages.user-account.title'}}</h1>
         </div>
       </div>
-
-      <div class="user-account__panel">
-        <UserAccountPanel @user={{@model}} />
+      {{#if this.isEmailEditionMode}}
+      <div class="user-account__update-email">
+        <UserAccountUpdateEmail
+                @user={{@model}}
+                @disableEmailEditionMode={{this.disableEmailEditionMode}}
+                @saveNewEmail={{this.saveNewEmail}}/>
       </div>
+      {{else}}
+      <div class="user-account__panel">
+        <UserAccountPanel
+                @user={{@model}}
+                @enableEmailEditionMode={{this.enableEmailEditionMode}}/>
+      </div>
+      {{/if}}
     </main>
 
     <Footer />

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -39565,8 +39565,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#70c0c562d0f56cd8ecc678dbc63724c361f986cf",
-      "from": "git://github.com/1024pix/pix-ui.git#semver:^v1.3.0",
+      "version": "git://github.com/1024pix/pix-ui.git#0c2ba5ff4322455790cb14877fc883123e3735f0",
+      "from": "git://github.com/1024pix/pix-ui.git#v2.0.3",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -110,7 +110,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.20",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#semver:^v1.3.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.0.3",
     "sass": "^1.30.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.8.0",

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -44,7 +44,8 @@ describe('Acceptance | User account page', function() {
 
       // when
       await click('button[data-test-edit-email]');
-      await fillIn('input[data-test-new-email]', newEmail);
+      await fillIn('#newEmail', newEmail);
+      await fillIn('#newEmailConfirmation', newEmail);
       await click('button[data-test-submit-email]');
 
       // then

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
-import { click, fillIn, find, render } from '@ember/test-helpers';
+import { find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
@@ -10,7 +10,6 @@ describe('Integration | Component | User account panel', () => {
   setupIntlRenderingTest();
 
   it('should display values', async function() {
-
     // given
     const user = {
       firstName: 'John',
@@ -30,10 +29,22 @@ describe('Integration | Component | User account panel', () => {
     expect(find('span[data-test-username]').textContent).to.include(user.username);
   });
 
+  it('should call Enable Email Edition method', async function() {
+    // given
+    const enableEmailEditionMode = sinon.stub();
+    this.set('enableEmailEditionMode', enableEmailEditionMode);
+    await render(hbs`<UserAccountPanel @enableEmailEditionMode={{this.enableEmailEditionMode}} />`);
+
+    // when
+    await click('button[data-test-edit-email]');
+
+    // then
+    sinon.assert.called(enableEmailEditionMode);
+  });
+
   context('when user does not have a username', function() {
 
     it('should not display username', async function() {
-
       // given
       const user = {};
       this.set('user', user);
@@ -43,74 +54,6 @@ describe('Integration | Component | User account panel', () => {
 
       // then
       expect(find('span[data-test-username]')).to.not.exist;
-    });
-  });
-
-  context('when editing e-mail', function() {
-    let user;
-    beforeEach(function() {
-      // given
-      user = {
-        firstName: 'John',
-        lastName: 'DOE',
-        email: 'john.doe@example.net',
-        username: 'john.doe0101',
-      };
-      this.set('user', user);
-    });
-
-    it('should display save and cancel button', async function() {
-      // when
-      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
-      await click('button[data-test-edit-email]');
-
-      // then
-      expect(find('label[for=new-email]')).to.exist;
-      expect(find('input[data-test-new-email]')).to.exist;
-      expect(find('button[data-test-cancel-email]')).to.exist;
-      expect(find('button[data-test-submit-email]')).to.exist;
-    });
-
-    context('when the user cancel edition', function() {
-      it('should not display save and cancel button and display edit button', async function() {
-        // given
-        await render(hbs`<UserAccountPanel @user={{this.user}} />`);
-        await click('button[data-test-edit-email]');
-
-        // when
-        await click('button[data-test-cancel-email]');
-
-        // then
-        expect(find('label[for=new-email]')).to.not.exist;
-        expect(find('input[data-test-new-email]')).to.not.exist;
-        expect(find('button[data-test-cancel-email]')).to.not.exist;
-        expect(find('button[data-test-submit-email]')).to.not.exist;
-        expect(find('button[data-test-edit-email]')).to.exist;
-      });
-    });
-
-    context('when the user save', function() {
-      it('should call update user method and disable editing mode', async function() {
-        // given
-        const newEmail = 'newEmail@example.net';
-        const saveStub = sinon.stub();
-        saveStub.resolves();
-        this.user.save = saveStub;
-        await render(hbs`<UserAccountPanel @user={{this.user}} />`);
-
-        // when
-        await click('button[data-test-edit-email]');
-        await fillIn('input[data-test-new-email]', newEmail);
-        await click('button[data-test-submit-email]');
-
-        // then
-        sinon.assert.calledWith(saveStub, { adapterOptions: { updateEmail: true } });
-        expect(find('button[data-test-edit-email]')).to.exist;
-        expect(find('input[data-test-new-email]')).to.not.exist;
-        expect(find('button[data-test-cancel-email]')).to.not.exist;
-        expect(find('button[data-test-submit-email]')).to.not.exist;
-        expect(this.user.email).to.equal(newEmail);
-      });
     });
   });
 });

--- a/mon-pix/tests/integration/components/user-account-update-email-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-test.js
@@ -1,0 +1,181 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+import { click, fillIn, find, render, triggerEvent } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+
+describe('Integration | Component | User account update email', () => {
+
+  setupIntlRenderingTest();
+
+  context('when editing e-mail', function() {
+    let user;
+    beforeEach(function() {
+      // given
+      user = {
+        firstName: 'John',
+        lastName: 'DOE',
+        email: 'john.doe@example.net',
+        username: 'john.doe0101',
+      };
+      this.set('user', user);
+    });
+
+    it('should display save and cancel button', async function() {
+      // when
+      await render(hbs`<UserAccountUpdateEmail/>`);
+
+      // then
+      expect(find('div[data-test-new-email]')).to.exist;
+      expect(find('button[data-test-cancel-email]')).to.exist;
+      expect(find('button[data-test-submit-email]')).to.exist;
+    });
+
+    context('when the user cancel edition', function() {
+      it('should call disable Email Edition method', async function() {
+        // given
+        const disableEmailEditionMode = sinon.stub();
+        this.set('disableEmailEditionMode', disableEmailEditionMode);
+        await render(hbs`<UserAccountUpdateEmail @disableEmailEditionMode={{this.disableEmailEditionMode}} />`);
+
+        // when
+        await click('button[data-test-cancel-email]');
+
+        // then
+        sinon.assert.called(disableEmailEditionMode);
+      });
+    });
+
+    context('when the user fills inputs with errors', function() {
+
+      context('in new email input', function() {
+
+        it('should display a wrong format error message when focus-out', async function() {
+          // given
+          const wrongEmail = 'wrongEmail';
+
+          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+
+          // when
+          await fillIn('#newEmail', wrongEmail);
+          await triggerEvent('#newEmail', 'blur');
+
+          // then
+          expect(find('#validationMessage-newEmail').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
+        });
+      });
+
+      context('in new email confirmation input', function() {
+
+        it('should display a wrong format error message when focus-out', async function() {
+          // given
+          const wrongEmail = 'wrongEmail';
+
+          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+
+          // when
+          await fillIn('#newEmailConfirmation', wrongEmail);
+          await triggerEvent('#newEmailConfirmation', 'blur');
+
+          // then
+          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
+        });
+      });
+
+      context('when newEmail and newEmailConfirmation are different', function() {
+
+        it('should display a mismatching error message when focus-out', async function() {
+          // given
+          const newEmail = 'new-email@example.net';
+          const newEmailConfirmation = 'new-email-confirmation@example.net';
+
+          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+
+          // when
+          await fillIn('#newEmail', newEmail);
+          await fillIn('#newEmailConfirmation', newEmailConfirmation);
+          await triggerEvent('#newEmailConfirmation', 'blur');
+
+          // then
+          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.mismatching'));
+        });
+      });
+    });
+
+    context('when the user save', function() {
+
+      it('should call save new email method', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+
+        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await click('button[data-test-submit-email]');
+
+        // then
+        sinon.assert.calledWith(saveNewEmail, newEmail);
+      });
+
+      it('should display wrong format error if response status is 422', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({ errors: [{ status: '422' }] });
+
+        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
+      });
+
+      it('should display error message from server if response status is 400 or 403', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const expectedErrorMessage = 'An error message';
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({ errors: [{ status: '400', detail: expectedErrorMessage }] });
+
+        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(expectedErrorMessage);
+      });
+
+      it('should display default error message if response status is unknown', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({});
+
+        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.unknown'));
+      });
+    });
+  });
+});

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -946,10 +946,26 @@
                 "first-name": "First name",
                 "last-name": "Last name",
                 "email": "Email address",
-                "new-email": "New email address",
                 "username": "Username",
-                "edit-button": "Edit",
-                "save-button": "Save"
+                "edit-button": "Edit"
+            },
+            "account-update-email": {
+                "title": "",
+                "informations": "",
+                "save-button": "",
+                "fields": {
+                    "new-email": {
+                        "label": "Email address"
+                    },
+                    "new-email-confirmation": {
+                        "label": ""
+                    },
+                    "errors": {
+                        "wrong-format": "Your email address is invalid.",
+                        "mismatching": "",
+                        "unknown": ""
+                    }
+                }
             }
         },
         "user-tutorials": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -946,10 +946,26 @@
                 "first-name": "Prénom",
                 "last-name": "Nom",
                 "email": "Adresse e-mail",
-                "new-email": "Nouvelle adresse e-mail",
                 "username": "Identifiant",
-                "edit-button": "Modifier",
-                "save-button": "Enregistrer"
+                "edit-button": "Modifier"
+            },
+            "account-update-email": {
+                "title": "Modification de votre adresse e-mail",
+                "informations": "Cette adresse e-mail doit être valide en cas de mot de passe oublié. '<br>' Elle sera votre nouvelle adresse de connexion.",
+                "save-button": "Confirmer",
+                "fields": {
+                    "new-email": {
+                        "label": "Adresse e-mail"
+                    },
+                    "new-email-confirmation": {
+                        "label": "Confirmation de l'adresse e-mail"
+                    },
+                    "errors": {
+                        "wrong-format": "Votre adresse e-mail n’est pas valide.",
+                        "mismatching": "Les deux adresses e-mail ne sont pas identiques. Veuillez vérifier votre saisie.",
+                        "unknown": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
+                    }
+                }
             }
         },
         "user-tutorials": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement l'utilisateur peut modifier l'adresse e-mail via un seul champ.
Nous souhaitons que l’utilisateur entre la nouvelle adresse e-mail deux fois afin d'être sûr qu’il n’y ait pas de fautes.
## :robot: Solution

Ajout d'un deuxième champ avec une gestion des erreurs suivantes: 

- Affichage d'un message d'erreur si l'adresse e-mail n'est pas valide/ si l'adresse e-mail est vide.

- Affichage d'un message d'erreur si l'adresse e-mail de confirmation n'est pas identique à la première.

Toujours étant couvert par un feature toggle, nous proposons simplement de modifier l'adresse e-mail et d'enregistrer la modification, sans demander le mot de passe.

## :rainbow: Remarques

- Ajout d'un nouveau component, `UserAccountUpdateEmail`, pour afficher la modification de l'email séparement des infos de l'utilisateur.

- Mise à jour de la version de Pix Ui pour pouvoir appliquer l'attribut @backgroundColor dans le PixButton

- Suppression de la balise `<img>` présente dans la page mon-compte: choix de ne plus afficher l'illustration présente dans le mockup `<img src="{{rootURL}}/images/user-account/banner-icon.svg" />`

Coté API :

- Ajout d'une erreur 403 si l'id du user présent dans le token est différent de celui présent dans l'url.
- Suppression de l'erreur renvoyé dans le cas ou un utilisateur SCO souhaite modifier son adresse e-mail :
```
const schoolingRegistrations = await schoolingRegistrationRepository.findByUserId({ userId });
  if (!isEmpty(schoolingRegistrations)) {
    throw new UserNotAuthorizedToUpdateEmailError();
  }
```

## :100: Pour tester
Aller sur la page : `/mon-compte` et modifier l'adresse e-mail de l'utilisateur.
(Ajout `FT_MY_ACCOUNT= true` en RA, à ajouter en local si test local)