### PR TITLE
[FEATURE] Ne plus afficher l'état d'avancement lorsque le participant a partagé ses résultats (PIX-2127).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -28,12 +28,14 @@
             {{moment-format @campaignAssessmentParticipation.createdAt 'DD MMM YYYY'}}
           </div>
         </li>
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">Avancement</div>
-          <div class="value-text panel-header-data-content__value">
-            {{@campaignAssessmentParticipation.progression}}%
-          </div>
-        </li>
+        {{#unless @campaignAssessmentParticipation.isShared }}
+          <li class="panel-header-data__content">
+            <div class="label-text panel-header-data-content__label">Avancement</div>
+            <div class="value-text panel-header-data-content__value">
+              {{@campaignAssessmentParticipation.progression}}%
+            </div>
+          </li>
+        {{/unless}}
         <li class="panel-header-data__content">
           <div class="label-text panel-header-data-content__label">Envoyé le</div>
           {{#if @campaignAssessmentParticipation.sharedAt}}

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
@@ -56,6 +56,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
     await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
 
+    assert.contains('Avancement');
     assert.contains('75%');
   });
 
@@ -152,6 +153,23 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
   module('results information', function() {
     module('when the participation is shared', function() {
+      test('it should not display campaign progression', async function(assert) {
+        const campaignAssessmentParticipation = {
+          progression: 100,
+          isShared: true,
+        };
+
+        const campaign = {};
+
+        this.campaignAssessmentParticipation = campaignAssessmentParticipation;
+        this.campaign = campaign;
+
+        await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
+
+        assert.notContains('Avancement');
+        assert.notContains('100%');
+      });
+
       test('it displays campaign participation details of mastery percentage (validated skills over total skills)', async function(assert) {
         const campaignAssessmentParticipation = {
           validatedSkillsCount: 45,


### PR DESCRIPTION
## :unicorn: Problème
Un manque de place se fait ressentir lorsque nous avons des badges / paliers dans la page détail utilisateur

## :robot: Solution
Une fois la campagne partagé la progression n'est plus intéressante (forcément à 100%). Nous la cachons afin d'avoir plus de place pour afficher les badges/paliers

## :100: Pour tester
Se connecter avec `pro.admin@example.net` . Vérifiez que sur une campagne en cours la progression apparaît. Et que sur une campagne partagé, elle n'apparait plus.