### PR TITLE
[BUG] Correction d'un flaky test dans CampaignController (PIX-2223)

### DIFF
--- a/api/tests/acceptance/application/campaign-controller_test.js
+++ b/api/tests/acceptance/application/campaign-controller_test.js
@@ -708,8 +708,8 @@ describe('Acceptance | API | Campaign Controller', () => {
 
   describe('GET /api/campaigns/{id}/assessment-participations', () => {
 
-    const participant1 = { firstName: 'John', lastName: 'McClane', id: 12 };
-    const participant2 = { firstName: 'John', lastName: 'McClane', id: 13 };
+    const participant1 = { firstName: 'John', lastName: 'McClane', id: 12, email: 'john.mclane@die.hard' };
+    const participant2 = { firstName: 'Holly', lastName: 'McClane', id: 13, email: 'holly.mclane@die.hard' };
 
     let campaign;
     let userId;


### PR DESCRIPTION
## :unicorn: Problème

Un test échoue aléatoirement dans la CI.

```
Acceptance | API | Campaign Controller
GET /api/campaigns/{id}/assessment-participations
"before each" hook for "should return the campaign participation result summaries as JSONAPI":
error: insert into "users" ("cgu", "createdAt", "email", "firstName", "hasSeenAssessmentInstructions", "hasSeenNewDashboardInfo", "hasSeenNewLevelInfo", "id", "isAnonymous", "lang", "lastName", "lastTermsOfServiceValidatedAt", "mustValidateTermsOfService", "pixCertifTermsOfServiceAccepted", "pixOrgaTermsOfServiceAccepted", "updatedAt", "username") values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) - duplicate key value violates unique constraint "users_email_unique"
at createQueryBuilder (node_modules/knex/lib/util/make-knex.js:313:26)
at knex (node_modules/knex/lib/util/make-knex.js:99:12)
at DatabaseBuilder.commit (db/database-builder/database-builder.js:21:15)
at runMicrotasks (<anonymous>)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

## :robot: Solution

La génération aléatoire des emails par Faker n'est pas assez grande, on peut se retrouver avec le même email.
Les emails ont été écrit en dur dans le test pour les utilisateurs créés

NB: Il me semble que @laura-bergoens prévoit de supprimer Faker dans les tests pour éviter ce genre d'inconvénients.

## :rainbow: Remarques

N/A

## :100: Pour tester

Tout devrait rouler dans la CI.
