### PR TITLE
[BUGFIX] Pôle-emploi - Corriger la gestion du refus d'un demandeur d'emploi, interdisant PIX d'utiliser ses données (PIX-2165).

### DIFF
--- a/mon-pix/app/routes/login-pe.js
+++ b/mon-pix/app/routes/login-pe.js
@@ -35,6 +35,8 @@ export default class LoginPeRoute extends Route {
         queryParams.code,
         queryParams.state,
       );
+    } else if (queryParams.error) {
+      return this.replaceWith('login');
     }
 
     return this._handleRedirectRequest();

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -157,7 +157,7 @@ module.exports = function(environment) {
     }
 
     ENV.APP.IS_POLE_EMPLOI_ENABLED = true;
-    ENV['ember-simple-auth-oidc'].host = 'https://authentification-candidat.pole-emploi.fr';
+    ENV['ember-simple-auth-oidc'].host = 'https://authentification-candidat-r.pe-qvr.fr';
     ENV['ember-simple-auth-oidc'].afterLogoutUri = 'http://localhost:8080/';
   }
 

--- a/mon-pix/tests/unit/routes/login-pe-test.js
+++ b/mon-pix/tests/unit/routes/login-pe-test.js
@@ -1,0 +1,51 @@
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | login-pe', function() {
+
+  setupTest();
+
+  let route;
+
+  beforeEach(function() {
+    route = this.owner.lookup('route:login-pe');
+    sinon.stub(route, 'replaceWith');
+  });
+
+  context('when pole-emploi user disallow PIX to use data', function() {
+
+    const queryParams = {
+      error: 'access_denied',
+    };
+
+    it('should redirect to login route if transition.to exist', async function() {
+      // given
+      const transition = {
+        to: {
+          queryParams,
+        },
+      };
+
+      // when
+      await route.afterModel(null, transition);
+
+      // then
+      sinon.assert.calledWith(route.replaceWith, 'login');
+    });
+
+    it('should redirect to login route if transition exist', async function() {
+      // given
+      const transition = {
+        queryParams,
+      };
+
+      // when
+      await route.afterModel(null, transition);
+
+      // then
+      sinon.assert.calledWith(route.replaceWith, 'login');
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Sur le formulaire Pôle emploi, lorsque qu'un demandeur d'emploi n'autorise pas PIX à utiliser ses données, il doit être redirigé vers Pix App.
<div align="center">
<img src="https://user-images.githubusercontent.com/88607/108206438-af610880-7126-11eb-8891-935023ad834a.png" width="300" />
</div>

Or, cette redirection ne fonctionne pas.

## :robot: Solution
Corriger la gestion de l'erreur `access_denied`, et rediriger l'utilisateur vers la page de connexion (profil si l'utilisateur était déjà connecté).

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
cf. [Wiki Pôle emploi](https://1024pix.atlassian.net/wiki/spaces/DEV/pages/1949663259/Int+gration+P+le+Emploi+-+Pix)

Dans Pix App,
* A partir de la page de connexion, aller sur Pôle emploi, identifiez-vous et "Refuser"
  * Vérifiez le retour à la page de connexion Pix App
* Connectez-vous à Pix App
  * Utiliser un code campagne Pôle emploi (ex. QWERTY789)
  * Identifiez-vous et "Refuser"
  * Vérifiez le retour à votre page `profil`