### PR TITLE
[FEATURE] Traduire la page de modification pour les campagnes d'évaluation et de collecte de profils (PIX-2204) 

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/update.hbs
+++ b/orga/app/components/routes/authenticated/campaign/update.hbs
@@ -2,7 +2,7 @@
   <h1 class="page__title page-title">{{ t 'pages.campaign-modification.title' }}</h1>
   <h2 class="page-sub-title">{{@subTitle}}</h2>
 
-  <form {{on 'submit' @update}} class="campaign-creation-form">
+  <form class="campaign-creation-form">
     <div class="form__field">
       <label for="campaign-name" class="label">{{ t 'pages.campaign-modification.campaign-name' }}</label>
       <Input
@@ -35,9 +35,12 @@
     </div>
 
     <div class="form__validation">
-      <button class="button button--no-color" type="button" {{on 'click' (fn @cancel @campaign.id)}}>{{t 'common.actions.cancel'}}</button>
-      <button class="button" type="submit">{{t 'pages.campaign-modification.actions.edit'}}</button>
+      <PixButton @triggerAction={{fn @cancel @campaign.id}} class="button button--no-color">
+        {{ t 'common.actions.cancel' }}
+      </PixButton>
+      <PixButton @type="submit" @triggerAction={{@update}} class="button">
+        {{t 'pages.campaign-modification.actions.edit'}}
+      </PixButton>
     </div>
   </form>
 </div>
-

--- a/orga/app/components/routes/authenticated/campaign/update.hbs
+++ b/orga/app/components/routes/authenticated/campaign/update.hbs
@@ -1,5 +1,5 @@
 <div class="update-campaign-page">
-  <h1 class="page__title page-title">Modification d'une campagne</h1>
+  <h1 class="page__title page-title">{{ t 'pages.campaign-modification.title' }}</h1>
   <h2 class="page-sub-title">{{@subTitle}}</h2>
 
   <form {{on 'submit' @update}} class="campaign-creation-form">
@@ -35,8 +35,8 @@
     </div>
 
     <div class="form__validation">
-      <button class="button button--no-color" type="button" {{on 'click' (fn @cancel @campaign.id)}}>Annuler</button>
-      <button class="button" type="submit">Modifier</button>
+      <button class="button button--no-color" type="button" {{on 'click' (fn @cancel @campaign.id)}}>{{t 'common.actions.cancel'}}</button>
+      <button class="button" type="submit">{{t 'pages.campaign-modification.actions.edit'}}</button>
     </div>
   </form>
 </div>

--- a/orga/app/components/routes/authenticated/campaign/update.hbs
+++ b/orga/app/components/routes/authenticated/campaign/update.hbs
@@ -4,7 +4,7 @@
 
   <form {{on 'submit' @update}} class="campaign-creation-form">
     <div class="form__field">
-      <label for="campaign-name" class="label">Nom de la campagne</label>
+      <label for="campaign-name" class="label">{{ t 'pages.campaign-modification.campaign-name' }}</label>
       <Input
         @id="campaign-name"
         @name="campaign-name"
@@ -17,7 +17,7 @@
 
     {{#if @campaign.isTypeAssessment}}
       <div class="form__field">
-        <label for="campaign-title" class="label">Titre du parcours</label>
+        <label for="campaign-title" class="label">{{ t 'pages.campaign-modification.personalised-test-title' }}</label>
         <Input
           @id="campaign-title"
           @name="campaign-title"
@@ -30,7 +30,7 @@
     {{/if}}
 
     <div class="form__field">
-      <label for="campaign-custom-landing-page-text" class="label">Texte de la page d'accueil</label>
+      <label for="campaign-custom-landing-page-text" class="label">{{ t 'pages.campaign-modification.landing-page-text' }}</label>
       <Textarea @id="campaign-custom-landing-page-text" @name="campaign-custom-landing-page-text" @maxlength="350" @rows={{8}} @value={{@campaign.customLandingPageText}} class="textarea" />
     </div>
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
@@ -1,5 +1,5 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 
 module('Integration | Component | routes/authenticated/campaign/update', function(hooks) {
 
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
     this.campaign = EmberObject.create({ isTypeAssessment: true });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -176,6 +176,9 @@
       "actions": {
         "edit": "Edit"
       },
+      "campaign-name": "Name of the campaign",
+      "landing-page-text": "Text to display on the starting page",
+      "personalised-test-title": "Title of the personalised test",
       "title": "Edit a campaign"
     },
     "campaign-review": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -172,6 +172,12 @@
         }
       }
     },
+    "campaign-modification" : {
+      "actions": {
+        "edit": "Edit"
+      },
+      "title": "Edit a campaign"
+    },
     "campaign-review": {
       "description": "According to the target profile selected and the results of your campaign, Pix recommends focusing on the following subjects, sorted by relevance ({bubble}).",
       "header": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -176,6 +176,9 @@
       "actions": {
         "edit": "Modifier"
       },
+      "campaign-name": "Nom de la campagne",
+      "landing-page-text": "Texte de la page d'accueil",
+      "personalised-test-title": "Titre du parcours",
       "title": "Modification d'une campagne"
     },
     "campaign-review": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -172,6 +172,12 @@
         }
       }
     },
+    "campaign-modification" : {
+      "actions": {
+        "edit": "Modifier"
+      },
+      "title": "Modification d'une campagne"
+    },
     "campaign-review": {
       "description": "En fonction du référentiel testé et des résultats de la campagne, Pix vous recommande ces sujets à travailler, classés par degré de pertinence ({bubble}).",
       "header": {


### PR DESCRIPTION
## :unicorn: Problème
La page pour modifier les campagnes d'évaluation et celle pour les collectes de profils n'étaient pas traduites.

## :robot: Solution
Traduire les pages.

## :rainbow: Remarques

## :100: Pour tester
se connecter à pix orga et essayer de modifier une campagne d'évaluation et de collecte de profils .