### PR TITLE
[BUGFIX] Affichage du nom de la compétence dans les notifications de gain de niveau (PIX-2172).

### DIFF
--- a/api/lib/application/answers/answer-controller.js
+++ b/api/lib/application/answers/answer-controller.js
@@ -8,7 +8,8 @@ module.exports = {
   async save(request, h) {
     const answer = answerSerializer.deserialize(request.payload);
     const userId = requestResponseUtils.extractUserIdFromRequest(request);
-    const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId });
+    const locale = requestResponseUtils.extractLocaleFromRequest(request);
+    const createdAnswer = await usecases.correctAnswerThenUpdateAssessment({ answer, userId, locale });
 
     return h.response(answerSerializer.serialize(createdAnswer)).created();
   },

--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -10,6 +10,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
   {
     answer,
     userId,
+    locale,
     answerRepository,
     assessmentRepository,
     challengeRepository,
@@ -80,6 +81,7 @@ module.exports = async function correctAnswerThenUpdateAssessment(
     competenceEvaluationRepository,
     knowledgeElementRepository,
     scorecardBeforeAnswer,
+    locale,
   });
 
   return answerSaved;
@@ -131,6 +133,7 @@ async function _addLevelUpInformation(
     competenceEvaluationRepository,
     knowledgeElementRepository,
     scorecardBeforeAnswer,
+    locale,
   }) {
   answerSaved.levelup = {};
 
@@ -144,6 +147,7 @@ async function _addLevelUpInformation(
     competenceRepository,
     competenceEvaluationRepository,
     knowledgeElementRepository,
+    locale,
   });
 
   if (scorecardBeforeAnswer.level < scorecardAfterAnswer.level) {

--- a/api/tests/unit/application/answers/answer-controller_test.js
+++ b/api/tests/unit/application/answers/answer-controller_test.js
@@ -28,6 +28,7 @@ describe('Unit | Controller | answer-controller', () => {
     const resultDetails = null;
     const value = 'NumA = "4", NumB = "1", NumC = "3", NumD = "2"';
     const elapsedTime = 1000;
+    const locale = 'fr-fr';
 
     let request;
     let deserializedAnswer;
@@ -61,6 +62,9 @@ describe('Unit | Controller | answer-controller', () => {
 
     beforeEach(() => {
       request = {
+        headers: {
+          'accept-language': locale,
+        },
         payload: {
           data: {
             attributes: {
@@ -112,7 +116,8 @@ describe('Unit | Controller | answer-controller', () => {
         createdAnswer = domainBuilder.buildAnswer({ assessmentId });
         answerSerializer.serialize.returns(serializedAnswer);
         usecases.correctAnswerThenUpdateAssessment.resolves(createdAnswer);
-        requestResponseUtils.extractUserIdFromRequest.returns(userId);
+        requestResponseUtils.extractUserIdFromRequest.withArgs(request).returns(userId);
+        requestResponseUtils.extractLocaleFromRequest.withArgs(request).returns(locale);
 
         // when
         response = await answerController.save(request, hFake);
@@ -121,7 +126,7 @@ describe('Unit | Controller | answer-controller', () => {
       it('should call the usecase to save the answer', () => {
         // then
         expect(usecases.correctAnswerThenUpdateAssessment)
-          .to.have.been.calledWith({ answer: deserializedAnswer, userId });
+          .to.have.been.calledWith({ answer: deserializedAnswer, userId, locale });
       });
 
       it('should serialize the answer', () => {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -5,10 +5,11 @@ import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 
 export default class ChallengeController extends Controller {
-  queryParams = ['newLevel'];
+  queryParams = ['newLevel', 'competenceLeveled'];
   @service intl;
   @service currentUser;
   @tracked newLevel = null;
+  @tracked competenceLeveled = null;
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;

--- a/mon-pix/app/controllers/assessments/checkpoint.js
+++ b/mon-pix/app/controllers/assessments/checkpoint.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class CheckpointController extends Controller {
-  queryParams = ['finalCheckpoint', 'newLevel'];
+  queryParams = ['finalCheckpoint', 'newLevel', 'competenceLeveled'];
 
   @service intl;
   @service currentUser;
@@ -14,6 +14,7 @@ export default class CheckpointController extends Controller {
   @tracked finalCheckpoint = false;
   @tracked isShowingModal = false;
   @tracked newLevel = null;
+  @tracked competenceLeveled = null;
 
   get showLevelup() {
     return this.model.showLevelup && this.newLevel;

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -25,5 +25,5 @@
 </div>
 
 {{#if this.showLevelup}}
-  <LevelupNotif @level={{this.newLevel}} @competenceName={{@model.assessment.title}} />
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
 {{/if}}

--- a/mon-pix/app/templates/assessments/checkpoint.hbs
+++ b/mon-pix/app/templates/assessments/checkpoint.hbs
@@ -59,5 +59,5 @@
 </div>
 
 {{#if this.showLevelup}}
-  <LevelupNotif @level={{this.newLevel}} @competenceName={{@model.title}} />
+  <LevelupNotif @level={{this.newLevel}} @competenceName={{this.competenceLeveled}} />
 {{/if}}


### PR DESCRIPTION
## :unicorn: Problème
La traduction du nom de la compétence fonctionne bien sur les notifications de gain de niveau lors d'une évaluation de compétence. Mais lors d'une campagne, le nom de la compétence ne s'affiche pas.

## :robot: Solution
1. Traduire le nom de la compétence côté api
2. Passer le nom de la compétence en queryParam lors du changement de page vers une nouvelle épreuve/checkpoint

## :100: Pour tester
- sur une campagne, vérifier que le nom de la compétence d'une notification de levelup s'affiche bien en **français**
- sur une évaluation de compétence, vérifier que le nom de la compétence d'une notification de levelup s'affiche bien en **français**

En suffixant l'url avec `lang=en`:
- sur une campagne, vérifier que le nom de la compétence d'une notification de levelup  s'affiche bien en **anglais**
- sur une évaluation de compétence, vérifier que le nom de la compétence d'une notification de levelup  s'affiche bien en **anglais**