### PR TITLE
[BUGFIX] Eviter l'échec du hook des seeds dans les RAs en évitant d'ouvrir plusieurs connexions à la BDD (PIX-2139)

### DIFF
--- a/api/db/seeds/seed.js
+++ b/api/db/seeds/seed.js
@@ -83,7 +83,7 @@ exports.seed = async (knex) => {
   await databaseBuilder.commit();
   await alterSequenceIfPG(knex);
   const campaignParticipationData = await getEligibleCampaignParticipations(50000);
-  await generateKnowledgeElementSnapshots(campaignParticipationData, 3);
+  await generateKnowledgeElementSnapshots(campaignParticipationData, 1);
 };
 
 /**


### PR DESCRIPTION
## :unicorn: Problème
Au moment de retirer le lazy calcul des snapshots KE, il fallait s'assurer que les participations partagées présentes dans les seeds disposaient de leur snapshot.
Les snapshots devaient dont être créés dans les seeds. Pour cela, on exécute des fonctions qui permettent de faire cela.
Ces fonctions permettent aussi d'ajuster la concurrence

## :robot: Solution
On avait mis 3 de concurrence histoire d'aller plus vite, en oubliant que le pool de connexions BDD dans les RAs pouvait être très limité. On redescend donc la concurrence à 1.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
