### PR TITLE
[FEATURE] Ajouter la saisie du mot de passe pour le changement d'adresse e-mail sur Pix App (PIX-1745).

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -261,6 +261,10 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
 
+  if (error instanceof DomainErrors.InvalidPasswordForUpdateEmailError) {
+    return new HttpErrors.BadRequestError(error.message);
+  }
+
   return new HttpErrors.BaseHttpError(error.message);
 }
 

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -209,6 +209,7 @@ exports.register = async function(server) {
               type: Joi.string().valid('users').required(),
               attributes: {
                 email: Joi.string().email().required(),
+                password: Joi.string().required(),
               },
             },
           }),

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -50,12 +50,13 @@ module.exports = {
   async updateEmail(request, h) {
     const userId = parseInt(request.params.id);
     const authenticatedUserId = request.auth.credentials.userId;
-    const { email } = request.payload.data.attributes;
+    const { email, password } = request.payload.data.attributes;
 
     await usecases.updateUserEmail({
       email,
       userId,
       authenticatedUserId,
+      password,
     });
 
     return h.response({}).code(204);

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -432,6 +432,12 @@ class InvalidExternalUserTokenError extends DomainError {
   }
 }
 
+class InvalidPasswordForUpdateEmailError extends DomainError {
+  constructor(message = 'Le mot de passe que vous avez saisi est invalide.') {
+    super(message);
+  }
+}
+
 class InvalidResultRecipientTokenError extends DomainError {
   constructor(message = 'Le token de récupération des résultats de la session de certification est invalide.') {
     super(message);
@@ -748,6 +754,7 @@ module.exports = {
   InvalidCertificationReportForFinalization,
   InvalidCertificationIssueReportForSaving,
   InvalidExternalUserTokenError,
+  InvalidPasswordForUpdateEmailError,
   InvalidRecaptchaTokenError,
   InvalidResultRecipientTokenError,
   InvalidSessionResultError,

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -1,10 +1,14 @@
-const { UserNotAuthorizedToUpdateEmailError } = require('../errors');
+const AuthenticationMethod = require('../models/AuthenticationMethod');
+const { UserNotAuthorizedToUpdateEmailError, InvalidPasswordForUpdateEmailError } = require('../errors');
 
 module.exports = async function updateUserEmail({
   email,
   userId,
   authenticatedUserId,
+  password,
   userRepository,
+  authenticationMethodRepository,
+  encryptionService,
 }) {
   if (userId !== authenticatedUserId) {
     throw new UserNotAuthorizedToUpdateEmailError();
@@ -13,6 +17,22 @@ module.exports = async function updateUserEmail({
   const user = await userRepository.get(userId);
   if (!user.email) {
     throw new UserNotAuthorizedToUpdateEmailError();
+  }
+
+  const authenticationMethod = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({
+    userId,
+    identityProvider: AuthenticationMethod.identityProviders.PIX,
+  });
+
+  try {
+    const passwordHash = authenticationMethod.authenticationComplement.password;
+
+    await encryptionService.checkPassword({
+      password,
+      passwordHash,
+    });
+  } catch (e) {
+    throw new InvalidPasswordForUpdateEmailError();
   }
 
   await userRepository.isEmailAvailable(email);

--- a/api/sample.env
+++ b/api/sample.env
@@ -267,3 +267,10 @@ LOG_ENABLED=true
 # type: String
 # default: none
 AUTH_SECRET=Change me!
+
+# Allow email change in API
+
+# presence: optional
+# type: String
+# default: false
+FT_MY_ACCOUNT=false

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -1,12 +1,19 @@
+const bcrypt = require('bcrypt');
+
 const updateUserEmail = require('../../../../lib/domain/usecases/update-user-email');
-const { AlreadyRegisteredEmailError, UserNotAuthorizedToUpdateEmailError } = require('../../../../lib/domain/errors');
+const { AlreadyRegisteredEmailError, UserNotAuthorizedToUpdateEmailError, InvalidPasswordForUpdateEmailError } = require('../../../../lib/domain/errors');
 
 const { sinon, expect, catchErr } = require('../../../test-helper');
 
 describe('Unit | UseCase | update-user-email', () => {
 
   let userRepository;
-  let schoolingRegistrationRepository;
+  let authenticationMethodRepository;
+  let encryptionService;
+
+  const password = 'password123';
+  // eslint-disable-next-line no-sync
+  const passwordHash = bcrypt.hashSync(password, 1);
 
   beforeEach(() => {
     userRepository = {
@@ -15,8 +22,12 @@ describe('Unit | UseCase | update-user-email', () => {
       get: sinon.stub().resolves({ email: 'old_email@example.net' }),
     };
 
-    schoolingRegistrationRepository = {
-      findByUserId: sinon.stub().resolves([]),
+    authenticationMethodRepository = {
+      findOneByUserIdAndIdentityProvider: sinon.stub().resolves({ authenticationComplement: { password: passwordHash } }),
+    };
+
+    encryptionService = {
+      checkPassword: sinon.stub().resolves(),
     };
   });
 
@@ -31,8 +42,10 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      password,
       userRepository,
-      schoolingRegistrationRepository,
+      authenticationMethodRepository,
+      encryptionService,
     });
 
     // then
@@ -54,8 +67,10 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      password,
       userRepository,
-      schoolingRegistrationRepository,
+      authenticationMethodRepository,
+      encryptionService,
     });
 
     // then
@@ -65,7 +80,7 @@ describe('Unit | UseCase | update-user-email', () => {
     });
   });
 
-  it('throw AlreadyRegisteredEmailError if email already exists', async () => {
+  it('should throw AlreadyRegisteredEmailError if email already exists', async () => {
     // given
     userRepository.isEmailAvailable.rejects(new AlreadyRegisteredEmailError());
     const userId = 1;
@@ -77,15 +92,17 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      password,
       userRepository,
-      schoolingRegistrationRepository,
+      authenticationMethodRepository,
+      encryptionService,
     });
 
     // then
     expect(error).to.be.an.instanceOf(AlreadyRegisteredEmailError);
   });
 
-  it('throw UserNotAuthorizedToUpdateEmailError if the authenticated user try to change the email of an other user', async () => {
+  it('should throw UserNotAuthorizedToUpdateEmailError if the authenticated user try to change the email of an other user', async () => {
     // given
     const userId = 1;
     const authenticatedUserId = 2;
@@ -97,14 +114,15 @@ describe('Unit | UseCase | update-user-email', () => {
       authenticatedUserId,
       email: newEmail,
       userRepository,
-      schoolingRegistrationRepository,
+      authenticationMethodRepository,
+      encryptionService,
     });
 
     // then
     expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
   });
 
-  it('throw UserNotAuthorizedToUpdateEmailError if user has not email', async () => {
+  it('should throw UserNotAuthorizedToUpdateEmailError if user does not have an email', async () => {
     // given
     userRepository.get.resolves({});
     const userId = 1;
@@ -117,10 +135,32 @@ describe('Unit | UseCase | update-user-email', () => {
       authenticatedUserId,
       email: newEmail,
       userRepository,
-      schoolingRegistrationRepository,
+      authenticationMethodRepository,
+      encryptionService,
     });
 
     // then
     expect(error).to.be.an.instanceOf(UserNotAuthorizedToUpdateEmailError);
+  });
+
+  it('should throw InvalidPasswordForUpdateEmailError if the password is invalid', async () => {
+    // given
+    encryptionService.checkPassword.rejects();
+    const userId = 1;
+    const authenticatedUserId = 1;
+    const newEmail = 'new_email@example.net';
+
+    // when
+    const error = await catchErr(updateUserEmail)({
+      userId,
+      authenticatedUserId,
+      email: newEmail,
+      userRepository,
+      authenticationMethodRepository,
+      encryptionService,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(InvalidPasswordForUpdateEmailError);
   });
 });

--- a/mon-pix/app/components/user-account-update-email.js
+++ b/mon-pix/app/components/user-account-update-email.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import isEmailValid from '../utils/email-validator';
 import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 
 const STATUS_MAP = {
   defaultStatus: 'default',
@@ -12,9 +13,11 @@ const STATUS_MAP = {
 };
 
 const ERROR_INPUT_MESSAGE_MAP = {
-  wrongFormat: 'pages.user-account.account-update-email.fields.errors.wrong-format',
-  mismatching: 'pages.user-account.account-update-email.fields.errors.mismatching',
-  unknown: 'pages.user-account.account-update-email.fields.errors.unknown',
+  wrongEmailFormat: 'pages.user-account.account-update-email.fields.errors.wrong-email-format',
+  mismatchingEmail: 'pages.user-account.account-update-email.fields.errors.mismatching-email',
+  emptyPassword: 'pages.user-account.account-update-email.fields.errors.empty-password',
+  invalidPassword: 'pages.user-account.account-update-email.fields.errors.invalid-password',
+  unknownError: 'pages.user-account.account-update-email.fields.errors.unknown-error',
 };
 
 class NewEmailValidation {
@@ -27,15 +30,26 @@ class NewEmailConfirmationValidation {
   @tracked message = null;
 }
 
+class PasswordValidation {
+  @tracked status = STATUS_MAP['defaultStatus'];
+  @tracked message = null;
+}
+
 export default class UserAccountUpdateEmail extends Component {
 
   @service intl;
   @tracked newEmail = '';
   @tracked newEmailConfirmation = '';
+  @tracked password = '';
   @tracked errorMessage = null;
 
   @tracked newEmailValidation = new NewEmailValidation();
   @tracked newEmailConfirmationValidation = new NewEmailConfirmationValidation();
+  @tracked passwordValidation = new PasswordValidation();
+
+  get isFormValid() {
+    return this.newEmail === this.newEmailConfirmation && isEmailValid(this.newEmail) && !isEmpty(this.password);
+  }
 
   @action
   validateNewEmail() {
@@ -46,7 +60,7 @@ export default class UserAccountUpdateEmail extends Component {
 
     if (isInvalidInput) {
       this.newEmailValidation.status = STATUS_MAP['errorStatus'];
-      this.newEmailValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+      this.newEmailValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongEmailFormat']);
     }
   }
 
@@ -59,10 +73,23 @@ export default class UserAccountUpdateEmail extends Component {
 
     if (isInvalidInput) {
       this.newEmailConfirmationValidation.status = STATUS_MAP['errorStatus'];
-      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongEmailFormat']);
     } else if (this.newEmail !== this.newEmailConfirmation) {
       this.newEmailConfirmationValidation.status = STATUS_MAP['errorStatus'];
-      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['mismatching']);
+      this.newEmailConfirmationValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['mismatchingEmail']);
+    }
+  }
+
+  @action
+  validatePassword() {
+    const isInvalidInput = isEmpty(this.password);
+
+    this.passwordValidation.status = STATUS_MAP['successStatus'];
+    this.passwordValidation.message = null;
+
+    if (isInvalidInput) {
+      this.passwordValidation.status = STATUS_MAP['errorStatus'];
+      this.passwordValidation.message = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
     }
   }
 
@@ -70,18 +97,24 @@ export default class UserAccountUpdateEmail extends Component {
   async onSubmit(event) {
     event && event.preventDefault();
     this.errorMessage = null;
-
-    if (this.newEmail === this.newEmailConfirmation && isEmailValid(this.newEmail)) {
+    if (this.isFormValid) {
       try {
-        await this.args.saveNewEmail(this.newEmail);
+        await this.args.saveNewEmail(this.newEmail, this.password);
       } catch (response) {
         const status = get(response, 'errors[0].status');
+
         if (status === '422') {
-          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongFormat']);
+          const pointer = get(response, 'errors[0].source.pointer');
+          if (pointer.endsWith('email')) {
+            this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['wrongEmailFormat']);
+          }
+          if (pointer.endsWith('password')) {
+            this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
+          }
         } else if (status === '400' || status === '403') {
           this.errorMessage = get(response, 'errors[0].detail');
         } else {
-          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknown']);
+          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
         }
       }
     }

--- a/mon-pix/app/controllers/user-account.js
+++ b/mon-pix/app/controllers/user-account.js
@@ -17,9 +17,11 @@ export default class UserAccountController extends Controller {
   }
 
   @action
-  async saveNewEmail(newEmail) {
+  async saveNewEmail(newEmail, password) {
     this.model.email = newEmail.trim().toLowerCase();
+    this.model.password = password;
     await this.model.save({ adapterOptions: { updateEmail: true } });
+    this.model.password = null;
     this.disableEmailEditionMode();
   }
 }

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -10,6 +10,10 @@
     color: $grey-90;
     font-family: $font-open-sans;
     line-height: 1.75rem;
+
+    &:nth-child(3) {
+      padding-top: 25px;
+    }
   }
 
   &__form {

--- a/mon-pix/app/templates/components/user-account-update-email.hbs
+++ b/mon-pix/app/templates/components/user-account-update-email.hbs
@@ -2,7 +2,7 @@
     <div class="user-account-update-email">
       <h3>{{t 'pages.user-account.account-update-email.title'}}</h3>
       <div class="user-account-update-email__informations">
-        <span>{{t 'pages.user-account.account-update-email.informations' htmlSafe=true}}</span>
+        <span>{{t 'pages.user-account.account-update-email.email-information' htmlSafe=true}}</span>
       </div>
       <form class="sign-form__body user-account-update-email__form">
         <div class="sign-form-body__input" data-test-new-email>
@@ -15,7 +15,6 @@
                        @autocomplete="off"
                        @require={{true}}/>
         </div>
-
         <div class="sign-form-body__input" data-test-new-email-confirmation>
           <FormTextfield @label="{{t 'pages.user-account.account-update-email.fields.new-email-confirmation.label'}}"
                        @textfieldName="newEmailConfirmation"
@@ -25,6 +24,19 @@
                        @validationStatus={{this.newEmailConfirmationValidation.status}}
                        @autocomplete="off"
                        @require={{true}}/>
+        </div>
+        <div class="user-account-update-email__informations">
+          <span>{{t 'pages.user-account.account-update-email.password-information'}}</span>
+        </div>
+        <div class="sign-form-body__input" data-test-password>
+          <FormTextfield @label="{{t 'pages.user-account.account-update-email.fields.password.label'}}"
+                         @textfieldName="password"
+                         @inputBindingValue={{this.password}}
+                         @onValidate={{this.validatePassword}}
+                         @validationMessage={{this.passwordValidation.message}}
+                         @validationStatus={{this.passwordValidation.status}}
+                         @autocomplete="off"
+                         @require={{true}}/>
         </div>
         {{#if this.errorMessage}}
         <div class="user-account-update-email__error">
@@ -43,6 +55,7 @@
           <PixButton
                   class="user-account-update-email-actions__button"
                   @type="submit"
+                  @isDisabled={{not this.isFormValid}}
                   @triggerAction={{this.onSubmit}}
                   data-test-submit-email>
           {{t 'pages.user-account.account-update-email.save-button'}}

--- a/mon-pix/app/templates/user-account.hbs
+++ b/mon-pix/app/templates/user-account.hbs
@@ -14,7 +14,6 @@
       {{#if this.isEmailEditionMode}}
       <div class="user-account__update-email">
         <UserAccountUpdateEmail
-                @user={{@model}}
                 @disableEmailEditionMode={{this.disableEmailEditionMode}}
                 @saveNewEmail={{this.saveNewEmail}}/>
       </div>

--- a/mon-pix/mirage/routes/users/index.js
+++ b/mon-pix/mirage/routes/users/index.js
@@ -26,6 +26,9 @@ export default function index(config) {
   config.patch('/users/:id/email', (schema, request) => {
     const body = JSON.parse(request.requestBody);
     const user = schema.users.find(request.params.id);
+    if (user.password !== body.data.attributes.password) {
+      return new Response(400);
+    }
     user.update({ email: body.data.attributes.email });
     return new Response(204);
   });

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -39565,8 +39565,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#0c2ba5ff4322455790cb14877fc883123e3735f0",
-      "from": "git://github.com/1024pix/pix-ui.git#v2.0.3",
+      "version": "git://github.com/1024pix/pix-ui.git#2a24ca3a656809066a20ea7003d8ecd9a95548a3",
+      "from": "git://github.com/1024pix/pix-ui.git#v2.1.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -110,7 +110,7 @@
     "loader.js": "^4.7.0",
     "lodash": "^4.17.20",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.0.3",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.1.0",
     "sass": "^1.30.0",
     "showdown": "^1.9.1",
     "stylelint": "^13.8.0",

--- a/mon-pix/tests/acceptance/user-account-test.js
+++ b/mon-pix/tests/acceptance/user-account-test.js
@@ -46,6 +46,7 @@ describe('Acceptance | User account page', function() {
       await click('button[data-test-edit-email]');
       await fillIn('#newEmail', newEmail);
       await fillIn('#newEmailConfirmation', newEmail);
+      await fillIn('#password', user.password);
       await click('button[data-test-submit-email]');
 
       // then

--- a/mon-pix/tests/integration/components/user-account-update-email-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-test.js
@@ -10,17 +10,6 @@ describe('Integration | Component | User account update email', () => {
   setupIntlRenderingTest();
 
   context('when editing e-mail', function() {
-    let user;
-    beforeEach(function() {
-      // given
-      user = {
-        firstName: 'John',
-        lastName: 'DOE',
-        email: 'john.doe@example.net',
-        username: 'john.doe0101',
-      };
-      this.set('user', user);
-    });
 
     it('should display save and cancel button', async function() {
       // when
@@ -37,6 +26,7 @@ describe('Integration | Component | User account update email', () => {
         // given
         const disableEmailEditionMode = sinon.stub();
         this.set('disableEmailEditionMode', disableEmailEditionMode);
+
         await render(hbs`<UserAccountUpdateEmail @disableEmailEditionMode={{this.disableEmailEditionMode}} />`);
 
         // when
@@ -55,14 +45,14 @@ describe('Integration | Component | User account update email', () => {
           // given
           const wrongEmail = 'wrongEmail';
 
-          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+          await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
           await fillIn('#newEmail', wrongEmail);
           await triggerEvent('#newEmail', 'blur');
 
           // then
-          expect(find('#validationMessage-newEmail').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
+          expect(find('#validationMessage-newEmail').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
         });
       });
 
@@ -72,14 +62,14 @@ describe('Integration | Component | User account update email', () => {
           // given
           const wrongEmail = 'wrongEmail';
 
-          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+          await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
           await fillIn('#newEmailConfirmation', wrongEmail);
           await triggerEvent('#newEmailConfirmation', 'blur');
 
           // then
-          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
+          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
         });
       });
 
@@ -90,7 +80,7 @@ describe('Integration | Component | User account update email', () => {
           const newEmail = 'new-email@example.net';
           const newEmailConfirmation = 'new-email-confirmation@example.net';
 
-          await render(hbs`<UserAccountUpdateEmail @user={{this.user}} />`);
+          await render(hbs`<UserAccountUpdateEmail />`);
 
           // when
           await fillIn('#newEmail', newEmail);
@@ -98,8 +88,36 @@ describe('Integration | Component | User account update email', () => {
           await triggerEvent('#newEmailConfirmation', 'blur');
 
           // then
-          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.mismatching'));
+          expect(find('#validationMessage-newEmailConfirmation').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.mismatching-email'));
         });
+      });
+
+      context('in password input', function() {
+
+        it('should display an empty password error message when focus-out', async function() {
+          // given
+          const newEmail = 'newEmail@example.net';
+          const emptyPassword = '';
+
+          await render(hbs`<UserAccountUpdateEmail />`);
+
+          // when
+          await fillIn('#newEmail', newEmail);
+          await fillIn('#newEmailConfirmation', newEmail);
+          await fillIn('#password', emptyPassword);
+          await triggerEvent('#password', 'blur');
+
+          // then
+          expect(find('#validationMessage-password').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'));
+        });
+      });
+
+      it('should disable the confirm button if the form is not valid', async function() {
+        // when
+        await render(hbs`<UserAccountUpdateEmail />`);
+
+        // then
+        expect(find('button[data-test-submit-email]')).to.have.attr('disabled');
       });
     });
 
@@ -108,51 +126,39 @@ describe('Integration | Component | User account update email', () => {
       it('should call save new email method', async function() {
         // given
         const newEmail = 'newEmail@example.net';
+        const password = 'password';
+
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
 
-        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
         await fillIn('#newEmail', newEmail);
         await fillIn('#newEmailConfirmation', newEmail);
+        await fillIn('#password', password);
         await click('button[data-test-submit-email]');
 
         // then
         sinon.assert.calledWith(saveNewEmail, newEmail);
       });
 
-      it('should display wrong format error if response status is 422', async function() {
-        // given
-        const newEmail = 'newEmail@example.net';
-        const saveNewEmail = sinon.stub();
-        this.set('saveNewEmail', saveNewEmail);
-        saveNewEmail.rejects({ errors: [{ status: '422' }] });
-
-        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
-
-        // when
-        await fillIn('#newEmail', newEmail);
-        await fillIn('#newEmailConfirmation', newEmail);
-        await click('button[data-test-submit-email]');
-
-        // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-format'));
-      });
-
       it('should display error message from server if response status is 400 or 403', async function() {
         // given
         const newEmail = 'newEmail@example.net';
+        const password = 'password';
         const expectedErrorMessage = 'An error message';
+
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
         saveNewEmail.rejects({ errors: [{ status: '400', detail: expectedErrorMessage }] });
 
-        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
         await fillIn('#newEmail', newEmail);
         await fillIn('#newEmailConfirmation', newEmail);
+        await fillIn('#password', password);
         await click('button[data-test-submit-email]');
 
         // then
@@ -162,19 +168,64 @@ describe('Integration | Component | User account update email', () => {
       it('should display default error message if response status is unknown', async function() {
         // given
         const newEmail = 'newEmail@example.net';
+        const password = 'password';
+
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
         saveNewEmail.rejects({});
 
-        await render(hbs`<UserAccountUpdateEmail @user={{this.user}} @saveNewEmail={{this.saveNewEmail}} />`);
+        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
         await fillIn('#newEmail', newEmail);
         await fillIn('#newEmailConfirmation', newEmail);
+        await fillIn('#password', password);
         await click('button[data-test-submit-email]');
 
         // then
-        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.unknown'));
+        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.unknown-error'));
+      });
+
+      it('should display wrong email format error if response status is 422', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const password = 'password';
+
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({ errors: [{ status: '422', source: { pointer: 'attributes/email' } }] });
+
+        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await fillIn('#password', password);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.wrong-email-format'));
+      });
+
+      it('should display empty password error if response status is 422', async function() {
+        // given
+        const newEmail = 'newEmail@example.net';
+        const password = 'password';
+
+        const saveNewEmail = sinon.stub();
+        this.set('saveNewEmail', saveNewEmail);
+        saveNewEmail.rejects({ errors: [{ status: '422', source: { pointer: 'attributes/password' } }] });
+
+        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
+
+        // when
+        await fillIn('#newEmail', newEmail);
+        await fillIn('#newEmailConfirmation', newEmail);
+        await fillIn('#password', password);
+        await click('button[data-test-submit-email]');
+
+        // then
+        expect(find('span[data-test-error-message]').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'));
       });
     });
   });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -953,7 +953,8 @@
             },
             "account-update-email": {
                 "title": "",
-                "informations": "",
+                "email-information": "",
+                "password-information": "",
                 "save-button": "",
                 "fields": {
                     "new-email": {
@@ -962,10 +963,15 @@
                     "new-email-confirmation": {
                         "label": ""
                     },
+                    "password": {
+                        "label": "Password"
+                    },
                     "errors": {
-                        "wrong-format": "Your email address is invalid.",
-                        "mismatching": "",
-                        "unknown": ""
+                        "wrong-email-format": "Your email address is invalid.",
+                        "mismatching-email": "",
+                        "empty-password": "Your password can't be empty.",
+                        "invalid-password": "",
+                        "unknown-error": ""
                     }
                 }
             }

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -953,7 +953,8 @@
             },
             "account-update-email": {
                 "title": "Modification de votre adresse e-mail",
-                "informations": "Cette adresse e-mail doit être valide en cas de mot de passe oublié. '<br>' Elle sera votre nouvelle adresse de connexion.",
+                "email-information": "Cette adresse e-mail doit être valide en cas de mot de passe oublié. '<br>' Elle sera votre nouvelle adresse de connexion.",
+                "password-information": "Saisissez votre mot de passe pour confirmer",
                 "save-button": "Confirmer",
                 "fields": {
                     "new-email": {
@@ -962,10 +963,15 @@
                     "new-email-confirmation": {
                         "label": "Confirmation de l'adresse e-mail"
                     },
+                    "password": {
+                        "label": "Mot de passe"
+                    },
                     "errors": {
-                        "wrong-format": "Votre adresse e-mail n’est pas valide.",
-                        "mismatching": "Les deux adresses e-mail ne sont pas identiques. Veuillez vérifier votre saisie.",
-                        "unknown": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
+                        "wrong-email-format": "Votre adresse e-mail n’est pas valide.",
+                        "mismatching-email": "Les deux adresses e-mail ne sont pas identiques. Veuillez vérifier votre saisie.",
+                        "empty-password": "Votre mot de passe ne peut pas être vide.",
+                        "invalid-password": "Le mot de passe que vous avez saisi est invalide.",
+                        "unknown-error": "Une erreur est survenue. Veuillez recommencer ou contacter le support."
                     }
                 }
             }


### PR DESCRIPTION
## :unicorn: Problème
Dans la page mon-compte, il est aujourd'hui possible de modifier son adresse e-mail or nous souhaitons garantir l'identité de l'utilisateur. 

## :robot: Solution
Forcer la saisie du mot de passe de l'utilisateur afin d'effectuer le changement de son adresse e-mail. 

## :rainbow: Remarques
Mise à jour de la version de Pix-UI afin d'ajouter la gestion de l'attribut `disabled` sur un bouton.

## :100: Pour tester
Etapes:
- activer le changement d'email : alimenter  la variable d'environnement `FT_MY_ACCOUNT=true`
- se connecter avec `pro.member@example.net` / `pix123`
- aller sur la [page cachée ](https://app-pr2539.review.pix.fr/mon-compte)
- saisir l'email `foo@example.net`
- saisir le mot de passe `pix123`
- vérifier en BDD et dans le menu déroulant
- refaire l'action mais avec un mot de passe erroné
- vérifier que le message `Le mot de passe que vous avez saisi est invalide.`  est affiché