### PR TITLE
[TECH] Réactiver le linter pour Pix Admin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,9 @@ jobs:
           paths:
             - ~/.npm
       - run:
+          name: Lint
+          command: npm run lint
+      - run:
           name: Test
           command: npm test
 

--- a/admin/app/components/certification-list-select-all.js
+++ b/admin/app/components/certification-list-select-all.js
@@ -1,3 +1,8 @@
+/* eslint-disable ember/no-actions-hash */
+/* eslint-disable ember/require-tagless-components */
+/* eslint-disable ember/no-classic-classes */
+/* eslint-disable ember/no-classic-components */
+
 import Component from '@ember/component';
 
 export default Component.extend({

--- a/admin/app/components/organization-members-section.js
+++ b/admin/app/components/organization-members-section.js
@@ -1,3 +1,6 @@
+/* eslint-disable ember/require-tagless-components */
+/* eslint-disable ember/no-classic-components */
+
 import Component from '@ember/component';
 import { action } from '@ember/object';
 

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -15,7 +15,9 @@
         {{#each @stages as |stage|}}
           <tr>
             <td>{{stage.id}}</td>
-            <td class="stages-table__image"><img src={{@targetProfileImageUrl}} alt="" /></td>
+            <td class="stages-table__image">
+              <img src={{@targetProfileImageUrl}} alt="" role="presentation" />
+            </td>
             <td>{{stage.threshold}}</td>
             <td>{{stage.title}}</td>
             <td>{{stage.message}}</td>

--- a/admin/app/controllers/authenticated/certification-centers/list.js
+++ b/admin/app/controllers/authenticated/certification-centers/list.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';

--- a/admin/app/controllers/authenticated/certifications/certification/details.js
+++ b/admin/app/controllers/authenticated/certifications/certification/details.js
@@ -1,3 +1,6 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';

--- a/admin/app/controllers/authenticated/certifications/certification/informations.js
+++ b/admin/app/controllers/authenticated/certifications/certification/informations.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
 import { action, computed } from '@ember/object';

--- a/admin/app/controllers/authenticated/organizations/get/members.js
+++ b/admin/app/controllers/authenticated/organizations/get/members.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -8,7 +8,7 @@ import { action } from '@ember/object';
 const DEFAULT_PAGE_NUMBER = 1;
 
 export default class AuthenticatedSessionsListAllController extends Controller {
-    
+
   queryParams = ['pageNumber', 'pageSize', 'id', 'certificationCenterName', 'status', 'resultsSentToPrescriberAt'];
   DEBOUNCE_MS = config.pagination.debounce;
 

--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';

--- a/admin/app/controllers/authenticated/sessions/session/certifications.js
+++ b/admin/app/controllers/authenticated/sessions/session/certifications.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import some from 'lodash/some';
 
 import { inject as service } from '@ember/service';

--- a/admin/app/controllers/authenticated/sessions/session/informations.js
+++ b/admin/app/controllers/authenticated/sessions/session/informations.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';

--- a/admin/app/controllers/authenticated/target-profiles/list.js
+++ b/admin/app/controllers/authenticated/target-profiles/list.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';

--- a/admin/app/controllers/authenticated/tools.js
+++ b/admin/app/controllers/authenticated/tools.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';

--- a/admin/app/controllers/authenticated/users/list.js
+++ b/admin/app/controllers/authenticated/users/list.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-no-classic-methods */
+
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';

--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 

--- a/admin/app/models/certification.js
+++ b/admin/app/models/certification.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { computed } from '@ember/object';
 import Model, { attr, hasMany } from '@ember-data/model';
 

--- a/admin/app/models/jury-certification-summary.js
+++ b/admin/app/models/jury-certification-summary.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { computed } from '@ember/object';
 import Model, { attr } from '@ember-data/model';
 import find from 'lodash/find';

--- a/admin/app/models/membership.js
+++ b/admin/app/models/membership.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { computed } from '@ember/object';
 import Model, { belongsTo, attr } from '@ember-data/model';
 

--- a/admin/app/models/organization-invitation.js
+++ b/admin/app/models/organization-invitation.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import Model, { belongsTo, attr } from '@ember-data/model';
 import { equal } from '@ember/object/computed';
 

--- a/admin/app/models/organization.js
+++ b/admin/app/models/organization.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import { memberAction } from 'ember-api-actions';
 import Model, { hasMany, attr } from '@ember-data/model';
 import { equal } from '@ember/object/computed';

--- a/admin/app/models/session.js
+++ b/admin/app/models/session.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import isEmpty from 'lodash/isEmpty';
 import sumBy from 'lodash/sumBy';
 import some from 'lodash/some';

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-computed-properties-in-native-classes */
+
 import Model, { hasMany, attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/classic-decorator-hooks */
+
 import EmberRouter from '@ember/routing/router';
 import config from 'pix-admin/config/environment';
 

--- a/admin/app/routes/authenticated/sessions/index.js
+++ b/admin/app/routes/authenticated/sessions/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-classic-classes */
+
 import Route from '@ember/routing/route';
 
 export default Route.extend({

--- a/admin/app/routes/authenticated/sessions/list/all.js
+++ b/admin/app/routes/authenticated/sessions/list/all.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-classic-classes */
+
 import Route from '@ember/routing/route';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import { FINALIZED } from 'pix-admin/models/session';

--- a/admin/app/services/csv-service.js
+++ b/admin/app/services/csv-service.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/no-classic-classes */
+
 import Service from '@ember/service';
 
 export default Service.extend({

--- a/admin/tests/integration/components/organizations-test.js
+++ b/admin/tests/integration/components/organizations-test.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/require-valid-css-selector-in-test-helpers */
-
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render } from '@ember/test-helpers';
@@ -58,7 +56,7 @@ module('Integration | Component | target-profiles organizations', function(hooks
 
     // when
     await render(hbs`<TargetProfiles::Organizations @organizations={{this.organizations}} @organizationsToAttach={{this.organizationsToAttach}} @attachOrganizations={{action this.attachOrganizations}} @goToOrganizationPage={{this.goToOrganizationPage}} @triggerFiltering={{this.triggerFiltering}}/>`);
-    await fillIn('[aria-label="ID de ou des organisation(s)', '1, 2');
+    await fillIn('[aria-label="ID de ou des organisation(s)"]', '1, 2');
     await click('[aria-label="Rattacher une ou plusieurs organisation(s)"] button');
 
     sinon.assert.called(attachOrganizations);

--- a/admin/tests/integration/components/organizations-test.js
+++ b/admin/tests/integration/components/organizations-test.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/require-valid-css-selector-in-test-helpers */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render } from '@ember/test-helpers';

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,5 +1,3 @@
-/* eslint-disable ember/require-valid-css-selector-in-test-helpers */
-
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find, render } from '@ember/test-helpers';
@@ -23,7 +21,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').exists();
+      assert.dom('button[aria-label="Modifier"]').exists();
     });
 
     test('should not display the update button when user is connected from GAR only', async function(assert) {
@@ -37,7 +35,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should not display the update button when user is connected with username only', async function(assert) {
@@ -51,7 +49,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should not display the update button when user is connected with username and email', async function(assert) {
@@ -65,7 +63,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should not display the update button when user is connected with email and GAR', async function(assert) {
@@ -79,7 +77,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should not display the update button when user is connected with username and GAR', async function(assert) {
@@ -93,7 +91,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should not display the update button when user is connected with username, email and GAR', async function(assert) {
@@ -107,7 +105,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      assert.dom('button[aria-label=\'Modifier\'').doesNotExist();
+      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
     test('should display user’s first name', async function(assert) {
@@ -283,10 +281,10 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Modifier\'');
+      await click('button[aria-label="Modifier"]');
 
-      assert.dom('button[aria-label=\'Editer\'').exists();
-      assert.dom('button[aria-label=\'Annuler\'').exists();
+      assert.dom('button[aria-label="Editer"]').exists();
+      assert.dom('button[aria-label="Annuler"]').exists();
     });
 
     test('should display user’s first name,last name and email in edit mode', async function(assert) {
@@ -295,7 +293,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Modifier\'');
+      await click('button[aria-label="Modifier"]');
 
       assert.dom('.user-edit-form__first-name').hasValue(this.user.firstName);
       assert.dom('.user-edit-form__last-name').hasValue(this.user.lastName);
@@ -307,7 +305,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Modifier\'');
+      await click('button[aria-label="Modifier"]');
 
       assert.dom('.user__cgu').doesNotExist();
       assert.dom('.user__pix-orga-terms-of-service-accepted').doesNotExist();
@@ -333,7 +331,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       this.set('user', user);
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-      await click('button[aria-label=\'Anonymiser\']');
+      await click('button[aria-label="Anonymiser"]');
 
       assert.dom('.modal-dialog').exists();
       assert.contains('Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible.');
@@ -342,7 +340,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
     test('should close the modal to cancel action', async function(assert) {
       this.set('user', user);
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-      await click('button[aria-label=\'Anonymiser\']');
+      await click('button[aria-label="Anonymiser"]');
 
       await click('.modal-dialog .btn-secondary');
 

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/require-valid-css-selector-in-test-helpers */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, find, render } from '@ember/test-helpers';


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, le linter de la CI est désactivé sur l'app admin car il y a de nombreux problèmes à corriger (cf. [discussion sur slack](https://1024pix.slack.com/archives/C658LDBAQ/p1613641315007800)). Si quelqu'un a mal configuré son IDE et ne lance pas un lint manuel (difficile à lire sur admin car il y a déjà beaucoup d'erreurs), il peut potentiellement ajouter de nouvelles erreurs (et donc aggraver le problème).

## :robot: Solution
Pour pouvoir réactiver le linter de la CI, je propose d'ajouter des exceptions pour de désactiver individuellement les règles d'erreurs pour chaque erreur dans chaque fichier de l'app admin. Cela permet de réactiver le linter dans la CI tout en gardant une trace des erreurs à corriger.

## :rainbow: Remarques
- J'ai déjà proposé une autre solution pour le même problème dans la PR #2606
- Cette nouvelle PR fait suite à un commentaire de @sbedeau dans la première qui proposait une autre approche ne nécessitant pas d'ajouter des dépendances
- Cette PR s'inspire de la PR #1601 qui appliquait la même démarche dans mon-pix

## :100: Pour tester
- Lancer `npm run lint` dans admin et constater qu'il n'y a plus d'erreurs
- Constater dans le workflow Circle CI que le linter est exécuté pour admin
