### PR TITLE
[TECH] Mettre le composant PixIconButton partout dans PixOrga (PIX-2138).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -39,7 +39,7 @@ when(`je recherche une campagne avec le nom {string}`, (campaignSearchName) => {
 });
 
 then(`je vois le détail de la campagne {string}`, (campaignName) => {
-  cy.get('.page__title').should('contain', campaignName);
+  cy.get('[aria-label="Nom de la campagne"]').contains(campaignName);
 });
 
 then(`je vois {int} participants`, (numberOfParticipants) => {

--- a/orga/app/components/chevron.hbs
+++ b/orga/app/components/chevron.hbs
@@ -1,7 +1,8 @@
-  <button type="button" class="icon-button" {{on 'click' @toggleParent}} aria-expanded="{{@isOpen}}">
-    {{#if @isOpen}}
-      <FaIcon @icon="chevron-up" />
-    {{else}}
-      <FaIcon @icon="chevron-down" />
-    {{/if}}
-  </button>
+<PixIconButton
+  @icon="{{if @isOpen 'chevron-up' 'chevron-down'}}"
+  aria-expanded="{{@isOpen}}"
+  @triggerAction={{@toggleParent}}
+  @withBackground={{false}}
+  @size="small"
+  @color="dark-grey"
+/>

--- a/orga/app/components/dropdown/icon-trigger.hbs
+++ b/orga/app/components/dropdown/icon-trigger.hbs
@@ -1,14 +1,12 @@
 <div id="icon-trigger" class="dropdown" ...attributes>
-  <button 
-    type="button"
-    class="button button--round-with-icon {{@dropdownButtonClass}}"
-    aria-haspopup="listbox"
-    aria-expanded="{{this.display}}"
+  <PixIconButton
+    @icon={{@icon}}
     aria-label="Afficher les actions"
-    {{on 'click' this.toggle}}
-  >
-    <FaIcon @icon={{@icon}} />
-  </button>
+    class="{{@dropdownButtonClass}}"
+    @triggerAction={{this.toggle}}
+    @size="small"
+    @color="dark-grey"
+  />
   <Dropdown::Content @display={{this.display}} @close={{this.close}} class="{{@dropdownContentClass}}" aria-label="Actions">
     {{yield}}
   </Dropdown::Content>

--- a/orga/app/components/manage-authentication-method-modal.hbs
+++ b/orga/app/components/manage-authentication-method-modal.hbs
@@ -42,7 +42,7 @@
                   @clipboardText={{@student.email}}
                   @success={{this.clipboardSuccessEmail}}
                   {{ on 'mouseout' this.clipboardOutEmail}}
-                  @classNames="icon-button manage-authentication-window__clipboard-button">
+                  @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
                   <FaIcon @icon="copy" @prefix="far" />
                 </CopyButton>
               </PixTooltip>
@@ -89,7 +89,7 @@
                       @clipboardText={{@student.username}}
                       @success={{this.clipboardSuccessUsername}}
                       {{ on 'mouseout' this.clipboardOutUsername}}
-                      @classNames="icon-button manage-authentication-window__clipboard-button">
+                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
                       <FaIcon @icon="copy" @prefix="far" />
                     </CopyButton>
                   </PixTooltip>
@@ -127,7 +127,7 @@
                       @clipboardText={{this.generatedPassword}}
                       @success={{this.clipboardSuccessGeneratedPassword}}
                       {{on 'mouseout' this.clipboardOutGeneratedPassword}}
-                      @classNames="icon-button manage-authentication-window__clipboard-button">
+                      @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey manage-authentication-window__clipboard-button">
                       <FaIcon @icon="copy" @prefix="far" class="fa-inverse" />
                     </CopyButton>
                   </PixTooltip>

--- a/orga/app/components/modal/dialog.hbs
+++ b/orga/app/components/modal/dialog.hbs
@@ -12,9 +12,13 @@
         <h2 class="modal-header__title" id={{this.labelId}}>
           {{@title}}
         </h2>
-        <button class="modal-header__icon icon-button" aria-label="Fermer la fenêtre" type="button" {{on 'click' @close}}>
-          <FaIcon @icon='times'></FaIcon>
-        </button>
+        <PixIconButton
+          @icon="times"
+          aria-label="Fermer la fenêtre"
+          @triggerAction={{@close}}
+          @withBackground={{false}}
+          class="modal-header__icon"
+        />
       </div>
       <div>
         {{yield}}

--- a/orga/app/components/pagination-control.hbs
+++ b/orga/app/components/pagination-control.hbs
@@ -31,7 +31,7 @@
       />
     </div>
     <div>
-      {{t 'common.pagination.page-number' current=this.currentPage total=this.pageCount}}
+      {{t 'common.pagination.page-number' current=this.currentPage total=(if this.pageCount this.pageCount 1)}}
     </div>
     <div class="page-navigation__arrow page-navigation__arrow--next">
       <PixIconButton
@@ -41,8 +41,8 @@
         @withBackground={{false}}
         @size="small"
         @color="dark-grey"
-        disabled={{eq this.currentPage this.pageCount}}
-        aria-disabled="{{eq this.currentPage this.pageCount}}"
+        disabled={{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}
+        aria-disabled="{{or (eq this.currentPage this.pageCount) (eq this.pageCount 0)}}"
       />
     </div>
   </div>

--- a/orga/app/components/pagination-control.hbs
+++ b/orga/app/components/pagination-control.hbs
@@ -18,30 +18,32 @@
     </div>
   </div>
   <div class="page-navigation">
-    <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq this.currentPage 1) "page-navigation__arrow--disabled"}}">
-      <LinkTo
+    <div class="page-navigation__arrow page-navigation__arrow--previous">
+      <PixIconButton
+        @icon="arrow-left"
         aria-label={{t 'common.pagination.action.previous'}}
-        @query={{hash pageNumber=this.previousPage}}
-        @disabledWhen={{eq this.currentPage 1}}
-        @replace={{true}}
-        class="icon-button icon-button--link"
-      >
-        <FaIcon @icon='arrow-left'></FaIcon>
-      </LinkTo>
+        @triggerAction={{this.goToPreviousPage}}
+        @withBackground={{false}}
+        @size="small"
+        @color="dark-grey"
+        disabled={{eq this.currentPage 1}}
+        aria-disabled="{{eq this.currentPage 1}}"
+      />
     </div>
     <div>
       {{t 'common.pagination.page-number' current=this.currentPage total=this.pageCount}}
     </div>
-    <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq this.currentPage this.pageCount) "page-navigation__arrow--disabled"}}">
-      <LinkTo
+    <div class="page-navigation__arrow page-navigation__arrow--next">
+      <PixIconButton
+        @icon="arrow-right"
         aria-label={{t 'common.pagination.action.next'}}
