### PR TITLE
[FEATURE] Traduction de la page de résultats individuels d'une campagne d'évaluation (PIX-2148).

### DIFF
--- a/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/campaign.js
@@ -87,7 +87,7 @@ then(`je vois que le sujet {string} est {string}`, (tubeName, recommendationLeve
 });
 
 when(`je retourne au détail de la campagne`, () => {
-  cy.get('[aria-label="Retourner au détail de la campagne"]').click();
+  cy.get('[aria-label="Retour"]').click();
 });
 
 when('je clique sur le bouton "Associer"', () => {

--- a/orga/app/components/progress-bar.hbs
+++ b/orga/app/components/progress-bar.hbs
@@ -1,4 +1,4 @@
-<div class="progress-bar">
+<div class="progress-bar" aria-hidden={{true}}>
   <div class="progress-bar progress-bar--completion" style={{this.progressBarStyle}}></div>
 </div>
 <div class="label-text label-text--dark label-text--small">

--- a/orga/app/components/progression-gauge.hbs
+++ b/orga/app/components/progression-gauge.hbs
@@ -1,5 +1,5 @@
 <div class={{concat "progression-gauge " @progressionClass}} style={{this.totalGaugeStyle}}>
-  <div class="progression-gauge__marker" style={{this.valueGaugeStyle}}></div>
+  <div class="progression-gauge__marker" aria-hidden={{true}} style={{this.valueGaugeStyle}}></div>
 
   <div class="progression-gauge__tooltip-wrapper" style={{this.valueGaugeStyle}}>
     <div class="progression-gauge__tooltip content-text--small">{{yield}}</div>

--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -3,8 +3,8 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.assessments"
      @routeId={{@campaign.id}}
-     @backButtonAriaLabel="Retourner au détail de la campagne"
-     aria-label="Nom de la campagne"
+     @backButtonAriaLabel={{t 'common.actions.back'}}
+     aria-label={{t 'pages.campaign-individual-results.campaign-name'}}
    >
     {{@campaign.name}}
    </PreviousPageButton>
@@ -24,27 +24,27 @@
           </li>
         {{/if}}
         <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">Commencé le</div>
+          <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.start-date'}}</div>
           <div class="value-text panel-header-data-content__value">
             {{moment-format @campaignAssessmentParticipation.createdAt 'DD MMM YYYY'}}
           </div>
         </li>
         {{#unless @campaignAssessmentParticipation.isShared }}
           <li class="panel-header-data__content">
-            <div class="label-text panel-header-data-content__label">Avancement</div>
+            <div class="label-text panel-header-data-content__label">{{t 'pages.assessment-individual-results.progression'}}</div>
             <div class="value-text panel-header-data-content__value">
               {{@campaignAssessmentParticipation.progression}}%
             </div>
           </li>
         {{/unless}}
         <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">Envoyé le</div>
+          <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.shared-date'}}</div>
           {{#if @campaignAssessmentParticipation.sharedAt}}
             <div class="value-text panel-header-data-content__value">
               {{moment-format @campaignAssessmentParticipation.sharedAt 'DD MMM YYYY'}}
             </div>
           {{else}}
-            <div class="value-text panel-header-data-content__value">Non disponible</div>
+            <div class="value-text panel-header-data-content__value">{{t 'pages.campaign-individual-results.not-shared'}}</div>
           {{/if}}
         </li>
       </ul>
@@ -52,17 +52,17 @@
       {{#if @campaignAssessmentParticipation.isShared}}
         <ul class="panel-header__data panel-header__data--highlight">
           {{#if this.displayBadges}}
-            <li aria-label="Résultats Thématiques" class="panel-header-data__content panel-header-data-content__badges">
+            <li aria-label={{t 'pages.assessment-individual-results.badges'}} class="panel-header-data__content panel-header-data-content__badges">
               <Badges @badges={{@campaignAssessmentParticipation.badges}}/>
             </li>
           {{/if}}
-          <li aria-label="Résultat" class="panel-header-data__content panel-header-data-content__progress-bar">
+          <li aria-label={{t 'pages.assessment-individual-results.result.label'}} class="panel-header-data__content panel-header-data-content__progress-bar">
             <ProgressBar @value={{@campaignAssessmentParticipation.masteryPercentage}}>
-              {{@campaignAssessmentParticipation.validatedSkillsCount}} / {{@campaignAssessmentParticipation.targetedSkillsCount}} ACQUIS
+              {{t 'pages.assessment-individual-results.result.value' count=@campaignAssessmentParticipation.validatedSkillsCount total=@campaignAssessmentParticipation.targetedSkillsCount}}
             </ProgressBar>
           </li>
           {{#if @campaign.hasStages}}
-            <li aria-label="Paliers" class="panel-header-data__content panel-header-data-content__stages">
+            <li aria-label={{t 'pages.assessment-individual-results.stages.label'}} class="panel-header-data__content panel-header-data-content__stages">
               <StageStars @result={{@campaignAssessmentParticipation.masteryPercentage}} @stages={{@campaign.stages}}/>
             </li>
           {{else}}
@@ -78,10 +78,10 @@
   <div class="panel campaign-details__controls">
     <nav class="navbar campaign-details-controls__navbar-tabs">
       <LinkTo @route="authenticated.campaigns.assessment.results" class="navbar-item" @models={{array @campaign.id @campaignAssessmentParticipation.id}}>
-        Résultats
+        {{t 'pages.assessment-individual-results.tab.results'}}
       </LinkTo>
       <LinkTo @route="authenticated.campaigns.assessment.analysis" class="navbar-item" @models={{array @campaign.id @campaignAssessmentParticipation.id}}>
-        Analyse
+        {{t 'pages.assessment-individual-results.tab.review'}}
       </LinkTo>
     </nav>
   </div>

--- a/orga/app/components/routes/authenticated/campaign/assessment/results.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/results.hbs
@@ -2,17 +2,17 @@
   <table>
     <thead>
     <tr>
-      <th class="table__column--wide">Compétences ({{if @displayResults @campaignAssessmentParticipationResult.sortedCompetenceResults.length '-' }})</th>
-      <th class="table__column--wide">Résultats</th>
-      <th class="table__column--small">Acquis validés</th>
-      <th class="table__column--small">Acquis évalués</th>
+      <th class="table__column--wide">{{t 'pages.assessment-individual-results.table.column.competences' count=@campaignAssessmentParticipationResult.sortedCompetenceResults.length}}</th>
+      <th class="table__column--wide">{{t 'pages.assessment-individual-results.table.column.results.label'}}</th>
+      <th class="table__column--small">{{t 'pages.assessment-individual-results.table.column.validatedSkills'}}</th>
+      <th class="table__column--small">{{t 'pages.assessment-individual-results.table.column.totalSkills'}}</th>
     </tr>
     </thead>
 
     {{#if @displayResults}}
       <tbody>
       {{#each @campaignAssessmentParticipationResult.sortedCompetenceResults as |competenceResult|}}
-        <tr aria-label="Résultats par compétence">
+        <tr aria-label={{t 'pages.assessment-individual-results.table.title'}}>
           <td class="competences-col__name">
             <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
             <span>
@@ -21,7 +21,7 @@
           </td>
           <td>
             <ProgressionGauge @total={{competenceResult.totalSkillsCountPercentage}} @value={{competenceResult.validatedSkillsCountPercentage}}>
-              <p class="sr-only">Ce participant a validé </p>{{competenceResult.validatedSkillsCountPercentage}}%<p class="sr-only"> de la compétence {{competenceResult.name}}.</p>
+              <span class="sr-only">{{t 'pages.assessment-individual-results.table.column.results.explanation-begin'}}</span>{{competenceResult.validatedSkillsCountPercentage}}%<span class="sr-only">{{t 'pages.assessment-individual-results.table.column.results.explanation-end' competence=competenceResult.name}}</span>
             </ProgressionGauge>
           </td>
           <td>{{competenceResult.validatedSkillsCount}}</td>
@@ -32,6 +32,6 @@
     {{/if}}
   </table>
   {{#unless @displayResults}}
-    <div class="table__empty content-text">En attente de résultats</div>
+    <div class="table__empty content-text">{{t 'pages.assessment-individual-results.table.empty'}}</div>
   {{/unless}}
 </div>

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -3,7 +3,7 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.profiles"
      @routeId={{@campaign.id}}
-     @backButtonAriaLabel="Retourner au détail de la campagne"
+     @backButtonAriaLabel="Retour"
      aria-label="Nom de la campagne"
    >
     {{@campaign.name}}

--- a/orga/app/components/stage-stars.js
+++ b/orga/app/components/stage-stars.js
@@ -1,3 +1,4 @@
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
 const _isStageReached = (result, stage) => result >= stage.threshold;
@@ -5,6 +6,7 @@ const _isStageReached = (result, stage) => result >= stage.threshold;
 const _hasStars = (stage) => stage.threshold > 0;
 
 export default class StageStars extends Component {
+  @service intl;
 
   get starsAcquired() {
     const { result, stages } = this.args;
@@ -17,6 +19,6 @@ export default class StageStars extends Component {
   }
 
   get altMessage() {
-    return `${this.starsAcquired} étoiles sur ${this.starsTotal}`;
+    return this.intl.t('pages.assessment-individual-results.stages.value', { count: this.starsAcquired, total: this.starsTotal });
   }
 }

--- a/orga/tests/acceptance/campaign-participants-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-results-test.js
@@ -46,7 +46,7 @@ module('Acceptance | Campaign Participants Results', function(hooks) {
     test('it could return on list of participants', async function(assert) {
       // when
       await visit('/campagnes/1/evaluations/1');
-      await clickByLabel('Retourner au détail de la campagne');
+      await clickByLabel('Retour');
 
       // then
       assert.equal(currentURL(), '/campagnes/1/evaluations');

--- a/orga/tests/acceptance/profile-test.js
+++ b/orga/tests/acceptance/profile-test.js
@@ -33,7 +33,7 @@ module('Acceptance | Campaign Profile', function(hooks) {
 
     // when
     await visit('/campagnes/1/profils/1');
-    await clickByLabel('Retourner au détail de la campagne');
+    await clickByLabel('Retour');
 
     // then
     assert.equal(currentURL(), '/campagnes/1/profils');

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/assessment/details', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     this.owner.setupRouter();

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/results-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/results-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/assessment/results', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/orga/tests/integration/components/stage-stars-test.js
+++ b/orga/tests/integration/components/stage-stars-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | stage-stars', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should render stars for given stages', async function(assert) {
     // given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -31,6 +31,43 @@
     }
   },
   "pages": {
+    "assessment-individual-results": {
+      "badges": "Thematic results",
+      "mastery-percentage": "Result",
+      "progression": "Progression",
+      "result": {
+        "label": "Result",
+        "value": "{count} / {total} ITEMS"
+      },
+      "stages": {
+        "label": "Steps",
+        "value": "{count} out of {total} stars"
+      },
+      "tab": {
+        "results": "Results",
+        "review": "Review"
+      },
+      "table": {
+        "title": "Results by skill",
+        "column": {
+          "competences": "Skills ({count, plural, =0 {-} other {{count}}})",
+          "results": {
+            "label": "Results",
+            "explanation-begin": "This participant has validated ",
+            "explanation-end": " of the skill {competence}."
+          },
+          "totalSkills": "Items tested",
+          "validatedSkills": "Items successfully completed"
+        },
+        "empty": "Results pending"
+      }
+    },
+    "campaign-individual-results": {
+      "campaign-name": "Name of the campaign",
+      "not-shared": "Not available",
+      "shared-date": "Sent on",
+      "start-date": "Started on"
+    },
     "campaign": {
       "actions": {
         "export-results": "Export the results (.csv)",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -53,6 +53,38 @@
         "review": "Review"
       }
     },
+    "campaign-creation": {
+      "actions": {
+        "create": "Create a campaign"
+      },
+      "external-id-label": {
+        "question-label": "Do you need an external user ID?",
+        "label": "external user ID label",
+        "suggestion": "Example : \"Student Number\" or \"Email address\" *"
+      },
+      "landing-page-text": {
+        "label": "Text to display on the starting page"
+      },
+      "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
+      "name": {
+        "label": "Name of the campaign"
+      },
+      "no": "No",
+      "purpose": {
+        "assessment": "Assess participants",
+        "label": "What is the purpose of your campaign?",
+        "profiles-collection": "Collect the participants' Pix profiles"
+      },
+      "target-profile-informations": "If you want more information, see <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> the corresponding documentation</a>.",
+      "target-profiles-list": {
+        "label": "What would you like to test?"
+      },
+      "test-title": {
+        "label": "Title of the personalised test"
+      },
+      "title": "Create a campaign",
+      "yes": "Yes"
+    },
     "campaign-details": {
       "actions": {
         "edit": "Edit",
@@ -98,38 +130,6 @@
           "by-name": "Search a campaign"
         }
       }
-    },
-    "campaign-creation": {
-      "actions": {
-        "create": "Create a campaign"
-      },
-      "external-id-label": {
-        "question-label": "Do you need an external user ID?",
-        "label": "external user ID label",
-        "suggestion": "Example : \"Student Number\" or \"Email address\" *"
-      },
-      "landing-page-text": {
-        "label": "Text to display on the starting page"
-      },
-      "legal-warning": "*In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), and as data controller, please be careful not to ask for significant or identifying personal data unless it is absolutely necessary. Asking for social security numbers, as well as any sensitive data, is strictly prohibited.",
-      "name": {
-        "label": "Name of the campaign"
-      },
-      "no": "No",
-      "purpose": {
-        "assessment": "Assess participants",
-        "label": "What is the purpose of your campaign?",
-        "profiles-collection": "Collect the participants' Pix profiles"
-      },
-      "target-profile-informations": "If you want more information, see <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> the corresponding documentation</a>.",
-      "target-profiles-list": {
-        "label": "What would you like to test?"
-      },
-      "test-title": {
-        "label": "Title of the personalised test"
-      },
-      "title": "Create a campaign",
-      "yes": "Yes"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -53,6 +53,38 @@
         "review": "Analyse"
       }
     },
+    "campaign-creation": {
+      "actions": {
+        "create": "Créer la campagne"
+      },
+      "external-id-label": {
+        "question-label": "Souhaitez-vous demander un identifiant externe ?",
+        "label": "Libellé de l’identifiant",
+        "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
+      },
+      "landing-page-text": {
+        "label": "Texte de la page d'accueil"
+      },
+      "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
+      "name": {
+        "label": "Nom de la campagne"
+      },
+      "no": "Non",
+      "purpose": {
+        "assessment": "Évaluer les participants",
+        "label": "Quel est l'objectif de votre campagne ?",
+        "profiles-collection": "Collecter les profils Pix des participants"
+      },
+      "target-profile-informations": "Si vous souhaitez avoir plus d'information, consulter <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> la documentation correspondante</a>.",
+      "target-profiles-list": {
+        "label": "Que souhaitez-vous tester ?"
+      },
+      "test-title": {
+        "label": "Titre du parcours"
+      },
+      "title": "Création d'une campagne",
+      "yes": "Oui"
+    },
     "campaign-details": {
       "actions": {
         "archive": "Archiver",
@@ -98,38 +130,6 @@
           "by-name": "Rechercher une campagne"
         }
       }
-    },
-    "campaign-creation": {
-      "actions": {
-        "create": "Créer la campagne"
-      },
-      "external-id-label": {
-        "question-label": "Souhaitez-vous demander un identifiant externe ?",
-        "label": "Libellé de l’identifiant",
-        "suggestion": "Exemple: \"Numéro de l'étudiant\" ou \"Adresse e-mail professionnelle\" *"
-      },
-      "landing-page-text": {
-        "label": "Texte de la page d'accueil"
-      },
-      "legal-warning": "* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.",
-      "name": {
-        "label": "Nom de la campagne"
-      },
-      "no": "Non",
-      "purpose": {
-        "assessment": "Évaluer les participants",
-        "label": "Quel est l'objectif de votre campagne ?",
-        "profiles-collection": "Collecter les profils Pix des participants"
-      },
-      "target-profile-informations": "Si vous souhaitez avoir plus d'information, consulter <a class=\"link\" href=\"https://cloud.pix.fr/s/3joGMGYWSpmHg5w\" target=\"_blank\" rel=\"noopener noreferrer\"> la documentation correspondante</a>.",
-      "target-profiles-list": {
-        "label": "Que souhaitez-vous tester ?"
-      },
-      "test-title": {
-        "label": "Titre du parcours"
-      },
-      "title": "Création d'une campagne",
-      "yes": "Oui"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -31,6 +31,43 @@
     }
   },
   "pages": {
+    "assessment-individual-results": {
+      "badges": "Résultats Thématiques",
+      "mastery-percentage": "Résultat",
+      "progression": "Avancement",
+      "result": {
+        "label": "Résultat",
+        "value": "{count} / {total} ACQUIS"
+      },
+      "stages": {
+        "label": "Paliers",
+        "value": "{count} étoiles sur {total}"
+      },
+      "tab": {
+        "results": "Résultats",
+        "review": "Analyse"
+      },
+      "table": {
+        "title": "Résultats par compétence",
+        "column": {
+          "competences": "Compétences ({count, plural, =0 {-} other {{count}}})",
+          "results": {
+            "label": "Résultats",
+            "explanation-begin": "Ce participant a validé ",
+            "explanation-end": " de la compétence {competence}."
+          },
+          "totalSkills": "Acquis évalués",
+          "validatedSkills": "Acquis validés"
+        },
+        "empty": "En attente de résultats"
+      }
+    },
+    "campaign-individual-results": {
+      "campaign-name": "Nom de la campagne",
+      "not-shared": "Non disponible",
+      "shared-date": "Envoyé le",
+      "start-date": "Commencé le"
+    },
     "campaign": {
       "actions": {
         "export-results": "Exporter les résultats (.csv)",


### PR DESCRIPTION
## :unicorn: Problème
La page de résultats individuels d'une campagne d'évaluation n'est pas internationalisée.

## :robot: Solution
L'internationaliser et ajouter les traductions anglaises.

## :rainbow: Remarques
NA

## :100: Pour tester
Se connecter à Pix Orga, ouvrir une campagne d'évaluation et aller voir le détail d'un participant :
- dont les résultats sont partagés ;
- dont les résultats ne sont pas partagés.
Vérifier également le bon affichage des résultats thématiques et des paliers et du pourcentage de maîtrise lorsqu'il n'y a pas de paliers.
