### PR TITLE
[FEATURE] Créer la route de récupération des résultats de certif pour orga (PIX-2191)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -132,6 +132,33 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/organizations/{id}/certification-results',
+      config: {
+        pre: [
+          {
+            method: securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled,
+            assign: 'isCertificationResultsInOrgaEnabled',
+          },
+          {
+            method: securityPreHandlers.checkUserBelongsToOrganizationManagingStudents,
+            assign: 'belongsToOrganizationManagingStudents',
+          },
+        ],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationController.downloadCertificationResults,
+        tags: ['api', 'organizations'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle retourne les certifications liées à l\'organisation sous forme de fichier CSV.',
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/organizations/{id}/target-profiles',
       config: {
         handler: organizationController.findTargetProfiles,

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -80,6 +80,15 @@ module.exports = {
     return membershipSerializer.serialize(memberships, pagination);
   },
 
+  async downloadCertificationResults(_request, h) {
+    const csvResult = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n';
+    const fileName = '20190428_0242_resultats_NomDeLaClasse.csv';
+
+    return h.response(csvResult)
+      .header('Content-Type', 'text/csv;charset=utf-8')
+      .header('Content-Disposition', `attachment; filename=${fileName}`);
+  },
+
   async findTargetProfiles(request) {
     const requestedOrganizationId = parseInt(request.params.id);
 

--- a/api/lib/application/security-pre-handlers.js
+++ b/api/lib/application/security-pre-handlers.js
@@ -6,6 +6,7 @@ const checkUserBelongsToOrganizationManagingStudentsUseCase = require('./usecase
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('./usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('./usecases/checkUserBelongsToOrganization');
 const checkUserIsAdminAndManagingStudentsForOrganization = require('./usecases/checkUserIsAdminAndManagingStudentsForOrganization');
+const config = require('../config');
 const Organization = require('../../lib/domain/models/Organization');
 const boom = require('boom');
 
@@ -132,6 +133,15 @@ async function checkUserBelongsToOrganizationOrHasRolePixMaster(request, h) {
   return _replyWithAuthorizationError(h);
 }
 
+function checkIsCertificationResultsInOrgaToggleEnabled(request, h) {
+  const isCertificationResultsInOrgaEnabled = config.featureToggles.isCertificationResultsInOrgaEnabled;
+  if (isCertificationResultsInOrgaEnabled) {
+    return h.response(true);
+  }
+
+  return _replyWithAuthorizationError(h);
+}
+
 async function checkUserIsAdminInOrganizationOrHasRolePixMaster(request, h) {
   if (!request.auth.credentials || !request.auth.credentials.userId) {
     return _replyWithAuthorizationError(h);
@@ -221,6 +231,7 @@ module.exports = {
   checkUserBelongsToOrganizationManagingStudents,
   checkUserBelongsToScoOrganizationAndManagesStudents,
   checkUserHasRolePixMaster,
+  checkIsCertificationResultsInOrgaToggleEnabled,
   checkUserIsAuthenticated,
   checkUserIsAdminInOrganization,
   checkUserIsAdminInOrganizationOrHasRolePixMaster,

--- a/api/tests/acceptance/application/organization-controller_test.js
+++ b/api/tests/acceptance/application/organization-controller_test.js
@@ -10,6 +10,7 @@ const createServer = require('../../../server');
 const Membership = require('../../../lib/domain/models/Membership');
 const OrganizationInvitation = require('../../../lib/domain/models/OrganizationInvitation');
 const AuthenticationMethod = require('../../../lib/domain/models/AuthenticationMethod');
+const config = require('../../../lib/config');
 
 describe('Acceptance | Application | organization-controller', () => {
 
@@ -1340,4 +1341,66 @@ describe('Acceptance | Application | organization-controller', () => {
       });
     });
   });
+
+  describe('GET /api/organizations/{id}/certification-results', () => {
+
+    const ft = config.featureToggles.isCertificationResultsInOrgaEnabled;
+
+    afterEach(() => {
+      config.featureToggles.isCertificationResultsInOrgaEnabled = ft;
+    });
+
+    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is enabled', () => {
+
+      it('should return HTTP status 200', async () => {
+        // given
+        config.featureToggles.isCertificationResultsInOrgaEnabled = true;
+
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: '234', userId: user.id });
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/certification-results`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+      });
+    });
+
+    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is not enabled', () => {
+
+      it('should return HTTP status 403', async () => {
+        // given
+        config.featureToggles.isCertificationResultsInOrgaEnabled = false;
+
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildAuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, externalIdentifier: '234', userId: user.id });
+        const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id });
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'GET',
+          url: `/api/organizations/${organization.id}/certification-results`,
+          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+    });
+  });
+
 });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -612,4 +612,15 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       expect(response.headers['Content-Disposition']).to.equal('attachment; filename=modele-import.csv');
     });
   });
+
+  describe('#downloadCertificationResults', () => {
+    it('should return a response with an empty CSV', async () => {
+      // given
+      const response = await organizationController.downloadCertificationResults(request, hFake);
+
+      // then
+      expect(response.headers['Content-Type']).to.equal('text/csv;charset=utf-8');
+      expect(response.headers['Content-Disposition']).to.equal('attachment; filename=20190428_0242_resultats_NomDeLaClasse.csv');
+    });
+  });
 });

--- a/api/tests/unit/application/security-pre-handlers_test.js
+++ b/api/tests/unit/application/security-pre-handlers_test.js
@@ -9,6 +9,8 @@ const checkUserBelongsToOrganizationManagingStudentsUseCase = require('../../../
 const checkUserBelongsToScoOrganizationAndManagesStudentsUseCase = require('../../../lib/application/usecases/checkUserBelongsToScoOrganizationAndManagesStudents');
 const checkUserBelongsToOrganizationUseCase = require('../../../lib/application/usecases/checkUserBelongsToOrganization');
 
+const config = require('../../../lib/config');
+
 describe('Unit | Application | SecurityPreHandlers', () => {
 
   describe('#checkUserIsAuthenticated', () => {
@@ -678,6 +680,44 @@ describe('Unit | Application | SecurityPreHandlers', () => {
         // then
         expect(response.statusCode).to.equal(403);
         expect(response.isTakeOver).to.be.true;
+      });
+    });
+  });
+
+  describe('#checkIsCertificationResultsInOrgaToggleEnabled', () => {
+
+    const ft = config.featureToggles.isCertificationResultsInOrgaEnabled;
+
+    afterEach(() => {
+      config.featureToggles.isCertificationResultsInOrgaEnabled = ft;
+    });
+
+    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is enabled', () => {
+
+      it('it returns true', () => {
+        // given
+        const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
+        config.featureToggles.isCertificationResultsInOrgaEnabled = true;
+
+        // when
+        const response = securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled(request, hFake);
+
+        //then
+        expect(response.source).to.equal(true);
+      });
+    });
+
+    context('when FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED is not enabled', () => {
+
+      it('should forbid resource access', async () => {
+        // given
+        const request = { auth: { credentials: { accessToken: 'valid.access.token', userId: 1234 } } };
+
+        // when
+        const response = await securityPreHandlers.checkIsCertificationResultsInOrgaToggleEnabled(request, hFake);
+
+        //then
+        expect(response.statusCode).to.equal(403);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Des sessions de certification sont organisées dans les lycées volontaires depuis le 11/01. Si les résultats sont visibles pour les candidats depuis leur compte Pix lorsque la session est publiée, il n’est pour le moment pas possible pour les chefs d'établissements/professeurs d’avoir accès aux résultats des élèves de leur établissement.

Dans le cadre de l'épix 2076 (https://1024pix.atlassian.net/browse/PIX-2076), nous parallélisons le travail front et back. Afin de vérifier l'inter-connexion des deux applications, il manque une route API pour récupérer les résultats de certif par classe d'une orga. Le but de ce ticket est de préparer cette route en créant dans un premier temps une route générique renvoyant un csv vide

## :robot: Solution
Créer une route `api/organization/{id}/certification-results` permettant de télécharger un csv vide

