### PR TITLE
[FEATURE] Rattacher un utilisateur à un centre de certification dans Pix Admin (PIX-503).

### DIFF
--- a/admin/app/adapters/certification-center-membership.js
+++ b/admin/app/adapters/certification-center-membership.js
@@ -11,4 +11,22 @@ export default class CertificationCenterMembershipAdapter extends ApplicationAda
     }
     return super.urlForQuery(...arguments);
   }
+
+  createRecord(store, type, snapshot) {
+    const { adapterOptions } = snapshot;
+
+    if (adapterOptions && adapterOptions.createByEmail) {
+      const { certificationCenterId, email } = adapterOptions;
+      delete adapterOptions.certificationCenterId;
+      delete adapterOptions.createByEmail;
+      delete adapterOptions.email;
+
+      const url = `${this.buildURL('certification-center', certificationCenterId)}/certification-center-memberships`;
+      const payload = { data: { email } };
+
+      return this.ajax(url, 'POST', payload);
+    }
+
+    return super.createRecord(...arguments);
+  }
 }

--- a/admin/app/controllers/authenticated/certification-centers/get.js
+++ b/admin/app/controllers/authenticated/certification-centers/get.js
@@ -1,0 +1,96 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import isEmailValid from '../../../utils/email-validator';
+
+export default class AuthenticatedCertificationCentersGetController extends Controller {
+
+  EMAIL_INVALID_ERROR_MESSAGE = 'L\'adresse e-mail saisie n\'est pas valide.';
+  EMAIL_REQUIRED_ERROR_MESSAGE = 'Ce champ est requis.';
+
+  ERROR_MESSAGES = {
+    DEFAULT: 'Une erreur est survenue.',
+    STATUS_400: this.EMAIL_INVALID_ERROR_MESSAGE,
+    STATUS_404: 'Cet utilisateur n\'existe pas.',
+    STATUS_412: 'Ce membre est déjà rattaché.',
+  };
+
+  @service notifications;
+
+  @tracked userEmailToAdd;
+  @tracked errorMessage;
+
+  get isDisabled() {
+    return (!this.userEmailToAdd || !!this.errorMessage);
+  }
+
+  @action
+  updateEmailErrorMessage() {
+    this.errorMessage = this._getEmailErrorMessage(this.userEmailToAdd);
+  }
+
+  @action
+  async addCertificationCenterMembership(event) {
+    event && event.preventDefault();
+
+    this.errorMessage = this._getEmailErrorMessage(this.userEmailToAdd);
+    if (!this.userEmailToAdd) {
+      this.errorMessage = this.EMAIL_REQUIRED_ERROR_MESSAGE;
+    }
+    if (!this.errorMessage) {
+      try {
+        await this._createCertificationCenterMembership();
+        this.notifications.success('Membre ajouté avec succès.');
+      } catch (responseError) {
+        this._handleResponseError(responseError);
+      }
+    }
+  }
+
+  _getEmailErrorMessage(email) {
+    return (email && !isEmailValid(email)) ? this.EMAIL_INVALID_ERROR_MESSAGE : null;
+  }
+
+  async _createCertificationCenterMembership() {
+    const { certificationCenter } = this.model;
+
+    await this.store.createRecord('certification-center-membership')
+      .save({
+        adapterOptions: {
+          createByEmail: true,
+          certificationCenterId: certificationCenter.id,
+          email: this.userEmailToAdd.trim(),
+        },
+      });
+
+    this.userEmailToAdd = null;
+    this.send('refreshModel');
+  }
+
+  _handleResponseError({ errors }) {
+    let errorMessages = [];
+
+    if (errors) {
+      errorMessages = errors.map((error) => {
+        switch (error.status) {
+          case '400':
+            return this.ERROR_MESSAGES.STATUS_400;
+          case '404':
+            return this.ERROR_MESSAGES.STATUS_404;
+          case '412':
+            return this.ERROR_MESSAGES.STATUS_412;
+          default:
+            return this.ERROR_MESSAGES.DEFAULT;
+        }
+      });
+    } else {
+      errorMessages.push(this.ERROR_MESSAGES.DEFAULT);
+    }
+
+    const uniqueErrorMessages = new Set(errorMessages);
+    uniqueErrorMessages.forEach((errorMessage) => this.notifications.error(errorMessage));
+  }
+
+}

