### PR TITLE
[TECH] Transférer la traduction de l'email de création de compte dans l'API (PIX-2213).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,8 +1,8 @@
 const settings = require('../../config');
 const mailer = require('../../infrastructure/mailers/mailer');
 const moment = require('moment');
-const FrTranslations = require('../../../translations/fr');
-const EnTranslations = require('../../../translations/en');
+const frTranslations = require('../../../translations/fr');
+const enTranslations = require('../../../translations/en');
 const tokenService = require('./token-service');
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
@@ -30,7 +30,9 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
       redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion/?lang=fr`,
-      locale,
+      helpdeskUrl: HELPDESK_FR,
+      displayNationalLogo: false,
+      ...frTranslations['pix-account-creation-email'],
     };
 
     pixName = PIX_NAME_FR;
@@ -42,7 +44,9 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
       redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldOrg}/connexion/?lang=en`,
-      locale,
+      helpdeskUrl: HELPDESK_EN,
+      displayNationalLogo: false,
+      ...enTranslations['pix-account-creation-email'],
     };
 
     pixName = PIX_NAME_EN;
@@ -54,7 +58,9 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
       homeName: `pix${settings.domain.tldFr}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
       redirectionUrl: redirectionUrl || `${settings.domain.pixApp + settings.domain.tldFr}/connexion`,
-      locale,
+      helpdeskUrl: HELPDESK_FR,
+      displayNationalLogo: true,
+      ...frTranslations['pix-account-creation-email'],
     };
 
     pixName = PIX_NAME_FR;
@@ -170,7 +176,7 @@ function sendOrganizationInvitationEmail({
     pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldFr}`,
     redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldFr}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
     supportUrl: HELPDESK_FR,
