### PR TITLE
[FEATURE] Déconnecter un utilisateur anonyme lorsqu'il accède à une campagne à accès simplifié (PIX-2097).

### DIFF
--- a/mon-pix/app/components/navbar-desktop-header.js
+++ b/mon-pix/app/components/navbar-desktop-header.js
@@ -7,6 +7,7 @@ export default class NavbarDesktopHeader extends Component {
   @service router;
   @service session;
   @service intl;
+  @service currentUser;
 
   @tracked isUserLogged = this.session.isAuthenticated;
 
@@ -27,5 +28,9 @@ export default class NavbarDesktopHeader extends Component {
 
   get showDashboard() {
     return ENV.APP.FT_DASHBOARD;
+  }
+
+  get showHeaderMenuItem() {
+    return this.isUserLogged && !this.currentUser.user.isAnonymous;
   }
 }

--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -19,7 +19,7 @@ export default class FillInCampaignCodeController extends Controller {
   }
 
   get firstTitle() {
-    return this.isUserAuthenticated
+    return this.isUserAuthenticated && !this.currentUser.user.isAnonymous
       ? this.intl.t('pages.fill-in-campaign-code.first-title-connected', { firstName: this.currentUser.user.firstName })
       : this.intl.t('pages.fill-in-campaign-code.first-title-not-connected');
   }
@@ -29,6 +29,10 @@ export default class FillInCampaignCodeController extends Controller {
       firstName: this.currentUser.user.firstName,
       lastName: this.currentUser.user.lastName,
     });
+  }
+
+  get showWarningMessage() {
+    return this.isUserAuthenticated && !this.currentUser.user.isAnonymous;
   }
 
   @action

