### PR TITLE
[TECH] Rendre les tests de target-profile-repository déterministes.

### DIFF
--- a/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-with-learning-content-repository_test.js
@@ -203,7 +203,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id });
 
       // then
-      expect(targetProfile.badges).to.deep.equal([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
+      expect(targetProfile.badges).to.have.deep.members([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
     });
 
     it('should return target profile stages', async () => {
@@ -251,7 +251,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.get({ id: targetProfileDB.id });
 
       // then
-      expect(targetProfile.stages).to.deep.equal([ stage1, stage2 ]);
+      expect(targetProfile.stages).to.have.deep.members([ stage1, stage2 ]);
     });
 
     it('should return target profile filled with objects with appropriate translation', async () => {
@@ -527,7 +527,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
 
       // then
-      expect(targetProfile.stages).to.deep.equal([ stage1, stage2 ]);
+      expect(targetProfile.stages).to.have.deep.members([ stage1, stage2 ]);
     });
 
     it('should return target profile badges without imageUrl', async () => {
@@ -576,7 +576,7 @@ describe('Integration | Repository | Target-profile-with-learning-content', () =
       const targetProfile = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
 
       // then
-      expect(targetProfile.badges).to.deep.equal([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
+      expect(targetProfile.badges).to.have.deep.members([ { ...badge1, imageUrl: null }, { ...badge2, imageUrl: null } ]);
     });
 
     it('should return target profile filled with objects with appropriate translation', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Le test de `target-profile-with-learning-content-repository_test.js` [sort en erreur](https://app.circleci.com/pipelines/github/1024pix/pix/21067/workflows/7c64733f-b922-41b9-ba30-ba8cb08c0eef/jobs/177006) car les éléments comparés ne sont pas ordonnés

## :robot: Solution
Utiliser un opérateur de comparaison non sensible à l'ordre

## :100: Pour tester
Vérifier que la CI passe, et l'avenir nous dira la suite !
