### PR TITLE
[TECH] Récupération de la dernière release du référentiel chaque jour.

### DIFF
--- a/api/lib/infrastructure/lcms.js
+++ b/api/lib/infrastructure/lcms.js
@@ -3,10 +3,10 @@ const { lcms } = require('../config');
 
 module.exports = {
   async getCurrentContent() {
-    const response = await axios.get('/current-content', {
+    const response = await axios.get('/releases/latest', {
       baseURL: lcms.url,
       headers: { Authorization: `Bearer ${lcms.apiKey}` },
     });
-    return response.data;
+    return response.data.content;
   },
 };

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -150,9 +150,9 @@ chai.use(function(chai) {
 
 function mockLearningContent(learningContent) {
   nock('https://lcms-test.pix.fr/api')
-    .get('/current-content')
+    .get('/releases/latest')
     .matchHeader('Authorization', 'Bearer test-api-key')
-    .reply(200, learningContent);
+    .reply(200, { content: learningContent });
 }
 
 module.exports = {

--- a/api/tests/unit/infrastructure/lcms_test.js
+++ b/api/tests/unit/infrastructure/lcms_test.js
@@ -5,10 +5,10 @@ const lcms = require('../../../lib/infrastructure/lcms');
 describe('Unit | Infrastructure | LCMS', () => {
   describe('#getCurrentContent', () => {
 
-    it('calls LCMS API to get learning content release', async () => {
+    it('calls LCMS API to get learning content latest release', async () => {
       // given
       const lcmsCall = nock('https://lcms-test.pix.fr/api')
-        .get('/current-content')
+        .get('/releases/latest')
         .matchHeader('Authorization', 'Bearer test-api-key')
         .reply(200);
 
@@ -23,9 +23,9 @@ describe('Unit | Infrastructure | LCMS', () => {
       // given
       const learningContent = { models: [{ id: 'recId' }] };
       nock('https://lcms-test.pix.fr/api')
-        .get('/current-content')
+        .get('/releases/latest')
         .matchHeader('Authorization', 'Bearer test-api-key')
-        .reply(200, learningContent);
+        .reply(200, { content: learningContent });
 
       // when
       const response = await lcms.getCurrentContent();
@@ -37,7 +37,7 @@ describe('Unit | Infrastructure | LCMS', () => {
     it('rejects when learning content release failed to get', async () => {
       // given
       nock('https://lcms-test.pix.fr/api')
-        .get('/current-content')
+        .get('/releases/latest')
         .matchHeader('Authorization', 'Bearer test-api-key')
         .reply(500);
 


### PR DESCRIPTION
## :unicorn: Problème
La création de release quotidienne est désormais réalisée par l'API LCMS (avec la PR https://github.com/1024pix/pix-editor/pull/111).
Il n'est plus nécessaire de demander le dernier contenu, mais plutôt de récupérer la dernière release disponible.

## :robot: Solution
Utiliser la route `GET /api/releases/latest` pour récupérer le contenu de la release quotidienne.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se connecter à PIX-Admin, recharger le cache et vérifier que celui-ci est bien mis à jour en utilisant la route `/api/releases/latest`.