### PR TITLE
[FEATURE] Affichage des sujets et tutos en anglais lorsque la langue saisie est "en" dans l'analyse individuelle d'une campagne d'évaluation (PIX-2101).

### DIFF
--- a/api/lib/application/campaign-participations/campaign-participation-controller.js
+++ b/api/lib/application/campaign-participations/campaign-participation-controller.js
@@ -72,8 +72,9 @@ module.exports = {
   async getAnalysis(request) {
     const { userId } = request.auth.credentials;
     const campaignParticipationId = request.params.id;
+    const locale = extractLocaleFromRequest(request);
 
-    const campaignAnalysis = await usecases.computeCampaignParticipationAnalysis({ userId, campaignParticipationId });
+    const campaignAnalysis = await usecases.computeCampaignParticipationAnalysis({ userId, campaignParticipationId, locale });
     return campaignAnalysisSerializer.serialize(campaignAnalysis);
   },
 

--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -1,15 +1,15 @@
 const { UserNotAuthorizedToAccessEntity } = require('../errors');
 
-module.exports = async function computeCampaignParticipationAnalysis(
-  {
-    userId,
-    campaignParticipationId,
-    campaignParticipationRepository,
-    campaignRepository,
-    campaignAnalysisRepository,
-    targetProfileWithLearningContentRepository,
-    tutorialRepository,
-  } = {}) {
+module.exports = async function computeCampaignParticipationAnalysis({
+  userId,
+  campaignParticipationId,
+  campaignParticipationRepository,
+  campaignRepository,
+  campaignAnalysisRepository,
+  targetProfileWithLearningContentRepository,
+  tutorialRepository,
+  locale,
+} = {}) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
   const campaignId = campaignParticipation.campaignId;
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
@@ -22,8 +22,8 @@ module.exports = async function computeCampaignParticipationAnalysis(
     return null;
   }
 
-  const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId });
-  const tutorials = await tutorialRepository.list();
+  const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale });
+  const tutorials = await tutorialRepository.list({ locale });
 
   return campaignAnalysisRepository.getCampaignParticipationAnalysis(campaignId, campaignParticipation, targetProfileWithLearningContent, tutorials);
 };

--- a/api/lib/infrastructure/repositories/tutorial-repository.js
+++ b/api/lib/infrastructure/repositories/tutorial-repository.js
@@ -28,7 +28,7 @@ module.exports = {
     }
   },
 
-  async list({ locale = FRENCH_FRANCE } = {}) {
+  async list({ locale = FRENCH_FRANCE }) {
     let tutorialData = await tutorialDatasource.list();
     const lang = _extractLangFromLocale(locale);
     tutorialData = tutorialData.filter((tutorial) => _extractLangFromLocale(tutorial.locale) === lang);

--- a/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tutorial-repository_test.js
@@ -190,7 +190,7 @@ describe('Integration | Repository | tutorial-repository', () => {
       mockLearningContent(learningContent);
 
       // when
-      const tutorials = await tutorialRepository.list();
+      const tutorials = await tutorialRepository.list({});
 
       // then
       expect(tutorials).to.have.lengthOf(2);

--- a/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
+++ b/api/tests/unit/application/campaignParticipations/campaign-participation-controller_test.js
@@ -1,8 +1,9 @@
 const { sinon, expect, domainBuilder, hFake } = require('../../../test-helper');
 
 const campaignParticipationController = require('../../../../lib/application/campaign-participations/campaign-participation-controller');
-const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
+const campaignAnalysisSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-analysis-serializer');
 const campaignAssessmentParticipationResultSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-assessment-participation-result-serializer');
+const campaignParticipationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-participation-serializer');
 const campaignProfileSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/campaign-profile-serializer');
 const requestResponseUtils = require('../../../../lib/infrastructure/utils/request-response-utils');
 const events = require('../../../../lib/domain/events');
@@ -339,6 +340,38 @@ describe('Unit | Application | Controller | Campaign-Participation', () => {
 
       // when
       const response = await campaignParticipationController.getCampaignProfile(request);
+
+      // then
+      expect(response).to.equal(expectedResults);
+    });
+  });
+
+  describe('#getAnalysis', () => {
+
+    const userId = 456;
+    const campaignParticipationId = 789;
+    const locale = FRENCH_SPOKEN;
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'computeCampaignParticipationAnalysis');
+      sinon.stub(campaignAnalysisSerializer, 'serialize');
+    });
+
+    it('should call usecase and serializer with expected parameters', async () => {
+      // given
+      const campaignAnalysis = Symbol('campaignAnalysis');
+      const expectedResults = Symbol('results');
+      usecases.computeCampaignParticipationAnalysis.withArgs({ userId, campaignParticipationId, locale }).resolves(campaignAnalysis);
+      campaignAnalysisSerializer.serialize.withArgs(campaignAnalysis).returns(expectedResults);
+
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: campaignParticipationId },
+        headers: { 'accept-language': locale },
+      };
+
+      // when
+      const response = await campaignParticipationController.getAnalysis(request);
 
       // then
       expect(response).to.equal(expectedResults);

--- a/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -29,7 +29,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
       const campaignAnalysis = Symbol('analysis');
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
       targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId, locale }).resolves(targetProfile);
