### PR TITLE
[BUGFIX] Eviter de voir l'écran de warning après une épreuve timée (PIX-2176).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -65,7 +65,6 @@ export default class ChallengeItemGeneric extends Component {
       }
 
       this.errorMessage = null;
-      this.hasUserConfirmedWarning = false;
       this.isValidateButtonEnabled = false;
 
       return this.args.answerValidated(this.args.challenge, this.args.assessment, this._getAnswerValue(), this._getTimeout(), this._elapsedTime)
@@ -82,7 +81,6 @@ export default class ChallengeItemGeneric extends Component {
   skipChallenge() {
     if (this.isValidateButtonEnabled && this.isSkipButtonEnabled) {
       this.errorMessage = null;
-      this.hasUserConfirmedWarning = false;
       this.isSkipButtonEnabled = false;
 
       return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout(), this._elapsedTime)


### PR DESCRIPTION
## :unicorn: Problème
Sur une épreuve timée, après avoir validé ou passé l'épreuve, l'écran de Warning est de nouveau visible, surtout sur des connexions lentes.

## :robot: Solution
Le problème survenait car nous remettions la variable `hasUserConfirmedWarning` à `false` dès le clic sur le bouton. On considérait alors que l'utilisateur n'avait pas vu le warning et nous lui remontrons de nouveau.
Il n'y a pas besoin de remettre cette valeur à false. 
Le `@tracked hasUserConfirmedWarning = false;` en début de composant suffit.

## :rainbow: Remarques


## :100: Pour tester
https://app-pr2608.review.pix.fr/courses/recVhpqHADC8KxyvG