-        @query={{hash pageNumber=this.nextPage}}
-        @disabledWhen={{eq this.currentPage this.pageCount}}
-        @replace={{true}}
-        class="icon-button icon-button--link"
-      >
-        <FaIcon @icon='arrow-right'></FaIcon>
-      </LinkTo>
+        @triggerAction={{this.goToNextPage}}
+        @withBackground={{false}}
+        @size="small"
+        @color="dark-grey"
+        disabled={{eq this.currentPage this.pageCount}}
+        aria-disabled="{{eq this.currentPage this.pageCount}}"
+      />
     </div>
   </div>
 </div>

--- a/orga/app/components/pagination-control.js
+++ b/orga/app/components/pagination-control.js
@@ -30,4 +30,14 @@ export default class PaginationControl extends Component {
   changePageSize(event) {
     this.router.replaceWith({ queryParams: { pageSize: event.target.value, pageNumber: 1 } });
   }
+
+  @action
+  goToNextPage() {
+    this.router.replaceWith({ queryParams: { pageNumber: this.nextPage } });
+  }
+
+  @action
+  goToPreviousPage() {
+    this.router.replaceWith({ queryParams: { pageNumber: this.previousPage } });
+  }
 }

--- a/orga/app/components/previous-page-button.hbs
+++ b/orga/app/components/previous-page-button.hbs
@@ -1,12 +1,13 @@
 <div class="previous-page-button">
-  <LinkTo
-    @route={{@route}}
-    @model={{@routeId}}
-    class="icon-button previous-page-button__return-button"
+  <PixIconButton
+    @icon="arrow-left"
     aria-label={{@ariaLabel}}
-  >
-    <FaIcon @icon='arrow-left'></FaIcon>
-  </LinkTo>
+    class="previous-page-button__return-button"
+    @triggerAction={{this.goToPage}}
+    @withBackground={{false}}
+    @size="small"
+    @color="dark-grey"
+  />
   <h1 class="back-title">
     {{yield}}
   </h1>

--- a/orga/app/components/previous-page-button.hbs
+++ b/orga/app/components/previous-page-button.hbs
@@ -1,14 +1,14 @@
 <div class="previous-page-button">
   <PixIconButton
     @icon="arrow-left"
-    aria-label={{@ariaLabel}}
+    aria-label={{@backButtonAriaLabel}}
     class="previous-page-button__return-button"
     @triggerAction={{this.goToPage}}
     @withBackground={{false}}
     @size="small"
     @color="dark-grey"
   />
-  <h1 class="back-title">
+  <h1 class="back-title" ...attributes>
     {{yield}}
   </h1>
 </div>

