### PR TITLE
[TECH] Empêcher le démarrage de l'API si la configuration est incorrecte.

### DIFF
--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -1,0 +1,39 @@
+const Joi = require('joi');
+
+const schema = Joi.object({
+  REDIS_URL: Joi.string().uri().optional(),
+  DATABASE_URL: Joi.string().uri().optional(),
+  TEST_DATABASE_URL: Joi.string().optional(),
+  MAILING_ENABLED: Joi.string().optional().valid('true', 'false'),
+  MAILING_PROVIDER: Joi.string().optional().valid('sendinblue', 'mailjet'),
+  MAILJET_API_KEY: Joi.string().optional(),
+  MAILJET_API_SECRET: Joi.string().optional(),
+  MAILJET_ACCOUNT_CREATION_TEMPLATE_ID: Joi.number().optional(),
+  MAILJET_ORGANIZATION_INVITATION_TEMPLATE_ID: Joi.number().optional(),
+  MAILJET_PASSWORD_RESET_TEMPLATE_ID: Joi.number().optional(),
+  SENDINBLUE_API_KEY: Joi.string().optional(),
+  SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID: Joi.number().optional(),
+  SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID: Joi.number().optional(),
+  SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID: Joi.number().optional(),
+  SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID: Joi.number().optional(),
+  TLD_FR: Joi.string().optional(),
+  TLD_ORG: Joi.string().optional(),
+  DOMAIN_PIX: Joi.string().optional(),
+  DOMAIN_PIX_APP: Joi.string().optional(),
+  DOMAIN_PIX_ORGA: Joi.string().optional(),
+  LCMS_API_KEY: Joi.string().required(),
+  LCMS_API_URL: Joi.string().uri().required(),
+  LOG_ENABLED: Joi.string().optional().valid('true', 'false'),
+  LOG_LEVEL: Joi.string().optional().valid('fatal', 'error', 'warn', 'info', 'debug', 'trace'),
+  AUTH_SECRET: Joi.string().required(),
+}).options({ allowUnknown: true });
+
+const validateEnvironmentVariables = function() {
+  const { error } = schema.validate(process.env);
+  if (error) {
+    throw new Error('Configuration is invalid: ' + error.message + ', but was: ' + error.details[0].context.value);
+  }
+
+};
+
+module.exports = validateEnvironmentVariables;

--- a/api/server.js
+++ b/api/server.js
@@ -1,6 +1,7 @@
 // As early as possible in your application, require and configure dotenv.
 // https://www.npmjs.com/package/dotenv#usage
 require('dotenv').config();
+const validateEnvironmentVariables = require('./lib/infrastructure/validate-environement-variables');
 
 const Hapi = require('@hapi/hapi');
 
@@ -14,6 +15,8 @@ const security = require('./lib/infrastructure/security');
 const { handleFailAction } = require('./lib/validate');
 
 const createServer = async () => {
+
+  validateEnvironmentVariables();
 
   const server = new Hapi.server({
     compression: false,


### PR DESCRIPTION
## :unicorn: Problème
La configuration est passée par l'intermédiaire des variables d'environnement.
Celles-ci sont alimentées :
- automatiquement à partir du fichier .env en local
- depuis l'IHM CircleCI en CI
- depuis l'IHM Scalingo sur les autres environements

Cette configuration est documentée dans le fichier `sample.env`, mais nous ne sommes pas à l'abri d'une erreur d'innatention (copier/coller, etc.). 

### Local
Les fréquentes modifications de configuration, pas forcément connues du développeur qui n'a pas implémenté la fonctionnalité, rendent la mise à jour du fichier` .env` complexe

### Production
Lorsque le déploiement de l'application lieu sur Scalingo, si la configuration est incorrecte et permet tout de même le démarrage de l'application, alors elle sera exposée au traffic réseau, avec un résultat imprévisible.

## :robot: Solution
Contrôler la configuration avec une validation Joi au démarrage
Si elle est incorrecte, arrêter le démarrage en spécifiant la variable incriminée

## :rainbow: Remarques
Cette PR est peut être inutile.
La vérification pourrait être non-bloquante.

La spécification JOI est minimale et peut être enrichie, par exemple:
* sur CircleCI 
  *  certaines variables sont optionelles
  * certaines variables sont incorrectes interntionellement (ex:  `TEST_DATABASE_URL=bad_url npm run test:api:path -- tests/unit`)
* des contrôles plus stricts peuvent être ajoutées (ex: la configuration de mailing si le mailing est activée..)

## :100: Pour tester
RA
- passer la variable `LCMS_API_URL` à `1`
- redéployer 
- vérifier que le déploiement a échoué
- vérifier que les logs mentionnent `Configuration is invalid: \"LCMS_API_URL\"must be a valid string, but was: 1`
