### PR TITLE
[TECH] Ajouter le feature toggle sur la récupération des résultats de certif SCO sur Pix Orga (pix-2180)

### DIFF
--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -137,6 +137,7 @@ module.exports = (function() {
       isLivretScolaireSandboxApiEnabled: isFeatureEnabled(process.env.FT_IS_LIVRET_SCOLAIRE_SANDBOX_API_ENABLED),
       reportsCategorization: isFeatureEnabled(process.env.FT_REPORTS_CATEGORISATION),
       myAccount: isFeatureEnabled(process.env.FT_MY_ACCOUNT),
+      isCertificationResultsInOrgaEnabled: isFeatureEnabled(process.env.FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED),
     },
 
     infra: {
@@ -181,6 +182,7 @@ module.exports = (function() {
     config.featureToggles.certifPrescriptionSco = false;
     config.featureToggles.reportsCategorization = false;
     config.featureToggles.isLivretScolaireSandboxApiEnabled = false;
+    config.featureToggles.isCertificationResultsInOrgaEnabled = false;
 
     config.mailing.enabled = false;
     config.mailing.provider = 'sendinblue';

--- a/api/tests/acceptance/application/feature-controller_tests.js
+++ b/api/tests/acceptance/application/feature-controller_tests.js
@@ -30,6 +30,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
             'is-livret-scolaire-sandbox-api-enabled': false,
             'is-pole-emploi-enabled': false,
             'my-account': false,
+            'is-certification-results-in-orga-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/orga/app/models/feature-toggle.js
+++ b/orga/app/models/feature-toggle.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FeatureToggle extends Model {
+  @attr('boolean') isCertificationResultsInOrgaEnabled;
+}

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -14,8 +14,10 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   @service url;
   @service intl;
   @service moment;
+  @service featureToggles;
 
-  beforeModel(transition) {
+  async beforeModel(transition) {
+    await this.featureToggles.load();
     const lang = transition.to.queryParams.lang;
     return this._getUserAndLocale(lang);
   }

--- a/orga/app/services/feature-toggles.js
+++ b/orga/app/services/feature-toggles.js
@@ -1,0 +1,9 @@
+import Service, { inject as service } from '@ember/service';
+
+export default class FeatureTogglesService extends Service {
+  @service store;
+
+  async load() {
+    this.featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+  }
+}

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -314,4 +314,7 @@ export default function() {
     return student.update({ email: null });
   });
 
+  this.get('feature-toggles', (schema) => {
+    return schema.featureToggles.findOrCreateBy({ id: 0 });
+  });
 }

--- a/orga/mirage/factories/feature-toggle.js
+++ b/orga/mirage/factories/feature-toggle.js
@@ -1,0 +1,6 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id: 0,
+  isCertificationResultsInOrgaEnabled: false,
+});

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -83,6 +83,10 @@ module('Unit | Route | application', function(hooks) {
       saveStub = sinon.stub().resolves();
       prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
       prescriber.save = saveStub;
+      class FeatureTogglesMock extends Service {
+        load = sinon.stub();
+      }
+      this.owner.register('service:feature-toggles', FeatureTogglesMock);
     });
 
     test('should set the locales', async function(assert) {
@@ -154,6 +158,23 @@ module('Unit | Route | application', function(hooks) {
       const currentUserStub = Service.create({ load: loadStub, prescriber });
       const route = this.owner.lookup('route:application');
       route.set('currentUser', currentUserStub);
+
+      // when
+      await route.beforeModel(transition);
+
+      // then
+      assert.ok(loadStub.called);
+    });
+
+    test('it should load feature toggles', async function(assert) {
+      // given
+      const transition = { to: { queryParams: {} } };
+      const currentUserStub = Service.create({ load: sinon.stub(), prescriber });
+      const route = this.owner.lookup('route:application');
+      route.set('currentUser', currentUserStub);
+      const featureTogglesService = this.owner.lookup('service:feature-toggles');
+      const loadStub = sinon.stub();
+      featureTogglesService.load = loadStub;
 
       // when
       await route.beforeModel(transition);

--- a/orga/tests/unit/services/feature-toggle-test.js
+++ b/orga/tests/unit/services/feature-toggle-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { resolve } from 'rsvp';
+import Object from '@ember/object';
+import Service from '@ember/service';
+
+module('Unit | Service | feature toggles', function(hooks) {
+
+  setupTest(hooks);
+
+  module('feature toggles are loaded', function() {
+
+    test('should load the feature toggles', async function(assert) {
+      // Given
+      const featureToggles = Object.create({
+        isCertificationResultsInOrgaEnabled: false,
+      });
+      const storeStub = Service.create({
+        queryRecord: () => resolve(featureToggles),
+      });
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // When
+      await featureToggleService.load();
+
+      // Then
+      assert.equal(featureToggleService.featureToggles.isCertificationResultsInOrgaEnabled, false);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Des sessions de certification sont organisées dans les lycées volontaires depuis le 11/01. Si les résultats sont visibles pour les candidats depuis leur compte Pix lorsque la session est publiée, il n’est pour le moment pas possible pour les chefs d'établissements/professeurs d’avoir accès aux résultats des élèves de leur établissement.

On ne souhaite pas que les changements intermédiaires suivants affectent les utilisateurs :
- Nouvel onglet "Mes certifications"
- Endpoint fictif qui renvoie un fichier bouchon
- Ajout du bouton Exporter + Notififcation
- Implémentation du téléchargement de tous les résultats

D'autres améliorations arriveront par la suite.

## :robot: Solution
On met en place un feature toggle ( FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED ) côté API qui conditionnera la récupération des résultats de certification dans le contexte SCO sur Pix Orga. 

