### PR TITLE
[BUGFIX] Dans Pix Orga, interdire l'accès à la page de détail d'une campagne, à un utilisateur qui n'est pas membre de organisation liée (PIX-2183).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -45,9 +45,12 @@ module.exports = {
   },
 
   async getById(request) {
+    const { userId } = request.auth.credentials;
     const campaignId = request.params.id;
-    const tokenForCampaignResults = tokenService.createTokenForCampaignResults(request.auth.credentials.userId);
-    const campaign = await usecases.getCampaign({ campaignId });
+
+    const tokenForCampaignResults = tokenService.createTokenForCampaignResults(userId);
+
+    const campaign = await usecases.getCampaign({ campaignId, userId });
     return campaignReportSerializer.serialize(campaign, {}, { tokenForCampaignResults });
   },
 

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -79,7 +79,7 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserAlreadyExistsWithAuthenticationMethodError) {
     return new HttpErrors.ConflictError(error.message);
   }
-  if (error instanceof DomainErrors.UserNotAuthorizedToAccessEntity) {
+  if (error instanceof DomainErrors.UserNotAuthorizedToAccessEntityError) {
     return new HttpErrors.ForbiddenError('Utilisateur non autorisé à accéder à la ressource');
   }
   if (error instanceof DomainErrors.UserNotAuthorizedToUpdateResourceError) {

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -626,7 +626,7 @@ class UserNotAuthorizedToUpdateEmailError extends DomainError {
   }
 }
 
-class UserNotAuthorizedToAccessEntity extends DomainError {
+class UserNotAuthorizedToAccessEntityError extends DomainError {
   constructor(message = 'User is not authorized to access ressource') {
     super(message);
   }
@@ -790,7 +790,7 @@ module.exports = {
   UserAlreadyLinkedToCandidateInSessionError,
   UserCantBeCreatedError,
   UserCouldNotBeReconciledError,
-  UserNotAuthorizedToAccessEntity,
+  UserNotAuthorizedToAccessEntityError,
   UserNotAuthorizedToCertifyError,
   UserNotAuthorizedToCreateCampaignError,
   UserNotAuthorizedToCreateResourceError,

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -1,5 +1,8 @@
 const Assessment = require('../models/Assessment');
-const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntity } = require('../../domain/errors');
+const {
+  AlreadySharedCampaignParticipationError,
+  UserNotAuthorizedToAccessEntityError,
+} = require('../../domain/errors');
 
 module.exports = async function beginCampaignParticipationImprovement({
   campaignParticipationId,
@@ -9,7 +12,7 @@ module.exports = async function beginCampaignParticipationImprovement({
 }) {
   const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, {});
   if (campaignParticipation.userId !== userId) {
-    throw new UserNotAuthorizedToAccessEntity();
+    throw new UserNotAuthorizedToAccessEntityError();
   }
 
   if (campaignParticipation.isShared) {

--- a/api/lib/domain/usecases/compute-campaign-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-analysis.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function computeCampaignAnalysis(
   {
@@ -14,7 +14,7 @@ module.exports = async function computeCampaignAnalysis(
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
 
   if (!hasUserAccessToResult) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
   }
 
   const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale });

--- a/api/lib/domain/usecases/compute-campaign-collective-result.js
+++ b/api/lib/domain/usecases/compute-campaign-collective-result.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function computeCampaignCollectiveResult(
   {
@@ -13,7 +13,7 @@ module.exports = async function computeCampaignCollectiveResult(
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
 
   if (!hasUserAccessToResult) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
   }
 
   const targetProfileWithLearningContent = await targetProfileWithLearningContentRepository.getByCampaignId({ campaignId, locale });

--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function computeCampaignParticipationAnalysis({
   userId,
@@ -15,7 +15,7 @@ module.exports = async function computeCampaignParticipationAnalysis({
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
 
   if (!hasUserAccessToResult) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
   }
 
   if (!campaignParticipation.isShared) {

--- a/api/lib/domain/usecases/find-answer-by-assessment.js
+++ b/api/lib/domain/usecases/find-answer-by-assessment.js
@@ -1,4 +1,7 @@
-const { UserNotAuthorizedToAccessEntity, EntityValidationError } = require('../errors');
+const {
+  UserNotAuthorizedToAccessEntityError,
+  EntityValidationError,
+} = require('../errors');
 
 module.exports = async function findAnswerByAssessment(
   {
@@ -14,7 +17,7 @@ module.exports = async function findAnswerByAssessment(
 
   const ownedByUser = await assessmentRepository.ownedByUser({ id: assessmentId, userId });
   if (!ownedByUser) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this assessment.');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have an access to this assessment.');
   }
   return answerRepository.findByAssessment(integerAssessmentId);
 };

--- a/api/lib/domain/usecases/find-association-between-user-and-schooling-registration.js
+++ b/api/lib/domain/usecases/find-association-between-user-and-schooling-registration.js
@@ -1,4 +1,7 @@
-const { CampaignCodeError, UserNotAuthorizedToAccessEntity } = require('../errors');
+const {
+  CampaignCodeError,
+  UserNotAuthorizedToAccessEntityError,
+} = require('../errors');
 
 module.exports = async function findAssociationBetweenUserAndSchoolingRegistration({
   authenticatedUserId,
@@ -8,7 +11,7 @@ module.exports = async function findAssociationBetweenUserAndSchoolingRegistrati
   schoolingRegistrationRepository,
 }) {
   if (authenticatedUserId !== requestedUserId) {
-    throw new UserNotAuthorizedToAccessEntity();
+    throw new UserNotAuthorizedToAccessEntityError();
   }
 
   const campaign = await campaignRepository.getByCode(campaignCode);

--- a/api/lib/domain/usecases/find-campaign-participations-related-to-assessment.js
+++ b/api/lib/domain/usecases/find-campaign-participations-related-to-assessment.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function findCampaignParticipationsRelatedToAssessment({
   userId,
@@ -7,7 +7,7 @@ module.exports = async function findCampaignParticipationsRelatedToAssessment({
   campaignParticipationRepository,
 }) {
   if (!(await assessmentRepository.ownedByUser({ id: assessmentId, userId }))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this campaign participation');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have an access to this campaign participation');
   }
   return campaignParticipationRepository.findByAssessmentId(assessmentId);
 };

--- a/api/lib/domain/usecases/find-campaign-profiles-collection-participation-summaries.js
+++ b/api/lib/domain/usecases/find-campaign-profiles-collection-participation-summaries.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function findCampaignProfilesCollectionParticipationSummaries({
   userId,
@@ -9,7 +9,7 @@ module.exports = async function findCampaignProfilesCollectionParticipationSumma
   campaignProfilesCollectionParticipationSummaryRepository,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not belong to an organization that owns the campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to an organization that owns the campaign');
   }
   return campaignProfilesCollectionParticipationSummaryRepository.findPaginatedByCampaignId(campaignId, page, filters);
 };

--- a/api/lib/domain/usecases/find-competence-evaluations-by-assessment.js
+++ b/api/lib/domain/usecases/find-competence-evaluations-by-assessment.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function findCompetenceEvaluationsByAssessment({
   userId,
@@ -7,7 +7,7 @@ module.exports = async function findCompetenceEvaluationsByAssessment({
   competenceEvaluationRepository,
 }) {
   if (!(await assessmentRepository.ownedByUser({ id: assessmentId, userId }))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this competence evaluation');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have an access to this competence evaluation');
   }
 
   return competenceEvaluationRepository.findByAssessmentId(assessmentId);

--- a/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
+++ b/api/lib/domain/usecases/find-paginated-campaign-assessment-participation-summaries.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function findPaginatedCampaignAssessmentParticipationSummaries({
   userId,
@@ -31,6 +31,6 @@ module.exports = async function findPaginatedCampaignAssessmentParticipationSumm
 async function _checkUserAccessToCampaign(campaignId, userId, campaignRepository) {
   const hasAccess = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
   if (!hasAccess) {
-    throw new UserNotAuthorizedToAccessEntity('User does not belong to an organization that owns the campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to an organization that owns the campaign');
   }
 }

--- a/api/lib/domain/usecases/find-tutorials.js
+++ b/api/lib/domain/usecases/find-tutorials.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const Scorecard = require('../models/Scorecard');
 const KnowledgeElement = require('../models/KnowledgeElement');
 const _ = require('lodash');
@@ -16,7 +16,7 @@ module.exports = async function findTutorials({
   const { userId, competenceId } = Scorecard.parseId(scorecardId);
 
   if (parseInt(authenticatedUserId) !== parseInt(userId)) {
-    throw new UserNotAuthorizedToAccessEntity();
+    throw new UserNotAuthorizedToAccessEntityError();
   }
 
   const knowledgeElements = await knowledgeElementRepository.findUniqByUserIdAndCompetenceId({ userId, competenceId });

--- a/api/lib/domain/usecases/get-attendance-sheet.js
+++ b/api/lib/domain/usecases/get-attendance-sheet.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const writeOdsUtils = require('../../infrastructure/utils/ods/write-ods-utils');
 const readOdsUtils = require('../../infrastructure/utils/ods/read-ods-utils');
 const sessionXmlService = require('../services/session-xml-service');
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const { featureToggles } = require('../../config');
 const {
   EXTRA_EMPTY_CANDIDATE_ROWS,
@@ -15,7 +15,7 @@ module.exports = async function getAttendanceSheet({ userId, sessionId, sessionR
 
   const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
   if (!hasMembership) {
-    throw new UserNotAuthorizedToAccessEntity('User is not allowed to access session.');
+    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to access session.');
   }
 
   const [ stringifiedXml, session ] = await Promise.all([

--- a/api/lib/domain/usecases/get-campaign-assessment-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-assessment-participation-result.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getCampaignAssessmentParticipationResult(
   {
@@ -10,7 +10,7 @@ module.exports = async function getCampaignAssessmentParticipationResult(
     locale,
   } = {}) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not belong to the organization that owns the campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
   }
 
   return campaignAssessmentParticipationResultRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId, locale });

--- a/api/lib/domain/usecases/get-campaign-assessment-participation.js
+++ b/api/lib/domain/usecases/get-campaign-assessment-participation.js
@@ -1,8 +1,8 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getCampaignAssessmentParticipation({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationRepository, badgeAcquisitionRepository }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not belong to the organization that owns the campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
   }
 
   const campaignAssessmentParticipation = await campaignAssessmentParticipationRepository.getByCampaignIdAndCampaignParticipationId({ campaignId, campaignParticipationId });

--- a/api/lib/domain/usecases/get-campaign-participation-result.js
+++ b/api/lib/domain/usecases/get-campaign-participation-result.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getCampaignParticipationResult({
   userId,
@@ -32,6 +32,6 @@ async function _checkIfUserHasAccessToThisCampaignParticipation(userId, campaign
   );
 
   if (!campaignParticipationBelongsToUser && !userIsMemberOfCampaignOrganization) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have access to this campaign participation');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign participation');
   }
 }

--- a/api/lib/domain/usecases/get-campaign-participation.js
+++ b/api/lib/domain/usecases/get-campaign-participation.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getCampaignParticipation({
   campaignParticipationId,
@@ -15,5 +15,5 @@ module.exports = async function getCampaignParticipation({
     return campaignParticipation;
   }
 
-  throw new UserNotAuthorizedToAccessEntity('User does not have access to campaign participation');
+  throw new UserNotAuthorizedToAccessEntityError('User does not have access to campaign participation');
 };

--- a/api/lib/domain/usecases/get-campaign-profile.js
+++ b/api/lib/domain/usecases/get-campaign-profile.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getCampaignProfile({
   userId,
@@ -9,7 +9,7 @@ module.exports = async function getCampaignProfile({
   locale,
 }) {
   if (!(await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId))) {
-    throw new UserNotAuthorizedToAccessEntity('User does not belong to an organization that owns the campaign');
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to an organization that owns the campaign');
   }
 
   return campaignProfileRepository.findProfile({ campaignId, campaignParticipationId, locale });

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,14 +1,24 @@
-const { NotFoundError } = require('../../domain/errors');
+const {
+  NotFoundError,
+  UserNotAuthorizedToAccessEntityError,
+} = require('../../domain/errors');
 
 module.exports = async function getCampaign({
   campaignId,
+  userId,
   badgeRepository,
+  campaignRepository,
   campaignReportRepository,
   stageRepository,
 }) {
   const integerCampaignId = parseInt(campaignId);
   if (!Number.isFinite(integerCampaignId)) {
     throw new NotFoundError(`Campaign not found for ID ${campaignId}`);
+  }
+
+  const userHasAccessToCampaign = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
+  if (!userHasAccessToCampaign) {
+    throw new UserNotAuthorizedToAccessEntityError('User does not belong to the organization that owns the campaign');
   }
 
   const [campaignReport, badges, stages] = await Promise.all([

--- a/api/lib/domain/usecases/get-campaign.js
+++ b/api/lib/domain/usecases/get-campaign.js
@@ -1,6 +1,11 @@
 const { NotFoundError } = require('../../domain/errors');
 
-module.exports = async function getCampaign({ campaignId, badgeRepository, campaignReportRepository, stageRepository }) {
+module.exports = async function getCampaign({
+  campaignId,
+  badgeRepository,
+  campaignReportRepository,
+  stageRepository,
+}) {
   const integerCampaignId = parseInt(campaignId);
   if (!Number.isFinite(integerCampaignId)) {
     throw new NotFoundError(`Campaign not found for ID ${campaignId}`);

--- a/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
+++ b/api/lib/domain/usecases/get-next-challenge-for-competence-evaluation.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-unused-vars */
-const { AssessmentEndedError, UserNotAuthorizedToAccessEntity } = require('../errors');
+const {
+  AssessmentEndedError,
+  UserNotAuthorizedToAccessEntityError,
+} = require('../errors');
 
 const smartRandom = require('../services/smart-random/smart-random');
 const dataFetcher = require('../services/smart-random/data-fetcher');
@@ -37,6 +40,6 @@ module.exports = async function getNextChallengeForCompetenceEvaluation({
 
 function _checkIfAssessmentBelongsToUser(assessment, userId) {
   if (assessment.userId !== userId) {
-    throw new UserNotAuthorizedToAccessEntity();
+    throw new UserNotAuthorizedToAccessEntityError();
   }
 }

--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -1,5 +1,5 @@
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
 const SchoolingRegistrationParser = require('../../infrastructure/serializers/csv/schooling-registration-parser');
 
@@ -12,7 +12,7 @@ module.exports = async function getSchoolingRegistrationsCsvTemplate({
   const [membership] = await membershipRepository.findByUserIdAndOrganizationId({ userId, organizationId, includeOrganization: true });
 
   if (!_isAdminOrganizationManagingStudent(membership)) {
-    throw new UserNotAuthorizedToAccessEntity('User is not allowed to download csv template.');
+    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to download csv template.');
   }
 
   const { isSup, isSco, isAgriculture } = membership.organization;
@@ -22,7 +22,7 @@ module.exports = async function getSchoolingRegistrationsCsvTemplate({
   } else if (isSco && isAgriculture) {
     header = _getCsvColumns(SchoolingRegistrationParser.COLUMNS);
   } else {
-    throw new UserNotAuthorizedToAccessEntity('User organization is not allowed to download csv template.');
+    throw new UserNotAuthorizedToAccessEntityError('User organization is not allowed to download csv template.');
   }
 
   //Create HEADER of CSV

--- a/api/lib/domain/usecases/get-scorecard.js
+++ b/api/lib/domain/usecases/get-scorecard.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const Scorecard = require('../models/Scorecard');
 
 module.exports = async function getScorecard({
@@ -14,7 +14,7 @@ module.exports = async function getScorecard({
   const { userId, competenceId } = Scorecard.parseId(scorecardId);
 
   if (authenticatedUserId !== userId) {
-    throw new UserNotAuthorizedToAccessEntity();
+    throw new UserNotAuthorizedToAccessEntityError();
   }
 
   return scorecardService.computeScorecard({

--- a/api/lib/domain/usecases/get-session-with-candidates.js
+++ b/api/lib/domain/usecases/get-session-with-candidates.js
@@ -1,10 +1,10 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 
 module.exports = async function getSessionWithCandidates({ userId, sessionId, sessionRepository }) {
 
   const hasMembership = await sessionRepository.doesUserHaveCertificationCenterMembershipForSession(userId, sessionId);
   if (!hasMembership) {
-    throw new UserNotAuthorizedToAccessEntity('User is not allowed to access session.');
+    throw new UserNotAuthorizedToAccessEntityError('User is not allowed to access session.');
   }
 
   return sessionRepository.getWithCertificationCandidates(sessionId);

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -1,4 +1,4 @@
-const { UserNotAuthorizedToAccessEntity } = require('../errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const CampaignParticipationResultsShared = require('../events/CampaignParticipationResultsShared');
 
 module.exports = async function shareCampaignResult({
@@ -20,7 +20,7 @@ module.exports = async function shareCampaignResult({
 
 function _checkUserIsOwnerOfCampaignParticipation(campaignParticipation, userId) {
   if (campaignParticipation.userId !== userId) {
-    throw new UserNotAuthorizedToAccessEntity('User does not have an access to this campaign participation');
+    throw new UserNotAuthorizedToAccessEntityError('User does not have an access to this campaign participation');
   }
 }
 

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -1,9 +1,18 @@
 const faker = require('faker');
 const jwt = require('jsonwebtoken');
-const createServer = require('../../../server');
-const { expect, databaseBuilder, knex, generateValidRequestAuthorizationHeader, mockLearningContent, learningContentBuilder } = require('../../test-helper');
+
+const {
+  databaseBuilder,
+  expect,
+  generateValidRequestAuthorizationHeader,
+  knex,
+  learningContentBuilder,
+  mockLearningContent,
+} = require('../../test-helper');
+
 const settings = require('../../../lib/config');
 const Membership = require('../../../lib/domain/models/Membership');
+const createServer = require('../../../server');
 
 describe('Acceptance | API | Campaign Controller', () => {
 
@@ -16,7 +25,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     server = await createServer();
   });
 
-  describe('GET /api/campaign', () => {
+  describe('GET /api/campaigns', () => {
 
     it('should return the campaign requested by code', async () => {
       // given
@@ -40,11 +49,12 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaign/{id}/collective-result', function() {
+  describe('GET /api/campaigns/{id}/collective-result', () => {
+
+    const assessmentStartDate = '2018-01-02';
+    const participationStartDate = '2018-01-01';
 
     let userId;
-    const participationStartDate = '2018-01-01';
-    const assessmentStartDate = '2018-01-02';
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser({ firstName: 'Jean', lastName: 'Bono' }).id;
@@ -176,7 +186,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaign/{id}/csv-assessment-results', function() {
+  describe('GET /api/campaigns/{id}/csv-assessment-results', () => {
 
     let accessToken;
 
@@ -230,7 +240,6 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
 
     it('should return csv file with statusCode 200', async () => {
-
       // given
       const url = `/api/campaigns/${campaign.id}/csv-assessment-results?accessToken=${accessToken}`;
       const request = {
@@ -246,7 +255,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaign/{id}/csv-profiles-collection-results', function() {
+  describe('GET /api/campaigns/{id}/csv-profiles-collection-results', () => {
 
     let accessToken;
 
@@ -313,7 +322,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaign/{id}/analyses', function() {
+  describe('GET /api/campaigns/{id}/analyses', () => {
 
     let userId;
 
@@ -444,7 +453,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('POST /api/campaign', () => {
+  describe('POST /api/campaigns', () => {
 
     let options, payload;
 
@@ -575,6 +584,7 @@ describe('Acceptance | API | Campaign Controller', () => {
   });
 
   describe('GET /api/campaigns/{id}/profiles-collection-participations', () => {
+
     beforeEach(async () => {
       const learningContent = [{
         id: 'recArea1',
@@ -595,6 +605,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
 
     context('when there is one divisions', () => {
+
       it('should returns profiles collection campaign participations', async () => {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
@@ -640,7 +651,9 @@ describe('Acceptance | API | Campaign Controller', () => {
         expect(response.result.data[0].attributes['last-name']).to.equal('Withe');
       });
     });
+
     context('when there are several divisions', () => {
+
       it('should returns profiles collection campaign participations', async () => {
         // given
         const userId = databaseBuilder.factory.buildUser().id;
@@ -693,11 +706,13 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaigns/{id}/assessment-participations', function() {
-    let userId;
-    let campaign;
+  describe('GET /api/campaigns/{id}/assessment-participations', () => {
+
     const participant1 = { firstName: 'John', lastName: 'McClane', id: 12 };
     const participant2 = { firstName: 'John', lastName: 'McClane', id: 13 };
+
+    let campaign;
+    let userId;
 
     beforeEach(async () => {
       userId = databaseBuilder.factory.buildUser().id;
@@ -752,7 +767,7 @@ describe('Acceptance | API | Campaign Controller', () => {
     });
   });
 
-  describe('GET /api/campaigns/{id}/divisions', function() {
+  describe('GET /api/campaigns/{id}/divisions', () => {
 
     it('should return the campaign participants division', async () => {
       const division = '3emeA';

--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -788,4 +788,53 @@ describe('Acceptance | API | Campaign Controller', () => {
       expect(response.result.data[0].attributes.name).to.equal(division);
     });
   });
+
+  describe('GET /api/campaigns/{id}', () => {
+
+    const options = {
+      headers: { authorization: null },
+      method: 'GET',
+      url: null,
+    };
+
+    let campaign;
+    let userId;
+
+    beforeEach(async () => {
+      campaign = databaseBuilder.factory.buildCampaign();
+      userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildMembership({
+        organizationId: campaign.organizationId,
+        userId,
+      });
+
+      options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+      options.url = `/api/campaigns/${campaign.id}`;
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return the campaign by id', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result.data.id).to.equal(campaign.id.toString());
+      expect(response.result.data.attributes.name).to.equal(campaign.name);
+    });
+
+    it('should return HTTP code 403 if the authenticated user is not authorize to access the campaign', async () => {
+      // given
+      userId = databaseBuilder.factory.buildUser().id;
+      options.headers.authorization = generateValidRequestAuthorizationHeader(userId);
+      await databaseBuilder.commit();
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -188,8 +188,8 @@ describe('Integration | API | Controller Error', () => {
   context('403 Forbidden', () => {
     const FORBIDDEN_ERROR = 403;
 
-    it('responds Forbidden when a UserNotAuthorizedToAccessEntity error occurs', async () => {
-      routeHandler.throws(new DomainErrors.UserNotAuthorizedToAccessEntity());
+    it('responds Forbidden when a UserNotAuthorizedToAccessEntityError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.UserNotAuthorizedToAccessEntityError());
       const response = await server.inject(options);
 
       expect(response.statusCode).to.equal(FORBIDDEN_ERROR);

--- a/api/tests/integration/domain/usecases/find-paginated-campaign-assessment-participation-summaries_test.js
+++ b/api/tests/integration/domain/usecases/find-paginated-campaign-assessment-participation-summaries_test.js
@@ -1,6 +1,6 @@
 const { expect, catchErr, databaseBuilder, learningContentBuilder, mockLearningContent } = require('../../../test-helper');
 const useCases = require('../../../../lib/domain/usecases');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Integration | UseCase | find-paginated-campaign-assessment-participation-summaries', () => {
 
@@ -15,7 +15,7 @@ describe('Integration | UseCase | find-paginated-campaign-assessment-participati
       await databaseBuilder.commit();
     });
 
-    it('should throw a UserNotAuthorizedToAccessEntity error', async () => {
+    it('should throw a UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const error = await catchErr(useCases.findPaginatedCampaignAssessmentParticipationSummaries)({
         userId: user.id,
@@ -23,7 +23,7 @@ describe('Integration | UseCase | find-paginated-campaign-assessment-participati
       });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
       expect(error.message).to.equal('User does not belong to an organization that owns the campaign');
     });
   });

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -8,7 +8,7 @@ const campaignCollectiveResultSerializer = require('../../../../lib/infrastructu
 
 const tokenService = require('../../../../lib/domain/services/token-service');
 const usecases = require('../../../../lib/domain/usecases');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
@@ -348,7 +348,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
     it('should return an unauthorized error', async () => {
       // given
-      const error = new UserNotAuthorizedToAccessEntity('User does not have access to this campaign participation');
+      const error = new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign participation');
       const request = {
         params: { id: campaignId },
         auth: {
@@ -361,7 +361,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       const errorCatched = await catchErr(campaignController.getCollectiveResult)(request);
 
       // then
-      expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntity);
+      expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntityError);
     });
 
   });
@@ -398,7 +398,7 @@ describe('Unit | Application | Controller | Campaign', () => {
 
     it('should return an unauthorized error', async () => {
       // given
-      const error = new UserNotAuthorizedToAccessEntity('User does not have access to this campaign');
+      const error = new UserNotAuthorizedToAccessEntityError('User does not have access to this campaign');
       const request = {
         params: { id: campaignId },
         auth: {
@@ -411,7 +411,7 @@ describe('Unit | Application | Controller | Campaign', () => {
       const errorCatched = await catchErr(campaignController.getAnalysis)(request);
 
       // then
-      expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntity);
+      expect(errorCatched).to.be.instanceof(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -222,6 +222,10 @@ describe('Unit | Application | Controller | Campaign', () => {
   });
 
   describe('#getById', () => {
+
+    const campaignId = 1;
+    const userId = 1;
+
     let request, campaign;
 
     beforeEach(() => {
@@ -248,19 +252,20 @@ describe('Unit | Application | Controller | Campaign', () => {
 
       queryParamsUtils.extractParameters.withArgs({}).returns({});
       tokenService.createTokenForCampaignResults.withArgs(request.auth.credentials.userId).returns('token');
+      usecases.getCampaign.resolves(campaign);
     });
 
     it('should return the campaign', async () => {
       // given
       const expectedResult = Symbol('ok');
       const tokenForCampaignResults = 'token';
-      usecases.getCampaign.withArgs({ campaignId: campaign.id }).resolves(campaign);
       campaignReportSerializer.serialize.withArgs(campaign, {}, { tokenForCampaignResults }).returns(expectedResult);
 
       // when
       const response = await campaignController.getById(request, hFake);
 
       // then
+      expect(usecases.getCampaign).calledWith({ campaignId, userId });
       expect(response).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -2,7 +2,7 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
 const { beginCampaignParticipationImprovement } = require('../../../../lib/domain/usecases');
-const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { AlreadySharedCampaignParticipationError, UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
 
@@ -28,7 +28,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     const error = await catchErr(beginCampaignParticipationImprovement)({ campaignParticipationId, userId, ...dependencies });
 
     // then
-    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
   });
 
   it('should throw an error if the campaign participation is shared', async () => {

--- a/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-analysis_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const { computeCampaignAnalysis } = require('../../../../lib/domain/usecases');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | UseCase | compute-campaign-analysis', () => {
@@ -53,7 +53,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntity error', async () => {
+    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignAnalysis)({
         userId,
@@ -65,7 +65,7 @@ describe('Unit | UseCase | compute-campaign-analysis', () => {
       });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-collective-result_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const { computeCampaignCollectiveResult } = require('../../../../lib/domain/usecases');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | compute-campaign-collective-result', () => {
   const userId = 1;
@@ -50,7 +50,7 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntity error', async () => {
+    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignCollectiveResult)({
         userId,
@@ -62,7 +62,7 @@ describe('Unit | UseCase | compute-campaign-collective-result', () => {
       });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const { computeCampaignParticipationAnalysis } = require('../../../../lib/domain/usecases');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
@@ -91,7 +91,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('it should throw an UserNotAuthorizedToAccessEntity error', async () => {
+    it('it should throw an UserNotAuthorizedToAccessEntityError error', async () => {
       // when
       const result = await catchErr(computeCampaignParticipationAnalysis)({
         userId,
@@ -105,7 +105,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
       });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-answer-by-assessment_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const findAnswerByAssessment = require('../../../../lib/domain/usecases/find-answer-by-assessment');
-const { UserNotAuthorizedToAccessEntity, EntityValidationError } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError, EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
 
@@ -62,7 +62,7 @@ describe('Unit | UseCase | find-answer-by-challenge-and-assessment', () => {
       const result = await catchErr(findAnswerByAssessment)({ assessmentId, userId: userId + 1, answerRepository, assessmentRepository });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-association-between-user-and-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/find-association-between-user-and-schooling-registration_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const usecases = require('../../../../lib/domain/usecases');
 const SchoolingRegistration = require('../../../../lib/domain/models/SchoolingRegistration');
-const { CampaignCodeError, UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { CampaignCodeError, UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const campaignRepository = require('../../../../lib/infrastructure/repositories/campaign-repository');
 const schoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/schooling-registration-repository');
 
@@ -78,7 +78,7 @@ describe('Unit | UseCase | find-association-between-user-and-schooling-registrat
       const result = await catchErr(usecases.findAssociationBetweenUserAndSchoolingRegistration)({ authenticatedUserId: '999', requestedUserId: userId, campaignCode });
 
       // then
-      expect(result).to.be.instanceof(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceof(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/find-campaign-participations-related-to-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-participations-related-to-assessment_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const findCampaignParticipationsRelatedToAssessment = require('../../../../lib/domain/usecases/find-campaign-participations-related-to-assessment');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-campaign-participations-related-to-assessment', () => {
 
@@ -43,8 +43,8 @@ describe('Unit | UseCase | find-campaign-participations-related-to-assessment', 
 
         requestErr = await catchErr(findCampaignParticipationsRelatedToAssessment)({ userId, assessmentId, campaignParticipationRepository, assessmentRepository });
       });
-      it('should throw a UserNotAuthorizedToAccessEntity error', () => {
-        expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      it('should throw a UserNotAuthorizedToAccessEntityError error', () => {
+        expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
+++ b/api/tests/unit/domain/usecases/find-campaign-profiles-collection-participation-summaries_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const findCampaignProfilesCollectionParticipationSummaries = require('../../../../lib/domain/usecases/find-campaign-profiles-collection-participation-summaries');
 const CampaignProfilesCollectionParticipationSummary = require('../../../../lib/domain/read-models/CampaignProfilesCollectionParticipationSummary');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-campaign-profiles-collection-participation-summaries', () => {
 
@@ -49,7 +49,7 @@ describe('Unit | UseCase | find-campaign-profiles-collection-participation-summa
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.resolves(false);
     });
 
-    it('should throw a UserNotAuthorizedToAccessEntity error', async () => {
+    it('should throw a UserNotAuthorizedToAccessEntityError error', async () => {
       const requestErr = await catchErr(findCampaignProfilesCollectionParticipationSummaries)({
         userId,
         campaignId,
@@ -57,7 +57,7 @@ describe('Unit | UseCase | find-campaign-profiles-collection-participation-summa
         campaignProfilesCollectionParticipationSummaryRepository,
       });
 
-      expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
+++ b/api/tests/unit/domain/usecases/find-competence-evaluations-by-assessment_test.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const { expect, sinon, catchErr } = require('../../../test-helper');
 const findCompetenceEvaluationsByAssessment = require('../../../../lib/domain/usecases/find-competence-evaluations-by-assessment');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | find-competence-evaluations-by-assessment', () => {
 
@@ -15,7 +15,7 @@ describe('Unit | UseCase | find-competence-evaluations-by-assessment', () => {
     competenceEvaluationRepository.findByAssessmentId = sinon.stub();
   });
 
-  it('should throw an UserNotAuthorizedToAccessEntity error when user is not the owner of the assessment', async () => {
+  it('should throw an UserNotAuthorizedToAccessEntityError error when user is not the owner of the assessment', async () => {
     // given
     assessmentRepository.ownedByUser.withArgs({ id: assessmentId, userId }).resolves(false);
 
@@ -28,7 +28,7 @@ describe('Unit | UseCase | find-competence-evaluations-by-assessment', () => {
     });
 
     // then
-    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+    expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
   });
 
   it('should return the assessment competence-evaluations', async () => {

--- a/api/tests/unit/domain/usecases/find-tutorials_test.js
+++ b/api/tests/unit/domain/usecases/find-tutorials_test.js
@@ -1,5 +1,5 @@
 const { sinon, expect, domainBuilder } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const findTutorials = require('../../../../lib/domain/usecases/find-tutorials');
@@ -219,7 +219,7 @@ describe('Unit | UseCase | find-tutorials', () => {
     });
 
     context('And user asks for a scorecard that do not belongs to him', () => {
-      it('should reject a "UserNotAuthorizedToAccessEntity" domain error', () => {
+      it('should reject a "UserNotAuthorizedToAccessEntityError" domain error', () => {
         // given
         const unauthorizedUserId = 42;
 
@@ -235,7 +235,7 @@ describe('Unit | UseCase | find-tutorials', () => {
         });
 
         // then
-        return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
+        return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntityError);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
+++ b/api/tests/unit/domain/usecases/get-attendance-sheet_test.js
@@ -9,7 +9,7 @@ const writeOdsUtils = require('../../../../lib/infrastructure/utils/ods/write-od
 const readOdsUtils = require('../../../../lib/infrastructure/utils/ods/read-ods-utils');
 const sessionXmlService = require('../../../../lib/domain/services/session-xml-service');
 const _ = require('lodash');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-attendance-sheet-in-ods-format', () => {
 
@@ -139,7 +139,7 @@ describe('Unit | UseCase | get-attendance-sheet-in-ods-format', () => {
       });
 
       it('should return an error when user does not have access', () => {
-        expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+        expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-assessment-participation-result_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getCampaignAssessmentParticipationResult = require('../../../../lib/domain/usecases/get-campaign-assessment-participation-result');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-campaign-assessment-participation-result', () => {
 
@@ -47,12 +47,12 @@ describe('Unit | UseCase | get-campaign-assessment-participation-result', () => 
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('should throw UserNotAuthorizedToAccessEntity', async () => {
+    it('should throw UserNotAuthorizedToAccessEntityError', async () => {
       // when
       const result = await catchErr(getCampaignAssessmentParticipationResult)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationResultRepository, locale });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-assessment-participation_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getCampaignAssessmentParticipation = require('../../../../lib/domain/usecases/get-campaign-assessment-participation');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const CampaignAssessmentParticipation = require('../../../../lib/domain/read-models/CampaignAssessmentParticipation');
 
 describe('Unit | UseCase | get-campaign-assessment-participation', () => {
@@ -67,12 +67,12 @@ describe('Unit | UseCase | get-campaign-assessment-participation', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('should throw UserNotAuthorizedToAccessEntity', async () => {
+    it('should throw UserNotAuthorizedToAccessEntityError', async () => {
       // when
       const result = await catchErr(getCampaignAssessmentParticipation)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignAssessmentParticipationRepository, badgeAcquisitionRepository });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation-result_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
 const getCampaignParticipationResult = require('../../../../lib/domain/usecases/get-campaign-participation-result');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-campaign-participation-result', () => {
 
@@ -170,7 +170,7 @@ describe('Unit | UseCase | get-campaign-participation-result', () => {
       });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getCampaignParticipation = require('../../../../lib/domain/usecases/get-campaign-participation');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-campaign-participation', () => {
 
@@ -64,7 +64,7 @@ describe('Unit | UseCase | get-campaign-participation', () => {
       const result = await catchErr(getCampaignParticipation)({ campaignParticipationId, options, campaignParticipationRepository, campaignRepository, userId });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
 
     });
   });

--- a/api/tests/unit/domain/usecases/get-campaign-profile_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-profile_test.js
@@ -1,6 +1,6 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getCampaignProfile = require('../../../../lib/domain/usecases/get-campaign-profile');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const { FRENCH_SPOKEN } = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | UseCase | get-campaign-profile', () => {
@@ -48,12 +48,12 @@ describe('Unit | UseCase | get-campaign-profile', () => {
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
-    it('should throw UserNotAuthorizedToAccessEntity', async () => {
+    it('should throw UserNotAuthorizedToAccessEntityError', async () => {
       // when
       const result = await catchErr(getCampaignProfile)({ userId, campaignId, campaignParticipationId, campaignRepository, campaignProfileRepository, locale });
 
       // then
-      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 });

--- a/api/tests/unit/domain/usecases/get-campaign_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign_test.js
@@ -4,15 +4,22 @@ const getCampaign = require('../../../../lib/domain/usecases/get-campaign');
 
 describe('Unit | UseCase | get-campaign', () => {
 
-  let campaign;
+  const badges = Symbol('badges');
+  const stages = Symbol('stages');
+
+  const campaignId = 1;
+  const campaign = {
+    id: campaignId,
+    name: 'My campaign',
+  };
+
   let campaignReportRepository;
   let stageRepository;
   let badgeRepository;
 
   beforeEach(() => {
-    campaign = {
-      id: '1',
-      name: 'My campaign',
+    badgeRepository = {
+      findByCampaignId: sinon.stub(),
     };
     campaignReportRepository = {
       get: sinon.stub(),
@@ -20,57 +27,61 @@ describe('Unit | UseCase | get-campaign', () => {
     stageRepository = {
       findByCampaignId: sinon.stub(),
     };
-    badgeRepository = {
-      findByCampaignId: sinon.stub(),
-    };
+
+    badgeRepository.findByCampaignId.resolves(badges);
+    campaignReportRepository.get.resolves(campaign);
+    stageRepository.findByCampaignId.resolves(stages);
   });
 
   it('should get the campaign', async () => {
-    // given
-    campaignReportRepository.get.withArgs(parseInt(campaign.id)).resolves(campaign);
-    stageRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves();
-
     // when
-    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
+    const resultCampaign = await getCampaign({
+      campaignId,
+      badgeRepository,
+      campaignReportRepository,
+      stageRepository,
+    });
 
     // then
     expect(resultCampaign.name).to.equal(campaign.name);
   });
 
   it('should get campaign stages', async () => {
-    // given
-    const stages = Symbol('stages');
-    campaignReportRepository.get.withArgs(parseInt(campaign.id)).resolves(campaign);
-    stageRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves(stages);
-
     // when
-    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
+    const resultCampaign = await getCampaign({
+      campaignId,
+      badgeRepository,
+      campaignReportRepository,
+      stageRepository,
+    });
 
     // then
     expect(resultCampaign.stages).to.equal(stages);
   });
 
   it('should get campaign badges', async () => {
-    // given
-    const badges = Symbol('badges');
-    campaignReportRepository.get.withArgs(parseInt(campaign.id)).resolves(campaign);
-    badgeRepository.findByCampaignId.withArgs(parseInt(campaign.id)).resolves(badges);
-
     // when
-    const resultCampaign = await getCampaign({ campaignId: campaign.id, badgeRepository, campaignReportRepository, stageRepository });
+    const resultCampaign = await getCampaign({
+      campaignId,
+      badgeRepository,
+      campaignReportRepository,
+      stageRepository,
+    });
 
     // then
     expect(resultCampaign.badges).to.equal(badges);
   });
 
   it('should throw a Not found error when the campaign is searched with a not valid ID', async () => {
-    // given
-    const invalidCampaignId = 'abc';
-
     // when
-    const error = await catchErr(getCampaign)({ campaignId: invalidCampaignId, campaignReportRepository });
+    const error = await catchErr(getCampaign)({
+      campaignId: 'invalid Campaign Id',
+      badgeRepository,
+      campaignReportRepository,
+      stageRepository,
+    });
 
     // then
-    return expect(error).to.be.instanceOf(NotFoundError);
+    expect(error).to.be.instanceOf(NotFoundError);
   });
 });

--- a/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
+++ b/api/tests/unit/domain/usecases/get-next-challenge-for-competence-evaluation_test.js
@@ -1,5 +1,5 @@
 const { expect, sinon, catchErr, domainBuilder } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const getNextChallengeForCompetenceEvaluation = require('../../../../lib/domain/usecases/get-next-challenge-for-competence-evaluation');
 const smartRandom = require('../../../../lib/domain/services/smart-random/smart-random');
 
@@ -65,8 +65,8 @@ describe('Unit | Domain | Use Cases | get-next-challenge-for-competence-evaluat
           locale,
         });
       });
-      it('should throw a UserNotAuthorizedToAccessEntity error', () => {
-        expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      it('should throw a UserNotAuthorizedToAccessEntityError error', () => {
+        expect(requestErr).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
       });
     });
 

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getSchoolingRegistrationsCsvTemplate = require('../../../../lib/domain/usecases/get-schooling-registrations-csv-template');
 const _ = require('lodash');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
 
@@ -46,7 +46,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 
@@ -59,7 +59,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 
@@ -103,7 +103,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 
@@ -117,7 +117,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 
@@ -130,7 +130,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 
@@ -143,7 +143,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       const error = await catchErr(getSchoolingRegistrationsCsvTemplate)({ userId, organizationId, membershipRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-scorecard_test.js
+++ b/api/tests/unit/domain/usecases/get-scorecard_test.js
@@ -1,5 +1,5 @@
 const { sinon, expect } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const Scorecard = require('../../../../lib/domain/models/Scorecard');
 const getScorecard = require('../../../../lib/domain/usecases/get-scorecard');
 
@@ -82,7 +82,7 @@ describe('Unit | UseCase | get-scorecard', () => {
     });
 
     context('And user asks for a scorecard that do not belongs to him', () => {
-      it('should reject a "UserNotAuthorizedToAccessEntity" domain error', () => {
+      it('should reject a "UserNotAuthorizedToAccessEntityError" domain error', () => {
         // given
         const unauthorizedUserId = 42;
         scorecardService.computeScorecard.resolves({});
@@ -95,7 +95,7 @@ describe('Unit | UseCase | get-scorecard', () => {
         });
 
         // then
-        return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntity);
+        return expect(promise).to.be.rejectedWith(UserNotAuthorizedToAccessEntityError);
       });
     });
   });

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -1,5 +1,5 @@
 const { sinon, expect, domainBuilder, catchErr } = require('../../../test-helper');
-const { UserNotAuthorizedToAccessEntity } = require('../../../../lib/domain/errors');
+const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
 const CampaignParticipationResultsShared = require('../../../../lib/domain/events/CampaignParticipationResultsShared');
 const shareCampaignResult = require('../../../../lib/domain/usecases/share-campaign-result');
 
@@ -13,7 +13,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
   const campaignParticipationId = 456;
 
   context('when user is not the owner of the campaign participation', () => {
-    it('throws a UserNotAuthorizedToAccessEntity error ', async () => {
+    it('throws a UserNotAuthorizedToAccessEntityError error ', async () => {
       // given
       campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves({ userId: userId + 1 });
 
@@ -21,7 +21,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
       const error = await catchErr(shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository });
 
       // then
-      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntity);
+      expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
   context('when user is the owner of the campaign participation', () => {


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, un utilisateur connecté peut accéder à n'importe quelle campagne, en changeant l'URL du navigateur.

## :robot: Solution
Interdire l'accès à une campagne aux utilisateurs qui ne sont pas membres de l'organisation liée à cette campagne.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Dans Pix Orga, essayer d'accéder à une campagne créée par une organisation dont vous n'êtes pas membre, en changeant l'URL du navigateur.
* Vérifier que vous êtes redirigé vers la page des campagnes