### PR TITLE
[TECH] Améliorer l'accessibilité du tableaux de résultats par compétences en campagne (PIX-1885).

### DIFF
--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -1,8 +1,8 @@
 <table class="default-table">
   <thead>
   <tr>
-    <th>{{t 'pages.skill-review.details.header-skill'}}</th>
-    <th>{{t 'pages.skill-review.details.header-result'}}</th>
+    <th scope="col">{{t 'pages.skill-review.details.header-skill'}}</th>
+    <th scope="col">{{t 'pages.skill-review.details.header-result'}}</th>
   </tr>
   </thead>
 
@@ -10,10 +10,10 @@
   {{#if @showCleaCompetences}}
     {{#each @partnerCompetenceResults as |partnerCompetence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
-        <td>
+        <th scope="row">
           <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}" aria-hidden="true">&#8226;</span>
           <span>{{partnerCompetence.name}}</span>
-        </td>
+        </th>
         <td>
           <ProgressionGauge @total={{partnerCompetence.totalSkillsCountPercentage}}
                             @value={{partnerCompetence.masteryPercentage}}>
@@ -25,10 +25,10 @@
     {{else}}
     {{#each @competenceResults as |competence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
-        <td>
+        <th scope="row">
           <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}" aria-hidden="true">&#8226;</span>
           <span>{{competence.name}}</span>
-        </td>
+        </th>
         <td>
           <ProgressionGauge @total={{competence.totalSkillsCountPercentage}}
                             @value={{competence.masteryPercentage}}>

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -82,10 +82,10 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('table tbody tr td:nth-child(1) span:nth-child(2)').textContent).to.equal(competenceResultName);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge').getAttribute('style')).to.equal('width: ' + PROGRESSION_MAX_WIDTH);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge__marker').getAttribute('style')).to.equal('width: ' + COMPETENCE_MASTERY_PERCENTAGE);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge__tooltip').textContent).to.include(COMPETENCE_MASTERY_PERCENTAGE);
+        expect(find('table tbody tr th span:nth-child(2)').textContent).to.equal(competenceResultName);
+        expect(find('table tbody tr td .progression-gauge').getAttribute('style')).to.equal('width: ' + PROGRESSION_MAX_WIDTH);
+        expect(find('table tbody tr td .progression-gauge__marker').getAttribute('style')).to.equal('width: ' + COMPETENCE_MASTERY_PERCENTAGE);
+        expect(find('table tbody tr td .progression-gauge__tooltip').textContent).to.include(COMPETENCE_MASTERY_PERCENTAGE);
       });
 
       it('should display different competences results when the badge key is PIX_EMPLOI_CLEA', async function() {
@@ -117,10 +117,10 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
         await visit(`/campagnes/${campaign.code}/evaluation/resultats/${campaignParticipation.assessment.id}`);
 
         // then
-        expect(find('table tbody tr td:nth-child(1) span:nth-child(2)').textContent).to.equal(partnerCompetenceResultName);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge').getAttribute('style')).to.equal('width: ' + PROGRESSION_MAX_WIDTH);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge__marker').getAttribute('style')).to.equal('width: ' + BADGE_PARTNER_COMPETENCE_MASTERY_PERCENTAGE);
-        expect(find('table tbody tr td:nth-child(2) .progression-gauge__tooltip').textContent).to.include(BADGE_PARTNER_COMPETENCE_MASTERY_PERCENTAGE);
+        expect(find('table tbody tr th span:nth-child(2)').textContent).to.equal(partnerCompetenceResultName);
+        expect(find('table tbody tr td .progression-gauge').getAttribute('style')).to.equal('width: ' + PROGRESSION_MAX_WIDTH);
+        expect(find('table tbody tr td .progression-gauge__marker').getAttribute('style')).to.equal('width: ' + BADGE_PARTNER_COMPETENCE_MASTERY_PERCENTAGE);
+        expect(find('table tbody tr td .progression-gauge__tooltip').textContent).to.include(BADGE_PARTNER_COMPETENCE_MASTERY_PERCENTAGE);
       });
 
       it('should display the Pix emploi badge when badge is acquired', async function() {


### PR DESCRIPTION
## :unicorn: Problème
Le tableaux qui détaille les % de réussite par compétence n'est pas totalement accessible

## :robot: Solution
Suivre les recommandations Tanaguru > Mettre des `th` et les `scope`

## :rainbow: Remarques
https://developer.mozilla.org/fr/docs/Web/HTML/Element/th

## :100: Pour tester
Aller à la fin d'une campagne et regarder le HTML