### PR TITLE
[CLEANUP] Suppression du toggle d'envoi automatique des resultats (PIX-2153)

### DIFF
--- a/certif/app/components/certification-candidate-in-staging-item.hbs
+++ b/certif/app/components/certification-candidate-in-staging-item.hbs
@@ -69,7 +69,6 @@
         {{on 'input' (fn @updateCandidateData @candidateData 'birthCountry')}} >
     </div>
   </td>
-  {{#if this.isResultRecipientEmailVisible}}
   <td data-test-id='panel-candidate__result-recipient-email__add-staging'>
     <div class="certification-candidates-input-wrapper">
         <input
@@ -79,7 +78,6 @@
           {{on 'input' (fn @updateCandidateData @candidateData 'resultRecipientEmail')}} >
     </div>
   </td>
-  {{/if}}
   <td data-test-id='panel-candidate__email__add-staging'>
     <div class="certification-candidates-input-wrapper">
       <input

--- a/certif/app/components/certification-candidate-in-staging-item.js
+++ b/certif/app/components/certification-candidate-in-staging-item.js
@@ -5,13 +5,9 @@ import { action } from '@ember/object';
 import { computed } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
-import config from 'pix-certif/config/environment';
-
 const firstOf20thCentury = -2206310961000;
 
 export default class CertificationCandidateInStagingItem extends Component {
-
-  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   birthProvinceCodePattern = '^[0-9][A,a,B,b,0-9][0-9]?$'
 

--- a/certif/app/components/enrolled-candidates.hbs
+++ b/certif/app/components/enrolled-candidates.hbs
@@ -60,14 +60,12 @@
             {{/if}}
             Pays de naissance
           </th>
-          {{#if this.isResultRecipientEmailVisible}}
-            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <th>Adresse e-mail du destinataire des résultats</th>
-            {{/unless}}
-          {{/if}}
-            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-              <th>Adresse e-mail de convocation</th>
-            {{/unless}}
+          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+            <th>Adresse e-mail du destinataire des résultats</th>
+          {{/unless}}
+          {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+            <th>Adresse e-mail de convocation</th>
+          {{/unless}}
           {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
             <th>Identifiant externe</th>
           {{/unless}}
@@ -93,14 +91,12 @@
             <td data-test-id='panel-candidate__birthCity__{{candidate.id}}'>{{candidate.birthCity}}</td>
             <td data-test-id='panel-candidate__birthProvinceCode__{{candidate.id}}'>{{candidate.birthProvinceCode}}</td>
             <td data-test-id='panel-candidate__birthCountry__{{candidate.id}}'>{{candidate.birthCountry}}</td>
-            {{#if this.isResultRecipientEmailVisible}}
-              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
-              {{/unless}}
-            {{/if}}
-              {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
-                <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
-              {{/unless}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <td data-test-id='panel-candidate__result-recipient-email__{{candidate.id}}'>{{candidate.resultRecipientEmail}}</td>
+            {{/unless}}
+            {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
+              <td data-test-id='panel-candidate__email__{{candidate.id}}'>{{candidate.email}}</td>
+            {{/unless}}
             {{#unless @shouldDisplayPrescriptionScoStudentRegistrationFeature}}
               <td data-test-id='panel-candidate__externalId__{{candidate.id}}'>{{candidate.externalId}}</td>
             {{/unless}}

--- a/certif/app/components/enrolled-candidates.js
+++ b/certif/app/components/enrolled-candidates.js
@@ -5,10 +5,7 @@ import EmberObject, { action } from '@ember/object';
 import get from 'lodash/get';
 import toNumber from 'lodash/toNumber';
 
-import config from 'pix-certif/config/environment';
-
 export default class EnrolledCandidates extends Component {
-  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @service store;
   @service notifications;

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -17,8 +17,7 @@
         </div>
       </div>
       <div class="panel-actions__button">
-        <a data-test-id="attendance_sheet_download_button"
-          class="button button--link button--with-icon"
+        <a class="button button--link button--with-icon"
           href="{{@session.urlToDownloadCandidatesImportTemplate}}" target="_blank" rel="noopener noreferrer" download>
           Télécharger (.ods)<FaIcon @icon='file-download' />
         </a>
@@ -41,8 +40,7 @@
         </div>
         <div class="panel-actions__button">
           <FileUpload @name="file-upload" @for="upload-attendance-sheet" @accept=".ods" @multiple={{false}} @onfileadd={{this.importCertificationCandidates}}>
-            <span data-test-id="attendance_sheet_upload_button"
-                  class="button button--with-icon"
+            <span class="button button--with-icon"
                   role="button"
                   tabindex="0">
               Importer (.ods)<FaIcon @icon='cloud-upload-alt' />

--- a/certif/app/components/import-candidates.hbs
+++ b/certif/app/components/import-candidates.hbs
@@ -6,91 +6,38 @@
       </div>
       <div class="panel-actions__header-title">Ajouter des candidats</div>
     </div>
-    {{#if this.isResultRecipientEmailVisible}}
-      <div class="panel-actions__action-row">
-        <div class="panel-actions__action-icon">
-          <FaIcon @icon="file-download" />
-        </div>
-        <div class="panel-actions__description">
-          <div class="panel-actions__title">Télécharger le modèle de liste des candidats</div>
-          <div class="panel-actions__subtitle">Pour ajouter des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document.
-            <br> Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats ajoutés à la session.
-          </div>
-        </div>
-        <div class="panel-actions__button">
-          <a data-test-id="attendance_sheet_download_button"
-            class="button button--link button--with-icon"
-            href="{{@session.urlToDownloadCandidatesImportTemplate}}" target="_blank" rel="noopener noreferrer" download>
-            Télécharger (.ods)<FaIcon @icon='file-download' />
-          </a>
+    <div class="panel-actions__action-row">
+      <div class="panel-actions__action-icon">
+        <FaIcon @icon="file-download" />
+      </div>
+      <div class="panel-actions__description">
+        <div class="panel-actions__title">Télécharger le modèle de liste des candidats</div>
+        <div class="panel-actions__subtitle">Pour ajouter des candidats à la session, renseignez leurs informations (Nom, Prénom, …) dans ce document.
+          <br> Lors du premier téléchargement, le modèle de liste des candidats est vide. Il contiendra ensuite les informations des candidats ajoutés à la session.
         </div>
       </div>
-    {{else}}
-      <div class="panel-actions__action-row">
-        <div class="panel-actions__action-icon">
-          <FaIcon @icon="file-download" />
-        </div>
-        <div class="panel-actions__description">
-          <div class="panel-actions__title">
-            {{#if @isReportsCategorizationFeatureToggleEnabled}}
-              Télécharger la feuille d'émargement
-            {{else}}
-              Télécharger le PV de session
-            {{/if}}
-          </div>
-          <div class="panel-actions__subtitle">Renseignez les informations des candidats (Nom, Prénom, &#x2026;)
-            <br>
-            {{#if @isReportsCategorizationFeatureToggleEnabled}}
-              Lors du premier téléchargement, la feuille d'émargement est vide. Elle contiendra ensuite les informations des candidats ajoutés à la session.
-            {{else}}
-              Lors du premier téléchargement, le PV de session est vide. Il contiendra ensuite les informations des candidats ajoutés à la session.
-            {{/if}}
-          </div>
-        </div>
-        <div class="panel-actions__button">
-          <a data-test-id="attendance_sheet_download_button"
-            class="button button--link button--with-icon"
-            href="{{@session.urlToDownloadAttendanceSheet}}" target="_blank" rel="noopener noreferrer" download>
-            Télécharger (.ods)<FaIcon @icon='file-download' />
-          </a>
-        </div>
+      <div class="panel-actions__button">
+        <a data-test-id="attendance_sheet_download_button"
+          class="button button--link button--with-icon"
+          href="{{@session.urlToDownloadCandidatesImportTemplate}}" target="_blank" rel="noopener noreferrer" download>
+          Télécharger (.ods)<FaIcon @icon='file-download' />
+        </a>
       </div>
-    {{/if}}
+    </div>
     <div class="panel-actions__action-row">
       {{#if @importAllowed}}
         <div class="panel-actions__action-icon">
           <FaIcon @icon="cloud-upload-alt" />
         </div>
         <div class="panel-actions__description">
-          {{#if this.isResultRecipientEmailVisible}}
-            <div class="panel-actions__title">Importer la liste des candidats</div>
-            <div class="panel-actions__subtitle">
-              Sélectionnez la liste des candidats préalablement remplie.
-              <br>
-              <strong>
-                Attention, tout nouvel import efface la liste des candidats existante.
-              </strong>
-            </div>
-          {{else}}
-            <div class="panel-actions__title">
-              {{#if @isReportsCategorizationFeatureToggleEnabled}}
-                Importer la feuille d'émargement
-              {{else}}
-                Importer le PV de session
-              {{/if}}
-            </div>
-            <div class="panel-actions__subtitle">
-              {{#if @isReportsCategorizationFeatureToggleEnabled}}
-                Sélectionnez la feuille d'émargement préalablement remplie.
-              {{else}}
-                Sélectionnez le PV de session préalablement rempli.
-              {{/if}}
-              <br>
-              <strong>
-                Attention, tout nouvel import efface la liste des candidats existante.
-              </strong>
-            </div>
-          {{/if}}
+          <div class="panel-actions__title">Importer la liste des candidats</div>
+          <div class="panel-actions__subtitle">
+            Sélectionnez la liste des candidats préalablement remplie.
+            <br>
+            <strong>
+              Attention, tout nouvel import efface la liste des candidats existante.
+            </strong>
+          </div>
         </div>
         <div class="panel-actions__button">
           <FileUpload @name="file-upload" @for="upload-attendance-sheet" @accept=".ods" @multiple={{false}} @onfileadd={{this.importCertificationCandidates}}>

--- a/certif/app/components/import-candidates.js
+++ b/certif/app/components/import-candidates.js
@@ -2,10 +2,8 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { action } from '@ember/object';
-import config from 'pix-certif/config/environment';
 
 export default class ImportCandidates extends Component {
-  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @service session;
   @service notifications;
@@ -13,9 +11,7 @@ export default class ImportCandidates extends Component {
   @action
   async importCertificationCandidates(file) {
     const { access_token } = this.session.data.authenticated;
-    const importError = this.isResultRecipientEmailVisible ?
-      'Veuillez télécharger à nouveau le modèle de liste des candidats et l\'importer à nouveau.' :
-      'Veuillez modifier votre fichier et l’importer à nouveau.';
+
     this.notifications.clearAll();
 
     try {
@@ -32,7 +28,12 @@ export default class ImportCandidates extends Component {
       if (err.body.errors) {
         err.body.errors.forEach((error) => {
           if (error.status === '422') {
-            errorMessage = htmlSafe(`<p>${errorPrefix}<b>${error.detail}</b> <br>${importError}</p>`);
+            errorMessage = htmlSafe(`
+              <p>
+                ${errorPrefix}<b>${error.detail}</b><br>
+                Veuillez télécharger à nouveau le modèle de liste des candidats et l'importer à nouveau.
+              </p>`,
+            );
           }
           if (error.status === '403' && error.detail === 'At least one candidate is already linked to a user') {
             errorMessage = 'La session a débuté, il n\'est plus possible de modifier la liste des candidats.';

--- a/certif/app/controllers/authenticated/sessions/details.js
+++ b/certif/app/controllers/authenticated/sessions/details.js
@@ -4,12 +4,9 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import config from 'pix-certif/config/environment';
 
 export default class SessionsDetailsController extends Controller {
   @service currentUser;
-
-  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   @alias('model.session') session;
   @alias('model.certificationCandidates') certificationCandidates;
@@ -28,13 +25,13 @@ export default class SessionsDetailsController extends Controller {
     return certificationCandidatesCount > 0;
   }
 
-  @computed('hasOneOrMoreCandidates', 'shouldDisplayPrescriptionScoStudentRegistrationFeature', 'isResultRecipientEmailVisible')
+  @computed('hasOneOrMoreCandidates')
   get shouldDisplayDownloadButton() {
-    return this.hasOneOrMoreCandidates && (this.shouldDisplayPrescriptionScoStudentRegistrationFeature || this.isResultRecipientEmailVisible);
+    return this.hasOneOrMoreCandidates;
   }
 
-  @computed('isResultRecipientEmailVisible', 'currentUser.currentCertificationCenter.isScoManagingStudents')
+  @computed('shouldDisplayPrescriptionScoStudentRegistrationFeature')
   get shouldDisplayResultRecipientInfoMessage() {
-    return this.isResultRecipientEmailVisible === true && this.currentUser.currentCertificationCenter.isScoManagingStudents === false;
+    return !this.shouldDisplayPrescriptionScoStudentRegistrationFeature;
   }
 }

--- a/certif/app/controllers/authenticated/sessions/list.js
+++ b/certif/app/controllers/authenticated/sessions/list.js
@@ -4,14 +4,11 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { action, computed } from '@ember/object';
 import { notEmpty, sort } from '@ember/object/computed';
-import config from 'pix-certif/config/environment';
 
 const SORTING_ORDER = ['date:desc', 'time:desc'];
 
 export default class SessionsListController extends Controller {
   @service currentUser;
-
-  isResultRecipientEmailVisible = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
   sortingOrder = SORTING_ORDER;
 
@@ -24,8 +21,8 @@ export default class SessionsListController extends Controller {
     this.transitionToRoute('authenticated.sessions.details', session.id);
   }
 
-  @computed('isResultRecipientEmailVisible', 'currentUser.currentCertificationCenter.isScoManagingStudents')
+  @computed('currentUser.currentCertificationCenter.isScoManagingStudents')
   get shouldDisplayResultRecipientInfoMessage() {
-    return this.isResultRecipientEmailVisible === true && this.currentUser.currentCertificationCenter.isScoManagingStudents === false;
+    return !this.currentUser.currentCertificationCenter.isScoManagingStudents;
   }
 }

--- a/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
+++ b/certif/app/templates/authenticated/sessions/details/certification-candidates.hbs
@@ -13,7 +13,6 @@
   <ImportCandidates
           @session={{this.currentSession}}
           @certificationCandidates={{this.certificationCandidates}}
-          @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
           @reloadCertificationCandidate={{this.reloadCertificationCandidateInController}}
           @importAllowed={{this.importAllowed}}/>
   <EnrolledCandidates

--- a/certif/config/environment.js
+++ b/certif/config/environment.js
@@ -51,7 +51,6 @@ module.exports = function(environment) {
         NOT_FOUND: '404',
       },
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
-      FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS: _isFeatureEnabled(process.env.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS),
     },
 
     googleFonts: [

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, only } from 'qunit';
 import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import moment from 'moment';
@@ -141,7 +141,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
           await upload('#upload-attendance-sheet', file);
 
           // then
-          assert.dom('[data-test-notification-message="error"]').hasText('Aucun candidat n’a été importé. Une erreur personnalisée Veuillez modifier votre fichier et l’importer à nouveau.');
+          assert.dom('[data-test-notification-message="error"]').hasText('Aucun candidat n’a été importé. Une erreur personnalisée Veuillez télécharger à nouveau le modèle de liste des candidats et l\'importer à nouveau.');
         });
 
         test('it should display a specific error message when importing is forbidden', async function(assert) {

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -1,4 +1,4 @@
-import { module, test, only } from 'qunit';
+import { module, test } from 'qunit';
 import { click, currentURL, visit, fillIn } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import moment from 'moment';
@@ -10,7 +10,6 @@ import {
 import { upload } from 'ember-file-upload/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import config from 'pix-certif/config/environment';
 
 module('Acceptance | Session Details Certification Candidates', function(hooks) {
 
@@ -27,7 +26,6 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
   hooks.afterEach(function() {
     const notificationMessagesService = this.owner.lookup('service:notifications');
     notificationMessagesService.clearAll();
-    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
   });
 
   module('When certificationPointOfContact is not logged in', function() {
@@ -61,10 +59,8 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
         await visit(`/sessions/${session.id}/candidats`);
 
         // then
-        assert.dom('[data-test-id="attendance_sheet_download_button"]').exists();
-        assert.dom('[data-test-id="attendance_sheet_download_button"]').hasText('Télécharger (.ods)');
-        assert.dom('[data-test-id="attendance_sheet_upload_button"]').exists();
-        assert.dom('[data-test-id="attendance_sheet_upload_button"]').hasText('Importer (.ods)');
+        assert.contains('Télécharger (.ods)');
+        assert.contains('Importer (.ods)');
       });
 
       test('it should display a sentence when there is no certification candidates yet', async function(assert) {
@@ -73,7 +69,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
         // then
         assert.dom('table tbody').doesNotExist();
-        assert.dom('.table__empty').hasText('En attente de candidats');
+        assert.contains('En attente de candidats');
       });
     });
 
@@ -84,7 +80,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
       hooks.beforeEach(function() {
         sessionWithCandidates = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
-        candidates = server.createList('certification-candidate', 3, { sessionId: sessionWithCandidates.id, isLinked: false });
+        candidates = server.createList('certification-candidate', 3, { sessionId: sessionWithCandidates.id, isLinked: false, resultRecipientEmail: 'recipient@example.com' });
       });
 
       test('it should display the list of certification candidates', async function(assert) {
@@ -96,14 +92,15 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
         // then
         assert.dom('table tbody tr').exists({ count: 3 });
-        assert.dom(`[data-test-id="panel-candidate__lastName__${aCandidate.id}"]`).hasText(`${aCandidate.lastName}`);
-        assert.dom(`[data-test-id="panel-candidate__firstName__${aCandidate.id}"]`).hasText(`${aCandidate.firstName}`);
-        assert.dom(`[data-test-id="panel-candidate__birthdate__${aCandidate.id}"]`).hasText(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
-        assert.dom(`[data-test-id="panel-candidate__birthCity__${aCandidate.id}"]`).hasText(`${aCandidate.birthCity}`);
-        assert.dom(`[data-test-id="panel-candidate__birthProvinceCode__${aCandidate.id}"]`).hasText(`${aCandidate.birthProvinceCode}`);
-        assert.dom(`[data-test-id="panel-candidate__birthCountry__${aCandidate.id}"]`).hasText(`${aCandidate.birthCountry}`);
-        assert.dom(`[data-test-id="panel-candidate__email__${aCandidate.id}"]`).hasText(`${aCandidate.email}`);
-        assert.dom(`[data-test-id="panel-candidate__externalId__${aCandidate.id}"]`).hasText(`${aCandidate.externalId}`);
+        assert.contains(`${aCandidate.lastName}`);
+        assert.contains(`${aCandidate.firstName}`);
+        assert.contains(`${moment(aCandidate.birthdate, 'YYYY-MM-DD').format('DD/MM/YYYY')}`);
+        assert.contains(`${aCandidate.birthCity}`);
+        assert.contains(`${aCandidate.birthProvinceCode}`);
+        assert.contains(`${aCandidate.birthCountry}`);
+        assert.contains(`${aCandidate.email}`);
+        assert.contains(`${aCandidate.resultRecipientEmail}`);
+        assert.contains(`${aCandidate.externalId}`);
       });
 
       module('on import', function() {

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -3,8 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-import config from 'pix-certif/config/environment';
-
 module('Integration | Component | enrolled-candidates', function(hooks) {
   setupRenderingTest(hooks);
 
@@ -24,16 +22,6 @@ module('Integration | Component | enrolled-candidates', function(hooks) {
   const BIRTH_COUNTRY_SELECTOR = 'panel-candidate__birthCountry__';
   const EMAIL_SELECTOR = 'panel-candidate__email__';
   const EXTRA_TIME_SELECTOR = 'panel-candidate__extraTimePercentage__';
-
-  const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
-
-  hooks.before(() => {
-    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
-  });
-
-  hooks.after(() => {
-    config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = ft;
-  });
 
   test('it display candidates information', async function(assert) {
 

--- a/certif/tests/integration/components/import-candidates-test.js
+++ b/certif/tests/integration/components/import-candidates-test.js
@@ -2,47 +2,32 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | import-candidates', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders old texts about PV session when isReportsCategorizationFeatureToggleEnabled is false', async function(assert) {
+  test('it renders texts about Feuille émargement', async function(assert) {
     // given
-    this.set('session', {
-      certificationCandidates: [],
+    const certificationCandidate = EmberObject.create({
+      firstName: 'Julie',
+      lastName: 'Abba',
     });
-    this.set('isReportsCategorizationFeatureToggleEnabled', false);
+    this.set('session', {
+      certificationCandidates: [
+        certificationCandidate,
+      ],
+    });
     this.set('importAllowed', true);
 
     // when
     await render(hbs`<ImportCandidates
       @session={{this.session}}
-      @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
       @importAllowed={{this.importAllowed}}
       />`);
 
     // then
-    assert.contains('Télécharger le PV de session');
-    assert.contains('Importer le PV de session');
-  });
-
-  test('it renders new texts about Feuille émargement when isReportsCategorizationFeatureToggleEnabled is true', async function(assert) {
-    // given
-    this.set('session', {
-      certificationCandidates: [],
-    });
-    this.set('isReportsCategorizationFeatureToggleEnabled', true);
-    this.set('importAllowed', true);
-
-    // when
-    await render(hbs`<ImportCandidates
-      @session={{this.session}}
-      @isReportsCategorizationFeatureToggleEnabled={{this.isReportsCategorizationFeatureToggleEnabled}}
-      @importAllowed={{this.importAllowed}}
-      />`);
-
-    // then
-    assert.contains('Télécharger la feuille d\'émargement');
-    assert.contains('Importer la feuille d\'émargement');
+    assert.contains('Télécharger le modèle de liste des candidats');
+    assert.contains('Importer la liste des candidats');
   });
 });

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -78,72 +78,34 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
           // then
           assert.ok(shouldDisplayDownloadButton);
         });
-
       });
 
-      module('when it should not display the CertifPrescriptionScoFeature', function() {
+      test('Should return true', function(assert) {
+        // given
+        const controller = this.owner.lookup('controller:authenticated/sessions/details');
+        controller.model = {
+          certificationCandidates: ['candidate1', 'candidate2'],
+          shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
+        };
 
-        test('should return false ', function(assert) {
-          // given
-          const controller = this.owner.lookup('controller:authenticated/sessions/details');
-          controller.model = {
-            certificationCandidates: ['candidate1', 'candidate2'],
-            shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
-          };
+        // when
+        const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
 
-          // when
-          const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
-
-          // then
-          assert.notOk(shouldDisplayDownloadButton);
-        });
-      });
-
-      module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled', function() {
-        test('Should return true', function(assert) {
-          // given
-          config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
-          const controller = this.owner.lookup('controller:authenticated/sessions/details');
-          controller.model = {
-            certificationCandidates: ['candidate1', 'candidate2'],
-            shouldDisplayPrescriptionScoStudentRegistrationFeature: false,
-          };
-
-          // when
-          const shouldDisplayDownloadButton = controller.shouldDisplayDownloadButton;
-
-          // then
-          assert.ok(shouldDisplayDownloadButton);
-        });
+        // then
+        assert.ok(shouldDisplayDownloadButton);
       });
     });
   });
 
   module('#shouldDisplayResultRecipientInfoMessage', function() {
-    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
-      test('should return false', function(assert) {
-        // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
-        const controller = this.owner.lookup('controller:authenticated/sessions/details');
-        controller.currentUser = {
-          currentCertificationCenter: { isScoManagingStudents: false },
-        };
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.notOk(shouldDisplayResultRecipientInfoMessage);
-      });
-    });
 
     module('when the current user certification center does manage students', function() {
       test('should also return false', function(assert) {
         // given
         config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
-        controller.currentUser = {
-          currentCertificationCenter: { isScoManagingStudents: true },
+        controller.model = {
+          shouldDisplayPrescriptionScoStudentRegistrationFeature: true,
         };
 
         // when

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -1,8 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-import config from 'pix-certif/config/environment';
-
 module('Unit | Controller | authenticated/sessions/details', function(hooks) {
   setupTest(hooks);
 
@@ -102,7 +100,6 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
     module('when the current user certification center does manage students', function() {
       test('should also return false', function(assert) {
         // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
         controller.model = {
           shouldDisplayPrescriptionScoStudentRegistrationFeature: true,
@@ -116,10 +113,9 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
       });
     });
 
-    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled and current user is if of type Sco and does not managing students', function() {
+    module('when current user is if of type Sco and does not managing students', function() {
       test('should return true', function(assert) {
         // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
         controller.currentUser = {
           currentCertificationCenter: { isScoManagingStudents: false },

--- a/certif/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -2,8 +2,6 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
 
-import config from 'pix-certif/config/environment';
-
 module('Unit | Controller | authenticated/sessions/list', function(hooks) {
   setupTest(hooks);
 
@@ -42,27 +40,10 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
   });
 
   module('#shouldDisplayResultRecipientInfoMessage', function() {
-    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is disabled', function() {
-      test('should return false', function(assert) {
-        // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = false;
-        const controller = this.owner.lookup('controller:authenticated/sessions/list');
-        controller.currentUser = {
-          currentCertificationCenter: { isScoManagingStudents: false },
-        };
-
-        // when
-        const shouldDisplayResultRecipientInfoMessage = controller.shouldDisplayResultRecipientInfoMessage;
-
-        // then
-        assert.notOk(shouldDisplayResultRecipientInfoMessage);
-      });
-    });
 
     module('when the current user certification center does manage students', function() {
       test('should also return false', function(assert) {
         // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/list');
         controller.currentUser = {
           currentCertificationCenter: { isScoManagingStudents: true },
@@ -76,10 +57,9 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
       });
     });
 
-    module('when the toggle FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is enabled and current user is not sco managing students', function() {
+    module('when current user is not sco managing students', function() {
       test('should return true', function(assert) {
         // given
-        config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS = true;
         const controller = this.owner.lookup('controller:authenticated/sessions/list');
         controller.currentUser = {
           currentCertificationCenter: { isScoManagingStudents: false },


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui le toggle d’envoi auto des résultats est activé en production (techniquement parlant : FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS).


## :robot: Solution
Il n’est plus nécessaire de garder ce toggle car il n’a plus de raison d’exister (étant donné que si on le désactive le toggle la fonctionnalité d’imports des candidats n’est plus fonctionnelle).

Afin d'éviter toute erreur, il a été convenu d’enlever ce toggle au plus vite.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Vérifier que l'import avec la liste des candidats ( et seulement ce doc ) est possible lors de la création de session pour tous les type de centre de certification hors SCO

- Vérifier que la CI passe