### PR TITLE
[TECH] Expliciter la cause de l'échec du vidage des tables.

### DIFF
--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -52,8 +52,14 @@ module.exports = class DatabaseBuilder {
   }
 
   async _emptyDatabase() {
+
     const query = 'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?';
     const resultSet = await this.knex.raw(query, [this.knex.client.database()]);
+
+    if (resultSet.rowCount === 0) {
+      throw new Error('Database has no tables to empty');
+    }
+
     const rows = resultSet.rows;
     const tableNames = _.map(rows, 'table_name');
     const tablesToDelete = _.without(tableNames,

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -48,7 +48,13 @@ async function listAllTableNames() {
 }
 
 async function emptyAllTables() {
+
   const tableNames = await listAllTableNames();
+
+  if (tableNames.length === 0) {
+    throw new Error('Database has no tables to empty');
+  }
+
   const tablesToDelete = _.without(tableNames,
     'knex_migrations',
     'knex_migrations_lock',


### PR DESCRIPTION
## :unicorn: Problème
Lorsque 
- le serveur de BDD est joignable 
- une BDD existe, mais ne contient pas de tables
- un database-builer est appelé 

Alors l'erreur `TRUNCATE  - syntax error at end of input `est remontée. 
```
error: TRUNCATE  - syntax error at end of input
    at Object.raw (node_modules/knex/lib/util/make-knex.js:114:30)
    at Function.value (node_modules/knex/lib/util/make-knex.js:90:29)
    at DatabaseBuilder._emptyDatabase (db/database-builder/database-builder.js:65:22)
```

La chaine d'appel dans `database-builder `est 
- commit 
- _init
- _emptyDatabase 
-  emptyAllTables

Cette dernière ne prévoit pas le cas où aucune table n'existe.

## :robot: Solution
Si aucune table n'existe, remonter une erreur explicite

## :rainbow: Remarques
La même modification a été apportée sur le script `db:empty`
On pourrait aller plus loin et ne pas remonter d'erreur, mais cela sera une autre PR
On pourrait aussi se demander pourquoi ce besoin émerge et déclencher automatiquement la création de la BDD lors du démarrage de Docker (ex. ci-dessous) mais cela sera une autre PR:
```
 volumes:
      - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql
```


## :100: Pour tester
En local

Database-builder
- supprimer l'ensemble des tables (ex: arrêter et redémarrer le conteneur Docker BDD)
- lancer le test `api/tests/acceptance/application/authentication-controller_test.js`
- vérifier l'affichage du message `Error: Database has no tables to empty`

Script npm
- supprimer l'ensemble des tables (ex: arrêter et redémarrer le conteneur Docker BDD)
- lancer le script `npm run db:empty`
- vérifier l'affichage du message `Error: Database has no tables to empty`
