### PR TITLE
[FEATURE] Voir le nombre de participants et supprimer les filtres dans la bannière de filtres (PIX-2056).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -3,6 +3,8 @@
   @selectedDivisions={{@selectedDivisions}}
   @selectedBadges={{@selectedBadges}}
   @selectedStages={{@selectedStages}}
+  @rowCount={{@participations.meta.rowCount}}
+  @resetFiltering={{@resetFiltering}}
   @triggerFiltering={{@triggerFiltering}}
 />
 

--- a/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
@@ -1,5 +1,12 @@
 {{#if this.displayFilters }}
-  <PixFilterBanner @title="Filtres" class="participant-filter-banner" aria-label="Filtres sur les participations">
+  <PixFilterBanner
+    @title="Filtres"
+    class="participant-filter-banner"
+    aria-label="Filtres sur les participations"
+    @details={{t 'pages.campaign.filters.participations-count' count=@rowCount}}
+    @clearFiltersLabel={{t 'pages.campaign.filters.actions.clear'}}
+    @onClearFilters={{@resetFiltering}}
+    >
     {{#if this.displayDivisionFilter }}
       <PixMultiSelect
         @id="division"

--- a/orga/app/components/routes/authenticated/campaign/participation-filters.js
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.js
@@ -37,8 +37,12 @@ export default class ParticipationFilters extends Component {
     this.args.triggerFiltering({ badges });
   }
 
+  get isDivisionsLoaded() {
+    return this.args.campaign.divisions.content.isLoaded;
+  }
+
   get displayDivisionFilter() {
-    return this.currentUser.isSCOManagingStudents;
+    return this.isDivisionsLoaded && this.currentUser.isSCOManagingStudents;
   }
 
   get divisionOptions() {

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -1,7 +1,9 @@
-<Routes::Authenticated::Campaign::ParticipationFilters 
+<Routes::Authenticated::Campaign::ParticipationFilters
   @campaign={{@campaign}}
   @selectedDivisions={{@selectedDivisions}}
   @triggerFiltering={{@triggerFiltering}}
+  @rowCount={{@profiles.meta.rowCount}}
+  @resetFiltering={{@resetFiltering}}
 />
 
 <div class="panel">
@@ -67,4 +69,3 @@
 {{#if @profiles}}
   <PaginationControl @pagination={{@profiles.meta}}/>
 {{/if}}
-

--- a/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
@@ -23,4 +23,12 @@ export default class AssessmentsController extends Controller {
     this.badges = filters.badges || this.badges;
     this.stages = filters.stages || this.stages;
   }
+
+  @action
+  resetFiltering() {
+    this.pageNumber = null;
+    this.divisions = [];
+    this.badges = [];
+    this.stages = [];
+  }
 }

--- a/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
@@ -13,9 +13,15 @@ export default class ProfilesController extends Controller {
     this.transitionToRoute('authenticated.campaigns.profile', campaignId, campaignParticipationId);
   }
 
- @action
+  @action
   triggerFiltering(filters) {
     this.pageNumber = null;
     this.divisions = filters.divisions;
+  }
+
+  @action
+  resetFiltering() {
+    this.pageNumber = null;
+    this.divisions = [];
   }
 }

--- a/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/assessments.hbs
@@ -6,4 +6,5 @@
   @selectedDivisions={{this.divisions}}
   @selectedBadges={{this.badges}}
   @selectedStages={{this.stages}}
+  @resetFiltering={{this.resetFiltering}}
 />

--- a/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
+++ b/orga/app/templates/authenticated/campaigns/campaign/profiles.hbs
@@ -4,5 +4,5 @@
   @goToProfilePage={{this.goToProfilePage}}
   @triggerFiltering={{this.triggerFiltering}}
   @selectedDivisions={{this.divisions}}
+  @resetFiltering={{this.resetFiltering}}
 />
-

--- a/orga/config/icons.js
+++ b/orga/config/icons.js
@@ -26,6 +26,7 @@ module.exports = function() {
     'free-regular-svg-icons': [
       'check-circle',
       'copy',
+      'trash-alt',
     ],
   };
 };

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26183,8 +26183,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#1ed8b0f461262b3c48224650792a724d1b5026b7",
-      "from": "git://github.com/1024pix/pix-ui.git#v2.0.0",
+      "version": "git://github.com/1024pix/pix-ui.git#4301dd38ca86976dfb11c78784c8cedb0f5d321f",
+      "from": "git://github.com/1024pix/pix-ui.git#pix-ui-2032-adding-reset-filtered-elements-button-on-filterBanner",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26183,8 +26183,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#4301dd38ca86976dfb11c78784c8cedb0f5d321f",
-      "from": "git://github.com/1024pix/pix-ui.git#pix-ui-2032-adding-reset-filtered-elements-button-on-filterBanner",
+      "version": "git://github.com/1024pix/pix-ui.git#f76816f408c58a7b0052914f618c2822caa34a1b",
+      "from": "git://github.com/1024pix/pix-ui.git#v2.2.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -88,7 +88,7 @@
     "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.0.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.2.0",
     "query-string": "^6.13.6",
     "qunit-dom": "^1.6.0",
     "sass": "^1.27.0"

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -319,8 +319,8 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
       const campaign = store.createRecord('campaign', {
         id: 1,
         name: 'campagne 1',
-        divisions: [division],
       });
+      campaign.set('divisions', [division]);
 
       const participations = [{ firstName: 'John', lastName: 'Doe', masteryPercentage: 60, isShared: true }];
       participations.meta = { rowCount: 1 };

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
@@ -171,8 +171,8 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
         id: 1,
         name: 'campagne 1',
         stages: [],
-        divisions: [division],
       });
+      campaign.set('divisions', [division]);
 
       const profiles = [{ firstName: 'John', lastName: 'Doe', isShared: true }];
       profiles.meta = { rowCount: 1 };

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
@@ -63,4 +63,23 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessments', funct
       });
     });
   });
