### PR TITLE
[BUGFIX] Le mauvais nombre de paliers est affiché sur les cartes de participations (PIX-2277).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -41,12 +41,16 @@ class CampaignParticipationOverview {
   get validatedStagesCount() {
     if (_.isEmpty(this.targetProfile.stages) || !this.isShared) return null;
 
-    const validatedStages = this.targetProfile.stages.filter((stage) => stage.threshold <= this.masteryPercentage);
+    const validatedStages = this._getReachableStages().filter((stage) => stage.threshold <= this.masteryPercentage);
     return validatedStages.length;
   }
 
   get totalStagesCount() {
-    return this.targetProfile.stages.length;
+    return this._getReachableStages().length;
+  }
+
+  _getReachableStages() {
+    return this.targetProfile.stages.filter((stage) => stage.threshold > 0);
   }
 }
 

--- a/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationOverview_test.js
@@ -90,12 +90,15 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', () => {
             threshold: 0,
           });
           const stage2 = new Stage({
-            threshold: 30,
+            threshold: 10,
           });
           const stage3 = new Stage({
+            threshold: 30,
+          });
+          const stage4 = new Stage({
             threshold: 70,
           });
-          const targetProfile = new TargetProfileWithLearningContent({ stages: [ stage3, stage1, stage2], skills: [new Skill(), new Skill()] });
+          const targetProfile = new TargetProfileWithLearningContent({ stages: [ stage3, stage1, stage2, stage4], skills: [new Skill(), new Skill()] });
           const campaignParticipationOverview = new CampaignParticipationOverview({
             isShared: true,
             validatedSkillsCount: 1,
@@ -147,7 +150,7 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', () => {
 
   describe('#totalStagesCount', ()=> {
     context('the target profile has stages', () => {
-      it('should return the count of the all stages of a target profile', ()=> {
+      it('should return the count of stages with a threshold over 0', ()=> {
         const stage1 = new Stage({
           threshold: 0,
         });
@@ -172,7 +175,7 @@ describe('Unit | Domain | Read-Models | CampaignParticipationOverview', () => {
           targetProfile: targetProfileWithLearningContent,
         });
 
-        expect(campaignParticipationOverview.totalStagesCount).to.equal(6);
+        expect(campaignParticipationOverview.totalStagesCount).to.equal(5);
       });
     });
 

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -49,8 +49,8 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'campaign-title': 'My campaign',
             'campaign-archived-at': new Date('2021-01-01'),
             'mastery-percentage': 50,
-            'validated-stages-count': 2,
-            'total-stages-count': 3,
+            'validated-stages-count': 1,
+            'total-stages-count': 2,
           },
         },
       };


### PR DESCRIPTION
## :unicorn: Problème
Le mauvais nombre de paliers est affiché sur les cartes de participations. Quand il y a 4 palier on voit 5 étoiles, et quand le palier 1 est atteint on voit 2 étoiles obtenues.

## :robot: Solution
Ne pas prendre en compte le palier avec un seuil à 0.

## :rainbow: Remarques
Lors du calcul des paliers atteint je crois qu'on ignore toujours le palier 0.
À voir si ce palier à utilité ailleurs ou dans un autre cas pour essayer de le supprimer après.

## :100: Pour tester
Aller sur MonPix avec le compte jaune.attent@example.net
Aller sur la page mes parcours
La campagne 'Parcours archivé avec paliers' et la campagne sans nom de 'Dragon & Co' doivent afficher 4 étoiles : Une pleine et 3 vides  
