### PR TITLE
[FEATURE] Endpoint de téléchargement des résultats de certification SCO par classe depuis pix-orga (PIX-2193)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -127,6 +127,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.InvalidCertificationReportForFinalization) {
     return new HttpErrors.BadRequestError(error.message);
   }
+  if (error instanceof DomainErrors.NoCertificationResultForDivision) {
+    return new HttpErrors.NotFoundError(error.message);
+  }
   if (error instanceof DomainErrors.UnexpectedUserAccount) {
     return new HttpErrors.ConflictError(error.message, error.code, error.meta);
   }

--- a/api/lib/application/organizations/index.js
+++ b/api/lib/application/organizations/index.js
@@ -140,7 +140,7 @@ exports.register = async (server) => {
             assign: 'isCertificationResultsInOrgaEnabled',
           },
           {
-            method: securityPreHandlers.checkUserBelongsToOrganizationManagingStudents,
+            method: securityPreHandlers.checkUserIsAdminInSCOOrganizationManagingStudents,
             assign: 'belongsToOrganizationManagingStudents',
           },
         ],

--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -11,6 +11,8 @@ const userWithSchoolingRegistrationSerializer = require('../../infrastructure/se
 const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
 const queryParamsUtils = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
+const moment = require('moment');
+const certificationResultUtils = require('../../infrastructure/utils/csv/certification-results');
 
 module.exports = {
 
@@ -80,9 +82,16 @@ module.exports = {
     return membershipSerializer.serialize(memberships, pagination);
   },
 
-  async downloadCertificationResults(_request, h) {
-    const csvResult = '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n';
-    const fileName = '20190428_0242_resultats_NomDeLaClasse.csv';
+  async downloadCertificationResults(request, h) {
+    const organizationId = parseInt(request.params.id);
+    const { division } = request.query;
+
+    const certificationResults = await usecases.getScoCertificationResultsByDivision({ organizationId, division });
+
+    const csvResult = await certificationResultUtils.getDivisionCertificationResultsCsv({ certificationResults });
+
+    const now = moment();
+    const fileName = `${now.format('YYYYMMDD')}_resultats_${division}.csv`;
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -129,7 +129,7 @@ module.exports = {
   async getSessionResults(request, h) {
     const sessionId = request.params.id;
     const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
-    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getSessionCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
@@ -147,7 +147,7 @@ module.exports = {
     const token = request.params.token;
     const { sessionId } = tokenService.extractSessionId(token);
     const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
-    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getSessionCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')
@@ -158,7 +158,7 @@ module.exports = {
     const token = request.params.token;
     const { resultRecipientEmail, sessionId } = tokenService.extractResultRecipientEmailAndSessionId(token);
     const { session, certificationResults, fileName } = await usecases.getSessionResultsByResultRecipientEmail({ sessionId, resultRecipientEmail });
-    const csvResult = await certificationResultUtils.getCertificationResultsCsv({ session, certificationResults });
+    const csvResult = await certificationResultUtils.getSessionCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)
       .header('Content-Type', 'text/csv;charset=utf-8')

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -538,6 +538,12 @@ class NotFoundError extends DomainError {
   }
 }
 
+class NoCertificationResultForDivision extends DomainError {
+  constructor(message = 'Aucun résultat de certification pour cette classe.') {
+    super(message);
+  }
+}
+
 class ObjectValidationError extends DomainError {
   constructor(message = 'Erreur, objet non valide.') {
     super(message);
@@ -787,6 +793,7 @@ module.exports = {
   MissingAssessmentId,
   MissingOrInvalidCredentialsError,
   NoCampaignParticipationForUserAndCampaign,
+  NoCertificationResultForDivision,
   NotEligibleCandidateError,
   NotFoundError,
   NotImplementedError,

--- a/api/lib/domain/usecases/get-sco-certification-results-by-division.js
+++ b/api/lib/domain/usecases/get-sco-certification-results-by-division.js
@@ -1,0 +1,18 @@
+const bluebird = require('bluebird');
+
+module.exports = async function getScoCertificationResultsByDivision({
+  organizationId,
+  division,
+  scoCertificationCandidateRepository,
+  certificationCourseRepository,
+  getCertificationResultByCertifCourse,
+}) {
+  const candidateIds = await scoCertificationCandidateRepository.findIdsByOrganizationIdAndDivision({ organizationId, division });
+  const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds });
+
+  const certificationResults = await bluebird.mapSeries(certificationCourses,
+    (certificationCourse) => getCertificationResultByCertifCourse({ certificationCourse }),
+  );
+
+  return certificationResults;
+};

--- a/api/lib/domain/usecases/get-sco-certification-results-by-division.js
+++ b/api/lib/domain/usecases/get-sco-certification-results-by-division.js
@@ -1,4 +1,6 @@
 const bluebird = require('bluebird');
+const isEmpty = require('lodash/isEmpty');
+const { NoCertificationResultForDivision } = require('../errors');
 
 module.exports = async function getScoCertificationResultsByDivision({
   organizationId,
@@ -13,6 +15,10 @@ module.exports = async function getScoCertificationResultsByDivision({
   const certificationResults = await bluebird.mapSeries(certificationCourses,
     (certificationCourse) => getCertificationResultByCertifCourse({ certificationCourse }),
   );
+
+  if (isEmpty(certificationResults)) {
+    throw new NoCertificationResultForDivision();
+  }
 
   return certificationResults;
 };

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -207,6 +207,7 @@ module.exports = injectDependencies({
   getPrescriber: require('./get-prescriber'),
   getPrivateCertificate: require('./certificate/get-private-certificate'),
   getProgression: require('./get-progression'),
+  getScoCertificationResultsByDivision: require('./get-sco-certification-results-by-division'),
   getSchoolingRegistrationsCsvTemplate: require('./get-schooling-registrations-csv-template'),
   getScorecard: require('./get-scorecard'),
   getSession: require('./get-session'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -49,6 +49,7 @@ const dependencies = {
   divisionRepository: require('../../infrastructure/repositories/division-repository'),
   encryptionService: require('../../domain/services/encryption-service'),
   getCompetenceLevel: require('../../domain/services/get-competence-level'),
+  getCertificationResultByCertifCourse: require('../../domain/services/certification-service').getCertificationResultByCertifCourse,
   finalizedSessionRepository: require('../../infrastructure/repositories/finalized-session-repository'),
   higherSchoolingRegistrationRepository: require('../../infrastructure/repositories/higher-schooling-registration-repository'),
   improvementService: require('../../domain/services/improvement-service'),

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -98,6 +98,19 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObjects(CertificationCourseBookshelf, bookshelfCertificationCourses);
   },
 
+  async findCertificationCoursesByCandidateIds({ candidateIds }) {
+    const bookshelfCertificationCourses = await CertificationCourseBookshelf
+      .query((qb) => {
+        qb.join('certification-candidates', function() {
+          this.on({ 'certification-candidates.sessionId': 'certification-courses.sessionId' })
+            .andOn({ 'certification-candidates.userId': 'certification-courses.userId' });
+        });
+        qb.whereIn('certification-candidates.id', candidateIds);
+      })
+      .fetchAll();
+    return bookshelfToDomainConverter.buildDomainObjects(CertificationCourseBookshelf, bookshelfCertificationCourses);
+  },
+
   async findBySessionIdAndUserIds({ sessionId, userIds }) {
     const bookshelfCertificationCourses = await CertificationCourseBookshelf
       .where({ sessionId })

--- a/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
+++ b/api/lib/infrastructure/repositories/sco-certification-candidate-repository.js
@@ -22,6 +22,19 @@ module.exports = {
 
     await knex.batchInsert('certification-candidates', candidatesToBeEnrolledDTOs);
   },
+
+  async findIdsByOrganizationIdAndDivision({ organizationId, division }) {
+    const rows = await knex
+      .select(['certification-candidates.id'])
+      .from('certification-candidates')
+      .join('schooling-registrations', 'schooling-registrations.id', 'certification-candidates.schoolingRegistrationId')
+      .where('schooling-registrations.organizationId', '=', organizationId)
+      .whereRaw('LOWER("schooling-registrations"."division") LIKE ?', `${division.toLowerCase()}`)
+      .orderBy('certification-candidates.lastName', 'ASC')
+      .orderBy('certification-candidates.firstName', 'ASC');
+
+    return rows.map((row) => row.id);
+  },
 };
 
 function _scoCandidateToDTOForSession(sessionId) {

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -3,13 +3,154 @@ const { status: assessmentResultStatuses } = require('../../../domain/models/Ass
 const _ = require('lodash');
 const moment = require('moment');
 
-const competenceIndexes = [
-  '1.1', '1.2', '1.3',
-  '2.1', '2.2', '2.3', '2.4',
-  '3.1', '3.2', '3.3', '3.4',
-  '4.1', '4.2', '4.3',
-  '5.1', '5.2',
-];
+async function getDivisionCertificationResultsCsv({
+  certificationResults,
+}) {
+  const data = _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults });
+  const fileHeaders = _buildCertificationResultsFileHeadersWithoutCertificationCenterName();
+
+  return getCsvContent({ data, fileHeaders });
+}
+
+async function getSessionCertificationResultsCsv({
+  session,
+  certificationResults,
+}) {
+  const data = _buildCertificationResultsFileDataWithCertificationCenterName({ session, certificationResults });
+  const fileHeaders = _buildCertificationResultsFileHeadersWithCertificationCenterName();
+
+  return getCsvContent({ data, fileHeaders });
+}
+
+function _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults }) {
+  return certificationResults.map(_getRowItemsFromResults);
+}
+
+function _getRowItemsFromResults(certificationResult) {
+  const rowWithoutCompetences = {
+    [_headers.CERTIFICATION_NUMBER]: certificationResult.id,
+    [_headers.FIRSTNAME]: certificationResult.firstName,
+    [_headers.LASTNAME]: certificationResult.lastName,
+    [_headers.BIRTHDATE]: _formatDate(certificationResult.birthdate),
+    [_headers.BIRTHPLACE]: certificationResult.birthplace,
+    [_headers.EXTERNAL_ID]: certificationResult.externalId,
+    [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
+    [_headers.SESSION_ID]: certificationResult.sessionId,
+    [_headers.CERTIFICATION_DATE]: _formatDate(certificationResult.createdAt),
+  };
+  const competencesRow = {};
+  _competenceIndexes.forEach((competenceIndex) => {
+    competencesRow[competenceIndex] = _getCompetenceLevel({
+      competencesWithMark: certificationResult.competencesWithMark,
+      competenceIndex,
+      certificationResult,
+    });
+  });
+  return { ...rowWithoutCompetences, ...competencesRow };
+}
+
+function _buildCertificationResultsFileHeadersWithoutCertificationCenterName() {
+  return _.concat(
+    [
+      _headers.CERTIFICATION_NUMBER,
+      _headers.FIRSTNAME,
+      _headers.LASTNAME,
+      _headers.BIRTHDATE,
+      _headers.BIRTHPLACE,
+      _headers.EXTERNAL_ID,
+      _headers.PIX_SCORE,
+    ],
+    _competenceIndexes,
+    [
+      _headers.SESSION_ID,
+      _headers.CERTIFICATION_DATE,
+    ],
+  );
+}
+
+function _buildCertificationResultsFileDataWithCertificationCenterName({ session, certificationResults }) {
+  return certificationResults.map(_getRowItemsFromSessionAndResults(session));
+}
+
+function _buildCertificationResultsFileHeadersWithCertificationCenterName() {
+  return _.concat(
+    [
+      _headers.CERTIFICATION_NUMBER,
+      _headers.FIRSTNAME,
+      _headers.LASTNAME,
+      _headers.BIRTHDATE,
+      _headers.BIRTHPLACE,
+      _headers.EXTERNAL_ID,
+      _headers.PIX_SCORE,
+    ],
+    _competenceIndexes,
+    [
+      _headers.SESSION_ID,
+      _headers.CERTIFICATION_CENTER,
+      _headers.CERTIFICATION_DATE,
+    ],
+  );
+}
+
+const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => {
+  const rowWithoutCompetences = {
+    [_headers.CERTIFICATION_NUMBER]: certificationResult.id,
+    [_headers.FIRSTNAME]: certificationResult.firstName,
+    [_headers.LASTNAME]: certificationResult.lastName,
+    [_headers.BIRTHDATE]: _formatDate(certificationResult.birthdate),
+    [_headers.BIRTHPLACE]: certificationResult.birthplace,
+    [_headers.EXTERNAL_ID]: certificationResult.externalId,
+    [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
+    [_headers.SESSION_ID]: session.id,
+    [_headers.CERTIFICATION_CENTER]: session.certificationCenter,
+    [_headers.CERTIFICATION_DATE]: _formatDate(certificationResult.createdAt),
+  };
+
+  const competencesCells = _getCompetenceCells(certificationResult);
+  return { ...rowWithoutCompetences, ...competencesCells };
+};
+
+function _formatPixScore(certificationResult) {
+  return _isCertificationRejected(certificationResult) ? '0' : certificationResult.pixScore;
+}
+
+function _isCertificationRejected(certificationResult) {
+  return certificationResult.status === assessmentResultStatuses.REJECTED;
+}
+
+function _formatDate(date) {
+  return moment(date).format('DD/MM/YYYY');
+}
+
+function _getCompetenceCells(certificationResult) {
+  const competencesRow = {};
+  _competenceIndexes.forEach((competenceIndex) => {
+    competencesRow[competenceIndex] = _getCompetenceLevel({
+      competencesWithMark: certificationResult.competencesWithMark,
+      competenceIndex,
+      certificationResult,
+    });
+  });
+  return competencesRow;
+}
+
+function _getCompetenceLevel({ certificationResult, competenceIndex }) {
+  const competencesWithMark = certificationResult.competencesWithMark;
+  const levelByCompetenceCode = _getLevelByCompetenceCode({ competencesWithMark });
+  const competence = levelByCompetenceCode[competenceIndex];
+  const notTestedCompetence = !competence;
+
+  let competenceLevel = '';
+  if (notTestedCompetence) {
+    competenceLevel = '-';
+  } else if (_isCertificationRejected(certificationResult) || _isCompetenceFailed(competence)) {
+    competenceLevel = 0;
+  } else {
+    competenceLevel = competence.level;
+  }
+
+  return competenceLevel;
+}
 
 function _getLevelByCompetenceCode({ competencesWithMark }) {
   return competencesWithMark.reduce((result, competence) => {
@@ -19,25 +160,19 @@ function _getLevelByCompetenceCode({ competencesWithMark }) {
   }, {});
 }
 
-function _competenceIsFailedOrCertifRejected(competence, isCertifRejected) { return isCertifRejected || competence.level <= 0; }
-
-function _getCompetenceLevel({ competencesWithMark, competenceIndex, isCertifRejected }) {
-  const levelByCompetenceCode = _getLevelByCompetenceCode({ competencesWithMark });
-  const competence = levelByCompetenceCode[competenceIndex];
-  const notTestedCompetence = !competence;
-
-  let competenceLevel = '';
-  if (notTestedCompetence) {
-    competenceLevel = '-';
-  } else if (_competenceIsFailedOrCertifRejected(competence, isCertifRejected)) {
-    competenceLevel = 0;
-  } else {
-    competenceLevel = competence.level;
-  }
-
-  return competenceLevel;
+function _isCompetenceFailed(competence) {
+  return competence.level <= 0;
 }
-const headers = {
+
+const _competenceIndexes = [
+  '1.1', '1.2', '1.3',
+  '2.1', '2.2', '2.3', '2.4',
+  '3.1', '3.2', '3.3', '3.4',
+  '4.1', '4.2', '4.3',
+  '5.1', '5.2',
+];
+
+const _headers = {
   CERTIFICATION_NUMBER: 'Numéro de certification',
   FIRSTNAME: 'Prénom',
   LASTNAME: 'Nom',
@@ -48,71 +183,9 @@ const headers = {
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',
   CERTIFICATION_DATE: 'Date de passage de la certification',
-
 };
 
-function formatDate(date) {
-  return moment(date).format('DD/MM/YYYY');
-}
-
-function _buildCertificationResultsFileData({ session, certificationResults }) {
-  return certificationResults.map((certifResult) => {
-    const isCertifRejected = certifResult.status === assessmentResultStatuses.REJECTED;
-    const rowItem = {
-      [headers.CERTIFICATION_NUMBER]: certifResult.id,
-      [headers.FIRSTNAME]: certifResult.firstName,
-      [headers.LASTNAME]: certifResult.lastName,
-      [headers.BIRTHDATE]: formatDate(certifResult.birthdate),
-      [headers.BIRTHPLACE]: certifResult.birthplace,
-      [headers.EXTERNAL_ID]: certifResult.externalId,
-      [headers.PIX_SCORE]: isCertifRejected ? '0' : certifResult.pixScore,
-      [headers.SESSION_ID]: session.id,
-      [headers.CERTIFICATION_CENTER]: session.certificationCenter,
-      [headers.CERTIFICATION_DATE]: formatDate(certifResult.createdAt),
-    };
-
-    competenceIndexes.forEach((competenceIndex) => {
-      rowItem[competenceIndex] = _getCompetenceLevel({
-        competencesWithMark: certifResult.competencesWithMark,
-        competenceIndex,
-        isCertifRejected,
-      });
-    });
-
-    return rowItem;
-  });
-}
-
-function _buildCertificationResultsFileHeaders() {
-  return _.concat(
-    [
-      headers.CERTIFICATION_NUMBER,
-      headers.FIRSTNAME,
-      headers.LASTNAME,
-      headers.BIRTHDATE,
-      headers.BIRTHPLACE,
-      headers.EXTERNAL_ID,
-      headers.PIX_SCORE,
-    ],
-    competenceIndexes,
-    [
-      headers.SESSION_ID,
-      headers.CERTIFICATION_CENTER,
-      headers.CERTIFICATION_DATE,
-    ],
-  );
-}
-
-async function getCertificationResultsCsv({
-  session,
-  certificationResults,
-}) {
-  const data = _buildCertificationResultsFileData({ session, certificationResults });
-  const fileHeaders = _buildCertificationResultsFileHeaders();
-
-  return getCsvContent({ data, fileHeaders });
-}
-
 module.exports = {
-  getCertificationResultsCsv,
+  getSessionCertificationResultsCsv,
+  getDivisionCertificationResultsCsv,
 };

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -139,6 +139,14 @@ describe('Integration | API | Controller Error', () => {
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('La demande de réinitialisation de mot de passe n\'existe pas.');
     });
+
+    it('responds Not Found when a NoCertificationResultForDivision error occurs', async () => {
+      routeHandler.throws(new DomainErrors.NoCertificationResultForDivision());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
+      expect(responseDetail(response)).to.equal('Aucun résultat de certification pour cette classe.');
+    });
   });
 
   context('409 Conflict', () => {

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -458,7 +458,7 @@ describe('Integration | Repository | Certification Course', function() {
       expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
     });
 
-    it('returns only the certification course that is linked to the candidate sessions', async () => {
+    it('returns only the certification course that is linked to the candidate\'s session', async () => {
       const aSessionId = databaseBuilder.factory.buildSession().id;
       const anotherSessionId = databaseBuilder.factory.buildSession().id;
       const userId = databaseBuilder.factory.buildUser().id;

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -411,10 +411,6 @@ describe('Integration | Repository | Certification Course', function() {
     let user1;
     let user2;
 
-    function _cleanCertificationCourse(certificationCourse) {
-      return _.omit(certificationCourse, 'certificationIssueReports', 'assessment', 'challenges', 'updatedAt');
-    }
-
     it('should returns all certification courses id with given session id and user ids', async () => {
       // given
       sessionId = databaseBuilder.factory.buildSession().id;
@@ -432,4 +428,76 @@ describe('Integration | Repository | Certification Course', function() {
       expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(firstCertifCourse));
     });
   });
+
+  describe('#findCertificationCoursesByCandidateIds', () => {
+    it('returns an empty array when none exists', async () => {
+      // given
+      const candidateIds = [1, 2, 3];
+      // when
+      const certificationCourses = certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds });
+      // then
+      expect(certificationCourses).to.be.empty;
+    });
+
+    it('returns the certifications courses of given candidates Ids', async () => {
+      // given
+      const sessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certifCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId, userId });
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        userId,
+        sessionId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds: [certificationCandidateId] });
+      // then
+      expect(certificationCourses).to.have.lengthOf(1);
+      expect(certificationCourses[0]).to.be.an.instanceof(CertificationCourse);
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+    });
+
+    it('returns only the certification course that is linked to the candidate sessions', async () => {
+      const aSessionId = databaseBuilder.factory.buildSession().id;
+      const anotherSessionId = databaseBuilder.factory.buildSession().id;
+      const userId = databaseBuilder.factory.buildUser().id;
+      const certifCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: aSessionId, userId });
+      databaseBuilder.factory.buildCertificationCourse({ sessionId: anotherSessionId, userId });
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        userId,
+        sessionId: aSessionId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds: [certificationCandidateId] });
+      // then
+      expect(certificationCourses).to.have.lengthOf(1);
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+    });
+
+    it('returns only the certification course that is linked to the candidate\'s user', async () => {
+      const aSessionId = databaseBuilder.factory.buildSession().id;
+      const aUserId = databaseBuilder.factory.buildUser().id;
+      const anotherUserId = databaseBuilder.factory.buildUser().id;
+      const certifCourse = databaseBuilder.factory.buildCertificationCourse({ sessionId: aSessionId, userId: aUserId });
+      databaseBuilder.factory.buildCertificationCourse({ sessionId: aSessionId, userId: anotherUserId });
+      const certificationCandidateId = databaseBuilder.factory.buildCertificationCandidate({
+        userId: aUserId,
+        sessionId: aSessionId,
+      }).id;
+      await databaseBuilder.commit();
+
+      // when
+      const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds: [certificationCandidateId] });
+      // then
+      expect(certificationCourses).to.have.lengthOf(1);
+      expect(_cleanCertificationCourse(certificationCourses[0])).to.deep.equal(_cleanCertificationCourse(certifCourse));
+    });
+  });
 });
+
+function _cleanCertificationCourse(certificationCourse) {
+  return _.omit(certificationCourse, 'certificationIssueReports', 'assessment', 'challenges', 'updatedAt');
+}

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -1,14 +1,14 @@
 const { expect, domainBuilder, databaseBuilder } = require('../../../../test-helper');
-const { getCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
+const { getSessionCertificationResultsCsv, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', () => {
 
-  describe('#getCertificationResultsCsv', () => {
+  describe('#getSessionCertificationResultsCsv', () => {
 
     it('should return correct csvContent', async () => {
       // given
       const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
-      const session = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+      const session = databaseBuilder.factory.buildSession({ certificationCenterId });
 
       const birthdate = new Date('1990-01-01');
       const createdAt = new Date('2020-01-01');
@@ -44,15 +44,68 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       const certificationResults = [ certifResult1, certifResult2 ];
 
       // when
-      const result = await getCertificationResultsCsv({ session, certificationResults });
+      const result = await getSessionCertificationResultsCsv({ session, certificationResults });
 
       // then
       const expectedBirthDate = '01/01/1990';
       const expectedCreatedAt = '01/01/2020';
       const expectedResult = '\uFEFF' +
         '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-        `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;;"${expectedCreatedAt}"\n` +
-        `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;;;"${expectedCreatedAt}"`;
+        `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+        `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+
+  describe('#getDivisionCertificationResultsCsv', () => {
+
+    it('returns a csv without session informations', async () => {
+      // given
+      const birthdate = new Date('1990-01-01');
+      const createdAt = new Date('2020-01-01');
+
+      const competencesWithMark1 = [
+        { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+        { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+      ];
+      const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+
+      const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+        status: 'validated',
+        competenceMarks: competencesWithMark1,
+      });
+      const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+        status: 'rejected',
+        competenceMarks: competencesWithMark2,
+      });
+
+      const certifResult1 = domainBuilder.buildCertificationResult({
+        lastAssessmentResult: lastAssessmentResult1,
+        firstName: 'Lili',
+        birthdate,
+        createdAt,
+        sessionId: 'sessionId1',
+      });
+      const certifResult2 = domainBuilder.buildCertificationResult({
+        lastAssessmentResult: lastAssessmentResult2,
+        firstName: 'Tom',
+        birthdate,
+        createdAt,
+        sessionId: 'sessionId2',
+      });
+
+      const certificationResults = [ certifResult1, certifResult2 ];
+
+      // when
+      const result = await getDivisionCertificationResultsCsv({ certificationResults });
+
+      // then
+      const expectedBirthDate = '01/01/1990';
+      const expectedCreatedAt = '01/01/2020';
+      const expectedResult = '\uFEFF' +
+              '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Date de passage de la certification"\n' +
+              `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult1.sessionId}";"${expectedCreatedAt}"\n` +
+              `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;"${certifResult2.sessionId}";"${expectedCreatedAt}"`;
       expect(result).to.deep.equal(expectedResult);
     });
   });

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -429,8 +429,8 @@ describe('Unit | Controller | sessionController', () => {
           certificationResults: [],
           fileName: '20200101_1200_resultats_session_1.csv',
         });
-      sinon.stub(certificationResults, 'getCertificationResultsCsv');
-      certificationResults.getCertificationResultsCsv.withArgs({ session, certificationResults: [] })
+      sinon.stub(certificationResults, 'getSessionCertificationResultsCsv');
+      certificationResults.getSessionCertificationResultsCsv.withArgs({ session, certificationResults: [] })
         .resolves('csv content');
 
       // when

--- a/api/tests/unit/domain/usecases/get-sco-certification-results-by-division_test.js
+++ b/api/tests/unit/domain/usecases/get-sco-certification-results-by-division_test.js
@@ -1,0 +1,81 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const getScoCertificationResultsByDivision = require('../../../../lib/domain/usecases/get-sco-certification-results-by-division');
+
+describe('Unit | UseCase | get-sco-certification-results-by-division', () => {
+  it('returns an empty list when no candidates match the organization and division', async () => {
+    // given
+    const scoCertificationCandidateRepository = { findIdsByOrganizationIdAndDivision: sinon.stub() };
+    scoCertificationCandidateRepository.findIdsByOrganizationIdAndDivision.withArgs({
+      organizationId: 1,
+      division: '3ème A',
+    }).resolves([]);
+    const certificationCourseRepository = { findCertificationCoursesByCandidateIds: sinon.stub() };
+    certificationCourseRepository.findCertificationCoursesByCandidateIds.withArgs({
+      candidateIds: [],
+    }).resolves([]);
+
+    const dependencies = {
+      scoCertificationCandidateRepository,
+      certificationCourseRepository,
+      getCertificationResultByCertifCourse: undefined,
+    };
+
+    // when
+    const certificationResults = await getScoCertificationResultsByDivision({
+      ...dependencies,
+      organizationId: 1,
+      division: '3ème A',
+    });
+
+    // then
+    expect(certificationResults).to.be.empty;
+  });
+
+  it('returns the list of results of candidates matching the organization and division', async () => {
+    // given
+    const scoCertificationCandidateRepository = { findIdsByOrganizationIdAndDivision: sinon.stub() };
+    scoCertificationCandidateRepository.findIdsByOrganizationIdAndDivision.withArgs({
+      organizationId: 1,
+      division: '3ème A',
+    }).resolves([10, 11]);
+    const certificationCourseRepository = { findCertificationCoursesByCandidateIds: sinon.stub() };
+
+    const firstMatchingCandidateCertificationCourse = domainBuilder.buildCertificationCourse();
+    const firstMatchingCandidateCertificationResult = domainBuilder.buildCertificationResult();
+    const secondMatchingCandidateCertificationCourse = domainBuilder.buildCertificationCourse();
+    const secondMatchingCandidateCertificationResult = domainBuilder.buildCertificationResult();
+
+    certificationCourseRepository.findCertificationCoursesByCandidateIds.withArgs({
+      candidateIds: [10, 11],
+    }).resolves([
+      firstMatchingCandidateCertificationCourse,
+      secondMatchingCandidateCertificationCourse,
+    ]);
+
+    const getCertificationResultByCertifCourse = sinon.stub();
+    getCertificationResultByCertifCourse.withArgs({ certificationCourse: firstMatchingCandidateCertificationCourse })
+      .resolves(firstMatchingCandidateCertificationResult);
+    getCertificationResultByCertifCourse.withArgs({ certificationCourse: secondMatchingCandidateCertificationCourse })
+      .resolves(secondMatchingCandidateCertificationResult);
+
+    const dependencies = {
+      scoCertificationCandidateRepository,
+      certificationCourseRepository,
+      getCertificationResultByCertifCourse,
+    };
+
+    // when
+    const certificationResults = await getScoCertificationResultsByDivision({
+      ...dependencies,
+      organizationId: 1,
+      division: '3ème A',
+    });
+
+    // then
+    expect(certificationResults).to.deep.equal([
+      firstMatchingCandidateCertificationResult,
+      secondMatchingCandidateCertificationResult,
+    ]);
+  });
+
+});

--- a/api/tests/unit/domain/usecases/get-sco-certification-results-by-division_test.js
+++ b/api/tests/unit/domain/usecases/get-sco-certification-results-by-division_test.js
@@ -1,8 +1,8 @@
-const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
 const getScoCertificationResultsByDivision = require('../../../../lib/domain/usecases/get-sco-certification-results-by-division');
-
+const { NoCertificationResultForDivision } = require('../../../../lib/domain/errors');
 describe('Unit | UseCase | get-sco-certification-results-by-division', () => {
-  it('returns an empty list when no candidates match the organization and division', async () => {
+  it('throws when no results is found for organization and division', async () => {
     // given
     const scoCertificationCandidateRepository = { findIdsByOrganizationIdAndDivision: sinon.stub() };
     scoCertificationCandidateRepository.findIdsByOrganizationIdAndDivision.withArgs({
@@ -21,14 +21,14 @@ describe('Unit | UseCase | get-sco-certification-results-by-division', () => {
     };
 
     // when
-    const certificationResults = await getScoCertificationResultsByDivision({
+    const error = await catchErr(getScoCertificationResultsByDivision)({
       ...dependencies,
       organizationId: 1,
       division: '3ème A',
     });
 
     // then
-    expect(certificationResults).to.be.empty;
+    expect(error).to.be.instanceof(NoCertificationResultForDivision);
   });
 
   it('returns the list of results of candidates matching the organization and division', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Des sessions de certification sont organisées dans les lycées volontaires depuis le 11/01. Si les résultats sont visibles pour les candidats depuis leur compte Pix lorsque la session est publiée, il n’est pour le moment pas possible pour les chefs d'établissements/professeurs d’avoir accès aux résultats des élèves de leur établissement.

## :robot: Solution
Permettre uniquement aux Administrateurs Pix Orga de télécharger les résultats de certification des élèves de leur établissement.

## :rainbow: Remarques
Cette PR ne concerne que le back-end, elle s'appuie sur la PR #2581
PR front : #2598 et #2617

## :100: Pour tester
- Se mettre dans le dossier `api`
- Lancer le script `node scripts/data-generation/generate-campaign-with-participants.js --organizationId 3 --participantCount 1000 --profileType light --campaignType assessment --createSchoolingRegistrations`
- Lancer le script `node scripts/data-generation/generate-certifications-for-organization.js --organizationId 3 --certificationCenterId 1`
- Lancer l'api avec `FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true`
- se connecter en tant que `sco.member@example.net`
- Copier une des requêtes cURL du front depuis le navigateur
- Coller la requête dans un terminal, la modifier pour faire un `GET http://localhost:4201/api/organizations/3/certification-results?division=5eme`
- Lancer cette requête en pipant dans un fichier CSV
- Constater que le fichier CSV est non vide
- Relancer la requête en modifier `division=invalidDivision`
- Constater qu'on reçoit une 404 : "Aucun résultat de certification pour cette classe."
