### PR TITLE
[FEATURE] Retirer les succès pour les utilisateurs anonymes (PIX-2275).

### DIFF
--- a/mon-pix/app/routes/assessments/challenge.js
+++ b/mon-pix/app/routes/assessments/challenge.js
@@ -1,8 +1,11 @@
 import { action } from '@ember/object';
 import RSVP from 'rsvp';
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class ChallengeRoute extends Route {
+  @service currentUser;
+
   async model(params) {
     const store = this.store;
 
@@ -49,14 +52,17 @@ export default class ChallengeRoute extends Route {
     try {
       await answer.save();
 
+      let queryParams = { queryParams: {} };
       const levelup = await answer.get('levelup');
 
-      const queryParams = levelup ? {
-        queryParams: {
-          newLevel: levelup.level,
-          competenceLeveled: levelup.competenceName,
-        },
-      } : { queryParams: {} };
+      if (this.currentUser.user && !this.currentUser.user.isAnonymous && levelup) {
+        queryParams = {
+          queryParams: {
+            newLevel: levelup.level,
+            competenceLeveled: levelup.competenceName,
+          },
+        };
+      }
 
       return this.transitionTo('assessments.resume', assessment.get('id'), queryParams);
     }

--- a/mon-pix/tests/unit/controllers/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/challenge-test.js
@@ -57,4 +57,36 @@ describe('Unit | Controller | Assessments | Challenge', function() {
     });
   });
 
+  describe('#showLevelup', () => {
+    it('should display level up pop-in', function() {
+      // given
+      controller.newLevel = true;
+      const model = { assessment: { showLevelup: true } };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.true;
+    });
+
+    it('should not display level up pop-in when user has not leveled up', function() {
+      // given
+      controller.newLevel = false;
+      const model = { assessment: { showLevelup: true } };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.false;
+    });
+
+    it('should not display level up pop-in when it is not in assessment with level up', function() {
+      // given
+      controller.newLevel = true;
+      const model = { assessment: { showLevelup: false } };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.false;
+    });
+  });
+
 });

--- a/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
+++ b/mon-pix/tests/unit/controllers/assessments/checkpoint-test.js
@@ -109,4 +109,37 @@ describe('Unit | Controller | Assessments | Checkpoint', function() {
       expect(controller.displayHomeLink).to.be.true;
     });
   });
+
+  describe('#showLevelup', () => {
+    it('should display level up pop-in when user has level up', function() {
+      // given
+      controller.newLevel = true;
+      const model = { showLevelup: true };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.true;
+    });
+
+    it('should not display level up pop-in when user has not leveled up', function() {
+      // given
+      controller.newLevel = false;
+      const model = { showLevelup: true };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.false;
+    });
+
+    it('should not display level up pop-in when it is not in assessment with level up', function() {
+      // given
+      controller.newLevel = true;
+      const model = { showLevelup: false };
+      controller.model = model;
+
+      // then
+      expect(controller.showLevelup).to.be.false;
+    });
+  });
+
 });


### PR DESCRIPTION
## :unicorn: Problème
Des utilisateurs anonymes passent des campagnes. Les succès de gain de niveau continuent de s'afficher, alors que ces utilisateurs n'ont pas de profil.

## :robot: Solution
Ne pas passer les level up si l'user est anonyme (ou s'il est aussi déconnecté, dans le cas des démo).

## :rainbow: Remarques
- On affiche les succès sur les challenges et sur les checkpoints
- Les succès sont calculés quand on enregistre la réponse, et sont ensuite passés en paramètres à la page suivante

## :100: Pour tester
Passer la campagne AZERTY123 (qui est simplifié), sans compte, et ne pas voir les succès.
Passer une compétence et voir les succès