+
+  module('resetFiltering', function() {
+    test('reset the filters', function(assert) {
+      //given
+      controller.set('pageNumber', 1);
+      controller.set('divisions', ['3eme']);
+      controller.set('badges', ['badge1']);
+      controller.set('stages', ['stage1']);
+
+      //when
+      controller.resetFiltering();
+
+      //then
+      assert.deepEqual(controller.pageNumber, null);
+      assert.deepEqual(controller.divisions, []);
+      assert.deepEqual(controller.badges, []);
+      assert.deepEqual(controller.stages, []);
+    });
+  });
 });

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
@@ -22,4 +22,19 @@ module('Unit | Controller | authenticated/campaigns/campaign/profiles', function
       assert.deepEqual(controller.pageNumber, null);
     });
   });
+
+  module('resetFiltering', function() {
+    test('reset the divisions', function(assert) {
+      //given
+      controller.set('pageNumber', 1);
+      controller.set('divisions', ['3eme']);
+
+      //when
+      controller.resetFiltering();
+
+      //then
+      assert.deepEqual(controller.divisions, []);
+      assert.deepEqual(controller.pageNumber, null);
+    });
+  });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -24,6 +24,14 @@
     }
   },
   "pages": {
+    "campaign": {
+      "filters": {
+        "actions": {
+          "clear": "Clear filters"
+        },
+        "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}"
+      }
+    },
     "campaigns-list": {
       "action": {
         "archived": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -24,6 +24,14 @@
     }
   },
   "pages": {
+    "campaign": {
+      "filters": {
+        "actions": {
+          "clear": "Effacer les filtres"
+        },
+        "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}"
+      }
+    },
     "campaigns-list": {
       "action": {
         "archived": {


### PR DESCRIPTION
## :unicorn: Problème
Il n'est actuellement pas possible de voir le nombre de participants filtrés sur une campaign d'évaluation ou les profiles dans une campaign de collecte de profils. de plus , un bouton permettant à réinitialiser les participants ou les profils déjà filtrés à leur état initial est souhaité dans le filter banner

## :robot: Solution
Intégrer dans Pix Orga, le composant Pix-UI filter banner qui a une propriété 'détails' qui affichera le nombre de participants ou de profils filtrés, ainsi qu'un bouton qui réinitialisera les éléments filtrés à leur état initial

## :rainbow: Remarques
N/A

## :100: Pour tester
- Se connecter sur pix Orga
- Cliquez sur campagnes , puis sélectionnez une campagne d'évaluation ou une campagne de collect de profiles.
- Cliquer sur l'onglet participants pour voire la liste de participants dans cette campagne
- Sur le côté droit du filter banner, le nombre de participants disponibles ainsi que le bouton 'Effacer les filtres' pour cette campagne peuvent  être vus
- Une fois qu'un filtre est appliqué à la liste et en fonction du filtre sélectionné, le nombre de participants/profils se réduira au nombre de participants/profils filtrés
- En cliquant sur le bouton "effacer les filtres", tous les filtres appliqués disparaissent et le nombre de participants/profils revient à son état initial 

Bien tester sur une campagne d'évaluation ET une campagne de collect de profiles.