### PR TITLE
[FEATURE] Ajout de la traduction pour la tooltip des crédits (PIX-2197)

### DIFF
--- a/orga/app/components/organization-credit-info.hbs
+++ b/orga/app/components/organization-credit-info.hbs
@@ -1,8 +1,8 @@
 {{#if this.canShowCredit}}
   <div class="organization-credit-info">
-    <span class="organization-credit-info__label">{{this.credit}}</span>
+    <span class="organization-credit-info__label">{{t 'pages.credits.number' count=this.currentUser.organization.credit}}</span>
     <PixTooltip
-      @text={{this.tooltipContent}}
+      @text={{t 'pages.credits.tooltip-text' htmlSafe=true}}
       @position='bottom-left'
       @isWide={{true}}
       @isLight={{true}}>

--- a/orga/app/components/organization-credit-info.hbs
+++ b/orga/app/components/organization-credit-info.hbs
@@ -1,8 +1,8 @@
 {{#if this.canShowCredit}}
   <div class="organization-credit-info">
-    <span class="organization-credit-info__label">{{t 'pages.credits.number' count=this.currentUser.organization.credit}}</span>
+    <span class="organization-credit-info__label">{{t 'navigation.credits.number' count=this.currentUser.organization.credit}}</span>
     <PixTooltip
-      @text={{t 'pages.credits.tooltip-text' htmlSafe=true}}
+      @text={{t 'navigation.credits.tooltip-text' htmlSafe=true}}
       @position='bottom-left'
       @isWide={{true}}
       @isLight={{true}}>

--- a/orga/app/components/organization-credit-info.js
+++ b/orga/app/components/organization-credit-info.js
@@ -1,18 +1,8 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/string';
 
 export default class OrganizationCreditInfoComponent extends Component {
     @service currentUser
-
-    get tooltipContent() {
-      return htmlSafe('Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>');
-    }
-
-    get credit() {
-      const creditText = this.currentUser.organization.credit > 1 ? ' crédits' : ' crédit';
-      return this.currentUser.organization.credit.toLocaleString() + creditText;
-    }
 
     get canShowCredit() {
       return this.currentUser.isAdminInOrganization && this.currentUser.organization.credit > 0;

--- a/orga/tests/integration/components/organization-credit-info-test.js
+++ b/orga/tests/integration/components/organization-credit-info-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
@@ -12,7 +12,7 @@ class CurrentUserStub extends Service {
 }
 
 module('Integration | Component | organization-credit-info', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let currentUserStub;
 
   hooks.beforeEach(function() {
@@ -33,7 +33,7 @@ module('Integration | Component | organization-credit-info', function(hooks) {
     // when
     await render(hbs`<OrganizationCreditInfo />`);
     const displayedCredit = document.querySelector('.organization-credit-info__label').textContent;
-    const expectedCredit = currentUserStub.organization.credit.toLocaleString() + ' crédits';
+    const expectedCredit = '10 000 crédits';
 
     // then
     assert.contains(expectedCredit);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -19,6 +19,10 @@
     }
   },
   "navigation": {
+    "credits": {
+      "number":"{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}",
+      "tooltip-text": "The number of credits displayed is the number of credits acquired by the organisation and currently valid (regardless of their activation). For more information, please contact us at the following address: <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
+    },
     "main": {
       "campaigns": "Campaigns",
       "certifications": "Certifications",
@@ -198,10 +202,6 @@
         "tutorial-total":"{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
       },
       "waiting-results": "Waiting results"
-    },
-    "credits": {
-      "number":"{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}",
-      "tooltip-text": "The number of credits displayed is the number of credits acquired by the organisation and currently valid (regardless of their activation). For more information, please contact us at the following address: <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     }
   }
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -198,6 +198,10 @@
         "tutorial-total":"{count, plural, =1 {1 tutorial} other {{count} tutorials}}"
       },
       "waiting-results": "Waiting results"
+    },
+    "credits": {
+      "number":"{count, plural, =0 {0 credits} =1 {1 credit} other {{count, number} credits}}",
+      "tooltip-text": "The number of credits displayed is the number of credits acquired by the organisation and currently valid (regardless of their activation). For more information, please contact us at the following address: <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -19,6 +19,10 @@
     }
   },
   "navigation": {
+    "credits": {
+      "number":"{count, plural, =0 {0 crédit} =1 {1 crédit} other {{count, number} crédits}}",
+      "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
+    },
     "main": {
       "campaigns": "Campagnes",
       "certifications": "Certifications",
@@ -198,10 +202,6 @@
         "tutorial-total":"{count, plural, =1 {1 tuto} other {{count} tutos}}"
       },
       "waiting-results": "En attente de résultats"
-    },
-    "credits": {
-      "number":"{count, plural, =0 {0 crédit} =1 {1 crédit} other {{count, number} crédits}}",
-      "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -198,6 +198,10 @@
         "tutorial-total":"{count, plural, =1 {1 tuto} other {{count} tutos}}"
       },
       "waiting-results": "En attente de résultats"
+    },
+    "credits": {
+      "number":"{count, plural, =0 {0 crédit} =1 {1 crédit} other {{count, number} crédits}}",
+      "tooltip-text": "Le nombre de crédits affichés correspond au nombre de crédits acquis par l’organisation et en cours de validité (indépendamment de leur activation). Pour plus d’information contactez-nous à l’adresse <a href=mailto:pro@pix.fr>pro@pix.fr</a>"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Le texte contenu dans la tooltip des crédits n'était pas traduit.

## :robot: Solution
Ajouter la traduction.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter avec le compte de `pro.admin@example.net`
