### PR TITLE
[TECH] Rafraîchir le cache en ligne de commande.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -96,6 +96,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules",
+    "cache:refresh": "node scripts/refresh-cache",
     "coverage:check": "NODE_ENV=test npm run db:migrate && NODE_ENV=test nyc --silent _mocha --recursive --exit --reporter dot tests && nyc report --reporter=lcovonly --report-dir=../coverage",
     "coverage:rename": "mv ../coverage/lcov.info ../coverage/api_lcov.info",
     "coverage": "npm run coverage:check && npm run coverage:rename",

--- a/api/scripts/refresh-cache.js
+++ b/api/scripts/refresh-cache.js
@@ -1,0 +1,10 @@
+#! /usr/bin/env node
+'use strict';
+require('dotenv').config();
+const learningContentDatasource = require('../lib/infrastructure/datasources/learning-content/datasource');
+
+if (require.main === module) {
+  learningContentDatasource.refreshLearningContentCacheRecords().catch((e) =>
+    console.error('Error while reloading cache', e),
+  );
+}


### PR DESCRIPTION
## :unicorn: Problème
Les tests seeds utilisent le référentiel privé
Les tests E2E utilisent le référentiel public

Pour passer de l'un à l'autre, il faut, en plus de modifier les variables d'environnement, rafraîchir le cache:
- soit depuis redis-cli `flush-db` (mais il faut l'avoir installé)
- soit depuis pix-admin (mais il faut le démarrer)
- soit en redémarrant le contenur docker redis

## :robot: Solution
Créer un script npm dédié

## :rainbow: Remarques
Peut-être y a-t-il d'autres solutions plus simples, auquels cas je peux fermer la PR

## :100: Pour tester
Etapes:
- exécuter les seeds
- `npm run cache:refresh`
- activer `CYPRESS_LMCS_*`
- exécuter les tests E2E
- vérifier que le résultat est OK
