### PR TITLE
[FEATURE] Affichage des sujets et tutos en anglais lorsque la langue saisie est "en" dans l'analyse globale d'une campagne d'évaluation (PIX-2100).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -132,8 +132,9 @@ module.exports = {
   async getAnalysis(request) {
     const { userId } = request.auth.credentials;
     const campaignId = request.params.id;
+    const locale = extractLocaleFromRequest(request);
 
-    const campaignAnalysis = await usecases.computeCampaignAnalysis({ userId, campaignId });
+    const campaignAnalysis = await usecases.computeCampaignAnalysis({ userId, campaignId, locale });
     return campaignAnalysisSerializer.serialize(campaignAnalysis);
   },
 

--- a/api/lib/domain/usecases/compute-campaign-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-analysis.js
@@ -8,6 +8,7 @@ module.exports = async function computeCampaignAnalysis(
     campaignAnalysisRepository,
     targetProfileWithLearningContentRepository,
     tutorialRepository,
+    locale,
   } = {}) {
 
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
@@ -16,8 +17,8 @@ module.exports = async function computeCampaignAnalysis(
     throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
   }
 
-  const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
-  const tutorials = await tutorialRepository.list();
+  const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale });
+  const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignAnalysis(campaignId, targetProfileWithLearningContent, tutorials);
 };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -4,6 +4,7 @@ const userTutorialRepository = require('./user-tutorial-repository');
 const tutorialEvaluationRepository = require('./tutorial-evaluation-repository');
 const tutorialDatasource = require('../datasources/learning-content/tutorial-datasource');
 const { NotFoundError } = require('../../domain/errors');
+const { FRENCH_FRANCE } = require('../../domain/constants').LOCALE;
 
 module.exports = {
   async findByRecordIdsForCurrentUser({ ids, userId, locale }) {
@@ -27,8 +28,10 @@ module.exports = {
     }
   },
 
-  async list() {
-    const tutorialData = await tutorialDatasource.list();
+  async list({ locale = FRENCH_FRANCE } = {}) {
+    let tutorialData = await tutorialDatasource.list();
+    const lang = _extractLangFromLocale(locale);
+    tutorialData = tutorialData.filter((tutorial) => _extractLangFromLocale(tutorial.locale) === lang);
     return _.map(tutorialData, _toDomain);
   },
 

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -58,7 +58,7 @@ async function _findByRecordIds({ ids, locale }) {
 }
 
 function _extractLangFromLocale(locale) {
-  return locale.split('-')[0];
+  return locale && locale.split('-')[0];
 }
 
 function _getUserTutorial(userTutorials, tutorial) {

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -360,6 +360,7 @@ describe('Acceptance | API | Campaign Controller', () => {
                 source: 'covid-19',
                 link: 'www.liberez-moi.fr',
                 duration: '00:03:31',
+                locale: 'fr-fr',
               }],
             }, {
               id: 'recSkillId2',

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -231,5 +231,26 @@ describe('Integration | Repository | tutorial-repository', () => {
       const expectedTutorial = _.omit(englishTutorial, 'locale');
       expect(tutorials[0]).to.deep.equal(expectedTutorial);
     });
+
+    it('should not break or return tutorials without locale', async () => {
+      // given
+      const locale = ENGLISH_SPOKEN;
+      const tutorial = {
+        duration: '00:00:54',
+        format: 'video',
+        link: 'https://tuto.fr',
+        source: 'tuto.fr',
+        title: 'tuto0',
+        id: 'recTutorial0',
+      };
+      const learningContent = { tutorials: [tutorial] };
+      mockLearningContent(learningContent);
+
+      // when
+      const tutorials = await tutorialRepository.list({ locale });
+
+      // then
+      expect(tutorials).to.have.lengthOf(0);
+    });
   });
 });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -10,6 +10,7 @@ const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Application | Controller | Campaign', () => {
 
@@ -317,14 +318,14 @@ describe('Unit | Application | Controller | Campaign', () => {
 
     const campaignId = 1;
     const userId = 1;
-    const locale = 'fr';
+    const locale = FRENCH_SPOKEN;
 
     beforeEach(() => {
       sinon.stub(usecases, 'computeCampaignCollectiveResult');
       sinon.stub(campaignCollectiveResultSerializer, 'serialize');
     });
 
-    it('should return ok', async () => {
+    it('should return expected results', async () => {
       // given
       const campaignCollectiveResult = Symbol('campaignCollectiveResults');
       const expectedResults = Symbol('results');
@@ -365,13 +366,33 @@ describe('Unit | Application | Controller | Campaign', () => {
   });
 
   describe('#getAnalysis', () => {
-
     const campaignId = 1;
     const userId = 1;
+    const locale = FRENCH_SPOKEN;
 
     beforeEach(() => {
       sinon.stub(usecases, 'computeCampaignAnalysis');
       sinon.stub(campaignAnalysisSerializer, 'serialize');
+    });
+
+    it('should return expected results', async () => {
+      // given
+      const campaignAnalysis = Symbol('campaignAnalysis');
+      const expectedResults = Symbol('results');
+      usecases.computeCampaignAnalysis.withArgs({ userId, campaignId, locale }).resolves(campaignAnalysis);
+      campaignAnalysisSerializer.serialize.withArgs(campaignAnalysis).returns(expectedResults);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: campaignId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignController.getAnalysis(request);
+
+      // then
+      expect(response).to.equal(expectedResults);
     });
 
     it('should return an unauthorized error', async () => {

--- a/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const { computeCampaignAnalysis } = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | UseCase | compute-campaign-analysis', () => {
 
@@ -11,6 +12,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
 
   const userId = 1;
   const campaignId = 'someCampaignId';
+  const locale = FRENCH_SPOKEN;
 
   beforeEach(() => {
     campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
@@ -26,7 +28,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
       const tutorials = Symbol('tutorials');
       const campaignAnalysis = Symbol('analysis');
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-      targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId }).resolves(targetProfile);
+      targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId, locale }).resolves(targetProfile);
       tutorialRepository.list.resolves(tutorials);
       campaignAnalysisRepository.getCampaignAnalysis.withArgs(campaignId, targetProfile, tutorials).resolves(campaignAnalysis);
 
@@ -38,6 +40,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
         campaignAnalysisRepository,
         targetProfileWithLearningContentRepository,
         tutorialRepository,
+        locale,
       });
 
       // then
@@ -58,6 +61,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
         campaignRepository,
         campaignAnalysisRepository,
         targetProfileWithLearningContentRepository,
+        locale,
       });
 
       // then


### PR DESCRIPTION
## :unicorn: Problème
Nous commençons la traduction de Pix Orga en anglais. Cependant il faut également traduire tout le référentiel et récupérer celui-ci dans Pix Orga.

## :robot: Solution
Côté Pix Orga, tout est déjà prêt désormais.
Côté Pix API, pour la route en question, récupérer la locale et récupérer les sujets et tutos correspondants.

## :rainbow: Remarques
NA

## :100: Pour tester
Dans Pix Orga, aller dans une campagne d'évaluation, puis dans l'onglet "Analyse". Saisir dans l'url à la fin "?lang=en" et vérifier qu'après rechargement, les sujets et les tutos s'affichent en anglais.