### PR TITLE
[FEATURE] Traduction de la page d'analyse d'une campagne d'évaluation dans Pix Orga (PIX-2147).

### DIFF
--- a/orga/app/components/chevron.hbs
+++ b/orga/app/components/chevron.hbs
@@ -1,4 +1,5 @@
 <PixIconButton
+  aria-label={{@ariaLabel}}
   @icon="{{if @isOpen 'chevron-up' 'chevron-down'}}"
   aria-expanded="{{@isOpen}}"
   @triggerAction={{@toggleParent}}

--- a/orga/app/components/routes/authenticated/campaign/analysis/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tab.hbs
@@ -1,22 +1,17 @@
-<h4 class="campaign-details-analysis campaign-details-analysis__header">Recommandation de sujets à travailler</h4>
+<h4 class="campaign-details-analysis campaign-details-analysis__header">{{t 'pages.campaign-review.title'}}</h4>
 
 <p class="campaign-details-analysis campaign-details-analysis__text">
-  En fonction du référentiel testé et des résultats de la campagne,
-  Pix vous recommande ces sujets à travailler, classés par degré de pertinence (
-  <svg height="10" width="10">
-    <circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" />
-  </svg>
-  )
+  {{this.description}}
 </p>
 
 <div class="panel panel--light-shadow content-text content-text--small campaign-details-table">
 
-  <table aria-label="Analyse par sujet">
+  <table aria-label={{t 'pages.campaign-review.header.title'}}>
     <thead>
       <tr>
-        <Table::Header @size="wide"> Sujets ({{if @displayAnalysis this.sortedRecommendations.length '-' }})</Table::Header>
+        <Table::Header @size="wide">{{t 'pages.campaign-review.header.subjects' count=this.sortedRecommendations.length}}</Table::Header>
         <Table::HeaderSort @size="small" @align="center" @onSort={{this.sortRecommendationOrder}} @isDisabled={{not
-          @displayAnalysis}}>Pertinence </Table::HeaderSort>
+          @displayAnalysis}}>{{t 'pages.campaign-review.header.relevance'}} </Table::HeaderSort>
         <Table::Header @size="small" @align="center" />
         <Table::Header @size="small" />
       </tr>
