### PR TITLE
[FEATURE][i18n] Contextualisation des en-têtes sur l'export de résultats pour une campagne de collecte de profils (Pix-2205).

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -83,7 +83,7 @@ module.exports = {
 
     const writableStream = new PassThrough();
 
-    const { fileName } = await usecases.startWritingCampaignProfilesCollectionResultsToStream({ userId, campaignId, writableStream });
+    const { fileName } = await usecases.startWritingCampaignProfilesCollectionResultsToStream({ userId, campaignId, writableStream, i18n: request.i18n });
     const escapedFileName = requestResponseUtils.escapeFileName(fileName);
 
     writableStream.headers = {

--- a/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
@@ -2,16 +2,18 @@ const csvSerializer = require('../../serializers/csv/csv-serializer');
 const moment = require('moment');
 
 const EMPTY_ARRAY = [];
-const NOT_SHARED = 'NA';
 
 class CampaignProfileCollectionResultLine {
 
-  constructor(campaign, organization, campaignParticipationResult, competences, placementProfile) {
+  constructor(campaign, organization, campaignParticipationResult, competences, placementProfile, translate) {
     this.organization = organization;
     this.campaign = campaign;
     this.campaignParticipationResult = campaignParticipationResult;
     this.competences = competences;
     this.placementProfile = placementProfile;
+    this.translate = translate;
+
+    this.notShared = translate('campaign.common.not-available');
   }
 
   toCsvLine() {
@@ -44,11 +46,11 @@ class CampaignProfileCollectionResultLine {
   }
 
   _getCompetencesCountColumn() {
-    return this.campaignParticipationResult.isShared ? this.placementProfile.getCertifiableCompetencesCount() : NOT_SHARED;
+    return this.campaignParticipationResult.isShared ? this.placementProfile.getCertifiableCompetencesCount() : this.notShared;
   }
 
   _getIsCertifiableColumn() {
-    return this.campaignParticipationResult.isShared ? this._yesOrNo(this.placementProfile.isCertifiable()) : NOT_SHARED;
+    return this.campaignParticipationResult.isShared ? this._yesOrNo(this.placementProfile.isCertifiable()) : this.notShared;
   }
 
   _getIdPixLabelColumn() {
@@ -64,11 +66,11 @@ class CampaignProfileCollectionResultLine {
   }
 
   _getSharedAtColumn() {
-    return this.campaignParticipationResult.isShared ? moment.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD') : NOT_SHARED;
+    return this.campaignParticipationResult.isShared ? moment.utc(this.campaignParticipationResult.sharedAt).format('YYYY-MM-DD') : this.notShared;
   }
 
   _getTotalEarnedPixColumn() {
-    let totalEarnedPix = NOT_SHARED;
+    let totalEarnedPix = this.notShared;
     if (this.campaignParticipationResult.isShared) {
       totalEarnedPix = 0;
       this.placementProfile.userCompetences.forEach(({ pixScore }) => {
@@ -80,7 +82,7 @@ class CampaignProfileCollectionResultLine {
   }
 
   _yesOrNo(value) {
-    return value ? 'Oui' : 'Non';
+    return this.translate(`campaign.common.${value ? 'yes' : 'no'}`);
   }
 
   _competenceColumns() {
@@ -91,7 +93,7 @@ class CampaignProfileCollectionResultLine {
       if (this.campaignParticipationResult.isShared) {
         columns.push(estimatedLevel, pixScore);
       } else {
-        columns.push(NOT_SHARED, NOT_SHARED);
+        columns.push(this.notShared, this.notShared);
       }
     });
 

--- a/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
@@ -3,15 +3,15 @@ const bluebird = require('bluebird');
 const csvSerializer = require('./csv-serializer');
 const constants = require('../../constants');
 const CampaignProfileCollectionResultLine = require('../../exports/campaigns/campaign-profile-collection-result-line');
-
 class CampaignProfileCollectionExport {
 
-  constructor(outputStream, organization, campaign, competences) {
+  constructor(outputStream, organization, campaign, competences, translate) {
     this.stream = outputStream;
     this.organization = organization;
     this.campaign = campaign;
     this.idPixLabel = campaign.idPixLabel;
     this.competences = competences;
+    this.translate = translate;
   }
 
   export(campaignParticipationResultDatas, placementProfileService) {
@@ -36,20 +36,20 @@ class CampaignProfileCollectionExport {
     const displayDivision = this.organization.isSco && this.organization.isManagingStudents;
 
     const header = [
-      'Nom de l\'organisation',
-      'ID Campagne',
-      'Nom de la campagne',
-      'Nom du Participant',
-      'Prénom du Participant',
-      displayDivision && 'Classe',
-      displayStudentNumber && 'Numéro Étudiant',
+      this.translate('campaign.profiles-collection.organization-name'),
+      this.translate('campaign.profiles-collection.campaign-id'),
+      this.translate('campaign.profiles-collection.campaign-name'),
+      this.translate('campaign.profiles-collection.participant-lastname'),
+      this.translate('campaign.profiles-collection.participant-firstname'),
+      displayDivision && this.translate('campaign.profiles-collection.participant-division'),
+      displayStudentNumber && this.translate('campaign.profiles-collection.participant-student-number'),
       this.idPixLabel,
-      'Envoi (O/N)',
-      'Date de l\'envoi',
-      'Nombre de pix total',
-      'Certifiable (O/N)',
-      'Nombre de compétences certifiables',
-      ...(this._competenceColumnHeaders(this.competences)),
+      this.translate('campaign.profiles-collection.is-sent'),
+      this.translate('campaign.profiles-collection.sent-on'),
+      this.translate('campaign.profiles-collection.pix-score'),
+      this.translate('campaign.profiles-collection.is-certifiable'),
+      this.translate('campaign.profiles-collection.certifiable-skills'),
+      ...(this._competenceColumnHeaders()),
     ];
 
     return '\uFEFF' + csvSerializer.serializeLine(_.compact(header));
@@ -73,16 +73,16 @@ class CampaignProfileCollectionExport {
     for (const placementProfile of placementProfiles) {
       const campaignParticipationResultData = campaignParticipationResultDatas.find(({ userId }) => userId === placementProfile.userId);
 
-      const line = new CampaignProfileCollectionResultLine(this.campaign, this.organization, campaignParticipationResultData, this.competences, placementProfile);
+      const line = new CampaignProfileCollectionResultLine(this.campaign, this.organization, campaignParticipationResultData, this.competences, placementProfile, this.translate);
       csvLines = csvLines.concat(line.toCsvLine());
     }
     return csvLines;
   }
 
-  _competenceColumnHeaders(competencesList) {
-    return _.flatMap(competencesList, (competence) => [
-      `Niveau pour la compétence ${competence.name}`,
-      `Nombre de pix pour la compétence ${competence.name}`,
+  _competenceColumnHeaders() {
+    return _.flatMap(this.competences, (competence) => [
+      this.translate('campaign.profiles-collection.skill-level', { name: competence.name }),
+      this.translate('campaign.profiles-collection.skill-ranking', { name: competence.name }),
     ]);
   }
 }

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,5 +1,5 @@
 const { PassThrough } = require('stream');
-const { expect, mockLearningContent, databaseBuilder, streamToPromise } = require('../../../test-helper');
+const { expect, mockLearningContent, databaseBuilder, streamToPromise, sinon } = require('../../../test-helper');
 
 const startWritingCampaignProfilesCollectionResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream');
 
@@ -22,7 +22,14 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     let campaignParticipation;
     let writableStream;
     let csvPromise;
+
+    const translate = sinon.stub();
     const createdAt = new Date('2019-02-25T10:00:00Z');
+
+    const i18n = {
+      __: translate,
+      getLocale: sinon.stub(),
+    };
 
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser();
@@ -113,6 +120,23 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
+
+      translate.withArgs('campaign.profiles-collection.campaign-id').returns('ID Campagne');
+      translate.withArgs('campaign.profiles-collection.organization-name').returns('Nom de l\'organisation');
+      translate.withArgs('campaign.profiles-collection.campaign-name').returns('Nom de la campagne');
+      translate.withArgs('campaign.profiles-collection.participant-lastname').returns('Nom du Participant');
+      translate.withArgs('campaign.profiles-collection.participant-firstname').returns('Prénom du Participant');
+      translate.withArgs('campaign.profiles-collection.participant-division').returns('Classe');
+      translate.withArgs('campaign.profiles-collection.participant-student-number').returns('Numéro Étudiant');
+      translate.withArgs('campaign.profiles-collection.is-sent').returns('Envoi (O/N)');
+      translate.withArgs('campaign.profiles-collection.sent-on').returns('Date de l\'envoi');
+      translate.withArgs('campaign.profiles-collection.pix-score').returns('Nombre de pix total');
+      translate.withArgs('campaign.profiles-collection.is-certifiable').returns('Certifiable (O/N)');
+      translate.withArgs('campaign.profiles-collection.certifiable-skills').returns('Nombre de compétences certifiables');
+
+      translate.withArgs('campaign.common.no').returns('Non');
+      translate.withArgs('campaign.common.yes').returns('Oui');
+      translate.withArgs('campaign.common.not-available').returns('NA');
     });
 
     context('When the organization is PRO', () => {
@@ -167,6 +191,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           userId: user.id,
           campaignId: campaign.id,
           writableStream,
+          i18n,
           campaignRepository,
           userRepository,
           competenceRepository,
@@ -240,6 +265,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           userId: user.id,
           campaignId: campaign.id,
           writableStream,
+          i18n,
           campaignRepository,
           userRepository,
           competenceRepository,
@@ -313,6 +339,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
           userId: user.id,
           campaignId: campaign.id,
           writableStream,
+          i18n,
           campaignRepository,
           userRepository,
           competenceRepository,

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -41,6 +41,9 @@ describe('Unit | Application | Controller | Campaign', () => {
             },
           },
         },
+        i18n: {
+          __: sinon.stub(),
+        },
       };
       const campaign = {
         name: 'name',
@@ -76,6 +79,9 @@ describe('Unit | Application | Controller | Campaign', () => {
       },
       params: {
         id: campaignId,
+      },
+      i18n: {
+        __: sinon.stub(),
       },
     };
 
@@ -132,6 +138,9 @@ describe('Unit | Application | Controller | Campaign', () => {
       },
       params: {
         id: campaignId,
+      },
+      i18n: {
+        __: sinon.stub(),
       },
     };
 

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -7,6 +7,8 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
   describe('#toCsvLine', () => {
     let organization, campaign, competences;
 
+    const translate = sinon.stub();
+
     const placementProfile = new PlacementProfile({
       userId: 123,
       userCompetences: [{
@@ -23,6 +25,10 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
     beforeEach(() => {
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
       const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
+
+      translate.withArgs('campaign.common.no').returns('Non');
+      translate.withArgs('campaign.common.yes').returns('Oui');
+      translate.withArgs('campaign.common.not-available').returns('NA');
 
       organization = {};
       campaign = {};
@@ -79,7 +85,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -122,7 +128,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -168,7 +174,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -219,7 +225,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
        '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -271,7 +277,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
         //when
-        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+        const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
         //then
         expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -324,7 +330,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -371,7 +377,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -424,7 +430,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
             //when
-            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
             //then
             expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -479,7 +485,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -526,7 +532,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
         '\n';
 
           //when
-          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+          const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
           //then
           expect(line.toCsvLine()).to.equal(csvExcpectedLine);
@@ -579,7 +585,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
           '\n';
 
             //when
-            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile);
+            const line = new CampaignProfileCollectionResultLine(campaign, organization, campaignParticipationResultData, competences, placementProfile, translate);
 
             //then
             expect(line.toCsvLine()).to.equal(csvExcpectedLine);

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -11,6 +11,8 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       getPlacementProfilesWithSnapshotting: sinon.stub(),
     };
 
+    const translate = sinon.stub();
+
     beforeEach(() => {
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
@@ -36,11 +38,30 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
         },
       ];
 
+      translate.withArgs('campaign.profiles-collection.campaign-id').returns('ID Campagne');
+      translate.withArgs('campaign.profiles-collection.organization-name').returns('Nom de l\'organisation');
+      translate.withArgs('campaign.profiles-collection.campaign-name').returns('Nom de la campagne');
+      translate.withArgs('campaign.profiles-collection.participant-lastname').returns('Nom du Participant');
+      translate.withArgs('campaign.profiles-collection.participant-firstname').returns('Prénom du Participant');
+      translate.withArgs('campaign.profiles-collection.participant-division').returns('Classe');
+      translate.withArgs('campaign.profiles-collection.participant-student-number').returns('Numéro Étudiant');
+      translate.withArgs('campaign.profiles-collection.is-sent').returns('Envoi (O/N)');
+      translate.withArgs('campaign.profiles-collection.sent-on').returns('Date de l\'envoi');
+      translate.withArgs('campaign.profiles-collection.pix-score').returns('Nombre de pix total');
+      translate.withArgs('campaign.profiles-collection.is-certifiable').returns('Certifiable (O/N)');
+      translate.withArgs('campaign.profiles-collection.certifiable-skills').returns('Nombre de compétences certifiables');
+
+      translate.withArgs('campaign.profiles-collection.skill-level', { name: competences[0].name }).returns(`Niveau pour la compétence ${competences[0].name}`);
+      translate.withArgs('campaign.profiles-collection.skill-ranking', { name: competences[0].name }).returns(`Nombre de pix pour la compétence ${competences[0].name}`);
+
+      translate.withArgs('campaign.profiles-collection.skill-level', { name: competences[1].name }).returns(`Niveau pour la compétence ${competences[1].name}`);
+      translate.withArgs('campaign.profiles-collection.skill-ranking', { name: competences[1].name }).returns(`Nombre de pix pour la compétence ${competences[1].name}`);
+
     });
 
     it('should display common header parts of csv', async () => {
       //given
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences);
+      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -72,7 +93,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       organization.isSco = true;
       organization.isManagingStudents = true;
 
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences);
+      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -105,7 +126,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       organization.isSup = true;
       organization.isManagingStudents = true;
 
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences);
+      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +
@@ -136,7 +157,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
     it('should display idPixLabel header when campaign has one', async () => {
       //given
       campaign.idPixLabel = 'email';
-      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences);
+      const campaignProfile = new CampaignProfileCollectionExport(writableStream, organization, campaign, competences, translate);
 
       const expectedHeader = '\uFEFF"Nom de l\'organisation";' +
           '"ID Campagne";' +

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -22,5 +22,29 @@
     "moreOn": "More on",
     "doNotAnswer": "This is an automated email message, please do not reply.",
     "askForHelp": "Any questions? We’re here to help, contact us"
+  },
+  "campaign" : {
+    "common" :{
+      "yes": "Yes",
+      "no": "No",
+      "not-available": "NA"  
+    },
+    "profiles-collection" : {
+      "campaign-id": "Campaign ID",
+      "campaign-name": "Campaign's name",
+      "certifiable-skills": "Number of skills eligible for certification",
+      "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
+      "is-certifiable" :"Eligible for certification (Y/N)",
+      "is-sent": "Sent (Y/N)",
+      "participant-division": "Class",
+      "participant-firstname": "Participant's first name",
+      "participant-lastname": "Participant's last name",
+      "participant-student-number": "Student number",
+      "organization-name": "Organisation’s name",
+      "pix-score": "Total pix score",
+      "sent-on": "Sent on",
+      "skill-level": "Level reached in the skill {{name}}",
+      "skill-ranking": "Pix score for the skill {{name}}"
+    }
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -22,5 +22,29 @@
     "moreOn": "En savoir plus sur",
     "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
     "askForHelp": "Besoin d’aide, contactez-nous"
+  },
+  "campaign": {
+    "common" : {
+      "yes": "Oui",
+      "no": "Non",
+      "not-available": "NA"
+    },
+    "profiles-collection" : {
+      "campaign-id": "ID Campagne",
+      "campaign-name": "Nom de la campagne",
+      "certifiable-skills": "Nombre de compétences certifiables",
+      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
+      "is-certifiable" :"Certifiable (O/N)",
+      "is-sent": "Envoi (O/N)",
+      "organization-name": "Nom de l'organisation",
+      "participant-division": "Classe",
+      "participant-firstname": "Prénom du Participant",
+      "participant-lastname": "Nom du Participant",
+      "participant-student-number": "Numéro Étudiant",
+      "pix-score": "Nombre de pix total",
+      "sent-on": "Date de l'envoi",
+      "skill-level": "Niveau pour la compétence {{name}}",
+      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+    }
   }
 }

--- a/orga/app/components/routes/authenticated/campaign/report.hbs
+++ b/orga/app/components/routes/authenticated/campaign/report.hbs
@@ -74,7 +74,7 @@
     </nav>
 
     <div class="campaign-details-controls__export-button">
-      <a class="button button--link" href="{{@campaign.urlToResult}}" target="_blank" rel="noopener noreferrer" download>
+      <a class="button button--link" href="{{this.downloadUrl}}" target="_blank" rel="noopener noreferrer" download>
         {{t 'pages.campaign.actions.export-results'}}
       </a>
     </div>

--- a/orga/app/components/routes/authenticated/campaign/report.js
+++ b/orga/app/components/routes/authenticated/campaign/report.js
@@ -6,6 +6,7 @@ export default class Report extends Component {
 
   @service store;
   @service notifications;
+  @service currentUser;
 
   get participationsCount() {
     const participationsCount = this.args.campaign.participationsCount;
@@ -17,6 +18,10 @@ export default class Report extends Component {
     const sharedParticipationsCount = this.args.campaign.sharedParticipationsCount;
 
     return sharedParticipationsCount > 0 ? sharedParticipationsCount : '-';
+  }
+
+  get downloadUrl() {
+    return this.args.campaign.urlToResult + `&lang=${this.currentUser.prescriber.lang}`;
   }
 
   @action

--- a/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
@@ -2,6 +2,13 @@ import { module, test } from 'qunit';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+class CurrentUserStub extends Service {
+  prescriber = {
+    lang: 'fr',
+  }
+}
 
 module('Integration | Component | routes/authenticated/campaign/report', function(hooks) {
   setupIntlRenderingTest(hooks);
@@ -10,6 +17,8 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
 
   hooks.beforeEach(function() {
     store = this.owner.lookup('service:store');
+    this.owner.register('service:current-user', CurrentUserStub);
+    this.owner.lookup('service:current-user', CurrentUserStub);
   });
 
   test('it should display campaign name', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Internationalisation des exports non réalisé

## :robot: Solution
Ajout de l'internationalistion dans les fichiers d'export afin de contextualiser les colonnes en fonction de la langue. 

## :rainbow: Remarques


## :100: Pour tester
Allez sur pixOrga, campagne collecte de profile. cliquez sur exporter les résultats. en fonction du paramètre lang de l'url. les colonnes s'afficheront dans la langue selectionnéee.