### PR TITLE
[FEATURE] Traduire la page de participant d'une collecte de profils (PIX-2203).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/profile/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/details.hbs
@@ -3,8 +3,8 @@
    <PreviousPageButton
      @route="authenticated.campaigns.campaign.profiles"
      @routeId={{@campaign.id}}
-     @backButtonAriaLabel="Retour"
-     aria-label="Nom de la campagne"
+     @backButtonAriaLabel={{t "common.actions.back"}}
+     aria-label={{t "pages.campaign-individual-results.campaign-name"}}
    >
     {{@campaign.name}}
    </PreviousPageButton>
@@ -16,7 +16,9 @@
         {{@campaignProfile.firstName}} {{@campaignProfile.lastName}}
       </h2>
       {{#if (and @campaignProfile.isCertifiable @campaignProfile.isShared)}}
-        <PixTag @color="green-light" class="profile-user__certifiable">Certifiable</PixTag>
+        <PixTag @color="green-light" class="profile-user__certifiable">
+          {{t "pages.profiles-individual-results.certifiable"}}
+        </PixTag>
       {{/if}}
     </header>
 
@@ -29,12 +31,16 @@
           </li>
         {{/if}}
         <li class="panel-header-data__content">
-          <div class="label-text panel-header-data-content__label">Commencé le</div>
+          <div class="label-text panel-header-data-content__label">
+            {{t "pages.campaign-individual-results.start-date"}}
+          </div>
           <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.createdAt 'DD MMM YYYY'}}</div>
         </li>
         {{#if @campaignProfile.isShared}}
           <li class="panel-header-data__content">
-            <div class="label-text panel-header-data-content__label">Envoyé le</div>
+            <div class="label-text panel-header-data-content__label">
+              {{t "pages.campaign-individual-results.shared-date"}}
+            </div>
               <div class="value-text panel-header-data-content__value">{{moment-format @campaignProfile.sharedAt 'DD MMM YYYY'}}</div>
           </li>
         {{/if}}
@@ -43,15 +49,19 @@
       {{#if @campaignProfile.isShared}}
         <ul class="panel-header__data panel-header__data--highlight">
           <li class="panel-header-data__content">
-            <span class="value-text value-text--highlight">{{@campaignProfile.pixScore}}</span>
-            <span class="label-text label-text--dark label-text--small">PIX</span>
+            <span class="value-text value-text--highlight">{{t "pages.profiles-individual-results.pix-score" score=@campaignProfile.pixScore}}</span>
+            <span class="label-text label-text--dark label-text--small">
+              {{t "pages.profiles-individual-results.pix"}}
+            </span>
           </li>
           <li class="panel-header-data__content">
             <span class="value-text">
               <span class="value-text value-text--highlight">{{@campaignProfile.certifiableCompetencesCount}}</span>
               <span>&nbsp;/&nbsp;{{@campaignProfile.competencesCount}}</span>
             </span>
-            <span class="label-text label-text--dark label-text--small">COMP. CERTIFIABLES</span>
+            <span class="label-text label-text--dark label-text--small">
+              {{t "pages.profiles-individual-results.competences-certifiables"}}
+            </span>
           </li>
         </ul>
       {{/if}}

--- a/orga/app/components/routes/authenticated/campaign/profile/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/list.hbs
@@ -17,7 +17,7 @@
             <th>{{@campaign.idPixLabel}}</th>
           {{/if}}
           <th class="table__column--center">{{t 'pages.profiles-list.table.column.sending-date.label'}}</th>
-          <th class="table__column--center">{{t 'pages.profiles-list.table.column.pix-score'}}</th>
+          <th class="table__column--center">{{t 'pages.profiles-list.table.column.pix-score.label'}}</th>
           <th class="table__column--center">{{t 'pages.profiles-list.table.column.certifiable'}}</th>
           <th class="table__column--center">{{t 'pages.profiles-list.table.column.competences-certifiables'}}</th>
         </tr>
@@ -42,7 +42,7 @@
             <td class="table__column--center">
               {{#if profile.sharedAt }}
                 <PixTag @color="purple" class="pix-score-tag">
-                  {{profile.pixScore}}
+                  {{t 'pages.profiles-list.table.column.pix-score.value' score=profile.pixScore}}
                 </PixTag>
               {{/if}}
             </td>

--- a/orga/app/components/routes/authenticated/campaign/profile/table.hbs
+++ b/orga/app/components/routes/authenticated/campaign/profile/table.hbs
@@ -1,18 +1,20 @@
 <table>
   <thead>
     <tr>
-      <th>Compétence</th>
-      <th class="table__column table__column--center">
-        Niveau
+      <th>
+        {{t "pages.profiles-individual-results.table.column.skill"}}
       </th>
       <th class="table__column table__column--center">
-        Score Pix
+        {{t "pages.profiles-individual-results.table.column.level"}}
+      </th>
+      <th class="table__column table__column--center">
+        {{t "pages.profiles-individual-results.table.column.pix-score"}}
       </th>
     </tr>
   </thead>
   <tbody>
     {{#each @competences as |competence|}}
-      <tr aria-label="Competence">
+      <tr aria-label={{t "pages.profiles-individual-results.table.row-title"}}>
         <td class="competences-col__name">
           <span class="competences-col__border competences-col__border--{{competence.areaColor}}"></span>
           <span>
@@ -31,5 +33,7 @@
 </table>
 
 {{#unless @isShared }}
-  <div class="table__empty content-text">En attente de résultats</div>
+  <div class="table__empty content-text">
+    {{t "pages.profiles-individual-results.table.empty"}}
+  </div>
 {{/unless}}

--- a/orga/app/styles/components/pix-score-tag.scss
+++ b/orga/app/styles/components/pix-score-tag.scss
@@ -1,3 +1,3 @@
 .pix-score-tag {
-  width: 50px;
+  min-width: 50px;
 }

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/profile/details', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it displays user information', async function(assert) {
     const campaignProfile = {
@@ -113,7 +113,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
     module('when the  profile is shared', function() {
       test('it displays the pix score', async function(assert) {
         const campaignProfile = {
-          pixScore: '1024',
+          pixScore: '124',
           isShared: true,
         };
 
@@ -124,7 +124,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
 
         await render(hbs`<Routes::Authenticated::Campaign::Profile::Details @campaignProfile={{campaignProfile}} @campaign={{campaign}} />`);
 
-        assert.contains('1024');
+        assert.contains('124');
       });
 
       test('it displays the total number of competence', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/table-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/table-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | routes/authenticated/campaign/profile/table', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('when profile is not shared', function() {
     test('it displays empty table message', async function(assert) {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -258,9 +258,24 @@
     },
     "certifications": {
       "description": "Please select the class for which you would like to export the certification results in a csv file.",
-      "title": "My certifications",
+      "download-button": "Export the results",
       "select-label": "Class",
-      "download-button": "Export the results"
+      "title": "My certifications"
+    },
+    "profiles-individual-results": {
+      "certifiable": "Eligible for certification",
+      "competences-certifiables": "SKILLS ELIGIBLE FOR CERTIFICATION",
+      "pix": "PIX",
+      "pix-score": "{score, number}",
+      "table": {
+        "column": {
+          "level": "Level",
+          "pix-score": "Pix score",
+          "skill": "Skill"
+        },
+        "empty": "Results pending",
+        "row-title": "Skill"
+      }
     }
   }
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -188,7 +188,10 @@
           "competences-certifiables": "Skills eligible for certification",
           "first-name": "First name",
           "last-name": "Last name",
-          "pix-score": "Pix score",
+          "pix-score": {
+            "label": "Pix score",
+            "value": "{score, number}"
+          },
           "sending-date": {
             "label": "Sending date",
             "on-hold": "Pending"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -188,7 +188,10 @@
           "competences-certifiables": "Comp. certifiables",
           "first-name": "Nom",
           "last-name": "Prénom",
-          "pix-score": "Score Pix",
+          "pix-score": {
+            "label": "Score Pix",
+            "value": "{score, number}"
+          },
           "sending-date": {
             "label": "Date d'envoi",
             "on-hold": "En attente"

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -258,9 +258,24 @@
     },
     "certifications": {
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.",
-      "title": "Mes certifications",
+      "download-button": "Exporter mes résultats",
       "select-label": "Classes",
-      "download-button": "Exporter mes résultats"
+      "title": "Mes certifications"
+    },
+    "profiles-individual-results": {
+      "certifiable": "Certifiable",
+      "competences-certifiables": "COMP. CERTIFIABLES",
+      "pix": "PIX",
+      "pix-score": "{score, number}",
+      "table": {
+        "column": {
+          "level": "Niveau",
+          "pix-score": "Score Pix",
+          "skill": "Compétence"
+        },
+        "empty": "En attente de résultats",
+        "row-title": "Compétence"
+      }
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème

La page de participant d'une collecte de profile n'est pas internationalisée.

## :robot: Solution

Traduire la page de participant d'une collecte de profile.

## :rainbow: Remarques

N/A

## :100: Pour tester

1. Se connecter à orga avec le compte pro.admin
2. Aller sur la collecte de profile "Pro - Campagne de collecte de profils"
3. Aller sur la page d'un participant certifiable et tester avec `lang=fr` et `lang=en`
4. Aller sur la page d'un participant en attente de résultat et tester avec `lang=fr` et `lang=en`