--- a/admin/app/routes/authenticated/certification-centers/get.js
+++ b/admin/app/routes/authenticated/certification-centers/get.js
@@ -1,6 +1,8 @@
-import Route from '@ember/routing/route';
-import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import RSVP from 'rsvp';
+
+import Route from '@ember/routing/route';
+import { action } from '@ember/object';
+import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
 export default class CertificationCentersGetRoute extends Route.extend(AuthenticatedRouteMixin) {
 
@@ -16,5 +18,10 @@ export default class CertificationCentersGetRoute extends Route.extend(Authentic
       certificationCenterMemberships,
       certificationCenter,
     });
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/admin/app/styles/authenticated/certification-center/index.scss
+++ b/admin/app/styles/authenticated/certification-center/index.scss
@@ -12,4 +12,23 @@
       margin-bottom: 20px;
     }
   }
+
+  .certification-center {
+
+    &__section {
+      display: flex;
+      justify-content: center;
+
+      input {
+        width: 310px;
+      }
+    }
+
+  }
+
+  .error {
+    padding-top: 5px;
+    color: $error;
+    font-size: .85rem;
+  }
 }

--- a/admin/app/templates/authenticated/certification-centers/get.hbs
+++ b/admin/app/templates/authenticated/certification-centers/get.hbs
@@ -17,6 +17,40 @@
     </div>
   </section>
 
