### PR TITLE
[FEATURE] Ajout du filtre sur les classes pour pouvoir récupérer les résultats de certification par classe sur PixOrga (PIX-2195)

### DIFF
--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -132,6 +132,27 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/organizations/{id}/divisions',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
+          assign: 'isAdminInOrganizationManagingStudents',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.organizationId,
+          }),
+        },
+        handler: organizationController.getDivisions,
+        tags: ['api', 'organizations'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs authentifiés',
+          'Elle retourne les classes rattachées à l’organisation.',
+        ],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/organizations/{id}/certification-results',
       config: {
         pre: [

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -3,6 +3,7 @@ const tokenService = require('../../domain/services/token-service');
 const usecases = require('../../domain/usecases');
 
 const campaignReportSerializer = require('../../infrastructure/serializers/jsonapi/campaign-report-serializer');
+const divisionSerializer = require('../../infrastructure/serializers/jsonapi/sco-certification-center-division-serializer');
 const membershipSerializer = require('../../infrastructure/serializers/jsonapi/membership-serializer');
 const organizationSerializer = require('../../infrastructure/serializers/jsonapi/organization-serializer');
 const organizationInvitationSerializer = require('../../infrastructure/serializers/jsonapi/organization-invitation-serializer');
@@ -111,6 +112,12 @@ module.exports = {
       .map((targetProfileToAttach) => parseInt(targetProfileToAttach));
     await usecases.attachTargetProfilesToOrganization({ organizationId: requestedOrganizationId, targetProfileIdsToAttach });
     return h.response().code(204);
+  },
+
+  async getDivisions(request) {
+    const organizationId = parseInt(request.params.id);
+    const divisions = await usecases.findDivisionsByOrganization({ organizationId });
+    return divisionSerializer.serialize(divisions);
   },
 
   async findPaginatedFilteredSchoolingRegistrations(request) {

--- a/api/lib/domain/usecases/find-divisions-by-organization.js
+++ b/api/lib/domain/usecases/find-divisions-by-organization.js
@@ -1,0 +1,8 @@
+
+module.exports = function findDivisionsByOrganization({
+  organizationId,
+  schoolingRegistrationRepository,
+}) {
+  return schoolingRegistrationRepository.findDivisionsByOrganizationId({ organizationId });
+};
+

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -156,6 +156,7 @@ module.exports = injectDependencies({
   findCompletedUserCertifications: require('./find-completed-user-certifications'),
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),
+  findDivisionsByOrganization: require('./find-divisions-by-organization'),
   findFinalizedSessionsToPublish: require('./find-finalized-sessions-to-publish'),
   findFinalizedSessionsWithRequiredAction: require('./find-finalized-sessions-with-required-action'),
   findPaginatedCampaignAssessmentParticipationSummaries: require('./find-paginated-campaign-assessment-participation-summaries'),

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1425,4 +1425,43 @@ describe('Acceptance | Application | organization-controller', () => {
     });
   });
 
+  describe('GET /api/organization/{organizationId}/divisions', () => {
+    it('should return the divisions', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
+      databaseBuilder.factory.buildMembership({
+        userId,
+        organizationId: organization.id,
+        organizationRole: Membership.roles.ADMIN,
+      });
+
+      _buildSchoolingRegistrations(
+        organization,
+        { id: 1, division: '2ndB', firstName: 'Laura', lastName: 'Certif4Ever' },
+        { id: 2, division: '2ndA', firstName: 'Laura', lastName: 'Booooo' },
+        { id: 3, division: '2ndA', firstName: 'Laura', lastName: 'aaaaa' },
+        { id: 4, division: '2ndA', firstName: 'Bart', lastName: 'Coucou' },
+        { id: 5, division: '2ndA', firstName: 'Arthur', lastName: 'Coucou' },
+      );
+
+      await databaseBuilder.commit();
+
+      const request = {
+        method: 'GET',
+        url: '/api/organizations/' + organization.id + '/divisions',
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+
+      // when
+      const response = await server.inject(request);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
 });
+
+function _buildSchoolingRegistrations(organization, ...students) {
+  return students.map((student) => databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id, ...student }));
+}

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -106,6 +106,69 @@ describe('Unit | Application | Organizations | organization-controller', () => {
     });
   });
 