-      tutorialRepository.list.resolves(tutorials);
+      tutorialRepository.list.withArgs({ locale }).resolves(tutorials);
       campaignAnalysisRepository.getCampaignAnalysis.withArgs(campaignId, targetProfile, tutorials).resolves(campaignAnalysis);
 
       // when

--- a/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -1,6 +1,7 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const { computeCampaignParticipationAnalysis } = require('../../../../lib/domain/usecases');
 const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
 
@@ -14,6 +15,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
   const campaignId = 'someCampaignId';
   const campaignParticipationId = 'campaignParticipationId';
   let campaignParticipation;
+  const locale = FRENCH_SPOKEN;
 
   beforeEach(() => {
     campaignRepository = { checkIfUserOrganizationHasAccessToCampaign: sinon.stub() };
@@ -35,8 +37,8 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
         campaignParticipation.userId = userId;
         campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
-        targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId }).resolves(targetProfile);
-        tutorialRepository.list.resolves(tutorials);
+        targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId, locale }).resolves(targetProfile);
+        tutorialRepository.list.withArgs({ locale }).resolves(tutorials);
         campaignAnalysisRepository.getCampaignParticipationAnalysis
           .withArgs(campaignId, campaignParticipation, targetProfile, tutorials).resolves(campaignParticipationAnalysis);
 
@@ -49,6 +51,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
           campaignParticipationRepository,
           targetProfileWithLearningContentRepository,
           tutorialRepository,
+          locale,
         });
 
         // then
@@ -73,6 +76,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
           campaignParticipationRepository,
           targetProfileWithLearningContentRepository,
           tutorialRepository,
+          locale,
         });
 
         // then
@@ -97,6 +101,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
         campaignAnalysisRepository,
         targetProfileWithLearningContentRepository,
         tutorialRepository,
+        locale,
       });
 
       // then


### PR DESCRIPTION
## :unicorn: Problème
Nous commençons la traduction de Pix Orga en anglais. Cependant il faut également traduire tout le référentiel et récupérer celui-ci dans Pix Orga.

## :robot: Solution
Côté Pix Orga, tout est déjà prêt désormais.
Côté Pix API, pour la route en question, récupérer la locale et récupérer les sujets et tutos correspondants.

## :rainbow: Remarques
NA

## :100: Pour tester
Dans Pix Orga, aller dans une campagne d'évaluation, puis dans l'onglet "Participants". Choisir le sous-onglet "Analyse". Saisir dans l'url à la fin "?lang=en" et vérifier qu'après rechargement, les sujets et les tutos s'affichent en anglais.