### PR TITLE
[FEATURE] Affichage des compétences en anglais lorsque la langue saisie est "en" dans les résultats individuels d'une campagne de collecte de profils (PIX-2114).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -166,7 +166,7 @@ function _buildCampaignForPro(databaseBuilder) {
     organizationId: PRO_COMPANY_ID,
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
-    idPixLabel: null,
+    idPixLabel: 'identifiant entreprise',
   });
 
   databaseBuilder.factory.buildCampaign({
@@ -179,7 +179,7 @@ function _buildCampaignForPro(databaseBuilder) {
     organizationId: PRO_COMPANY_ID,
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
-    idPixLabel: null,
+    idPixLabel: 'identifiant entreprise',
     archivedAt: new Date('2020-01-02T15:00:34Z'),
   });
 
@@ -193,7 +193,7 @@ function _buildCampaignForPro(databaseBuilder) {
     organizationId: PRO_COMPANY_ID,
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
-    idPixLabel: null,
+    idPixLabel: 'identifiant entreprise',
     archivedAt: new Date('2020-01-01T15:00:34Z'),
   });
 }

--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -80,8 +80,9 @@ module.exports = {
   async getCampaignProfile(request) {
     const { userId } = request.auth.credentials;
     const { campaignId, campaignParticipationId } = request.params;
+    const locale = extractLocaleFromRequest(request);
 
-    const campaignProfile = await usecases.getCampaignProfile({ userId, campaignId, campaignParticipationId });
+    const campaignProfile = await usecases.getCampaignProfile({ userId, campaignId, campaignParticipationId, locale });
     return campaignProfileSerializer.serialize(campaignProfile);
   },
 

--- a/api/lib/domain/services/placement-profile-service.js
+++ b/api/lib/domain/services/placement-profile-service.js
@@ -10,8 +10,8 @@ const knowledgeElementRepository = require('../../infrastructure/repositories/kn
 const competenceRepository = require('../../infrastructure/repositories/competence-repository');
 const scoringService = require('./scoring/scoring-service');
 
-async function getPlacementProfile({ userId, limitDate, isV2Certification = true, allowExcessPixAndLevels = true }) {
-  const pixCompetences = await competenceRepository.listPixCompetencesOnly();
+async function getPlacementProfile({ userId, limitDate, isV2Certification = true, allowExcessPixAndLevels = true, locale }) {
+  const pixCompetences = await competenceRepository.listPixCompetencesOnly({ locale });
   if (isV2Certification) {
     return _generatePlacementProfileV2({ userId, profileDate: limitDate, competences: pixCompetences, allowExcessPixAndLevels });
   }

--- a/api/lib/domain/usecases/get-campaign-profile.js
+++ b/api/lib/domain/usecases/get-campaign-profile.js
@@ -1,9 +1,16 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
-module.exports = async function getCampaignProfile({ userId, campaignId, campaignParticipationId, campaignRepository, campaignProfileRepository }) {
+module.exports = async function getCampaignProfile({
+  userId,
+  campaignId,
+  campaignParticipationId,
+  campaignRepository,
+  campaignProfileRepository,
+  locale,
+}) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
     throw new UserNotAuthorizedToAccessEntity('User does not belong to an organization that owns the campaign');
   }
 
-  return campaignProfileRepository.findProfile(campaignId, campaignParticipationId);
+  return campaignProfileRepository.findProfile({ campaignId, campaignParticipationId, locale });
 };

--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -4,12 +4,12 @@ const { NotFoundError } = require('../../../lib/domain/errors');
 const { knex } = require('../bookshelf');
 
 module.exports = {
-  async findProfile(campaignId, campaignParticipationId) {
+  async findProfile({ campaignId, campaignParticipationId, locale }) {
 
     const profile = await _fetchCampaignProfileAttributesFromCampaignParticipation(campaignId, campaignParticipationId);
 
     const { sharedAt, userId } = profile;
-    const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate: sharedAt, allowExcessPixAndLevels: false });
+    const placementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate: sharedAt, allowExcessPixAndLevels: false, locale });
 
     return new CampaignProfile({ ...profile, placementProfile });
   },

--- a/api/lib/infrastructure/repositories/competence-repository.js
+++ b/api/lib/infrastructure/repositories/competence-repository.js
@@ -29,6 +29,7 @@ function _toDomain({ competenceData, areaDatas, locale }) {
       id: areaData.id,
       code: areaData.code,
       title: translatedAreaTitle,
+      name: areaData.name,
       color: areaData.color,
     }),
   });