+  describe('#getDivisions', () => {
+
+    it('Should return a serialized list of divisions', async () => {
+      // given
+      const request = {
+        auth: {
+          credentials: { userId: '111' },
+        },
+        params: {
+          id: '99',
+        },
+      };
+
+      sinon
+        .stub(usecases, 'findDivisionsByOrganization')
+        .withArgs({ organizationId: 99 })
+        .resolves([
+          {
+            id: '3A',
+            name: '3A',
+          },
+          {
+            id: '3B',
+            name: '3B',
+          },
+          {
+            id: '4C',
+            name: '4C',
+          },
+        ]);
+
+      // when
+      const response = await organizationController.getDivisions(request, hFake);
+
+      // then
+      expect(response).to.deep.equal(
+        {
+          data: [{
+            'type': 'divisions',
+            'id': '3A',
+            'attributes': {
+              'name': '3A',
+            },
+          },
+          {
+            'type': 'divisions',
+            'id': '3B',
+            'attributes': {
+              'name': '3B',
+            },
+          },
+          {
+            'type': 'divisions',
+            'id': '4C',
+            'attributes': {
+              'name': '4C',
+            },
+          }],
+        },
+      );
+    });
+  });
+
   describe('#updateOrganizationInformation', () => {
 
     let organization;

--- a/api/tests/unit/domain/usecases/find-divisions-by-organization_test.js
+++ b/api/tests/unit/domain/usecases/find-divisions-by-organization_test.js
@@ -1,0 +1,31 @@
+const { expect, sinon } = require('../../../test-helper');
+
+const findDivisionsByOrganization = require('../../../../lib/domain/usecases/find-divisions-by-organization');
+
+describe('Unit | UseCase | find-divisions-by-organization', () => {
+
+  describe('when user has access to organization', () => {
+
+    it('should return all divisions', async () => {
+      // given
+      const schoolingRegistrationRepository = {
+        findDivisionsByOrganizationId: sinon.stub(),
+      };
+      const organizationId = 1234;
+      schoolingRegistrationRepository.findDivisionsByOrganizationId
+        .withArgs({ organizationId })
+        .resolves([{ id: '3a', name: '3a' }, { id: '3b', name: '3b' }, { id: '5c', name: '5c' }]);
+
+      // when
+      const divisions = await findDivisionsByOrganization({
+        organizationId,
+        schoolingRegistrationRepository,
+      });
+
+      // then
+      expect(divisions).to.be.deep.equal([
+        { id: '3a', name: '3a' }, { id: '3b', name: '3b' }, { id: '5c', name: '5c' },
+      ]);
+    });
+  });
+});

--- a/orga/app/adapters/division.js
+++ b/orga/app/adapters/division.js
@@ -1,0 +1,13 @@
+import ApplicationAdapter from './application';
+
+export default class DivisionAdapter extends ApplicationAdapter {
+
+  urlForQuery(query) {
+    const { organizationId } = query;
+    if (organizationId) {
+      delete query.organizationId;
+      return `${this.host}/${this.namespace}/organizations/${organizationId}/divisions`;
+    }
+    return super.urlForQuery(...arguments);
+  }
+}

--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -26,6 +26,6 @@ export default class SidebarMenu extends Component {
   }
 
   get shouldDisplayCertificationsEntry() {
-    return this.featureToggles.isCertificationResultsInOrgaEnabled && this.currentUser.isSCOManagingStudents;
+    return this.featureToggles.isCertificationResultsInOrgaEnabled && (this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents);
   }
 }

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -1,0 +1,44 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class AuthenticatedCertificationsController extends Controller {
+  @service fileSaver;
+  @service session;
+  @service currentUser;
+  @service notifications;
+
+  @tracked selectedDivision = this.model.options[0].value ;
+
+  @action
+  onSelectDivision(event) {
+    this.selectedDivision = event.target.value;
+  }
+
+  @action
+  async downloadSessionResultFile() {
+
+    const organizationId = this.currentUser.organization.id;
+
+    try {
+      const url = `/api/organizations/${organizationId}/certification-results?division=${this.selectedDivision}`;
+
+      let token = '';
+
+      if (this.session.isAuthenticated) {
+        token = this.session.data.authenticated.access_token;
+      }
+
+      await this.fileSaver.save({ url, token });
+    } catch (error) {
+      if (_isErrorNotFound(error)) {
+        this.notifications.error('Aucun résultat de certification pour cette classe.');
+      }
+    }
+  }
+}
+
+function _isErrorNotFound(error) {
+  return error[0] && error[0].status == 404;
+}

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -10,4 +10,20 @@ export default class AuthenticatedCertificationsRoute extends Route {
       this.replaceWith('application');
     }
   }
