### PR TITLE
[FEATURE] Marquer le signalement 'Problème technique' en tant que signalement impactant (PIX-2058)

### DIFF
--- a/api/lib/domain/models/CertificationIssueReport.js
+++ b/api/lib/domain/models/CertificationIssueReport.js
@@ -85,6 +85,7 @@ const categorySchemas = {
 };
 
 const categoryCodeWithRequiredAction = {
+  [CertificationIssueReportCategories.TECHNICAL_PROBLEM]: 'A1',
   [CertificationIssueReportCategories.OTHER]: 'A2',
   [CertificationIssueReportCategories.FRAUD]: 'C6',
 };

--- a/api/tests/unit/domain/models/CertificationIssueReport_test.js
+++ b/api/tests/unit/domain/models/CertificationIssueReport_test.js
@@ -322,6 +322,7 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'LINK_NOT_WORKING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'IMAGE_NOT_DISPLAYING', questionNumber: 42 },
         { certificationCourseId: 42, category: 'IN_CHALLENGE', subcategory: 'EMBED_NOT_WORKING', questionNumber: 42 },
+        { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
       ].forEach((certificationIssueReportDTO) => {
         it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isActionRequired to true`, () => {
           expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isActionRequired).to.be.true;
@@ -332,7 +333,6 @@ describe('Unit | Domain | Models | CertificationIssueReport', () => {
         { certificationCourseId: 42, category: 'CANDIDATE_INFORMATIONS_CHANGES', subcategory: 'EXTRA_TIME_PERCENTAGE', description: 'toto' },
         { certificationCourseId: 42, category: 'LATE_OR_LEAVING', subcategory: 'SIGNATURE_ISSUE' },
         { certificationCourseId: 42, category: 'CONNECTION_OR_END_SCREEN' },
-        { certificationCourseId: 42, category: 'TECHNICAL_PROBLEM', description: 'toto' },
       ].forEach((certificationIssueReportDTO) => {
         it(`for ${certificationIssueReportDTO.category} ${certificationIssueReportDTO.subcategory ? certificationIssueReportDTO.subcategory : ''} should tag certificationIssueReport with isActionRequired to false`, () => {
           expect(new CertificationIssueReport({ ...certificationIssueReportDTO }).isActionRequired).to.be.false;


### PR DESCRIPTION
## :unicorn: Problème
On s’est rendu compte qu’à l’utilisation, les surveillants utilisent cette catégories notamment pour remonter des incidents concernant des problèmes rencontrés sur une épreuve du test de certification, incident qui pour le coup nécessite une action du pôle certif. Aujourd’hui (et en attendant qu’on trouve une solution pour bien faire comprendre aux surveillants l’utilité de cette catégorie), le pôle certif se retrouve donc à checker chaque session avec un signalement même lorsque celui-ci n’est pas impactant pour voir si un des signalements concerne cette catégorie, pour ne pas louper une info importante.

## :robot: Solution
Marquer la catégorie comme "impactante" côté API

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Finaliser une session en ajoutant un signalement type "Problème technique" puis constater sur PixAdmin:
apparition du signalement ETQ signalement impactant partout (count de signalements impactants dans les colonnes, sur la page de détails d'une session, sur la page de détails d'une certif)