@@ -33,6 +28,6 @@
   </table>
 
   {{#unless @displayAnalysis }}
-    <div class="table__empty content-text">En attente de résultats</div>
+    <div class="table__empty content-text">{{t 'pages.campaign-review.waiting-results'}}</div>
   {{/unless}}
 </div>

--- a/orga/app/components/routes/authenticated/campaign/analysis/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tab.js
@@ -1,8 +1,11 @@
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 
 export default class Tab extends Component {
+  @service intl;
   @tracked
   sortedRecommendations;
 
@@ -11,6 +14,12 @@ export default class Tab extends Component {
     this.sortedRecommendations = this.args.campaignTubeRecommendations
       ? this.args.campaignTubeRecommendations.sortBy('averageScore')
       : [];
+  }
+
+  get description() {
+    return htmlSafe(this.intl.t('pages.campaign-review.description',
+      { bubble: '<svg height="10" width="10"><circle cx="5" cy="5" r="5" class="campaign-details-analysis recommendation-indicator__bubble" /></svg>' },
+    ));
   }
 
   @action

--- a/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
+++ b/orga/app/components/routes/authenticated/campaign/analysis/tube-recommendation-row.hbs
@@ -1,4 +1,4 @@
-<tr aria-label="Sujet">
+<tr aria-label="{{t 'pages.campaign-review.tube-recommendations.subject'}}">
   <td class="competences-col__name">
     <div class="competences-col-name-wrapper">
       <span class="competences-col__border {{if this.isOpen " competences-col__border--top"}}
@@ -19,7 +19,7 @@
   </td>
   <td class="table__column--right">
     {{#if (gt @tubeRecommendation.tutorials.length 0)}}
-      <Chevron @isOpen={{this.isOpen}} @toggleParent={{this.toggleTutorialsSection}} />
+      <Chevron @isOpen={{this.isOpen}} @toggleParent={{this.toggleTutorialsSection}} @ariaLabel={{t 'pages.campaign-review.tube-recommendations.show-tutorial'}} />
     {{/if}}
   </td>
 </tr>
@@ -33,21 +33,17 @@
         {{@tubeRecommendation.tubeDescription}}
       </div>
       <h3 class="tube-recommendation-tutorial__title">
-        {{#if (eq @tubeRecommendation.tutorials.length 1)}}
-          1 tuto recommandé par la communauté Pix
-        {{else}}
-          {{@tubeRecommendation.tutorials.length}} tutos recommandés par la communauté Pix
-        {{/if}}
+        {{t 'pages.campaign-review.tube-recommendations.recommended-tutorial' count=@tubeRecommendation.tutorials.length}}
       </h3>
       <table class="tube-recommendation-tutorial-table">
         <tbody>
           {{#each @tubeRecommendation.tutorials as |tutorial|}}
-            <tr aria-label="Tutoriel" class="table__row--small">
+            <tr aria-label={{t 'pages.campaign-review.tube-recommendations.name'}} class="table__row--small">
               <td class="tube-recommendation-tutorial-table__row">
                 <a href={{tutorial.link}} class="link" target="_blank" rel="noopener noreferrer">{{tutorial.title}}</a>
                 <span class="tube-recommendation-tutorial-table__details">
                   <strong>·</strong>
-                  Par {{tutorial.source}}
+                  {{t 'pages.campaign-review.tube-recommendations.tutorial-source' source=tutorial.source}}
                   <strong>·</strong>
                   <span class="tube-recommendation-tutorial-table__format">{{tutorial.format}}</span>
                   <strong>·</strong>

--- a/orga/app/components/tutorial-counter.hbs
+++ b/orga/app/components/tutorial-counter.hbs
@@ -1,7 +1,5 @@
 <div class="table__column--center">
-  {{#if (eq @tutorials.length 1)}}
-    1 tuto
-  {{else if (gt @tutorials.length 1)}}
-    {{@tutorials.length }} tutos
+  {{#if (gt @tutorials.length 0)}}
+    {{t 'pages.campaign-review.tube-recommendations.tutorial-total' count=@tutorials.length}}
   {{/if}}
 </div>

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/campaign/analysis/tab', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
   let campaignTubeRecommendation_1;

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/analysis/tube-recommendation-row', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
   let tubeRecommendation;

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -167,6 +167,24 @@
           "by-name": "Search a campaign"
         }
       }
+    },
+    "campaign-review": {
+      "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following subjects, sorted by relevance ({bubble}).",
+      "header": {
+        "title": "Review by subject",
+        "relevance": "Relevance",  
+        "subjects": "Subjects ({count, plural, =0 {-} other {{count}}})"
+      },
+      "title": "Recommendations of subjects to focus on",
+      "tube-recommendations": {
+        "name": "Tutorial",
+        "recommended-tutorial": "{count, plural, =1 {1 tutorial} other{{count} tutorials}} recommended by the Pix community",
+        "show-tutorial": "Show all tutorials",
+        "subject": "Subject",
+        "tutorial-source": "By {source}",
+        "tutorial-total":"{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
+      },
+      "waiting-results": "Waiting results"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -167,6 +167,24 @@
           "by-name": "Rechercher une campagne"
         }
       }
+    },
+    "campaign-review": {
+      "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
+      "header": {
+        "title": "Analyse par sujet",
+        "relevance": "Pertinence",  
+        "subjects": "Sujets ({count, plural, =0 {-} other {{count}}})"
+      },
+      "title": "Recommandation de sujets à travailler",
+      "tube-recommendations": {
+        "name": "Tutoriel",
+        "recommended-tutorial": "{count, plural, =1 {1 tuto recommandé} other{{count} tutos recommandés}} par la communauté Pix",
+        "show-tutorial": "Afficher la liste des tutos",
+        "subject": "Sujet",
+        "tutorial-source": "Par {source}",
+        "tutorial-total":"{count, plural, =1 {1 tuto} other {{count} tutos}}"
+      },
+      "waiting-results": "En attente de résultats"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
pix Orga n'est pas internationnalisé

## :robot: Solution
Traduire la page de resultat de campagne individuel

## :rainbow: Remarques
Je n'ai pas trouvé comment inséré dynamiquement le svg de la description. ça pourra potentiellement générer des souci futurs dans une autre langue. 

## :100: Pour tester
Se connecter sur pix Orga, aller dans une campagne ayant des résultats.
cliquez sur un individu et vérifier que la liste des tutos est entièrement traduite.