### PR TITLE
[FEATURE] Désactiver la saisie automatique des champs dans le formulaire de changement d'e-mail de Pix App (PIX-2189).

### DIFF
--- a/mon-pix/app/templates/components/user-account-update-email.hbs
+++ b/mon-pix/app/templates/components/user-account-update-email.hbs
@@ -35,7 +35,7 @@
                          @onValidate={{this.validatePassword}}
                          @validationMessage={{this.passwordValidation.message}}
                          @validationStatus={{this.passwordValidation.status}}
-                         @autocomplete="off"
+                         @autocomplete="new-password"
                          @require={{true}}/>
         </div>
         {{#if this.errorMessage}}

--- a/mon-pix/tests/integration/components/user-account-update-email-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-test.js
@@ -110,6 +110,17 @@ describe('Integration | Component | User account update email', () => {
           // then
           expect(find('#validationMessage-password').textContent).to.equal(this.intl.t('pages.user-account.account-update-email.fields.errors.empty-password'));
         });
+
+        it('should have the autocomplete attribute set to "new-password" in order to prevent the web browsers to autocomplete the password and email fields', async () => {
+          // given
+          const expectedAutocompleteValue = 'new-password';
+
+          // when
+          await render(hbs`<UserAccountUpdateEmail />`);
+
+          // then
+          expect(find('#password').autocomplete).to.equal(expectedAutocompleteValue);
+        });
       });
 
       it('should disable the confirm button if the form is not valid', async function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -958,7 +958,7 @@
                 "save-button": "",
                 "fields": {
                     "new-email": {
-                        "label": "Email address"
+                        "label": ""
                     },
                     "new-email-confirmation": {
                         "label": ""

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -958,7 +958,7 @@
                 "save-button": "Confirmer",
                 "fields": {
                     "new-email": {
-                        "label": "Adresse e-mail"
+                        "label": "Nouvelle adresse e-mail"
                     },
                     "new-email-confirmation": {
                         "label": "Confirmation de l'adresse e-mail"


### PR DESCRIPTION
## :unicorn: Problème
Il est possible pour un utilisateur de modifier son adresse e-mail depuis la page /mon-compte de Pix App. Il doit pour cela saisir sa nouvelle adresse-email, la confirmer et saisir son mot de passe. Cependant, les navigateurs peuvent saisir automatiquement la valeur de ces champs, notamment le mot de passe, ce qui peut poser un problème de sécurite.

## :robot: Solution
Désactiver la saisie automatique de ces champs par le navigateur.

## :rainbow: Remarques
Testé sur Chrome et Firefox.

## :100: Pour tester
- Se connecter à Pix tout en ayant fait le choix de stocker les informations de connexion.
- Se rendre sur l'url /mon-compte.
- Cliquer sur le bouton de modification de l'adresse e-mail.
- S'assurer que les champs du formulaire ne sont pas remplis.
