### PR TITLE
[FEATURE] Ajouter un lien à la bannière du TDB (PIX-2123).

### DIFF
--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -39,6 +39,7 @@
                         @backgroundColorClass="new-information--yellow-background"
                         @linkText={{t 'pages.dashboard.empty-dashboard.link-to-competences'}}
                         @linkTo="profile"
+                        @linkDisplayType="button"
                         @textColorClass="new-information--black-text"/>
       </div>
     </section>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -7,8 +7,8 @@
                       @image="/images/discovery_TDB_pix.svg"
                       @backgroundColorClass="new-information--blue-gradient-background"
                       @textColorClass="new-information--white-text"
-                      @linkText="{{t 'pages.dashboard.presentation.link.text'}}"
-                      @linkTo="{{t 'pages.dashboard.presentation.link.url'}}"
+                      @linkText="{{this.newDashboardInfoLink.text}}"
+                      @linkTo="{{this.newDashboardInfoLink.url}}"
                       @closeaction={{this.closeInformationAboutNewDashboard}}
       />
     </section>
@@ -28,8 +28,8 @@
                         @image="/images/discovery_TDB_pix.svg"
                         @backgroundColorClass="new-information--blue-gradient-background"
                         @textColorClass="new-information--white-text"
-                        @linkText="{{t 'pages.dashboard.presentation.link.text'}}"
-                        @linkTo="{{t 'pages.dashboard.presentation.link.url'}}"
+                        @linkText="{{this.newDashboardInfoLink.text}}"
+                        @linkTo="{{this.newDashboardInfoLink.url}}"
                         @closeaction={{this.closeInformationAboutNewDashboard}}
         />
       </section>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -3,10 +3,12 @@
 
   {{#unless this.hasUserSeenNewDashboardInfo}}
     <section class="dashboard-content__banner" data-test-new-dashboard-info>
-      <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
+      <NewInformation @information="{{t 'pages.dashboard.presentation.message' firstname=this.userFirstname}}"
                       @image="/images/discovery_TDB_pix.svg"
                       @backgroundColorClass="new-information--blue-gradient-background"
                       @textColorClass="new-information--white-text"
+                      @linkText="{{t 'pages.dashboard.presentation.link.text'}}"
+                      @linkTo="{{t 'pages.dashboard.presentation.link.url'}}"
                       @closeaction={{this.closeInformationAboutNewDashboard}}
       />
     </section>
@@ -22,10 +24,12 @@
   <section class="dashboard-content__main">
     {{#unless this.hasUserSeenNewDashboardInfo}}
       <section class="dashboard-content-main__banner">
-        <NewInformation @information="{{t 'pages.dashboard.presentation' firstname=this.userFirstname}}"
+        <NewInformation @information="{{t 'pages.dashboard.presentation.message' firstname=this.userFirstname}}"
                         @image="/images/discovery_TDB_pix.svg"
                         @backgroundColorClass="new-information--blue-gradient-background"
                         @textColorClass="new-information--white-text"
+                        @linkText="{{t 'pages.dashboard.presentation.link.text'}}"
+                        @linkTo="{{t 'pages.dashboard.presentation.link.url'}}"
                         @closeaction={{this.closeInformationAboutNewDashboard}}
         />
       </section>

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -7,6 +7,8 @@ export default class Content extends Component {
   MAX_SCORECARDS_TO_DISPLAY = 4;
 
   @service currentUser;
+  @service url;
+  @service intl;
 
   get hasNothingToShow() {
     return !this.hasCampaignParticipationOverviews && !this.hasStartedCompetences && !this.hasRecommendedCompetences;
@@ -57,5 +59,12 @@ export default class Content extends Component {
   @action
   async closeInformationAboutNewDashboard() {
     await this.currentUser.user.save({ adapterOptions: { rememberUserHasSeenNewDashboardInfo: true } });
+  }
+
+  get newDashboardInfoLink() {
+    return {
+      text: this.url.isFrenchDomainExtension ? this.intl.t('pages.dashboard.presentation.link.text') : null,
+      url: this.url.isFrenchDomainExtension ? this.intl.t('pages.dashboard.presentation.link.url') : null,
+    };
   }
 }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -108,9 +108,24 @@
     }
   }
 
-  &-text__button {
-    margin-top: 20px;
-    padding: 10px 20px;
-    display: inline-table;
+  &-text {
+
+    &__button {
+      margin-top: 20px;
+      padding: 10px 20px;
+      display: inline-table;
+    }
+
+    &__link {
+      margin-top: 14px;
+      font-size: 0.875rem;
+      font-weight: $font-normal;
+      letter-spacing: 0.009rem;
+      line-height: 1.375rem;
+
+      .fa-arrow-right {
+        margin-right: 5px;
+      }
+    }
   }
 }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -131,6 +131,11 @@
       @include device-is('desktop') {
         display: inline-table;
       }
+
+      &:focus span,
+      &:hover span {
+        border-bottom: 1px solid $white;
+      }
     }
   }
 }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -117,6 +117,7 @@
     }
 
     &__link {
+      display: none;
       margin-top: 14px;
       font-size: 0.875rem;
       font-weight: $font-normal;
@@ -125,6 +126,10 @@
 
       .fa-arrow-right {
         margin-right: 5px;
+      }
+
+      @include device-is('desktop') {
+        display: inline-table;
       }
     }
   }

--- a/mon-pix/app/templates/components/new-information.hbs
+++ b/mon-pix/app/templates/components/new-information.hbs
@@ -16,8 +16,7 @@
              target="_blank"
              rel="noopener noreferrer"
              class="new-information-content-text__link {{@textColorClass}}">
