### PR TITLE
Corrige le tri des competences pour le livret scolaire

### DIFF
--- a/api/lib/domain/usecases/certificate/get-certifications-results-for-ls.js
+++ b/api/lib/domain/usecases/certificate/get-certifications-results-for-ls.js
@@ -14,11 +14,12 @@ module.exports = async function getCertificationsResultsForLS({
   ]);
 
   const areas = referential.areas;
-  const competences = areas.flatMap((area) => area.competences).map((competence) => {
-    const { code: id, title: name } = competence.area;
-    const area = { id, name };
-    return new Competence({ area, id: competence.index, name: competence.name });
-  });
+  const competences = areas.flatMap(({ competences, code, title }) =>
+    competences.map((competence) => {
+      const area = { id: code, name: title };
+      return new Competence({ area, id: competence.index, name: competence.name });
+    }),
+  );
   const sortedCompetences = sortBy(competences, 'id');
 
   return new CertificationsResults({ certifications, competences: sortedCompetences });

--- a/api/lib/domain/usecases/certificate/get-certifications-results-for-ls.js
+++ b/api/lib/domain/usecases/certificate/get-certifications-results-for-ls.js
@@ -1,5 +1,6 @@
 const CertificationsResults = require('../../read-models/livret-scolaire/CertificationsResults');
 const Competence = require('../../read-models/livret-scolaire/Competence');
+const sortBy = require('lodash/sortBy');
 
 module.exports = async function getCertificationsResultsForLS({
   uai,
@@ -17,7 +18,8 @@ module.exports = async function getCertificationsResultsForLS({
     const { code: id, title: name } = competence.area;
     const area = { id, name };
     return new Competence({ area, id: competence.index, name: competence.name });
-  }).sort((competenceA, competenceB) => competenceA.id - competenceB.id);
+  });
+  const sortedCompetences = sortBy(competences, 'id');
 
-  return new CertificationsResults({ certifications, competences });
+  return new CertificationsResults({ certifications, competences: sortedCompetences });
 };


### PR DESCRIPTION
## :unicorn: Problème
Le tri sur les competence d'une certification n'est pas correctement implémenté. 

## :robot: Solution
La méthode array.sort de javascript n'est pas évidente à la lecture ni à l'implementation (effet de bord, function de tri verbeuse).
On peut remplacer par un [sortBy de lodash](https://lodash.com/docs/4.17.15#sortBy)


## :rainbow: Remarques
Petit SR en supplément pour simplifier un flatMap

## :100: Pour tester
Les tests sont deja implémentés, mais ils étaient flacky.

Pour tester fonctionnellement en locale:

1. Déclarer les variables d'env suivante `LSU_CLIENT_ID=lsu;LSU_CLIENT_SECRET=lsusecret` puis lancer l'api.

2. Générer un jeton via l'appel curl suivant:

```
curl -X POST \
  http://localhost:3000/api/application/token \
  -H 'content-type: application/x-www-form-urlencoded' \
  -d 'grant_type=client_credentials&client_id=lsu&client_secret=lsusecret&scope=organizations-certifications-result'
```


3. Copier coller le jeton pour l'utiliser dans l'appel ci-dessous afin d'authentifier l'application:

```
curl -X GET \
  http://localhost:3000/api/organizations/0382495F/certifications \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJsc3UiLCJzb3VyY2UiOiJsc3UiLCJzY29wZSI6Im9yZ2FuaXphdGlvbnMtY2VydGlmaWNhdGlvbnMtcmVzdWx0IiwiaWF0IjoxNjE0MjY1MjgwLCJleHAiOjE2MTQyNjg4ODB9.7GrDHcvwnlJf9MnwOmq_wtrpE26K98SjpD4H3As2BS8' 
```
