### PR TITLE
[FEATURE] Traduction de la liste des campagnes dans Pix Orga (PIX-2142).

### DIFF
--- a/orga/app/components/pagination-control.hbs
+++ b/orga/app/components/pagination-control.hbs
@@ -1,8 +1,14 @@
 <div class="pagination-control content-text content-text--small">
   <div class="page-size">
-    <div class="page-size__label">Voir</div>
+    <div class="page-size__label">
+      {{t 'common.pagination.result-by-page'}}
+    </div>
     <div class="page-size__choice">
-      <select aria-label="Sélectionner une pagination" class="content-text content-text--small" {{on "change" this.changePageSize}}>
+      <select
+        aria-label={{t 'common.pagination.action.select-page-size'}}
+        class="content-text content-text--small"
+        {{on "change" this.changePageSize}}
+      >
         <option value="10" selected="{{if (eq this.pageSize 10) true}}">10</option>
         <option value="25" selected="{{if (eq this.pageSize 25) true}}">25</option>
         <option value="50" selected="{{if (eq this.pageSize 50) true}}">50</option>
@@ -14,7 +20,7 @@
   <div class="page-navigation">
     <div class="page-navigation__arrow page-navigation__arrow--previous {{if (eq this.currentPage 1) "page-navigation__arrow--disabled"}}">
       <LinkTo
-        aria-label="Aller à la page précédente"
+        aria-label={{t 'common.pagination.action.previous'}}
         @query={{hash pageNumber=this.previousPage}}
         @disabledWhen={{eq this.currentPage 1}}
         @replace={{true}}
@@ -24,11 +30,11 @@
       </LinkTo>
     </div>
     <div>
-      Page {{this.currentPage}} / {{this.pageCount}}
+      {{t 'common.pagination.page-number' current=this.currentPage total=this.pageCount}}
     </div>
     <div class="page-navigation__arrow page-navigation__arrow--next {{if (eq this.currentPage this.pageCount) "page-navigation__arrow--disabled"}}">
       <LinkTo
-        aria-label="Aller à la page suivante"
+        aria-label={{t 'common.pagination.action.next'}}
         @query={{hash pageNumber=this.nextPage}}
         @disabledWhen={{eq this.currentPage this.pageCount}}
         @replace={{true}}

--- a/orga/app/components/routes/authenticated/campaign/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/list.hbs
@@ -4,25 +4,35 @@
       <table>
         <thead>
           <tr>
-            <th class="table__column table__column--wide">Campagnes</th>
-            <th class="table__column">Créé par</th>
-            <th class="table__column table__column--small">Créé le</th>
-            <th class="table__column table__column--small">Participants</th>
-            <th class="table__column table__column--small">Résultats reçus</th>
+            <th class="table__column table__column--wide">
+              {{t 'pages.campaigns-list.table.column.campaign'}}
+            </th>
+            <th class="table__column">
+              {{t 'pages.campaigns-list.table.column.created-by'}}
+            </th>
+            <th class="table__column table__column--small">
+              {{t 'pages.campaigns-list.table.column.created-on'}}
+            </th>
+            <th class="table__column table__column--small">
+              {{t 'pages.campaigns-list.table.column.participants'}}
+            </th>
+            <th class="table__column table__column--small">
+              {{t 'pages.campaigns-list.table.column.results'}}
+            </th>
           </tr>
           <tr>
             <Table::HeaderFilterInput
               @field="name"
               @value={{@nameFilter}}
-              @placeholder="Rechercher une campagne"
-              @ariaLabel="Rechercher une campagne"
+              @placeholder={{t 'pages.campaigns-list.table.filter.by-name'}}
+              @ariaLabel={{t 'pages.campaigns-list.table.filter.by-name'}}
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::HeaderFilterInput
               @field="creatorName"
               @value={{@creatorNameFilter}}
-              @placeholder="Rechercher un créateur"
-              @ariaLabel="Rechercher un créateur"
+              @placeholder={{t 'pages.campaigns-list.table.filter.by-creator'}}
+              @ariaLabel={{t 'pages.campaigns-list.table.filter.by-creator'}}
               @triggerFiltering={{@triggerFiltering}}
             />
             <Table::Header/>
