### PR TITLE
[BUGFIX] Affichage de l'instruction avec des liens (PIX-2267).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -20,7 +20,7 @@
     color: $blue;
 
     @include device-is('tablet') {
-      white-space: nowrap;
+      display: inline-block;
     }
 
     &:active,


### PR DESCRIPTION
## :unicorn: Problème
Sur les épreuves contenant des instructions avec des liens trop longs, le texte sort en dehors du cadre qui lui est alloué:

<img width="1448" alt="Screenshot 2021-02-26 at 15 42 06" src="https://user-images.githubusercontent.com/11294487/109314101-3742c300-7849-11eb-9b8b-edd133afe799.png">

## :robot: Solution
Cette PR fixe cela en supprimant le `white-space: nowrap;` et en ajoutant `display: inline-block` sur l'élément `<a>`

## :rainbow: Remarques
- Veiller à ce que l'icon qui s'affiche après le lien (pour indiquer que le lien s'ouvre dans une nouvel onglet) soit toujours sur la même ligne que le lien.

## :100: Pour tester
Vérifier que les instructions s'affichent correctement sur les épreuves avec des liens (ex: recjLHrwCUE0ke8z7 et rechH1WtSPVntUYbX).
