### PR TITLE
[FEATURE] Ne pas afficher le lien de partage pour les campagnes pour débutant (PIX-2131).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -59,10 +59,10 @@
             </div>
           {{else}}
             {{#if @model.campaignParticipation.campaign.isForAbsoluteNovice}}
-              <LinkTo @route="logout"
-                      class="skill-review-share__back-to-home link" data-link-to-sign-up>
+              <a href="#" {{on "click" this.redirectForNoviceCampaign}}
+                      class="skill-review-share__back-to-home link" data-link-to-continue-pix>
                 {{t 'pages.skill-review.actions.continue'}}
-              </LinkTo>
+              </a>
             {{else}}
               <CampaignShareButton
                       @isShared={{@model.campaignParticipation.isShared}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -99,7 +99,9 @@
     {{/if}}
   {{/if}}
 
-  <main class="skill-review-result__content">
+  {{#unless @model.campaignParticipation.campaign.isForAbsoluteNovice}}
+
+    <main class="skill-review-result__content">
     <div class="skill-review-result__table-header">
       <h2 class="skill-review-result__subtitle">
         {{t 'pages.skill-review.details.title'}}
@@ -124,5 +126,5 @@
       {{t 'pages.skill-review.information'}}
     </div>
   </div>
-
+  {{/unless}}
 </PixBlock>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -58,10 +58,17 @@
                       'pages.profile.resume-campaign-banner.actions.resume'}}</LinkTo>
             </div>
           {{else}}
-            <CampaignShareButton
-                    @isShared={{@model.campaignParticipation.isShared}}
-                    @shareCampaignParticipation={{this.shareCampaignParticipation}}
-            />
+            {{#if @model.campaignParticipation.campaign.isForAbsoluteNovice}}
+              <LinkTo @route="logout"
+                      class="skill-review-share__back-to-home link" data-link-to-sign-up>
+                {{t 'pages.skill-review.actions.continue'}}
+              </LinkTo>
+            {{else}}
+              <CampaignShareButton
+                      @isShared={{@model.campaignParticipation.isShared}}
+                      @shareCampaignParticipation={{this.shareCampaignParticipation}}
+              />
+            {{/if}}
           {{/if}}
         </div>
       </div>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -9,6 +9,7 @@ export default class SkillReview extends Component {
   @service intl
   @service router
   @service session;
+  @service currentUser;
   @service url
 
   @tracked displayErrorMessage = false;
@@ -81,4 +82,13 @@ export default class SkillReview extends Component {
     return window.location.replace(this.url.homeUrl);
   }
 
+  @action
+  async redirectForNoviceCampaign() {
+    if (this.currentUser.user.isAnonymous) {
+      await this.session.invalidate();
+      this.router.transitionTo('inscription');
+    } else {
+      this.router.transitionTo('index');
+    }
+  }
 }

--- a/mon-pix/mirage/factories/user.js
+++ b/mon-pix/mirage/factories/user.js
@@ -149,6 +149,9 @@ export default Factory.extend({
   lang() {
     return 'fr';
   },
+  isAnonymous() {
+    return false;
+  },
   shouldChangePassword: trait({
     shouldChangePassword: true,
   }),

--- a/mon-pix/mirage/serializers/user.js
+++ b/mon-pix/mirage/serializers/user.js
@@ -12,6 +12,7 @@ export default ApplicationSerializer.extend({
     'pixCertifTermsOfServiceAccepted',
     'hasSeenAssessmentInstructions',
     'hasSeenNewDashboardInfo',
+    'isAnonymous',
   ],
   include: ['competences'],
   links(user) {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -106,4 +106,53 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
     });
   });
+  context('When campaign is for Absolute Novice', function() {
+    beforeEach(async function() {
+      // Given
+      const campaignParticipation = {
+        campaignParticipation: {
+          id: 8654,
+          isShared: false,
+          save: sinon.stub().rejects(),
+          set: sinon.stub().resolves(),
+          rollbackAttributes: sinon.stub(),
+          campaign: {
+            isForAbsoluteNovice: true,
+          },
+          campaignParticipationResult: {
+            masteryPercentage: 90,
+            totalSkillsCount: 5,
+            testedSkillsCount: 3,
+            validatedSkillsCount: 3,
+            stageCount: 2,
+            get: sinon.stub().returns([]),
+          },
+        },
+      };
+
+      this.set('campaignParticipation', campaignParticipation);
+      this.set('assessmentId', 'BADGES123');
+      this.set('acquiredBadges', null);
+
+      // When
+      await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+          @model={{campaignParticipation}}
+          @assessmentId={{assessmentId}}
+          @acquiredBadges={{acquiredBadge}}
+         />`);
+    });
+
+    it('should show a link to main page instead of the shared button ', function() {
+      // Then
+      expect(find('.skill-review-share__button')).to.not.exist;
+      expect(find('a[data-link-to-continue-pix]')).to.exist;
+    });
+
+    it('should not show competence results ', function() {
+      // Then
+      expect(find('.skill-review-result__content')).to.not.exist;
+      expect(find('.skill-review-result__information')).to.not.exist;
+    });
+
+  });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -154,5 +154,11 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       expect(find('.skill-review-result__information')).to.not.exist;
     });
 
+    it('should not show competence results ', function() {
+      // Then
+      expect(find('.skill-review-result__content')).to.not.exist;
+      expect(find('.skill-review-result__information')).to.not.exist;
+    });
+
   });
 });

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -154,11 +154,5 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       expect(find('.skill-review-result__information')).to.not.exist;
     });
 
-    it('should not show competence results ', function() {
-      // Then
-      expect(find('.skill-review-result__content')).to.not.exist;
-      expect(find('.skill-review-result__information')).to.not.exist;
-    });
-
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les campagnes pour débutants n'ont pas pour objectif d'être partagé

## :robot: Solution
Ne pas afficher le bouton de partage et proposer de continuer Pix
Ne pas afficher les résultats par compétences (trop complexe)

## :rainbow: Remarques
Pour continuer pix, il y a 2 cas : 
- L'utilisateur a un compte et est connecté : on le renvoie sur l'index
- L'utilisateur est anonyme et utilise l'accès simplifié : on le déconnecte et on lui propose de s'inscrire

## :100: Pour tester
- Voir avec la campagne AZERTY123
- Arriver à la fin
- Ne pas voir le bouton de partage