### PR TITLE
[TECH] Ne pas jeter d'erreur s'il n'y a pas de solution à une clé de réponse donnée

### DIFF
--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -1,6 +1,7 @@
 const jsYaml = require('js-yaml');
 const levenshtein = require('fast-levenshtein');
 const _ = require('../../infrastructure/utils/lodash-utils');
+const logger = require('../../infrastructure/logger');
 const { applyPreTreatments, applyTreatments } = require('./validation-treatments');
 
 const AnswerStatus = require('../models/AnswerStatus');
@@ -37,6 +38,9 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments) {
       results[answerKey] = _areApproximatelyEqualAccordingToLevenshteinDistanceRatio(answer, solutionVariants);
     } else if (solutionVariants) {
       results[answerKey] = solutionVariants.includes(answer);
+    }
+    if (!solutionVariants) {
+      logger.warn(`[PROBLÈME RÉPONSE ÉPREUVE] La clé ${answerKey} n'existe pas.`);
     }
   });
   return results;

--- a/api/lib/domain/services/solution-service-qrocm-ind.js
+++ b/api/lib/domain/services/solution-service-qrocm-ind.js
@@ -35,7 +35,7 @@ function _compareAnswersAndSolutions(answers, solutions, enabledTreatments) {
     const solutionVariants = solutions[answerKey];
     if (enabledTreatments.includes('t3')) {
       results[answerKey] = _areApproximatelyEqualAccordingToLevenshteinDistanceRatio(answer, solutionVariants);
-    } else {
+    } else if (solutionVariants) {
       results[answerKey] = solutionVariants.includes(answer);
     }
   });

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -76,6 +76,19 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       const expected = { 'phrase1': true, 'phrase2': true, 'phrase3': false };
       expect(actual).to.deep.equal(expected);
     });
+
+    it('should do nothing if there is no solutions for one input but answers', () => {
+      // given
+      const answers = { 'phrase1': 'Le silence est d\'ours', 'phrase2': 'facebook', 'phraseSansSolution': 'lasagne' };
+      const solutions = { 'phrase1': ['Le silence est d\'or'], 'phrase2': ['facebook'] };
+      const enabledTreatments = [];
+
+      // when
+      const result = service._compareAnswersAndSolutions(answers, solutions, enabledTreatments);
+
+      // then
+      expect(result).to.deep.equal({ 'phrase1': false, 'phrase2': true });
+    });
   });
 
   describe('#_formatResult', function() {


### PR DESCRIPTION
## :unicorn: Problème
Sentry nous a remonté l'erreur suivante : `Cannot read property 'includes' of undefined` sur un `POST /api/answers` 
(voir https://sentry.io/organizations/pix/issues/2099732854/?project=1398749&referrer=slack).

En effet, dans le code il y a : 
```
const solutionVariants = solutions[answerKey];
if (enabledTreatments.includes('t3')) {
      results[answerKey] = _areApproximatevelyEqualAccordingToLevenshteinDistanceRatio(answer, solutionVariants);
} else {
      results[answerKey] = solutionVariants.includes(answer);
}
```
Or si `solutionVariants` est vide ou non définit, ce morceau de code lancera une erreur.

## :robot: Solution
Conditionner la partie du `else` afin de ne rajouter un résultat à la question uniquement si on a une solution pour la clé choisie.

## :rainbow: Remarques
Ce petit fix n'est certainement pas la meilleure solution à l'erreur remontée par Sentry.
Pourquoi il est arrivé qu'on ait pas de solution pour une clé de réponse donnée ? 
Est-ce que c'est une faute de l'utilisateur ? Ou est-ce un autre problème ? 

## :100: Pour tester
- Lancer les tests api et constater qu'il n'y a pas de soucis
