### PR TITLE
[FEATURE] Je veux des alt corrects pour les logo Pix qui me renvoie sur l'accueil (PIX-1837).

### DIFF
--- a/mon-pix/app/templates/components/password-reset-demand-form.hbs
+++ b/mon-pix/app/templates/components/password-reset-demand-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.homepage'}}>
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
+  <a href={{this.homeUrl}} class="pix-logo__link">
+    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/templates/components/pix-logo.hbs
+++ b/mon-pix/app/templates/components/pix-logo.hbs
@@ -1,5 +1,5 @@
 <div class="pix-logo">
-  <LinkTo @route="index" class="pix-logo__link" @title={{t 'navigation.homepage'}}>
-    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt={{t 'common.pix'}}>
+  <LinkTo @route="index" class="pix-logo__link">
+    <img class="pix-logo__image" src="{{this.rootURL}}/images/pix-logo.svg" alt={{t 'navigation.homepage'}}>
   </LinkTo>
 </div>

--- a/mon-pix/app/templates/components/reset-password-form.hbs
+++ b/mon-pix/app/templates/components/reset-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.back-to-homepage'}}>
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
+  <a href={{this.homeUrl}} class="pix-logo__link">
+    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -1,7 +1,7 @@
 <main class="sign-form__container">
 
-  <a href={{this.homeUrl}} class="pix-logo__link" title="{{t 'navigation.homepage'}}">
-    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'common.pix'}}">
+  <a href={{this.homeUrl}} class="pix-logo__link">
+    <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/templates/components/signup-form.hbs
+++ b/mon-pix/app/templates/components/signup-form.hbs
@@ -1,8 +1,8 @@
 {{!-- template-lint-disable no-implicit-this no-action no-curly-component-invocation --}}
 <main class="sign-form__container">
 
-  <a href={{homeUrl}} class="pix-logo__link" title="{{t 'navigation.homepage'}}">
-    <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'common.pix'}}">
+  <a href={{homeUrl}} class="pix-logo__link">
+    <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
   </a>
 
   <div class="sign-form__header">

--- a/mon-pix/app/templates/components/update-expired-password-form.hbs
+++ b/mon-pix/app/templates/components/update-expired-password-form.hbs
@@ -1,7 +1,7 @@
 <div class="update-expired-password-form__container">
 
-    <a href={{this.homeUrl}} class="pix-logo__link" title={{t 'navigation.back-to-homepage'}}>
-      <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="Pix">
+    <a href={{this.homeUrl}} class="pix-logo__link">
+      <img class="pix-logo__image" src="{{@rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
     </a>
 
     <div class="update-expired-password-form__header">

--- a/mon-pix/app/templates/terms-of-service-pe.hbs
+++ b/mon-pix/app/templates/terms-of-service-pe.hbs
@@ -4,8 +4,8 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{homeUrl}} title={{t 'navigation.homepage'}}>
-        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+      <a href={{homeUrl}}>
+        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt={{t 'navigation.homepage'}}>
       </a>
     </div>
 

--- a/mon-pix/app/templates/terms-of-service.hbs
+++ b/mon-pix/app/templates/terms-of-service.hbs
@@ -4,8 +4,8 @@
   <div class="terms-of-service-form">
 
     <div class="terms-of-service-form__logo">
-      <a href={{homeUrl}} title={{t 'navigation.homepage'}}>
-        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="Pix">
+      <a href={{homeUrl}}>
+        <img class="pix-logo__image" src="{{rootURL}}/images/pix-logo.svg" alt="{{t 'navigation.homepage'}}">
       </a>
     </div>
 

--- a/mon-pix/tests/integration/components/pix-logo-test.js
+++ b/mon-pix/tests/integration/components/pix-logo-test.js
@@ -21,11 +21,7 @@ describe('Integration | Component | pix logo', function() {
   });
 
   it('should have a textual alternative', function() {
-    expect(find('.pix-logo__image').getAttribute('alt')).to.equal('pix');
-  });
-
-  it('should have a title in the link', function() {
-    expect(find('.pix-logo__link').getAttribute('title')).to.equal('Page d\'accueil');
+    expect(find('.pix-logo__image').getAttribute('alt')).to.equal('Page d\'accueil de Pix');
   });
 
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -1045,7 +1045,7 @@
     "navigation": {
         "copyrights": "©",
         "error": "Error",
-        "homepage": "Homepage",
+        "homepage": "Pix's Homepage",
         "back-to-homepage": "Return to homepage",
         "back-to-profile": "Return to profile",
         "footer": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -1045,7 +1045,7 @@
     "navigation": {
         "copyrights": "©",
         "error": "Erreur",
-        "homepage": "Page d'accueil",
+        "homepage": "Page d'accueil de Pix",
         "back-to-homepage": "Revenir à la page d’accueil",
         "back-to-profile": "Revenir au profil",
         "footer": {


### PR DESCRIPTION
## :unicorn: Problème
Remonté durant l'audit : 
> Le lien image du logo PIX possède à la fois un intitulé de lien et une alternative d'image. Privilégier l'un des deux et le compléter afin d'avoir un seul intitulé explicite (ar exemple : "Page d'accueil de PIX.fr"

## :robot: Solution
- Garder le Alt, retirer le title.
- Indiquer dans la traduction que c'est bien l'accueil de pix vers laquelle on renvoit
- Le faire sur toutes les images de Pix servant de lien vers l'accueil

## :100: Pour tester
- Regarder le `alt` de l'image de connexion