### PR TITLE
[TECH][API] Ajout d'un module i18n dans l'API pour dynamiser les traductions (Pix-2285)

### DIFF
--- a/api/lib/application/healthcheck/healthcheck-controller.js
+++ b/api/lib/application/healthcheck/healthcheck-controller.js
@@ -6,7 +6,7 @@ const { knex } = require('../../../db/knex-database-connection');
 
 module.exports = {
 
-  get() {
+  get(request) {
     return {
       'name': packageJSON.name,
       'version': packageJSON.version,
@@ -14,6 +14,7 @@ module.exports = {
       'environment': settings.environment,
       'container-version': process.env.CONTAINER_VERSION,
       'container-app-name': process.env.APP,
+      'current-lang': request.i18n.__('current-lang'),
     };
   },
 

--- a/api/lib/application/prescribers/index.js
+++ b/api/lib/application/prescribers/index.js
@@ -28,7 +28,6 @@ exports.register = async function(server) {
         tags: ['api', 'user', 'prescription'],
       },
     },
-
   ]);
 };
 

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -3,6 +3,7 @@ const settings = require('./config');
 const Blipp = require('blipp');
 const Inert = require('@hapi/inert');
 const Vision = require('@hapi/vision');
+
 const isProduction = ['production', 'staging'].includes(process.env.NODE_ENV);
 
 const consoleReporters =
@@ -41,6 +42,17 @@ const plugins = [
   Inert,
   Vision,
   Blipp,
+  {
+    plugin: require('hapi-i18n'),
+    options: {
+      locales: ['en', 'fr'],
+      directory: __dirname + '/../translations',
+      defaultLocale: 'fr',
+      queryParameter: 'lang',
+      objectNotation: true,
+      updateFiles: false,
+    },
+  },
   {
     plugin: require('good'),
     options: {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1079,6 +1079,11 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E="
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -3625,6 +3630,18 @@
         }
       }
     },
+    "hapi-i18n": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-i18n/-/hapi-i18n-3.0.0.tgz",
+      "integrity": "sha512-l3X+A9dGTyihr9tyLdesC8ex9tulbrmZIgy6gSouGHr4LuIsfxOP723iMyRAZBwHNu7iAKy4KElXgZyQXkMe2Q==",
+      "requires": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/hoek": "^9.0.2",
+        "accept-language-parser": "^1.5.0",
+        "i18n": "^0.8.5",
+        "lodash": "^4.17.4"
+      }
+    },
     "hapi-sentry": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hapi-sentry/-/hapi-sentry-3.1.0.tgz",
@@ -3791,6 +3808,26 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.5.0.tgz",
       "integrity": "sha512-wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg=="
+    },
+    "i18n": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.6.tgz",
+      "integrity": "sha512-aMsJq8i1XXrb+BBsgmJBwak9mr69zPEIAUPb6c5yw2G/O4k1Q52lBxL+agZdQDN/RGf1ylQzrCswsOOgIiC1FA==",
+      "requires": {
+        "debug": "*",
+        "make-plural": "^6.0.1",
+        "math-interval-parser": "^2.0.1",
+        "messageformat": "^2.3.0",
+        "mustache": "*",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.6.2",
@@ -4805,6 +4842,11 @@
         "kind-of": "^6.0.2"
       }
     },
+    "make-plural": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -4817,6 +4859,47 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "math-interval-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
+      "integrity": "sha512-VmlAmb0UJwlvMyx8iPhXUDnVW1F9IrGEd9CIOmv+XL8AErCUUuozoDMrgImvnYt2A+53qVX/tPW6YJurMKYsvA=="
+    },
+    "messageformat": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-2.3.0.tgz",
+      "integrity": "sha512-uTzvsv0lTeQxYI2y1NPa1lItL5VRI8Gb93Y2K2ue5gBPyrbJxfDi/EYWxh2PKv5yO42AJeeqblS9MJSh/IEk4w==",
+      "requires": {
+        "make-plural": "^4.3.0",
+        "messageformat-formatters": "^2.0.1",
+        "messageformat-parser": "^4.1.2"
+      },
+      "dependencies": {
+        "make-plural": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
+          "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "optional": true
+        }
+      }
+    },
+    "messageformat-formatters": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/messageformat-formatters/-/messageformat-formatters-2.0.1.tgz",
+      "integrity": "sha512-E/lQRXhtHwGuiQjI7qxkLp8AHbMD5r2217XNe/SREbBlSawe0lOqsFb7rflZJmlQFSULNLIqlcjjsCPlB3m3Mg=="
+    },
+    "messageformat-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -5218,6 +5301,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mustache": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.1.0.tgz",
+      "integrity": "sha512-0FsgP/WVq4mKyjolIyX+Z9Bd+3WS8GOwoUTyKXT5cTYMGeauNTi2HPCwERqseC1IHAy0Z7MDZnJBfjabd4O8GQ=="
     },
     "mv": {
       "version": "2.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -42,6 +42,7 @@
     "good": "^8.1.2",
     "good-console": "^8.0.0",
     "good-squeeze": "^5.1.0",
+    "hapi-i18n": "^3.0.0",
     "hapi-sentry": "^3.1.0",
     "hapi-swagger": "^14.1.0",
     "hash-int": "^1.0.0",

--- a/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
+++ b/api/tests/unit/application/healthcheck/healthcheck-controller_test.js
@@ -10,7 +10,9 @@ describe('Unit | Controller | healthcheckController', () => {
 
     it('should reply with the API description', async function() {
       // when
-      const response = await healthcheckController.get(null, hFake);
+      const mockedRequest = { i18n: { __: sinon.stub() } };
+
+      const response = await healthcheckController.get(mockedRequest, hFake);
 
       // then
       expect(response).to.include.keys('name', 'version', 'description');

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "current-lang" : "en",
   "organization-invitation-email": {
     "title": "You are invited to join Pix Orga",
     "subtitle": "With the Pix Orga platform, create and manage testing campaigns and monitor the progress of your participants.",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,4 +1,5 @@
 {
+  "current-lang": "fr",
   "organization-invitation-email": {
     "title": "Vous êtes invité(e) à rejoindre Pix Orga",
     "subtitle": "La plateforme Pix Orga vous permet de créer, gérer des campagnes de test et suivre la progression de vos participants.",


### PR DESCRIPTION
## :unicorn: Problème
Côté pix Orga nous avons à rendre les csv d'export multilingue. Or nous avons besoin de traduction dynamique pour celà.

## :robot: Solution
Ajout du module [hapi-i18n](https://github.com/funktionswerk/hapi-i18n) qui se base sur le module [i18n-node](https://github.com/mashpie/i18n-node)

## :rainbow: Remarques
le i18next pour hapi ne me semblait pas trop fiable,  dernière update en 2k17 🤒 

Par défaut hapi-i18n, utilise le contenu d' Accept-language . j'ai rajouté le query parameter lang afin de pouvoir lancer des `get` (téléchargement de ressources entre autre) .

NB : dans le doc , il semble que le `queryparameter` est plus fort que  le header `accept language` si les deux sont présents.


Si il faut je peux retirer à la fin le current-lang du healtcheck. c'était pour avoir une route de vérification

## :100: Pour tester
aller sur /api (healthchecker) . rajouter le paramètre `?lang=en` `?lang=fr` vérifier que current-lang change bien en fonction du paramètre.