### PR TITLE
[TECH] Empêcher le reset du timer lors du refresh d'une page

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/challenge.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/challenge.feature
@@ -1,0 +1,12 @@
+#language: fr
+Fonctionnalité: Épreuve
+
+  Scénario: Je lance une démo contenant une épreuve timée
+    Étant donné que je vais sur Pix
+    Lorsque je lance le course "recKUFCoFaJD87SMi"
+    Alors je suis redirigé vers une page d'épreuve
+    Lorsque je clique sur "Commencer"
+    Alors je vois l'épreuve "Combien font 2 * 5 ?"
+    Lorsque je rafraichis ma page
+    Alors je vois que l'épreuve a déjà été répondue
+

--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -41,3 +41,7 @@ then(`j'ai bien répondu à {string}`, (challenge) => {
   cy.contains('.result-item', challenge).find('.result-item__icon svg')
     .should('have.class', 'fa-check-circle').and('have.class', 'result-item__icon--green');
 });
+
+then(`je vois que l'épreuve a déjà été répondue`, () => {
+  cy.get('.challenge-actions__already-answered').should('exist');
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/browser-events.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/browser-events.js
@@ -1,0 +1,3 @@
+when(`je rafraichis ma page`, () => {
+  cy.reload();
+});

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -1,5 +1,6 @@
 import { action } from '@ember/object';
 import { cancel, later } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import isInteger from 'lodash/isInteger';
@@ -7,6 +8,7 @@ import ENV from 'mon-pix/config/environment';
 
 export default class ChallengeItemGeneric extends Component {
 
+  @service intl;
   @tracked isValidateButtonEnabled = true;
   @tracked isSkipButtonEnabled = true;
   @tracked hasUserConfirmedWarning = false;
@@ -139,6 +141,7 @@ export default class ChallengeItemGeneric extends Component {
   _addQuitTimedChallengeListeners() {
     this._pageBeforeUnloadListener = (event) => {
       event.preventDefault();
+      event.returnValue = this.intl.t('pages.challenge.timed.page-refresh-warning');
     };
     this._pageUnloadListener = async (event) => {
       event.preventDefault();

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -30,7 +30,7 @@ export default class ChallengeItemGeneric extends Component {
 
   willDestroy() {
     super.willDestroy(...arguments);
-    this._removeEventListeners();
+    // this._removeEventListeners();
   }
 
   cancelTimer() {
@@ -126,7 +126,7 @@ export default class ChallengeItemGeneric extends Component {
       this.isSkipButtonEnabled = false;
       this._hasAnswerBeenRecorded = true;
 
-      return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout(), this._elapsedTime)
+      return await this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout(), this._elapsedTime)
         .finally(() => this.isSkipButtonEnabled = true);
     }
   }
@@ -143,14 +143,15 @@ export default class ChallengeItemGeneric extends Component {
       event.preventDefault();
       event.returnValue = this.intl.t('pages.challenge.timed.page-refresh-warning');
     };
-    this._pageUnloadListener = async (event) => {
-      event.preventDefault();
+    this._pageUnloadListener = async () => {
       if (!this._hasAnswerBeenRecorded) {
-        await this.skipChallenge();
+        setTimeout(async () => {
+          await this.skipChallenge();
+        }, 1000);
       }
     };
     window.addEventListener('beforeunload', this._pageBeforeUnloadListener);
-    window.addEventListener('unload', this._pageUnloadListener);
+    window.addEventListener('pagehide', this._pageUnloadListener);
   }
 
   _removeEventListeners() {
@@ -158,7 +159,7 @@ export default class ChallengeItemGeneric extends Component {
       window.removeEventListener('beforeunload', this._pageBeforeUnloadListener);
     }
     if (this._pageUnloadListener) {
-      window.removeEventListener('unload', this._pageUnloadListener);
+      window.removeEventListener('pagehide', this._pageUnloadListener);
     }
   }
 }

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -117,7 +117,7 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   @action
-  skipChallenge() {
+  async skipChallenge() {
     if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
       this.errorMessage = null;
       this.hasUserConfirmedWarning = false;
@@ -130,20 +130,20 @@ export default class ChallengeItemGeneric extends Component {
   }
 
   @action
-  setUserConfirmation() {
+  async setUserConfirmation() {
     this._start();
     this.hasUserConfirmedWarning = true;
-    this._addQuitTimedChallengeListeners();
+    await this._addQuitTimedChallengeListeners();
   }
 
   _addQuitTimedChallengeListeners() {
     this._pageBeforeUnloadListener = (event) => {
       event.preventDefault();
     };
-    this._pageUnloadListener = (event) => {
+    this._pageUnloadListener = async (event) => {
       event.preventDefault();
       if (!this._hasAnswerBeenRecorded) {
-        this.skipChallenge();
+        await this.skipChallenge();
       }
     };
     window.addEventListener('beforeunload', this._pageBeforeUnloadListener);

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -391,7 +391,8 @@
                 "qroc-number": "Please enter a number, or skip the question."
             },
             "timed": {
-                "cannot-answer": "You've run out of time."
+                "cannot-answer": "You've run out of time.",
+                "page-refresh-warning": ""
             }
         },
         "checkpoint": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -391,7 +391,8 @@
                 "qrocm": "Pour valider, veuillez remplir tous les champs réponse. Sinon, passez."
             },
             "timed" : {
-                "cannot-answer": "Le temps imparti est écoulé."
+                "cannot-answer": "Le temps imparti est écoulé.",
+                "page-refresh-warning": "Vous n'avez pas finalisé l'épreuve et êtes sur le point de rafraichir la page. Souhaitez-vous continuer?"
             }
         },
         "checkpoint": {


### PR DESCRIPTION
## :unicorn: Problème
Sur une épreuve timée, le temps est limitée.
Mais lorsque l'utilisateur rafraichit la page ou la quitte, le timer se reset et l'utilisateur dispose à nouveau de tout le temps nécessaire pour répondre à l'épreuve.

## :robot: Solution
1. Ajouter un listener sur l'évènement `beforeunload`: cet évènement est trigger lorsque la demande de rechargement de la page est faite. En utilisant `event.preventDefault`, on demande confirmation à l'utilisateur pour quitter la page.

2. Si l'utilisateur décide tout de même de quitter/rafraichir la page, alors l'event listener `unload` est triggered et on procède comme si l'utilisateur avait cliqué sur "Je passe".

## :rainbow: Remarques
- Je ne pense pas qu'il soit possible de customiser le message dans la popup de confirmation de quitter la page. J'ai l'impression que les navigateurs ont bloqué cette feature.

Autres pistes explorées:
- dans `router.js`, on écoutait déjà sur `routeDidChange`. Cet évènement peut prendre en paramètre la **transition** (permet savoir de quelle url on vient et vers quel url on va). Mais ça ne marche que si on navigue à l'intérieur de l'app. Si on quitte l'app, l'évènement n'est pas déclenché
- stocker un cookie contenant les épreuves timers en cours, mais les cookies peuvent être supprimés du navigateur

## :100: Pour tester

- Pour tester seulement une épreuve timée: rec1cSZ2hePondDBl.
- Pour tester dans le contexte d'une évaluation de compétence: la compétence "Gérer des données" a une épreuve timée dans ses premières questions (penser à reset la compétence).
