### PR TITLE
[BUGFIX] Une erreur floue s'affiche lorsqu'on publie une session sur PixAdmin (PIX-2154)

### DIFF
--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -19,11 +19,9 @@ module.exports = {
   },
 
   async updatePublishedAt({ sessionId, publishedAt }) {
-    const updatedFinalizedSession = await FinalizedSessionBookshelf
+    await FinalizedSessionBookshelf
       .where({ sessionId })
-      .save({ publishedAt }, { method: 'update' });
-
-    return bookshelfToDomainConverter.buildDomainObject(FinalizedSessionBookshelf, updatedFinalizedSession);
+      .save({ publishedAt }, { method: 'update', require: false });
   },
 
   async findFinalizedSessionsToPublish() {


### PR DESCRIPTION
## :unicorn: Problème
![image](https://user-images.githubusercontent.com/48727874/107801430-5842e880-6d60-11eb-84d5-1e8ce44c82cc.png)
Lorsqu'un utilisateur PixAdmin tente de publier une session, il peut constater l'affichage de deux notifications : une notification indiquant le succès de publication des certificats, et une autre indiquant un échec peu explicite.

## :robot: Solution
La nouvelle table "finalized-sessions" ne contient pas toutes les sessions de certification depuis le début. De fait, un grand nombre de sessions de certification n'ont pas d'enregistrement correspondant dans cette table.
Du coup, au moment de publier une telle session, on obtient une erreur : l'API tente de mettre à jour la date de publication le champs publishedAt dans la table "finalized-sessions" mais ne trouve aucun enregistrement répondant à l'id donné.

Il faut donc rendre "facultatif" cette mise à jour. Pour cela, on configure l'appel Bookshelf `.save()` pour qu'il ne jette pas d'erreur lorsqu'un aucun enregistrement n'est trouvé pour un id donné.

## :rainbow: Remarques
On a trouvé les raisons du problème à l'aide de Sentry ! 🚀 

## :100: Pour tester
Lancer PixAdmin 
Essayer de publier la session n°5, ne plus reproduire l'apparition de la notif rouge
Pour reproduire le bug, aller sur dev, et faire la même chose :D
