### PR TITLE
[FEATURE] Amélioration de l'a11y sur la page d'accès aux campagnes (PIX-1873).

### DIFF
--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -46,7 +46,8 @@
 
         {{#if this.isUserAuthenticated}}
           <div class="fill-in-campaign-code__warning">
-            <span>{{this.warningMessage}}</span>&nbsp;<span class="link" {{action this.disconnect}}>{{t 'pages.fill-in-campaign-code.warning-message-logout'}}</span>
+            <span>{{this.warningMessage}}</span>
+            <a href="#" class="link" {{action this.disconnect}}>{{t 'pages.fill-in-campaign-code.warning-message-logout'}}</a>
           </div>
         {{/if}}
       </main>


### PR DESCRIPTION
## :unicorn: Problème

Sur la page https://app.pix.fr/campagnes : Le lien "Se déconnecter" est un `<span></span>` et non un `<a></a>` ce qui le rend inaccessible au clavier.

## :robot: Solution

Remplacement du `span` par un  `a` sans redirection pour conserver le comportement initial de l'application.

## :rainbow: Remarques

RAS

## :100: Pour tester

Se rendre sur la page `/campagnes` de Pix-App et accéder à la déconnexion au clavier.
