### PR TITLE
[TECH] Suppression des espaces inutiles dans les fichiers servers.conf. 

### DIFF
--- a/admin/servers.conf.erb
+++ b/admin/servers.conf.erb
@@ -78,13 +78,13 @@ server {
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
 
-  <% ENV.each do |key,value| %>
-    <% if key.start_with? 'ADD_HTTP_HEADER' %>
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=
-          key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
-        %> "<%=
-          value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
-        %>" ;
-    <% end %>
-  <% end %>
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }

--- a/certif/servers.conf.erb
+++ b/certif/servers.conf.erb
@@ -78,13 +78,13 @@ server {
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
 
-  <% ENV.each do |key,value| %>
-    <% if key.start_with? 'ADD_HTTP_HEADER' %>
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=
-          key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
-        %> "<%=
-          value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
-        %>" ;
-    <% end %>
-  <% end %>
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }

--- a/mon-pix/servers.conf.erb
+++ b/mon-pix/servers.conf.erb
@@ -78,13 +78,13 @@ server {
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
 
-  <% ENV.each do |key,value| %>
-    <% if key.start_with? 'ADD_HTTP_HEADER' %>
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=
-          key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
-        %> "<%=
-          value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
-        %>" ;
-    <% end %>
-  <% end %>
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }

--- a/orga/servers.conf.erb
+++ b/orga/servers.conf.erb
@@ -78,13 +78,13 @@ server {
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
 
-  <% ENV.each do |key,value| %>
-    <% if key.start_with? 'ADD_HTTP_HEADER' %>
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=
-          key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
-        %> "<%=
-          value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
-        %>" ;
-    <% end %>
-  <% end %>
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -40,13 +40,13 @@ server {
   add_header X-Frame-Options "SAMEORIGIN";
   add_header X-XSS-Protection 1;
 
-  <% ENV.each do |key,value| %>
-    <% if key.start_with? 'ADD_HTTP_HEADER' %>
+  <% ENV.each do |key,value|
+    if key.start_with? 'ADD_HTTP_HEADER' %>
       add_header <%=
-          key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
-        %> "<%=
-          value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
-        %>" ;
-    <% end %>
-  <% end %>
+        key.sub(/^ADD_HTTP_HEADER_/, '').split("_").map(&:capitalize).join("-")
+      %> "<%=
+        value.gsub('\\', '\\\\\\\\').gsub('"','\\"').gsub('$','\\$')
+      %>" ;
+    <% end
+  end %>
 }


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'on génère les fichiers `servers.conf.erb`, nous pouvons constater que nous avons des lignes vides à la fin de celui-ci.
Cela est du au fonctionnement de erb. 
En effet, à chaque balise `<% %>`, erb va copier le code Ruby comme tel. Quand il s'agit de texte erb va effectuer un `puts <text>`.

Le bout de code suivant : 
```erb
<% (0..3).each do |i| %>
<%=  i %>
<% end %>
```

Le moteur de erb le convertit en  : 
```ruby
(0..3).each do |i|
puts <les espaces>
i 
puts <les espaces>
end
```

Pour devenir : 
```

0

1

2

3

```

Merci @jonathanperret pour l'explication. 

## :robot: Solution
Afin d'éviter cela nous pouvons tout simplement réunir ensemble les blocs de code Ruby dans la même balise `<% %>`. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Lancer la commande avant changement et après  : 
`erb servers.conf.erb > servers.conf` 