### PR TITLE
[TECH] Mise à jour du paquet de SendInBlue de la 7.2.4 pour 8.2.0.

### DIFF
--- a/api/lib/infrastructure/mailers/SendinblueProvider.js
+++ b/api/lib/infrastructure/mailers/SendinblueProvider.js
@@ -44,7 +44,7 @@ class SendinblueProvider extends MailingProvider {
   }
 
   static createSendinblueSMTPApi() {
-    return new SibApiV3Sdk.SMTPApi();
+    return new SibApiV3Sdk.TransactionalEmailsApi();
   }
 
   sendEmail(options) {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2176,9 +2176,9 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
     },
     "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -3296,9 +3296,9 @@
       "integrity": "sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg=="
     },
     "formidable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
-      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "frac": {
       "version": "1.1.2",
@@ -6204,9 +6204,9 @@
       }
     },
     "qs": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "ramda": {
       "version": "0.27.1",
@@ -6709,43 +6709,11 @@
       "dev": true
     },
     "sib-api-v3-sdk": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/sib-api-v3-sdk/-/sib-api-v3-sdk-7.2.4.tgz",
-      "integrity": "sha512-aTv+yQ1cGRQGtl+uX2MWYcnHJzZs4B6nNG7U+jFBgqRrY5k+FRaC9AzsIhc8BkrKhvEXe97InJFimVjrEzODKg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/sib-api-v3-sdk/-/sib-api-v3-sdk-8.2.0.tgz",
+      "integrity": "sha512-Qqr6y1wT7BZMWAKn5ouuCyqz8X0L3fB6jFRJK4pOIcnzvaSK2HLKwj0Enxz8Rsk+wuitWRptiJOBJgkcGm6dxA==",
       "requires": {
         "superagent": "3.7.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "superagent": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
-          "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
-          "requires": {
-            "component-emitter": "^1.2.0",
-            "cookiejar": "^2.1.0",
-            "debug": "^3.1.0",
-            "extend": "^3.0.0",
-            "form-data": "^2.3.1",
-            "formidable": "^1.1.1",
-            "methods": "^1.1.1",
-            "mime": "^1.4.1",
-            "qs": "^6.5.1",
-            "readable-stream": "^2.0.5"
-          }
-        }
       }
     },
     "signal-exit": {
@@ -7141,6 +7109,38 @@
         "@tokenizer/token": "^0.1.1",
         "@types/debug": "^4.1.5",
         "peek-readable": "^3.1.0"
+      }
+    },
+    "superagent": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.7.0.tgz",
+      "integrity": "sha512-/8trxO6NbLx4YXb7IeeFTSmsQ35pQBiTBsLNvobZx7qBzBeHYvKCyIIhW2gNcWbLzYxPAjdgFbiepd8ypwC0Gw==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.1.1",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "supports-color": {

--- a/api/package.json
+++ b/api/package.json
@@ -70,7 +70,7 @@
     "samlify": "^2.7.6",
     "sax": "^1.2.4",
     "saxpath": "^0.6.5",
-    "sib-api-v3-sdk": "^7.2.4",
+    "sib-api-v3-sdk": "^8.2.0",
     "xlsx": "^0.16.1",
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.4.23",


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, nous utilisons une ancienne version du paquet de SendInBlue :  `sib-api-v3-sdk`

## :robot: Solution
Mettre à jour cette dépendance, en prenant en compte le Breaking Changes de la [8.0.0](https://github.com/sendinblue/APIv3-nodejs-library/releases/tag/v8.0.0)
qui consiste à changer le nom de l'instance `SMTPApi` en `TransactionalEmailsApi`.

## :rainbow: Remarques
Nous espérons faire disparaître l'erreur Sentry liée à cette dépendance : https://sentry.io/organizations/pix/issues/2200596267/events/d8e2fa28756e44d3989a3f85dad29a77/?project=1398749

## :100: Pour tester
- Activer les e-mails dans RA 
- Faire une création de compte avec votre e-mail
- Constater que vous recevez bien l'e-mail.