### PR TITLE
[BUGFIX] Corriger la taille de l'abeille sur la page de partage de profil (PIX-2115)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -83,7 +83,6 @@
           />
         {{/each}}
       </div>
-      <div class="skill-review-result__dash-line"></div>
     {{/if}}
 
     {{#if @model.displayImprovementButton}}
@@ -93,9 +92,7 @@
     {{/if}}
   {{/if}}
 
-  <div class="skill-review-result__dash-line"></div>
-
-  <main>
+  <main class="skill-review-result__content">
     <div class="skill-review-result__table-header">
       <h2 class="skill-review-result__subtitle">
         {{t 'pages.skill-review.details.title'}}

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -70,9 +70,10 @@
 }
 
 .campaign-landing-page__start__custom-text {
+  border-top: 1px dashed $grey-22;
   width: 80%;
-  margin: auto;
-  padding: 5px;
+  margin-top: 50px;
+  padding: 50px 5px 5px 5px;
   font-family: $font-open-sans;
   font-size: 1rem;
   text-align: left;
@@ -163,6 +164,12 @@
 
   @include device-is('tablet') {
     flex-direction: row;
+  }
+
+  &--dashline {
+    border-top: 1px dashed $grey-22;
+    margin-top: 50px;
+    padding: 50px 10px 10px 10px;
   }
 }
 

--- a/mon-pix/app/styles/pages/_send-profile.scss
+++ b/mon-pix/app/styles/pages/_send-profile.scss
@@ -1,5 +1,10 @@
 .send-profile-header {
-  padding: 30px;
+  padding: 30px 10px;
+  margin-top: -160px;
+
+  @include device-is('tablet') {
+    padding: 32px 24px;
+  }
 
   &__announcement {
     display: flex;

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -48,6 +48,7 @@
   }
 
   &__begin-improvement {
+    border-top: 1px dashed $grey-22;
     padding: 30px;
     display: flex;
     flex-direction: row;
@@ -159,13 +160,9 @@
     }
   }
 
-  &__dash-line {
-    height: 1px;
-    top: 0;
-    left: 0;
-    width: 100%;
-    background-image: linear-gradient(to right, transparent 50%, #BBBBBB 50%);
-    background-size: 10px 100%;
+  &__content {
+    border-top: 1px dashed $grey-22;
+    margin-top: 24px;
   }
 
   &__information {
@@ -278,8 +275,12 @@
 
 .skill-review__campaign-archived {
   position: relative;
-  top: -80px;
   text-align: center;
+  margin-bottom: 10px;
+}
+
+.skill-review__campaign-archived-image {
+  margin-top: -50px;
 }
 
 .skill-review__campaign-archived-text {

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -52,9 +52,7 @@
             </a>
           </p>
 
-          <hr class="campaign-landing-page__dash-line">
-
-          <div class="campaign-landing-page__details__measure__container">
+          <div class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline">
             <img src="{{this.rootURL}}/images/landing-page/icon-conseil.svg" role="none" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">
@@ -66,9 +64,8 @@
             </div>
 
           </div>
-          <hr class="campaign-landing-page__dash-line">
 
-          <div class="campaign-landing-page__details__measure__container">
+          <div class="campaign-landing-page__details__measure__container campaign-landing-page__details__measure__container--dashline">
             <img src="{{this.rootURL}}/images/landing-page/icon-certif.svg" role="none" alt="">
             <div class="campaign-landing-page__details__article-side">
               <p class="campaign-landing-page__details__text article-title ">

--- a/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
+++ b/mon-pix/app/templates/campaigns/profiles-collection/profile-already-shared.hbs
@@ -3,9 +3,9 @@
 
 <div class="background-banner-wrapper">
   <div class="background-banner"></div>
-  <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner send-profile-header">
-    <img class="send-profile-header__image" src="{{rootURL}}/images/bees/fat-bee.svg" alt={{t "pages.profile-already-shared.first-title"}}>
+  <PixBlock @shadow="heavy" class="send-profile-header">
     <div class="send-profile-header__announcement">
+      <img class="send-profile-header__image" src="{{rootURL}}/images/bees/fat-bee.svg" alt={{t "pages.profile-already-shared.first-title"}}>
       <p class="send-profile-header__instruction">
         {{t "pages.profile-already-shared.explanation" organization=this.model.campaign.organizationName date=this.model.sharedProfile.sharedAt hour=this.model.sharedProfile.sharedAt htmlSafe=true}}
       </p>
@@ -17,12 +17,12 @@
       <HexagonScore @pixScore={{this.model.sharedProfile.pixScore}} />
       <div class="send-profile-header__profile__cards">
         <ProfileScorecards
-          class="send-profile-header__profile__cards"
-          @interactive={{false}}
-          @areasCode={{this.model.sharedProfile.areasCode}}
-          @scorecards={{this.model.sharedProfile.scorecards}}
+                class="send-profile-header__profile__cards"
+                @interactive={{false}}
+                @areasCode={{this.model.sharedProfile.areasCode}}
+                @scorecards={{this.model.sharedProfile.scorecards}}
         />
       </div>
     </div>
-  </div>
+  </PixBlock>
 </div>

--- a/mon-pix/app/templates/components/campaign-start-block.hbs
+++ b/mon-pix/app/templates/components/campaign-start-block.hbs
@@ -31,8 +31,6 @@
   </div>
 
   {{#if @campaign.customLandingPageText}}
-    <hr class="campaign-landing-page__dash-line">
-
     <div class="campaign-landing-page__start__custom-text">
       <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
     </div>

--- a/mon-pix/app/templates/components/skill-review-try-again.hbs
+++ b/mon-pix/app/templates/components/skill-review-try-again.hbs
@@ -1,5 +1,4 @@
 {{#unless @campaignParticipation.isShared}}
-  <div class="skill-review-result__dash-line"></div>
   <div class="skill-review__begin-improvement">
     <div>
       <h2 class="skill-review__subtitle">


### PR DESCRIPTION
## :unicorn: Problème
Sur certains navigateurs, l'abeille sur la page de partage de profil à la fin d'une campagne de profil n'était pas à la bonne taille :
![fatbee](https://user-images.githubusercontent.com/48727874/107380812-80c3ac00-6aee-11eb-9765-07db09925d29.png)

## :robot: Solution
Diverses corrections CSS (uniformisation html des pages de résultats de campagne d'évaluation archivée ET de partage de profil)
Uniformation du dessin des "dashlines" sur les pages de fin de parcours, mais aussi sur la page de présentation de campagne

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier la correction de la taille de l'abeille en :
- Aller sur pix app, partager son profil sur la campagne au code SNAP123
- Quitter la page
- Y retourner via la saisie du code campagne
- Voir que la taille de l'abeille est correcte
