### PR TITLE
[FEATURE] Afficher un lien de téléchargement des résultats d'une session dans Pix Admin (PIX-2042)

### DIFF
--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -5,6 +5,7 @@ import trim from 'lodash/trim';
 
 import Model, { belongsTo, hasMany, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
+import { memberAction } from 'ember-api-actions';
 
 function _getNumberOf(juryCertificationSummaries, booleanFct) {
   return sumBy(
@@ -107,4 +108,13 @@ export default class Session extends Model {
   get displayStatus() {
     return statusToDisplayName[this.status];
   }
+
+  getDownloadLink = memberAction({
+    path: 'generate-results-download-link',
+    type: 'get',
+    urlType: 'findRecord',
+    after(response) {
+      return response.sessionResultsLink;
+    },
+  })
 }

--- a/admin/app/styles/authenticated/sessions/session/informations.scss
+++ b/admin/app/styles/authenticated/sessions/session/informations.scss
@@ -5,6 +5,7 @@
     margin: inherit;
 
     .btn {
+      height: 36px;
       margin-right: 20px;
 
       &--right {
@@ -30,6 +31,31 @@
 
   &__actions {
     padding-top: 32px;
+  }
+
+  &__copy-button {
+    display: flex;
+    justify-content: center;
+    position: relative;
+
+    p {
+      background-color: $black;
+      border-radius: 5px;
+      color: $white;
+      padding: 5px 10px;
+      position: absolute;
+      top: calc(-23px + -10px + -10px);
+
+      &::before {
+        content: "";
+        position: absolute;
+        border-width: 5px;
+        border-style: solid;
+        border-color: $black transparent transparent transparent;
+        bottom: -10px;
+        left: calc(50% - 5px);
+      }
+    }
   }
 }
 

--- a/admin/app/templates/authenticated/sessions/session/informations.hbs
+++ b/admin/app/templates/authenticated/sessions/session/informations.hbs
@@ -109,12 +109,25 @@
         Récupérer le fichier avant jury
       </button>
 
-      <button type="button" class="btn btn-primary btn--right" {{on 'click' this.downloadSessionResultFile}}>
+      <button type="button" class="btn btn-secondary btn--right" {{on 'click' this.downloadSessionResultFile}}>
         Exporter les résultats
       </button>
 
+      <div class="session-info__copy-button">
+        {{#if this.isCopyButtonClicked}}
+          <p class="session-info__tooltip">
+            {{this.copyButtonText}}
+          </p>
+        {{/if}}
+
+        <button type="button" class="btn btn-secondary btn--right" {{on 'click' this.copyResultsDownloadLink}}>
+          Copier le lien de téléchargement &nbsp;
+          <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
+        </button>
+      </div>
+
       {{#if this.sessionModel.areResultsToBeSentToPrescriber}}
-        <button type="button" class="btn btn-primary" {{on 'click' this.tagSessionAsSentToPrescriber}}>
+        <button type="button" class="btn btn-secondary" {{on 'click' this.tagSessionAsSentToPrescriber}}>
           Résultats transmis au prescripteur
         </button>
       {{/if}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -58,6 +58,8 @@ export default function() {
 
   this.get('/admin/certifications/:id');
 
+  this.get('/admin/sessions/:id/generate-results-download-link', { sessionResultsLink: 'http://link-to-results.fr' });
+
   this.post('/organizations/:id/invitations', (schema, request) => {
     const params = JSON.parse(request.requestBody);
     const email = params.data.attributes.email;

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -33,7 +33,7 @@ module('Acceptance | Session page', function(hooks) {
     const SENT_TO_PRESCRIPTEUR_DATE_SECTION = 11;
     const LABEL_ROW_INDEX = 1;
     const VALUE_ROW_INDEX = 2;
-    const SEND_TO_PRESCRIPTEUR_BUTTON_INDEX = 4;
+    const SEND_TO_PRESCRIPTEUR_BUTTON_INDEX = 5;
 
     hooks.beforeEach(async function() {
       await visitSessionsPage();

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -4,6 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { FINALIZED } from 'pix-admin/models/session';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import sinon from 'sinon';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
@@ -107,10 +108,27 @@ module('Acceptance | Session pages', function(hooks) {
 
         test('it shows all buttons', function(assert) {
           // then
-          assert.dom('.session-info__actions div button:first-child').hasText('M\'assigner la session');
-          assert.dom('.session-info__actions div button:nth-child(2)').hasText('Récupérer le fichier avant jury');
-          assert.dom('.session-info__actions div button:nth-child(3)').hasText('Exporter les résultats');
-          assert.dom('.session-info__actions div button:nth-child(4)').hasText('Résultats transmis au prescripteur');
+          assert.contains('M\'assigner la session');
+          assert.contains('Récupérer le fichier avant jury');
+          assert.contains('Exporter les résultats');
+          assert.contains('Copier le lien de téléchargement');
+          assert.contains('Résultats transmis au prescripteur');
+        });
+
+        module('copy link button', function() {
+          test('it should copy \'http://link-to-results.fr\' in navigator clipboard on click', async (assert) => {
+            // given
+
+            // We were unable to access clipboard in test environement so we used a stub
+            const writeTextStub = sinon.stub();
+            sinon.stub(navigator, 'clipboard').value({ writeText: writeTextStub.returns() });
+
+            // when
+            await click('.session-info__actions .session-info__copy-button button');
+
+            // then
+            assert.ok(writeTextStub.calledWithExactly('http://link-to-results.fr'));
+          });
         });
       });
     });

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
@@ -120,7 +120,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
         await visit(`/sessions/${session.id}`);
 
         // then
-        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(4)');
+        const buttonSendResultsToCandidates = this.element.querySelector('.session-info__actions .row button:nth-child(5)');
         assert.equal(buttonSendResultsToCandidates.innerHTML.trim(), 'Résultats transmis au prescripteur');
       });
 

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -206,4 +206,51 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       assert.equal(controller.isShowingAssignmentModal, false);
     });
   });
+
+  module('#copyResultsDownloadLink', function(hooks) {
+
+    hooks.afterEach(function() {
+      sinon.restore();
+    });
+
+    test('it should retrieve link from api and copy it', async (assert) => {
+      // given
+      const getDownloadLink = sinon.stub();
+      getDownloadLink.resolves('www.jeremypluquet.com');
+      controller.model = { getDownloadLink };
+
+      const writeTextStub = sinon.stub();
+      writeTextStub.returns();
+      sinon.stub(navigator, 'clipboard').value({
+        writeText: writeTextStub,
+      });
+      sinon.stub(window, 'setTimeout').returns();
+
+      // when
+      await controller.actions.copyResultsDownloadLink.call(controller);
+
+      // then
+      assert.ok(writeTextStub.calledWithExactly('www.jeremypluquet.com'));
+      assert.equal(controller.copyButtonText, 'Copié');
+      assert.ok(controller.isCopyButtonClicked);
+      assert.ok(window.setTimeout);
+    });
+
+    test('it should notify error when retrieving link fails', async (assert) => {
+      // given
+      const getDownloadLink = sinon.stub();
+      getDownloadLink.rejects('An error');
+      controller.model = { getDownloadLink };
+
+      sinon.stub(window, 'setTimeout').returns();
+
+      // when
+      await controller.actions.copyResultsDownloadLink.call(controller);
+
+      // then
+      assert.equal(controller.copyButtonText, 'Erreur !');
+      assert.ok(controller.isCopyButtonClicked);
+      assert.ok(window.setTimeout);
+    });
+  });
 });

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -295,6 +295,23 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/admin/sessions/{id}/generate-results-download-link',
+      config: {
+        validate: {
+          params: Joi.object({
+            id: identifiersType.sessionId,
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.generateSessionResultsDownloadLink,
+        tags: ['api', 'sessions'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/sessions/download-results/{token}',
       config: {
         auth: false,

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -307,6 +307,18 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/sessions/download-all-results/{token}',
+      config: {
+        auth: false,
+        handler: sessionController.getSessionResultsToDownload,
+        tags: ['api', 'sessions', 'results'],
+        notes: [
+          'Elle retourne les résultats de certifications d\'une session agrégés par email de destinataire des résultats',
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/sessions/{id}/certification-reports',
       config: {
         validate: {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -1,6 +1,7 @@
 const { BadRequestError } = require('../http-errors');
 const usecases = require('../../domain/usecases');
 const tokenService = require('../../domain/services/token-service');
+const sessionResultsLinkService = require('../../domain/services/session-results-link-service');
 const sessionValidator = require('../../domain/validators/session-validator');
 const events = require('../../domain/events');
 const { CertificationCandidateAlreadyLinkedToUserError } = require('../../domain/errors');
@@ -135,6 +136,13 @@ module.exports = {
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
       .header('Content-Disposition', `attachment; filename=${fileName}`);
+  },
+
+  async generateSessionResultsDownloadLink(request, h) {
+    const sessionId = request.params.id;
+    const sessionResultsLink = sessionResultsLinkService.generateResultsLink(sessionId);
+
+    return h.response({ sessionResultsLink });
   },
 
   async getSessionResultsToDownload(request, h) {

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -137,6 +137,17 @@ module.exports = {
       .header('Content-Disposition', `attachment; filename=${fileName}`);
   },
 
+  async getSessionResultsToDownload(request, h) {
+    const token = request.params.token;
+    const { sessionId } = tokenService.extractSessionId(token);
+    const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
+    const csvResult = await getCertificationResultsCsv({ session, certificationResults });
+
+    return h.response(csvResult)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', `attachment; filename=${fileName}`);
+  },
+
   async getSessionResultsByRecipientEmail(request, h) {
     const token = request.params.token;
     const { resultRecipientEmail, sessionId } = tokenService.extractResultRecipientEmailAndSessionId(token);

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -14,7 +14,7 @@ const juryCertificationSummaryRepository = require('../../infrastructure/reposit
 const jurySessionRepository = require('../../infrastructure/repositories/jury-session-repository');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const requestResponseUtils = require('../../infrastructure/utils/request-response-utils');
-const { getCertificationResultsCsv } = require('../../infrastructure/utils/csv/certification-results');
+const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 const fillCandidatesImportSheet = require('../../infrastructure/files/candidates-import/fill-candidates-import-sheet');
 const trim = require('lodash/trim');
 const UserLinkedToCertificationCandidate = require('../../domain/events/UserLinkedToCertificationCandidate');
@@ -131,7 +131,7 @@ module.exports = {
   async getSessionResults(request, h) {
     const sessionId = request.params.id;
     const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
-    const csvResult = await getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
@@ -149,7 +149,7 @@ module.exports = {
     const token = request.params.token;
     const { sessionId } = tokenService.extractSessionId(token);
     const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
-    const csvResult = await getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
@@ -160,7 +160,7 @@ module.exports = {
     const token = request.params.token;
     const { resultRecipientEmail, sessionId } = tokenService.extractResultRecipientEmailAndSessionId(token);
     const { session, certificationResults, fileName } = await usecases.getSessionResultsByResultRecipientEmail({ sessionId, resultRecipientEmail });
-    const csvResult = await getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -438,6 +438,12 @@ class InvalidResultRecipientTokenError extends DomainError {
   }
 }
 
+class InvalidSessionResultError extends DomainError {
+  constructor(message = 'Le token de récupération des résultats de la session de certification est invalide.') {
+    super(message);
+  }
+}
+
 class InvalidRecaptchaTokenError extends DomainError {
   constructor(message = 'Token de recaptcha invalide.') {
     super(message);
@@ -744,6 +750,7 @@ module.exports = {
   InvalidExternalUserTokenError,
   InvalidRecaptchaTokenError,
   InvalidResultRecipientTokenError,
+  InvalidSessionResultError,
   InvalidTemporaryKeyError,
   ManyOrganizationsFoundError,
   MatchingReconciledStudentNotFoundError,

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -74,7 +74,7 @@ function sendCertificationResultEmail({
 }) {
   const pixName = PIX_NAME_FR;
   const formatedSessionDate = moment(sessionDate).locale('fr').format('L');
-  const token = tokenService.createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
+  const token = tokenService.createCertificationResultsByRecipientEmailLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
   const link = `${settings.domain.pixApp + settings.domain.tldOrg}/api/sessions/download-results/${token}`;
 
   const variables = {

--- a/api/lib/domain/services/session-results-link-service.js
+++ b/api/lib/domain/services/session-results-link-service.js
@@ -1,0 +1,14 @@
+const tokenService = require('./token-service');
+const settings = require('../../config');
+
+module.exports = {
+
+  generateResultsLink(sessionId) {
+    const daysBeforeExpiration = 30;
+
+    const token = tokenService.createCertificationResultsLinkToken({ sessionId, daysBeforeExpiration });
+    const link = `${settings.domain.pixApp + settings.domain.tldOrg}/api/sessions/download-all-results/${token}`;
+
+    return link;
+  },
+};

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -1,5 +1,5 @@
 const jsonwebtoken = require('jsonwebtoken');
-const { InvalidTemporaryKeyError, InvalidExternalUserTokenError, InvalidResultRecipientTokenError } = require('../../domain/errors');
+const { InvalidTemporaryKeyError, InvalidExternalUserTokenError, InvalidResultRecipientTokenError, InvalidSessionResultError } = require('../../domain/errors');
 const settings = require('../../config');
 
 function createAccessTokenFromUser(userId, source) {
@@ -76,6 +76,17 @@ function extractResultRecipientEmailAndSessionId(token) {
   };
 }
 
+function extractSessionId(token) {
+  const decoded = getDecodedToken(token);
+  if (!decoded.session_id) {
+    throw new InvalidSessionResultError();
+  }
+
+  return {
+    sessionId: decoded.session_id,
+  };
+}
+
 function extractUserId(token) {
   const decoded = getDecodedToken(token);
   return decoded.user_id || null;
@@ -115,6 +126,7 @@ module.exports = {
   extractPayloadFromPoleEmploiIdToken,
   extractResultRecipientEmailAndSessionId,
   extractSamlId,
+  extractSessionId,
   extractTokenFromAuthChain,
   extractUserId,
   extractUserIdForCampaignResults,

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -23,12 +23,20 @@ function createIdTokenForUserReconciliation(externalUser) {
   }, settings.authentication.secret, { expiresIn: settings.authentication.tokenForStudentReconciliationLifespan });
 }
 
-function createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration }) {
+function createCertificationResultsByRecipientEmailLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration }) {
   return jsonwebtoken.sign({
     session_id: sessionId,
     result_recipient_email: resultRecipientEmail,
   }, settings.authentication.secret, {
     expiresIn: `${daysBeforeExpiration}d`,
+  });
+}
+
+function createCertificationResultsLinkToken({ sessionId }) {
+  return jsonwebtoken.sign({
+    session_id: sessionId,
+  }, settings.authentication.secret, {
+    expiresIn: '30d',
   });
 }
 
@@ -120,7 +128,8 @@ module.exports = {
   createAccessTokenFromUser,
   createTokenForCampaignResults,
   createIdTokenForUserReconciliation,
-  createCertificationResultLinkToken,
+  createCertificationResultsByRecipientEmailLinkToken,
+  createCertificationResultsLinkToken,
   decodeIfValid,
   extractExternalUserFromIdToken,
   extractPayloadFromPoleEmploiIdToken,

--- a/api/lib/domain/services/token-service.js
+++ b/api/lib/domain/services/token-service.js
@@ -32,11 +32,11 @@ function createCertificationResultsByRecipientEmailLinkToken({ sessionId, result
   });
 }
 
-function createCertificationResultsLinkToken({ sessionId }) {
+function createCertificationResultsLinkToken({ sessionId, daysBeforeExpiration }) {
   return jsonwebtoken.sign({
     session_id: sessionId,
   }, settings.authentication.secret, {
-    expiresIn: '30d',
+    expiresIn: `${daysBeforeExpiration}d`,
   });
 }
 

--- a/api/tests/acceptance/application/session/session-controller-generate-session-results-download-link_test.js
+++ b/api/tests/acceptance/application/session/session-controller-generate-session-results-download-link_test.js
@@ -1,0 +1,57 @@
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | session-controller-generate-session-results-download-link', () => {
+
+  let server;
+
+  const sessionId = 121;
+  const options = {
+    method: 'GET',
+    url: `/api/admin/sessions/${sessionId}/generate-results-download-link`,
+    payload: { },
+  };
+
+  beforeEach(async () => {
+    server = await createServer();
+    await insertUserWithRolePixMaster();
+  });
+
+  describe('GET /api/admin/sessions/{id}/generate-results-download-link', () => {
+    context('when user is Pix Master', () => {
+      it('should return a 200 status code response', async () => {
+        databaseBuilder.factory.buildSession({ id: sessionId });
+        await databaseBuilder.commit();
+
+        // when
+        options.headers = { authorization: generateValidRequestAuthorizationHeader() };
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when user is not PixMaster', () => {
+      it('should return 403 HTTP status code', async () => {
+        // when
+        options.headers = { authorization: generateValidRequestAuthorizationHeader(1111) };
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+
+    context('when user is not connected', () => {
+      it('should return 401 HTTP status code if user is not authenticated', async () => {
+        // when
+        options.headers = {};
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(401);
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/session/session-controller-get-session-results-to-download_test.js
+++ b/api/tests/acceptance/application/session/session-controller-get-session-results-to-download_test.js
@@ -1,0 +1,52 @@
+const { expect, databaseBuilder } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const jsonwebtoken = require('jsonwebtoken');
+const settings = require('../../../../lib/config');
+
+describe('Acceptance | Controller | session-controller-get-session-results-to-download', () => {
+
+  describe('GET /api/sessions/download-all-results/{token}', function() {
+
+    context('when a valid token is given', () => {
+
+      it('should return 200 HTTP status code', async () => {
+        // given
+        const server = await createServer();
+
+        const dbf = databaseBuilder.factory;
+
+        const session = dbf.buildSession({ date: '2020/01/01', time: '12:00' });
+        const sessionId = session.id;
+
+        const candidate1 = dbf.buildCertificationCandidate({ sessionId, resultRecipientEmail: 'recipientEmail@example.net' });
+        const candidate2 = dbf.buildCertificationCandidate({ sessionId, resultRecipientEmail: 'recipientEmail@example.net' });
+
+        const certif1 = dbf.buildCertificationCourse({ sessionId: candidate1.sessionId, userId: candidate1.userId, lastName: candidate1.lastName, birthdate: candidate1.birthdate, createdAt: candidate1.createdAt });
+        const certif2 = dbf.buildCertificationCourse({ sessionId: candidate2.sessionId, userId: candidate2.userId, lastName: candidate2.lastName, birthdate: candidate2.birthdate, createdAt: candidate2.createdAt });
+
+        const assessmentId1 = dbf.buildAssessment({ certificationCourseId: certif1.id }).id;
+        dbf.buildAssessment({ certificationCourseId: certif2.id });
+
+        dbf.buildAssessmentResult({ assessmentId: assessmentId1, createdAt: new Date('2018-04-15T00:00:00Z') });
+
+        const token = jsonwebtoken.sign({
+          session_id: sessionId,
+        }, settings.authentication.secret, { expiresIn: '30d' });
+
+        const request = {
+          method: 'GET',
+          url: `/api/sessions/download-all-results/${token}`,
+          payload: {},
+        };
+
+        await databaseBuilder.commit();
+
+        // when
+        const response = await server.inject(request);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -78,7 +78,7 @@ describe('Unit | Service | MailService', () => {
       const certificationCenterName = 'Vincennes';
       const resultRecipientEmail = 'email1@example.net';
       const daysBeforeExpiration = 30;
-      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultLinkToken');
+      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultsByRecipientEmailLinkToken');
       tokenServiceStub.withArgs({ sessionId, resultRecipientEmail, daysBeforeExpiration }).returns('token-1');
       const link = 'https://pix.app.org/api/sessions/download-results/token-1';
       const expectedOptions = {

--- a/api/tests/unit/domain/services/session-results-link-service_test.js
+++ b/api/tests/unit/domain/services/session-results-link-service_test.js
@@ -1,0 +1,23 @@
+
+const { expect, sinon } = require('../../../test-helper');
+const sessionResultsLinkService = require('../../../../lib/domain/services/session-results-link-service');
+const tokenService = require('../../../../lib/domain/services/token-service');
+
+describe('Unit | Domain | Service | Session Results Link Service', () => {
+
+  describe('#generateResultsLink', () => {
+
+    it('should return a valid download link', () => {
+      // given
+      const tokenServiceStub = sinon.stub(tokenService, 'createCertificationResultsLinkToken');
+      tokenServiceStub.withArgs({ sessionId: 12345, daysBeforeExpiration: 30 }).returns('a_valid_token');
+
+      // when
+      const link = sessionResultsLinkService.generateResultsLink(12345);
+
+      // then
+      expect(link).to.deep.equal('https://app.pix.org/api/sessions/download-all-results/a_valid_token');
+    });
+  });
+
+});

--- a/api/tests/unit/domain/services/token-service_test.js
+++ b/api/tests/unit/domain/services/token-service_test.js
@@ -292,7 +292,7 @@ describe('Unit | Domain | Service | Token Service', () => {
 
   });
 
-  describe('#createCertificationResultLinkToken', () => {
+  describe('#createCertificationResultsByRecipientEmailLinkToken', () => {
     it('should return a valid token with sessionId and resultRecipientEmail', () => {
       // given
       const sessionId = 'abcd1234';
@@ -304,7 +304,25 @@ describe('Unit | Domain | Service | Token Service', () => {
       };
 
       // when
-      const linkToken = tokenService.createCertificationResultLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
+      const linkToken = tokenService.createCertificationResultsByRecipientEmailLinkToken({ sessionId, resultRecipientEmail, daysBeforeExpiration });
+
+      // then
+      const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);
+      expect(omit(decodedToken, ['iat', 'exp'])).to.deep.equal(expectedTokenAttributes);
+    });
+  });
+
+  describe('#createCertificationResultsLinkToken', () => {
+    it('should return a valid token with sessionId and resultRecipientEmail', () => {
+      // given
+      const sessionId = 'abcd1234';
+      const daysBeforeExpiration = 30;
+      const expectedTokenAttributes = {
+        'session_id': 'abcd1234',
+      };
+
+      // when
+      const linkToken = tokenService.createCertificationResultsLinkToken({ sessionId, daysBeforeExpiration });
 
       // then
       const decodedToken = jsonwebtoken.verify(linkToken, settings.authentication.secret);


### PR DESCRIPTION
## :unicorn: Problème
Lorsque les fonctionnalités de l'épix “Envoi auto des résultats aux prescripteurs” seront activées, les résultats de certification seront envoyés automatiquement à la publication d’une session aux destinataires renseignés lors de la création de la session.

Pour différentes raisons (mail tombé dans les spam, mauvaise adresse mail renseignée, oubli de renseigner le champ “Destinataire des résultats”, etc.) il peut être nécessaire de renvoyer les résultats de certification à la demande d’un utilisateur.

## :robot: Solution
Dans un premier temps, le pôle certif estime que dans la majorité des cas, il y aura 1 destinataire pour la session dans son ensemble. Il s’agit donc de faciliter le renvoi manuel du mail des résultats de certification : 

- Dans Pix Admin > page de détails d’une session : ajouter un nouveau bouton Générer un lien sous le bouton “Copier le lien de téléchargement” : il copie dans le presse papier de l'utilisateur, le lien de téléchargement du fichier CSV des résultats de la session

TODO:
- [x] Test unitaire du controller `session.getSessionResultsByRecipientEmail`(oublié dans une PR précédente)
- [x] Test unitaire du controller `session.getSessionResultsToDownload` (ajouté dans cette PR)
- [x] Tests d'acceptance du bouton côté front

## :rainbow: Remarques
_RAS_

## :100: Pour tester
- Se connecter dans pix Admin
- Aller sur la page de détail d'une session
- Cliquer sur le bouton 'Copier le lien de téléchargement'
- Utiliser ce lien pour télécharger le fichier csv de résultats de la session
