### PR TITLE
[BUGFIX] Corriger un problème d'affichage des tables dans Pix Admin (PIX-2179)

### DIFF
--- a/admin/app/styles/misc/table-admin.scss
+++ b/admin/app/styles/misc/table-admin.scss
@@ -26,7 +26,7 @@
 }
 
 .table-admin__auto-width {
-  width: auto;
+  table-layout: auto;
 }
 
 .table-admin-input {


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, sous Firefox, lorsqu'une table est plus petite que la largeur de la page (cas qui se produit pour la table de la page "Sessions à publier" ajoutée récemment par la PR #2499, lorsque la table est vide), l'en-tête de la table est prolongé ce qui produit un effet visuel disgracieux.

![Capture d’écran 2021-02-16 à 17 49 11](https://user-images.githubusercontent.com/5627688/108094632-4f635700-707f-11eb-90db-921c35bf4d5f.png)

## :robot: Solution
Le problème est causé par la propriété CSS `width: auto`. Elle permet que lorsque la table soit scrollable horizontalement lorsqu'elle est plus large que la page, on ne peut donc pas la retirer. Mais si on la replace par `table-layout: auto`, ça permet de garder ce comportement, tout en laissant `width` à `100%`, ce qui corrige le problème sous Firefox.

## :rainbow: Remarques
_RAS_

## :100: Pour tester
- Lancer l'API et Pix Admin
- Se rendre dans **Sessions de certification**
- Constater que la table de l'onglet **Toutes les sessions** est toujours scrollable horizontalement
- Se rendre dans l'onglet **Sessions à publier**
- Publier les éventuelles sessions affichées pour qu'elles disparaissent jusqu'à pour vider la table
- Constater que le problème d'affichage de la capture ci-dessus n'est pas présent
