### PR TITLE
[BUGFIX] Utiliser replace au lieu de replaceAll (PIX-2155).

### DIFF
--- a/mon-pix/app/components/challenge-statement.js
+++ b/mon-pix/app/components/challenge-statement.js
@@ -72,7 +72,7 @@ export default class ChallengeStatement extends Component {
 
   _formatLink(instruction) {
     const externalLinkRegex = /(\[(.*?)\]\((.*?)\))+/g;
-    return instruction.replaceAll(externalLinkRegex, this._insertLinkTitle.bind(this));
+    return instruction.replace(externalLinkRegex, this._insertLinkTitle.bind(this));
   }
 
   _insertLinkTitle(markdownLink) {


### PR DESCRIPTION
ReplaceAll is not supported by many browsers

## :unicorn: Problème
Dans le PR #2529, nous utilisons un replaceAll qui n'est pas supporté sur certains navigateurs: https://caniuse.com/?search=replaceall.

## :robot: Solution
La regex est déjà suffixé par `g/` pour le caractère `global` et utiliser `replace` au lieu de `replaceAll`.

## :100: Pour tester
Sur un challenge avec des liens (ex: recgzvi9msKskBUf8, recxDBTrZbLTPiaDi), vérifier que un title="Nouvelle fenêtre" a bien été ajouté sur l'élément lien.
