### PR TITLE
[TECH] Suppression du timer en doublon

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -48,7 +48,7 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   @action
-  updateChallengeTimedOut() {
+  setChallengeAsTimedOut() {
     this.hasChallengeTimedOut = true;
   }
 

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -53,7 +53,9 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   @action
-  validateAnswer() {
+  validateAnswer(event) {
+    event.preventDefault();
+
     if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
 
       if (this._hasError() && !this.hasChallengeTimedOut) {

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,9 +1,7 @@
 import { action } from '@ember/object';
-import { cancel, later } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';
-import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeItemGeneric extends Component {
 
@@ -13,19 +11,6 @@ export default class ChallengeItemGeneric extends Component {
   @tracked hasChallengeTimedOut = false;
   @tracked errorMessage = null;
   @tracked _elapsedTime = null;
-
-  _timer = null;
-
-  constructor() {
-    super(...arguments);
-    if (!this.isTimedChallenge) {
-      this._start();
-    }
-  }
-
-  cancelTimer() {
-    cancel(this._timer);
-  }
 
   get isTimedChallenge() {
     return isInteger(this.args.challenge.timer);
@@ -62,25 +47,9 @@ export default class ChallengeItemGeneric extends Component {
     }
   }
 
-  _start() {
-    this._elapsedTime = 0;
-    this._tick();
-  }
-
-  _tick() {
-    if (ENV.APP.isChallengeTimerEnable) {
-      const timer = later(this, function() {
-        const elapsedTime = this._elapsedTime;
-        this._elapsedTime = elapsedTime + 1;
-        if ((this._elapsedTime - this.args.challenge.timer) >= 0) {
-          this.hasChallengeTimedOut = true;
-        } else {
-          this._tick();
-        }
-      }, 1000);
-
-      this._timer = timer;
-    }
+  @action
+  updateChallengeTimedOut() {
+    this.hasChallengeTimedOut = true;
   }
 
   @action
@@ -121,7 +90,6 @@ export default class ChallengeItemGeneric extends Component {
 
   @action
   setUserConfirmation() {
-    this._start();
     this.hasUserConfirmedWarning = true;
   }
 }

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -87,7 +87,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   @action
-  removeEventListener() {
+  removeEmbedAutoEventListener() {
     window.removeEventListener('message', this.postMessageHandler);
   }
 

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -87,7 +87,6 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
   }
 
   removeEventListener() {
-    this.cancelTimer();
     window.removeEventListener('message', this.postMessageHandler);
   }
 

--- a/mon-pix/app/components/challenge-item-qroc.js
+++ b/mon-pix/app/components/challenge-item-qroc.js
@@ -86,6 +86,7 @@ export default class ChallengeItemQroc extends ChallengeItemGeneric {
     this.errorMessage = null;
   }
 
+  @action
   removeEventListener() {
     window.removeEventListener('message', this.postMessageHandler);
   }

--- a/mon-pix/app/components/timeout-gauge.js
+++ b/mon-pix/app/components/timeout-gauge.js
@@ -33,6 +33,7 @@ export default class TimeoutGauge extends Component {
         this.remainingSeconds = this.remainingSeconds - 1;
 
         if (this._isTimedOut()) {
+          this.args.updateChallengeTimedOut();
           this._stopTimer();
         }
       }, TICK_INTERVAL_IN_MILLISECONDS);

--- a/mon-pix/app/components/timeout-gauge.js
+++ b/mon-pix/app/components/timeout-gauge.js
@@ -33,7 +33,7 @@ export default class TimeoutGauge extends Component {
         this.remainingSeconds = this.remainingSeconds - 1;
 
         if (this._isTimedOut()) {
-          this.args.updateChallengeTimedOut();
+          this.args.setChallengeAsTimedOut();
           this._stopTimer();
         }
       }, TICK_INTERVAL_IN_MILLISECONDS);

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -1,15 +1,14 @@
-{{!-- template-lint-disable no-action --}}
 <article class="challenge-item"
          data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
-      <TimedChallengeInstructions @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+      <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@challenge.timer}} />
     {{/unless}}
   {{/if}}
 
   {{#if this.displayChallenge}}
-    <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
+    <form {{on "submit" this.validateAnswer}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
@@ -18,7 +17,7 @@
           <QcmProposals @answer={{@answer}}
                         @answerValue={{@answer.value}}
                         @proposals={{@challenge.proposals}}
-                        @answerChanged={{action "answerChanged"}} />
+                        @answerChanged={{this.answerChanged}} />
         </div>
 
         {{#if @answer}}
@@ -35,7 +34,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}} />
+                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}} />
           </div>
         {{/if}}
       </div>
@@ -49,9 +48,9 @@
       {{#if @assessment}}
         <ChallengeActions @challenge={{@challenge}}
                           @answer={{@answer}}
-                          @resumeAssessment={{action "resumeAssessment"}}
-                          @validateAnswer={{action "validateAnswer"}}
-                          @skipChallenge={{action "skipChallenge"}}
+                          @resumeAssessment={{this.resumeAssessment}}
+                          @validateAnswer={{this.validateAnswer}}
+                          @skipChallenge={{this.skipChallenge}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
                           @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -34,7 +34,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}} />
+                          @setChallengeAsTimedOut={{this.setChallengeAsTimedOut}} />
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -1,7 +1,6 @@
 {{!-- template-lint-disable no-action --}}
 <article class="challenge-item"
-         data-challenge-id="{{@challenge.id}}"
-         {{will-destroy (action this.cancelTimer)}}>
+         data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
@@ -35,7 +34,8 @@
 
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
-            <TimeoutGauge @allottedTime={{@challenge.timer}} />
+            <TimeoutGauge @allottedTime={{@challenge.timer}}
+                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}} />
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -35,7 +35,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}}/>
+                          @setChallengeAsTimedOut={{this.setChallengeAsTimedOut}}/>
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,8 +1,7 @@
 {{!-- template-lint-disable no-action --}}
 <article
     class="challenge-item"
-    data-challenge-id="{{@challenge.id}}"
-    {{will-destroy (action this.cancelTimer)}}>
+    data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
@@ -36,7 +35,8 @@
 
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
-            <TimeoutGauge @allottedTime={{@challenge.timer}} />
+            <TimeoutGauge @allottedTime={{@challenge.timer}}
+                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}}/>
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -1,16 +1,15 @@
-{{!-- template-lint-disable no-action --}}
 <article
     class="challenge-item"
     data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
