### PR TITLE
[BUGFIX] Pouvoir envoyer une réponse vide quand le temps est passé (PIX-2170).

### DIFF
--- a/api/lib/application/answers/index.js
+++ b/api/lib/application/answers/index.js
@@ -13,7 +13,7 @@ exports.register = async function(server) {
           payload: Joi.object({
             data: Joi.object({
               attributes: Joi.object({
-                value: Joi.string().required(),
+                value: Joi.string().allow('').allow(null),
                 'elapsed-time': Joi.number().allow(null),
                 result: Joi.string().allow(null),
                 'result-details': Joi.string().allow(null),

--- a/api/tests/acceptance/application/answers/answer-controller-save_test.js
+++ b/api/tests/acceptance/application/answers/answer-controller-save_test.js
@@ -213,5 +213,78 @@ describe('Acceptance | Controller | answer-controller-save', () => {
 
     });
 
+    context('when the answer is empty and timeout', () => {
+
+      beforeEach(() => {
+        // given
+        const learningContent = {
+          areas: [{ id: 'recArea1', competenceIds: ['recCompetence'] }],
+          competences: [{
+            id: 'recCompetence',
+            areaId: 'recArea1',
+            skillIds: ['recSkill1'],
+            origin: 'Pix',
+          }],
+          skills: [{
+            id: 'recSkill1',
+            name: '@recArea1_Competence1_Tube1_Skill1',
+            status: 'actif',
+            competenceId: 'recCompetence',
+          }],
+          challenges: [{
+            id: challengeId,
+            competenceId: 'recCompetence',
+            skillIds: ['recSkill1'],
+            status: 'validé',
+            solution: correctAnswer,
+            locales: ['fr-fr'],
+            type: 'QROC',
+          }],
+        };
+        mockLearningContent(learningContent);
+
+        postAnswersOptions = {
+          method: 'POST',
+          url: '/api/answers',
+          headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+          payload: {
+            data: {
+              type: 'answers',
+              attributes: {
+                value: '',
+                timeout: 25,
+                'elapsed-time': 100,
+              },
+              relationships: {
+                assessment: {
+                  data: {
+                    type: 'assessments',
+                    id: insertedAssessmentId,
+                  },
+                },
+                challenge: {
+                  data: {
+                    type: 'challenges',
+                    id: challengeId,
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        // when
+        promise = server.inject(postAnswersOptions);
+      });
+
+      it('should return 201 HTTP status code', async () => {
+        // when
+        const response = await promise;
+
+        // then
+        expect(response.statusCode).to.equal(201);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible d'envoyer une réponse vide si on n'a pas fini l'épreuve à temps pour une épreuve timée

## :robot: Solution
- Autoriser les réponses vides ou null

## :rainbow: Remarques

## :100: Pour tester
Tester l'épreuve `rec1cSZ2hePondDBl`, ne rien mettre, et "Passer" une fois le timer fini.