### PR TITLE
[FEATURE] Préparation à l'affichage des sessions à traiter (PIX-2040)

### DIFF
--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -6,4 +6,9 @@ module.exports = {
     const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
     return finalizedSessionSerializer.serialize(finalizedSessionsToPublish);
   },
+
+  async findFinalizedSessionsWithRequiredAction() {
+    const finalizedSessionsWithRequiredAction = await usecases.findFinalizedSessionsWithRequiredAction();
+    return finalizedSessionSerializer.serialize(finalizedSessionsWithRequiredAction);
+  },
 };

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -1,14 +1,15 @@
 const usecases = require('../../domain/usecases');
-const finalizedSessionSerializer = require('../../infrastructure/serializers/jsonapi/finalized-session-serializer');
+const publishableSessionSerializer = require('../../infrastructure/serializers/jsonapi/publishable-session-serializer');
+const sessionWithRequiredActionSerializer = require('../../infrastructure/serializers/jsonapi/session-with-required-action-serializer');
 
 module.exports = {
   async findFinalizedSessionsToPublish() {
     const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
-    return finalizedSessionSerializer.serialize(finalizedSessionsToPublish);
+    return publishableSessionSerializer.serialize(finalizedSessionsToPublish);
   },
 
   async findFinalizedSessionsWithRequiredAction() {
     const finalizedSessionsWithRequiredAction = await usecases.findFinalizedSessionsWithRequiredAction();
-    return finalizedSessionSerializer.serialize(finalizedSessionsWithRequiredAction);
+    return sessionWithRequiredActionSerializer.serialize(finalizedSessionsWithRequiredAction);
   },
 };

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -71,6 +71,18 @@ exports.register = async (server) => {
     },
     {
       method: 'GET',
+      path: '/api/admin/sessions/with-required-action',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: finalizedSessionController.findFinalizedSessionsWithRequiredAction,
+        tags: ['api', 'finalized-sessions'],
+      },
+    },
+    {
+      method: 'GET',
       path: '/api/sessions/{id}/attendance-sheet',
       config: {
         auth: false,

--- a/api/lib/domain/usecases/find-finalized-sessions-with-required-action.js
+++ b/api/lib/domain/usecases/find-finalized-sessions-with-required-action.js
@@ -1,0 +1,3 @@
+module.exports = function findFinalizedSessionsWithRequiredAction({ finalizedSessionRepository }) {
+  return finalizedSessionRepository.findFinalizedSessionsWithRequiredAction();
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -157,6 +157,7 @@ module.exports = injectDependencies({
   findLatestOngoingUserCampaignParticipations: require('./find-latest-ongoing-user-campaign-participations'),
   findDivisionsByCertificationCenter: require('./find-divisions-by-certification-center'),
   findFinalizedSessionsToPublish: require('./find-finalized-sessions-to-publish'),
+  findFinalizedSessionsWithRequiredAction: require('./find-finalized-sessions-with-required-action'),
   findPaginatedCampaignAssessmentParticipationSummaries: require('./find-paginated-campaign-assessment-participation-summaries'),
   findPaginatedFilteredCertificationCenters: require('./find-paginated-filtered-certification-centers'),
   findPaginatedFilteredOrganizationCampaigns: require('./find-paginated-filtered-organization-campaigns'),

--- a/api/lib/infrastructure/repositories/finalized-session-repository.js
+++ b/api/lib/infrastructure/repositories/finalized-session-repository.js
@@ -32,6 +32,15 @@ module.exports = {
 
     return bookshelfToDomainConverter.buildDomainObjects(FinalizedSessionBookshelf, publishableFinalizedSessions);
   },
+
+  async findFinalizedSessionsWithRequiredAction() {
+    const publishableFinalizedSessions = await FinalizedSessionBookshelf
+      .where({ isPublishable: false, publishedAt: null })
+      .orderBy('finalizedAt')
+      .fetchAll();
+
+    return bookshelfToDomainConverter.buildDomainObjects(FinalizedSessionBookshelf, publishableFinalizedSessions);
+  },
 };
 
 function _toDTO(finalizedSession) {

--- a/api/lib/infrastructure/serializers/jsonapi/publishable-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/publishable-session-serializer.js
@@ -1,0 +1,19 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+
+  serialize(finalizedSessions) {
+    return new Serializer('publishable-session', {
+      transform(finalizedSession) {
+        return { ...finalizedSession, id: finalizedSession.sessionId };
+      },
+      attributes: [
+        'sessionId',
+        'sessionDate',
+        'sessionTime',
+        'finalizedAt',
+        'certificationCenterName',
+      ],
+    }).serialize(finalizedSessions);
+  },
+};

--- a/api/lib/infrastructure/serializers/jsonapi/session-with-required-action-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/session-with-required-action-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
 
   serialize(finalizedSessions) {
-    return new Serializer('publishable-session', {
+    return new Serializer('with-required-action-session', {
       transform(finalizedSession) {
         return { ...finalizedSession, id: finalizedSession.sessionId };
       },
@@ -15,6 +15,5 @@ module.exports = {
         'certificationCenterName',
       ],
     }).serialize(finalizedSessions);
-
   },
 };

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
@@ -39,7 +39,7 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
-        expect(response.result.data[0].type).to.equal('publishable-sessions');
+        expect(response.result.data[0].type).to.equal('with-required-action-sessions');
       });
     });
   });

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-with-required-action_test.js
@@ -1,0 +1,46 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder, insertUserWithRolePixMaster,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('Acceptance | Controller | finalized-session-controller-find-finalized-sessions-with-required-action', () => {
+
+  describe('GET /api/admin/sessions/with-required-action', () => {
+
+    context('When user is authorized', () => {
+
+      it('should return a 200 status code response with JSON API serialized', async () => {
+
+        await insertUserWithRolePixMaster();
+
+        databaseBuilder.factory.buildSession({ id: 121 });
+        databaseBuilder.factory.buildSession({ id: 333 });
+        databaseBuilder.factory.buildSession({ id: 323 });
+        databaseBuilder.factory.buildSession({ id: 423 });
+
+        databaseBuilder.factory.buildFinalizedSession({ sessionId: 121, isPublishable: false, publishedAt: null });
+        databaseBuilder.factory.buildFinalizedSession({ sessionId: 333, isPublishable: false, publishedAt: null });
+        databaseBuilder.factory.buildFinalizedSession({ sessionId: 323, isPublishable: true, publishedAt: null });
+        databaseBuilder.factory.buildFinalizedSession({ sessionId: 423, isPublishable: false, publishedAt: '2021-01-02' });
+
+        await databaseBuilder.commit();
+
+        const server = await createServer();
+        const options = {
+          method: 'GET',
+          url: '/api/admin/sessions/with-required-action',
+          payload: { },
+          headers: { authorization: generateValidRequestAuthorizationHeader() },
+        };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(200);
+        expect(response.result.data).to.have.lengthOf(2);
+        expect(response.result.data[0].type).to.equal('publishable-sessions');
+      });
+    });
+  });
+});

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -1,7 +1,8 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const usecases = require('../../../../lib/domain/usecases');
-const finalizedSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/finalized-session-serializer');
+const publishableSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/publishable-session-serializer');
+const sessionWithRequiredActionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-with-required-action-serializer');
 
 describe('Unit | Controller | finalized-session', () => {
   let request;
@@ -11,7 +12,7 @@ describe('Unit | Controller | finalized-session', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'findFinalizedSessionsToPublish').resolves();
-      sinon.stub(finalizedSessionSerializer, 'serialize');
+      sinon.stub(publishableSessionSerializer, 'serialize');
 
       request = {
         payload: { },
@@ -30,7 +31,7 @@ describe('Unit | Controller | finalized-session', () => {
         const foundFinalizedSessions = Symbol('foundSession');
         const serializedFinalizedSessions = Symbol('serializedSession');
         usecases.findFinalizedSessionsToPublish.resolves(foundFinalizedSessions);
-        finalizedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
+        publishableSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
 
         // when
         const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake);
@@ -61,9 +62,9 @@ describe('Unit | Controller | finalized-session', () => {
         sinon.stub(usecases, 'findFinalizedSessionsWithRequiredAction');
         usecases.findFinalizedSessionsWithRequiredAction.resolves(foundFinalizedSessions);
 
-        sinon.stub(finalizedSessionSerializer, 'serialize');
+        sinon.stub(sessionWithRequiredActionSerializer, 'serialize');
         const serializedFinalizedSessions = Symbol('serializedSession');
-        finalizedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
+        sessionWithRequiredActionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
 
         // when
         const response = await finalizedSessionController.findFinalizedSessionsWithRequiredAction(request, hFake);

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -41,4 +41,37 @@ describe('Unit | Controller | finalized-session', () => {
     });
 
   });
+
+  describe('#findFinalizedSessionsWithRequiredAction', () => {
+
+    context('When there are finalized sessions with required action', () => {
+
+      it('should find finalized sessions with required action', async () => {
+        // given
+        request = {
+          payload: { },
+          auth: {
+            credentials: {
+              userId,
+            },
+          },
+        };
+
+        const foundFinalizedSessions = Symbol('foundSession');
+        sinon.stub(usecases, 'findFinalizedSessionsWithRequiredAction');
+        usecases.findFinalizedSessionsWithRequiredAction.resolves(foundFinalizedSessions);
+
+        sinon.stub(finalizedSessionSerializer, 'serialize');
+        const serializedFinalizedSessions = Symbol('serializedSession');
+        finalizedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
+
+        // when
+        const response = await finalizedSessionController.findFinalizedSessionsWithRequiredAction(request, hFake);
+
+        // then
+        expect(response).to.deep.equal(serializedFinalizedSessions);
+      });
+    });
+
+  });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -379,4 +379,44 @@ describe('Unit | Application | Sessions | Routes', () => {
       expect(response.statusCode).to.equal(404);
     });
   });
+
+  describe('GET /api/admin/sessions/to-publish', () => {
+    it('exists', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+    it('is protected by a prehandler checking the Pix Master role', async () => {
+      // given
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/sessions/to-publish');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
+
+  describe('GET /api/admin/sessions/with-required-action', () => {
+    it('exists', async () => {
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+    it('is protected by a prehandler checking the Pix Master role', async () => {
+      // given
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+
+      // when
+      const response = await httpTestServer.request('GET', '/api/admin/sessions/with-required-action');
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+  });
 });

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -12,6 +12,7 @@ const {
 
 const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
 const sessionController = require('../../../../lib/application/sessions/session-controller');
+const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const sessionAuthorization = require('../../../../lib/application/preHandlers/session-authorization');
 
 const moduleUnderTest = require('../../../../lib/application/sessions');
@@ -42,6 +43,8 @@ describe('Unit | Application | Sessions | Routes', () => {
     sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
     sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
     sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+    sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
+    sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -408,6 +411,7 @@ describe('Unit | Application | Sessions | Routes', () => {
       // then
       expect(response.statusCode).to.equal(200);
     });
+
     it('is protected by a prehandler checking the Pix Master role', async () => {
       // given
       securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());

--- a/api/tests/unit/domain/usecases/find-finalized-sessions-with-required-action_test.js
+++ b/api/tests/unit/domain/usecases/find-finalized-sessions-with-required-action_test.js
@@ -1,0 +1,42 @@
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const findFinalizedSessionsWithRequiredAction = require('../../../../lib/domain/usecases/find-finalized-sessions-with-required-action');
+
+describe('Unit | UseCase | findFinalizedSessionsWithRequiredAction', () => {
+  context('when there are finalized sessions with required actions', () => {
+
+    it('should get a list of publishable sessions', async () => {
+      // given
+      const finalizedSessionRepository = {
+        findFinalizedSessionsWithRequiredAction: sinon.stub(),
+      };
+
+      const sessionsWithRequiredActions = [
+        domainBuilder.buildFinalizedSession({ isPublishable: false, publishedAt: null }),
+      ];
+
+      finalizedSessionRepository.findFinalizedSessionsWithRequiredAction.resolves(sessionsWithRequiredActions);
+      // when
+      const result = await findFinalizedSessionsWithRequiredAction({ finalizedSessionRepository });
+
+      // then
+      expect(result).to.deep.equal(sessionsWithRequiredActions);
+    });
+  });
+
+  context('when there are no finalized sessions with required action', () => {
+
+    it('should get an empty array', async () => {
+      // given
+      const finalizedSessionRepository = {
+        findFinalizedSessionsWithRequiredAction: sinon.stub(),
+      };
+      finalizedSessionRepository.findFinalizedSessionsWithRequiredAction.resolves([]);
+      // when
+      const result = await findFinalizedSessionsWithRequiredAction({ finalizedSessionRepository });
+
+      // then
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/publishable-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/publishable-session-serializer_test.js
@@ -1,8 +1,8 @@
 const { expect } = require('../../../../test-helper');
-const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/finalized-session-serializer');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/publishable-session-serializer');
 const FinalizedSession = require('../../../../../lib/domain/models/FinalizedSession');
 
-describe('Unit | Serializer | JSONAPI | finalized-session-serializer', function() {
+describe('Unit | Serializer | JSONAPI | publishable-session-serializer', function() {
 
   describe('#serialize()', function() {
 


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix “Gestion des sessions sans problème”, nous allons permettre au pôle certification de publier en masse les sessions qui ne nécessitent aucune action du jury avant publication. Il faut donc que le pôle certif puisse identifier simplement les sessions “à problèmes” = nécessitant potentiellement une action du jury

## :robot: Solution

Dans Pix Admin > Sessions de certification : 
- ajouter un onglet “Sessions à traiter” : 
- liste des sessions au statut “Finalisée” et à problème
- colonnes : 
  - ID : numéro de session, cliquable, redirige vers la page de détails de la session
  - Centre de certification
  - Date de session
  - Date de finalisation => tri antéchronologique sur cette colonne

## :rainbow: Remarques
Cette PR ne concerne que le développement du endpoint coté back-end pour la récupération des sessions à traiter.

## :100: Pour tester
- Se connecter à pix-admin avec un compte pix master
- Copier une requête depuis le navigateur sous forme de cURL
- La modifier pour appeler `GET /api/admin/sessions/with-required-action`
- Constater que l'on reçoit une liste de with-required-action-sessions
