### PR TITLE
[TECH] Proposer et appliquer des conventions de code / bonnes pratiques Ember sur le stub de services dans les tests auto sur PixOrga et PixCertif (PIX-2132)

### DIFF
--- a/admin/app/components/member-item.js
+++ b/admin/app/components/member-item.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { inject as service } from '@ember/service';
 
 const options = [
   { value: 'ADMIN', label: 'Administrateur' },
@@ -9,8 +8,6 @@ const options = [
 ];
 
 export default class MemberItem extends Component {
-
-  @service notifications;
 
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -10,7 +10,6 @@ export default class IndexController extends Controller {
   @service sessionInfoService;
   @service notifications;
   @service currentUser;
-  @service notifications;
   @service fileSaver;
   @service session;
 

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -5,7 +5,6 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin) {
 
   @service currentUser;
-  @service notifications;
   @service url;
 
   routeAfterAuthentication = 'authenticated';

--- a/certif/tests/unit/adapters/certification-issue-report-test.js
+++ b/certif/tests/unit/adapters/certification-issue-report-test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 module('Unit | Adapter | certification issue report', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', async function(assert) {
+  test('it should return modified URL for createRecord', async function(assert) {
     // given
     const modelName = 'certification-issue-report';
     const certificationCourseId = 1;

--- a/certif/tests/unit/components/add-student-list-test.js
+++ b/certif/tests/unit/components/add-student-list-test.js
@@ -4,16 +4,19 @@ import ArrayProxy from '@ember/array/proxy';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
 import times from 'lodash/times';
+import Service from '@ember/service';
 
 module('Unit | Component | add-student-list', function(hooks) {
   setupTest(hooks);
 
   let component;
-  let store;
 
   hooks.beforeEach(function() {
+    class StoreStub extends Service {
+      peekAll = sinon.stub().returns([]);
+    }
+    this.owner.register('service:store', StoreStub);
     component = createGlimmerComponent('component:add-student-list');
-    store = this.owner.lookup('service:store');
   });
 
   module('#computed hasCheckedSomething', function() {
@@ -114,7 +117,8 @@ module('Unit | Component | add-student-list', function(hooks) {
       component.args.studentList = [...unselectedStudents, ...selectedStudents];
       component.args.session = { id: sessionId, save: sinon.stub().resolves() };
       component.args.returnToSessionCandidates = sinon.spy();
-      sinon.stub(store, 'peekAll').withArgs('student').returns(selectedStudents);
+      const store = this.owner.lookup('service:store');
+      store.peekAll = sinon.stub().withArgs('student').returns(selectedStudents);
 
       // when
       await component.enrollStudents();

--- a/certif/tests/unit/components/enrolled-candidates-test.js
+++ b/certif/tests/unit/components/enrolled-candidates-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
+import Service from '@ember/service';
 
 module('Unit | Component | enrolled-candidates', function(hooks) {
   setupTest(hooks);
@@ -9,6 +10,10 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
   let component;
 
   hooks.beforeEach(function() {
+    class StoreStub extends Service {
+      createRecord = sinon.stub();
+    }
+    this.owner.register('service:store', StoreStub);
     component = createGlimmerComponent('component:enrolled-candidates');
   });
 
@@ -21,9 +26,8 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       const savableCandidate = _buildCandidate(
         { ...certificationCandidateData },
         { save: sinon.stub().resolves(), deleteRecord: sinon.stub().returns() });
-      const store = { createRecord: sinon.stub().returns(savableCandidate) };
+      this.owner.lookup('service:store').createRecord = sinon.stub().returns(savableCandidate);
 
-      component.store = store;
       component.args = {
         certificationCandidates: [],
         sessionId,
@@ -51,9 +55,8 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
       const savableCandidate = _buildCandidate(
         { ...certificationCandidateData },
         { save: sinon.stub().resolves(), deleteRecord: sinon.stub() });
-      const store = { createRecord: sinon.stub().returns(savableCandidate) };
+      this.owner.lookup('service:store').createRecord = sinon.stub().returns(savableCandidate);
 
-      component.store = store;
       component.args = {
         certificationCandidates: [_buildCandidate({
           ...certificationCandidateData,

--- a/certif/tests/unit/components/login-form-test.js
+++ b/certif/tests/unit/components/login-form-test.js
@@ -16,12 +16,11 @@ module('Unit | Component | login-form', (hooks) => {
   let component;
 
   hooks.beforeEach(function() {
-    const sessionStub = Service.create({
-      authenticate: authenticateStub,
-    });
-
+    class SessionStub extends Service {
+      authenticate = authenticateStub;
+    }
+    this.owner.register('service:session', SessionStub);
     component = createGlimmerComponent('component:login-form');
-    component.session = sessionStub;
   });
 
   module('#authenticate', () => {

--- a/certif/tests/unit/controllers/terms-of-service-test.js
+++ b/certif/tests/unit/controllers/terms-of-service-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Controller | terms-of-service', function(hooks) {
   setupTest(hooks);
@@ -9,17 +10,23 @@ module('Unit | Controller | terms-of-service', function(hooks) {
   module('#action submit', function(hooks) {
 
     hooks.beforeEach(function() {
+      class CurrentUserStub extends Service {
+        certificationPointOfContact = { save: sinon.stub().resolves() };
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       controller = this.owner.lookup('controller:terms-of-service');
       controller.transitionToRoute = sinon.stub().resolves();
-      controller.currentUser = { certificationPointOfContact: { save: sinon.stub().resolves() } };
     });
 
     test('it should save acceptance of terms of service', async function(assert) {
+      // given
+      const saveStub = this.owner.lookup('service:current-user').certificationPointOfContact.save;
+
       // when
       await controller.send('submit');
 
       // then
-      sinon.assert.calledWith(controller.currentUser.certificationPointOfContact.save, { adapterOptions: { acceptPixCertifTermsOfService: true } });
+      sinon.assert.calledWith(saveStub, { adapterOptions: { acceptPixCertifTermsOfService: true } });
       assert.ok(controller);
     });
 

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import EmberObject from '@ember/object';
 
-module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
+module.only('Unit | Route | authenticated/sessions/add-student', function(hooks) {
   setupTest(hooks);
   let route;
 

--- a/certif/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/list-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | authenticated/sessions/list', function(hooks) {
   setupTest(hooks);
@@ -9,6 +10,10 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
 
     test('it should return certification center sessions', async function(assert) {
       // given
+      class CurrentUserStub extends Service {
+        currentCertificationCenter;
+      }
+      this.owner.register('service:current-user', CurrentUserStub);
       const reloadedSessions = Symbol('Sessions');
       const reloadStub = sinon.stub().resolves(reloadedSessions);
       const expectedSessions = { reload: reloadStub };

--- a/certif/tests/unit/routes/authenticated/sessions/update-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/update-test.js
@@ -1,12 +1,17 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
+import Service from '@ember/service';
 
 module('Unit | Route | authenticated/sessions/update', function(hooks) {
   setupTest(hooks);
   let route;
 
   hooks.beforeEach(function() {
+    class StoreStub extends Service {
+      findRecord = sinon.stub();
+    }
+    this.owner.register('service:store', StoreStub);
     route = this.owner.lookup('route:authenticated/sessions/update');
   });
 
@@ -14,7 +19,8 @@ module('Unit | Route | authenticated/sessions/update', function(hooks) {
     const session_id = 1;
 
     hooks.beforeEach(function() {
-      route.store.findRecord = sinon.stub().withArgs('session', session_id).resolves({});
+      const store = this.owner.lookup('service:store');
+      store.findRecord = sinon.stub().withArgs('session', session_id).resolves({});
     });
 
     test('it should return session with time', async function(assert) {

--- a/mon-pix/app/components/certification-joiner.js
+++ b/mon-pix/app/components/certification-joiner.js
@@ -23,7 +23,6 @@ function _isMatchingReconciledStudentNotFoundError(err) {
 export default class CertificationJoiner extends Component {
   @service store;
   @service peeker;
-  @service currentUser;
 
   @tracked isLoading = false;
   @tracked errorMessage = null;

--- a/mon-pix/app/components/competence-card-default.js
+++ b/mon-pix/app/components/competence-card-default.js
@@ -4,8 +4,6 @@ import { action } from '@ember/object';
 
 export default class CompetenceCardDefault extends Component {
   @service currentUser;
-  @service store;
-  @service router;
   @service competenceEvaluation;
 
   get displayedLevel() {

--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import ENV from 'mon-pix/config/environment';
 
 export default class NavbarDesktopHeader extends Component {
-  @service router;
   @service session;
   @service intl;
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -6,7 +6,6 @@ import Component from '@glimmer/component';
 
 export default class SkillReview extends Component {
 
-  @service intl
   @service router
   @service session;
   @service url

--- a/mon-pix/app/components/routes/login-form.js
+++ b/mon-pix/app/components/routes/login-form.js
@@ -14,7 +14,6 @@ export default class LoginForm extends Component {
   @inject session;
   @inject store;
   @inject router;
-  @inject currentUser;
   @inject intl;
 
   login = null;

--- a/mon-pix/app/components/scorecard-details.js
+++ b/mon-pix/app/components/scorecard-details.js
@@ -6,8 +6,6 @@ import { A as EmberArray } from '@ember/array';
 
 export default class ScorecardDetails extends Component {
   @service currentUser;
-  @service store;
-  @service router;
   @service competenceEvaluation;
 
   @tracked showResetModal = false;

--- a/mon-pix/app/controllers/campaigns/restricted/join.js
+++ b/mon-pix/app/controllers/campaigns/restricted/join.js
@@ -7,8 +7,6 @@ export default class JoinRestrictedCampaignController extends Controller {
   participantExternalId = null;
 
   @service session;
-  @service store;
-  @service intl;
   @service currentUser;
 
   @action

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -5,7 +5,6 @@ import Controller from '@ember/controller';
 
 export default class FillInCampaignCodeController extends Controller {
 
-  @service store;
   @service intl;
   @service session;
   @service currentUser;

--- a/mon-pix/app/controllers/terms-of-service-pe.js
+++ b/mon-pix/app/controllers/terms-of-service-pe.js
@@ -7,7 +7,6 @@ export default class TermsOfServicePeController extends Controller {
   queryParams = ['authenticationKey'];
 
   @service session;
-  @service store;
   @service url;
 
   @tracked authenticationKey = null;

--- a/mon-pix/app/controllers/user-tests.js
+++ b/mon-pix/app/controllers/user-tests.js
@@ -1,7 +1,0 @@
-import { inject as service } from '@ember/service';
-import Controller from '@ember/controller';
-
-export default class UserTestsController extends Controller {
-  @service intl;
-
-}

--- a/mon-pix/app/routes/competences/details.js
+++ b/mon-pix/app/routes/competences/details.js
@@ -4,7 +4,6 @@ import Route from '@ember/routing/route';
 
 export default class DetailsRoute extends Route.extend(SecuredRouteMixin) {
   @service currentUser;
-  @service session;
 
   model(params, transition) {
     const scorecardId = this.currentUser.user.id + '_' + transition.to.parent.params.competence_id;

--- a/mon-pix/app/routes/competences/resume.js
+++ b/mon-pix/app/routes/competences/resume.js
@@ -1,10 +1,7 @@
-import { inject as service } from '@ember/service';
 import SecuredRouteMixin from 'mon-pix/mixins/secured-route-mixin';
 import Route from '@ember/routing/route';
 
 export default class ResumeRoute extends Route.extend(SecuredRouteMixin) {
-  @service session;
-  @service router;
 
   competenceId = null;
 

--- a/mon-pix/app/routes/error.js
+++ b/mon-pix/app/routes/error.js
@@ -1,10 +1,7 @@
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import get from 'lodash/get';
 
 export default class ErrorRoute extends Route {
-  @service session;
-
   hasUnauthorizedError(error) {
     const statusCode = get(error, 'errors[0].code');
     return statusCode === 401;

--- a/mon-pix/app/routes/login.js
+++ b/mon-pix/app/routes/login.js
@@ -5,7 +5,6 @@ import Route from '@ember/routing/route';
 
 export default class LoginRoute extends Route.extend(UnauthenticatedRouteMixin) {
   @service session;
-  @service store;
 
   @action
   async authenticate(login, password) {

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -5,7 +5,6 @@ import get from 'lodash/get';
 export default class ResetPasswordRoute extends Route {
   @service errors;
   @service intl;
-  @service session;
 
   async model(params) {
     const passwordResetTemporaryKey = params.temporary_key;

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -9,9 +9,6 @@ export default class ListItems extends Component {
 
   @service currentUser;
   @service session;
-  @service store;
-  @service router;
-  @service notifications;
 
   @tracked student = null;
   @tracked isShowingAuthenticationMethodModal = false;

--- a/orga/app/components/routes/join-request-form.js
+++ b/orga/app/components/routes/join-request-form.js
@@ -1,5 +1,4 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import InputValidator from '../../utils/input-validator';
@@ -7,9 +6,6 @@ import InputValidator from '../../utils/input-validator';
 const isStringValid = (value) => value ? Boolean(value.trim()) : undefined;
 
 export default class JoinRequestForm extends Component {
-
-  @service session;
-  @service store;
 
   @tracked uai;
   @tracked firstName;

--- a/orga/app/controllers/authenticated/campaigns/list.js
+++ b/orga/app/controllers/authenticated/campaigns/list.js
@@ -1,6 +1,5 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import ENV from 'pix-orga/config/environment';
 import debounce from 'lodash/debounce';
@@ -13,8 +12,6 @@ export default class ListController extends Controller {
   @tracked name = '';
   @tracked creatorName = '';
   @tracked status = null;
-
-  @service currentUser;
 
   get isArchived() {
     return this.status === 'archived';

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -4,7 +4,6 @@ import Controller from '@ember/controller';
 
 export default class NewController extends Controller {
 
-  @service store;
   @service notifications;
 
   @action

--- a/orga/app/controllers/authenticated/team/new.js
+++ b/orga/app/controllers/authenticated/team/new.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 
 export default class NewController extends Controller {
 
-  @service store;
   @service notifications;
 
   @tracked isLoading = false;

--- a/orga/app/routes/authenticated/campaigns/new.js
+++ b/orga/app/routes/authenticated/campaigns/new.js
@@ -4,7 +4,6 @@ import RSVP from 'rsvp';
 
 export default class NewRoute extends Route {
 
-  @service store;
   @service currentUser;
 
   model() {

--- a/orga/app/routes/authenticated/index.js
+++ b/orga/app/routes/authenticated/index.js
@@ -1,9 +1,6 @@
-import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class IndexRoute extends Route {
-
-  @service currentUser;
 
   beforeModel() {
     return this.replaceWith('authenticated.campaigns');

--- a/orga/tests/unit/adapters/application-test.js
+++ b/orga/tests/unit/adapters/application-test.js
@@ -1,9 +1,26 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Unit | Adapters | ApplicationAdapter', function(hooks) {
   setupTest(hooks);
+
+  class SessionStub extends Service {
+    isAuthenticated = true;
+    data = {
+      authenticated: { access_token: 'someAccessToken' },
+    };
+  }
+
+  class AjaxQueueStub extends Service {
+    add = null;
+  }
+
+  hooks.beforeEach(async function() {
+    this.owner.register('service:session', SessionStub);
+    this.owner.register('service:ajaxQueue', AjaxQueueStub);
+  });
 
   test('should specify /api as the root url', function(assert) {
     // Given
@@ -21,7 +38,8 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
       const applicationAdapter = this.owner.lookup('adapter:application');
 
       // When
-      applicationAdapter.set('session', { isAuthenticated: true, data: { authenticated: { access_token } } });
+      this.owner.lookup('service:session').set('isAuthenticated', true);
+      this.owner.lookup('service:session').set('data', { authenticated: { access_token } });
 
       // Then
       assert.equal(applicationAdapter.headers['Authorization'], `Bearer ${access_token}`);
@@ -32,7 +50,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
       const applicationAdapter = this.owner.lookup('adapter:application');
 
       // When
-      applicationAdapter.set('session', {});
+      this.owner.lookup('service:session').set('isAuthenticated', false);
 
       // Then
       assert.notOk(applicationAdapter.headers['Authorization']);
@@ -78,13 +96,14 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');
-      applicationAdapter.ajaxQueue = { add: sinon.stub().resolves() };
+      const addStub = sinon.stub().resolves();
+      this.owner.lookup('service:ajaxQueue').set('add', addStub);
 
       // When
       applicationAdapter.findRecord(null, { modelName: 'user' }, 1);
 
       // Then
-      sinon.assert.calledOnce(applicationAdapter.ajaxQueue.add);
+      sinon.assert.calledOnce(addStub);
       assert.ok(applicationAdapter);
     });
   });

--- a/orga/tests/unit/components/routes/login-form-test.js
+++ b/orga/tests/unit/components/routes/login-form-test.js
@@ -1,36 +1,38 @@
 import sinon from 'sinon';
-
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
+import Service from '@ember/service';
 
-module('Unit | Component | Routes | login-form', (hooks) => {
-
+module('Unit | Component | Routes | login-form', function(hooks) {
   setupTest(hooks);
+
+  class SessionStub extends Service {
+    authenticate = null;
+  }
 
   let component;
 
   hooks.beforeEach(function() {
     component = createGlimmerComponent('component:routes/login-form');
+    this.owner.register('service:session', SessionStub);
   });
 
-  module('#authenticate', () => {
+  module('#authenticate', function() {
 
-    test('should save email without spaces', (assert) => {
+    test('should save email without spaces', function(assert) {
       // given
       const emailWithSpaces = '    user@example.net  ';
       component.email = emailWithSpaces;
-
-      const _authenticateStub = sinon.stub().resolves();
-      component._authenticate = _authenticateStub;
-
+      const authenticateStub = sinon.stub().resolves();
+      this.owner.lookup('service:session').set('authenticate', authenticateStub);
       const expectedEmail = emailWithSpaces.trim();
 
       // when
       component.authenticate(new Event('stub'));
 
       // then
-      assert.ok(_authenticateStub.calledWith(sinon.match.any, expectedEmail));
+      assert.ok(authenticateStub.calledWith(sinon.match.any, expectedEmail));
     });
   });
 

--- a/orga/tests/unit/components/user-logged-menu-test.js
+++ b/orga/tests/unit/components/user-logged-menu-test.js
@@ -1,18 +1,23 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-module('Unit | Component | user-logged-menu', (hooks) => {
-
+module('Unit | Component | user-logged-menu', function(hooks) {
   setupTest(hooks);
+
+  class currentUserStub extends Service {
+    organization = null;
+  }
 
   let component;
 
   hooks.beforeEach(function() {
     component = createGlimmerComponent('component:user-logged-menu');
+    this.owner.register('service:currentUser', currentUserStub);
   });
 
-  module('action#toggleUserMenu', () => {
+  module('action#toggleUserMenu', function() {
     test('should return false as default value', function(assert) {
       // then
       assert.equal(component.isMenuOpen, false);
@@ -34,29 +39,29 @@ module('Unit | Component | user-logged-menu', (hooks) => {
     });
   });
 
-  module('organizationNameAndExternalId', () => {
+  module('organizationNameAndExternalId', function() {
 
-    test('should return the organization name if the externalId is not defined', (assert) => {
+    test('should return the organization name if the externalId is not defined', function(assert) {
       // given
       const expectedOrganizationName = 'expectedOrganizationName';
-      const currentUser = { organization: { name: expectedOrganizationName } };
-      component.currentUser = currentUser;
+      this.owner.lookup('service:currentUser').set('organization', { name: expectedOrganizationName, externalId: null });
 
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
+
       // then
       assert.equal(computedOrganizationName, expectedOrganizationName);
     });
 
-    test('should return the organization name and externalId if the externalId is defined', (assert) => {
+    test('should return the organization name and externalId if the externalId is defined', function(assert) {
       // given
-      const expectedOrganizationName = 'expectedOrganizationName';
       const expectedExternalId = 'expectedExternalId';
-      const currentUser = { organization: { name: expectedOrganizationName, externalId: expectedExternalId } };
-      component.currentUser = currentUser;
+      const expectedOrganizationName = 'expectedOrganizationName';
+      this.owner.lookup('service:currentUser').set('organization', { name: expectedOrganizationName, externalId: expectedExternalId });
 
       // when
       const computedOrganizationName = component.organizationNameAndExternalId;
+
       // then
       assert.equal(computedOrganizationName, `${expectedOrganizationName} (${expectedExternalId})`);
     });


### PR DESCRIPTION
## :unicorn: Problème
Dans le sens de l'harmonisation / homogénéisation du code, ajout d'une bonne pratique concernant l'écriture des tests : comment stubber correctement un service dans un test auto.

## :robot: Solution
Voir l'ajout de la convention dans le doc, fondamentalement il s'agit de faire en sorte d'exploiter le mécanisme d'injection des services.

## :rainbow: Remarques
Première PR qui traite de PixOrga et PixCertif. PixAdmin et PixApp à suivre dans une autre PR.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
