### PR TITLE
[FEATURE] Dans la page Mon compte de Pix App (.org), mettre le label "Langages" au singulier (PIX-2282).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -947,7 +947,7 @@
                 "last-name": "Last name",
                 "email": "Email address",
                 "username": "Username",
-                "lang": "Languages",
+                "lang": "Language",
                 "edit-button": "Edit",
                 "fields": {
                     "select": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -947,7 +947,7 @@
                 "last-name": "Nom",
                 "email": "Adresse e-mail",
                 "username": "Identifiant",
-                "lang": "Langues",
+                "lang": "Langue",
                 "edit-button": "Modifier",
                 "fields": {
                     "select": {


### PR DESCRIPTION
## :unicorn: Problème
Dans la page Mon compte, de pix.org, le label "Langages" devrait être au singulier.

## :robot: Solution
Faire la modification dans les fichiers `/translations/fr et en`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
* Dans Pix App (.org), verifier que dans la page Mon compte, le label est au singulier.
* Changer la langue (en anglais), et faire la même vérification.