### PR TITLE
[FEATURE] Ne pas afficher "Envoyé le" lorsque que la campagne n'est pas partagé ( PIX-2149)

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -37,16 +37,14 @@
             </div>
           </li>
         {{/unless}}
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.shared-date'}}</div>
-          {{#if @campaignAssessmentParticipation.sharedAt}}
-            <div class="value-text panel-header-data-content__value">
-              {{moment-format @campaignAssessmentParticipation.sharedAt 'DD MMM YYYY'}}
-            </div>
-          {{else}}
-            <div class="value-text panel-header-data-content__value">{{t 'pages.campaign-individual-results.not-shared'}}</div>
-          {{/if}}
-        </li>
+        {{#if @campaignAssessmentParticipation.isShared }}
+          <li class="panel-header-data__content">
+            <div class="label-text panel-header-data-content__label">{{t 'pages.campaign-individual-results.shared-date'}}</div>
+              <div class="value-text panel-header-data-content__value">
+                {{moment-format @campaignAssessmentParticipation.sharedAt 'DD MMM YYYY'}}
+              </div>
+          </li>
+        {{/if}}
       </ul>
 
       {{#if @campaignAssessmentParticipation.isShared}}

--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -32,14 +32,12 @@
           <div class="label-text panel-header-data-content__label">Commencé le</div>
           <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</div>
         </li>
-        <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">Envoyé le</div>
-          {{#if @campaignProfile.sharedAt}}
-            <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
-          {{else}}
-            <div class="value-text panel-header-data-content__value">Non disponible</div>
-          {{/if}}
-        </li>
+        {{#if @campaignProfile.isShared}}
+          <li class="panel-header-data__content">
+            <div class="label-text panel-header-data-content__label">Envoyé le</div>
+              <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
+          </li>
+        {{/if}}
       </ul>
 
       {{#if @campaignProfile.isShared}}

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
@@ -80,10 +80,11 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
     assert.dom(`a[href="/campagnes/${campaign.id}/evaluations/${campaignAssessmentParticipation.id}/analyse"]`).hasText('Analyse');
   });
 
-  module('shared at', function() {
-    module('when the sharing date is present', function() {
+  module('is shared', function() {
+    module('when participant has shared results', function() {
       test('it displays the sharing date', async function(assert) {
         const campaignAssessmentParticipation = {
+          isShared: true,
           sharedAt: '2020-01-02',
         };
 
@@ -94,12 +95,16 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
         await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
 
+        assert.contains('Envoyé le');
         assert.contains('02 janv. 2020');
       });
     });
-    module('when the sharing date is not present', function() {
-      test('it displays "non disponible"', async function(assert) {
-        const campaignAssessmentParticipation = {};
+
+    module('when participant has not shared results', function() {
+      test('it does not displays the sharing date', async function(assert) {
+        const campaignAssessmentParticipation = {
+          isShared: false,
+        };
 
         const campaign = {};
 
@@ -108,7 +113,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
         await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
 
-        assert.contains('Non disponible');
+        assert.notContains('Envoyé le');
       });
     });
   });
@@ -146,7 +151,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
 
         await render(hbs`<Routes::Authenticated::Campaign::Assessment::Details @campaignAssessmentParticipation={{campaignAssessmentParticipation}} @campaign={{campaign}} />`);
 
-        assert.dom('li').exists({ count: 3 });
+        assert.dom('li').exists({ count: 2 });
       });
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
@@ -37,10 +37,11 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
     assert.contains('01 janv. 2020');
   });
 
-  module('shared at', function() {
-    module('when the sharing date is present', function() {
+  module('is shared', function() {
+    module('when participant has shared results', function() {
       test('it displays the sharing date', async function(assert) {
         const campaignProfile = {
+          isShared: true,
           sharedAt: '2020-01-02',
         };
 
@@ -51,12 +52,14 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
 
         await render(hbs`<Routes::Authenticated::Campaign::Profile::Details @campaignProfile={{campaignProfile}} @campaign={{campaign}} />`);
 
+        assert.contains('Envoyé le');
         assert.contains('02 janv. 2020');
       });
     });
-    module('when the sharing date is not present', function() {
-      test('it displays non disponible', async function(assert) {
+    module('when participant has not shared results', function() {
+      test('it does not displays the sharing date', async function(assert) {
         const campaignProfile = {
+          isShared: false,
         };
 
         const campaign = {};
@@ -66,7 +69,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
 
         await render(hbs`<Routes::Authenticated::Campaign::Profile::Details @campaignProfile={{campaignProfile}} @campaign={{campaign}} />`);
 
-        assert.contains('Non disponible');
+        assert.notContains('Envoyé le');
       });
     });
   });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -64,7 +64,6 @@
     },
     "campaign-individual-results": {
       "campaign-name": "Name of the campaign",
-      "not-shared": "Not available",
       "shared-date": "Sent on",
       "start-date": "Started on"
     },

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -64,7 +64,6 @@
     },
     "campaign-individual-results": {
       "campaign-name": "Nom de la campagne",
-      "not-shared": "Non disponible",
       "shared-date": "Envoyé le",
       "start-date": "Commencé le"
     },


### PR DESCRIPTION
## :unicorn: Problème
On affiche "Envoyé le" / "Non disponible" lorsque le participant n'a pas encore envoyé ses résultats.

## :robot: Solution
Masquer ce champs tant que l'utilisateur n'a pas partagé son résultat.

## :rainbow: Remarques

## :100: Pour tester
`pro.admin@example.net` aller sur une campagne avec des participation.

Vérifier que :
- pour une campagne partagé. Envoyé le et la date s'affiche.
- pour une campagne non partagé. Envoyé le / Non disponible ne s'affcihe plus