### PR TITLE
[FEATURE] Traduction de la page de la liste des participants d'une campagne d'évaluation(PIX-2158).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -13,14 +13,14 @@
     <table>
       <thead>
         <tr>
-          <th>Nom</th>
-          <th>Prénom</th>
+          <th>{{t 'pages.assessment-participants-list.table.column.first-name'}}</th>
+          <th>{{t 'pages.assessment-participants-list.table.column.last-name'}}</th>
           {{#if @campaign.idPixLabel}}
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}
-          <th>Résultats</th>
+          <th>{{t 'pages.assessment-participants-list.table.column.results.label'}}</th>
           {{#if @campaign.hasBadges}}
-            <th>Résultats Thématiques</th>
+            <th>{{t 'pages.assessment-participants-list.table.column.badges'}}</th>
           {{/if}}
         </tr>
       </thead>
@@ -28,7 +28,7 @@
       {{#if @participations}}
         <tbody>
         {{#each @participations as |participation|}}
-          <tr aria-label="Participant" role="button" {{on 'click' (fn @goToAssessmentPage @campaign.id participation.id)}} class="tr--clickable">
+          <tr aria-label={{t 'pages.assessment-participants-list.table.row-title'}} role="button" {{on 'click' (fn @goToAssessmentPage @campaign.id participation.id)}} class="tr--clickable">
             <td>{{participation.lastName}}</td>
             <td>{{participation.firstName}}</td>
             {{#if @campaign.idPixLabel}}
@@ -51,12 +51,12 @@
                   <span class="participant-list__icon">
                     <FaIcon @icon='share-square'></FaIcon>
                   </span>
-                  En attente
+                  {{t 'pages.assessment-participants-list.table.column.results.on-hold'}}
                 {{else}}
                   <span class="participant-list__icon">
                     <FaIcon @icon='hourglass-half'></FaIcon>
                   </span>
-                  En cours de test
+                  {{t 'pages.assessment-participants-list.table.column.results.under-test'}}
                 {{/if}}
               {{/if}}
             </td>
@@ -74,7 +74,7 @@
     </table>
 
     {{#unless @participations}}
-      <div class="table__empty content-text">Aucun participant</div>
+      <div class="table__empty content-text">{{t 'pages.assessment-participants-list.table.empty'}}</div>
     {{/unless}}
   </div>
 </div>

--- a/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
+++ b/orga/app/components/routes/authenticated/campaign/participation-filters.hbs
@@ -1,8 +1,8 @@
 {{#if this.displayFilters }}
   <PixFilterBanner
-    @title="Filtres"
+    @title={{t 'pages.campaign.filters.title'}}
     class="participant-filter-banner"
-    aria-label="Filtres sur les participations"
+    aria-label={{t 'pages.campaign.filters.aria-label'}}
     @details={{t 'pages.campaign.filters.participations-count' count=@rowCount}}
     @clearFiltersLabel={{t 'pages.campaign.filters.actions.clear'}}
     @onClearFilters={{@resetFiltering}}
@@ -10,11 +10,11 @@
     {{#if this.displayDivisionFilter }}
       <PixMultiSelect
         @id="division"
-        @title="Classes"
-        @placeholder="Classes"
+        @title={{t 'pages.campaign.filters.type.divisions.title'}}
+        @placeholder={{t 'pages.campaign.filters.type.divisions.title'}}
         @isSearchable={{true}}
         @showOptionsOnInput={{true}}
-        @emptyMessage="Pas de classe"
+        @emptyMessage={{t 'pages.campaign.filters.type.divisions.empty'}}
         @onSelect={{this.onSelectDivision}}
         @selected={{@selectedDivisions}}
         @options={{this.divisionOptions}} as |option|
@@ -25,7 +25,7 @@
     {{#if this.displayStagesFilter }}
       <PixMultiSelect
         @id="stage"
-        @title="Paliers"
+        @title={{t 'pages.campaign.filters.type.stages'}}
         @onSelect={{this.onSelectStage}}
         @selected={{@selectedStages}}
         @options={{this.stageOptions}} as |stage|
@@ -36,7 +36,7 @@
     {{#if this.displayBadgesFilter }}
       <PixMultiSelect
         @id="badge"
-        @title="Thématiques"
+        @title={{t 'pages.campaign.filters.type.badges'}}
         @onSelect={{this.onSelectBadge}}
         @selected={{@selectedBadges}}
         @options={{this.badgeOptions}} as |badge|

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
 import sinon from 'sinon';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/assessment/list', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -67,14 +67,26 @@
         "empty": "Results pending"
       }
     },
+    "assessment-participants-list": {
+      "table": {
+        "column": {
+          "badges": "Thematic results",
+          "first-name": "First name",
+          "last-name": "Last name",
+          "results": {
+            "label": "Results",
+            "on-hold": "Pending",
+            "under-test": "Testing in progress"
+          }
+        },
+        "empty": "No participants",
+        "row-title": "Participant"
+      }
+    },
     "campaign-individual-results": {
       "campaign-name": "Name of the campaign",
       "shared-date": "Sent on",
       "start-date": "Started on"
-    },
-    "certifications": {
-      "description": "You can export the certification results for all classes in a csv file.",
-      "title": "My certifications"
     },
     "campaign": {
       "actions": {
@@ -87,7 +99,17 @@
         "actions": {
           "clear": "Clear filters"
         },
-        "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}"
+        "aria-label": "Filters on participations",
+        "participations-count": "{count, plural, =0 {0 participants} =1 {1 participant} other {{count} participants}}",
+        "title": "Filters",
+        "type": {
+          "badges": "Thematic results",
+          "divisions": {
+            "empty": "No class",
+            "title": "Class"
+          },
+          "stages": "Success rate"
+        }
       },
       "participations-count": "Participants",
       "shared-participations-count": "Profiles submitted",
@@ -132,12 +154,12 @@
     },
     "campaign-details": {
       "actions": {
-        "edit": "Edit",
         "archive": "Archive",
         "copy-link": {
           "copied": "Copied!",
           "copy": "Copy direct link"
-        }
+        },
+        "edit": "Edit"
       },
       "direct-link": "Direct link",
       "external-user-id-label": "External user ID label",
@@ -189,7 +211,7 @@
       "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following subjects, sorted by relevance ({bubble}).",
       "header": {
         "title": "Review by subject",
-        "relevance": "Relevance",  
+        "relevance": "Relevance",
         "subjects": "Subjects ({count, plural, =0 {-} other {{count}}})"
       },
       "title": "Recommendations of subjects to focus on",
@@ -199,9 +221,13 @@
         "show-tutorial": "Show all tutorials",
         "subject": "Subject",
         "tutorial-source": "By {source}",
-        "tutorial-total":"{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
+        "tutorial-total": "{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
       },
       "waiting-results": "Waiting results"
+    },
+    "certifications": {
+      "description": "You can export the certification results for all classes in a csv file.",
+      "title": "My certifications"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -67,14 +67,26 @@
         "empty": "En attente de résultats"
       }
     },
+    "assessment-participants-list": {
+      "table": {
+        "column": {
+          "badges": "Résultats Thématiques",
+          "first-name": "Nom",
+          "last-name": "Prénom",
+          "results": {
+            "label": "Résultats",
+            "on-hold": " En attente",
+            "under-test": "En cours de test"
+          }
+        },
+        "empty": "Aucun participant",
+        "row-title": "Participant"
+      }
+    },
     "campaign-individual-results": {
       "campaign-name": "Nom de la campagne",
       "shared-date": "Envoyé le",
       "start-date": "Commencé le"
-    },
-    "certifications": {
-      "description": "Vous pouvez exporter les résultats de certification de toutes les classes au format csv.",
-      "title": "Mes certifications"
     },
     "campaign": {
       "actions": {
@@ -87,7 +99,17 @@
         "actions": {
           "clear": "Effacer les filtres"
         },
-        "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}"
+        "aria-label": "Filtres sur les participations",
+        "participations-count": "{count, plural, =0 {0 participant} =1 {1 participant} other {{count} participants}}",
+        "title": "Filtres",
+        "type": {
+          "badges": "Thématiques",
+          "divisions": {
+            "empty": "Pas de classe",
+            "title": "Classes"
+          },
+          "stages": "Paliers"
+        }
       },
       "participations-count": "Participants",
       "shared-participations-count": "Profils reçus",
@@ -189,7 +211,7 @@
       "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
       "header": {
         "title": "Analyse par sujet",
-        "relevance": "Pertinence",  
+        "relevance": "Pertinence",
         "subjects": "Sujets ({count, plural, =0 {-} other {{count}}})"
       },
       "title": "Recommandation de sujets à travailler",
@@ -199,9 +221,13 @@
         "show-tutorial": "Afficher la liste des tutos",
         "subject": "Sujet",
         "tutorial-source": "Par {source}",
-        "tutorial-total":"{count, plural, =1 {1 tuto} other {{count} tutos}}"
+        "tutorial-total": "{count, plural, =1 {1 tuto} other {{count} tutos}}"
       },
       "waiting-results": "En attente de résultats"
+    },
+    "certifications": {
+      "description": "Vous pouvez exporter les résultats de certification de toutes les classes au format csv.",
+      "title": "Mes certifications"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
La page de la liste des participants d'une campagne d'évaluation n'est pas internationalisée.

## :robot: Solution
Internationaliser la page de la liste des participants d'une campagne d'évaluation

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix Orga avec un compte pro et vérifier en anglais (en ajoutant "lang=en" dans l'URL) la page de la liste des participants d'une campagne d'évaluation.