### PR TITLE
[FEATURE] Afficher la bannière de création de campagne pour les organismes SCO Agriculture (PIX-2219)

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -15,7 +15,7 @@
   <PixBanner class="information-banner">
     <FaIcon @icon="bullhorn" class="icon--margin"/>
     Il est important de vérifier que les élèves soient <strong>certifiables</strong> avant de les inscrire en session de certification. Vous pouvez faire une
-    <a href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
+    <a href={{this.documentationLink}} class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
       campagne de collecte de profils
       <FaIcon @icon="external-link-alt"/></a>
     pour vous en assurer.

--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -10,7 +10,10 @@ export default class InformationBanner extends Component {
   }
 
   get displayNewYearCampaignsBanner() {
-    return this.currentUser.isSCOManagingStudents &&
-      !this.currentUser.isAgriculture;
+    return this.currentUser.isSCOManagingStudents;
+  }
+
+  get documentationLink() {
+    return this.currentUser.isAgriculture ? 'https://view.genial.ly/6034cdf633f5220dc1eb101d' : 'https://view.genial.ly/5fda0b5aebe82c0d17f177ea';
   }
 }

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -77,31 +77,11 @@ module('Integration | Component | information-banner', function(hooks) {
       });
 
     });
-
-    module('when prescriber’s organization is agriculture', function() {
-
-      test('should not display the banner regardless of whether students have been imported or not', async function(assert) {
-        // given
-        class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: false }
-          isSCOManagingStudents = true;
-          isAgriculture = true;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // when
-        await render(hbs`<InformationBanner/>`);
-
-        // then
-        assert.dom('.pix-banner').doesNotExist();
-      });
-
-    });
   });
 
   module('Campaign Banner', () => {
     module('when prescriber’s organization is of type SCO that manages students', function() {
-      test('should render the campaign banner', async function(assert) {
+      test('should render the campaign banner for non agriculture', async function(assert) {
         // given
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: true }
@@ -115,6 +95,22 @@ module('Integration | Component | information-banner', function(hooks) {
         // then
         assert.dom('a[href="https://view.genial.ly/5fda0b5aebe82c0d17f177ea"]').exists();
         assert.dom('.pix-banner').includesText('Il est important de vérifier que les élèves soient certifiables avant de les inscrire en session de certification. Vous pouvez faire une campagne de collecte de profils pour vous en assurer.');
+      });
+
+      test('should render the campaign banner with specific link for agriculture', async function(assert) {
+        // given
+        class CurrentUserStub extends Service {
+          prescriber = { areNewYearSchoolingRegistrationsImported: true }
+          isSCOManagingStudents = true;
+          isAgriculture = true;
+        }
+        this.owner.register('service:current-user', CurrentUserStub);
+
+        // when
+        await render(hbs`<InformationBanner/>`);
+
+        // then
+        assert.dom('a[href="https://view.genial.ly/6034cdf633f5220dc1eb101d"]').exists();
       });
     });
 
@@ -135,35 +131,6 @@ module('Integration | Component | information-banner', function(hooks) {
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: true }
           isSCOManagingStudents = false;
-        }
-        this.owner.register('service:current-user', CurrentUserStub);
-
-        // when
-        await render(hbs`<InformationBanner/>`);
-
-        // then
-        assert.dom('.pix-banner').doesNotExist();
-      });
-    });
-
-    module('when prescriber’s organization is agriculture', function() {
-      const now = new Date('2019-01-01T05:06:07Z');
-      let clock;
-
-      hooks.beforeEach(() => {
-        clock = sinon.useFakeTimers(now);
-      });
-
-      hooks.afterEach(() => {
-        clock.restore();
-      });
-
-      test('should not show the campaign banner', async function(assert) {
-        // given
-        class CurrentUserStub extends Service {
-          prescriber = { areNewYearSchoolingRegistrationsImported: true }
-          isSCOManagingStudents = true;
-          isAgriculture = true;
         }
         this.owner.register('service:current-user', CurrentUserStub);
 


### PR DESCRIPTION
## :unicorn: Problème
Nous n'affichons pas de bannière actuellement pour les organismes SCO agri afin de les inciter à vérifier que leur élèves soient certifiables.

## :robot: Solution
Afficher le bandeau de campagne pour les SCO Agri afin qu'il puisse préparer des campagnes de collectes de profil

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur sco.admin@example.net . aller sur l'orga SCO Agri . Vérifier la présence du bandeau avec le lien adéquat.