--- a/orga/app/components/previous-page-button.js
+++ b/orga/app/components/previous-page-button.js
@@ -7,6 +7,10 @@ export default class PreviousPageButton extends Component {
 
   @action
   goToPage() {
-    this.router.transitionTo(this.args.route, this.args.routeId);
+    if (this.args.routeId) {
+      this.router.transitionTo(this.args.route, this.args.routeId);
+    } else {
+      this.router.transitionTo(this.args.route);
+    }
   }
 }

--- a/orga/app/components/previous-page-button.js
+++ b/orga/app/components/previous-page-button.js
@@ -1,0 +1,12 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class PreviousPageButton extends Component {
+  @service router;
+
+  @action
+  goToPage() {
+    this.router.transitionTo(this.args.route, this.args.routeId);
+  }
+}

--- a/orga/app/components/routes/authenticated/campaign/analysis/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tab.js
@@ -8,7 +8,9 @@ export default class Tab extends Component {
 
   constructor() {
     super(...arguments);
-    this.sortedRecommendations = this.args.campaignTubeRecommendations.sortBy('averageScore');
+    this.sortedRecommendations = this.args.campaignTubeRecommendations
+      ? this.args.campaignTubeRecommendations.sortBy('averageScore')
+      : [];
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -3,7 +3,8 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.assessments"
      @routeId={{@campaign.id}}
-     @ariaLabel="Retourner au détail de la campagne"
+     @backButtonAriaLabel="Retourner au détail de la campagne"
+     aria-label="Nom de la campagne"
    >
     {{@campaign.name}}
    </PreviousPageButton>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.hbs
@@ -26,7 +26,7 @@
               @clipboardText={{this.campaignsRootUrl}}
               @success={{this.clipboardSuccess}}
               {{on 'mouseLeave' this.clipboardOut}}
-              @classNames="icon-button campaign-details-content__clipboard-button">
+              @classNames="pix-icon-button pix-icon-button--small pix-icon-button--dark-grey campaign-details-content__clipboard-button">
               <FaIcon @icon='copy' @prefix='far'/>
             </CopyButton>
           </PixTooltip>

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -3,7 +3,8 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.profiles"
      @routeId={{@campaign.id}}
-     @ariaLabel="Retourner au détail de la campagne"
+     @backButtonAriaLabel="Retourner au détail de la campagne"
+     aria-label="Nom de la campagne"
    >
     {{@campaign.name}}
    </PreviousPageButton>

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -1,10 +1,12 @@
 <div class="campaign-details-page">
   <div class="campaign-details__header">
     <div class="campaign-details-header__headline">
-      <LinkTo aria-label="Retour" @route="authenticated.campaigns" class="icon-button campaign-details-header__return-button">
-        <FaIcon @icon='arrow-left'></FaIcon>
-      </LinkTo>
-      <h1 class="page__title page-title campaign-details-header__title">{{@campaign.name}}</h1>
+      <PreviousPageButton
+        @route="authenticated.campaigns"
+        @ariaLabel="Retour"
+      >
+        {{@campaign.name}}
+      </PreviousPageButton>
     </div>
 
     <div class="campaign-details-header__report">

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -3,7 +3,8 @@
     <div class="campaign-details-header__headline">
       <PreviousPageButton
         @route="authenticated.campaigns"
-        @ariaLabel="Retour"
+        @backButtonAriaLabel="Retour"
+        aria-label="Nom de la campagne"
       >
         {{@campaign.name}}
       </PreviousPageButton>

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -36,10 +36,14 @@
         <button id='save-organization-role' type="button" class="button button--thin" {{on 'click' (fn this.updateRoleOfMember @membership)}}>
           Enregistrer
         </button>
-        <button aria-label="Annuler" id='cancel-update-organization-role' type="button" class="button button--round-with-icon"
-          {{on 'click' this.cancelUpdateRoleOfMember}}>
-          <FaIcon @icon='times'></FaIcon>
-        </button>
+        <PixIconButton
+          @icon="times"
+          id='cancel-update-organization-role'
+          aria-label="Annuler"
+          @triggerAction={{this.cancelUpdateRoleOfMember}}
+          @withBackground={{false}}
+          @color="dark-grey"
+        />
       </div>
     </td>
   {{/if}}

--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -44,13 +44,13 @@
           @autocomplete="current-password"
           @required='true'
         />
-        <button type="button" aria-label="rendre le mot de passe lisible" class="input-password__icon" {{on 'click' this.togglePasswordVisibility}} >
-           {{#if this.isPasswordVisible}}
-             <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}><FaIcon @icon='eye' @class="fa-fw input-password-icon__eye"></FaIcon></div>
-           {{else}}
-             <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}><FaIcon @icon='eye-slash' @class="fa-fw input-password-icon__eye"></FaIcon></div>
-          {{/if}}
-        </button>
+        <PixIconButton
+          @icon="{{if this.isPasswordVisible 'eye' 'eye-slash'}}"
+          aria-label="rendre le mot de passe lisible"
+          @triggerAction={{this.togglePasswordVisibility}}
+          @withBackground={{false}}
+          @color="dark-grey"
+        />
       </div>
     </div>
 

--- a/orga/app/components/routes/register-form.hbs
+++ b/orga/app/components/routes/register-form.hbs
@@ -64,17 +64,13 @@
           @autocomplete="current-password"
           {{on "focusout" (fn this.validateInput "password" this.user.password)}}
         />
-        <button type="button" aria-label="rendre le mot de passe lisible" class="input-password__icon" {{on 'click' this.togglePasswordVisibility}}>
-          {{#if this.isPasswordVisible}}
-            <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}>
-              <FaIcon @icon='eye' @class="fa-fw input-password-icon__eye"></FaIcon>
-            </div>
-          {{else}}
-            <div tabindex="-1" {{on 'mousedown' this.togglePasswordVisibility}}>
-              <FaIcon @icon='eye-slash' @class="fa-fw input-password-icon__eye"></FaIcon>
-            </div>
-          {{/if}}
-        </button>
+        <PixIconButton
+          @icon="{{if this.isPasswordVisible 'eye' 'eye-slash'}}"
+          aria-label="rendre le mot de passe lisible"
+          @triggerAction={{this.togglePasswordVisibility}}
+          @withBackground={{false}}
+          @color="dark-grey"
+        />
       </div>
     </div>
 

--- a/orga/app/components/table/header-sort.hbs
+++ b/orga/app/components/table/header-sort.hbs
@@ -1,14 +1,15 @@
 <Table::Header @size={{@size}} @align={{@align}} aria-sort={{this.order}} ...attributes>
-  <span class={{unless @isDisabled "table__column--clickable"}} role={{unless @isDisabled "button"}} {{on "click" this.toggleSort}}>
+  <span class="table__column--sort">
     {{yield}}
     {{#unless @isDisabled}}
-      <span class="icon-button column__icon">
-        {{#if (eq this.order "asc")}}
-          <FaIcon @icon="arrow-up" />
-        {{else}}
-          <FaIcon @icon="arrow-down" />
-        {{/if}}
-      </span>
+      <PixIconButton
+        @icon="{{if (eq this.order "asc") 'arrow-up' 'arrow-down'}}"
+        @triggerAction={{this.toggleSort}}
+        @withBackground={{false}}
+        @size="small"
+        @color="dark-grey"
+        aria-label="Trier par pertinence"
+      />
     {{/unless}}
   </span>
 </Table::Header>

--- a/orga/app/styles/components/modal.scss
+++ b/orga/app/styles/components/modal.scss
@@ -40,9 +40,6 @@
           position: absolute;
           right: 32px;
           top: 32px;
-          color: $grey-45;
-          font-size: 1.5rem;
-          padding: 3px 9px;
         }
       }
 

--- a/orga/app/styles/components/pagination-control.scss
+++ b/orga/app/styles/components/pagination-control.scss
@@ -49,15 +49,6 @@
   align-items: center;
 
   &__arrow {
-    &--disabled .icon-button{
-      color: $grey-22;
-      cursor: default;
-
-      &.icon-button:hover, &.icon-button:active {
-        background-color: transparent;
-      }
-    }
-
     &--previous {
       margin-right: 8px;
     }

--- a/orga/app/styles/globals/buttons.scss
+++ b/orga/app/styles/globals/buttons.scss
@@ -23,7 +23,7 @@
 
   &:disabled {
     background-color: $grey-30;
-    
+
     &:hover, &:active, &:focus {
       cursor: default;
       background-color: $grey-30;
@@ -96,50 +96,10 @@
   &--link {
     text-decoration: none;
   }
-
-  &--round-with-icon {
-    background-color: $white;
-    border-radius: 17px;
-    color: $grey-60;
-    font-size: 1.4rem;
-    height: 34px;
-    line-height: 34px;
-    padding: 1px 6px;
-    width: 34px;
-
-    &:hover {
-      background-color: $grey-10;
-    }
-
-    &:focus, &:active, &:visited {
-      background-color: $grey-20;
-    }
-  }
-
 }
 
 .loader-in-button {
   display: flex;
   background: url('/images/loader-white.svg') no-repeat center;
   background-size: 50px;
-}
-
-.icon-button {
-  color: $grey-60;
-  padding: 6px 8px;
-  border: none;
-  font-size: 1rem;
-  background-color: transparent;
-  cursor: pointer;
-  outline: none;
-
-  &:hover, &:active {
-    background-color: $grey-20;
-    border-radius: 16px;
-    transition: background-color 0.2s ease;
-  }
-
-  &--link {
-    text-decoration: none;
-  }
 }

--- a/orga/app/styles/globals/forms.scss
+++ b/orga/app/styles/globals/forms.scss
@@ -101,29 +101,6 @@
       display: none;
     }
   }
-
-  &__icon {
-    height: 20px;
-    width: 38px;
-    display: flex;
-    border: none;
-    background: none;
-    padding: 0;
-  }
-
-  &-icon {
-    &__eye {
-      color: $grey-60;
-      transition: .5s;
-      font-size: 1.1rem;
-      margin-top: 2px;
-
-      &:hover {
-        color: $grey-100;
-        cursor: pointer;
-      }
-    }
-  }
 }
 
 .textarea {

--- a/orga/app/styles/globals/tables.scss
+++ b/orga/app/styles/globals/tables.scss
@@ -100,10 +100,12 @@ th::first-letter {
     text-overflow: ellipsis;
   }
 
-  &--clickable {
-    cursor: pointer;
+  &--sort {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
-    &--icon {
+    .pix-icon-button {
       margin-left: 8px;
     }
   }
@@ -111,11 +113,6 @@ th::first-letter {
   &--highlight {
     color: $grey-80;
   }
-}
-
-.column__icon {
-  font-size: 0.9rem;
-  color: inherit;
 }
 
 .table__row {

--- a/orga/app/styles/pages/authenticated/campaigns/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details.scss
@@ -37,10 +37,6 @@
   &__title {
     margin-bottom: 10px;
   }
-
-  &__return-button {
-    margin-right: 6px;
-  }
 }
 
 .campaign-details-header-report {

--- a/orga/app/styles/pages/authenticated/campaigns/details/details.scss
+++ b/orga/app/styles/pages/authenticated/campaigns/details/details.scss
@@ -54,11 +54,6 @@
     flex-direction: row;
   }
 
-  &__return-button {
-    margin-bottom: 10px;
-    margin-right: 6px;
-  }
-
   &__clipboard-button {
     margin: -10px 6px 0 6px;
   }

--- a/orga/app/styles/pages/authenticated/students/list.scss
+++ b/orga/app/styles/pages/authenticated/students/list.scss
@@ -53,7 +53,6 @@ $margin-right: 32px;
   }
 
   &__dropdown-button {
-    font-size: 1.1rem;
     margin-right: $margin-right;
   }
 

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26183,8 +26183,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#f76816f408c58a7b0052914f618c2822caa34a1b",
-      "from": "git://github.com/1024pix/pix-ui.git#v2.2.0",
+      "version": "git://github.com/1024pix/pix-ui.git#dd58e0738b9627223b3093c7ae36cdc7c73d2919",
+      "from": "git://github.com/1024pix/pix-ui.git#v3.0.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/orga/package.json
+++ b/orga/package.json
@@ -88,7 +88,7 @@
     "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.2.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.0.0",
     "query-string": "^6.13.6",
     "qunit-dom": "^1.6.0",
     "sass": "^1.27.0"

--- a/orga/tests/integration/components/pagination-control-test.js
+++ b/orga/tests/integration/components/pagination-control-test.js
@@ -7,8 +7,7 @@ import Service from '@ember/service';
 import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import fillInByLabel from '../../helpers/extended-ember-test-helpers/fill-in-by-label';
 
-function getMetaForPage(pageNumber) {
-  const rowCount = 50;
+function getMetaForPage({ pageNumber, rowCount = 50 }) {
   const pageSize = 25;
   return {
     page: pageNumber,
@@ -30,9 +29,20 @@ module('Integration | Component | pagination-control', function(hooks) {
     this.owner.register('service:router', RouterStub);
   });
 
+  test('it should display correct pagination', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage({ pageNumber: 1}));
+
+    // when
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // then
+    assert.contains('Page 1 / 2');
+  });
+
   test('it should disable previous button when user is on first page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(1));
+    this.set('meta', getMetaForPage({ pageNumber: 1 }));
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -43,7 +53,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should disable next button when user is on last page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.set('meta', getMetaForPage({ pageNumber: 2 }));
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -52,9 +62,20 @@ module('Integration | Component | pagination-control', function(hooks) {
     assert.dom('[aria-label="Aller à la page suivante"]').hasAttribute('disabled');
   });
 
+  test('it should enable next button when user is on first page', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage({ pageNumber: 1 }));
+
+    // when
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // then
+    assert.dom('[aria-label="Aller à la page suivante"]').hasNoAttribute('disabled');
+  });
+
   test('it should enable previous button when user is on second page', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.set('meta', getMetaForPage({ pageNumber: 2 }));
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
@@ -65,7 +86,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should re-route to next page when clicking on next page button', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(1));
+    this.set('meta', getMetaForPage({ pageNumber: 1 }));
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // when
@@ -77,7 +98,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should re-route to previous page when clicking on previous page button', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.set('meta', getMetaForPage({ pageNumber: 2 }));
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // when
@@ -89,7 +110,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should re-route to page with changed page size', async function(assert) {
     // given
-    this.set('meta', getMetaForPage(2));
+    this.set('meta', getMetaForPage({ pageNumber: 2 }));
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // when
@@ -99,4 +120,28 @@ module('Integration | Component | pagination-control', function(hooks) {
     assert.ok(replaceWithStub.calledWith({ queryParams: { pageSize: '10', pageNumber: 1 } }));
   });
 
+  module('When no results', function() {
+    test('it should disable previous button and next button', async function(assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 0 }));
+
+      // when
+      await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.dom('[aria-label="Aller à la page précédente"]').hasAttribute('disabled');
+      assert.dom('[aria-label="Aller à la page suivante"]').hasAttribute('disabled');
+    });
+
+    test('it should display default pagination', async function(assert) {
+      // given
+      this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 0 }));
+
+      // when
+      await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+      // then
+      assert.contains('Page 1 / 1');
+    });
+  });
 });

