### PR TITLE
[FEATURE] Traduction de la page de résultats collectifs d’une campagne d'évaluation (PIX-2145).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
+++ b/orga/app/components/routes/authenticated/campaign/collective-results/tab.hbs
@@ -2,13 +2,13 @@
 
   <div class="participant-results-content__summary">
     <div class="participant-content participant-content--large participant-content--wide">
-      <div class="label-text participant-content__label-text">Acquis validés</div>
+      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.validated-items'}}</div>
       <div class="content-text content-text--big">
         {{ @campaignCollectiveResult.averageValidatedSkillsSum }}
       </div>
     </div>
     <div class="participant-content participant-content--large participant-content--wide">
-      <div class="label-text participant-content__label-text">Acquis évalués</div>
+      <div class="label-text participant-content__label-text">{{t 'pages.campaign-collective-results.table.column.tested-items'}}</div>
       <div class="content-text content-text--big">
         {{ @campaignCollectiveResult.totalSkills }}
       </div>
@@ -16,8 +16,8 @@
   </div>
 
   <div class="participant-content participant-results-content">
-    <div aria-label="Moyenne des résultats" class="participant-results-content__score">
-      <div class="content-text content-text--big content-text--bold">Résultat</div>
+    <div aria-label={{t 'pages.campaign-collective-results.average'}} class="participant-results-content__score">
+      <div class="content-text content-text--big content-text--bold">{{t 'pages.campaign-collective-results.table.column.results'}}</div>
       <div class="participant-results-content__circle-chart">
         <CircleChart @value={{@campaignCollectiveResult.averageResult}}>
           <span class="participant-results-content__circle-chart-value">
@@ -32,13 +32,13 @@
 <div class="panel panel--light-shadow participant-results__details content-text content-text--small">
 
 
-  <table aria-label="Résultats collectifs par compétence">
+  <table aria-label={{t 'pages.campaign-collective-results.table.title'}}>
     <thead>
     <tr>
-      <th class="table__column--wide">Compétences ({{if @sharedParticipationsCount @campaignCollectiveResult.campaignCompetenceCollectiveResults.length '-' }})</th>
-      <th class="table__column--wide">Résultats</th>
-      <th class="table__column--small">Acquis validés</th>
-      <th class="table__column--small">Acquis évalués</th>
+      <th class="table__column--wide">{{this.campaignCollectiveResultLabel}}</th>
+      <th class="table__column--wide">{{t 'pages.campaign-collective-results.table.column.results'}}</th>
+      <th class="table__column--small">{{t 'pages.campaign-collective-results.table.column.validated-items'}}</th>
+      <th class="table__column--small">{{t 'pages.campaign-collective-results.table.column.tested-items'}}</th>
     </tr>
     </thead>
 
@@ -46,7 +46,7 @@
 
       <tbody>
       {{#each @campaignCollectiveResult.campaignCompetenceCollectiveResults as |competenceResult|}}
-        <tr aria-label="Compétence">
+        <tr aria-label={{t 'pages.campaign-collective-results.table.row-title'}}>
           <td class="competences-col__name">
             <span class="competences-col__border competences-col__border--{{competenceResult.areaColor}}"></span>
             <span>
@@ -67,7 +67,7 @@
   </table>
 
   {{#unless @sharedParticipationsCount }}
-    <div class="table__empty content-text">En attente de résultats</div>
+    <div class="table__empty content-text">{{t 'pages.campaign-collective-results.table.empty'}}</div>
   {{/unless}}
 
 </div>

--- a/orga/app/components/routes/authenticated/campaign/collective-results/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/collective-results/tab.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { htmlSafe } from '@ember/string';
+
+export default class Tab extends Component {
+  @service intl;
+
+  get campaignCollectiveResultLabel() {
+    return htmlSafe(this.intl.t('pages.campaign-collective-results.table.column.competences',
+      { count: this.args.sharedParticipationsCount ? this.args.campaignCollectiveResult.get('campaignCompetenceCollectiveResults').length : '-' },
+    ));
+  }
+}

--- a/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/collective-results/tab', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   let store;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -120,6 +120,20 @@
         "review": "Review"
       }
     },
+    "campaign-collective-results": {
+      "average": "Average results",
+      "table": {
+        "column": {
+          "competences": "Skills ({count})",
+          "results": "Results",
+          "tested-items": "Items tested",
+          "validated-items": "Items successfully completed"
+        },
+        "empty": "Results pending",
+        "row-title": "Skill",
+        "title": "Collective results by skill"
+      }
+    },
     "campaign-creation": {
       "actions": {
         "create": "Create a campaign"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -120,6 +120,20 @@
         "review": "Analyse"
       }
     },
+    "campaign-collective-results": {
+      "average": "Moyenne des résultats",
+      "table": {
+        "column": {
+          "competences": "Compétences ({count})",
+          "results": "Résultat",
+          "tested-items": "Acquis évalués",
+          "validated-items": "Acquis validés"
+        },
+        "empty": "En attente de résultats",
+        "row-title": "Compétence",
+        "title": "Résultats collectifs par compétence"
+      }
+    },
     "campaign-creation": {
       "actions": {
         "create": "Créer la campagne"


### PR DESCRIPTION
## :unicorn: Problème
La page de résultats collectifs d’une campagne n'est pas internationalisée.

## :robot: Solution
Internationaliser de la page de résultats collectifs d’une campagne

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix Orga avec un compte pro et vérifier en anglais (en ajoutant "lang=en" dans l'URL) la page de résultats collectifs d’une campagne et vérifier si le contenu de la page est correctement affiché en fonction de la langue choisie