### PR TITLE
[FEATURE]Affichage des compétences en anglais lorsque la langue saisie est "en" dans les résultats individuels d'une campagne d'évaluation (PIX-2099).

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -8,6 +8,7 @@ const campaignAssessmentParticipationSerializer = require('../../infrastructure/
 const campaignAssessmentParticipationResultSerializer = require('../../infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer');
 const campaignProfileSerializer = require('../../infrastructure/serializers/jsonapi/campaign-profile-serializer');
 const DomainTransaction = require('../../infrastructure/DomainTransaction');
+const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
 
@@ -95,8 +96,9 @@ module.exports = {
   async getCampaignAssessmentParticipationResult(request) {
     const { userId } = request.auth.credentials;
     const { campaignId, campaignParticipationId } = request.params;
+    const locale = extractLocaleFromRequest(request);
 
-    const campaignAssessmentParticipationResult = await usecases.getCampaignAssessmentParticipationResult({ userId, campaignId, campaignParticipationId });
+    const campaignAssessmentParticipationResult = await usecases.getCampaignAssessmentParticipationResult({ userId, campaignId, campaignParticipationId, locale });
     return campaignAssessmentParticipationResultSerializer.serialize(campaignAssessmentParticipationResult);
   },
 };

--- a/api/lib/domain/usecases/get-campaign-assessment-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-assessment-participation-result.js
@@ -1,9 +1,17 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
-module.exports = async function getCampaignAssessmentParticipationResult({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository }) {
+module.exports = async function getCampaignAssessmentParticipationResult(
+  {
+    userId,
+    campaignId,
+    campaignParticipationId,
+    campaignRepository,
+    campaignAssessmentParticipationResultRepository,
+    locale,
+  } = {}) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntity('User does not belong to the organization that owns the campaign');
   }
 
-  return campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId });
+  return campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId, locale });
 };

--- a/api/lib/infrastructure/repositories/campaign-assessment-participation-result-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-assessment-participation-result-repository.js
@@ -5,8 +5,8 @@ const knowledgeElementRepository = require('./knowledge-element-repository');
 const targetProfileWithLearningContentRepository = require('./target-profile-with-learning-content-repository');
 
 module.exports = {
-  async getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId }) {
-    const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
+  async getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId, locale }) {
+    const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale });
 
     const result = await _fetchCampaignAssessmentParticipationResultAttributesFromCampaignParticipation(campaignId, campaignParticipationId);
 

--- a/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-assessment-participation-result-repository_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, mockLearningContent, knex } = require('../../../test-helper');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const campaignAssessmentParticipationResultRepository = require('../../../../lib/infrastructure/repositories/campaign-assessment-participation-result-repository');
+const { ENGLISH_SPOKEN, FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Integration | Repository | Campaign Assessment Participation Result', () => {
 
@@ -26,6 +27,7 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
           skillIds: ['skill1'],
           origin: 'Pix',
           nameFrFr: 'Compétence 1',
+          nameEnUs: 'English competence 1',
         }, {
           id: 'rec2',
           index: '1.2',
@@ -33,6 +35,8 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
           skillIds: ['skill2'],
           origin: 'Pix',
           nameFrFr: 'Compétence 2',
+          nameEnUs: 'English competence 2',
+
         }],
         tubes: [{
           id: 'recTube1',
@@ -123,6 +127,71 @@ describe('Integration | Repository | Campaign Assessment Participation Result', 
         expect(campaignAssessmentParticipationResult.isShared).to.equal(true);
         expect(campaignAssessmentParticipationResult.competenceResults.length).to.equal(2);
         expect(campaignAssessmentParticipationResult.competenceResults).to.deep.equal(expectedResult);
+      });
+    });
+
+    context('When given locale is fr', () => {
+      const locale = FRENCH_SPOKEN;
+      beforeEach(() => {
+        campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          isShared: true,
+          sharedAt: new Date('2020-01-02'),
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
+        return databaseBuilder.commit();
+      });
+
+      it('returns french', async () => {
+        const campaignAssessmentParticipationResult = await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId, locale });
+
+        expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('Compétence 1');
+      });
+    });
+
+    context('When given locale is en', () => {
+      const locale = ENGLISH_SPOKEN;
+      beforeEach(() => {
+        campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          isShared: true,
+          sharedAt: new Date('2020-01-02'),
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
+        return databaseBuilder.commit();
+      });
+
+      it('returns english', async () => {
+        const campaignAssessmentParticipationResult = await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId, locale });
+
+        expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('English competence 1');
+      });
+    });
+
+    context('When no given locale', () => {
+      beforeEach(() => {
+        campaignId = databaseBuilder.factory.buildCampaign({ type: 'ASSESSMENT', targetProfileId }).id;
+        const userId = databaseBuilder.factory.buildUser().id;
+        campaignParticipationId = databaseBuilder.factory.buildCampaignParticipation({
+          campaignId,
+          userId,
+          isShared: true,
+          sharedAt: new Date('2020-01-02'),
+        }).id;
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId, userId });
+        return databaseBuilder.commit();
+      });
+
+      it('returns french', async () => {
+        const campaignAssessmentParticipationResult = await campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId });
+
+        expect(campaignAssessmentParticipationResult.competenceResults[0].name).to.equal('Compétence 1');
       });
     });
   });

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -1,7 +1,7 @@
 const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
-const serializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
+const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 const events = require('../../../../lib/domain/events');
 const usecases = require('../../../../lib/domain/usecases');
