### PR TITLE
[FEATURE] Dans Pix App, ajouter "Mon compte" dans le menu utilisateur (PIX-2106).

### DIFF
--- a/api/lib/application/preHandlers/feature-toggles.js
+++ b/api/lib/application/preHandlers/feature-toggles.js
@@ -1,11 +1,2 @@
-const config = require('../../config');
-const { NotFoundError } = require('../../application/http-errors');
-
 module.exports = {
-  async isMyAccountEnabled() {
-    if (!config.featureToggles.myAccount) {
-      throw new NotFoundError('cette route est désactivée');
-    }
-    return true;
-  },
 };

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -6,7 +6,6 @@ const userController = require('./user-controller');
 const { sendJsonApiError, BadRequestError } = require('../http-errors');
 const userVerification = require('../preHandlers/user-existence-verification');
 const { passwordValidationPattern } = require('../../config').account;
-const featureToggles = require('../preHandlers/feature-toggles');
 const { EntityValidationError } = require('../../domain/errors');
 const identifiersType = require('../../domain/types/identifiers-type');
 
@@ -190,10 +189,6 @@ exports.register = async function(server) {
           {
             method: securityPreHandlers.checkRequestedUserIsAuthenticatedUser,
             assign: 'requestedUserIsAuthenticatedUser',
-          },
-          {
-            method: featureToggles.isMyAccountEnabled,
-            assign: 'isMyAccountEnabled',
           },
         ],
         handler: userController.updateEmail,

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -129,7 +129,6 @@ module.exports = (function() {
 
     featureToggles: {
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
-      myAccount: isFeatureEnabled(process.env.FT_MY_ACCOUNT),
       isCertificationResultsInOrgaEnabled: isFeatureEnabled(process.env.FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED),
     },
 

--- a/api/sample.env
+++ b/api/sample.env
@@ -218,7 +218,3 @@ AUTH_SECRET=Change me!
 
 # Allow email change in API
 
-# presence: optional
-# type: String
-# default: false
-FT_MY_ACCOUNT=false

--- a/api/tests/acceptance/application/feature-controller_tests.js
+++ b/api/tests/acceptance/application/feature-controller_tests.js
@@ -24,7 +24,6 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
           id: '0',
           attributes: {
             'is-pole-emploi-enabled': false,
-            'my-account': false,
             'is-certification-results-in-orga-enabled': false,
           },
           type: 'feature-toggles',

--- a/api/tests/acceptance/application/users/users-controller-patch-email_test.js
+++ b/api/tests/acceptance/application/users/users-controller-patch-email_test.js
@@ -1,6 +1,5 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, sinon } = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const createServer = require('../../../../server');
-const config = require('../../../../lib/config');
 
 describe('Acceptance | Controller | users-controller', () => {
 
@@ -18,8 +17,6 @@ describe('Acceptance | Controller | users-controller', () => {
       const password = 'password123';
 
       beforeEach(async () => {
-        sinon.stub(config.featureToggles, 'myAccount').value(true);
-
         user = databaseBuilder.factory.buildUser.withRawPassword({
           email: 'old_email@example.net',
           rawPassword: password,
@@ -140,32 +137,6 @@ describe('Acceptance | Controller | users-controller', () => {
 
         // then
         expect(response.statusCode).to.equal(400);
-      });
-
-      it('should return 404 if FT_MY_ACCOUNT is not enabled', async () => {
-        // given
-        sinon.stub(config.featureToggles, 'myAccount').value(false);
-
-        const options = {
-          method: 'PATCH',
-          url: `/api/users/${user.id}/email`,
-          headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
-          payload: {
-            data: {
-              type: 'users',
-              attributes: {
-                'email': 'new_email@example.net',
-                'password': password,
-              },
-            },
-          },
-        };
-
-        // when
-        const response = await server.inject(options);
-
-        // then
-        expect(response.statusCode).to.equal(404);
       });
     });
   });

--- a/mon-pix/app/components/user-account-panel.js
+++ b/mon-pix/app/components/user-account-panel.js
@@ -3,9 +3,14 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class UserAccountPanel extends Component {
+
   @service intl;
   @service url;
   @service location;
+
+  get displayEmail() {
+    return !!this.args.user.email;
+  }
 
   get displayUsername() {
     return !!this.args.user.username;

--- a/mon-pix/app/components/user-account-update-email.js
+++ b/mon-pix/app/components/user-account-update-email.js
@@ -112,7 +112,7 @@ export default class UserAccountUpdateEmail extends Component {
             this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['emptyPassword']);
           }
         } else if (status === '400' || status === '403') {
-          this.errorMessage = get(response, 'errors[0].detail');
+          this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['invalidPassword']);
         } else {
           this.errorMessage = this.intl.t(ERROR_INPUT_MESSAGE_MAP['unknownError']);
         }

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -7,6 +7,8 @@
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.last-name'}}</span>
     <span class="user-account-panel-item__value" data-test-lastName>{{@user.lastName}}</span>
   </div>
+
+  {{#if this.displayEmail}}
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</span>
     <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
@@ -17,6 +19,8 @@
         {{t 'pages.user-account.account-panel.edit-button'}}
       </PixButton>
   </div>
+  {{/if}}
+
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">
     <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</span>

--- a/mon-pix/app/templates/components/user-logged-menu.hbs
+++ b/mon-pix/app/templates/components/user-logged-menu.hbs
@@ -15,10 +15,9 @@
         <div class="logged-user-menu" {{on-key 'Escape' this.closeMenu}}>
           <div class="logged-user-menu__details">
             <div class="logged-user-menu-details__fullname">{{this.currentUser.user.fullName}}</div>
-            <div class="logged-user-menu-details__identifier">{{this.displayedIdentifier}}</div>
           </div>
           <ul class="logged-user-menu__actions">
-            <li hidden>
+            <li>
               <LinkTo @route="user-account" class="logged-user-menu__link" >
                 {{t 'navigation.user.account'}}
               </LinkTo>

--- a/mon-pix/tests/acceptance/user-logged-menu-test.js
+++ b/mon-pix/tests/acceptance/user-logged-menu-test.js
@@ -8,8 +8,10 @@ import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 
 describe('Acceptance | User account', function() {
+
   setupApplicationTest();
   setupMirage();
+
   let user;
 
   beforeEach(async function() {
@@ -20,6 +22,7 @@ describe('Acceptance | User account', function() {
   });
 
   describe('When in profile', function() {
+
     it('should open tests page when click on menu', async function() {
       // when
       await click('.logged-user-name');
@@ -42,9 +45,20 @@ describe('Acceptance | User account', function() {
       // when
       await click('.logged-user-name');
       const helplink = findByLabel('Aide').getAttribute('href');
+
       // then
       expect(helplink).to.equal('https://pix.fr/aide');
     });
 
+    it('should open My account page when click on menu', async function() {
+      // given
+      await click('.logged-user-name');
+
+      // when
+      await clickByLabel('Mon compte');
+
+      // then
+      expect(currentURL()).to.equal('/mon-compte');
+    });
   });
 });

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -41,15 +41,44 @@ describe('Integration | Component | User account panel', () => {
 
   it('should call Enable Email Edition method', async function() {
     // given
+    const user = {
+      firstName: 'John',
+      lastName: 'DOE',
+      email: 'john.doe@example.net',
+      username: 'john.doe0101',
+      lang: 'fr',
+    };
     const enableEmailEditionMode = sinon.stub();
+    this.set('user', user);
     this.set('enableEmailEditionMode', enableEmailEditionMode);
-    await render(hbs`<UserAccountPanel @enableEmailEditionMode={{this.enableEmailEditionMode}} />`);
+
+    await render(hbs `<UserAccountPanel @user={{this.user}} @enableEmailEditionMode={{this.enableEmailEditionMode}} />`);
 
     // when
     await click('button[data-test-edit-email]');
 
     // then
     sinon.assert.called(enableEmailEditionMode);
+  });
+
+  context('when user does not have a email', function() {
+
+    it('should not display email', async function() {
+      // given
+      const user = {
+        firstName: 'John',
+        lastName: 'DOE',
+        username: 'john.doe0101',
+        lang: 'fr',
+      };
+      this.set('user', user);
+
+      // when
+      await render(hbs`<UserAccountPanel @user={{user}} />`);
+
+      // then
+      expect(find('button[data-test-edit-email]')).to.not.exist;
+    });
   });
 
   context('when user does not have a username', function() {

--- a/mon-pix/tests/integration/components/user-account-update-email-test.js
+++ b/mon-pix/tests/integration/components/user-account-update-email-test.js
@@ -158,13 +158,13 @@ describe('Integration | Component | User account update email', () => {
         // given
         const newEmail = 'newEmail@example.net';
         const password = 'password';
-        const expectedErrorMessage = 'An error message';
+        const expectedErrorMessage = this.intl.t('pages.user-account.account-update-email.fields.errors.invalid-password');
 
         const saveNewEmail = sinon.stub();
         this.set('saveNewEmail', saveNewEmail);
-        saveNewEmail.rejects({ errors: [{ status: '400', detail: expectedErrorMessage }] });
+        saveNewEmail.rejects({ errors: [{ status: '400' }] });
 
-        await render(hbs`<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
+        await render(hbs `<UserAccountUpdateEmail @saveNewEmail={{this.saveNewEmail}} />`);
 
         // when
         await fillIn('#newEmail', newEmail);

--- a/mon-pix/tests/integration/components/user-logged-menu-test.js
+++ b/mon-pix/tests/integration/components/user-logged-menu-test.js
@@ -74,7 +74,6 @@ describe('Integration | Component | user logged menu', function() {
       expect(find('.logged-user-menu')).to.exist;
       expect(findAll('.logged-user-menu__link')).to.have.lengthOf(MENU_ITEMS_COUNT);
       expect(contains('Hermione Granger')).to.exist;
-      expect(contains('hermione.granger@hogwarts.com')).to.exist;
     });
 
     it('should display link to user certifications', async function() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -947,7 +947,7 @@
                 "last-name": "Last name",
                 "email": "Email address",
                 "username": "Username",
-                "lang": "",
+                "lang": "Languages",
                 "edit-button": "Edit",
                 "fields": {
                     "select": {
@@ -959,26 +959,26 @@
                 }
             },
             "account-update-email": {
-                "title": "",
-                "email-information": "",
-                "password-information": "",
-                "save-button": "",
+                "title": "Change your email address",
+                "email-information": "Please provide a valid email address: it will be used to reset your password if you forget it. '<br>'This will change the email address you use to log in.",
+                "password-information": "Enter your password to confirm",
+                "save-button": "Confirm",
                 "fields": {
                     "new-email": {
-                        "label": ""
+                        "label": "New email address"
                     },
                     "new-email-confirmation": {
-                        "label": ""
+                        "label": "Confirm your email address"
                     },
                     "password": {
                         "label": "Password"
                     },
                     "errors": {
                         "wrong-email-format": "Your email address is invalid.",
-                        "mismatching-email": "",
+                        "mismatching-email": "The email addresses you entered do not match. Please check your entry for spelling errors.",
                         "empty-password": "Your password can't be empty.",
-                        "invalid-password": "",
-                        "unknown-error": ""
+                        "invalid-password": "There was an error in the password entered.",
+                        "unknown-error": "An error has occured. Please try again or contact the support."
                     }
                 }
             }


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix App, on veut permettre à un utilisateur d'aller vers une page dédiée pour gérer son compte. 

## :robot: Solution
* Dans le menu utilisateur, ajouter une entrée "Mon compte", qui redirigera l'utilisateur vers la page `/mon-compte` en premier item du menu.
* Supprimer l'affichage de l'adresse e-mail ou de l'identifiant, dans ce menu

## :rainbow: Remarques
* Suppression de la variable d'environnement **FT_MY_ACCOUNT** et de son utilisation, afin de rendre cette feature effective.
* Ajout de quelques traductions anglaises manquantes
* Correction de l'affichage erroné du champ `Adresse e-mail`, alors que l'utilisateur n'a pas d'adresse e-mail.

## :100: Pour tester
* Se connecter à Pix App
* Vérifier dans le menu utilisateur que le sous-menu "Mon compte" est bien affiché
* Cliquer sur ce sous-menu et verifier que la page affichée est `/mon-compte`