### PR TITLE
[TECH] Ignorer l'indisponibilité temporaire de martinfowler.com.

### DIFF
--- a/docs/link--check-config.json
+++ b/docs/link--check-config.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/1024pix/pix-editor/pull/"
+    },
+    {
+      "pattern": "^https://martinfowler.com/"
     }
   ]
 }


### PR DESCRIPTION
## :unicorn: Problème
Depuis ce matin, [plusieurs CI ](https://app.circleci.com/pipelines/github/1024pix/pix/21629/workflows/c3664eda-b921-4d12-aeb2-d6fd804deb05/jobs/181146 )tombent en erreur avec le message suivant
```
ERROR: 1 dead links found!
[✖] https://martinfowler.com/eaaDev/EventNarrative.html#HandlingEvents → Status: 0
```

Le site `https://martinfowler.com` répond, mais pas très rapidement, et pas toujours
## :robot: Solution
Les options de retry/timeout par défaut semblent OK (timeout de 10 secondes, 2 tentatives)
Ignorer les ressources de `https://martinfowler.com` en utilisant [le fichier de configuration](https://github.com/tcort/markdown-link-check#usage)

## :rainbow: Remarques
Depuis 1 mois, ce check fonctione. 
Si dans 6 mois, on se retrouve à ignorer la 10% des liens, j'enlèverai le code qui vérifie les liens

## :100: Pour tester
Relancer plusieurs fois la CI et vérifier qu'elle est OK
L'avenir nous dira si cela fonctionne