-      <TimedChallengeInstructions @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+      <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@challenge.timer}} />
     {{/unless}}
   {{/if}}
 
   {{#if this.displayChallenge}}
-    <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
+    <form {{on "submit" this.validateAnswer}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}} {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
@@ -19,7 +18,7 @@
           <QcuProposals @answer={{@answer}}
                         @answerValue={{@answer.value}}
                         @proposals={{@challenge.proposals}}
-                        @answerChanged={{action "answerChanged"}} />
+                        @answerChanged={{this.answerChanged}} />
         </div>
 
         {{#if @answer}}
@@ -36,7 +35,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}}/>
+                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}}/>
           </div>
         {{/if}}
       </div>
@@ -50,9 +49,9 @@
       {{#if @assessment}}
         <ChallengeActions @challenge={{@challenge}}
                           @answer={{@answer}}
-                          @resumeAssessment={{action "resumeAssessment"}}
-                          @validateAnswer={{action "validateAnswer"}}
-                          @skipChallenge={{action "skipChallenge"}}
+                          @resumeAssessment={{this.resumeAssessment}}
+                          @validateAnswer={{this.validateAnswer}}
+                          @skipChallenge={{this.skipChallenge}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
                           @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,6 +1,6 @@
 <article class="challenge-item"
          data-challenge-id="{{@challenge.id}}"
-         {{will-destroy this.removeEventListener}}>
+         {{will-destroy this.removeEmbedAutoEventListener}}>
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
       <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@challenge.timer}} />
@@ -37,7 +37,7 @@
           {{#if this.displayTimer}}
             <div class="timeout-gauge-wrapper">
               <TimeoutGauge @allottedTime={{@challenge.timer}}
-                            @updateChallengeTimedOut={{this.updateChallengeTimedOut}}/>
+                            @setChallengeAsTimedOut={{this.setChallengeAsTimedOut}}/>
             </div>
           {{/if}}
         </div>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -37,7 +37,8 @@
 
           {{#if this.displayTimer}}
             <div class="timeout-gauge-wrapper">
-              <TimeoutGauge @allottedTime={{@challenge.timer}} />
+              <TimeoutGauge @allottedTime={{@challenge.timer}}
+                            @updateChallengeTimedOut={{action "updateChallengeTimedOut"}}/>
             </div>
           {{/if}}
         </div>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -1,15 +1,14 @@
-{{!-- template-lint-disable no-action --}}
 <article class="challenge-item"
          data-challenge-id="{{@challenge.id}}"
-         {{will-destroy (action this.removeEventListener)}}>
+         {{will-destroy this.removeEventListener}}>
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
-      <TimedChallengeInstructions @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+      <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@challenge.timer}} />
     {{/unless}}
   {{/if}}
 
   {{#if this.displayChallenge}}
-    <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
+    <form {{on "submit" this.validateAnswer}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       {{#if this.showProposal}}
@@ -20,7 +19,7 @@
                           @format={{@challenge.format}}
                           @proposals={{@challenge.proposals}}
                           @answerValue={{@answer.value}}
-                          @answerChanged={{action "answerChanged"}}
+                          @answerChanged={{this.answerChanged}}
                           />
           </div>
 
@@ -38,7 +37,7 @@
           {{#if this.displayTimer}}
             <div class="timeout-gauge-wrapper">
               <TimeoutGauge @allottedTime={{@challenge.timer}}
-                            @updateChallengeTimedOut={{action "updateChallengeTimedOut"}}/>
+                            @updateChallengeTimedOut={{this.updateChallengeTimedOut}}/>
             </div>
           {{/if}}
         </div>
@@ -53,9 +52,9 @@
       {{#if @assessment}}
         <ChallengeActions @challenge={{@challenge}}
                           @answer={{@answer}}
-                          @resumeAssessment={{action "resumeAssessment"}}
-                          @validateAnswer={{action "validateAnswer"}}
-                          @skipChallenge={{action "skipChallenge"}}
+                          @resumeAssessment={{this.resumeAssessment}}
+                          @validateAnswer={{this.validateAnswer}}
+                          @skipChallenge={{this.skipChallenge}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
                           @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,15 +1,14 @@
-{{!-- template-lint-disable no-action --}}
 <article class="challenge-item"
          data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
-      <TimedChallengeInstructions @hasUserConfirmedWarning={{action "setUserConfirmation"}} @time={{@challenge.timer}} />
+      <TimedChallengeInstructions @hasUserConfirmedWarning={{this.setUserConfirmation}} @time={{@challenge.timer}} />
     {{/unless}}
   {{/if}}
 
   {{#if this.displayChallenge}}
-    <form {{action "validateAnswer" on="submit"}} class="rounded-panel">
+    <form {{on "submit" this.validateAnswer}} class="rounded-panel">
       <ChallengeStatement @challenge={{@challenge}} @assessment={{@assessment}} />
 
       <div class="rounded-panel__row challenge-response {{if @answer 'challenge-response--locked'}}  {{if this.hasChallengeTimedOut 'challenge-response--locked'}}">
@@ -19,7 +18,7 @@
                          @format={{@challenge.format}}
                          @proposals={{@challenge.proposals}}
                          @answersValue={{this.answersValue}}
-                         @answerChanged={{action "answerChanged"}} />
+                         @answerChanged={{this.answerChanged}} />
         </div>
 
         {{#if @answer}}
@@ -36,7 +35,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}} />
+                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}} />
           </div>
         {{/if}}
       </div>
@@ -50,9 +49,9 @@
       {{#if @assessment}}
         <ChallengeActions @challenge={{@challenge}}
                           @answer={{@answer}}
-                          @resumeAssessment={{action "resumeAssessment"}}
-                          @validateAnswer={{action "validateAnswer"}}
-                          @skipChallenge={{action "skipChallenge"}}
+                          @resumeAssessment={{this.resumeAssessment}}
+                          @validateAnswer={{this.validateAnswer}}
+                          @skipChallenge={{this.skipChallenge}}
                           @isValidateButtonEnabled={{this.isValidateButtonEnabled}}
                           @hasChallengeTimedOut={{this.hasChallengeTimedOut}}
                           @isSkipButtonEnabled={{this.isSkipButtonEnabled}}/>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -35,7 +35,7 @@
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
             <TimeoutGauge @allottedTime={{@challenge.timer}}
-                          @updateChallengeTimedOut={{this.updateChallengeTimedOut}} />
+                          @setChallengeAsTimedOut={{this.setChallengeAsTimedOut}} />
           </div>
         {{/if}}
       </div>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -1,7 +1,6 @@
 {{!-- template-lint-disable no-action --}}
 <article class="challenge-item"
-         data-challenge-id="{{@challenge.id}}"
-         {{will-destroy (action this.cancelTimer)}}>
+         data-challenge-id="{{@challenge.id}}">
 
   {{#if this.isTimedChallengeWithoutAnswer}}
     {{#unless this.hasUserConfirmedWarning}}
@@ -36,7 +35,8 @@
 
         {{#if this.displayTimer}}
           <div class="timeout-gauge-wrapper">
-            <TimeoutGauge @allottedTime={{@challenge.timer}} />
+            <TimeoutGauge @allottedTime={{@challenge.timer}}
+                          @updateChallengeTimedOut={{action "updateChallengeTimedOut"}} />
           </div>
         {{/if}}
       </div>

--- a/mon-pix/tests/unit/components/timeout-gauge-test.js
+++ b/mon-pix/tests/unit/components/timeout-gauge-test.js
@@ -23,7 +23,7 @@ describe('Unit | Component | timeout-gauge-component ', function() {
         { remainingSeconds: 60, expected: '1:00' },
       ].forEach((data) => {
 
-        it(`should return "${data.expected}" when allotting ${data.allottedTime}s and remainingSeconds is ${data.remainingSeconds}s`, function() {
+        it(`should return "${data.expected}" when remainingSeconds is ${data.remainingSeconds}s`, function() {
           // given
           component.remainingSeconds = data.remainingSeconds;
           // when


### PR DESCRIPTION
## :unicorn: Problème
Lors d'une épreuve timée, un timer est démarré dans le composant TimeoutGauge et un autre dans le composant ChallengeItemGeneric. Nous n'avons pas besoin de deux timers.

## :robot: Solution
Le timer dans TimeoutGauge permettait d'afficher une représentation visuelle du temps restant.
Le timer dans ChallengeItemGeneric permettait de désactiver la zone de saisie + les boutons "Je valide" / "Je passe" de l'épreuve.

Le timer de ChallengeItemGeneric étant à supprimer, pour que ChallengeItemGeneric sache que l'épreuve est en timeout, TimeoutGauge prend en paramètre la méthode `updateChallengeTimedOut` de ChallengeItemGeneric pour lui indiquer que l'épreuve est timedout:
``` 
<TimeoutGauge @allottedTime={{@challenge.timer}}
   @updateChallengeTimedOut={{action "updateChallengeTimedOut"}}/>
```

## :rainbow: Remarques
La branche part de #2547 pour utiliser la version glimmerisée de TimeoutGauge.

## :100: Pour tester
- Aller sur une épreuve chronométrée (ex : rec1cSZ2hePondDBl ) et la tester avec mauvaise, bonne réponse et timeout.

- Le mot clé `action` a été aussi supprimé des templates de réponses. Tester aussi les autres types d'épreuves:
  - QCU: recWhL2fMLMhCiek2
  - QCM: recLt9uwa2dR3IYpi
  - QROC: recNanzf3oEjJ7vA9
  - QROCM: recUcM3s9DFvpnFqj
