### PR TITLE
[FEATURE] Traduction de la page de détails d'une campagne (PIX-2144).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/details/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.hbs
@@ -1,19 +1,19 @@
-<div class="panel panel--strong-shadow campaign-details-container" aria-label="Détails de la campagne">
+<div class="panel panel--strong-shadow campaign-details-container">
   <div class="campaign-details-row">
     {{#if @campaign.isTypeAssessment}}
       <div class="campaign-details-content">
-        <h4 class="label-text campaign-details-content__label">Profil cible</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign-details.target-profile'}}</h4>
         <p class="content-text campaign-details-content__text">{{@campaign.targetProfileName}}</p>
       </div>
     {{/if}}
     {{#if @campaign.idPixLabel}}
       <div class="campaign-details-content">
-        <h4 class="label-text campaign-details-content__label">Libellé de l'identifiant</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign-details.external-user-id-label'}}</h4>
         <p class="content-text campaign-details-content__text">{{@campaign.idPixLabel}}</p>
       </div>
     {{/if}}
     <div class="campaign-details-content">
-      <h4 class="label-text campaign-details-content__label">Lien direct</h4>
+      <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign-details.direct-link'}}</h4>
       <div class="campaign-details-content__clipboard">
         <p class="content-text campaign-details-content__text">{{this.campaignsRootUrl}}</p>
         {{#if (is-clipboard-supported)}}
@@ -38,7 +38,7 @@
   {{#if @campaign.isTypeAssessment}}
     <div class="campaign-details-row">
       <div class="campaign-details-content campaign-details-content--single">
-        <h4 class="label-text campaign-details-content__label">Titre du parcours</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign-details.personalised-test-title'}}</h4>
         <p class="content-text campaign-details-content__text">{{@campaign.title}}</p>
       </div>
     </div>
@@ -46,7 +46,7 @@
 
   <div class="campaign-details-row">
     <div class="campaign-details-content campaign-details-content--single">
-      <h4 class="label-text campaign-details-content__label">Texte de la page d'accueil</h4>
+      <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign-details.landing-page-text'}}</h4>
       <p class="content-text campaign-details-content__text">
         <MarkdownToHtml @markdown={{@campaign.customLandingPageText}} />
       </p>
@@ -60,9 +60,8 @@
             @route="authenticated.campaigns.update"
             @model={{@campaign.id}}
             class="button button--grey button--regular button--link campaign-details-content__update-button"
-            aria-label="Modifier"
           >
-            Modifier
+            {{t 'pages.campaign-details.actions.edit'}}
           </LinkTo>
         </div>
         <div class="campaign-details-content campaign-details-content--button campaign-details--button campaign-details-content--left">
@@ -70,9 +69,8 @@
             type="button"
             {{on 'click' (fn this.archiveCampaign @campaign.id)}}
             class="button button--grey button--regular button--link"
-            aria-label="Archiver"
           >
-            Archiver
+            {{t 'pages.campaign-details.actions.archive'}}
           </button>
         </div>
       </div>

--- a/orga/app/components/routes/authenticated/campaign/details/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.js
@@ -8,8 +8,9 @@ export default class Tab extends Component {
   @service store;
   @service notifications;
   @service url;
+  @service intl;
 
-  @tracked tooltipText = 'Copier le lien direct';
+  @tracked tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copy');
 
   get campaignsRootUrl() {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;
@@ -17,12 +18,12 @@ export default class Tab extends Component {
 
   @action
   clipboardSuccess() {
-    this.tooltipText = 'Copié !';
+    this.tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copied');
   }
 
   @action
   clipboardOut() {
-    this.tooltipText = 'Copier le lien direct';
+    this.tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copy');
   }
 
   @action
@@ -31,7 +32,7 @@ export default class Tab extends Component {
       const campaign = this.store.peekRecord('campaign', campaignId);
       await campaign.archive();
     } catch (err) {
-      this.notifications.error('Une erreur est survenue');
+      this.notifications.error(this.intl.t('api-error-messages.global-error'));
     }
   }
 }

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -12,21 +12,21 @@
 
     <div class="campaign-details-header__report">
       <div class="campaign-details-header-report__info">
-        <h4 class="label-text campaign-details-content__label">Code</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.code'}}</h4>
         <span class="content-text content-text--big campaign-details-content__text">
           {{@campaign.code}}
         </span>
       </div>
 
       <div class="campaign-details-header-report__info">
-        <h4 class="label-text campaign-details-content__label">Participants</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.participations-count'}}</h4>
         <span class="content-text content-text--big campaign-details-content__text">
           {{this.participationsCount}}
         </span>
       </div>
 
       <div class="campaign-details-header-report__shared">
-        <h4 class="label-text campaign-details-content__label">Profils reçus</h4>
+        <h4 class="label-text campaign-details-content__label">{{t 'pages.campaign.shared-participations-count'}}</h4>
         <span class="content-text content-text--big campaign-details-content__text">
           {{this.sharedParticipationsCount}}
         </span>
@@ -39,13 +39,13 @@
       <div class="campaign-archived-banner__icon">
         <FaIcon @icon='archive'></FaIcon>
       </div>
-      <div class="campaign-archived-banner__text">Campagne archivée</div>
+      <div class="campaign-archived-banner__text">{{t 'pages.campaign.archived'}}</div>
       <button
         type="button"
         class="button button--link campaign-archived-banner__unarchive-button"
         {{on 'click' (fn this.unarchiveCampaign @campaign.id)}}
       >
-        Désarchiver la campagne
+        {{t 'pages.campaign.actions.unarchive'}}
       </button>
     </div>
   {{/if}}
@@ -53,7 +53,7 @@
   <div class="panel campaign-details__controls">
     <nav class="navbar campaign-details-controls__navbar-tabs">
       <LinkTo @route="authenticated.campaigns.campaign.details" class="navbar-item" @model={{@campaign}} >
-        Détails
+        {{t 'pages.campaign.tab.details'}}
       </LinkTo>
 
       <LinkTo
@@ -61,21 +61,21 @@
         @model={{@campaign}}
         class="navbar-item"
       >
-        Participants ({{@campaign.participationsCount}})
+        {{t 'pages.campaign.tab.participants' count=@campaign.participationsCount}}
       </LinkTo>
       {{#if @campaign.isTypeAssessment}}
         <LinkTo @route="authenticated.campaigns.campaign.collective-results" @model={{@campaign}} class="navbar-item">
-          Résultats collectifs
+          {{t 'pages.campaign.tab.collective-results'}}
         </LinkTo>
         <LinkTo @route="authenticated.campaigns.campaign.analysis" class="navbar-item" @model={{@campaign}} >
-          Analyse
+          {{t 'pages.campaign.tab.review'}}
         </LinkTo>
       {{/if}}
     </nav>
 
     <div class="campaign-details-controls__export-button">
       <a class="button button--link" href="{{@campaign.urlToResult}}" target="_blank" rel="noopener noreferrer" download>
-        Exporter les résultats (.csv)
+        {{t 'pages.campaign.actions.export-results'}}
       </a>
     </div>
   </div>

--- a/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
@@ -1,18 +1,20 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
-import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
 
 module('Integration | Component | routes/authenticated/campaign/details/tab', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
+  class UrlStub extends Service {
+    campaignsRootUrl = 'root-url/';
+  }
 
   hooks.beforeEach(function() {
-    run(() => {
-      store = this.owner.lookup('service:store');
-    });
+    store = this.owner.lookup('service:store');
+    this.owner.register('service:url', UrlStub);
   });
 
   module('on TargetProfile display', function() {
@@ -30,7 +32,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('profil cible de la campagne 1');
+        assert.contains('profil cible de la campagne 1');
       });
     });
 
@@ -46,7 +48,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotHaveTextContaining('Profil cible');
+        assert.notContains('Profil cible');
       });
     });
   });
@@ -65,7 +67,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('idPixLabel');
+        assert.contains('idPixLabel');
       });
     });
 