+
+  async model() {
+    const organizationId = this.currentUser.organization.id;
+    const divisions = await this.store.query('division', { organizationId });
+
+    const options = _generateLabelsAndValues(divisions);
+
+    return { options };
+  }
+}
+
+function _generateLabelsAndValues(divisions) {
+  const options = [];
+  divisions.forEach((division) => options.push({ label: division.name, value: division.name }));
+
+  return options;
 }

--- a/orga/app/routes/authenticated/certifications.js
+++ b/orga/app/routes/authenticated/certifications.js
@@ -6,7 +6,7 @@ export default class AuthenticatedCertificationsRoute extends Route {
   @service featureToggles;
 
   beforeModel() {
-    if (!(this.featureToggles.isCertificationResultsInOrgaEnabled && this.currentUser.isSCOManagingStudents)) {
+    if (!(this.featureToggles.isCertificationResultsInOrgaEnabled && (this.currentUser.isAdminInOrganization && this.currentUser.isSCOManagingStudents))) {
       this.replaceWith('application');
     }
   }

--- a/orga/app/services/file-saver.js
+++ b/orga/app/services/file-saver.js
@@ -1,0 +1,57 @@
+import Service from '@ember/service';
+import fetch from 'fetch';
+
+export default class FileSaverService extends Service {
+
+  async save({
+    url,
+    token,
+    fetcher = _fetchData,
+    downloadFileForIEBrowser = _downloadFileForIEBrowser,
+    downloadFileForModernBrowsers = _downloadFileForModernBrowsers,
+  }) {
+    const response = await fetcher({ url, token });
+
+    if (response.status !== 200) {
+      const jsonResponse = await response.json();
+      throw jsonResponse.errors;
+    }
+
+    const fileName = _getFileNameFromHeader(response.headers);
+    const fileContent = await response.blob();
+
+    const browserIsInternetExplorer = window.document.documentMode;
+
+    browserIsInternetExplorer
+      ? downloadFileForIEBrowser({ fileContent, fileName })
+      : downloadFileForModernBrowsers({ fileContent, fileName });
+  }
+}
+
+function _fetchData({ url, token }) {
+  return fetch(url, {
+    headers: { 'Authorization': `Bearer ${token}` },
+  });
+}
+
+function _getFileNameFromHeader(headers) {
+  if (headers && headers.get('Content-Disposition')) {
+    const contentDispositionHeader = headers.get('Content-Disposition');
+    const [, fileName] = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDispositionHeader);
+    return fileName;
+  }
+}
+
+function _downloadFileForIEBrowser({ fileContent, fileName }) {
+  window.navigator.msSaveOrOpenBlob(fileContent, fileName);
+}
+
+function _downloadFileForModernBrowsers({ fileContent, fileName }) {
+  const link = document.createElement('a');
+  link.style.display = 'none';
+  link.href = URL.createObjectURL(fileContent);
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -22,14 +22,47 @@
 
   &__text {
     font-family: $roboto;
-    margin: 2px 0 29px 16px;
-    font-size: 0.875rem;
+    margin: 2px 0 32px 16px;
+    font-size: 16px;
     line-height: 1.375rem;
+    p {
+      margin: 0;
+    }
+  }
+
+  &__action {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+    width: 100%;
+    margin-left: 1rem;
+
+    button {
+      height: 36px;
+      line-height: 36px;
+    }
+
+    .certifications-page-action {
+
+      &__select-container {
+
+        label[for^="certifications-page-action__select"] {
+          font-size: 14px;
+          color: $grey-90;
+          margin-left: 2px;
+        }
+
+        .pix-select {
+          margin: 4px 24px 0 0;
+          width: 153px;
+          height: 36px;
+        }
+      }
+    }
   }
 }
 
 .certifications-page-header {
-
   &__add-member-button {
     margin-top: 20px;
     margin-left: auto;

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -4,11 +4,19 @@
       <h1 class="page__title page-title">{{t 'pages.certifications.title'}}</h1>
     </div>
     <div class="certifications-page__text">
-      {{t 'pages.certifications.description'}}
+      <p>
+        {{t 'pages.certifications.description'}}
+      </p>
     </div>
-    <div>
-      <PixSelect id="subcategory-for-category-candidate-information-change" @options={{@model.options}}
-        @selectedOption={{this.selectedDivision}} @onChange={{this.onSelectDivision}} />
+    <div class="certifications-page__action">
+      <div class='certifications-page-action__select-container'>
+        <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
+        <PixSelect id="certifications-page-action__select" @options={{@model.options}}
+          @selectedOption={{this.selectedDivision}} @onChange={{this.onSelectDivision}} />
+      </div>
+      <button class="button" type="button" {{on 'click' this.downloadSessionResultFile}}>
+        {{t 'pages.certifications.download-button'}}
+      </button>
     </div>
   </div>
 </div>

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -6,5 +6,9 @@
     <div class="certifications-page__text">
       {{t 'pages.certifications.description'}}
     </div>
+    <div>
+      <PixSelect id="subcategory-for-category-candidate-information-change" @options={{@model.options}}
+        @selectedOption={{this.selectedDivision}} @onChange={{this.onSelectDivision}} />
+    </div>
   </div>
 </div>

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -317,4 +317,8 @@ export default function() {
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
+
+  this.get('/organizations/:id/divisions', (schema, _) => {
+    return schema.divisions.all();
+  });
 }

--- a/orga/mirage/factories/division.js
+++ b/orga/mirage/factories/division.js
@@ -1,0 +1,9 @@
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
+
+export default Factory.extend({
+
+  name() {
+    return faker.random.alphaNumeric();
+  },
+});

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -323,7 +323,10 @@ module('Acceptance | authentication', function(hooks) {
             assert.dom('.sidebar-menu').containsText('Élèves');
             assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
             assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
-            assert.contains('Vous pouvez exporter les résultats de certification de toutes les classes au format csv.');
+            assert.contains('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.');
+            assert.contains('Exporter mes résultats');
+            assert.contains('Mes certifications');
+            assert.contains('Classes');
           });
         });
 

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -95,7 +95,8 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     // given
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });
-      isSCOManagingStudents = true;
+      isAdminInOrganization = true;
+      isSCOManagingStudents= true;
     }
 
     class FeatureToggleStub extends Service {
@@ -118,7 +119,8 @@ module('Integration | Component | sidebar-menu', function(hooks) {
     // given
     class CurrentUserStub extends Service {
       organization = Object.create({ id: 1, type: 'SCO' });
-      isSCOManagingStudents = true;
+      isAdminInOrganization = false;
+      isSCOManagingStudents= true;
     }
 
     class FeatureToggleStub extends Service {

--- a/orga/tests/unit/adapters/division-test.js
+++ b/orga/tests/unit/adapters/division-test.js
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { resolve } from 'rsvp';
+
+module('Unit | Adapters | division', function(hooks) {
+  setupTest(hooks);
+
+  let adapter;
+  const organizationId = 2;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:division');
+    const ajaxStub = () => resolve();
+    adapter.ajax = ajaxStub;
+  });
+
+  module('#urlForQuery', function() {
+
+    test('should build url from organizationId', async function(assert) {
+      // when
+      const query = { organizationId };
+      const url = await adapter.urlForQuery(query);
+
+      // then
+      assert.equal(url.endsWith(`/organizations/${organizationId}/divisions`), true);
+    });
+  });
+});

--- a/orga/tests/unit/controllers/authenticated/certifications-test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications-test.js
@@ -1,0 +1,77 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/certifications', function(hooks) {
+  setupTest(hooks);
+
+  module('#onSelectDivision', function() {
+
+    test('should change the value of the selected division', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      controller.model = {
+        options: [{ label: '3èmeA', value: '3èmeA' }],
+      };
+
+      controller.selectedDivision = '3èmeA';
+
+      const event = {
+        target: {
+          value: '2ndB',
+        },
+      };
+
+      // when
+      await controller.onSelectDivision(event);
+
+      // then
+      assert.equal(controller.selectedDivision, event.target.value);
+    });
+  });
+
+  module('#downloadSessionResultFile', function() {
+
+    test('should call the file-saver service with the right parametters', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated/certifications');
+
+      const token = 'a token';
+      const organizationId = 12345;
+      const selectedDivision = '3èmeA';
+
+      controller.selectedDivision = selectedDivision;
+
+      controller.session = {
+        isAuthenticated: true,
+        data: {
+          authenticated: {
+            access_token: token,
+          },
+        },
+      };
+
+      controller.currentUser = {
+        organization: {
+          id: organizationId,
+        },
+      };
+
+      controller.fileSaver = {
+        save: sinon.stub(),
+      };
+
+      // when
+      await controller.downloadSessionResultFile();
+
+      // then
+      assert.ok(controller.fileSaver.save.calledWith(
+        {
+          token,
+          url: `/api/organizations/${organizationId}/certification-results?division=${selectedDivision}`,
+        },
+      ));
+    });
+  });
+});