-            <FaIcon @icon='arrow-right' />
-            {{@linkText}}
+            <FaIcon @icon='arrow-right' />{{@linkText}}
           </a>
         {{/if}}
       {{/if}}

--- a/mon-pix/app/templates/components/new-information.hbs
+++ b/mon-pix/app/templates/components/new-information.hbs
@@ -16,7 +16,7 @@
              target="_blank"
              rel="noopener noreferrer"
              class="new-information-content-text__link {{@textColorClass}}">
-            <FaIcon @icon='arrow-right' />{{@linkText}}
+            <FaIcon @icon='arrow-right' /><span>{{@linkText}}</span>
           </a>
         {{/if}}
       {{/if}}

--- a/mon-pix/app/templates/components/new-information.hbs
+++ b/mon-pix/app/templates/components/new-information.hbs
@@ -11,6 +11,14 @@
       {{#if @linkText}}
         {{#if (eq @linkDisplayType 'button')}}
           <LinkTo @route="{{@linkTo}}" class="new-information-content-text__button button button--extra-thin button--link">{{@linkText}}</LinkTo>
+        {{else}}
+          <a href="{{@linkTo}}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="new-information-content-text__link {{@textColorClass}}">
+            <FaIcon @icon='arrow-right' />
+            {{@linkText}}
+          </a>
         {{/if}}
       {{/if}}
     </div>

--- a/mon-pix/app/templates/components/new-information.hbs
+++ b/mon-pix/app/templates/components/new-information.hbs
@@ -9,7 +9,9 @@
     <div class="new-information-content__text {{@textAlignment}} {{@textColorClass}}">
       {{{@information}}}
       {{#if @linkText}}
-        <LinkTo @route="{{@linkTo}}" class="new-information-content-text__button button button--extra-thin button--link">{{@linkText}}</LinkTo>
+        {{#if (eq @linkDisplayType 'button')}}
+          <LinkTo @route="{{@linkTo}}" class="new-information-content-text__button button button--extra-thin button--link">{{@linkText}}</LinkTo>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -232,6 +232,49 @@ describe('Integration | Component | Dashboard | Content', function() {
       expect(find('section[data-test-new-dashboard-info]')).not.to.exist;
     });
 
+    it('should display link on new dashboard banner when domain is pix.fr', async function() {
+      // given
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return true;
+        }
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.owner.register('service:url', UrlStub);
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        scorecards: [],
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+
+      // then
+      expect(find('.new-information')).to.exist;
+      expect(find('.new-information-content-text__link')).to.exist;
+    });
+
+    it('should hide link on new dashboard banner when domain is pix.org', async function() {
+      // given
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return false;
+        }
+      }
+      this.owner.register('service:currentUser', CurrentUserStub);
+      this.owner.register('service:url', UrlStub);
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        scorecards: [],
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}}/>`);
+
+      // then
+      expect(find('.new-information')).to.exist;
+      expect(find('.new-information-content-text__link')).not.to.exist;
+    });
   });
 
   describe('empty dashboard info rendering', function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -526,7 +526,13 @@
                 "link-to-competences": "See my skills",
                 "message": "<h2>Congrats! You've finished all the skills recommended for you!</h2> <p> Want to continue your Pix experience? You can try some skills again. </p>"
             },
-            "presentation": "<h2>Hi {firstname}, welcome to your dashboard.</h2><p>Quickly and easily access all your tests in progress.<br>Follow the evolution of your Pix score and check if your profile is ready for certification.</p>",
+            "presentation": {
+                "link": {
+                    "text": "",
+                    "url": ""
+                },
+                "message": "<h2>Hi {firstname}, welcome to your dashboard.</h2><p>Quickly and easily access all your tests in progress.<br>Follow the evolution of your Pix score and check if your profile is ready for certification.</p>"
+            },
             "recommended-competences": {
                 "profile-link": "See all skills",
                 "subtitle": "Discover the skills recommended for you.",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -526,7 +526,13 @@
                 "link-to-competences": "Voir mes compétences",
                 "message": "<h2>Bravo vous avez terminé les compétences recommandées !</h2> <p> Pour aller plus loin continuez à vous entraîner en retentant des compétences. </p>"
             },
-            "presentation": "<h2>Bonjour {firstname}, découvrez votre tableau de bord.</h2><p>Accédez rapidement et facilement à vos parcours et vos tests de compétence déjà commencés.<br>Retrouvez l’évolution de votre score Pix et vérifiez si votre profil est prêt pour la certification Pix.</p>",
+            "presentation": {
+                "link": {
+                    "text": "En savoir plus",
+                    "url": "https://pix.fr/actualites/decouvrez-votre-nouveau-tableau-de-bord"
+                },
+                "message": "<h2>Bonjour {firstname}, découvrez votre tableau de bord.</h2><p>Accédez rapidement et facilement à vos parcours et vos tests de compétence déjà commencés.<br>Retrouvez l’évolution de votre score Pix et vérifiez si votre profil est prêt pour la certification Pix.</p>"
+            },
             "recommended-competences": {
                 "profile-link": "Toutes les compétences",
                 "subtitle": "Explorez les compétences recommandées pour vous.",


### PR DESCRIPTION
## :unicorn: Problème
Il existe une bannière sur la page du tableau de bord pour introduire cette nouvelle page.
La bannière comporte actuellement une très brève description du tableau de bord. On souhaiterait ajouter un lien vers la age d'actualité de pix-site.

## :robot: Solution
Ajouter un lien vers l'article TDB de pix-site.

## :rainbow: Remarques
Le lien ne doit pas s'afficher dans les cas suivants:
- sur pix.org
- lorsque l'écran < 980px

## :100: Pour tester
- Se rendre sur le tableau de bord.
- Voir le lien "En savoir plus"
