### PR TITLE
[BUGFIX] Avoir une erreur 400 quand le format de réponse n'est pas le bon (PIX-2116).

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -2,7 +2,6 @@ const Joi = require('joi');
 const answerController = require('./answer-controller');
 const identifiersType = require('../../domain/types/identifiers-type');
 const { NotFoundError } = require('../../domain/errors');
-
 exports.register = async function(server) {
   server.route([
     {
@@ -10,6 +9,23 @@ exports.register = async function(server) {
       path: '/api/answers',
       config: {
         auth: false,
+        validate: {
+          payload: Joi.object({
+            data: Joi.object({
+              attributes: Joi.object({
+                value: Joi.string().required(),
+                'elapsed-time': Joi.number().allow(null),
+                result: Joi.string().allow(null),
+                'result-details': Joi.string().allow(null),
+                timeout: Joi.number().allow(null),
+              }).required(),
+              relationships: Joi.object().required(),
+              assessment: Joi.object(),
+              challenge: Joi.object(),
+              type: Joi.string(),
+            }).required(),
+          }).required(),
+        },
         handler: answerController.save,
         tags: ['api', 'answers'],
         notes: [

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -191,5 +191,27 @@ describe('Acceptance | Controller | answer-controller-save', () => {
       });
 
     });
+
+    context('when the payload is empty', () => {
+      beforeEach(() => {
+        postAnswersOptions = {
+          method: 'POST',
+          url: '/api/answers',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          payload: {},
+        };
+        promise = server.inject(postAnswersOptions);
+      });
+
+      it('should return 400 HTTP status code', async () => {
+        // when
+        const response = await promise;
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+
+    });
+
   });
 });

--- a/api/tests/unit/application/answers/index_test.js
+++ b/api/tests/unit/application/answers/index_test.js
@@ -24,8 +24,24 @@ describe('Unit | Router | answer-router', function() {
   describe('POST /api/answers', function() {
 
     it('should exist', async () => {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            value: 'test',
+            'elapsed-time': null,
+            result: null,
+            'result-details': null,
+            timeout: null,
+          },
+          relationships: {},
+          assessment: {},
+          challenge: {},
+          type: 'answers',
+        },
+      };
       // when
-      const result = await httpTestServer.request('POST', '/api/answers');
+      const result = await httpTestServer.request('POST', '/api/answers', payload);
 
       // then
       expect(result.statusCode).to.equal(201);


### PR DESCRIPTION
## :unicorn: Problème
Ce ticket répond à l'erreur sentry : https://sentry.io/organizations/pix/issues/2189926701/?project=1398749&referrer=slack
Quand on fait un `POST /api/answers` avec un payload vide, on a une erreur 500.

## :robot: Solution
- Ajouter un validateur sur le format attendu pour les answers

## :rainbow: Remarques
- Cette vérification est en partie exhaustif

## :100: Pour tester
- Pouvoir répondre aux épreuves
- Si on fait un appel vide sur cette route, avoir une erreur 400.