### PR TITLE
[TECH] Ajouter un titre sur les liens externes dans les consignes (PIX-2124).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -7,6 +7,7 @@ import get from 'lodash/get';
 
 export default class ChallengeStatement extends Component {
   @service mailGenerator;
+  @service intl;
 
   @tracked selectedAttachmentUrl;
   @tracked displayAlternativeInstruction = false;
@@ -21,7 +22,14 @@ export default class ChallengeStatement extends Component {
     if (!instruction) {
       return null;
     }
-    return instruction.replace('${EMAIL}', this._formattedEmailForInstruction());
+
+    const formattedEmailInstruction = this._formatEmail(instruction);
+    const formattedInstruction = this._formatLink(formattedEmailInstruction);
+    return formattedInstruction;
+  }
+
+  get linkTitle() {
+    return this.intl.t('pages.challenge.statement.external-link-title');
   }
 
   get challengeEmbedDocument() {
@@ -56,5 +64,19 @@ export default class ChallengeStatement extends Component {
   _formattedEmailForInstruction() {
     return this.mailGenerator
       .generateEmail(this.args.challenge.id, this.args.assessment.id, window.location.hostname, config.environment);
+  }
+
+  _formatEmail(instruction) {
+    return instruction.replace('${EMAIL}', this._formattedEmailForInstruction());
+  }
+
+  _formatLink(instruction) {
+    const externalLinkRegex = /(\[(.*?)\]\((.*?)\))+/;
+    return instruction.replace(externalLinkRegex, this._insertLinkTitle.bind(this));
+  }
+
+  _insertLinkTitle(markdownLink) {
+    const markdownLinkWithoutLastChar = markdownLink.substring(0, markdownLink.length - 1);
+    return markdownLinkWithoutLastChar + ' "' + this.linkTitle + '")';
   }
 }

--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -71,8 +71,8 @@ export default class ChallengeStatement extends Component {
   }
 
   _formatLink(instruction) {
-    const externalLinkRegex = /(\[(.*?)\]\((.*?)\))+/;
-    return instruction.replace(externalLinkRegex, this._insertLinkTitle.bind(this));
+    const externalLinkRegex = /(\[(.*?)\]\((.*?)\))+/g;
+    return instruction.replaceAll(externalLinkRegex, this._insertLinkTitle.bind(this));
   }
 
   _insertLinkTitle(markdownLink) {

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -88,14 +88,15 @@ describe('Integration | Component | ChallengeStatement', function() {
       addAssessmentToContext(this, { id: '267845' });
       addChallengeToContext(this, {
         id: 'recigAYl5bl96WGXj',
-        instruction: 'Cliquer sur ce lien [lien 1](https://monlien1.com)',
+        instruction: 'Cliquer sur les liens [lien 1](https://monlien1.com) et [lien 2](https://monlien2.com)',
       });
 
       // when
       await renderChallengeStatement();
 
       // then
-      expect(find('.challenge-statement__instruction').innerHTML).to.contain('title="Nouvelle fenêtre"');
+      const linkCount = find('.challenge-statement__instruction').innerHTML.match(/title="Nouvelle fenêtre"/g).length;
+      expect(linkCount).to.equal(2);
     });
 
   });

--- a/mon-pix/tests/integration/components/challenge-statement-test.js
+++ b/mon-pix/tests/integration/components/challenge-statement-test.js
@@ -82,6 +82,22 @@ describe('Integration | Component | ChallengeStatement', function() {
       expect(find('.challenge-statement__instruction').textContent.trim())
         .to.equal('Veuillez envoyer un email à l\'adresse recigAYl5bl96WGXj-267845-0502@pix-infra.ovh pour valider cette épreuve');
     });
+
+    it('should add title "Nouvelle fenêtre" to external links', async function() {
+      // given
+      addAssessmentToContext(this, { id: '267845' });
+      addChallengeToContext(this, {
+        id: 'recigAYl5bl96WGXj',
+        instruction: 'Cliquer sur ce lien [lien 1](https://monlien1.com)',
+      });
+
+      // when
+      await renderChallengeStatement();
+
+      // then
+      expect(find('.challenge-statement__instruction').innerHTML).to.contain('title="Nouvelle fenêtre"');
+    });
+
   });
 
   /*

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -369,6 +369,7 @@
                         "hide": "Hide alternative instruction"
                     }
                 },
+                "external-link-title": "New window",
                 "file-download": {
                     "actions": {
                         "choose-type": "Select the type of file you would like to use",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -369,6 +369,7 @@
                         "hide": "Cacher l'alternative textuelle"
                     }
                 },
+                "external-link-title": "Nouvelle fenêtre",
                 "file-download": {
                     "actions": {
                         "choose-type": "Choisissez le type de fichier que vous voulez utiliser",


### PR DESCRIPTION
## :unicorn: Problème
Une icone sur un lien externe permet d'indiquer visuellement qu'il s'agit d'une page qui s'ouvre sur une nouvelle fenêtre.
Or, avec un lecteur d'écran, rien n'indique que la page s'ouvre dans une nouvelle fenêtre. En ouvrant le lien, l'utilisateur a le focus directement dans la nouvelle page et ne sait pas forcément qu'il a quitté Pix.

## :robot: Solution
Ajouter un attribut "title=Nouvelle fenêtre" sur le lien

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Sur un challenge avec des liens (ex: recgzvi9msKskBUf8, recxDBTrZbLTPiaDi), vérifier que un `title="Nouvelle fenêtre"` a bien été ajouté sur l'élément lien.