--- a/mon-pix/app/templates/components/navbar-desktop-header.hbs
+++ b/mon-pix/app/templates/components/navbar-desktop-header.hbs
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    {{#if this.isUserLogged}}
+    {{#if this.showHeaderMenuItem}}
       <nav class="navbar-desktop-header-container__menu">
         <ul class="navbar-desktop-header-menu__list">
           {{#if this.showDashboard}}

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -44,7 +44,7 @@
           </div>
         </form>
 
-        {{#if this.isUserAuthenticated}}
+        {{#if this.showWarningMessage}}
           <div class="fill-in-campaign-code__warning">
             <span>{{this.warningMessage}}</span>
             <a href="#" class="link" {{action this.disconnect}}>{{t 'pages.fill-in-campaign-code.warning-message-logout'}}</a>

--- a/mon-pix/mirage/routes/auth/index.js
+++ b/mon-pix/mirage/routes/auth/index.js
@@ -45,6 +45,7 @@ export default function index(config) {
     const createdUser = schema.users.create({
       firstName: '',
       lastName: '',
+      isAnonymous: true,
     });
 
     return {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -641,23 +641,7 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           await click('#pix-cgu');
           await click('.button');
         });
-
       });
-
-      context('When campaign does not have external id but a participant external id is set in the url', function() {
-        beforeEach(async function() {
-          campaign = server.create('campaign');
-          await startCampaignByCodeAndExternalId(campaign.code);
-          await fillIn('#firstName', prescritUser.firstName);
-          await fillIn('#lastName', prescritUser.lastName);
-          await fillIn('#email', prescritUser.email);
-          await fillIn('#password', prescritUser.password);
-          await click('#pix-cgu');
-          await click('.button');
-        });
-
-      });
-
     });
 
     context('When user is logged in', function() {

--- a/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-workflow-test.js
@@ -63,6 +63,32 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           // then
           expect(find('.fill-in-campaign-code__start-button').textContent).to.contains('Commencer');
         });
+
+        context('When is a simplified access campaign', function() {
+
+          beforeEach(function() {
+            campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+          });
+
+          it('should redirect to landing page', async function() {
+            // when
+            await visit(`/campagnes/${campaign.code}`);
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/presentation`);
+          });
+
+          it('should redirect to tutorial page after starting campaign', async function() {
+            // when
+            await visit(`/campagnes/${campaign.code}`);
+            await click('button[type="submit"]');
+            await fillIn('#id-pix-label', 'vu');
+            await click('button[type="submit"]');
+
+            // then
+            expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
+          });
+        });
       });
 
       context('When campaign code exists', function() {
@@ -881,6 +907,33 @@ describe('Acceptance | Campaigns | Start Campaigns workflow', function() {
           // then
           expect(currentURL()).to.equal(`/campagnes/${campaign.code}/evaluation/didacticiel`);
         });
+
+      });
+    });
+
+    context('When user is logged as anonymous and campaign is simplified access', () => {
+
+      beforeEach(async () => {
+        campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+        await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
+      });
+
+      it('should replace previous connected anonymous user', async function() {
+        // given
+        const session = currentSession();
+        const previousUserId = session.data.authenticated['user_id'];
+
+        // when
+        await visit('/campagnes');
+        await fillIn('#campaign-code', campaign.code);
+        await click('.fill-in-campaign-code__start-button');
+        await click('button[type="submit"]');
+
+        const currentUserId = session.data.authenticated['user_id'];
+
+        // then
+        expect(currentUserId).to.be.finite;
+        expect(previousUserId).not.to.equal(currentUserId);
       });
     });
 

--- a/mon-pix/tests/integration/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-desktop-header-test.js
@@ -66,6 +66,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
         }
       }
       this.owner.register('service:session', sessionService);
+      class currentUserService extends Service {
+        user = { isAnonymous: false }
+      }
+      this.owner.register('service:currentUser', currentUserService);
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>}`);
     });
@@ -126,6 +130,10 @@ describe('Integration | Component | navbar-desktop-header', function() {
         }
       }
       this.owner.register('service:session', sessionService);
+      class currentUserService extends Service {
+        user = { isAnonymous: false }
+      }
+      this.owner.register('service:currentUser', currentUserService);
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>}`);
     });
@@ -156,6 +164,52 @@ describe('Integration | Component | navbar-desktop-header', function() {
         }
       }
       this.owner.register('service:session', sessionService);
+
+      setBreakpoint('desktop');
+      await render(hbs`<NavbarDesktopHeader/>`);
+    });
+
+    it('should be rendered', function() {
+      // then
+      expect(find('.navbar-desktop-header__container')).to.exist;
+    });
+
+    it('should display the Pix logo', function() {
+      // then
+      expect(find('.navbar-desktop-header-logo')).to.exist;
+      expect(find('.pix-logo')).to.exist;
+    });
+
+    it('should not display the navigation menu', function() {
+      // then
+      expect(find('.navbar-desktop-header-container__menu')).to.not.exist;
+    });
+
+    it('should not display link to signup page', function() {
+      // then
+      expect(find('.navbar-menu-signup-link')).to.not.exist;
+    });
+
+    it('should not display link to login page', function() {
+      // then
+      expect(find('.navbar-menu-signin-link')).to.not.exist;
+    });
+
+    it('should not display the join campaign link', function() {
+      expect(contains('J\'ai un code')).not.to.exist;
+    });
+  });
+
+  context('when logged user is anonymous', function() {
+    beforeEach(async function() {
+      class sessionService extends Service {
+        isAuthenticated = true
+      }
+      this.owner.register('service:session', sessionService);
+      class currentUserService extends Service {
+        user = { isAnonymous: true }
+      }
+      this.owner.register('service:currentUser', currentUserService);
 
       setBreakpoint('desktop');
       await render(hbs`<NavbarDesktopHeader/>`);

--- a/mon-pix/tests/unit/components/navbar-desktop-header-test.js
+++ b/mon-pix/tests/unit/components/navbar-desktop-header-test.js
@@ -8,6 +8,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
   setupTest();
   const sessionStubResolve = Service.create({ isAuthenticated: true });
   const sessionStubReject = Service.create({ isAuthenticated: false });
+  const currentUserStub = Service.create({ user: {} });
 
   let component;
 
@@ -15,6 +16,7 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
     beforeEach(function() {
       component = createGlimmerComponent('component:navbar-desktop-header');
       component.session = sessionStubResolve;
+      component.currentUser = currentUserStub;
     });
 
     context('#isUserLogged', function() {
@@ -31,6 +33,24 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
 
         // then
         expect(component.menu).to.deep.equal(expectedMenu);
+      });
+    });
+
+    context('#showHeaderMenuItem', () => {
+      it('should return true, when logged user is not anonymous', () => {
+        // given
+        currentUserStub.user.isAnonymous = false;
+
+        // then
+        expect(component.showHeaderMenuItem).to.be.true;
+      });
+
+      it('should return false, when logged user is anonymous', () => {
+        // given
+        currentUserStub.user.isAnonymous = true;
+
+        // then
+        expect(component.showHeaderMenuItem).to.be.false;
       });
     });
   });
@@ -60,6 +80,13 @@ describe('Unit | Component | Navbar Desktop Header Component', function() {
         expect(component.menu).to.have.lengthOf(expectedMenu.length);
         expect(component.menu[0].link).to.equal(expectedMenu[0].link);
         expect(component.menu[1].link).to.equal(expectedMenu[1].link);
+      });
+    });
+
+    context('#showHeaderMenuItem', () => {
+      it('should return false', () => {
+        // then
+        expect(component.showHeaderMenuItem).to.be.false;
       });
     });
   });

--- a/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
+++ b/mon-pix/tests/unit/controllers/fill-in-campaign-code-test.js
@@ -114,6 +114,22 @@ describe('Unit | Controller | Fill in Campaign Code', function() {
         expect(firstTitle).to.equal(expectedFirstTitle);
       });
     });
+
+    context('When user is anonymous', () => {
+
+      it('should return the not connected first title', () => {
+        // given
+        sessionStub.isAuthenticated = true;
+        currentUserStub.user.isAnonymous = true;
+        const expectedFirstTitle = controller.intl.t('pages.fill-in-campaign-code.first-title-not-connected');
+
+        // when
+        const firstTitle = controller.firstTitle;
+
+        // then
+        expect(firstTitle).to.equal(expectedFirstTitle);
+      });
+    });
   });
 
   describe('get isUserAuthenticated', () => {
@@ -127,6 +143,44 @@ describe('Unit | Controller | Fill in Campaign Code', function() {
 
       // then
       expect(isUserAuthenticated).to.equal(sessionStub.isAuthenticated);
+    });
+  });
+
+  describe('get showWarningMessage', () => {
+
+    it('should return true if user is authenticated and not anonymous', () => {
+      // given
+      sessionStub.isAuthenticated = true;
+      currentUserStub.user.isAnonymous = false;
+
+      // when
+      const showWarningMessage = controller.showWarningMessage;
+
+      // then
+      expect(showWarningMessage).to.be.true;
+    });
+
+    it('should return false if user is not authenticated', () => {
+      // given
+      sessionStub.isAuthenticated = false;
+
+      // when
+      const showWarningMessage = controller.showWarningMessage;
+
+      // then
+      expect(showWarningMessage).to.be.false;
+    });
+
+    it('should return false if user is authenticated and anonymous', () => {
+      // given
+      sessionStub.isAuthenticated = true;
+      currentUserStub.user.isAnonymous = true;
+
+      // when
+      const showWarningMessage = controller.showWarningMessage;
+
+      // then
+      expect(showWarningMessage).to.be.false;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'un utilisateur non connecté rejoint une campagne à accès simplifié, une compte utilisateur anonyme est crée. Si cet utilisateur ne termine pas son parcours et qu'un autre utilisateur souhaite le rejoindre, ce dernier reprendra le parcours du précédent utilisateur. 

## :robot: Solution
Déconnecter le précédent utilisateur anonyme afin que le suivant puisse accéder à la campagne avec un nouveau compte anonyme. 

## :rainbow: Remarques
Lors de l'accès à la route `/campagnes` en tant qu'utilisateur anonyme (n'ayant donc ni prénom ni nom), l'affichage de la page n'est pas correct, car on affiche le prénom et le nom de l'utilisateur.
De plus, les liens d'accès aux différentes parties de l'application sont toujours présents.
Cette PR inclut donc une modification de l'affichage de cette page pour les utilisateurs anonymes et reprend les règles d'affichage pour un utilisateur non connecté, ainsi que la disparition des liens d'inscription et de connexion.

## :100: Pour tester
- Rejoindre le parcours à accès simplifié (code: SIMPLIFIE).
- Commencer le parcours.
- Rejoindre la page /campagnes ou /campagnes/SIMPLIFIE.
- Vérifier que l'on arrive bien sur la page de présentation de la campagne.
- Commencer le parcours et vérifier qu'un nouvel utilisateur anonyme a été créé.