@@ -37,7 +37,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     beforeEach(() => {
       sinon.stub(usecases, 'findCampaignParticipationsRelatedToAssessment');
       sinon.stub(queryParamsUtils, 'extractParameters');
-      sinon.stub(serializer, 'serialize')
+      sinon.stub(campaignParticipationSerializer, 'serialize')
         .withArgs(resultWithPagination.models, resultWithPagination.pagination).returns(serialized)
         .withArgs(result).returns(serialized);
     });
@@ -131,7 +131,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'startCampaignParticipation');
-      sinon.stub(serializer, 'serialize');
+      sinon.stub(campaignParticipationSerializer, 'serialize');
       sinon.stub(events.eventDispatcher, 'dispatch');
       request = {
         headers: { authorization: 'token' },
@@ -204,13 +204,13 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
       });
 
       const serializedCampaignParticipation = { id: 88, assessmentId: 12 };
-      serializer.serialize.returns(serializedCampaignParticipation);
+      campaignParticipationSerializer.serialize.returns(serializedCampaignParticipation);
 
       // when
       const response = await campaignParticipationController.save(request, hFake);
 
       // then
-      expect(serializer.serialize).to.have.been.calledWith(campaignParticipation);
+      expect(campaignParticipationSerializer.serialize).to.have.been.calledWith(campaignParticipation);
       expect(response.statusCode).to.equal(201);
       expect(response.source).to.deep.equal(serializedCampaignParticipation);
     });
@@ -237,14 +237,14 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
 
       sinon.stub(queryParamsUtils, 'extractParameters');
       sinon.stub(usecases, 'getCampaignParticipation');
-      sinon.stub(serializer, 'serialize');
+      sinon.stub(campaignParticipationSerializer, 'serialize');
     });
 
     it('should return the campaignParticipation', async () => {
       // given
       queryParamsUtils.extractParameters.withArgs(query).returns(options);
       usecases.getCampaignParticipation.withArgs({ campaignParticipationId, options, userId }).resolves({});
-      serializer.serialize.withArgs({}).returns('ok');
+      campaignParticipationSerializer.serialize.withArgs({}).returns('ok');
 
       // when
       const response = await campaignParticipationController.getById(request);

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -2,6 +2,7 @@ const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
 const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
+const campaignAssessmentParticipationResultSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 const events = require('../../../../lib/domain/events');
 const usecases = require('../../../../lib/domain/usecases');
@@ -273,6 +274,39 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
 
       // then
       expect(usecases.beginCampaignParticipationImprovement).to.have.been.calledOnceWith({ campaignParticipationId, userId });
+    });
+  });
+
+  describe('#getCampaignAssessmentParticipationResult', () => {
+
+    const campaignId = 123;
+    const userId = 456;
+    const campaignParticipationId = 789;
+    const locale = 'fr';
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getCampaignAssessmentParticipationResult');
+      sinon.stub(campaignAssessmentParticipationResultSerializer, 'serialize');
+    });
+
+    it('should call usecase and serializer with expected parameters', async () => {
+      // given
+      const campaignAssessmentParticipationResult = Symbol('campaignAssessmentParticipationResult');
+      const expectedResults = Symbol('results');
+      usecases.getCampaignAssessmentParticipationResult.withArgs({ userId, campaignId, campaignParticipationId, locale }).resolves(campaignAssessmentParticipationResult);
+      campaignAssessmentParticipationResultSerializer.serialize.withArgs(campaignAssessmentParticipationResult).returns(expectedResults);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { campaignId, campaignParticipationId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignParticipationController.getCampaignAssessmentParticipationResult(request);
+
+      // then
+      expect(response).to.equal(expectedResults);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
@@ -6,6 +6,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', () => 
 
   let campaignRepository, campaignAssessmentParticipationResultRepository;
   let userId, campaignId, campaignParticipationId;
+  const locale = 'fr';
 
   beforeEach(() => {
     campaignRepository = {
@@ -28,10 +29,10 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', () => 
     it('should get the campaignAssessmentParticipationResult', async () => {
       // given
       const expectedResult = Symbol('Result');
-      campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId.withArgs({ campaignId, campaignParticipationId }).resolves(expectedResult);
+      campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId.withArgs({ campaignId, campaignParticipationId, locale }).resolves(expectedResult);
 
       // when
-      const result = await getCampaignAssessmentParticipationResult({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository });
+      const result = await getCampaignAssessmentParticipationResult({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository, locale });
 
       // then
       expect(result).to.equal(expectedResult);
@@ -48,7 +49,7 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', () => 
 
     it('should throw UserNotAuthorizedToAccessEntity', async () => {
       // when
-      const result = await catchErr(getCampaignAssessmentParticipationResult)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository });
+      const result = await catchErr(getCampaignAssessmentParticipationResult)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository, locale });
 
       // then
       expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);


### PR DESCRIPTION
## :unicorn: Problème
Nous commençons la traduction de Pix Orga en anglais. Cependant il faut également traduire tout le référentiel et récupérer celui-ci dans Pix Orga.

## :robot: Solution
Côté Pix Orga, tout est déjà prêt désormais.
Côté Pix API, pour la route en question, récupérer la locale et récupérer les noms des compétences correspondantes.

## :rainbow: Remarques
NA

## :100: Pour tester
Dans Pix Orga, aller dans une campagne d'évaluation, puis dans l'onglet "participants", et cliquer sur un participant ayant partagé ses résultats. Saisir dans l'url à la fin "?lang=en" et vérifier qu'après rechargement, les compétences s'affichent en anglais.