### PR TITLE
[FEATURE] Affichage de la liste des sessions à traiter dans pix-admin (PIX-2040)

### DIFF
--- a/admin/app/adapters/with-required-action-session.js
+++ b/admin/app/adapters/with-required-action-session.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class WithRequiredSessionAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+
+  urlForQuery() {
+    return `${this.host}/${this.namespace}/sessions/with-required-action`;
+  }
+}

--- a/admin/app/components/with-required-action-sessions/list-items.hbs
+++ b/admin/app/components/with-required-action-sessions/list-items.hbs
@@ -1,0 +1,29 @@
+<div class="content-text content-text--small table-admin__wrapper session-list">
+  <table class="table-admin table-admin__auto-width">
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Centre de certification</th>
+      <th>Date de session</th>
+      <th>Date de finalisation</th>
+    </tr>
+    </thead>
+
+    {{#if @withRequiredActionSessions}}
+      <tbody>
+      {{#each @withRequiredActionSessions as |withRequiredActionSession|}}
+        <tr>
+          <td><LinkTo @route="authenticated.sessions.session" @model={{withRequiredActionSession.id}}> {{withRequiredActionSession.id}} </LinkTo></td>
+          <td>{{withRequiredActionSession.certificationCenterName}}</td>
+          <td>{{withRequiredActionSession.printableDateAndTime}}</td>
+          <td>{{withRequiredActionSession.printableFinalizationDate}}</td>
+        </tr>
+      {{/each}}
+      </tbody>
+    {{/if}}
+  </table>
+
+  {{#unless @withRequiredActionSessions}}
+    <div class="table__empty content-text">Aucun résultat</div>
+  {{/unless}}
+</div>

--- a/admin/app/models/with-required-action-session.js
+++ b/admin/app/models/with-required-action-session.js
@@ -1,0 +1,17 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class WithRequiredActionSession extends Model {
+  @attr() certificationCenterName;
+  @attr('date-only') sessionDate;
+  @attr() sessionTime;
+  @attr() finalizedAt;
+
+  get printableDateAndTime() {
+    const formattedSessionDate = this.sessionDate.split('-').reverse().join('/');
+    return formattedSessionDate + ' à ' + this.sessionTime;
+  }
+
+  get printableFinalizationDate() {
+    return (new Date(this.finalizedAt)).toLocaleDateString('fr-FR');
+  }
+}

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -49,6 +49,7 @@ Router.map(function() {
       this.route('list', function() {
         this.route('all', { path: '/' });
         this.route('to-be-published');
+        this.route('with-required-action');
       });
       this.route('session', { path: '/:session_id' }, function() {
         this.route('informations', { path: '/' });

--- a/admin/app/routes/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/routes/authenticated/sessions/list/with-required-action.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticatedSessionsWithRequiredActionListRoute extends Route {
+  model() {
+    return this.store.query('with-required-action-session', {});
+  }
+}

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -7,6 +7,9 @@
     <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
         Sessions à publier
     </LinkTo>
+    <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
+      Sessions à traiter
+    </LinkTo>
   </nav>
 </header>
 

--- a/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
+++ b/admin/app/templates/authenticated/sessions/list/with-required-action.hbs
@@ -1,0 +1,3 @@
+<WithRequiredActionSessions::ListItems
+  @withRequiredActionSessions={{@model}}
+/>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -15,6 +15,14 @@ export default function() {
     const publishableSessions = schema.publishableSessions.all();
     return publishableSessions;
   });
+  this.get('/admin/sessions/to-publish', (schema) => {
+    const publishableSessions = schema.publishableSessions.all();
+    return publishableSessions;
+  });
+  this.get('/admin/sessions/with-required-action', (schema) => {
+    const withRequiredActionSessions = schema.withRequiredActionSessions.all();
+    return withRequiredActionSessions;
+  });
   this.patch('/admin/sessions/:id/publish', () => {
     return new Response(200);
   });

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | authenticated/sessions/list/with required action', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  module('When user is not logged in', function() {
+
+    test('it should not be accessible by an unauthenticated user', async function(assert) {
+      // when
+      await visit('/sessions/list/with-required-action');
+
+      // then
+      assert.equal(currentURL(), '/login');
+    });
+  });
+
+  module('When user is logged in', function(hooks) {
+
+    hooks.beforeEach(async () => {
+      // given
+      await createAuthenticateSession({ userId: 1 });
+    });
+
+    test('visiting /sessions/list/with-required-action', async function(assert) {
+      // when
+      await visit('/sessions/list/with-required-action');
+
+      // then
+      assert.equal(currentURL(), '/sessions/list/with-required-action');
+    });
+
+    test('it should display sessions with required action informations', async function(assert) {
+      // given
+      const sessionDate = '2021-01-01';
+      const sessionTime = '17:00:00';
+      const finalizedAt = new Date('2021-02-01T03:00:00Z');
+      server.create('with-required-action-session', {
+        id: '1',
+        certificationCenterName: 'Centre SCO des Anne-Étoiles',
+        finalizedAt,
+        sessionDate,
+        sessionTime,
+      });
+      server.create('with-required-action-session', {
+        id: '2',
+        certificationCenterName: 'Centre SUP et rieur',
+        finalizedAt,
+        sessionDate,
+        sessionTime,
+      });
+
+      // when
+      await visit('/sessions/list/with-required-action');
+
+      // then
+      assert.contains('Centre SCO des Anne-Étoiles');
+      assert.contains('Centre SUP et rieur');
+      assert.contains('1');
+      assert.contains('2');
+      assert.contains('01/01/2021 à 17:00:00');
+      assert.contains('01/02/2021');
+    });
+  });
+});

--- a/admin/tests/unit/adapters/with-required-action-session-test.js
+++ b/admin/tests/unit/adapters/with-required-action-session-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Adapter | with required action session', function(hooks) {
+  setupTest(hooks);
+
+  module('#urlForQuery', function() {
+    test('should return /admin/sessions/with-required-action', function(assert) {
+      // when
+      const adapter = this.owner.lookup('adapter:with-required-action-session');
+      const url = adapter.urlForQuery();
+
+      // then
+      assert.ok(url.endsWith('api/admin/sessions/with-required-action'));
+    });
+  });
+});

--- a/admin/tests/unit/models/with-required-action-session-test.js
+++ b/admin/tests/unit/models/with-required-action-session-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | with required action session', function(hooks) {
+  setupTest(hooks);
+
+  module('#printableDateAndTime', function() {
+    test('it should return a printable version of session with required action date and time', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const sessionWithRequiredAction = store.createRecord('with-required-action-session', {
+        sessionDate: '2020-02-01',
+        sessionTime: '14:30',
+      });
+
+      // when
+      const printableDateAndTime = sessionWithRequiredAction.printableDateAndTime;
+
+      // then
+      assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
+    });
+  });
+
+  module('#printableFinalizationDate', function() {
+    test('it should return a printable version of session with required action finalization date', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const sessionWithRequiredAction = store.createRecord('with-required-action-session', {
+        finalizedAt: new Date('2020-02-01T15:30:01Z'),
+      });
+
+      // when
+      const printableFinalizationDate = sessionWithRequiredAction.printableFinalizationDate;
+
+      // then
+      assert.equal(printableFinalizationDate, '01/02/2020');
+    });
+  });
+});