--- a/orga/tests/integration/components/pagination-control-test.js
+++ b/orga/tests/integration/components/pagination-control-test.js
@@ -1,7 +1,11 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import Service from '@ember/service';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
+import fillInByLabel from '../../helpers/extended-ember-test-helpers/fill-in-by-label';
 
 function getMetaForPage(pageNumber) {
   const rowCount = 50;
@@ -15,7 +19,16 @@ function getMetaForPage(pageNumber) {
 }
 
 module('Integration | Component | pagination-control', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
+  let replaceWithStub;
+
+  hooks.beforeEach(function() {
+    replaceWithStub = sinon.stub();
+    class RouterStub extends Service {
+      replaceWith = replaceWithStub;
+    }
+    this.owner.register('service:router', RouterStub);
+  });
 
   test('it should disable previous button when user is on first page', async function(assert) {
     // given
@@ -25,8 +38,7 @@ module('Integration | Component | pagination-control', function(hooks) {
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // then
-    assert.dom('.page-navigation__arrow--previous').hasClass('page-navigation__arrow--disabled');
-    assert.dom('.page-navigation__arrow--previous .icon-button').hasClass('disabled');
+    assert.dom('[aria-label="Aller à la page précédente"]').hasAttribute('disabled');
   });
 
   test('it should disable next button when user is on last page', async function(assert) {
@@ -37,8 +49,7 @@ module('Integration | Component | pagination-control', function(hooks) {
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // then
-    assert.dom('.page-navigation__arrow--next').hasClass('page-navigation__arrow--disabled');
-    assert.dom('.page-navigation__arrow--next .icon-button').hasClass('disabled');
+    assert.dom('[aria-label="Aller à la page suivante"]').hasAttribute('disabled');
   });
 
   test('it should enable previous button when user is on second page', async function(assert) {
@@ -49,8 +60,43 @@ module('Integration | Component | pagination-control', function(hooks) {
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);
 
     // then
-    assert.dom('.page-navigation__arrow--previous').hasNoClass('page-navigation__arrow--disabled');
-    assert.dom('.page-navigation__arrow--previous .icon-button').hasNoClass('disabled');
+    assert.dom('[aria-label="Aller à la page précédente"]').hasNoAttribute('disabled');
+  });
+
+  test('it should re-route to next page when clicking on next page button', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(1));
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // when
+    await clickByLabel('Aller à la page suivante');
+
+    // then
+    assert.ok(replaceWithStub.calledWith({ queryParams: { pageNumber: 2 } }));
+  });
+
+  test('it should re-route to previous page when clicking on previous page button', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(2));
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // when
+    await clickByLabel('Aller à la page précédente');
+
+    // then
+    assert.ok(replaceWithStub.calledWith({ queryParams: { pageNumber: 1 } }));
+  });
+
+  test('it should re-route to page with changed page size', async function(assert) {
+    // given
+    this.set('meta', getMetaForPage(2));
+    await render(hbs`<PaginationControl @pagination={{meta}}/>`);
+
+    // when
+    await fillInByLabel('Sélectionner une pagination', '10');
+
+    // then
+    assert.ok(replaceWithStub.calledWith({ queryParams: { pageSize: '10', pageNumber: 1 } }));
   });
 
 });

--- a/orga/tests/integration/components/pagination-control-test.js
+++ b/orga/tests/integration/components/pagination-control-test.js
@@ -31,7 +31,7 @@ module('Integration | Component | pagination-control', function(hooks) {
 
   test('it should display correct pagination', async function(assert) {
     // given
-    this.set('meta', getMetaForPage({ pageNumber: 1}));
+    this.set('meta', getMetaForPage({ pageNumber: 1 }));
 
     // when
     await render(hbs`<PaginationControl @pagination={{meta}}/>`);

--- a/orga/tests/integration/components/previous-page-button_test.js
+++ b/orga/tests/integration/components/previous-page-button_test.js
@@ -27,17 +27,31 @@ module('Integration | Component | previous-page-button', function(hooks) {
     assert.contains('Coucou');
   });
 
-  test('it should transition to specified route', async function(assert) {
-    // given
-    this.route = 'someRoute';
-    this.routeId = 'someRouteId';
-    await render(hbs`<PreviousPageButton @route={{this.route}} @routeId={{this.routeId}} @ariaLabel="Une instruction"></PreviousPageButton>`);
+  module('when clicked on', function() {
+    test('it should transition to specified route with provided routeId param if any', async function(assert) {
+      // given
+      this.route = 'someRoute';
+      this.routeId = 'someRouteId';
+      await render(hbs`<PreviousPageButton @route={{this.route}} @routeId={{this.routeId}} @ariaLabel="Une instruction"></PreviousPageButton>`);
 
-    // when
-    await clickByLabel('Une instruction');
+      // when
+      await clickByLabel('Une instruction');
 
-    // then
-    assert.ok(transitionToStub.calledWith(this.route, this.routeId));
+      // then
+      assert.ok(transitionToStub.calledWith(this.route, this.routeId));
+    });
+
+    test('it should transition to specified route without any params if no routeId param provided', async function(assert) {
+      // given
+      this.route = 'someRoute';
+      this.routeId = 'someRouteId';
+      await render(hbs`<PreviousPageButton @route={{this.route}} @ariaLabel="Une instruction"></PreviousPageButton>`);
+
+      // when
+      await clickByLabel('Une instruction');
+
+      // then
+      assert.ok(transitionToStub.calledWith(this.route));
+    });
   });
-
 });

--- a/orga/tests/integration/components/previous-page-button_test.js
+++ b/orga/tests/integration/components/previous-page-button_test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import sinon from 'sinon';
+import Service from '@ember/service';
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
+
+module('Integration | Component | previous-page-button', function(hooks) {
+  setupRenderingTest(hooks);
+  let transitionToStub;
+
+  hooks.beforeEach(function() {
+    transitionToStub = sinon.stub();
+    class RouterStub extends Service {
+      transitionTo = transitionToStub;
+    }
+    this.owner.register('service:router', RouterStub);
+  });
+
+  test('it should render button with yielded content', async function(assert) {
+    // when
+    await render(hbs`<PreviousPageButton @ariaLabel="Une instruction">Coucou</PreviousPageButton>`);
+
+    // then
+    assert.dom('[aria-label="Une instruction"]').exists();
+    assert.contains('Coucou');
+  });
+
+  test('it should transition to specified route', async function(assert) {
+    // given
+    this.route = 'someRoute';
+    this.routeId = 'someRouteId';
+    await render(hbs`<PreviousPageButton @route={{this.route}} @routeId={{this.routeId}} @ariaLabel="Une instruction"></PreviousPageButton>`);
+
+    // when
+    await clickByLabel('Une instruction');
+
+    // then
+    assert.ok(transitionToStub.calledWith(this.route, this.routeId));
+  });
+
+});

--- a/orga/tests/integration/components/previous-page-button_test.js
+++ b/orga/tests/integration/components/previous-page-button_test.js
@@ -18,12 +18,20 @@ module('Integration | Component | previous-page-button', function(hooks) {
     this.owner.register('service:router', RouterStub);
   });
 
-  test('it should render button with yielded content', async function(assert) {
+  test('it should render previous page button', async function(assert) {
     // when
-    await render(hbs`<PreviousPageButton @ariaLabel="Une instruction">Coucou</PreviousPageButton>`);
+    await render(hbs`<PreviousPageButton @backButtonAriaLabel="Une instruction"/>`);
 
     // then
     assert.dom('[aria-label="Une instruction"]').exists();
+  });
+
+  test('it should render with yielded content', async function(assert) {
+    // when
+    await render(hbs`<PreviousPageButton aria-label="Nom de la campagne">Coucou</PreviousPageButton>`);
+
+    // then
+    assert.dom('[aria-label="Nom de la campagne"]').containsText('Coucou');
     assert.contains('Coucou');
   });
 
@@ -32,7 +40,7 @@ module('Integration | Component | previous-page-button', function(hooks) {
       // given
       this.route = 'someRoute';
       this.routeId = 'someRouteId';
-      await render(hbs`<PreviousPageButton @route={{this.route}} @routeId={{this.routeId}} @ariaLabel="Une instruction"></PreviousPageButton>`);
+      await render(hbs`<PreviousPageButton @route={{this.route}} @routeId={{this.routeId}} @backButtonAriaLabel="Une instruction"></PreviousPageButton>`);
 
       // when
       await clickByLabel('Une instruction');
@@ -45,7 +53,7 @@ module('Integration | Component | previous-page-button', function(hooks) {
       // given
       this.route = 'someRoute';
       this.routeId = 'someRouteId';
-      await render(hbs`<PreviousPageButton @route={{this.route}} @ariaLabel="Une instruction"></PreviousPageButton>`);
+      await render(hbs`<PreviousPageButton @route={{this.route}} @backButtonAriaLabel="Une instruction"></PreviousPageButton>`);
 
       // when
       await clickByLabel('Une instruction');

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-import clickByLabel from '../../../../../../helpers/extended-ember-test-helpers/click-by-label';
+import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/analysis/tab', function(hooks) {
@@ -60,14 +59,14 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tab', f
     });
 
     test('it should order by recommendation asc', async function(assert) {
-      await clickByLabel('Pertinence');
+      await click('[aria-label="Trier par pertinence"]');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube B');
     });
 
     test('it should order by recommendation desc', async function(assert) {
-      await clickByLabel('Pertinence');
-      await clickByLabel('Pertinence');
+      await click('[aria-label="Trier par pertinence"]');
+      await click('[aria-label="Trier par pertinence"]');
 
       assert.dom('[aria-label="Sujet"]:first-child').containsText('Tube A');
     });

--- a/orga/tests/integration/components/tables/header-sort-test.js
+++ b/orga/tests/integration/components/tables/header-sort-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
-import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | Tables | header-sort', function(hooks) {
@@ -32,18 +31,10 @@ module('Integration | Component | Tables | header-sort', function(hooks) {
       assert.dom('[data-icon="arrow-down"]').exists();
     });
 
-    test('should be clickable', async function(assert) {
-      // when
-      await render(hbs`<Table::HeaderSort @isDisabled={{false}}>Header</Table::HeaderSort>`);
-
-      // then
-      assert.dom('[role="button"]').exists();
-    });
-
     test('should inverse arrow on click', async function(assert) {
       // when
       await render(hbs`<Table::HeaderSort @isDisabled={{false}} @onSort={{this.onSort}}>Header</Table::HeaderSort>`);
-      await clickByLabel('Header');
+      await click('[aria-label="Trier par pertinence"]');
 
       // then
       assert.ok(onSortStub.calledWith('asc'));
@@ -57,16 +48,7 @@ module('Integration | Component | Tables | header-sort', function(hooks) {
       await render(hbs`<Table::HeaderSort @isDisabled={{true}}>Header</Table::HeaderSort>`);
 
       // then
-      assert.dom('[data-icon="arrow-up"]').doesNotExist();
-      assert.dom('[data-icon="arrow-down"]').doesNotExist();
-    });
-
-    test('should not be clickable', async function(assert) {
-      // when
-      await render(hbs`<Table::HeaderSort @isDisabled={{true}}>Header</Table::HeaderSort>`);
-
-      // then
-      assert.dom('[role="button"]').doesNotExist();
+      assert.dom('[aria-label="Trier par pertinence"]').doesNotExist();
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il faut exploiter les composants définis dans PixUI et les positionner dans les applis PIX.
Dans cette PR, on va mettre le PixIconButton dans PixOrga où nécessaire.

## :robot: Solution
Endroits remplacés :
- Formulaire de connexion -> bouton de visibilité du mot de passe
- Formulaire pour créer un compte lors de l'acceptation d'une invitation -> bouton de visibilité mot de passe
- Bouton "page suivante" "page précédente" du contrôle de pagination
- Bouton de retour vers le détails d'une campagne depuis les détails d'une participation
- Bouton "Annuler" lors de l'édition du rôle d'un membre
- Chevron pour dérouler le détail d'une recommandation dans l'analyse
- Bouton retour depuis les détails d'une campagne vers la liste des campagnes
- Bouton de fermeture de la modale
- Bouton pour trier les sujets par pertinence dans l'analyse
- Bouton pour "afficher les actions" dans le menu élèves

Endroits où on utilise seulement les classes de pix-ui, parce que c'est un composant venant d'une librairie à part CopyButton :
- Bouton copier-coller du code campagne
- Boutons copier-coller des mots de passe, identifiants et email dans la modale de gestion des élèves

## :rainbow: Remarques
En bonus, dernier commit pour corriger le bug de la page d'analyse individuelle cassée lorsqu'on consulte sur une participation non partagée
![bug_analyse](https://user-images.githubusercontent.com/48727874/107642378-18eb9d80-6c75-11eb-8068-99b6667d1296.png)


## :100: Pour tester
Tester la non-régression de tous les boutons remplacés