--- a/orga/tests/unit/routes/authenticated/certifications-test.js
+++ b/orga/tests/unit/routes/authenticated/certifications-test.js
@@ -1,6 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
+import EmberObject from '@ember/object';
+
 import sinon from 'sinon';
 
 module('Unit | Route | authenticated/certifications', function(hooks) {
@@ -130,6 +132,52 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       // then
       sinon.assert.notCalled(replaceWithStub);
       assert.ok(true);
+    });
+  });
+
+  module('#model', function() {
+
+    test('it should return a list of options based on organization divisions', async function(assert) {
+      // given
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = true;
+        isSCOManagingStudents = true;
+        organization = {
+          id: 12345,
+        }
+      }
+
+      class FeatureToggleStub extends Service {
+        isCertificationResultsInOrgaEnabled = true;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.owner.register('service:feature-toggles', FeatureToggleStub);
+
+      const route = this.owner.lookup('route:authenticated/certifications');
+      const divisions = [EmberObject.create({ name: '3èmeA' }), EmberObject.create({ name: '2ndE' })];
+      const findRecordStub = sinon.stub();
+      route.store.findRecord = findRecordStub;
+      route.store.query = sinon.stub().resolves(divisions);
+
+      // when
+      const actualOptions = await route.model();
+
+      // then
+      assert.deepEqual(actualOptions,
+        {
+          options: [
+            {
+              label: '3èmeA',
+              value: '3èmeA',
+            },
+            {
+              label: '2ndE',
+              value: '2ndE',
+            },
+          ],
+        },
+      );
     });
   });
 });