@@ -82,7 +84,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Libellé de l\'identifiant');
+        assert.notContains('Libellé de l\'identifiant');
       });
     });
   });
@@ -98,7 +100,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
       // then
-      assert.dom('[aria-label="Détails de la campagne"]').includesText('/campagnes/1234');
+      assert.contains('root-url/1234');
     });
   });
 
@@ -117,7 +119,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('Mon titre de Campagne');
+        assert.contains('Mon titre de Campagne');
       });
     });
 
@@ -134,7 +136,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Titre du parcours');
+        assert.notContains('Titre du parcours');
       });
     });
   });
@@ -150,7 +152,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
       // then
-      assert.dom('[aria-label="Détails de la campagne"]').includesText('Archiver');
+      assert.contains('Archiver');
     });
   });
 
@@ -166,7 +168,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').includesText('Modifier');
+        assert.contains('Modifier');
       });
     });
 
@@ -181,7 +183,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
         await render(hbs`<Routes::Authenticated::Campaign::Details::Tab @campaign={{campaign}}/>`);
 
         // then
-        assert.dom('[aria-label="Détails de la campagne"]').doesNotContainText('Modifier');
+        assert.notContains('Modifier');
       });
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/report', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -5,6 +5,7 @@
   "current-lang": "en",
   "common": {
     "actions": {
+      "back": "Back",
       "cancel": "Cancel"
     },
     "pagination": {
@@ -31,11 +32,25 @@
   },
   "pages": {
     "campaign": {
+      "actions": {
+        "export-results": "Export the results (.csv)",
+        "unarchive": "Unarchive the campaign"
+      },
+      "archived": "Archived campaign",
+      "code": "Code",
       "filters": {
         "actions": {
           "clear": "Clear filters"
         },
         "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}"
+      },
+      "participations-count": "Participants",
+      "shared-participations-count": "Profiles submitted",
+      "tab": {
+        "collective-results": "Collective results",
+        "details": "Details",
+        "participants": "Participants ({count})",
+        "review": "Review"
       }
     },
     "campaigns-list": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -53,6 +53,21 @@
         "review": "Review"
       }
     },
