### PR TITLE
[CLEAN] Renommer PublishableSessions en ToBePublishedSessions

### DIFF
--- a/admin/app/adapters/to-be-published-session.js
+++ b/admin/app/adapters/to-be-published-session.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from './application';
 
-export default class PublishableSessionAdapter extends ApplicationAdapter {
+export default class ToBePublishedSessionAdapter extends ApplicationAdapter {
   namespace = 'api/admin';
 
   urlForQuery() {

--- a/admin/app/components/to-be-published-sessions/list-items.hbs
+++ b/admin/app/components/to-be-published-sessions/list-items.hbs
@@ -10,20 +10,20 @@
     </tr>
     </thead>
 
-    {{#if @publishableSessions}}
+    {{#if @toBePublishedSessions}}
       <tbody>
-      {{#each @publishableSessions as |publishableSession|}}
+      {{#each @toBePublishedSessions as |toBePublishedSession|}}
         <tr>
-          <td><LinkTo @route="authenticated.sessions.session" @model={{publishableSession.id}}> {{publishableSession.id}} </LinkTo></td>
-          <td>{{publishableSession.certificationCenterName}}</td>
-          <td>{{publishableSession.printableDateAndTime}}</td>
-          <td>{{publishableSession.printableFinalizationDate}}</td>
+          <td><LinkTo @route="authenticated.sessions.session" @model={{toBePublishedSession.id}}> {{toBePublishedSession.id}} </LinkTo></td>
+          <td>{{toBePublishedSession.certificationCenterName}}</td>
+          <td>{{toBePublishedSession.printableDateAndTime}}</td>
+          <td>{{toBePublishedSession.printableFinalizationDate}}</td>
           <td>
             <PixButton
-              @triggerAction={{fn this.showConfirmModal publishableSession}}
+              @triggerAction={{fn this.showConfirmModal toBePublishedSession}}
               @border="squircle-small"
               class="publish-session-button"
-              aria-label="Publier la session numéro {{publishableSession.id}}"
+              aria-label="Publier la session numéro {{toBePublishedSession.id}}"
             >
               <FaIcon @icon="paper-plane" />Publier
             </PixButton>
@@ -34,7 +34,7 @@
     {{/if}}
   </table>
 
-  {{#unless @publishableSessions}}
+  {{#unless @toBePublishedSessions}}
     <div class="table__empty content-text">Aucun résultat</div>
   {{/unless}}
 </div>

--- a/admin/app/components/to-be-published-sessions/list-items.js
+++ b/admin/app/components/to-be-published-sessions/list-items.js
@@ -2,7 +2,7 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-export default class PublishableSessionsList extends Component {
+export default class ToBePublishedSessionsList extends Component {
   @tracked shouldShowModal = false;
   currentSelectedSession;
 

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -7,9 +7,9 @@ export default class SessionToBePublishedController extends Controller {
   @service notifications;
 
   @action
-  async publishSession(publishableSession) {
+  async publishSession(toBePublishedSession) {
     try {
-      await publishableSession.publish();
+      await toBePublishedSession.publish();
     } catch (err) {
       const finalErr = get(err, 'errors[0].detail', err);
       this.notifications.error(finalErr);

--- a/admin/app/models/to-be-published-session.js
+++ b/admin/app/models/to-be-published-session.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
-export default class PublishableSessionModel extends Model {
+export default class ToBePublishedSessionModel extends Model {
   @attr() certificationCenterName;
   @attr('date-only') sessionDate;
   @attr() sessionTime;

--- a/admin/app/models/to-be-published-session.js
+++ b/admin/app/models/to-be-published-session.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
-export default class ToBePublishedSessionModel extends Model {
+export default class ToBePublishedSession extends Model {
   @attr() certificationCenterName;
   @attr('date-only') sessionDate;
   @attr() sessionTime;

--- a/admin/app/routes/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/routes/authenticated/sessions/list/to-be-published.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class AuthenticatedSessionsListToBePublishedRoute extends Route {
   model() {
-    return this.store.query('publishable-session', {});
+    return this.store.query('to-be-published-session', {});
   }
 }

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -1,4 +1,4 @@
-<PublishableSessions::ListItems
-  @publishableSessions={{@model}}
+<ToBePublishedSessions::ListItems
+  @toBePublishedSessions={{@model}}
   @publishSession={{this.publishSession}}
 />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -12,12 +12,12 @@ export default function() {
 
   this.get('/admin/sessions', findPaginatedAndFilteredSessions);
   this.get('/admin/sessions/to-publish', (schema) => {
-    const publishableSessions = schema.publishableSessions.all();
-    return publishableSessions;
+    const toBePublishedSessions = schema.toBePublishedSessions.all();
+    return toBePublishedSessions;
   });
   this.get('/admin/sessions/to-publish', (schema) => {
-    const publishableSessions = schema.publishableSessions.all();
-    return publishableSessions;
+    const toBePublishedSessions = schema.toBePublishedSessions.all();
+    return toBePublishedSessions;
   });
   this.get('/admin/sessions/with-required-action', (schema) => {
     const withRequiredActionSessions = schema.withRequiredActionSessions.all();

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
@@ -40,14 +40,14 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
       const sessionDate = '2021-01-01';
       const sessionTime = '17:00:00';
       const finalizedAt = new Date('2021-02-01T03:00:00Z');
-      server.create('publishable-session', {
+      server.create('to-be-published-session', {
         id: '1',
         certificationCenterName: 'Centre SCO des Anne-Étoiles',
         finalizedAt,
         sessionDate,
         sessionTime,
       });
-      server.create('publishable-session', {
+      server.create('to-be-published-session', {
         id: '2',
         certificationCenterName: 'Centre SUP et rieur',
         finalizedAt,
@@ -72,14 +72,14 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
       const sessionDate = '2021-01-01';
       const sessionTime = '17:00:00';
       const finalizedAt = new Date('2021-02-01T03:00:00Z');
-      server.create('publishable-session', {
+      server.create('to-be-published-session', {
         id: '1',
         certificationCenterName: 'Centre SCO des Anne-Étoiles',
         finalizedAt,
         sessionDate,
         sessionTime,
       });
-      server.create('publishable-session', {
+      server.create('to-be-published-session', {
         id: '2',
         certificationCenterName: 'Centre SUP et rieur',
         finalizedAt,

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.js
@@ -4,11 +4,11 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-module('Integration | Component | routes/authenticated/publishable-sessions | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', function(hooks) {
 
   setupRenderingTest(hooks);
 
-  test('it should display publishable sessions list', async function(assert) {
+  test('it should display to be published sessions list', async function(assert) {
     // given
     const firstSession = {
       id: '1',
@@ -31,10 +31,10 @@ module('Integration | Component | routes/authenticated/publishable-sessions | li
       sessionTime: '13:00:00',
       finalizedAt: new Date('2021-03-04T03:00:00Z'),
     };
-    this.publishableSessions = [ firstSession, secondSession, thirdSession];
+    this.toBePublishedSessions = [ firstSession, secondSession, thirdSession];
 
     // when
-    await render(hbs`<PublishableSessions::ListItems @publishableSessions={{this.publishableSessions}}/>`);
+    await render(hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`);
 
     // then
     assert.dom('table tbody tr').exists({ count: 3 });
@@ -45,10 +45,10 @@ module('Integration | Component | routes/authenticated/publishable-sessions | li
 
   test('it should "Aucun résultat" if there are no sessions to show', async function(assert) {
     // given
-    this.publishableSessions = [];
+    this.toBePublishedSessions = [];
 
     // when
-    await render(hbs`<PublishableSessions::ListItems @publishableSessions={{this.publishableSessions}}/>`);
+    await render(hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`);
 
     // then
     assert.contains('Aucun résultat');
@@ -63,8 +63,8 @@ module('Integration | Component | routes/authenticated/publishable-sessions | li
       sessionTime: '11:00:00',
       finalizedAt: new Date('2021-01-02T03:00:00Z'),
     };
-    this.publishableSessions = [ session ];
-    await render(hbs`<PublishableSessions::ListItems @publishableSessions={{this.publishableSessions}}/>`);
+    this.toBePublishedSessions = [ session ];
+    await render(hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}}/>`);
 
     // when
     await click('[aria-label="Publier la session numéro 1"]');
@@ -82,9 +82,9 @@ module('Integration | Component | routes/authenticated/publishable-sessions | li
       sessionTime: '11:00:00',
       finalizedAt: new Date('2021-01-02T03:00:00Z'),
     };
-    this.publishableSessions = [ session ];
+    this.toBePublishedSessions = [ session ];
     this.publishSession = sinon.stub();
-    await render(hbs`<PublishableSessions::ListItems @publishableSessions={{this.publishableSessions}} @publishSession={{this.publishSession}}/>`);
+    await render(hbs`<ToBePublishedSessions::ListItems @toBePublishedSessions={{this.toBePublishedSessions}} @publishSession={{this.publishSession}}/>`);
     await click('[aria-label="Publier la session numéro 1"]');
 
     // when

--- a/admin/tests/unit/adapters/to-be-published-session-test.js
+++ b/admin/tests/unit/adapters/to-be-published-session-test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | publishable session', function(hooks) {
+module('Unit | Adapter | to be published session', function(hooks) {
   setupTest(hooks);
 
   module('#urlForQuery', function() {
     test('should return /admin/sessions/to-publish', function(assert) {
       // when
-      const adapter = this.owner.lookup('adapter:publishable-session');
+      const adapter = this.owner.lookup('adapter:to-be-published-session');
       const url = adapter.urlForQuery();
 
       // then
@@ -18,7 +18,7 @@ module('Unit | Adapter | publishable session', function(hooks) {
   module('#urlForUpdateRecord', function() {
     test('should return /admin/sessions/:id', function(assert) {
       // when
-      const adapter = this.owner.lookup('adapter:publishable-session');
+      const adapter = this.owner.lookup('adapter:to-be-published-session');
       const url = adapter.urlForUpdateRecord(123);
 
       // then

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -13,12 +13,12 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
       const publishMock = sinon.stub();
       publishMock.resolves();
-      const publishableSession = {
+      const toBePublishedSession = {
         publish: publishMock,
       };
 
       // when
-      await controller.send('publishSession', publishableSession);
+      await controller.send('publishSession', toBePublishedSession);
 
       // then
       sinon.assert.called(publishMock);
@@ -36,12 +36,12 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       const publishMock = sinon.stub();
       const publishError = new Error('someError');
       publishMock.rejects(publishError);
-      const publishableSession = {
+      const toBePublishedSession = {
         publish: publishMock,
       };
 
       // when
-      await controller.send('publishSession', publishableSession);
+      await controller.send('publishSession', toBePublishedSession);
 
       // then
       sinon.assert.calledWith(errorMock, publishError);

--- a/admin/tests/unit/models/to-be-published-session-test.js
+++ b/admin/tests/unit/models/to-be-published-session-test.js
@@ -1,20 +1,20 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | publishable session', function(hooks) {
+module('Unit | Model | to be published session', function(hooks) {
   setupTest(hooks);
 
   module('#printableDateAndTime', function() {
-    test('it should return a printable version of publishable session date and time', function(assert) {
+    test('it should return a printable version of to be published session date and time', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const publishableSession = store.createRecord('publishable-session', {
+      const toBePublishedSession = store.createRecord('to-be-published-session', {
         sessionDate: '2020-02-01',
         sessionTime: '14:30',
       });
 
       // when
-      const printableDateAndTime = publishableSession.printableDateAndTime;
+      const printableDateAndTime = toBePublishedSession.printableDateAndTime;
 
       // then
       assert.equal(printableDateAndTime, '01/02/2020 à 14:30');
@@ -22,15 +22,15 @@ module('Unit | Model | publishable session', function(hooks) {
   });
 
   module('#printableFinalizationDate', function() {
-    test('it should return a printable version of publishable session finalization date', function(assert) {
+    test('it should return a printable version of to be published session finalization date', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
-      const publishableSession = store.createRecord('publishable-session', {
+      const toBePublishedSession = store.createRecord('to-be-published-session', {
         finalizedAt: new Date('2020-02-01T15:30:01Z'),
       });
 
       // when
-      const printableFinalizationDate = publishableSession.printableFinalizationDate;
+      const printableFinalizationDate = toBePublishedSession.printableFinalizationDate;
 
       // then
       assert.equal(printableFinalizationDate, '01/02/2020');

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
@@ -19,19 +19,19 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function(ho
     test('it should fetch the list of sessions to be published', async function(assert) {
       // given
       const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');
-      const publishableSessions = [{
+      const toBePublishedSessions = [{
         certificationCenterName: 'Centre SCO des Anne-Solo',
         finalizedAt: '2020-04-15T15:00:34.000Z',
       }];
       const queryStub = sinon.stub();
-      queryStub.withArgs('publishable-session', {}).resolves(publishableSessions);
+      queryStub.withArgs('to-be-published-session', {}).resolves(toBePublishedSessions);
       store.query = queryStub;
 
       // when
       const result = await route.model();
 
       // then
-      assert.equal(result, publishableSessions);
+      assert.equal(result, toBePublishedSessions);
     });
   });
 });

--- a/api/lib/application/sessions/finalized-session-controller.js
+++ b/api/lib/application/sessions/finalized-session-controller.js
@@ -1,11 +1,11 @@
 const usecases = require('../../domain/usecases');
-const publishableSessionSerializer = require('../../infrastructure/serializers/jsonapi/publishable-session-serializer');
+const toBePublishedSessionSerializer = require('../../infrastructure/serializers/jsonapi/to-be-published-session-serializer');
 const sessionWithRequiredActionSerializer = require('../../infrastructure/serializers/jsonapi/session-with-required-action-serializer');
 
 module.exports = {
   async findFinalizedSessionsToPublish() {
     const finalizedSessionsToPublish = await usecases.findFinalizedSessionsToPublish();
-    return publishableSessionSerializer.serialize(finalizedSessionsToPublish);
+    return toBePublishedSessionSerializer.serialize(finalizedSessionsToPublish);
   },
 
   async findFinalizedSessionsWithRequiredAction() {

--- a/api/lib/infrastructure/serializers/jsonapi/to-be-published-session-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/to-be-published-session-serializer.js
@@ -3,7 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 module.exports = {
 
   serialize(finalizedSessions) {
-    return new Serializer('publishable-session', {
+    return new Serializer('to-be-published-session', {
       transform(finalizedSession) {
         return { ...finalizedSession, id: finalizedSession.sessionId };
       },

--- a/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
+++ b/api/tests/acceptance/application/finalized-session/finalized-session-controller-find-finalized-sessions-to-publish_test.js
@@ -44,7 +44,7 @@ describe('Acceptance | Controller | finalized-session-controller-find-finalized-
         // then
         expect(response.statusCode).to.equal(200);
         expect(response.result.data).to.have.lengthOf(2);
-        expect(response.result.data[0].type).to.equal('publishable-sessions');
+        expect(response.result.data[0].type).to.equal('to-be-published-sessions');
       });
     });
   });

--- a/api/tests/unit/application/session/finalized-session-controller_test.js
+++ b/api/tests/unit/application/session/finalized-session-controller_test.js
@@ -1,7 +1,7 @@
 const { expect, sinon, hFake } = require('../../../test-helper');
 const finalizedSessionController = require('../../../../lib/application/sessions/finalized-session-controller');
 const usecases = require('../../../../lib/domain/usecases');
-const publishableSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/publishable-session-serializer');
+const toBePublishedSessionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/to-be-published-session-serializer');
 const sessionWithRequiredActionSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/session-with-required-action-serializer');
 
 describe('Unit | Controller | finalized-session', () => {
@@ -12,7 +12,7 @@ describe('Unit | Controller | finalized-session', () => {
 
     beforeEach(() => {
       sinon.stub(usecases, 'findFinalizedSessionsToPublish').resolves();
-      sinon.stub(publishableSessionSerializer, 'serialize');
+      sinon.stub(toBePublishedSessionSerializer, 'serialize');
 
       request = {
         payload: { },
@@ -31,7 +31,7 @@ describe('Unit | Controller | finalized-session', () => {
         const foundFinalizedSessions = Symbol('foundSession');
         const serializedFinalizedSessions = Symbol('serializedSession');
         usecases.findFinalizedSessionsToPublish.resolves(foundFinalizedSessions);
-        publishableSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
+        toBePublishedSessionSerializer.serialize.withArgs(foundFinalizedSessions).resolves(serializedFinalizedSessions);
 
         // when
         const response = await finalizedSessionController.findFinalizedSessionsToPublish(request, hFake);

--- a/api/tests/unit/infrastructure/serializers/jsonapi/to-be-published-session-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/to-be-published-session-serializer_test.js
@@ -1,8 +1,8 @@
 const { expect } = require('../../../../test-helper');
-const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/publishable-session-serializer');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/to-be-published-session-serializer');
 const FinalizedSession = require('../../../../../lib/domain/models/FinalizedSession');
 
-describe('Unit | Serializer | JSONAPI | publishable-session-serializer', function() {
+describe('Unit | Serializer | JSONAPI | to-be-published-session-serializer', function() {
 
   describe('#serialize()', function() {
 
@@ -10,7 +10,7 @@ describe('Unit | Serializer | JSONAPI | publishable-session-serializer', functio
       // given
       const expectedJsonApi = {
         data: {
-          type: 'publishable-sessions',
+          type: 'to-be-published-sessions',
           id: '123',
           attributes: {
             'session-id': 123,
@@ -29,7 +29,7 @@ describe('Unit | Serializer | JSONAPI | publishable-session-serializer', functio
         sessionTime: '14:30',
         finalizedAt: new Date('2020-02-17T14:23:56Z'),
         publishedAt: new Date('2020-02-21T14:23:56Z'),
-        isPublishable: true,
+        isToBePublished: true,
       });
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui sur PixAdmin il est facile de s'emmêler les pinceaux avec les différents termes techniques pour parler des sessions sans problèmes (et donc à publier pour le pôle certif).
On retrouve 2 nommages différents pour la même chose : publishableSessions et toBePublishedSessions.

## :robot: Solution
Harmoniser le nommage au privilège de toBePublishedSessions (utilisé partout dans l'api).

## :rainbow: Remarques
Je n'ai pas pris la peine de séparer la PR en commit car la rentabilité temps investis / apport me paraissait faible.

J'en profite pour faire la PUB à notre glossaire technique : https://1024pix.atlassian.net/wiki/spaces/COM/pages/1022820377/Produits

## :100: Pour tester
- Lancer les tests api et admin
- Se balader dans Pix Admin (surtout dans l'onglet session à publier en fait)