@@ -44,7 +54,9 @@
         </tbody>
       </table>
       {{#if (eq @campaigns.length 0)}}
-        <div class="table__empty content-text">Aucune campagne</div>
+        <div class="table__empty content-text">
+          {{t 'pages.campaigns-list.table.empty'}}
+        </div>
       {{/if}}
     </div>
   </div>

--- a/orga/app/components/routes/authenticated/campaign/no-campaign-panel.hbs
+++ b/orga/app/components/routes/authenticated/campaign/no-campaign-panel.hbs
@@ -1,13 +1,18 @@
 <div class="no-campaign-panel">
   <div class="no-campaign-panel__explain-create-campaign">
-    <img src="{{this.rootURL}}/icons/icon-campagne-start.svg" alt="Vous pouvez créer des campagnes.">
-    <h1 class="page-title">Créez votre première campagne</h1>
+    <img src="{{this.rootURL}}/icons/icon-campagne-start.svg" alt="" role="none">
+    <h1 class="page-title">
+      {{t 'pages.campaigns-list.no-campaign.title'}}
+    </h1>
+
     <div class="no-campaign-panel__information-text information-text">
-      Configurez et lancez votre première campagne. Vous pourrez ensuite inviter vos utilisateurs à rejoindre ce parcours.
+      {{t 'pages.campaigns-list.no-campaign.description'}}
     </div>
 
     <div class="no-campaign-panel__link-to-create">
-      <LinkTo @route="authenticated.campaigns.new" class="button button--link">Créer une campagne</LinkTo>
+      <LinkTo @route="authenticated.campaigns.new" class="button button--link">
+        {{t 'pages.campaigns-list.action.create'}}
+      </LinkTo>
     </div>
   </div>
 </div>

--- a/orga/app/templates/authenticated/campaigns/list.hbs
+++ b/orga/app/templates/authenticated/campaigns/list.hbs
@@ -3,10 +3,30 @@
     <Routes::Authenticated::Campaign::NoCampaignPanel />
   {{else}}
     <div class="list-campaigns-page__header-page">
-      <button role="tab" type="submit" class="list-campaigns-page__tab {{unless this.isArchived  'list-campaigns-page__tab--active' }}" aria-selected="{{ not this.isArchived }}" aria-label="Afficher les campagnes actives" {{on 'click' (fn this.updateCampaignStatus null)}}>Actives</button>
-      <button role="tab" type="submit" class="list-campaigns-page__tab {{if this.isArchived 'list-campaigns-page__tab--active' }}" aria-selected="{{ this.isArchived }}" aria-label="Afficher les campagnes archivées" {{on 'click' (fn this.updateCampaignStatus 'archived')}}>Archivées</button>
+      <button
+        role="tab"
+        type="submit"
+        class="list-campaigns-page__tab {{unless this.isArchived  'list-campaigns-page__tab--active' }}"
+        aria-selected="{{ not this.isArchived }}"
+        aria-label={{t 'pages.campaigns-list.action.ongoing.aria-label'}}
+        {{on 'click' (fn this.updateCampaignStatus null)}}
+      >
+        {{t 'pages.campaigns-list.action.ongoing.label'}}
+      </button>
+      <button
+        role="tab"
+        type="submit"
+        class="list-campaigns-page__tab {{if this.isArchived 'list-campaigns-page__tab--active' }}"
+        aria-selected="{{ this.isArchived }}"
+        aria-label={{t 'pages.campaigns-list.action.archived.aria-label'}}
+        {{on 'click' (fn this.updateCampaignStatus 'archived')}}
+      >
+        {{t 'pages.campaigns-list.action.archived.label'}}
+      </button>
       <div role="tabpanel" class="list-campaigns-page__create-campaign-button">
-        <LinkTo @route="authenticated.campaigns.new" class="button button--link">Créer une campagne</LinkTo>
+        <LinkTo @route="authenticated.campaigns.new" class="button button--link">
+         {{t 'pages.campaigns-list.action.create'}}
+        </LinkTo>
       </div>
     </div>
     <Routes::Authenticated::Campaign::List

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/campaign/list', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     this.set('goToCampaignPageSpy', () => {});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,5 +1,16 @@
 {
   "current-lang": "en",
+  "common": {
+    "pagination": {
+      "action": {
+        "next": "Go to next page",
+        "previous": "Go to previous page",
+        "select-page-size": "Select the number of items by page"
+      },
+      "page-number": "Page {current} / {total}",
+      "result-by-page": "See"
+    }
+  },
   "navigation": {
     "main" : {
       "campaigns" : "Campaigns",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -11,5 +11,38 @@
     "user-logged-menu": {
       "logout": "Log out"
     }
+  },
+  "pages": {
+    "campaigns-list": {
+      "action": {
+        "archived": {
+          "aria-label": "Display archived campaigns",
+          "label": "Archived"
+        },
+        "create": "Create a campaign",
+        "ongoing": {
+          "aria-label": "Display ongoing campaigns",
+          "label": "Ongoing"
+        }
+      },
+      "no-campaign": {
+        "description": "Set up and launch your first campaign. Then, invite your users to join this personalised test.",
+        "title": "Create your first campaign"
+      },
+      "table": {
+        "column": {
+          "campaign": "Campaigns",
+          "created-by": "Created by",
+          "created-on": "Created on",
+          "participants": "Participants",
+          "results": "Results submitted"
+        },
+        "empty": "No campaign",
+        "filter": {
+          "by-creator": "Search a creator",
+          "by-name": "Search a campaign"
+        }
+      }
+    }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,5 +1,16 @@
 {
   "current-lang": "fr",
+  "common": {
+    "pagination": {
+      "action": {
+        "next": "Aller à la page suivante",
+        "previous": "Aller à la page précédente",
+        "select-page-size": "Sélectionner une pagination"
+      },
+      "page-number": "Page {current} / {total}",
+      "result-by-page": "Voir"
+    }
+  },
   "navigation": {
     "main" : {
       "campaigns" : "Campagnes",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -11,5 +11,38 @@
     "user-logged-menu": {
       "logout": "Se déconnecter"
     }
+  },
+  "pages": {
+    "campaigns-list": {
+      "action": {
+        "archived": {
+          "aria-label": "Afficher les campagnes archivées",
+          "label": "Archivées"
+        },
+        "create": "Créer une campagne",
+        "ongoing": {
+          "aria-label": "Afficher les campagnes actives",
+          "label": "Actives"
+        }
+      },
+      "no-campaign": {
+        "description": "Configurez et lancez votre première campagne. Vous pourrez ensuite inviter vos utilisateurs à rejoindre ce parcours.",
+        "title": "Créez votre première campagne"
+      },
+      "table": {
+        "column": {
+          "campaign": "Campagnes",
+          "created-by": "Créé par",
+          "created-on": "Créé le",
+          "participants": "Participants",
+          "results": "Résultats reçus"
+        },
+        "empty": "Aucune campagne",
+        "filter": {
+          "by-creator": "Rechercher un créateur",
+          "by-name": "Rechercher une campagne"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

La page de la liste des campagne n'est pas internationalisée.

## :robot: Solution

Internationaliser la page de la liste des campagnes.
Découpée en 4 parties:
- Le composant "no-campaign-panel" (quand l'utilisateur n'a jamais créé de campagne)
- Le "header" de la page de la liste des campagnes
- Le "tableau" de la page de la liste des campagnes
- Le composant commun de "pagination" 

## :100: Pour tester

Se connecter avec n'importe quel compte et vérifier en anglais (en ajoutant lang=en dans l'URL) les cas suivants:
- quand l'utilisateur n'a jamais créé de campagne
- quand la liste des campagnes est vide (onglet campagne archivée)
- quand la liste a des campagnes (vérifier la pagination)