### PR TITLE
[FEATURE] Traduction de la page de la liste des participants d’une campagne de collecte de profils (PIX-2200).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -11,22 +11,22 @@
     <table>
       <thead>
         <tr>
-          <th>Nom</th>
-          <th>Prénom</th>
+          <th>{{t 'pages.profiles-list.table.column.first-name'}}</th>
+          <th>{{t 'pages.profiles-list.table.column.last-name'}}</th>
           {{#if @campaign.idPixLabel}}
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}
-          <th class="table__column--center">date d’envoi</th>
-          <th class="table__column--center">Score Pix</th>
-          <th class="table__column--center">Certifiable</th>
-          <th class="table__column--center">Comp. certifiables</th>
+          <th class="table__column--center">{{t 'pages.profiles-list.table.column.sending-date.label'}}</th>
+          <th class="table__column--center">{{t 'pages.profiles-list.table.column.pix-score'}}</th>
+          <th class="table__column--center">{{t 'pages.profiles-list.table.column.certifiable'}}</th>
+          <th class="table__column--center">{{t 'pages.profiles-list.table.column.competences-certifiables'}}</th>
         </tr>
       </thead>
 
       {{#if @profiles}}
         <tbody>
         {{#each @profiles as |profile|}}
-          <tr aria-label="Profil" role="button" {{on 'click' (fn @goToProfilePage @campaign.id profile.id)}} class="tr--clickable">
+          <tr aria-label={{t 'pages.profiles-list.table.row-title'}} role="button" {{on 'click' (fn @goToProfilePage @campaign.id profile.id)}} class="tr--clickable">
             <td>{{profile.lastName}}</td>
             <td>{{profile.firstName}}</td>
             {{#if @campaign.idPixLabel}}
@@ -36,7 +36,7 @@
               {{#if profile.sharedAt }}
                 {{moment-format profile.sharedAt 'DD/MM/YYYY'}}
               {{else}}
-                <span class="table__column--highlight">En attente</span>
+                <span class="table__column--highlight">{{t 'pages.profiles-list.table.column.sending-date.on-hold'}}</span>
               {{/if}}
             </td>
             <td class="table__column--center">
@@ -48,7 +48,7 @@
             </td>
             <td class="table__column--center">
               {{#if profile.certifiable }}
-                <PixTag @color="green-light">Certifiable</PixTag>
+                <PixTag @color="green-light">{{t 'pages.profiles-list.table.column.certifiable'}}</PixTag>
               {{/if}}
             </td>
             <td class="table__column--center">
@@ -61,7 +61,7 @@
     </table>
 
     {{#unless @profiles}}
-      <div class="table__empty content-text">En attente de profils</div>
+      <div class="table__empty content-text">{{t 'pages.profiles-list.table.empty'}}</div>
     {{/unless}}
   </div>
 </div>

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
@@ -1,12 +1,13 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Integration | Component | routes/authenticated/campaign/profile/list', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
+
   const goToProfilePage = () => {};
   let store;
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -181,6 +181,23 @@
       "personalised-test-title": "Title of the personalised test",
       "target-profile": "Target profile"
     },
+    "profiles-list": {
+      "table": {
+        "column": {
+          "certifiable": "Eligible for certification",
+          "competences-certifiables": "Skills eligible for certification",
+          "first-name": "First name",
+          "last-name": "Last name",
+          "pix-score": "Pix score",
+          "sending-date": {
+            "label": "Sending date",
+            "on-hold": "Pending"
+          }
+        },
+        "empty": "Waiting for profiles",
+        "row-title": "Profile"
+      }
+    },
     "campaigns-list": {
       "action": {
         "archived": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -181,6 +181,23 @@
       "personalised-test-title": "Titre du parcours",
       "target-profile": "Profil cible"
     },
+    "profiles-list": {
+      "table": {
+        "column": {
+          "certifiable": "Certifiable",
+          "competences-certifiables": "Comp. certifiables",
+          "first-name": "Nom",
+          "last-name": "Prénom",
+          "pix-score": "Score Pix",
+          "sending-date": {
+            "label": "Date d'envoi",
+            "on-hold": "En attente"
+          }
+        },
+        "empty": "En attente de profils",
+        "row-title": "Profil"
+      }
+    },
     "campaigns-list": {
       "action": {
         "archived": {


### PR DESCRIPTION
## :unicorn: Problème
La page de la liste des participants d’une campagne de collecte n'est pas internationalisée.

## :robot: Solution
Internationaliser La page de la liste des participants d’une campagne

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix Orga avec un compte pro et vérifier en anglais (en ajoutant "lang=en" dans l'URL) la page de la liste des participants d’une campagne de collecte et vérifier si le contenu de la page est correctement affiché en fonction de la langue choisie