### PR TITLE
[FEATURE] ABCDiag - Ne pas afficher la landing page pour les campagnes “ForAbsoluteNovice” (PIX-2129).

### DIFF
--- a/mon-pix/app/controllers/fill-in-campaign-code.js
+++ b/mon-pix/app/controllers/fill-in-campaign-code.js
@@ -52,7 +52,7 @@ export default class FillInCampaignCodeController extends Controller {
       const campaign = await this.store.queryRecord('campaign', {
         filter: { code: campaignCode },
       });
-      return this.transitionToRoute('campaigns.start-or-resume', campaign);
+      this.transitionToRoute('campaigns.start-or-resume', campaign);
     } catch (error) {
       this.onStartCampaignError(error);
     }

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -271,6 +271,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
       });
     });
   });
+
   context('when campaign is for Novice and isSimplifiedAccess', async function() {
     let campaignForNovice, anonymousUser;
 
@@ -286,7 +287,6 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
       // given
       await authenticateByEmail(user);
       await visit(`/campagnes/${campaignForNovice.code}`);
-      await click('.campaign-landing-page__start-button');
       await click('.checkpoint__continue-button');
       await click('a[data-link-to-continue-pix]');
 
@@ -299,7 +299,6 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
       await authenticateByGAR(anonymousUser);
 
       await visit(`/campagnes/${campaignForNovice.code}`);
-      await click('.campaign-landing-page__start-button');
       await click('.checkpoint__continue-button');
       await click('a[data-link-to-continue-pix]');
 

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -156,23 +156,16 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
         });
       });
 
-      context('When campaign does not have external id and is for absolute novice', function() {
+      context('When campaign does not require external id and is for absolute novice', function() {
 
         beforeEach(async function() {
           campaign = server.create('campaign', { idPixLabel: null, type: ASSESSMENT, isForAbsoluteNovice: true });
-          await startCampaignByCode(campaign.code);
-          await fillIn('#firstName', prescritUser.firstName);
-          await fillIn('#lastName', prescritUser.lastName);
-          await fillIn('#email', prescritUser.email);
-          await fillIn('#password', prescritUser.password);
-          await click('#pix-cgu');
-          await click('.button');
+          await visit(`/campagnes/${campaign.code}`);
         });
 
-        it('should redirect to assessment after completion of external id', async function() {
+        it('should redirect to signup page when starting a campaign', async function() {
           // then
-          expect(currentURL()).to.not.contains('/didacticiel');
-          expect(currentURL()).to.contains('/assessments');
+          expect(currentURL()).to.contains('/inscription');
         });
       });
 
@@ -317,10 +310,7 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           await visit(`campagnes/${campaign.code}`);
         });
 
-        it('should redirect to assessment after completion of external id', async function() {
-          // when
-          await click('.campaign-landing-page__start-button');
-
+        it('should redirect to assessment when starting a campaign', async function() {
           // then
           expect(currentURL()).to.not.contains('/didacticiel');
           expect(currentURL()).to.contains('/assessments');


### PR DESCRIPTION
## :unicorn: Problème

Dans les campagnes destinées à un public débutant, nous ne souhaitons pas afficher la page d'accueil de la campagne.

## :robot: Solution

Création d'une nouvelle condition d'entrée sur la campagne sur `mon-pix/app/routes/campaigns/start-or-resume.js` qui reprend la création d'une `campaignParticipation` telle que réalisée dans la méthode `_shouldStartCampaignParticipation`, et qui se base sur la propriété `isCampaignForNoviceUser`  (Boolean) de la campagne désirée.

## :rainbow: Remarques

Le fichier `campaigns/start-or-resume.js` agit comme un hub central au routage des campagnes et commence à dégager une très grande complexité, faite de beaucoup de conditions et de redirections, parfois cycliques vers ce même fichier, créant un couplage fort et des difficultés à pouvoir tester le code de façon simple.

## :100: Pour tester

Dans la BDD de la RA, setter `isCampaignForNoviceUser` à `true` pour la campagne `AZERTY123`
Se connecter à une campagne via le code `AZERTY123`
Ne pas voir la landing page avant d'arriver sur l'assessment.