+    "campaign-details": {
+      "actions": {
+        "edit": "Edit",
+        "archive": "Archive",
+        "copy-link": {
+          "copied": "Copied!",
+          "copy": "Copy direct link"
+        }
+      },
+      "direct-link": "Direct link",
+      "external-user-id-label": "External user ID label",
+      "landing-page-text": "Text to display on the starting page",
+      "personalised-test-title": "Title of the personalised test",
+      "target-profile": "Target profile"
+    },
     "campaigns-list": {
       "action": {
         "archived": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -5,6 +5,7 @@
   "current-lang": "fr",
   "common": {
     "actions": {
+      "back": "Retour",
       "cancel": "Annuler"
     },
     "pagination": {
@@ -21,8 +22,8 @@
     "main": {
       "campaigns": "Campagnes",
       "documentation": "Documentation",
-      "students-sco":"Élèves",
-      "students-sup":"Étudiants",
+      "students-sco": "Élèves",
+      "students-sup": "Étudiants",
       "team": "Équipe"
     },
     "user-logged-menu": {
@@ -31,11 +32,25 @@
   },
   "pages": {
     "campaign": {
+      "actions": {
+        "export-results": "Exporter les résultats (.csv)",
+        "unarchive": "Désarchiver la campagne"
+      },
+      "archived": "Campagne archivée",
+      "code": "Code",
       "filters": {
         "actions": {
           "clear": "Effacer les filtres"
         },
         "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}"
+      },
+      "participations-count": "Participants",
+      "shared-participations-count": "Profils reçus",
+      "tab": {
+        "collective-results": "Résultats collectifs",
+        "details": "Détails",
+        "participants": "Participants ({count})",
+        "review": "Analyse"
       }
     },
     "campaigns-list": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -53,6 +53,21 @@
         "review": "Analyse"
       }
     },
+    "campaign-details": {
+      "actions": {
+        "archive": "Archiver",
+        "copy-link": {
+          "copied": "Copié !",
+          "copy": "Copier le lien direct"
+        },
+        "edit": "Modifier"
+      },
+      "direct-link": "Lien direct",
+      "external-user-id-label": "Libellé de l'identifiant",
+      "landing-page-text": "Texte de la page d'accueil",
+      "personalised-test-title": "Titre du parcours",
+      "target-profile": "Profil cible"
+    },
     "campaigns-list": {
       "action": {
         "archived": {


### PR DESCRIPTION
## :unicorn: Problème
La page de détails d'une campagne n'est pas internationalisée.

## :robot: Solution
Internationaliser la page de détails d'une campagne.
Découpage en 2 parties :
- le header,
- le tab.

## :100: Pour tester
Se connecter avec n'importe quel compte et vérifier en anglais (en ajoutant "lang=en" dans l'URL) la page de détails d'une campagne d'évaluation avec identifiant externe, ainsi qu'une page de détails d'une collecte de profils. Vérifier également que la tooltip du lien s'affiche correctement.
