### PR TITLE
[BUGFIX] Corriger le changement de mot de passe à usage unique pour un élève qui tente de se réconcilier (PIX-2196).

### DIFF
--- a/mon-pix/app/routes/update-expired-password.js
+++ b/mon-pix/app/routes/update-expired-password.js
@@ -8,12 +8,12 @@ export default class UpdateExpiredPasswordRoute extends Route.extend(Unauthentic
 
   model() {
     const users = this.store.peekAll('user');
-    const user = users.firstObject;
+    const userWithExpiredPassword = users.find(({ id }) => id === null);
 
-    if (!user) {
+    if (!userWithExpiredPassword) {
       return this.replaceWith('');
     }
 
-    return user;
+    return userWithExpiredPassword;
   }
 }

--- a/mon-pix/tests/unit/routes/update-expired-password-test.js
+++ b/mon-pix/tests/unit/routes/update-expired-password-test.js
@@ -1,17 +1,42 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import sinon from 'sinon';
+
 import { setupTest } from 'ember-mocha';
 
+import EmberObject from '@ember/object';
+import Service from '@ember/service';
+
 describe('Unit | Route | update-expired-password', function() {
+
   setupTest();
 
   let route;
+  let peekAllStub;
 
   beforeEach(function() {
     route = this.owner.lookup('route:update-expired-password');
+
+    peekAllStub = sinon.stub();
+    const storeStub = Service.create({
+      peekAll: peekAllStub,
+    });
+    route.set('store', storeStub);
   });
 
-  it('exists', function() {
-    expect(route).to.be.ok;
+  it('should retrieve user model with unset id', async function() {
+    // given
+    const userThatWasPreviouslyConnectedWithWrongAccount = EmberObject.create({ id: 1, username: 'user.name0112' });
+    const userWithExpiredPassword = EmberObject.create({ id: null, username: 'user.toupdate1501' });
+    peekAllStub.returns([
+      userThatWasPreviouslyConnectedWithWrongAccount,
+      userWithExpiredPassword,
+    ]);
+
+    // when
+    const user = await route.model();
+
+    // then
+    expect(user).to.equal(userWithExpiredPassword);
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix App, durant le process de Réinitialisation d'un mot de passe d'un élève, erreur 404 se produit.

On peut voir, dans la console, que la requête qui est effectuée par Ember Data est un `PATCH http://localhost:4200/api/users/{id}` qui n’existe pas, et renvoie donc une erreur 404 au lieu de `POST /api/expired-password-updates`.

La raison de ce problème est qu’il existe à ce moment, deux users dans le store Ember 
<div align="center">
<img src="https://user-images.githubusercontent.com/88607/108976045-6ad5ef80-7687-11eb-9d21-2cf446781123.png" />
</div>

Cependant,  dans la route `update-expired-password` , nous récupérons le premier user (firstObject)

## :robot: Solution
Identifier de façon certaine le compte utilisateur pour lequel on souhaite mettre à jour le mot de passe.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

Rejoindre une campagne sur compte déjà réconcilié
* se connecter à Pix App avec `userpix1@example.net`
* rejoindre la [campagne](https://app-pr2615.review.pix.fr/campagnes/BADGES123) **BADGES123**
* remplir les champs du formulaire de réconciliation avec les informations George / De Cambridge / 22/07/2013
* _L'erreur R32 s'affiche et nous invite à nous connecter au compte, déjà réconcilié,  `george.decambridge2207`_
* cliquer sur Continuer avec mon compte Pix et S'ARRETER LA (le store a 1 enreg `userpix1@example.net`)

Réinitialiser le mot de passe dans Pix orga sur compte déjà réconcilié
* ouvrir un autre onglet
* rejoindre Pix Orga avec le compte `sco.admin@example.net`
* aller sur l'organisation Collège The Night Watch (1237457A)
* [Réinitialiser](https://orga-pr2615.review.pix.fr/eleves) le mot de passe du compte de **George De Cambridge**, et copier le mot de passe généré

Se reconnecter à Pix App sur compte déjà réconcilié
* revenir sur Pix App et, dans le formulaire de connexion de la double mire, se connecte avec le compte **george.decambridge2207** et le mot de passe à usage unique
* sur la page `/mise-a-jour-mot-de-passe-expire`, vérifier le stire (2 enregs, dont celui le username avec id à null)
* saisir un mot de passe valide Azerty123*
* vérifier que vous arrivez bien sur la page de début de parcours
* reconnectez-vous avec **george.decambridge2207** et Azerty123*