+  <section class="page-section mb_10">
+    <header class="page-section__header">
+      <h2 class="page-section__title">Ajouter un membre</h2>
+    </header>
+
+    <div class="certification-center__section">
+      <Input
+        id="userEmailToAdd"
+        @type="email"
+        @value={{this.userEmailToAdd}}
+        aria-label="Adresse e-mail"
+        class="form-field__text form-control"
+        placeholder="Adresse e-mail"
+        {{on "focusout" this.updateEmailErrorMessage}}
+      />
+
+      <PixButton
+        @triggerAction={{this.addCertificationCenterMembership}}
+        @backgroundColor="transparent"
+        @loading-color="grey"
+        @isDisabled={{this.isDisabled}}
+        class="btn btn-outline-default"
+        data-test-add-membership
+      >
+        Valider
+      </PixButton>
+    </div>
+    {{#if this.errorMessage}}
+      <div class="certification-center__section error">
+        {{this.errorMessage}}
+      </div>
+    {{/if}}
+  </section>
+
   <CertificationCenterMembershipsSection
     @certificationCenterMemberships={{@model.certificationCenterMemberships}}
   />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -35,6 +35,7 @@ export default function() {
     return schema.users.find(userId);
   });
   this.get('/admin/users/:id');
+
   this.get('/certification-centers');
   this.get('/certification-centers/:id');
   this.get('/certification-centers/:id/certification-center-memberships', (schema, request) => {
@@ -48,6 +49,19 @@ export default function() {
     const externalId = params.data.attributes.externalId;
 
     return schema.certificationCenters.create({ name, type, externalId });
+  });
+  this.post('/certification-centers/:id/certification-center-memberships', (schema, request) => {
+    const certificationCenterId = request.params.id;
+    const params = JSON.parse(request.requestBody);
+    const { email } = params;
+    const certificationCenter = schema.certificationCenters.findBy({ id: certificationCenterId });
+    const user = schema.users.create({ email });
+
+    return schema.certificationCenterMemberships.create({
+      certificationCenter,
+      createdAt: new Date(),
+      user,
+    });
   });
 
   this.post('/memberships', createMembership);

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -22522,8 +22522,8 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#0c2ba5ff4322455790cb14877fc883123e3735f0",
-      "from": "git://github.com/1024pix/pix-ui.git#v2.0.3",
+      "version": "git://github.com/1024pix/pix-ui.git#2a24ca3a656809066a20ea7003d8ecd9a95548a3",
+      "from": "git://github.com/1024pix/pix-ui.git#v2.1.0",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^7.23.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -95,7 +95,7 @@
     "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.1",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.0.3",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v2.1.0",
     "popper.js": "^1.16.1",
     "query-string": "^6.13.6",
     "qunit-dom": "^1.6.0",

--- a/admin/tests/integration/components/certification-center-memberships-section-test.js
+++ b/admin/tests/integration/components/certification-center-memberships-section-test.js
@@ -42,10 +42,18 @@ module('Integration | Component | certification-center-memberships-section', fun
 
   test('it should display a list of certification center memberships', async function(assert) {
     // given
-    const user1 = EmberObject.create({ firstName: 'Jojo', lastName: 'La Gringue', email: 'jojo@lagringue.fr' });
-    const user2 = EmberObject.create({ firstName: 'Froufrou', lastName: 'Le froussard', email: 'froufrou@lefroussard.fr' });
+    const user1 = EmberObject.create({
+      firstName: 'Jojo',
+      lastName: 'La Gringue',
+      email: 'jojo@example.net',
+    });
+    const user2 = EmberObject.create({
+      firstName: 'Froufrou',
+      lastName: 'Le froussard',
+      email: 'froufrou@example.net',
+    });
     const certificationCenterMembership1 = EmberObject.create({ id: 1, user: user1 });
-    const certificationCenterMembership2 = EmberObject.create({ id: 1, user: user2 });
+    const certificationCenterMembership2 = EmberObject.create({ id: 2, user: user2 });
     const certificationCenterMemberships = [certificationCenterMembership1, certificationCenterMembership2];
     this.set('certificationCenterMemberships', certificationCenterMemberships);
 

--- a/admin/tests/unit/adapters/certification-center-membership-test.js
+++ b/admin/tests/unit/adapters/certification-center-membership-test.js
@@ -1,16 +1,19 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapter | certificationCenterMembership', function(hooks) {
+
   setupTest(hooks);
 
   let adapter;
 
   hooks.beforeEach(function() {
     adapter = this.owner.lookup('adapter:certification-center-membership');
+    adapter.ajax = sinon.stub().resolves();
   });
 
-  module('#urlForQuery', () => {
+  module('#urlForQuery', function() {
 
     test('should build query url from certificationCenter id', async function(assert) {
       const query = { filter: { certificationCenterId: '1' } };
@@ -18,6 +21,36 @@ module('Unit | Adapter | certificationCenterMembership', function(hooks) {
 
       assert.ok(url.endsWith('/api/certification-centers/1/certification-center-memberships'));
       assert.equal(query.filter.certificationCenterId, undefined);
+    });
+  });
+
+  module('#createRecord', function() {
+
+    module('when createByEmail is true', function() {
+
+      test('should call /api/certification-centers/id/certification-center-memberships', async function(assert) {
+        // given
+        const certificationCenterId = 1;
+        const email = 'user@example.net';
+
+        const snapshot = {
+          adapterOptions: {
+            createByEmail: true,
+            certificationCenterId,
+            email,
+          },
+        };
+        const expectedUrl = `http://localhost:3000/api/certification-centers/${certificationCenterId}/certification-center-memberships`;
+        const expectedMethod = 'POST';
+        const expectedPayload = { data: { email } };
+
+        // when
+        await adapter.createRecord(null, null, snapshot);
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, expectedMethod, expectedPayload);
+        assert.ok(true);
+      });
     });
   });
 });

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get-test.js
@@ -1,0 +1,212 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import Service from '@ember/service';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/certification-centers/get', function(hooks) {
+
+  setupTest(hooks);
+
+  let certificationCenter;
+  let createRecordStub;
+  let saveStub;
+
+  let controller;
+
+  hooks.beforeEach(function() {
+    sinon.restore();
+
+    controller = this.owner.lookup('controller:authenticated/certification-centers/get');
+
+    createRecordStub = sinon.stub();
+    saveStub = sinon.stub();
+
+    saveStub.resolves();
+    createRecordStub.returns({
+      save: saveStub,
+    });
+
+    certificationCenter = { id: 1 };
+
+    controller.store = Service.create({
+      createRecord: createRecordStub,
+    });
+
+    controller.model = {
+      certificationCenter,
+    };
+
+    controller.notifications = {
+      success: sinon.stub(),
+      error: sinon.stub(),
+    };
+    controller.notifications.success.resolves();
+    controller.notifications.error.resolves();
+  });
+
+  module('#updateEmailErrorMessage', function() {
+
+    test('should set email error message if email syntax is invalid', function(assert) {
+      // given
+      controller.userEmailToAdd = 'an invalid email';
+
+      // when
+      controller.send('updateEmailErrorMessage');
+
+      // then
+      assert.equal(controller.errorMessage, controller.EMAIL_INVALID_ERROR_MESSAGE);
+    });
+
+    test('should set email error message to null if email is empty', function(assert) {
+      // given
+      controller.errorMessage = 'error message';
+      controller.userEmailToAdd = '';
+
+      // when
+      controller.send('updateEmailErrorMessage');
+
+      // then
+      assert.equal(controller.errorMessage, null);
+    });
+  });
+
+  module('#addCertificationCenterMembership', function(hooks) {
+
+    let event;
+
+    hooks.beforeEach(function() {
+      event = { preventDefault() {} };
+      controller.send = sinon.stub();
+    });
+
+    module('when email is valid', function() {
+
+      const emailWithSpaces = ' test@example.net ';
+
+      test('should create a certificationCenterMembership', async function(assert) {
+        // given
+        controller.userEmailToAdd = emailWithSpaces;
+        const expectedArguments = {
+          adapterOptions: {
+            createByEmail: true,
+            certificationCenterId: certificationCenter.id,
+            email: emailWithSpaces.trim(),
+          },
+        };
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        sinon.assert.calledWith(createRecordStub, 'certification-center-membership');
+        sinon.assert.calledWith(saveStub, expectedArguments);
+        sinon.assert.calledWith(controller.send, 'refreshModel');
+        assert.ok(true);
+      });
+
+      test('should not set any error message', async function(assert) {
+        // given
+        controller.userEmailToAdd = emailWithSpaces;
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        assert.equal(controller.errorMessage, null);
+      });
+
+      test('should send success notification', async function(assert) {
+        // given
+        controller.userEmailToAdd = emailWithSpaces;
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        sinon.assert.called(controller.notifications.success);
+        assert.ok(true);
+      });
+    });
+
+    module('when email is not valid', function() {
+
+      test('should be disabled if the email is empty', async function(assert) {
+        // given
+        controller.userEmailToAdd = '';
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        assert.equal(controller.isDisabled, true);
+      });
+
+      test('should set error message if the email is empty', async function(assert) {
+        // given
+        controller.userEmailToAdd = '';
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        assert.equal(controller.errorMessage, controller.EMAIL_REQUIRED_ERROR_MESSAGE);
+      });
+
+      test('should set error message if the email syntax is invalid', async function(assert) {
+        // given
+        controller.userEmailToAdd = 'an invalid email';
+
+        // when
+        await controller.addCertificationCenterMembership(event);
+
+        // then
+        assert.equal(controller.errorMessage, controller.EMAIL_INVALID_ERROR_MESSAGE);
+      });
+    });
+
+    module('when API response is not OK (201)', function() {
+
+      module('when the response error does not contains any errors property', function() {
+
+        test('should send default error notification', async function(assert) {
+          // given
+          controller.userEmailToAdd = 'test@example.net';
+          saveStub.rejects({});
+
+          // when
+          await controller.addCertificationCenterMembership(event);
+
+          // then
+          sinon.assert.calledWith(controller.notifications.error, controller.ERROR_MESSAGES.DEFAULT);
+          assert.ok(true);
+        });
+      });
+
+      module('when the response error contains an errors property', () => {
+
+        test('should send a specific error notification for http error 400, 404 and 412', async (assert) => {
+          // given
+          const responseError = {
+            errors: [
+              { status: '400' },
+              { status: '404' },
+              { status: '412' },
+            ],
+          };
+
+          controller.userEmailToAdd = 'test@example.net';
+          saveStub.throws(responseError);
+
+          // when
+          await controller.addCertificationCenterMembership(event);
+
+          // then
+          sinon.assert.calledWith(controller.notifications.error, controller.ERROR_MESSAGES.STATUS_400);
+          sinon.assert.calledWith(controller.notifications.error, controller.ERROR_MESSAGES.STATUS_404);
+          sinon.assert.calledWith(controller.notifications.error, controller.ERROR_MESSAGES.STATUS_412);
+          assert.ok(true);
+        });
+      });
+    });
+  });
+});

--- a/api/lib/application/certification-centers/certification-center-controller.js
+++ b/api/lib/application/certification-centers/certification-center-controller.js
@@ -72,4 +72,15 @@ module.exports = {
 
     return certificationCenterMembershipSerializer.serialize(certificationCenterMemberships);
   },
+
+  async createCertificationCenterMembershipByEmail(request, h) {
+    const certificationCenterId = parseInt(request.params.certificationCenterId);
+    const { email } = request.payload;
+
+    const certificationCenterMembership = await usecases.createCertificationCenterMembershipByEmail({
+      certificationCenterId,
+      email,
+    });
+    return h.response(certificationCenterMembershipSerializer.serialize(certificationCenterMembership)).created();
+  },
 };

--- a/api/lib/application/certification-centers/index.js
+++ b/api/lib/application/certification-centers/index.js
@@ -141,6 +141,31 @@ exports.register = async function(server) {
         tags: ['api', 'certification-center-membership'],
       },
     },
+    {
+      method: 'POST',
+      path: '/api/certification-centers/{certificationCenterId}/certification-center-memberships',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            certificationCenterId: identifiersType.certificationCenterId,
+          }),
+          payload: Joi.object().required().keys({
+            email: Joi.string().email().required(),
+          }),
+        },
+        handler: certificationCenterController.createCertificationCenterMembershipByEmail,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs Pix Master authentifiés**\n' +
+          '- Création d‘un nouveau membre d\'un centre de certification,\n' +
+          'à partir de l\'adresse e-mail d\'un utilisateur.',
+        ],
+        tags: ['api', 'certification-center-membership'],
+      },
+    },
   ]);
 };
 

