### PR TITLE
[BUGFIX] Corriger la marge dans les cartes de parcours (PIX-2140).

### DIFF
--- a/mon-pix/app/components/campaign-participation-overview/card.hbs
+++ b/mon-pix/app/components/campaign-participation-overview/card.hbs
@@ -13,15 +13,20 @@
     </time>
   </header>
   <section class="campaign-participation-overview-card-content">
-    {{#if this.cardInfo.hasMasteryPercentage}}
+    {{#if (eq @model.status "finished") }}
       <p class="campaign-participation-overview-card-content__content">
         {{t 'pages.campaign-participation-overview.card.results' result=@model.masteryPercentage}}
       </p>
+    {{else if this.cardInfo.hasMasteryPercentage }}
+      <p class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content--archived-result">
+        {{t 'pages.campaign-participation-overview.card.results' result=@model.masteryPercentage}}
+      </p>
     {{else if (eq @model.status "archived") }}
-      <p class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content__archived">
+      <p class="campaign-participation-overview-card-content__content campaign-participation-overview-card-content--archived">
         {{t 'pages.campaign-participation-overview.card.text-archived' htmlSafe=true}}
       </p>
     {{/if}}
+
     {{#if (not-eq @model.status "archived")}}
       <LinkTo class="{{this.cardInfo.actionClass}} campaign-participation-overview-card-content__action"
               @route="campaigns.start-or-resume"

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -45,11 +45,15 @@
     padding: 0;
   }
 
-  &__archived {
+  &--archived {
     font-family: $font-open-sans;
     font-size: 0.75rem;
     font-weight: $font-normal;
     text-align: center;
+    margin-bottom: 32px;
+  }
+
+  &--archived-result {
     margin-bottom: 32px;
   }
 }

--- a/mon-pix/app/styles/components/campaign-participation-overview/_grid.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_grid.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  justify-content: space-between;
   padding: 0;
 
   @include device-is('tablet') {
@@ -18,11 +17,13 @@
     }
 
     @include device-is('tablet') {
-      width: calc(50% - 10px);
+      width: calc(50% - 16px);
+      margin: 8px;
     }
 
     @include device-is('desktop') {
-      width: calc(33% - 10px);
+      width: calc(33% - 16px);
+      margin: 8px;
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les blocs de textes des carte de participation ne sont pas aligné.

## :robot: Solution
Supprimer un margin-bottom

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller sur la page mes parcours avec des cartes archivée / partagée et archivée / non partagée
