### PR TITLE
[BUGFIX] Corrige la publication de sessions sans certifications

### DIFF
--- a/api/lib/infrastructure/repositories/certification-repository.js
+++ b/api/lib/infrastructure/repositories/certification-repository.js
@@ -90,7 +90,7 @@ module.exports = {
     }
     await CertificationCourseBookshelf
       .where({ sessionId })
-      .save({ isPublished: true }, { method: 'update' });
+      .save({ isPublished: true }, { method: 'update', require: false });
   },
 
   async unpublishCertificationCoursesBySessionId(sessionId) {

--- a/api/tests/integration/infrastructure/repositories/certification-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-repository_test.js
@@ -199,6 +199,22 @@ describe('Integration | Repository | Certification ', () => {
 
       await Promise.all(sessionWithStartedAndErrorCertifCourseIds.map(async (id) => expect((await get(id)).isPublished).to.be.false));
     });
+
+    it('does nothing when there are no certification courses', async () => {
+      // given
+      const sessionWithNoCertificationCourses = databaseBuilder.factory.buildSession({
+        certificationCenterId,
+        certificationCenter,
+        finalizedAt: new Date('2020-01-01'),
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const publicationPromise = certificationRepository.publishCertificationCoursesBySessionId(sessionWithNoCertificationCourses.id);
+
+      // then
+      await expect(publicationPromise).not.to.be.rejected;
+    });
   });
 
   describe('#unpublishCertificationCoursesBySessionId', () => {


### PR DESCRIPTION
## :unicorn: Problème

Quand on publie une session finalisée qui n’a pas de certifications, le back renvoie une erreur 500, ce qui donne une jolie erreur incompréhensible dans Pix Admin.

En même temps ce n’est pas censé arriver car pour finaliser une session il faut qu’il y ait des certifications.

Oui mais il y a des petits malins qui modifient les URLs pour arriver à le faire quand même, c’est arrivé au moins une fois.

## :robot: Solution

Faire que la publication de session sans certification fonctionne.

## :rainbow: Remarques

On pourrait aussi faire que la finalisation de session sans certification ne fonctionne pas côté backend, ce qui éviterait les petits malins qui modifient l'URL.

Je trouve que l'assertion `expect(result).to.not.exist` est une mauvaise assertion, vous en pensez quoi ? On l'enlève ? Par quelle meilleur assertion est-ce qu'on pourrait la remplacer ?

## :100: Pour tester

Réussir à finaliser une session sans certifications, puis réussir à la publier.
