### PR TITLE
[FEATURE] Ajouter la traduction des messages d'erreurs lors de la création d'une campagne. (PIX-2198)

### DIFF
--- a/api/lib/domain/validators/campaign-validator.js
+++ b/api/lib/domain/validators/campaign-validator.js
@@ -10,8 +10,8 @@ const campaignValidationJoiSchema = Joi.object({
   name: Joi.string()
     .required()
     .messages({
-      'string.base': 'Veuillez donner un nom à votre campagne.',
-      'string.empty': 'Veuillez donner un nom à votre campagne.',
+      'string.base': 'CAMPAIGN_NAME_IS_REQUIRED',
+      'string.empty': 'CAMPAIGN_NAME_IS_REQUIRED',
     }),
 
   type: Joi.string()
@@ -19,25 +19,25 @@ const campaignValidationJoiSchema = Joi.object({
     .required()
     .error((errors) => first(errors))
     .messages({
-      'any.required': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
-      'string.base': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
-      'any.only': 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
+      'any.required': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+      'string.base': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+      'any.only': 'CAMPAIGN_PURPOSE_IS_REQUIRED',
     }),
 
   creatorId: Joi.number()
     .integer()
     .required()
     .messages({
-      'any.required': 'Le créateur n’est pas renseigné.',
-      'number.base': 'Le créateur n’est pas renseigné.',
+      'any.required': 'MISSING_CREATOR',
+      'number.base': 'MISSING_CREATOR',
     }),
 
   organizationId: Joi.number()
     .integer()
     .required()
     .messages({
-      'any.required': 'L‘organisation n’est pas renseignée.',
-      'number.base': 'L‘organisation n’est pas renseignée.',
+      'any.required': 'MISSING_ORGANIZATION',
+      'number.base': 'MISSING_ORGANIZATION',
     }),
 
   targetProfileId: Joi.number()
@@ -53,17 +53,17 @@ const campaignValidationJoiSchema = Joi.object({
     })
     .integer()
     .messages({
-      'any.required': 'Veuillez sélectionner un profil cible pour votre campagne.',
-      'number.base': 'Veuillez sélectionner un profil cible pour votre campagne.',
-      'any.only': 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.',
+      'any.required': 'TARGET_PROFILE_IS_REQUIRED',
+      'number.base': 'TARGET_PROFILE_IS_REQUIRED',
+      'any.only': 'TARGET_PROFILE_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
     }),
 
   idPixLabel: Joi.string()
     .allow(null)
     .min(3)
     .messages({
-      'string.empty': 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.',
-      'string.min': 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.',
+      'string.empty': 'EXTERNAL_USER_ID_IS_REQUIRED',
+      'string.min': 'EXTERNAL_USER_ID_IS_REQUIRED',
     }),
 
   title: Joi.string()
@@ -74,7 +74,7 @@ const campaignValidationJoiSchema = Joi.object({
       otherwise: Joi.optional(),
     })
     .messages({
-      'any.only': 'Le titre du parcours n’est pas autorisé pour les campagnes de collecte de profils.',
+      'any.only': 'TITLE_OF_PERSONALISED_TEST_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
     }),
 
 });

--- a/api/tests/unit/domain/validators/campaign-validator_test.js
+++ b/api/tests/unit/domain/validators/campaign-validator_test.js
@@ -74,7 +74,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // given
             const expectedError = {
               attribute: 'name',
-              message: 'Veuillez donner un nom à votre campagne.',
+              message: 'CAMPAIGN_NAME_IS_REQUIRED',
             };
 
             it('should reject with error when name is missing', () => {
@@ -111,7 +111,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // given
             const expectedError = {
               attribute: 'creatorId',
-              message: 'Le créateur n’est pas renseigné.',
+              message: 'MISSING_CREATOR',
             };
 
             it('should reject with error when creatorId is missing', () => {
@@ -150,7 +150,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // given
             const expectedError = {
               attribute: 'organizationId',
-              message: 'L‘organisation n’est pas renseignée.',
+              message: 'MISSING_ORGANIZATION',
             };
 
             it('should reject with error when organizationId is missing', () => {
@@ -190,7 +190,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
               // given
               const expectedError = {
                 attribute: 'idPixLabel',
-                message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.',
+                message: 'EXTERNAL_USER_ID_IS_REQUIRED',
               };
 
               try {
@@ -211,7 +211,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
               // given
               const expectedError = {
                 attribute: 'idPixLabel',
-                message: 'Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.',
+                message: 'EXTERNAL_USER_ID_IS_REQUIRED',
               };
 
               try {
@@ -234,7 +234,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
             // given
             const expectedError = {
               attribute: 'type',
-              message: 'Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.',
+              message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
             };
 
             it('should reject with error when type is a wrong type', () => {
@@ -318,7 +318,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
           // given
           const expectedError = {
             attribute: 'targetProfileId',
-            message: 'Un profil cible n’est pas autorisé pour les campagnes de collecte de profils.',
+            message: 'TARGET_PROFILE_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
           };
 
           try {
@@ -364,7 +364,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         // given
           const expectedError = {
             attribute: 'targetProfileId',
-            message: 'Veuillez sélectionner un profil cible pour votre campagne.',
+            message: 'TARGET_PROFILE_IS_REQUIRED',
           };
 
           try {
@@ -385,7 +385,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         // given
           const expectedError = {
             attribute: 'targetProfileId',
-            message: 'Veuillez sélectionner un profil cible pour votre campagne.',
+            message: 'TARGET_PROFILE_IS_REQUIRED',
           };
 
           try {
@@ -409,7 +409,7 @@ describe('Unit | Domain | Validators | campaign-validator', function() {
         // given
         const expectedError = {
           attribute: 'title',
-          message: 'Le titre du parcours n’est pas autorisé pour les campagnes de collecte de profils.',
+          message: 'TITLE_OF_PERSONALISED_TEST_IS_NOT_ALLOWED_FOR_PROFILES_COLLECTION_CAMPAIGN',
         };
 
         try {

--- a/orga/app/components/routes/authenticated/campaign/new.hbs
+++ b/orga/app/components/routes/authenticated/campaign/new.hbs
@@ -11,11 +11,11 @@
       @value={{@campaign.name}}
     />
 
-    {{#each @campaign.errors.name as |error|}}
+    {{#if @campaign.errors.name }}
       <div class='form__error error-message'>
-        {{error.message}}
+        {{display-campaign-errors @campaign.errors.name}}
       </div>
-    {{/each}}
+    {{/if}}
   </div>
 
   {{#if this.currentUser.organization.canCollectProfiles}}
@@ -31,11 +31,11 @@
         <label for="collect-participants-profile">{{t 'pages.campaign-creation.purpose.profiles-collection'}}</label>
       </div>
 
-      {{#each @campaign.errors.type as |error|}}
+      {{#if @campaign.errors.type }}
         <div class='form__error error-message'>
-          {{error.message}}
+          {{display-campaign-errors @campaign.errors.type}}
         </div>
-      {{/each}}
+      {{/if}}
 
     </div>
   {{/if}}
@@ -49,11 +49,11 @@
         @options={{this.targetProfilesOptions}}
         @emptyOptionLabel=""
       />
-      {{#each @campaign.errors.targetProfile as |error|}}
+      {{#if @campaign.errors.targetProfile}}
         <div class='form__error error-message'>
-          {{error.message}}
+          {{display-campaign-errors @campaign.errors.targetProfile}}
         </div>
-      {{/each}}
+      {{/if}}
       {{#if this.currentUser.isSCOManagingStudents}}
         <p class="form__comment">
           {{t 'pages.campaign-creation.target-profile-informations' htmlSafe=true}}
@@ -86,11 +86,11 @@
         @aria-required="true"
         @value={{@campaign.idPixLabel}}
       />
-      {{#each @campaign.errors.idPixLabel as |error|}}
+      {{#if @campaign.errors.idPixLabel }}
         <div class='form__error error-message'>
-          {{error.message}}
+          {{display-campaign-errors @campaign.errors.idPixLabel}}
         </div>
-      {{/each}}
+      {{/if}}
       <div class="form__information help-text">
         {{t 'pages.campaign-creation.external-id-label.suggestion'}}
       </div>

--- a/orga/app/controllers/authenticated/campaigns/new.js
+++ b/orga/app/controllers/authenticated/campaigns/new.js
@@ -17,7 +17,7 @@ export default class NewController extends Controller {
       .catch((errorResponse) => {
         errorResponse.errors.forEach((error) => {
           if (error.status === '500') {
-            return this.notifications.sendError(this.intl.t('api-errors.global'));
+            return this.notifications.sendError(this.intl.t('api-errors-messages.global'));
           }
         });
       });

--- a/orga/app/helpers/display-campaign-errors.js
+++ b/orga/app/helpers/display-campaign-errors.js
@@ -1,0 +1,30 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+const CAMPAIGN_CREATION_ERRORS = [
+  {
+    i18nKey: 'api-errors-messages.campaign-creation.name-required',
+    message: 'CAMPAIGN_NAME_IS_REQUIRED',
+  },
+  {
+    i18nKey: 'api-errors-messages.campaign-creation.purpose-required',
+    message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
+  },
+  {
+    i18nKey: 'api-errors-messages.campaign-creation.target-profile-required',
+    message: 'TARGET_PROFILE_IS_REQUIRED',
+  },
+  {
+    i18nKey: 'api-errors-messages.campaign-creation.external-user-id-required',
+    message: 'EXTERNAL_USER_ID_IS_REQUIRED',
+  },
+];
+
+export default class extends Helper {
+  @service intl;
+
+  compute([errors]) {
+    if (!errors.length) return;
+    return this.intl.t(CAMPAIGN_CREATION_ERRORS.find((error) => error.message === errors[0].message).i18nKey);
+  }
+}

--- a/orga/tests/unit/helpers/display-campaign-errors-test.js
+++ b/orga/tests/unit/helpers/display-campaign-errors-test.js
@@ -1,0 +1,25 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Helper | display-campaign-errors', function(hooks) {
+  setupTest(hooks);
+  let helper;
+  hooks.beforeEach(function() {
+    this.owner.lookup('service:intl').setLocale('fr');
+    helper = this.owner.factoryFor('helper:display-campaign-errors').create();
+  });
+
+  module('when there is an error', function() {
+    test('it returns the intlKey corresponding to the name error message', function(assert) {
+      const nameErrors = [{ attribute: 'name', message: 'CAMPAIGN_NAME_IS_REQUIRED' }];
+      assert.equal(helper.compute([nameErrors]), 'Veuillez donner un nom à votre campagne.');
+    });
+  });
+
+  module('when there is no error', function() {
+    test('it returns the intlKey corresponding to the type error message', function(assert) {
+      const noError = [];
+      assert.equal(helper.compute([noError]), null);
+    });
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,6 +1,12 @@
 {
   "api-errors-messages": {
-    "global": "An error occurred. Please try again later."
+    "global": "An error occurred. Please try again later.",
+    "campaign-creation": {
+      "name-required": "Please name your campaign.",
+      "purpose-required": "Please select the purpose of your campaign: assess participants or collect their profiles.",
+      "target-profile-required": "Please select a target profile for your campaign.",
+      "external-user-id-required": "Please specify the type of external user ID which the participants will be required to fill when starting the personalised test."
+    }
   },
   "current-lang": "en",
   "common": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "api-errors": {
+  "api-errors-messages": {
     "global": "An error occurred. Please try again later."
   },
   "current-lang": "en",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,5 +1,5 @@
 {
-  "api-errors": {
+  "api-errors-messages": {
     "global": "Une erreur est survenue. Veuillez réessayer ultérieurement."
   },
   "current-lang": "fr",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,6 +1,12 @@
 {
   "api-errors-messages": {
-    "global": "Une erreur est survenue. Veuillez réessayer ultérieurement."
+    "global": "Une erreur est survenue. Veuillez réessayer ultérieurement.",
+    "campaign-creation": {
+      "name-required": "Veuillez donner un nom à votre campagne.",
+      "purpose-required": "Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.",
+      "target-profile-required": "Veuillez sélectionner un profil cible pour votre campagne.",
+      "external-user-id-required": "Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours."
+    }
   },
   "current-lang": "fr",
   "common": {


### PR DESCRIPTION
## :unicorn: Problème
Dans le formulaire de création d'une campagne, les messages d'erreurs n'étaient pas traduits.

## :robot: Solution
Ajouter la traduction des messages d'erreurs.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Aller dans pix ORGA pour créer une nouvelle campagne. 
Laisser les champs vides et appuyer sur créer une campagne pour voir les messages d'erreurs s'afficher.