--- a/api/tests/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/integration/domain/services/placement-profile-service_test.js
@@ -1,138 +1,108 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
-
-const assessmentRepository = require('../../../../lib/infrastructure/repositories/assessment-repository');
-const challengeRepository = require('../../../../lib/infrastructure/repositories/challenge-repository');
-const competenceRepository = require('../../../../lib/infrastructure/repositories/competence-repository');
-const skillRepository = require('../../../../lib/infrastructure/repositories/skill-repository');
-const knowledgeElementRepository = require('../../../../lib/infrastructure/repositories/knowledge-element-repository');
+const { expect, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
 const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
-
-const Assessment = require('../../../../lib/domain/models/Assessment');
-const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
-const Challenge = require('../../../../lib/domain/models/Challenge');
-const Competence = require('../../../../lib/domain/models/Competence');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
-const Skill = require('../../../../lib/domain/models/Skill');
 
 describe('Integration | Service | Placement Profile Service', function() {
 
-  const userId = 63731;
-
-  function _createCompetence(id, index, name, areaCode) {
-    const competence = new Competence();
-    competence.id = id;
-    competence.index = index;
-    competence.name = name;
-    competence.area = { code: areaCode };
-
-    return competence;
-  }
-
-  function _createChallenge(id, competence, skills, testedSkill) {
-    const challenge = new Challenge();
-    challenge.id = id;
-    challenge.skills = skills;
-    challenge.competenceId = competence;
-    challenge.testedSkill = testedSkill;
-    return challenge;
-  }
-
-  const skillCitation4 = new Skill({ id: 10, name: '@citation4' });
-  const skillCollaborer4 = new Skill({ id: 20, name: '@collaborer4' });
-  const skillMoteur3 = new Skill({ id: 30, name: '@moteur3' });
-  const skillRecherche4 = new Skill({ id: 40, name: '@recherche4' });
-  const skillRemplir2 = new Skill({ id: 50, name: '@remplir2' });
-  const skillRemplir4 = new Skill({ id: 60, name: '@remplir4' });
-  const skillUrl3 = new Skill({ id: 70, name: '@url3' });
-  const skillWeb1 = new Skill({ id: 80, name: '@web1' });
-  const skillRequin5 = new Skill({ id: 110, name: '@requin5' });
-  const skillRequin8 = new Skill({ id: 120, name: '@requin8' });
-
-  const competenceFlipper = _createCompetence('competenceRecordIdOne', '1.1', '1.1 Construire un flipper', '1');
-  const competenceDauphin = _createCompetence('competenceRecordIdTwo', '1.2', '1.2 Adopter un dauphin', '1');
-  const competenceRequin = _createCompetence('competenceRecordIdThree', '1.3', '1.3 Se faire manger par un requin', '1');
-
-  const challengeForSkillCollaborer4 = _createChallenge('challengeRecordIdThree', 'competenceRecordIdThatDoesNotExistAnymore', [skillCollaborer4], '@collaborer4');
-
-  const challengeForSkillCitation4 = _createChallenge('challengeRecordIdOne', competenceFlipper.id, [skillCitation4], '@citation4');
-  const challengeForSkillCitation4AndMoteur3 = _createChallenge('challengeRecordIdTwo', competenceFlipper.id, [skillCitation4, skillMoteur3], '@citation4');
-  const challengeForSkillRecherche4 = _createChallenge('challengeRecordIdFour', competenceFlipper.id, [skillRecherche4], '@recherche4');
-  const challengeRecordWithoutSkills = _createChallenge('challengeRecordIdNine', competenceFlipper.id, [], null);
-  const anotherChallengeForSkillCitation4 = _createChallenge('challengeRecordIdTen', competenceFlipper.id, [skillCitation4], '@citation4');
-
-  const challengeForSkillRemplir2 = _createChallenge('challengeRecordIdFive', competenceDauphin.id, [skillRemplir2], '@remplir2');
-  const challengeForSkillRemplir4 = _createChallenge('challengeRecordIdSix', competenceDauphin.id, [skillRemplir4], '@remplir4');
-  const challengeForSkillUrl3 = _createChallenge('challengeRecordIdSeven', competenceDauphin.id, [skillUrl3], '@url3');
-  const challengeForSkillWeb1 = _createChallenge('challengeRecordIdEight', competenceDauphin.id, [skillWeb1], '@web1');
-
-  const challengeForSkillRequin5 = _createChallenge('challengeRecordIdNine', competenceRequin.id, [skillRequin5], '@requin5');
-  const challengeForSkillRequin8 = _createChallenge('challengeRecordIdTen', competenceRequin.id, [skillRequin8], '@requin8');
-
-  const competences = [
-    competenceFlipper,
-    competenceDauphin,
-    competenceRequin,
-  ];
+  let userId, assessmentId;
 
   beforeEach(() => {
-    sinon.stub(challengeRepository, 'findOperative').resolves([
-      challengeForSkillCitation4,
-      anotherChallengeForSkillCitation4,
-      challengeForSkillCitation4AndMoteur3,
-      challengeForSkillCollaborer4,
-      challengeForSkillRecherche4,
-      challengeForSkillRemplir2,
-      challengeForSkillRemplir4,
-      challengeForSkillUrl3,
-      challengeForSkillWeb1,
-      challengeRecordWithoutSkills,
-      challengeForSkillRequin5,
-      challengeForSkillRequin8,
-    ]);
-    sinon.stub(competenceRepository, 'listPixCompetencesOnly').resolves(competences);
-    sinon.stub(skillRepository, 'list').resolves([
-      skillCitation4,
-      skillCollaborer4,
-      skillMoteur3,
-      skillRecherche4,
-      skillRemplir2,
-      skillRemplir4,
-      skillRequin5,
-      skillRequin8,
-      skillUrl3,
-      skillWeb1,
-    ]);
+    const learningContent = [{
+      id: 'areaOne',
+      code: '1',
+      color: 'jaffa',
+      name: 'Domaine 1',
+      titleFr: '1. Domaine 1',
+      competences: [{
+        id: 'competenceRecordIdOne',
+        name: 'Construire un flipper',
+        index: '1.1',
+        tubes: [{
+          id: 'recCitation',
+          skills: [{
+            id: 'recCitation4',
+            nom: '@citation4',
+            pixValue: 1,
+            challenges: [
+              'challengeRecordIdOne',
+              'challengeRecordIdTwo',
+              'challengeRecordIdTen',
+            ],
+          }],
+        }],
+      }, {
+        id: 'competenceRecordIdTwo',
+        name: 'Adopter un dauphin',
+        index: '1.2',
+        tubes: [{
+          id: 'Remplir',
+          skills: [{
+            id: 'recRemplir2',
+            nom: '@remplir2',
+            pixValue: 1,
+            challenges: [
+              'challengeRecordIdOne',
+              'challengeRecordIdFive',
+            ],
+          }, {
+            id: 'recRemplir4',
+            nom: '@remplir4',
+            pixValue: 1,
+            challenges: [
+              'challengeRecordIdSix',
+            ],
+          }],
+        }],
+      }, {
+        id: 'competenceRecordIdThree',
+        name: 'Se faire manger par un requin',
+        index: '1.3',
+        tubes: [{
+          id: 'Requin',
+          skills: [{
+            id: 'recRequin5',
+            nom: '@requin5',
+            pixValue: 1,
+            challenges: [
+              'challengeRecordIdNine',
+            ],
+          }],
+        }],
+      }],
+    }];
+
+    const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+    mockLearningContent(learningContentObjects);
+
+    userId = databaseBuilder.factory.buildUser().id;
+    assessmentId = databaseBuilder.factory.buildAssessment({ userId }).id;
+    return databaseBuilder.commit();
   });
 
   context('V1 Profile', () => {
     describe('#getPlacementProfile', () => {
 
-      const assessmentResult1 = new AssessmentResult({ level: 1, pixScore: 12 });
-      const assessmentResult2 = new AssessmentResult({ level: 2, pixScore: 23 });
-      const assessmentResult3 = new AssessmentResult({ level: 0, pixScore: 2 });
-      const assessment1 = new Assessment({
+      const assessment1 = databaseBuilder.factory.buildAssessment({
         id: 13,
         status: 'completed',
         competenceId: 'competenceRecordIdOne',
-        assessmentResults: [assessmentResult1],
       });
-      const assessment2 = new Assessment({
+      const assessment2 = databaseBuilder.factory.buildAssessment({
         id: 1637,
         status: 'completed',
         competenceId: 'competenceRecordIdTwo',
-        assessmentResults: [assessmentResult2],
       });
-      const assessment3 = new Assessment({
+      const assessment3 = databaseBuilder.factory.buildAssessment({
         id: 145,
         status: 'completed',
         competenceId: 'competenceRecordIdUnknown',
-        assessmentResults: [assessmentResult3],
       });
+      databaseBuilder.factory.buildAssessmentResult({ level: 1, pixScore: 12, assessmentId: assessment1.id });
+      databaseBuilder.factory.buildAssessmentResult({ level: 2, pixScore: 23, assessmentId: assessment2.id });
+      databaseBuilder.factory.buildAssessmentResult({ level: 0, pixScore: 2, assessmentId: assessment3.id });
 
       beforeEach(() => {
-        sinon.stub(assessmentRepository, 'findLastCompletedAssessmentsForEachCompetenceByUser').resolves([
-          assessment1, assessment2, assessment3,
-        ]);
+        databaseBuilder.commit();
       });
 
       it('should load achieved assessments', async () => {
@@ -140,36 +110,15 @@ describe('Integration | Service | Placement Profile Service', function() {
         const limitDate = '2020-10-27 08:44:25';
 
         // when
-        await placementProfileService.getPlacementProfile({ userId, limitDate, isV2Certification: false });
-
-        // then
-        sinon.assert.calledOnce(assessmentRepository.findLastCompletedAssessmentsForEachCompetenceByUser);
-        sinon.assert.calledWith(assessmentRepository.findLastCompletedAssessmentsForEachCompetenceByUser, userId, '2020-10-27 08:44:25');
-      });
-    });
-  });
-
-  context('V2 Profile', () => {
-    describe('#getPlacementProfile', () => {
-
-      it('should assign 0 pixScore and level of 0 to user competence when not assessed', async () => {
-        // given
-        sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-          .withArgs({ userId, limitDate: sinon.match.any }).resolves({});
-
-        // when
-        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
-          userId,
-          limitDate: 'salut',
-        });
+        const actualPlacementProfile = await placementProfileService.getPlacementProfile({ userId, limitDate, isV2Certification: false });
 
         // then
         expect(actualPlacementProfile.userCompetences).to.deep.equal([
           {
             id: 'competenceRecordIdOne',
             index: '1.1',
-            area: { code: '1' },
-            name: '1.1 Construire un flipper',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Construire un flipper',
             skills: [],
             pixScore: 0,
             estimatedLevel: 0,
@@ -177,8 +126,8 @@ describe('Integration | Service | Placement Profile Service', function() {
           {
             id: 'competenceRecordIdTwo',
             index: '1.2',
-            area: { code: '1' },
-            name: '1.2 Adopter un dauphin',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Adopter un dauphin',
             skills: [],
             pixScore: 0,
             estimatedLevel: 0,
@@ -186,8 +135,53 @@ describe('Integration | Service | Placement Profile Service', function() {
           {
             id: 'competenceRecordIdThree',
             index: '1.3',
-            area: { code: '1' },
-            name: '1.3 Se faire manger par un requin',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Se faire manger par un requin',
+            skills: [],
+            pixScore: 0,
+            estimatedLevel: 0,
+          }]);
+      });
+    });
+  });
+
+  context('V2 Profile', () => {
+    const isV2Certification = true;
+    describe('#getPlacementProfile', () => {
+
+      it('should assign 0 pixScore and level of 0 to user competence when not assessed', async () => {
+        // when
+        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+          userId,
+          limitDate: '2020-10-27 08:44:25',
+          isV2Certification,
+        });
+
+        // then
+        expect(actualPlacementProfile.userCompetences).to.deep.equal([
+          {
+            id: 'competenceRecordIdOne',
+            index: '1.1',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Construire un flipper',
+            skills: [],
+            pixScore: 0,
+            estimatedLevel: 0,
+          },
+          {
+            id: 'competenceRecordIdTwo',
+            index: '1.2',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Adopter un dauphin',
+            skills: [],
+            pixScore: 0,
+            estimatedLevel: 0,
+          },
+          {
+            id: 'competenceRecordIdThree',
+            index: '1.3',
+            area: { id: 'areaOne', code: '1', color: 'jaffa', title: '1. Domaine 1', name: 'Domaine 1', competences: [] },
+            name: 'Se faire manger par un requin',
             skills: [],
             pixScore: 0,
             estimatedLevel: 0,
@@ -195,23 +189,22 @@ describe('Integration | Service | Placement Profile Service', function() {
       });
 
       describe('PixScore by competences', () => {
-
         it('should assign pixScore and level to user competence based on knowledge elements', async () => {
           // given
-
-          const ke = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdTwo',
-            skillId: skillRemplir2.id,
+            skillId: 'recRemplir2',
             earnedPix: 23,
+            userId,
+            assessmentId,
           });
-
-          sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-            .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdTwo: [ke] });
+          await databaseBuilder.commit();
 
           // when
           const actualPlacementProfile = await placementProfileService.getPlacementProfile({
             userId,
-            limitDate: 'salut',
+            limitDate: new Date(),
+            isV2Certification,
           });
 
           // then
@@ -225,7 +218,14 @@ describe('Integration | Service | Placement Profile Service', function() {
             id: 'competenceRecordIdTwo',
             pixScore: 23,
             estimatedLevel: 2,
-            skills: [skillRemplir2],
+            skills: [{
+              competenceId: 'competenceRecordIdTwo',
+              id: 'recRemplir2',
+              name: '@remplir2',
+              pixValue: 1,
+              tubeId: 'Remplir',
+              tutorialIds: [],
+            }],
           });
           expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
             id: 'competenceRecordIdThree',
@@ -237,30 +237,30 @@ describe('Integration | Service | Placement Profile Service', function() {
 
         it('should include both inferred and direct KnowlegdeElements to compute PixScore', async () => {
           // given
-          const inferredKe = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdTwo',
-            skillId: skillRemplir2.id,
+            skillId: 'recRemplir2',
             earnedPix: 8,
             source: KnowledgeElement.SourceType.INFERRED,
+            userId,
+            assessmentId,
           });
 
-          const directKe = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdTwo',
-            skillId: skillRemplir4.id,
+            skillId: 'recRemplir4',
             earnedPix: 9,
             source: KnowledgeElement.SourceType.DIRECT,
+            userId,
+            assessmentId,
           });
-
-          sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-            .withArgs({
-              userId,
-              limitDate: sinon.match.any,
-            }).resolves({ 'competenceRecordIdTwo': [inferredKe, directKe] });
+          await databaseBuilder.commit();
 
           // when
           const actualPlacementProfile = await placementProfileService.getPlacementProfile({
             userId,
-            limitDate: 'salut',
+            limitDate: new Date(),
+            isV2Certification,
           });
 
           // then
@@ -269,19 +269,19 @@ describe('Integration | Service | Placement Profile Service', function() {
 
         context('when we dont want to limit pix score', () => {
           it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async () => {
-
-            const ke = domainBuilder.buildKnowledgeElement({
+            databaseBuilder.factory.buildKnowledgeElement({
               competenceId: 'competenceRecordIdOne',
               earnedPix: 64,
+              userId,
+              assessmentId,
             });
-
-            sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-              .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdOne: [ke] });
+            await databaseBuilder.commit();
 
             // when
             const actualPlacementProfile = await placementProfileService.getPlacementProfile({
               userId,
-              limitDate: 'salut',
+              limitDate: new Date(),
+              isV2Certification,
               allowExcessPixAndLevels: true,
             });
 
@@ -297,19 +297,19 @@ describe('Integration | Service | Placement Profile Service', function() {
 
         context('when we want to limit pix score', () => {
           it('should limit pixScore to 40 and level to 5', async () => {
-
-            const ke = domainBuilder.buildKnowledgeElement({
+            databaseBuilder.factory.buildKnowledgeElement({
               competenceId: 'competenceRecordIdOne',
               earnedPix: 64,
+              userId,
+              assessmentId,
             });
-
-            sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-              .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdOne: [ke] });
+            await databaseBuilder.commit();
 
             // when
             const actualPlacementProfile = await placementProfileService.getPlacementProfile({
               userId,
-              limitDate: 'salut',
+              limitDate: new Date(),
+              isV2Certification,
               allowExcessPixAndLevels: false,
             });
 
@@ -324,30 +324,30 @@ describe('Integration | Service | Placement Profile Service', function() {
       });
 
       describe('Skills not found in learningContent', () => {
-
         it('should skip not found skills', async () => {
           // given
-
-          const kePointingToExistingSkill = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdTwo',
-            skillId: skillRemplir2.id,
+            skillId: 'recRemplir2',
             earnedPix: 11,
+            userId,
+            assessmentId,
           });
 
-          const kePointingToMissingSkill = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdTwo',
             skillId: 'missing skill id',
             earnedPix: 11,
+            userId,
+            assessmentId,
           });
-
-          sinon.stub(knowledgeElementRepository, 'findUniqByUserIdGroupedByCompetenceId')
-            .withArgs({ userId, limitDate: sinon.match.any }).resolves({ competenceRecordIdTwo: [
-              kePointingToExistingSkill, kePointingToMissingSkill] });
+          await databaseBuilder.commit();
 
           // when
           const actualPlacementProfile = await placementProfileService.getPlacementProfile({
             userId,
-            limitDate: 'salut',
+            limitDate: new Date(),
+            isV2Certification,
           });
 
           // then
@@ -361,7 +361,14 @@ describe('Integration | Service | Placement Profile Service', function() {
             id: 'competenceRecordIdTwo',
             pixScore: 22,
             estimatedLevel: 2,
-            skills: [skillRemplir2],
+            skills: [{
+              competenceId: 'competenceRecordIdTwo',
+              id: 'recRemplir2',
+              name: '@remplir2',
+              pixValue: 1,
+              tubeId: 'Remplir',
+              tutorialIds: [],
+            }],
           });
           expect(actualPlacementProfile.userCompetences[2]).to.deep.include({
             id: 'competenceRecordIdThree',
@@ -371,19 +378,34 @@ describe('Integration | Service | Placement Profile Service', function() {
           });
         });
       });
-
     });
   });
+
   describe('#getPlacementProfilesWithSnapshotting', () => {
+    const competences = [{
+      id: 'competenceRecordIdOne',
+      area: { id: 'areaOne', code: '1' },
+      name: 'Construire un flipper',
+      index: '1.1',
+      skillIds: ['recCitation4', 'recMoteur3', 'recRecherche4'],
+    }, {
+      id: 'competenceRecordIdTwo',
+      area: { id: 'areaOne', code: '1' },
+      name: 'Adopter un dauphin',
+      index: '1.2',
+      skillIds: ['recRemplir2', 'recRemplir4', 'recUrl3', 'recWeb1'],
+    }, {
+      id: 'competenceRecordIdThree',
+      area: { id: 'areaOne', code: '1' },
+      name: 'Se faire manger par un requin',
+      index: '1.3',
+      skillIds: ['recRequin5', 'recRequin8'],
+    }];
 
     it('should assign 0 pixScore and level of 0 to user competence when not assessed', async () => {
-      // given
-      sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
-        .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: {} });
-
       // when
       const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-        userIdsAndDates: { [userId]: 'someLimitDate' },
+        userIdsAndDates: { [userId]: new Date() },
         competences,
       });
 
@@ -392,8 +414,8 @@ describe('Integration | Service | Placement Profile Service', function() {
         {
           id: 'competenceRecordIdOne',
           index: '1.1',
-          area: { code: '1' },
-          name: '1.1 Construire un flipper',
+          area: { id: 'areaOne', code: '1' },
+          name: 'Construire un flipper',
           skills: [],
           pixScore: 0,
           estimatedLevel: 0,
@@ -401,8 +423,8 @@ describe('Integration | Service | Placement Profile Service', function() {
         {
           id: 'competenceRecordIdTwo',
           index: '1.2',
-          area: { code: '1' },
-          name: '1.2 Adopter un dauphin',
+          area: { id: 'areaOne', code: '1' },
+          name: 'Adopter un dauphin',
           skills: [],
           pixScore: 0,
           estimatedLevel: 0,
@@ -410,8 +432,8 @@ describe('Integration | Service | Placement Profile Service', function() {
         {
           id: 'competenceRecordIdThree',
           index: '1.3',
-          area: { code: '1' },
-          name: '1.3 Se faire manger par un requin',
+          area: { id: 'areaOne', code: '1' },
+          name: 'Se faire manger par un requin',
           skills: [],
           pixScore: 0,
           estimatedLevel: 0,
@@ -422,18 +444,18 @@ describe('Integration | Service | Placement Profile Service', function() {
 
       it('should assign pixScore and level to user competence based on knowledge elements', async () => {
         // given
-        const ke = domainBuilder.buildKnowledgeElement({
+        databaseBuilder.factory.buildKnowledgeElement({
           competenceId: 'competenceRecordIdTwo',
-          skillId: skillRemplir2.id,
+          skillId: 'recRemplir2',
           earnedPix: 23,
+          userId,
+          assessmentId,
         });
-
-        sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
-          .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdTwo: [ke] } });
+        await databaseBuilder.commit();
 
         // when
         const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-          userIdsAndDates: { [userId]: 'someLimitDate' },
+          userIdsAndDates: { [userId]: new Date() },
           competences,
         });
 
@@ -452,26 +474,28 @@ describe('Integration | Service | Placement Profile Service', function() {
 
       it('should include both inferred and direct KnowlegdeElements to compute PixScore', async () => {
         // given
-        const inferredKe = domainBuilder.buildKnowledgeElement({
+        databaseBuilder.factory.buildKnowledgeElement({
           competenceId: 'competenceRecordIdTwo',
-          skillId: skillRemplir2.id,
+          skillId: 'recRemplir2',
           earnedPix: 8,
           source: KnowledgeElement.SourceType.INFERRED,
+          userId,
+          assessmentId,
         });
 
-        const directKe = domainBuilder.buildKnowledgeElement({
+        databaseBuilder.factory.buildKnowledgeElement({
           competenceId: 'competenceRecordIdTwo',
-          skillId: skillRemplir4.id,
+          skillId: 'recRemplir4',
           earnedPix: 9,
           source: KnowledgeElement.SourceType.DIRECT,
+          userId,
+          assessmentId,
         });
-
-        sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
-          .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { 'competenceRecordIdTwo': [inferredKe, directKe] } });
+        await databaseBuilder.commit();
 
         // when
         const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-          userIdsAndDates: { [userId]: 'someLimitDate' },
+          userIdsAndDates: { [userId]: new Date() },
           competences,
         });
 
@@ -481,17 +505,17 @@ describe('Integration | Service | Placement Profile Service', function() {
 
       context('when we dont want to limit pix score', () => {
         it('should not limit pixScore and level to the max reachable for user competence based on knowledge elements', async () => {
-          const ke = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdOne',
             earnedPix: 64,
+            userId,
+            assessmentId,
           });
-
-          sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
-            .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdOne: [ke] } });
+          await databaseBuilder.commit();
 
           // when
           const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-            userIdsAndDates: { [userId]: 'someLimitDate' },
+            userIdsAndDates: { [userId]: new Date() },
             competences,
             allowExcessPixAndLevels: true,
           });
@@ -508,17 +532,17 @@ describe('Integration | Service | Placement Profile Service', function() {
 
       context('when we want to limit pix score', () => {
         it('should limit pixScore to 40 and level to 5', async () => {
-          const ke = domainBuilder.buildKnowledgeElement({
+          databaseBuilder.factory.buildKnowledgeElement({
             competenceId: 'competenceRecordIdOne',
             earnedPix: 64,
+            userId,
+            assessmentId,
           });
-
-          sinon.stub(knowledgeElementRepository, 'findSnapshotGroupedByCompetencesForUsers')
-            .withArgs({ [userId]: sinon.match.any }).resolves({ [userId]: { competenceRecordIdOne: [ke] } });
+          await databaseBuilder.commit();
 
           // when
           const actualPlacementProfiles = await placementProfileService.getPlacementProfilesWithSnapshotting({
-            userIdsAndDates: { [userId]: 'someLimitDate' },
+            userIdsAndDates: { [userId]: new Date() },
             competences,
             allowExcessPixAndLevels: false,
           });
@@ -533,5 +557,4 @@ describe('Integration | Service | Placement Profile Service', function() {
       });
     });
   });
-
 });

--- a/api/tests/integration/domain/services/placement-profile-service_test.js
+++ b/api/tests/integration/domain/services/placement-profile-service_test.js
@@ -1,6 +1,7 @@
 const { expect, databaseBuilder, mockLearningContent, learningContentBuilder } = require('../../../test-helper');
 const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const { ENGLISH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Integration | Service | Placement Profile Service', function() {
 
@@ -13,9 +14,11 @@ describe('Integration | Service | Placement Profile Service', function() {
       color: 'jaffa',
       name: 'Domaine 1',
       titleFr: '1. Domaine 1',
+      titleEn: '1. Area 1',
       competences: [{
         id: 'competenceRecordIdOne',
-        name: 'Construire un flipper',
+        nameFr: 'Construire un flipper',
+        nameEn: 'Build a pinball',
         index: '1.1',
         tubes: [{
           id: 'recCitation',
@@ -32,7 +35,8 @@ describe('Integration | Service | Placement Profile Service', function() {
         }],
       }, {
         id: 'competenceRecordIdTwo',
-        name: 'Adopter un dauphin',
+        nameFr: 'Adopter un dauphin',
+        nameEn: 'Adopt a dolphin',
         index: '1.2',
         tubes: [{
           id: 'Remplir',
@@ -55,7 +59,8 @@ describe('Integration | Service | Placement Profile Service', function() {
         }],
       }, {
         id: 'competenceRecordIdThree',
-        name: 'Se faire manger par un requin',
+        nameFr: 'Se faire manger par un requin',
+        nameEn: 'Getting eaten by a shark',
         index: '1.3',
         tubes: [{
           id: 'Requin',
@@ -186,6 +191,37 @@ describe('Integration | Service | Placement Profile Service', function() {
             pixScore: 0,
             estimatedLevel: 0,
           }]);
+      });
+
+      it('should return area and competence name according to given locale', async () => {
+        // when
+        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+          userId,
+          limitDate: new Date(),
+          isV2Certification,
+          locale: ENGLISH_SPOKEN,
+        });
+
+        // then
+        const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
+        const areaTitle = actualPlacementProfile.userCompetences.map((competence) => competence.area.title);
+        expect(competenceName).to.have.members(['Build a pinball', 'Adopt a dolphin', 'Getting eaten by a shark']);
+        expect(areaTitle).to.have.members(['1. Area 1', '1. Area 1', '1. Area 1']);
+      });
+
+      it('should return area and competence name according to default locale', async () => {
+        // when
+        const actualPlacementProfile = await placementProfileService.getPlacementProfile({
+          userId,
+          limitDate: new Date(),
+          isV2Certification,
+        });
+
+        // then
+        const competenceName = actualPlacementProfile.userCompetences.map((competence) => competence.name);
+        const areaTitle = actualPlacementProfile.userCompetences.map((competence) => competence.area.title);
+        expect(competenceName).to.have.members(['Construire un flipper', 'Adopter un dauphin', 'Se faire manger par un requin']);
+        expect(areaTitle).to.have.members(['1. Domaine 1', '1. Domaine 1', '1. Domaine 1']);
       });
 
       describe('PixScore by competences', () => {

--- a/api/tests/tooling/learning-content-builder/build-learning-content.js
+++ b/api/tests/tooling/learning-content-builder/build-learning-content.js
@@ -73,7 +73,8 @@ const buildLearningContent = function(learningContent) {
         areaId: area.id,
         origin: competence.origin || 'Pix',
         index: competence.index,
-        nameFrFr: competence.name,
+        nameFrFr: competence.nameFr || competence.name,
+        nameEnUs: competence.nameEn || competence.name,
       };
     });
     allCompetences.push(competences);

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -3,6 +3,7 @@ const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
 const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const campaignAssessmentParticipationResultSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer');
+const campaignProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-profile-serializer');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 const events = require('../../../../lib/domain/events');
 const usecases = require('../../../../lib/domain/usecases');
@@ -10,6 +11,7 @@ const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-par
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const CampaignParticipationStarted = require('../../../../lib/domain/events/CampaignParticipationStarted');
 const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Application | Controller | Campaign-Participation', () => {
 
@@ -282,7 +284,7 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
     const campaignId = 123;
     const userId = 456;
     const campaignParticipationId = 789;
-    const locale = 'fr';
+    const locale = FRENCH_SPOKEN;
 
     beforeEach(() => {
       sinon.stub(usecases, 'getCampaignAssessmentParticipationResult');
@@ -304,6 +306,39 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
 
       // when
       const response = await campaignParticipationController.getCampaignAssessmentParticipationResult(request);
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
+
+  describe('#getCampaignProfile', () => {
+
+    const campaignId = 123;
+    const userId = 456;
+    const campaignParticipationId = 789;
+    const locale = FRENCH_SPOKEN;
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'getCampaignProfile');
+      sinon.stub(campaignProfileSerializer, 'serialize');
+    });
+
+    it('should call usecase and serializer with expected parameters', async () => {
+      // given
+      const campaignProfile = Symbol('campaignProfile');
+      const expectedResults = Symbol('results');
+      usecases.getCampaignProfile.withArgs({ userId, campaignId, campaignParticipationId, locale }).resolves(campaignProfile);
+      campaignProfileSerializer.serialize.withArgs(campaignProfile).returns(expectedResults);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { campaignId, campaignParticipationId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignParticipationController.getCampaignProfile(request);
 
       // then
       expect(response).to.equal(expectedResults);

--- a/api/tests/unit/domain/usecases/get-campaign-profile_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-profile_test.js
@@ -1,0 +1,59 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const getCampaignProfile = require('../../../../lib/domain/usecases/get-campaign-profile');
+const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
+
+describe('Unit | UseCase | get-campaign-profile', () => {
+
+  let campaignRepository, campaignProfileRepository;
+  let userId, campaignId, campaignParticipationId;
+  const locale = FRENCH_SPOKEN;
+
+  beforeEach(() => {
+    campaignRepository = {
+      checkIfUserOrganizationHasAccessToCampaign: sinon.stub(),
+    };
+    campaignProfileRepository = {
+      findProfile: sinon.stub(),
+    };
+  });
+
+  context('when user has access to organization that owns campaign', () => {
+
+    beforeEach(() => {
+      userId = domainBuilder.buildUser().id;
+      campaignId = domainBuilder.buildCampaign().id;
+      campaignParticipationId = domainBuilder.buildCampaignParticipation({ campaignId, userId }).id;
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
+    });
+
+    it('should get the campaignProfile', async () => {
+      // given
+      const expectedResult = Symbol('Result');
+      campaignProfileRepository.findProfile.withArgs({ campaignId, campaignParticipationId, locale }).resolves(expectedResult);
+
+      // when
+      const result = await getCampaignProfile({ userId, campaignId, campaignParticipationId, campaignRepository, campaignProfileRepository, locale });
+
+      // then
+      expect(result).to.equal(expectedResult);
+    });
+  });
+
+  context('when user does not have access to organization that owns campaign', () => {
+    beforeEach(() => {
+      userId = domainBuilder.buildUser().id;
+      campaignId = domainBuilder.buildCampaign().id;
+      campaignParticipationId = domainBuilder.buildCampaignParticipation({ campaignId, userId }).id;
+      campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
+    });
+
+    it('should throw UserNotAuthorizedToAccessEntity', async () => {
+      // when
+      const result = await catchErr(getCampaignProfile)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignProfileRepository, locale });
+
+      // then
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    });
+  });
+});

--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -50,25 +50,25 @@
 
       {{#if @campaignAssessmentParticipation.isShared}}
         <ul class="panel-header__data panel-header__data--highlight">
-          <li class="panel-header-data__content panel-header-data__content--horizontal">
-            {{#if this.displayBadges}}
-              <div aria-label="Résultats Thématiques" class="panel-header-data-content__badges">
-                <Badges @badges={{@campaignAssessmentParticipation.badges}}/>
-              </div>
-            {{/if}}
-            <div aria-label="Résultat" class="panel-header-data-content__progress-bar">
-              <ProgressBar @value={{@campaignAssessmentParticipation.masteryPercentage}}>
-                {{@campaignAssessmentParticipation.validatedSkillsCount}} / {{@campaignAssessmentParticipation.targetedSkillsCount}} ACQUIS
-              </ProgressBar>
-            </div>
-            {{#if @campaign.hasStages}}
-              <div aria-label="Paliers" class="panel-header-data-content__stages">
-                <StageStars @result={{@campaignAssessmentParticipation.masteryPercentage}} @stages={{@campaign.stages}}/>
-              </div>
-            {{else}}
-              <div class="value-text value-text--highlight panel-header-data-content__mastery-percentage">{{@campaignAssessmentParticipation.masteryPercentage}}%</div>
-            {{/if}}
+          {{#if this.displayBadges}}
+            <li aria-label="Résultats Thématiques" class="panel-header-data__content panel-header-data-content__badges">
+              <Badges @badges={{@campaignAssessmentParticipation.badges}}/>
+            </li>
+          {{/if}}
+          <li aria-label="Résultat" class="panel-header-data__content panel-header-data-content__progress-bar">
+            <ProgressBar @value={{@campaignAssessmentParticipation.masteryPercentage}}>
+              {{@campaignAssessmentParticipation.validatedSkillsCount}} / {{@campaignAssessmentParticipation.targetedSkillsCount}} ACQUIS
+            </ProgressBar>
           </li>
+          {{#if @campaign.hasStages}}
+            <li aria-label="Paliers" class="panel-header-data__content panel-header-data-content__stages">
+              <StageStars @result={{@campaignAssessmentParticipation.masteryPercentage}} @stages={{@campaign.stages}}/>
+            </li>
+          {{else}}
+            <li class="panel-header-data__content value-text value-text--highlight panel-header-data-content__mastery-percentage">
+              {{@campaignAssessmentParticipation.masteryPercentage}}%
+            </li>
+          {{/if}}
         </ul>
       {{/if}}
     </div>

--- a/orga/app/styles/globals/panels.scss
+++ b/orga/app/styles/globals/panels.scss
@@ -73,22 +73,12 @@
     align-content: center;
     flex-direction: column;
     align-items: flex-start;
-    padding: 1px 28px 1px 24px;
-    border-right: 1px solid $grey-20;
-
-    &--horizontal {
-      flex-direction: row;
-      align-items: center;
-    }
+    padding: 0 16px;
+    border-left: 1px solid $grey-20;
   }
 
   &__content:first-child {
-    padding-left: 0;
-  }
-
-  &__content:last-child {
-    border-right: none;
-    padding-right: 0;
+    border-left: none;
   }
 }
 
@@ -96,9 +86,7 @@
   &__badges {
     display: flex;
     align-items: center;
-    height: 32px;
-    padding: 0 16px;
-    border-right: 1px solid $grey-20;
+    flex-direction: row;
 
     img {
       height: 40px;
@@ -117,15 +105,12 @@
   }
 
   &__progress-bar {
-    padding: 16px 16px 0 16px;
+    padding-top: 8px;
   }
 
   &__stages {
     display: flex;
     align-items: center;
-    height: 32px;
-    padding: 0 16px;
-    border-left: 1px solid $grey-20;
 
     .pix-stars svg {
       width: 26px;
@@ -134,7 +119,9 @@
   }
 
   &__mastery-percentage {
-    padding-right: 16px;
+    margin-bottom: 8px;
+    padding-left: 0;
+    border-left: none;
   }
 }
 


### PR DESCRIPTION
## :unicorn: Problème
Nous commençons la traduction de Pix Orga en anglais. Cependant il faut également traduire tout le référentiel et récupérer celui-ci dans Pix Orga.

## :robot: Solution
Côté Pix Orga, tout est déjà prêt désormais.
Côté Pix API, pour la route en question, récupérer la locale et récupérer les noms des compétences correspondantes.

## :rainbow: Remarques
BSR 1 : rendre un test vraiment "d'intégration"
BSR 2 : corriger l'affichage cassé des résultats d'une collecte de profils : 
![image](https://user-images.githubusercontent.com/23451175/107670202-c8833880-6c92-11eb-8f3f-5c0c3b749c70.png)

## :100: Pour tester
Dans Pix Orga, aller dans une campagne de collecte de profils, puis dans l'onglet "participants", et cliquer sur un participant ayant partagé ses résultats. Saisir dans l'url à la fin "?lang=en" et vérifier qu'après rechargement, les compétences s'affichent en anglais.