### PR TITLE
[FEATURE] Permettre à un utilisateur connecté à app.pix.org de changer sa langue sur la page "Mon compte" (PIX-1176).

### DIFF
--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -1,8 +1,36 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class UserAccountPanel extends Component {
+  @service intl;
+  @service url;
+  @service location;
 
   get displayUsername() {
     return !!this.args.user.username;
   }
+
+  get displayLanguageSwitch() {
+    return !this.url.isFrenchDomainExtension;
+  }
+
+  @action
+  async onChangeLang(event) {
+
+    if (!this.url.isFrenchDomainExtension) {
+      this.location.replace(`/mon-compte?lang=${event.target.value}`);
+    }
+  }
+
+  options = [
+    {
+      label: this.intl.t('pages.user-account.account-panel.fields.select.labels.french'),
+      value: 'fr',
+    },
+    {
+      label: this.intl.t('pages.user-account.account-panel.fields.select.labels.english'),
+      value: 'en',
+    },
+  ];
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -16,6 +16,7 @@ export default Route.extend(ApplicationRouteMixin, {
   moment: service(),
   headData: service(),
   featureToggles: service(),
+  currentDomain: service(),
 
   activate() {
     this.splash.hide();
@@ -72,14 +73,23 @@ export default Route.extend(ApplicationRouteMixin, {
 
   async _handleLanguage(locale = null) {
 
+    const isUserConnected = this.session.isAuthenticated;
+    const domain = this.currentDomain.getExtension();
     const defaultLocale = 'fr';
 
-    if (locale && this.currentUser.user) {
-      this.currentUser.user.lang = locale;
-      await this.currentUser.user.save({ adapterOptions: { lang: locale } });
-      await this._setLocale(this.currentUser.user.lang, defaultLocale);
-    } else if (this.currentUser.user) {
-      await this._setLocale(this.currentUser.user.lang, defaultLocale);
+    if (domain === 'fr') {
+      await this._setLocale(defaultLocale, defaultLocale);
+      return;
+    }
+
+    if (isUserConnected) {
+      if (locale) {
+        this.currentUser.user.lang = locale;
+        await this.currentUser.user.save({ adapterOptions: { lang: locale } });
+        await this._setLocale(locale, defaultLocale);
+      } else {
+        await this._setLocale(this.currentUser.user.lang, defaultLocale);
+      }
     } else {
       await this._setLocale(locale, defaultLocale);
     }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -43,10 +43,10 @@ export default Route.extend(ApplicationRouteMixin, {
 
     await this.featureToggles.load().catch();
 
-    const lang = transition.to.queryParams.lang;
+    const locale = transition.to.queryParams.lang;
 
     await this._loadCurrentUser();
-    await this._handleLanguage(lang);
+    await this._handleLanguage(locale);
   },
 
   async sessionAuthenticated() {
@@ -70,21 +70,22 @@ export default Route.extend(ApplicationRouteMixin, {
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
   sessionInvalidated() {},
 
-  async _handleLanguage(lang = null) {
+  async _handleLanguage(locale = null) {
 
-    if (lang && this.currentUser.user) {
-      this.currentUser.user.lang = lang;
-      await this.currentUser.user.save({ adapterOptions: { lang } });
+    const defaultLocale = 'fr';
+
+    if (locale && this.currentUser.user) {
+      this.currentUser.user.lang = locale;
+      await this.currentUser.user.save({ adapterOptions: { lang: locale } });
+      await this._setLocale(this.currentUser.user.lang, defaultLocale);
+    } else if (this.currentUser.user) {
+      await this._setLocale(this.currentUser.user.lang, defaultLocale);
+    } else {
+      await this._setLocale(locale, defaultLocale);
     }
-    await this._setLocale(lang);
   },
 
-  _setLocale(lang = null) {
-    const defaultLocale = 'fr';
-    let locale = lang || defaultLocale;
-    if (this.currentUser.user) {
-      locale = this.currentUser.user.lang || defaultLocale;
-    }
+  _setLocale(locale, defaultLocale) {
     this.intl.setLocale([locale, defaultLocale]);
     this.moment.setLocale(locale);
   },
@@ -99,5 +100,4 @@ export default Route.extend(ApplicationRouteMixin, {
     delete this.session.data.externalUser;
     return this.session.invalidate();
   },
-
 });

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -44,12 +44,16 @@ export default Route.extend(ApplicationRouteMixin, {
     await this.featureToggles.load().catch();
 
     const lang = transition.to.queryParams.lang;
-    return this._getUserAndLocal(lang);
+
+    await this._loadCurrentUser();
+    await this._handleLanguage(lang);
   },
 
   async sessionAuthenticated() {
     const _super = this._super;
-    await this._getUserAndLocal();
+
+    await this._loadCurrentUser();
+    await this._handleLanguage();
 
     const nextURL = this.session.data.nextURL;
     if (nextURL && get(this.session, 'data.authenticated.source') === 'pole_emploi_connect') {
@@ -66,14 +70,13 @@ export default Route.extend(ApplicationRouteMixin, {
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
   sessionInvalidated() {},
 
-  async _getUserAndLocal(lang = null) {
-    const currentUser = await this._loadCurrentUser();
+  async _handleLanguage(lang = null) {
+
     if (lang && this.currentUser.user) {
       this.currentUser.user.lang = lang;
       await this.currentUser.user.save({ adapterOptions: { lang } });
     }
     await this._setLocale(lang);
-    return currentUser;
   },
 
   _setLocale(lang = null) {

--- a/mon-pix/app/styles/components/_user-account-panel.scss
+++ b/mon-pix/app/styles/components/_user-account-panel.scss
@@ -18,6 +18,8 @@
 
   &__label {
     min-width: 200px;
+    display: flex;
+    align-items: center;
   }
 
   &__value {
@@ -30,8 +32,14 @@
     color: $blue;
     padding: 0 20px;
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
       background-color: transparent;
     }
+  }
+
+  &__select {
+    width: 165px;
   }
 }

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -36,11 +36,36 @@
 
 .user-account-update-email-actions {
 
-  &__button {
+  &__cancel-button {
+    min-width: 120px;
+
+    &:hover {
+      border-color: $grey-90;
+      background-color: $grey-10;
+    }
+
+    &:active {
+      border-color: $grey-90;
+      background-color: $grey-20;
+    }
+  }
+
+  &__confirm-button {
     min-width: 120px;
   }
 }
 
 abbr.mandatory-mark {
   text-decoration: none;
+}
+
+.confirm-button-enabled {
+
+  &:hover {
+    background-color: $blue-hover;
+  }
+
+  &:active {
+    background-color: darken($blue, 8%);
+  }
 }

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -23,4 +23,18 @@
     <span class="user-account-panel-item__value" data-test-username>{{@user.username}}</span>
   </div>
   {{/if}}
+  {{#if this.displayLanguageSwitch}}
+    <div class="user-account-panel__item">
+      <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.lang'}}</span>
+        <div class="user-account-panel-item__select">
+          <PixSelect
+            class="user-account-panel-item__value"
+            @options={{this.options}}
+            @onChange={{this.onChangeLang}}
+            @selectedOption={{@user.lang}}
+            data-test-lang
+          />
+        </div>
+    </div>
+  {{/if}}
 </PixBlock>

--- a/mon-pix/app/templates/components/user-account-update-email.hbs
+++ b/mon-pix/app/templates/components/user-account-update-email.hbs
@@ -45,7 +45,7 @@
         {{/if}}
         <div class="user-account-update-email__actions">
           <PixButton
-                  class="user-account-update-email-actions__button"
+                  class="user-account-update-email-actions__cancel-button"
                   @type="button"
                   @triggerAction={{@disableEmailEditionMode}}
                   @backgroundColor="transparent"
@@ -53,7 +53,7 @@
           {{t 'common.actions.cancel'}}
           </PixButton>
           <PixButton
-                  class="user-account-update-email-actions__button"
+                  class="user-account-update-email-actions__confirm-button {{if this.isFormValid 'confirm-button-enabled'}}"
                   @type="submit"
                   @isDisabled={{not this.isFormValid}}
                   @triggerAction={{this.onSubmit}}

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -27,6 +27,7 @@ module.exports = function() {
       'thumbs-up',
       'times',
       'times-circle',
+      'chevron-down',
     ],
     'free-regular-svg-icons': [
       'bookmark',

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -33155,6 +33155,68 @@
         }
       }
     },
+    "ember-test-selectors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-5.0.0.tgz",
+      "integrity": "sha512-hqAPqyJLEGBYcQ9phOKvHhSCyvcSbUL8Yj2si8OASsQWxwRqbxrtk5YlkN2aZiZdp9PAd2wErS8uClG0U7tNpA==",
+      "dev": true,
+      "requires": {
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-cli-babel": "^7.22.1",
+        "ember-cli-version-checker": "^5.1.1"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz",
+          "integrity": "sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^3.1.0",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "is-core-module": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+          "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-3.1.0.tgz",
+          "integrity": "sha512-2oC2EjWbMJwvSN6Z7DbDfJMnD8MYEouaLn5eIX0j8XwPsYCVIyY9bbnX88YHVkbr8XHqvZrYbxaLPibfTYKZMA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.17.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "ember-test-waiters": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ember-test-waiters/-/ember-test-waiters-1.1.1.tgz",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -99,6 +99,7 @@
     "ember-sinon": "^5.0.0",
     "ember-source": "^3.23.1",
     "ember-template-lint": "^2.15.0",
+    "ember-test-selectors": "^5.0.0",
     "ember-truth-helpers": "^3.0.0",
     "eslint": "^7.15.0",
     "eslint-plugin-ember": "^10.0.2",

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
@@ -16,8 +17,16 @@ describe('Integration | Component | User account panel', () => {
       lastName: 'DOE',
       email: 'john.doe@example.net',
       username: 'john.doe0101',
+      lang: 'fr',
     };
     this.set('user', user);
+
+    class UrlStub extends Service {
+      get isFrenchDomainExtension() {
+        return false;
+      }
+    }
+    this.owner.register('service:url', UrlStub);
 
     // when
     await render(hbs`<UserAccountPanel @user={{this.user}} />`);
@@ -27,6 +36,7 @@ describe('Integration | Component | User account panel', () => {
     expect(find('span[data-test-lastName]').textContent).to.include(user.lastName);
     expect(find('span[data-test-email]').textContent).to.include(user.email);
     expect(find('span[data-test-username]').textContent).to.include(user.username);
+    expect(find('select[data-test-lang] > option[selected]').textContent).to.include('Français');
   });
 
   it('should call Enable Email Edition method', async function() {
@@ -54,6 +64,50 @@ describe('Integration | Component | User account panel', () => {
 
       // then
       expect(find('span[data-test-username]')).to.not.exist;
+    });
+  });
+
+  context('when domain is pix.fr', function() {
+
+    it('should not display language selector', async function() {
+      // given
+      const user = {};
+
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return true;
+        }
+      }
+      this.set('user', user);
+      this.owner.register('service:url', UrlStub);
+
+      // when
+      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+
+      // then
+      expect(find('select[data-test-lang]')).to.not.exist;
+    });
+  });
+
+  context('when domain is pix.org', function() {
+
+    it('should display language selector', async function() {
+      // given
+      const user = {};
+
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return false;
+        }
+      }
+      this.set('user', user);
+      this.owner.register('service:url', UrlStub);
+
+      // when
+      await render(hbs`<UserAccountPanel @user={{this.user}} />`);
+
+      // then
+      expect(find('select[data-test-lang]')).to.exist;
     });
   });
 });

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -49,7 +49,7 @@ describe('Unit | Route | application', function() {
     expect(currentUserStub.called).to.be.true;
   });
 
-  describe('#_getUserAndLocal', function() {
+  describe('#_handleLanguage', function() {
     it('should set locales from users', async function() {
       // given
       const user = {
@@ -66,7 +66,7 @@ describe('Unit | Route | application', function() {
       route.set('intl', intlStub);
 
       // when
-      await route._getUserAndLocal();
+      await route._handleLanguage();
 
       // then
       sinon.assert.called(setLocaleStub);
@@ -92,7 +92,7 @@ describe('Unit | Route | application', function() {
       route.set('intl', intlStub);
 
       // when
-      await route._getUserAndLocal('en');
+      await route._handleLanguage('en');
 
       // then
       sinon.assert.called(saveStub);

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -3,7 +3,7 @@
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { beforeEach, describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import sinon from 'sinon';
 
@@ -49,54 +49,182 @@ describe('Unit | Route | application', function() {
     expect(currentUserStub.called).to.be.true;
   });
 
-  describe('#_handleLanguage', function() {
-    it('should set locales from users', async function() {
-      // given
-      const user = {
-        lang: 'en',
-      };
-      const load = sinon.stub().resolves(user);
-      const currentUserStub = Service.create({ load, user });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+  describe('#__handleLanguage', function() {
+
+    let intlSetLocaleStub;
+    let momentSetLocaleStub;
+    let intlStub;
+    let momentStub;
+    let route;
+
+    beforeEach(function() {
+      intlSetLocaleStub = sinon.stub();
+      momentSetLocaleStub = sinon.stub();
+
+      intlStub = Service.create({
+        setLocale: intlSetLocaleStub,
       });
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
+      momentStub = Service.create({
+        setLocale: momentSetLocaleStub,
+      });
+
+      route = this.owner.lookup('route:application');
       route.set('intl', intlStub);
-
-      // when
-      await route._handleLanguage();
-
-      // then
-      sinon.assert.called(setLocaleStub);
-      sinon.assert.calledWith(setLocaleStub, ['en', 'fr']);
+      route.set('moment', momentStub);
     });
 
-    it('should update users when there is a params', async function() {
-      // given
-      const saveStub = sinon.stub().resolves();
+    describe('when user is not connected', function() {
 
-      const user = {
-        lang: 'en',
-        save: saveStub,
-      };
-      const loadStub = sinon.stub().resolves(user);
-      const currentUserStub = Service.create({ load: loadStub, user });
-      const setLocaleStub = sinon.stub();
-      const intlStub = Service.create({
-        setLocale: setLocaleStub,
+      describe('when domain is pix.org', function() {
+
+        it('should update locale', async function() {
+          // given
+          route.set('currentDomain', { getExtension() { return 'org'; } });
+
+          // when
+          await route._handleLanguage('en');
+
+          // then
+          sinon.assert.called(intlSetLocaleStub);
+          sinon.assert.called(momentSetLocaleStub);
+          sinon.assert.calledWith(intlSetLocaleStub, ['en', 'fr']);
+          sinon.assert.calledWith(momentSetLocaleStub, 'en');
+        });
+
+        it('should ignore locale switch when is neither "fr" nor "en"', async function() {
+          // given
+          route.set('currentDomain', { getExtension() { return 'org'; } });
+
+          // when
+          await route._handleLanguage('bouh');
+
+          // then
+          sinon.assert.called(intlSetLocaleStub);
+          sinon.assert.called(momentSetLocaleStub);
+          sinon.assert.calledWith(intlSetLocaleStub, ['bouh', 'fr']);
+        });
       });
-      const route = this.owner.lookup('route:application');
-      route.set('currentUser', currentUserStub);
-      route.set('intl', intlStub);
 
-      // when
-      await route._handleLanguage('en');
+      describe('when domain is pix.fr', function() {
 
-      // then
-      sinon.assert.called(saveStub);
-      sinon.assert.calledWith(saveStub, { adapterOptions: { lang: 'en' } });
+        it('should keep locale in "fr"', async function() {
+          // given
+          route.set('currentDomain', { getExtension() { return 'fr'; } });
+
+          // when
+          await route._handleLanguage('en');
+
+          // then
+          sinon.assert.called(intlSetLocaleStub);
+          sinon.assert.called(momentSetLocaleStub);
+          sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
+          sinon.assert.calledWith(momentSetLocaleStub, 'fr');
+        });
+      });
+    });
+
+    describe('when user is connected', function() {
+
+      describe('when domain is pix.org', function() {
+
+        it('should set locale from user', async function() {
+          // given
+          const user = {
+            lang: 'fr',
+          };
+          const load = sinon.stub().resolves(user);
+          const currentUserStub = Service.create({ load, user });
+
+          route.set('session', { isAuthenticated: true });
+          route.set('currentUser', currentUserStub);
+          route.set('currentDomain', { getExtension() { return 'org'; } });
+
+          // when
+          await route._handleLanguage();
+
+          // then
+          sinon.assert.called(intlSetLocaleStub);
+          sinon.assert.called(momentSetLocaleStub);
+          sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
+          sinon.assert.calledWith(momentSetLocaleStub, 'fr');
+        });
+
+        describe('when user change locale', function() {
+
+          it('should save user locale', async function() {
+            // given
+            const saveStub = sinon.stub().resolves();
+
+            const user = {
+              lang: 'fr',
+              save: saveStub,
+            };
+            const loadStub = sinon.stub().resolves(user);
+            const currentUserStub = Service.create({ load: loadStub, user });
+
+            route.set('session', { isAuthenticated: true });
+            route.set('currentUser', currentUserStub);
+            route.set('currentDomain', { getExtension() { return 'org'; } });
+
+            // when
+            await route._handleLanguage('en');
+
+            // then
+            sinon.assert.called(saveStub);
+            sinon.assert.calledWith(saveStub, { adapterOptions: { lang: 'en' } });
+          });
+        });
+      });
+
+      describe('when domain is pix.fr', function() {
+
+        it('should ignore locale from user', async function() {
+          // given
+          const user = {
+            lang: 'en',
+          };
+          const load = sinon.stub().resolves(user);
+          const currentUserStub = Service.create({ load, user });
+
+          route.set('session', { isAuthenticated: true });
+          route.set('currentUser', currentUserStub);
+          route.set('currentDomain', { getExtension() { return 'fr'; } });
+
+          // when
+          await route._handleLanguage();
+
+          // then
+          sinon.assert.called(intlSetLocaleStub);
+          sinon.assert.called(momentSetLocaleStub);
+          sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
+          sinon.assert.calledWith(momentSetLocaleStub, 'fr');
+        });
+
+        describe('when user change locale', function() {
+
+          it('should not save user locale', async function() {
+            // given
+            const saveStub = sinon.stub().resolves();
+
+            const user = {
+              lang: 'fr',
+              save: saveStub,
+            };
+            const loadStub = sinon.stub().resolves(user);
+            const currentUserStub = Service.create({ load: loadStub, user });
+
+            route.set('session', { isAuthenticated: true });
+            route.set('currentUser', currentUserStub);
+            route.set('currentDomain', { getExtension() { return 'fr'; } });
+
+            // when
+            await route._handleLanguage('en');
+
+            // then
+            sinon.assert.notCalled(saveStub);
+          });
+        });
+      });
     });
   });
 });

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -173,6 +173,30 @@ describe('Unit | Route | application', function() {
             sinon.assert.called(saveStub);
             sinon.assert.calledWith(saveStub, { adapterOptions: { lang: 'en' } });
           });
+
+          it('should ignore locale switch when is neither "fr" nor "en"', async function() {
+            // given
+            const saveStub = sinon.stub().rejects({ errors: [{ status: '400' }] });
+            const rollbackAttributesStub = sinon.stub().resolves();
+
+            const user = {
+              lang: 'fr',
+              save: saveStub,
+              rollbackAttributes: rollbackAttributesStub,
+            };
+            const loadStub = sinon.stub().resolves(user);
+            const currentUserStub = Service.create({ load: loadStub, user });
+
+            route.set('session', { isAuthenticated: true });
+            route.set('currentUser', currentUserStub);
+            route.set('currentDomain', { getExtension() { return 'org'; } });
+
+            // when
+            await route._handleLanguage('bouh');
+
+            // then
+            sinon.assert.called(rollbackAttributesStub);
+          });
         });
       });
 

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -98,7 +98,5 @@ describe('Unit | Route | application', function() {
       sinon.assert.called(saveStub);
       sinon.assert.calledWith(saveStub, { adapterOptions: { lang: 'en' } });
     });
-
   });
-
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -949,7 +949,16 @@
                 "last-name": "Last name",
                 "email": "Email address",
                 "username": "Username",
-                "edit-button": "Edit"
+                "lang": "",
+                "edit-button": "Edit",
+                "fields": {
+                    "select": {
+                        "labels": {
+                            "french": "French",
+                            "english": "English"
+                        }
+                    }
+                }
             },
             "account-update-email": {
                 "title": "",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -949,7 +949,16 @@
                 "last-name": "Nom",
                 "email": "Adresse e-mail",
                 "username": "Identifiant",
-                "edit-button": "Modifier"
+                "lang": "Langues",
+                "edit-button": "Modifier",
+                "fields": {
+                    "select": {
+                        "labels": {
+                            "french": "Français",
+                            "english": "Anglais"
+                        }
+                    }
+                }
             },
             "account-update-email": {
                 "title": "Modification de votre adresse e-mail",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement sur Pix App, sauf s'il ajoute ou modifie le `?lang=` dans son url, un utilisateur ne peut pas changer sa langue. 
On souhaite qu'il puisse le faire via sa page "Mon compte" mais uniquement lorsqu'il est connecté sur app.pix.org.

On souhaite également empêcher un utilisateur connecté à app.pix.fr de changer sa langue via l'url et de rester en français.

## :robot: Solution

- Ajout d'un sélecteur pour choisir entre la langue française et anglaise (ce sélecteur n'est visible que sur pix.org)
- Modification de la gestion du langage en fonction du domaine sur lequel l'utilisateur se trouve ( app.pix.fr ou app.pix.org)

## :rainbow: Remarques

- Gestion du cas ou l'utilisateur entre une autre langue que `fr` ou `en` dans son url (exemple: `?lang=pt` )
- Ajout de l'effet hover sur les boutons présent dans la page de modification de l'adresse e-mail

## :100: Pour tester
**Commencer sur le domaine ORG :** 

Sur la page de connexion : 

- ajouter `connexion?lang=en` et s'assurer que la page est en anglais.
- ajouter `connexion?lang=fr`,  la page est en français.
- ajouter `connexion?lang=hello`, la page est en français (par défaut).

Se connecter (sco.admin@example.net) : 

- ajouter `profil?lang=en`, la page est en anglais (et la langue de l'utilisateur est en `en` également _(ember>data)_).
- ajouter `profil?lang=fr`,  la page est en français (et la langue de l'utilisateur est en `fr`).
- ajouter `profil?lang=hello`, selon si vous étiez en anglais ou français, la page reste dans la même langue (pas de modification coté user, sa langue est inchangée).
- modifier la langue via le sélecteur dans la page `/mon-compte`

_(assurez-vous d'avoir sco.admin@example.net avec `en` comme langue enregistrée avant de passer sur le domaine FR, afin de vérifier que l'on ignore la langue actuellement enregistrée)_

**Sur le domaine FR :** 

Sur la page de connexion :
 
ajouter `connexion?lang=en` et s'assurer que la page reste en français.
ajouter `connexion?lang=hello`, la page reste en français.

Se connecter (sco.admin@example.net) : 

- s'assurer que vous êtes en français (on ignore la langue enregistré coté user, on impose le français)
- ajouter `profil?lang=en`puis `profil?lang=hello`, la page reste en français.
- s'assurer que le sélecteur ne soit pas visible dans la page `/mon-compte`
