### PR TITLE
[FEATURE] Traduire dans l'API l'invitation à rejoindre Pix Orga (PIX-2212).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,16 +1,23 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 const moment = require('moment');
+const FrTranslations = require('../../../translations/fr');
+const EnTranslations = require('../../../translations/en');
 const tokenService = require('./token-service');
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
-const PIX_ORGA_NAME = 'Pix Orga - Ne pas répondre';
+const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
+const PIX_ORGA_NAME_EN = 'Pix Orga - Noreply';
 const PIX_NAME_FR = 'PIX - Ne pas répondre';
 const PIX_NAME_EN = 'PIX - Noreply';
 const ACCOUNT_CREATION_EMAIL_SUBJECT_FR = 'Votre compte Pix a bien été créé';
 const ACCOUNT_CREATION_EMAIL_SUBJECT_EN = 'Your Pix account has been created';
 const RESET_PASSWORD_EMAIL_SUBJECT_FR = 'Demande de réinitialisation de mot de passe PIX';
 const RESET_PASSWORD_EMAIL_SUBJECT_EN = 'Pix password reset request';
+const HELPDESK_FR = 'https://support.pix.fr/support/tickets/new';
+const HELPDESK_EN = 'https://pix.org/en-gb/help-form';
+const ORGANIZATION_INVITATION_EMAIL_SUBJECT_FR = 'Invitation à rejoindre Pix Orga';
+const ORGANIZATION_INVITATION_EMAIL_SUBJECT_EN = 'Invitation to join Pix Orga';
 
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
@@ -153,34 +160,52 @@ function sendOrganizationInvitationEmail({
   tags,
 }) {
   locale = locale ? locale : 'fr-fr';
+  let pixOrgaName = PIX_ORGA_NAME_FR;
+  let sendOrganizationInvitationEmailSubject = ORGANIZATION_INVITATION_EMAIL_SUBJECT_FR;
 
-  let variables = {
+  let templateParams = {
     organizationName,
     pixHomeName: `pix${settings.domain.tldFr}`,
     pixHomeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
     pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldFr}`,
     redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldFr}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-    locale,
+    supportUrl: HELPDESK_FR,
+    ...FrTranslations['organization-invitation-email'],
   };
 
   if (locale === 'fr') {
-    variables = {
+    templateParams = {
       organizationName,
       pixHomeName: `pix${settings.domain.tldOrg}`,
       pixHomeUrl: `${settings.domain.pix + settings.domain.tldOrg}`,
       pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}`,
       redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
-      locale,
+      supportUrl: HELPDESK_FR,
+      ...FrTranslations['organization-invitation-email'],
     };
+  }
+
+  if (locale === 'en') {
+    templateParams = {
+      organizationName,
+      pixHomeName: `pix${settings.domain.tldOrg}`,
+      pixHomeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
+      pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}?lang=en`,
+      redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
+      supportUrl: HELPDESK_EN,
+      ...EnTranslations['organization-invitation-email'],
+    };
+    pixOrgaName = PIX_ORGA_NAME_EN;
+    sendOrganizationInvitationEmailSubject = ORGANIZATION_INVITATION_EMAIL_SUBJECT_EN;
   }
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_ORGA_NAME,
+    fromName: pixOrgaName,
     to: email,
-    subject: 'Invitation à rejoindre Pix Orga',
+    subject: sendOrganizationInvitationEmailSubject,
     template: mailer.organizationInvitationTemplateId,
-    variables,
+    variables: templateParams,
     tags: tags || null,
   });
 }
@@ -220,7 +245,7 @@ function sendScoOrganizationInvitationEmail({
 
   return mailer.sendEmail({
     from: EMAIL_ADDRESS_NO_RESPONSE,
-    fromName: PIX_ORGA_NAME,
+    fromName: PIX_ORGA_NAME_FR,
     to: email,
     subject: 'Accès à votre espace Pix Orga',
     template: mailer.organizationInvitationScoTemplateId,

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,0 +1,14 @@
+{
+  "organization-invitation-email": {
+    "title": "You are invited to join Pix Orga",
+    "subtitle": "With the Pix Orga platform, create and manage testing campaigns and monitor the progress of your participants.",
+    "yourOrganization": "Your organization",
+    "acceptInvitation": "Accept the invitation",
+    "oneTimeLink": "This is a single-use link",
+    "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills.",
+    "moreAbout": "More on",
+    "doNotAnswer": "This is an automated email message, please do not reply.",
+    "needHelp": "Have questions? We’re here to help, contact us",
+    "here": "here"
+  }
+}

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,0 +1,14 @@
+{
+  "organization-invitation-email": {
+    "title": "Vous êtes invité(e) à rejoindre Pix Orga",
+    "subtitle": "La plateforme Pix Orga vous permet de créer, gérer des campagnes de test et suivre la progression de vos participants.",
+    "yourOrganization": "Votre organisation",
+    "acceptInvitation": "Accepter l’invitation",
+    "oneTimeLink": "Ce lien est à usage unique",
+    "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+    "moreAbout": "En savoir plus sur",
+    "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
+    "needHelp": "Besoin d’aide, contactez-nous",
+    "here": "ici"
+  }
+}


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, la traduction des e-mails transactionnels est géré grâce à des structures conditionnelles dans le template des e-mails et s’appuie sur la locale qui est envoyé à l’API de Sendinblue. Cette façon de faire rend l'évolution des templates des e-mails extrêmement compliqué. De plus, nous souhaitons créer la version anglaise du mail d'invitation à rejoindre Pix Orga. 

## :robot: Solution
- Création des clés et traductions relatives au mail d’invitation à rejoindre Pix Orga
- Envoi des variables à Sendinblue lors de l’envoi de l’email
- Mise à jour du template du mail afin qu’il se base sur les variables envoyées

## :rainbow: Remarques
Le numéro du template de l'email passe de 32 à 89

## :100: Pour tester
Tester l'invitation d'un membre sur:
- https://orga-pr2626.review.pix.fr/equipe/membres (fr-fr)
- https://orga-pr2626.review.pix.org/equipe/membres (fr)
- https://orga-pr2626.review.pix.org/equipe/membres?lang=en (en)