--- a/api/lib/domain/usecases/create-certification-center-membership-by-email.js
+++ b/api/lib/domain/usecases/create-certification-center-membership-by-email.js
@@ -1,0 +1,21 @@
+const { AlreadyExistingEntityError } = require('../errors');
+
+module.exports = async function createCertificationCenterMembershipByEmail({
+  certificationCenterId,
+  email,
+  certificationCenterMembershipRepository,
+  userRepository,
+}) {
+  const { id: userId } = await userRepository.getByEmail(email);
+
+  const isMembershipExisting = await certificationCenterMembershipRepository.isMemberOfCertificationCenter(
+    userId,
+    certificationCenterId,
+  );
+
+  if (isMembershipExisting) {
+    throw new AlreadyExistingEntityError(`Certification center membership already exists for the user ID ${userId} and certification center ID ${certificationCenterId}.`);
+  }
+
+  return certificationCenterMembershipRepository.save(userId, certificationCenterId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -127,6 +127,7 @@ module.exports = injectDependencies({
   createUserAndReconcileToSchoolingRegistrationFromExternalUser: require('./create-user-and-reconcile-to-schooling-registration-from-external-user'),
   createCampaign: require('./create-campaign'),
   createCertificationCenterMembership: require('./create-certification-center-membership'),
+  createCertificationCenterMembershipByEmail: require('./create-certification-center-membership-by-email'),
   createMembership: require('./create-membership'),
   createOrganization: require('./create-organization'),
   createOrganizationInvitations: require('./create-organization-invitations'),

--- a/api/lib/infrastructure/repositories/certification-center-membership-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-membership-repository.js
@@ -33,8 +33,13 @@ module.exports = {
 
   async save(userId, certificationCenterId) {
     try {
-      const newCertificationCenterMembership = await new BookshelfCertificationCenterMembership({ userId, certificationCenterId })
-        .save();
+      const newCertificationCenterMembership = await new BookshelfCertificationCenterMembership({
+        userId,
+        certificationCenterId,
+      })
+        .save()
+        .then((model) => model.fetch({ withRelated: ['user', 'certificationCenter'] }));
+
       return bookshelfToDomainConverter.buildDomainObject(BookshelfCertificationCenterMembership, newCertificationCenterMembership);
     } catch (err) {
       if (bookshelfUtils.isUniqConstraintViolated(err)) {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -28,7 +28,9 @@ module.exports = {
   // TODO use _toDomain()
   getByEmail(email) {
     return BookshelfUser
-      .where({ email: email.toLowerCase() })
+      .query((qb) => {
+        qb.where('email', 'ILIKE', email);
+      })
       .fetch({ require: true })
       .then((bookshelfUser) => {
         return bookshelfUser.toDomainEntity();

--- a/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/integration/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -1,0 +1,85 @@
+const {
+  catchErr,
+  databaseBuilder,
+  expect,
+  knex,
+} = require('../../../test-helper');
+
+const { UserNotFoundError, AlreadyExistingEntityError } = require('../../../../lib/domain/errors');
+
+const CertificationCenterMembership = require('../../../../lib/domain/models/CertificationCenterMembership');
+
+const certificationCenterMembershipRepository = require('../../../../lib/infrastructure/repositories/certification-center-membership-repository');
+const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
+
+const createCertificationCenterMembershipByEmail = require('../../../../lib/domain/usecases/create-certification-center-membership-by-email');
+
+describe('Integration | UseCases | create-certification-center-membership-by-email', () => {
+
+  let certificationCenterId;
+  let user;
+  let email;
+
+  afterEach(async() => {
+    await knex('certification-center-memberships').delete();
+  });
+
+  it('should throw UserNotFoundError if user\'s email does not exist', async () => {
+    // given
+    email = 'notExist@example.net';
+
+    // when
+    const error = await catchErr(createCertificationCenterMembershipByEmail)({
+      certificationCenterId,
+      email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotFoundError);
+    expect(error.message).to.equal(`User not found for email ${email}`);
+  });
+
+  it('should throw AlreadyExistingEntityError if certification center membership exist', async () => {
+    // given
+    certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    user = databaseBuilder.factory.buildUser();
+    databaseBuilder.factory.buildCertificationCenterMembership({ userId: user.id, certificationCenterId });
+    await databaseBuilder.commit();
+
+    // when
+    const error = await catchErr(createCertificationCenterMembershipByEmail)({
+      certificationCenterId,
+      email: user.email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(AlreadyExistingEntityError);
+  });
+
+  it('should create and return certification center membership ', async () => {
+    // given
+    certificationCenterId = databaseBuilder.factory.buildCertificationCenter().id;
+    user = databaseBuilder.factory.buildUser();
+    await databaseBuilder.commit();
+
+    // when
+    const certificationCenterMembership = await createCertificationCenterMembershipByEmail({
+      certificationCenterId,
+      email: user.email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(certificationCenterMembership).to.be.an.instanceOf(CertificationCenterMembership);
+    expect(certificationCenterMembership.certificationCenter.id).to.equal(certificationCenterId);
+    expect(certificationCenterMembership.user.id).to.equal(user.id);
+
+    const certificationCenterMembershipDB = await knex('certification-center-memberships').where({ id: certificationCenterMembership.id }).first();
+    expect(certificationCenterMembershipDB).to.exist;
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -112,6 +112,19 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         // then
         expect(user.email).to.equal(userInDb.email);
       });
+
+      it('should return a domain user when email match (case insensitive)', async () => {
+        // given
+        const mixCaseEmail = 'USER@example.net';
+        databaseBuilder.factory.buildUser({ email: mixCaseEmail });
+        await databaseBuilder.commit();
+
+        // when
+        const foundUser = await userRepository.getByEmail(mixCaseEmail.toLowerCase());
+
+        // then
+        expect(foundUser).to.exist;
+      });
     });
 
     describe('#getBySamlId', () => {
@@ -1344,6 +1357,7 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
   });
 
   describe('#updateHasSeenNewDashboardInfoToTrue', () => {
+
     let userId;
 
     beforeEach(() => {
@@ -1358,7 +1372,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       // then
       expect(actualUser.hasSeenNewDashboardInfo).to.be.true;
     });
-
   });
 
 });

--- a/api/tests/unit/application/certification-centers/certification-center-controller_test.js
+++ b/api/tests/unit/application/certification-centers/certification-center-controller_test.js
@@ -148,4 +148,34 @@ describe('Unit | Controller | certifications-center-controller', () => {
     });
   });
 
+  describe('#createCertificationCenterMembershipByEmail', () => {
+
+    const certificationCenterId = 1;
+    const email = 'user@example.net';
+
+    const request = {
+      params: { certificationCenterId },
+      payload: { email },
+    };
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'createCertificationCenterMembershipByEmail');
+      sinon.stub(certificationCenterMembershipSerializer, 'serialize');
+
+      usecases.createCertificationCenterMembershipByEmail.resolves();
+      certificationCenterMembershipSerializer.serialize.returns('ok');
+    });
+
+    it('should call usecase and serializer and return 201 HTTP code', async () => {
+      // when
+      const response = await certificationCenterController.createCertificationCenterMembershipByEmail(request, hFake);
+
+      // then
+      expect(usecases.createCertificationCenterMembershipByEmail)
+        .calledWith({ certificationCenterId, email });
+      expect(response.source).to.equal('ok');
+      expect(response.statusCode).to.equal(201);
+    });
+  });
+
 });

--- a/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
+++ b/api/tests/unit/domain/usecases/create-certification-center-membership-by-email_test.js
@@ -1,0 +1,82 @@
+const { catchErr, expect, sinon } = require('../../../test-helper');
+
+const {
+  AlreadyExistingEntityError,
+  UserNotFoundError,
+} = require('../../../../lib/domain/errors');
+
+const createCertificationCenterMembershipByEmail = require('../../../../lib/domain/usecases/create-certification-center-membership-by-email');
+
+describe('Unit | UseCase | create-certification-center-membership-by-email', () => {
+
+  const certificationCenterId = 1;
+  const email = 'user@exemple.net';
+  const userId = 1;
+
+  let certificationCenterMembershipRepository;
+  let userRepository;
+
+  beforeEach(() => {
+    certificationCenterMembershipRepository = {
+      isMemberOfCertificationCenter: sinon.stub(),
+      save: sinon.stub(),
+    };
+    userRepository = {
+      getByEmail: sinon.stub(),
+    };
+
+    certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(false);
+    certificationCenterMembershipRepository.save.resolves();
+    userRepository.getByEmail.resolves({ id: userId });
+  });
+
+  it('should call repositories', async () => {
+    // when
+    await createCertificationCenterMembershipByEmail({
+      certificationCenterId,
+      email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(userRepository.getByEmail).has.been.calledWith(email);
+    expect(certificationCenterMembershipRepository.isMemberOfCertificationCenter)
+      .has.been.calledWith(userId, certificationCenterId);
+    expect(certificationCenterMembershipRepository.save).has.been.calledWith(userId, certificationCenterId);
+  });
+
+  it('should throw UserNotFoundError if no user matches this email', async () => {
+    // given
+    userRepository.getByEmail.throws(new UserNotFoundError());
+
+    // when
+    const error = await catchErr(createCertificationCenterMembershipByEmail)({
+      certificationCenterId,
+      email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.an.instanceOf(UserNotFoundError);
+  });
+
+  it('should throw AlreadyExistingEntityError if certification center membership exist', async () => {
+    // given
+    certificationCenterMembershipRepository.isMemberOfCertificationCenter.resolves(true);
+
+    // when
+    const error = await catchErr(createCertificationCenterMembershipByEmail)({
+      certificationCenterId,
+      email,
+      certificationCenterMembershipRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(AlreadyExistingEntityError);
+    expect(error.message).to.equal(`Certification center membership already exists for the user ID ${userId} and certification center ID ${certificationCenterId}.`);
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Admin, la page de détail d'un centre de certification affiche la liste des utilisateurs rattachés à ce centre (membres).
Par contre, il n'est pas possible d'ajouter un nouveau membre.

## :robot: Solution
En gardant le même design utilisé sur la page de détail d'une organisation, permettre de rattacher un utilisateur au centre de certification, en utilisant son adresse e-mail.
<div align="center"><img src="https://user-images.githubusercontent.com/88607/108171573-00a7d280-70fc-11eb-9311-fe3b8eb9d726.png" width="350" /></div>

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Etapes:
* connectez-vous  à [PixAdmin](https://admin-pr2568.review.pix.fr/login): `pixmaster@example.net `/ `pix123`
* allez sur la page de détail d'un centre de certification
  * ex.https://admin-pr2568.review.pix.fr/certification-centers/1
* entrez l'adresse e-mail d'un utilisateur à rattacher (ex. userpix1@example.net) et valider.
* vérifiez que cet utilisateur a été ajouté à la liste des membres, et qu'une notification apparait.  
* vérifiez qu'un message d'erreur apparait si le format de l'adresse e-mail est erroné.
* vérifiez qu'une notification apparait si l'utilisateur correspondant n'existe pas.
* vérifiez qu'une notification apparait si l'adresse e-mail utilisée correspond à un utilisateur déjà membre de ce centre de certification.