--- a/orga/tests/unit/routes/authenticated/certifications-test.js
+++ b/orga/tests/unit/routes/authenticated/certifications-test.js
@@ -10,6 +10,7 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
     test('should redirect to application when featureToggles.isCertificationResultsInOrgaEnabled is false', function(assert) {
       // given
       class CurrentUserStub extends Service {
+        isAdminInOrganization = true;
         isSCOManagingStudents = true;
       }
 
@@ -31,9 +32,10 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       assert.ok(true);
     });
 
-    test('should redirect to application when currentUser.isSCOManagingStudents is false', function(assert) {
+    test('should redirect to application when currentUser.isAdminInOrganization is true && currentUser.isSCOManagingStudents is false', function(assert) {
       // given
       class CurrentUserStub extends Service {
+        isAdminInOrganization = true;
         isSCOManagingStudents = false;
       }
 
@@ -55,10 +57,36 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       assert.ok(true);
     });
 
-    test('should redirect to application when currentUser.isSCOManagingStudents and featureToggles.isCertificationResultsInOrgaEnabled are false', function(assert) {
+    test('should redirect to application when currentUser.isAdminInOrganization is false & currentUser.isSCOManagingStudents is true', function(assert) {
       // given
       class CurrentUserStub extends Service {
-        isSCOManagingStudents = false;
+        isAdminInOrganization = false;
+        isSCOManagingStudents = true;
+      }
+
+      class FeatureToggleStub extends Service {
+        isCertificationResultsInOrgaEnabled = true;
+      }
+
+      this.owner.register('service:current-user', CurrentUserStub);
+      this.owner.register('service:feature-toggles', FeatureToggleStub);
+      const route = this.owner.lookup('route:authenticated.certifications');
+      const replaceWithStub = sinon.stub();
+      route.replaceWith = replaceWithStub;
+
+      // when
+      route.beforeModel();
+
+      // then
+      sinon.assert.calledOnceWithExactly(replaceWithStub, 'application');
+      assert.ok(true);
+    });
+
+    test('should redirect to application when currentUser.isAdminInOrganization and featureToggles.isCertificationResultsInOrgaEnabled are false', function(assert) {
+      // given
+      class CurrentUserStub extends Service {
+        isAdminInOrganization = false;
+        isSCOManagingStudents = true;
       }
 
       class FeatureToggleStub extends Service {
@@ -79,9 +107,10 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
       assert.ok(true);
     });
 
-    test('should redirect to application when currentUser.isSCOManagingStudents and featureToggles.isCertificationResultsInOrgaEnabled are true', function(assert) {
+    test('should not redirect to application when currentUser.isAdminInOrganization and featureToggles.isCertificationResultsInOrgaEnabled are true', function(assert) {
       // given
       class CurrentUserStub extends Service {
+        isAdminInOrganization = true;
         isSCOManagingStudents = true;
       }
 

--- a/orga/tests/unit/services/file-saver-test.js
+++ b/orga/tests/unit/services/file-saver-test.js
@@ -1,0 +1,79 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | file-saver', function(hooks) {
+  setupTest(hooks);
+  let fileSaver;
+
+  hooks.beforeEach(function() {
+    fileSaver = this.owner.lookup('service:file-saver');
+  });
+
+  module('#save', function() {
+    const id = 123456;
+    const url = `/attestation/${id}`;
+    const token = 'mytoken';
+    const responseFileName = 'fichier.plouf';
+    const responseContent = new Blob();
+
+    let fetchStub;
+    let blobStub;
+    let downloadFileForIEBrowserStub;
+    let downloadFileForModernBrowsersStub;
+
+    hooks.beforeEach(function() {
+      fileSaver = this.owner.lookup('service:file-saver');
+      blobStub = sinon.stub().resolves(responseContent);
+      downloadFileForIEBrowserStub = sinon.stub().returns();
+      downloadFileForModernBrowsersStub = sinon.stub().returns();
+    });
+
+    module('when response has a status 200', function() {
+      test('should use fileName and fileContent from response', async function(assert) {
+        // given
+        const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
+        const jsonStub = sinon.stub().resolves('a json');
+
+        const response = { headers, blob: blobStub, status: 200, json: jsonStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        await fileSaver.save({
+          url,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        const expectedArgs = { fileContent: responseContent, fileName: responseFileName };
+        assert.ok(downloadFileForModernBrowsersStub.calledWith(expectedArgs));
+      });
+    });
+
+    module('when response has not a status 200', function() {
+      test('should throw', async function(assert) {
+        // given
+        const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
+        const jsonStub = sinon.stub().resolves({ errors: [] });
+        const response = { headers, blob: blobStub, status: 403, json: jsonStub };
+        fetchStub = sinon.stub().resolves(response);
+
+        // when
+        const promise = fileSaver.save({
+          url,
+          token,
+          fetcher: fetchStub,
+          downloadFileForIEBrowser: downloadFileForIEBrowserStub,
+          downloadFileForModernBrowsers: downloadFileForModernBrowsersStub,
+        });
+
+        // then
+        assert.rejects(promise);
+      });
+    });
+  });
+
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -257,8 +257,10 @@
       "waiting-results": "Waiting results"
     },
     "certifications": {
-      "description": "You can export the certification results for all classes in a csv file.",
-      "title": "My certifications"
+      "description": "Please select the class for which you would like to export the certification results in a csv file.",
+      "title": "My certifications",
+      "select-label": "Class",
+      "download-button": "Export the results"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -257,8 +257,10 @@
       "waiting-results": "En attente de résultats"
     },
     "certifications": {
-      "description": "Vous pouvez exporter les résultats de certification de toutes les classes au format csv.",
-      "title": "Mes certifications"
+      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.",
+      "title": "Mes certifications",
+      "select-label": "Classes",
+      "download-button": "Exporter mes résultats"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
La récupération des résultats de certification dans Pix Orga se fait pour une classe uniquement. Il faut donc pouvoir sélectionner une classe avant de cliquer sur le bouton d'export des résultats. 

## :robot: Solution
Ajout d'un menu de selection de la classe.

## :rainbow: Remarques

![image](https://user-images.githubusercontent.com/37305474/109314482-b506ce80-7849-11eb-83a2-2c63aafa6e86.png)


## :100: Pour tester
- Lancer l'api avec FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true 
- Se connecter à pix-orga avec un compte sco & admin ayant des résultats de certifications disponibles

( Note: Pour générer des résultats de certification pour une organisation donnée, utiliser ce script
` generate-certifications-for-organization.js --organizationId  <un id d'orga> --certificationCenterId <un id de centre de certif>` )

- Cliquer sur l'onglet Certifications
- Choisir une classe
- Cliquer sur "Exporter mes résultats"
- Constater que le téléchargement s'effectue