--- a/admin/tests/unit/routes/authenticated/sessions/list/with-required-action-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/with-required-action-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list/to-be-published', function(hooks) {
+module('Unit | Route | authenticated/sessions/list/with-required-action', function(hooks) {
   setupTest(hooks);
 
   let store;

--- a/admin/tests/unit/routes/authenticated/sessions/list/with-required-action-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/with-required-action-test.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Route | authenticated/sessions/list/to-be-published', function(hooks) {
+  setupTest(hooks);
+
+  let store;
+  hooks.beforeEach(function() {
+    class StoreStub extends Service {
+      query = null;
+    }
+    this.owner.register('service:store', StoreStub);
+    store = this.owner.lookup('service:store');
+  });
+
+  module('#model', function() {
+    test('it should fetch the list of sessions with required action', async function(assert) {
+      // given
+      const route = this.owner.lookup('route:authenticated/sessions/list/with-required-action');
+      const sessionsWithRequiredAction = [{
+        certificationCenterName: 'Centre SCO des Anne-Solo',
+        finalizedAt: '2020-04-15T15:00:34.000Z',
+      }];
+      const queryStub = sinon.stub();
+      queryStub.withArgs('with-required-action-session', {}).resolves(sessionsWithRequiredAction);
+      store.query = queryStub;
+
+      // when
+      const result = await route.model();
+
+      // then
+      assert.equal(result, sessionsWithRequiredAction);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix “Gestion des sessions sans problème”, nous allons permettre au pôle certification de publier en masse les sessions qui ne nécessitent aucune action du jury avant publication. Il faut donc que le pôle certif puisse identifier simplement les sessions “à problèmes” = nécessitant potentiellement une action du jury

## :robot: Solution
Dans Pix Admin > Sessions de certification : 
- ajouter un onglet “Sessions à traiter” : 
  - liste des sessions au statut “Finalisée” et à problème
    - colonnes : 
      - ID : numéro de session, cliquable, redirige vers la page de détails de la session
      - Centre de certification
      - Date de session
      - Date de finalisation => tri antéchronologique sur cette colonne

![image](https://user-images.githubusercontent.com/34715194/109510251-12955800-7aa2-11eb-91aa-f365c9fef6c8.png)


## :rainbow: Remarques
Cette PR ne concerne que la partie front-end et fait suite à la PR #2485 

## :100: Pour tester
- Se connecter à pix-admin en tant que pix master
- Se rendre dans la page des sessions (via le menu de gauche)
- Constater l'apparition d'un onglet "sessions à traiter"
- Se rendre sur l'onglet sus-mentionné
- Constater la présence de session dans cet onglet
- (Option : constater que ces sessions sont bien "à problème")