-    ...FrTranslations['organization-invitation-email'],
+    ...frTranslations['organization-invitation-email'],
   };
 
   if (locale === 'fr') {
@@ -181,7 +187,7 @@ function sendOrganizationInvitationEmail({
       pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}`,
       redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
       supportUrl: HELPDESK_FR,
-      ...FrTranslations['organization-invitation-email'],
+      ...frTranslations['organization-invitation-email'],
     };
   }
 
@@ -193,7 +199,7 @@ function sendOrganizationInvitationEmail({
       pixOrgaHomeUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}?lang=en`,
       redirectionUrl: `${settings.domain.pixOrga + settings.domain.tldOrg}/rejoindre?invitationId=${organizationInvitationId}&code=${code}&lang=en`,
       supportUrl: HELPDESK_EN,
-      ...EnTranslations['organization-invitation-email'],
+      ...enTranslations['organization-invitation-email'],
     };
     pixOrgaName = PIX_ORGA_NAME_EN;
     sendOrganizationInvitationEmailSubject = ORGANIZATION_INVITATION_EMAIL_SUBJECT_EN;

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -5,10 +5,8 @@ const {
   expect,
   knex,
   nock,
-  sinon,
 } = require('../../../test-helper');
 
-const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 const createServer = require('../../../../server');
@@ -51,7 +49,6 @@ describe('Acceptance | Controller | users-controller', () => {
     context('user is valid', () => {
 
       beforeEach(() => {
-        sinon.stub(mailer, 'sendEmail');
 
         nock('https://www.google.com')
           .post('/recaptcha/api/siteverify')
@@ -117,38 +114,6 @@ describe('Acceptance | Controller | users-controller', () => {
         expect(userFound.authenticationMethods[0].authenticationComplement.password).to.exist;
       });
 
-      it('should send account creation email to user', async () => {
-        // given
-        const expectedMail = {
-          from: 'ne-pas-repondre@pix.fr',
-          fromName: 'PIX - Ne pas répondre',
-          subject: 'Votre compte Pix a bien été créé',
-          template: 'test-account-creation-template-id',
-          to: user.email,
-          variables: {
-            homeName: 'pix.fr',
-            homeUrl: 'https://pix.fr',
-            redirectionUrl: 'https://app.pix.fr/connexion',
-            helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
-            displayNationalLogo: true,
-            title: 'Votre compte Pix a bien été créé !',
-            subtitle: 'Vous pouvez désormais commencer les tests.',
-            goToPix: 'Commencer les tests',
-            disclaimer: 'Si vous n\'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression',
-            helpdeskLinkLabel: 'ici',
-            pixPresentation: 'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.',
-            moreOn: 'En savoir plus sur',
-            doNotAnswer: 'Ceci est un e-mail automatique, merci de ne pas y répondre.',
-            askForHelp: 'Besoin d’aide, contactez-nous',
-          },
-        };
-
-        // when
-        await server.inject(options);
-
-        // then
-        expect(mailer.sendEmail).to.have.been.calledWith(expectedMail);
-      });
     });
 
     context('user is invalid', async () => {

--- a/api/tests/acceptance/application/users/users-controller-save_test.js
+++ b/api/tests/acceptance/application/users/users-controller-save_test.js
@@ -128,8 +128,18 @@ describe('Acceptance | Controller | users-controller', () => {
           variables: {
             homeName: 'pix.fr',
             homeUrl: 'https://pix.fr',
-            locale: 'fr-fr',
             redirectionUrl: 'https://app.pix.fr/connexion',
+            helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
+            displayNationalLogo: true,
+            title: 'Votre compte Pix a bien été créé !',
+            subtitle: 'Vous pouvez désormais commencer les tests.',
+            goToPix: 'Commencer les tests',
+            disclaimer: 'Si vous n\'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression',
+            helpdeskLinkLabel: 'ici',
+            pixPresentation: 'Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.',
+            moreOn: 'En savoir plus sur',
+            doNotAnswer: 'Ceci est un e-mail automatique, merci de ne pas y répondre.',
+            askForHelp: 'Besoin d’aide, contactez-nous',
           },
         };
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -5,14 +5,9 @@ const mailer = require('../../../../lib/infrastructure/mailers/mailer');
 const tokenService = require('../../../../lib/domain/services/token-service');
 const settings = require('../../../../lib/config');
 
-const organizationInvitationTranslationsMapping = {
-  'fr': require('../../../../translations/fr')['organization-invitation-email'],
-  'en': require('../../../../translations/en')['organization-invitation-email'],
-};
-
-const accountCreationTranslationsMapping = {
-  'fr': require('../../../../translations/fr')['pix-account-creation-email'],
-  'en': require('../../../../translations/en')['pix-account-creation-email'],
+const mainTranslationsMapping = {
+  'fr': require('../../../../translations/fr'),
+  'en': require('../../../../translations/en'),
 };
 
 describe('Unit | Service | MailService', () => {
@@ -70,7 +65,10 @@ describe('Unit | Service | MailService', () => {
 
     context('according to locale', () => {
 
-      const translationsMapping = accountCreationTranslationsMapping;
+      const translationsMapping = {
+        'fr': mainTranslationsMapping.fr['pix-account-creation-email'],
+        'en': mainTranslationsMapping.en['pix-account-creation-email'],
+      };
 
       context('should call sendEmail with localized variable options', () => {
         const testCases = [
@@ -285,7 +283,6 @@ describe('Unit | Service | MailService', () => {
     const organizationName = 'Organization Name';
     const organizationInvitationId = 1;
     const code = 'ABCDEFGH01';
-    const translationsMapping = organizationInvitationTranslationsMapping;
 
     it('should call sendEmail with from, to, organizationName', async () => {
 
@@ -350,6 +347,11 @@ describe('Unit | Service | MailService', () => {
     });
 
     context('according to locale', () => {
+
+      const translationsMapping = {
+        'fr': mainTranslationsMapping.fr['organization-invitation-email'],
+        'en': mainTranslationsMapping.en['organization-invitation-email'],
+      };
 
       context('should call sendEmail with localized variable options', () => {
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -21,55 +21,74 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendAccountCreationEmail', () => {
 
-    it('should use mailer to send an email with locale "fr-fr"', async () => {
-      // given
+    it('should call sendEmail with from, to, subject, template', async () => {
+
       const locale = 'fr-fr';
-      const domainFr = 'pix.fr';
+
+      // given
       const expectedOptions = {
         from: senderEmailAddress,
-        fromName: 'PIX - Ne pas répondre',
         to: userEmailAddress,
         subject: 'Votre compte Pix a bien été créé',
         template: 'test-account-creation-template-id',
-        variables: {
-          homeName: `${domainFr}`,
-          homeUrl: `https://${domainFr}`,
-          redirectionUrl: `https://app.${domainFr}/connexion`,
-          locale,
-        },
       };
 
       // when
       await mailService.sendAccountCreationEmail(userEmailAddress, locale);
 
       // then
-      expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      const options = mailer.sendEmail.firstCall.args[0];
+      expect(options).to.include(expectedOptions);
     });
 
-    it('should use mailer to send an email with redirectionUrl from parameters', async () => {
-      // given
-      const redirectionUrl = 'https://pix.fr';
-      const locale = 'fr-fr';
-      const domainFr = 'pix.fr';
-      const expectedOptions = {
-        from: senderEmailAddress,
-        fromName: 'PIX - Ne pas répondre',
-        to: userEmailAddress,
-        subject: 'Votre compte Pix a bien été créé',
-        template: 'test-account-creation-template-id',
-        variables: {
-          homeName: `${domainFr}`,
-          homeUrl: `https://${domainFr}`,
-          redirectionUrl,
-          locale,
-        },
-      };
+    context('according to redirectionUrl', () => {
 
-      // when
-      await mailService.sendAccountCreationEmail(userEmailAddress, locale, redirectionUrl);
+      context('if redirectionUrl is provided', () => {
 
-      // then
-      expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+        it('should call sendEmail with provided value', async () => {
+          // given
+          const redirectionUrl = 'https://pix.fr';
+          const locale = 'fr-fr';
+
+          // when
+          await mailService.sendAccountCreationEmail(userEmailAddress, locale, redirectionUrl);
+
+          // then
+          const actualRedirectionUrl = mailer.sendEmail.firstCall.args[0].variables.redirectionUrl;
+          expect(actualRedirectionUrl).to.equal(redirectionUrl);
+        });
+
+      });
+
+    });
+    context('according to locale', () => {
+
+      it('should use mailer to send an email with locale "fr-fr"', async () => {
+        // given
+        const locale = 'fr-fr';
+        const domainFr = 'pix.fr';
+        const expectedOptions = {
+          from: senderEmailAddress,
+          fromName: 'PIX - Ne pas répondre',
+          to: userEmailAddress,
+          subject: 'Votre compte Pix a bien été créé',
+          template: 'test-account-creation-template-id',
+          variables: {
+            homeName: `${domainFr}`,
+            homeUrl: `https://${domainFr}`,
+            redirectionUrl: `https://app.${domainFr}/connexion`,
+            locale,
+          },
+        };
+
+        // when
+        await mailService.sendAccountCreationEmail(userEmailAddress, locale);
+
+        // then
+        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+      });
+
+
     });
   });
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -10,6 +10,11 @@ const organizationInvitationTranslationsMapping = {
   'en': require('../../../../translations/en')['organization-invitation-email'],
 };
 
+const accountCreationTranslationsMapping = {
+  'fr': require('../../../../translations/fr')['pix-account-creation-email'],
+  'en': require('../../../../translations/en')['pix-account-creation-email'],
+};
+
 describe('Unit | Service | MailService', () => {
 
   const senderEmailAddress = 'ne-pas-repondre@pix.fr';
@@ -23,7 +28,8 @@ describe('Unit | Service | MailService', () => {
 
     it('should call sendEmail with from, to, subject, template', async () => {
 
-      const locale = 'fr-fr';
+      // given
+      const locale = undefined;
 
       // given
       const expectedOptions = {
@@ -61,35 +67,89 @@ describe('Unit | Service | MailService', () => {
       });
 
     });
+
     context('according to locale', () => {
 
-      it('should use mailer to send an email with locale "fr-fr"', async () => {
-        // given
-        const locale = 'fr-fr';
-        const domainFr = 'pix.fr';
-        const expectedOptions = {
-          from: senderEmailAddress,
-          fromName: 'PIX - Ne pas répondre',
-          to: userEmailAddress,
-          subject: 'Votre compte Pix a bien été créé',
-          template: 'test-account-creation-template-id',
-          variables: {
-            homeName: `${domainFr}`,
-            homeUrl: `https://${domainFr}`,
-            redirectionUrl: `https://app.${domainFr}/connexion`,
-            locale,
+      const translationsMapping = accountCreationTranslationsMapping;
+
+      context('should call sendEmail with localized variable options', () => {
+        const testCases = [
+          {
+            locale: undefined,
+            expected: {
+              fromName: 'PIX - Ne pas répondre',
+              variables: {
+                homeName: 'pix.fr',
+                homeUrl: 'https://pix.fr',
+                helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
+                displayNationalLogo: true,
+                redirectionUrl: 'https://app.pix.fr/connexion',
+                ...translationsMapping.fr,
+              },
+            },
           },
-        };
+          {
+            locale: 'fr-fr',
+            expected: {
+              fromName: 'PIX - Ne pas répondre',
+              variables: {
+                homeName: 'pix.fr',
+                homeUrl: 'https://pix.fr',
+                helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
+                displayNationalLogo: true,
+                redirectionUrl: 'https://app.pix.fr/connexion',
+                ...translationsMapping.fr,
+              },
+            },
+          },
+          {
+            locale: 'fr',
+            expected: {
+              fromName: 'PIX - Ne pas répondre',
+              variables: {
+                homeName: 'pix.org',
+                homeUrl: 'https://pix.org/fr/',
+                helpdeskUrl: 'https://support.pix.fr/support/tickets/new',
+                displayNationalLogo: false,
+                redirectionUrl: 'https://app.pix.org/connexion/?lang=fr',
+                ...translationsMapping.fr,
+              },
+            },
+          },
+          {
+            locale: 'en',
+            expected: {
+              fromName: 'PIX - Noreply',
+              variables: {
+                homeName: 'pix.org',
+                homeUrl: 'https://pix.org/en-gb/',
+                helpdeskUrl: 'https://pix.org/en-gb/help-form',
+                displayNationalLogo: false,
+                redirectionUrl: 'https://app.pix.org/connexion/?lang=en',
+                ...translationsMapping.en,
+              },
+            },
+          },
+        ]
+        ;
 
-        // when
-        await mailService.sendAccountCreationEmail(userEmailAddress, locale);
+        testCases.forEach((testCase) => {
+          it(`when locale is ${testCase.locale}`, async () => {
 
-        // then
-        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
+            // when
+            await mailService.sendAccountCreationEmail(userEmailAddress, testCase.locale);
+
+            // then
+            const options = mailer.sendEmail.firstCall.args[0];
+            expect(options.fromName).to.equal(testCase.expected.fromName);
+            expect(options.variables).to.include(testCase.expected.variables);
+          });
+        });
+
       });
 
-
     });
+
   });
 
   describe('#sendCertificationResultEmail', () => {

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -11,5 +11,16 @@
     "doNotAnswer": "This is an automated email message, please do not reply.",
     "needHelp": "Have questions? We’re here to help, contact us",
     "here": "here"
+  },
+  "pix-account-creation-email": {
+    "title": "Your Pix account has been created !",
+    "subtitle": "You can now start testing your skills.",
+    "goToPix": "Get started",
+    "disclaimer": "If you did not create this account, you can ask its deletion",
+    "helpdeskLinkLabel": "here",
+    "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
+    "moreOn": "More on",
+    "doNotAnswer": "This is an automated email message, please do not reply.",
+    "askForHelp": "Any questions? We’re here to help, contact us"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -11,5 +11,16 @@
     "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
     "needHelp": "Besoin d’aide, contactez-nous",
     "here": "ici"
+  },
+  "pix-account-creation-email": {
+    "title": "Votre compte Pix a bien été créé !",
+    "subtitle": "Vous pouvez désormais commencer les tests.",
+    "goToPix": "Commencer les tests",
+    "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
+    "helpdeskLinkLabel": "ici",
+    "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+    "moreOn": "En savoir plus sur",
+    "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
+    "askForHelp": "Besoin d’aide, contactez-nous"
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Les traductions ne sont pas stockées dans l'API, mais dans les templates SendInBlue

## :robot: Solution
Utiliser la même solution que #2626:
- stocker le mapping au format JSON, dans un fichier par langue
- envoyer la traduction dans des variables de templates
- créer un template qui exploite ces variables

## :rainbow: Remarques
BSR de cassage de dépendances entre tests
Utilisation de tests paramétrés pour les tests de locale

## :100: Pour tester
Tester en local:  activer le mailing et mettre à jour `SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID`
Se mettre dans les 3 locales (fr/fr-fr/en) et créer un compte
