### PR TITLE
[FEATURE] Traduire dans l'API la demande de réinitialisation du mot de passe d'un utilisateur (PIX-2214).

### DIFF
--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -12,8 +12,6 @@ const PIX_NAME_FR = 'PIX - Ne pas répondre';
 const PIX_NAME_EN = 'PIX - Noreply';
 const ACCOUNT_CREATION_EMAIL_SUBJECT_FR = 'Votre compte Pix a bien été créé';
 const ACCOUNT_CREATION_EMAIL_SUBJECT_EN = 'Your Pix account has been created';
-const RESET_PASSWORD_EMAIL_SUBJECT_FR = 'Demande de réinitialisation de mot de passe PIX';
-const RESET_PASSWORD_EMAIL_SUBJECT_EN = 'Pix password reset request';
 const HELPDESK_FR = 'https://support.pix.fr/support/tickets/new';
 const HELPDESK_EN = 'https://pix.org/en-gb/help-form';
 const ORGANIZATION_INVITATION_EMAIL_SUBJECT_FR = 'Invitation à rejoindre Pix Orga';
@@ -107,44 +105,41 @@ function sendCertificationResultEmail({
 }
 
 function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
-  let pixName;
-  let resetPasswordEmailSubject;
-  let variables;
+  const localeParam = locale ? locale : 'fr-fr';
 
-  if (locale === 'fr') {
-    variables = {
+  let pixName = PIX_NAME_FR;
+  let resetPasswordEmailSubject = FrTranslations['reset-password-demand-email'].subject;
+
+  let templateParams = {
+    locale: localeParam,
+    ...FrTranslations['reset-password-demand-email'].params,
+    homeName: `pix${settings.domain.tldFr}`,
+    homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+    resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
+    helpdeskURL: HELPDESK_FR,
+  };
+
+  if (localeParam === 'fr') {
+    templateParams = {
+      ...templateParams,
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
       resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
-      locale,
+      helpdeskURL: FrTranslations['reset-password-demand-email'].params.helpdeskURL,
     };
-
-    pixName = PIX_NAME_FR;
-    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_FR;
   }
 
-  else if (locale === 'en') {
-    variables = {
+  if (localeParam === 'en') {
+    templateParams = {
+      locale: localeParam,
+      ...EnTranslations['reset-password-demand-email'].params,
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
       resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=en`,
-      locale,
     };
 
     pixName = PIX_NAME_EN;
-    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_EN;
-  }
-
-  else {
-    variables = {
-      homeName: `pix${settings.domain.tldFr}`,
-      homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
-      resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
-      locale,
-    };
-
-    pixName = PIX_NAME_FR;
-    resetPasswordEmailSubject = RESET_PASSWORD_EMAIL_SUBJECT_FR;
+    resetPasswordEmailSubject = EnTranslations['reset-password-demand-email'].subject;
   }
 
   return mailer.sendEmail({
@@ -153,7 +148,7 @@ function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
     to: email,
     subject: resetPasswordEmailSubject,
     template: mailer.passwordResetTemplateId,
-    variables,
+    variables: templateParams,
   });
 }
 

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -1,9 +1,17 @@
-const settings = require('../../config');
-const mailer = require('../../infrastructure/mailers/mailer');
 const moment = require('moment');
+
+const tokenService = require('./token-service');
+const mailer = require('../../infrastructure/mailers/mailer');
+const settings = require('../../config');
+
 const frTranslations = require('../../../translations/fr');
 const enTranslations = require('../../../translations/en');
-const tokenService = require('./token-service');
+
+const {
+  ENGLISH_SPOKEN,
+  FRENCH_FRANCE,
+  FRENCH_SPOKEN,
+} = require('../../domain/constants').LOCALE;
 
 const EMAIL_ADDRESS_NO_RESPONSE = 'ne-pas-repondre@pix.fr';
 const PIX_ORGA_NAME_FR = 'Pix Orga - Ne pas répondre';
@@ -23,7 +31,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
   let accountCreationEmailSubject;
   let variables;
 
-  if (locale === 'fr') {
+  if (locale === FRENCH_SPOKEN) {
     variables = {
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
@@ -37,7 +45,7 @@ function sendAccountCreationEmail(email, locale, redirectionUrl) {
     accountCreationEmailSubject = ACCOUNT_CREATION_EMAIL_SUBJECT_FR;
   }
 
-  else if (locale === 'en') {
+  else if (locale === ENGLISH_SPOKEN) {
     variables = {
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
@@ -109,41 +117,41 @@ function sendResetPasswordDemandEmail({
   locale,
   temporaryKey,
 }) {
-  const localeParam = locale ? locale : 'fr-fr';
+  const localeParam = locale ? locale : FRENCH_FRANCE;
 
   let pixName = PIX_NAME_FR;
-  let resetPasswordEmailSubject = FrTranslations['reset-password-demand-email'].subject;
+  let resetPasswordEmailSubject = frTranslations['reset-password-demand-email'].subject;
 
   let templateParams = {
     locale: localeParam,
-    ...FrTranslations['reset-password-demand-email'].params,
+    ...frTranslations['reset-password-demand-email'].params,
     homeName: `pix${settings.domain.tldFr}`,
     homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
     resetUrl: `${settings.domain.pixApp + settings.domain.tldFr}/changer-mot-de-passe/${temporaryKey}`,
     helpdeskURL: HELPDESK_FR,
   };
 
-  if (localeParam === 'fr') {
+  if (localeParam === FRENCH_SPOKEN) {
     templateParams = {
       ...templateParams,
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
       resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
-      helpdeskURL: FrTranslations['reset-password-demand-email'].params.helpdeskURL,
+      helpdeskURL: frTranslations['reset-password-demand-email'].params.helpdeskURL,
     };
   }
 
-  if (localeParam === 'en') {
+  if (localeParam === ENGLISH_SPOKEN) {
     templateParams = {
       locale: localeParam,
-      ...EnTranslations['reset-password-demand-email'].params,
+      ...enTranslations['reset-password-demand-email'].params,
       homeName: `pix${settings.domain.tldOrg}`,
       homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
       resetUrl: `${settings.domain.pixApp + settings.domain.tldOrg}/changer-mot-de-passe/${temporaryKey}/?lang=en`,
     };
 
     pixName = PIX_NAME_EN;
-    resetPasswordEmailSubject = EnTranslations['reset-password-demand-email'].subject;
+    resetPasswordEmailSubject = enTranslations['reset-password-demand-email'].subject;
   }
 
   return mailer.sendEmail({
@@ -164,7 +172,7 @@ function sendOrganizationInvitationEmail({
   locale,
   tags,
 }) {
-  locale = locale ? locale : 'fr-fr';
+  locale = locale ? locale : FRENCH_FRANCE;
   let pixOrgaName = PIX_ORGA_NAME_FR;
   let sendOrganizationInvitationEmailSubject = ORGANIZATION_INVITATION_EMAIL_SUBJECT_FR;
 
@@ -178,7 +186,7 @@ function sendOrganizationInvitationEmail({
     ...frTranslations['organization-invitation-email'],
   };
 
-  if (locale === 'fr') {
+  if (locale === FRENCH_SPOKEN) {
     templateParams = {
       organizationName,
       pixHomeName: `pix${settings.domain.tldOrg}`,
@@ -190,7 +198,7 @@ function sendOrganizationInvitationEmail({
     };
   }
 
-  if (locale === 'en') {
+  if (locale === ENGLISH_SPOKEN) {
     templateParams = {
       organizationName,
       pixHomeName: `pix${settings.domain.tldOrg}`,
@@ -224,7 +232,7 @@ function sendScoOrganizationInvitationEmail({
   locale,
   tags,
 }) {
-  locale = locale ? locale : 'fr-fr';
+  locale = locale ? locale : FRENCH_FRANCE;
 
   let variables = {
     organizationName,
@@ -236,7 +244,7 @@ function sendScoOrganizationInvitationEmail({
     locale,
   };
 
-  if (locale === 'fr') {
+  if (locale === FRENCH_SPOKEN) {
     variables = {
       organizationName,
       firstName, lastName,

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -104,7 +104,11 @@ function sendCertificationResultEmail({
   });
 }
 
-function sendResetPasswordDemandEmail(email, locale, temporaryKey) {
+function sendResetPasswordDemandEmail({
+  email,
+  locale,
+  temporaryKey,
+}) {
   const localeParam = locale ? locale : 'fr-fr';
 
   let pixName = PIX_NAME_FR;

--- a/api/lib/domain/usecases/create-password-reset-demand.js
+++ b/api/lib/domain/usecases/create-password-reset-demand.js
@@ -16,7 +16,7 @@ module.exports = async function createPasswordResetDemand({
     userId,
   });
 
-  await mailService.sendResetPasswordDemandEmail(email, locale, temporaryKey);
+  await mailService.sendResetPasswordDemandEmail({ email, locale, temporaryKey });
 
   return passwordResetDemand;
 };

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -193,11 +193,12 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendResetPasswordDemandEmail', () => {
 
+    const fakeTemporaryKey = 'token';
+
     context('when provided passwordResetDemandBaseUrl is not production', () => {
 
       it('should call mailer', async () => {
         // given
-        const fakeTemporaryKey = 'token';
         const locale = 'fr-fr';
         const domainFr = 'pix.fr';
 
@@ -205,13 +206,15 @@ describe('Unit | Service | MailService', () => {
           from: senderEmailAddress,
           fromName: 'PIX - Ne pas répondre',
           to: userEmailAddress,
-          subject: 'Demande de réinitialisation de mot de passe PIX',
+          subject: translatedTextsFr['reset-password-demand-email'].subject,
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            locale,
+            ...translatedTextsFr['reset-password-demand-email'].params,
             homeName: `${domainFr}`,
             homeUrl: `https://${domainFr}`,
-            locale,
+            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            helpdeskURL: 'https://support.pix.fr/support/tickets/new',
           },
         };
 
@@ -224,7 +227,6 @@ describe('Unit | Service | MailService', () => {
 
       it('should call mailer with locale fr', async () => {
         // given
-        const fakeTemporaryKey = 'token';
         const locale = 'fr';
         const domainOrg = 'pix.org';
 
@@ -232,13 +234,14 @@ describe('Unit | Service | MailService', () => {
           from: senderEmailAddress,
           fromName: 'PIX - Ne pas répondre',
           to: userEmailAddress,
-          subject: 'Demande de réinitialisation de mot de passe PIX',
+          subject: translatedTextsFr['reset-password-demand-email'].subject,
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=fr`,
+            locale,
+            ...translatedTextsFr['reset-password-demand-email'].params,
             homeName: `${domainOrg}`,
             homeUrl: `https://${domainOrg}/fr/`,
-            locale,
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=fr`,
           },
         };
 
@@ -251,7 +254,6 @@ describe('Unit | Service | MailService', () => {
 
       it('should call mailer with locale en', async () => {
         // given
-        const fakeTemporaryKey = 'token';
         const locale = 'en';
         const domainOrg = 'pix.org';
 
@@ -259,13 +261,14 @@ describe('Unit | Service | MailService', () => {
           from: senderEmailAddress,
           fromName: 'PIX - Noreply',
           to: userEmailAddress,
-          subject: 'Pix password reset request',
+          subject: translatedTextsEn['reset-password-demand-email'].subject,
           template: 'test-password-reset-template-id',
           variables: {
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=en`,
+            locale,
+            ...translatedTextsEn['reset-password-demand-email'].params,
             homeName: `${domainOrg}`,
             homeUrl: `https://${domainOrg}/en-gb/`,
-            locale,
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=en`,
           },
         };
 

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -193,7 +193,7 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendResetPasswordDemandEmail', () => {
 
-    const fakeTemporaryKey = 'token';
+    const temporaryKey = 'token';
 
     context('when provided passwordResetDemandBaseUrl is not production', () => {
 
@@ -213,13 +213,17 @@ describe('Unit | Service | MailService', () => {
             ...translatedTextsFr['reset-password-demand-email'].params,
             homeName: `${domainFr}`,
             homeUrl: `https://${domainFr}`,
-            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${fakeTemporaryKey}`,
+            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${temporaryKey}`,
             helpdeskURL: 'https://support.pix.fr/support/tickets/new',
           },
         };
 
         // when
-        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale,
+          temporaryKey,
+        });
 
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
@@ -241,12 +245,16 @@ describe('Unit | Service | MailService', () => {
             ...translatedTextsFr['reset-password-demand-email'].params,
             homeName: `${domainOrg}`,
             homeUrl: `https://${domainOrg}/fr/`,
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=fr`,
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
           },
         };
 
         // when
-        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale,
+          temporaryKey,
+        });
 
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
@@ -268,12 +276,16 @@ describe('Unit | Service | MailService', () => {
             ...translatedTextsEn['reset-password-demand-email'].params,
             homeName: `${domainOrg}`,
             homeUrl: `https://${domainOrg}/en-gb/`,
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${fakeTemporaryKey}/?lang=en`,
+            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${temporaryKey}/?lang=en`,
           },
         };
 
         // when
-        await mailService.sendResetPasswordDemandEmail(userEmailAddress, locale, fakeTemporaryKey);
+        await mailService.sendResetPasswordDemandEmail({
+          email: userEmailAddress,
+          locale,
+          temporaryKey,
+        });
 
         // then
         expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -6,9 +6,15 @@ const tokenService = require('../../../../lib/domain/services/token-service');
 const settings = require('../../../../lib/config');
 
 const mainTranslationsMapping = {
-  'fr': require('../../../../translations/fr'),
-  'en': require('../../../../translations/en'),
+  fr: require('../../../../translations/fr'),
+  en: require('../../../../translations/en'),
 };
+
+const {
+  ENGLISH_SPOKEN,
+  FRENCH_FRANCE,
+  FRENCH_SPOKEN,
+} = require('../../../../lib/domain/constants').LOCALE;
 
 describe('Unit | Service | MailService', () => {
 
@@ -22,7 +28,6 @@ describe('Unit | Service | MailService', () => {
   describe('#sendAccountCreationEmail', () => {
 
     it('should call sendEmail with from, to, subject, template', async () => {
-
       // given
       const locale = undefined;
 
@@ -49,7 +54,7 @@ describe('Unit | Service | MailService', () => {
         it('should call sendEmail with provided value', async () => {
           // given
           const redirectionUrl = 'https://pix.fr';
-          const locale = 'fr-fr';
+          const locale = FRENCH_FRANCE;
 
           // when
           await mailService.sendAccountCreationEmail(userEmailAddress, locale, redirectionUrl);
@@ -58,16 +63,14 @@ describe('Unit | Service | MailService', () => {
           const actualRedirectionUrl = mailer.sendEmail.firstCall.args[0].variables.redirectionUrl;
           expect(actualRedirectionUrl).to.equal(redirectionUrl);
         });
-
       });
-
     });
 
     context('according to locale', () => {
 
       const translationsMapping = {
-        'fr': mainTranslationsMapping.fr['pix-account-creation-email'],
-        'en': mainTranslationsMapping.en['pix-account-creation-email'],
+        fr: mainTranslationsMapping.fr['pix-account-creation-email'],
+        en: mainTranslationsMapping.en['pix-account-creation-email'],
       };
 
       context('should call sendEmail with localized variable options', () => {
@@ -87,7 +90,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'fr-fr',
+            locale: FRENCH_FRANCE,
             expected: {
               fromName: 'PIX - Ne pas répondre',
               variables: {
@@ -101,7 +104,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'fr',
+            locale: FRENCH_SPOKEN,
             expected: {
               fromName: 'PIX - Ne pas répondre',
               variables: {
@@ -115,7 +118,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'en',
+            locale: ENGLISH_SPOKEN,
             expected: {
               fromName: 'PIX - Noreply',
               variables: {
@@ -128,12 +131,10 @@ describe('Unit | Service | MailService', () => {
               },
             },
           },
-        ]
-        ;
+        ];
 
         testCases.forEach((testCase) => {
           it(`when locale is ${testCase.locale}`, async () => {
-
             // when
             await mailService.sendAccountCreationEmail(userEmailAddress, testCase.locale);
 
@@ -143,11 +144,8 @@ describe('Unit | Service | MailService', () => {
             expect(options.variables).to.include(testCase.expected.variables);
           });
         });
-
       });
-
     });
-
   });
 
   describe('#sendCertificationResultEmail', () => {
@@ -193,102 +191,107 @@ describe('Unit | Service | MailService', () => {
 
   describe('#sendResetPasswordDemandEmail', () => {
 
+    const from = senderEmailAddress;
+    const to = userEmailAddress;
+    const template = 'test-password-reset-template-id';
     const temporaryKey = 'token';
 
-    context('when provided passwordResetDemandBaseUrl is not production', () => {
+    const translationsMapping = {
+      fr: mainTranslationsMapping.fr['reset-password-demand-email'],
+      en: mainTranslationsMapping.en['reset-password-demand-email'],
+    };
 
-      it('should call mailer', async () => {
-        // given
-        const locale = 'fr-fr';
-        const domainFr = 'pix.fr';
+    context('according to locale', () => {
 
-        const expectedOptions = {
-          from: senderEmailAddress,
-          fromName: 'PIX - Ne pas répondre',
-          to: userEmailAddress,
-          subject: translatedTextsFr['reset-password-demand-email'].subject,
-          template: 'test-password-reset-template-id',
-          variables: {
-            locale,
-            ...translatedTextsFr['reset-password-demand-email'].params,
-            homeName: `${domainFr}`,
-            homeUrl: `https://${domainFr}`,
-            resetUrl: `https://app.${domainFr}/changer-mot-de-passe/${temporaryKey}`,
-            helpdeskURL: 'https://support.pix.fr/support/tickets/new',
+      const testCases = [
+        {
+          locale: undefined,
+          expectedTranslationLanguage: FRENCH_SPOKEN,
+          expectedOptions: {
+            from,
+            to,
+            template,
+            fromName: 'PIX - Ne pas répondre',
+            subject: translationsMapping.fr.subject,
+            variables: {
+              locale: FRENCH_FRANCE,
+              ...translationsMapping.fr.params,
+              homeName: 'pix.fr',
+              homeUrl: 'https://pix.fr',
+              resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
+              helpdeskURL: 'https://support.pix.fr/support/tickets/new',
+            },
           },
-        };
-
-        // when
-        await mailService.sendResetPasswordDemandEmail({
-          email: userEmailAddress,
-          locale,
-          temporaryKey,
-        });
-
-        // then
-        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
-      });
-
-      it('should call mailer with locale fr', async () => {
-        // given
-        const locale = 'fr';
-        const domainOrg = 'pix.org';
-
-        const expectedOptions = {
-          from: senderEmailAddress,
-          fromName: 'PIX - Ne pas répondre',
-          to: userEmailAddress,
-          subject: translatedTextsFr['reset-password-demand-email'].subject,
-          template: 'test-password-reset-template-id',
-          variables: {
-            locale,
-            ...translatedTextsFr['reset-password-demand-email'].params,
-            homeName: `${domainOrg}`,
-            homeUrl: `https://${domainOrg}/fr/`,
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
+        },
+        {
+          locale: FRENCH_FRANCE,
+          expectedTranslationLanguage: FRENCH_SPOKEN,
+          expectedOptions: {
+            from,
+            to,
+            template,
+            fromName: 'PIX - Ne pas répondre',
+            subject: translationsMapping.fr.subject,
+            variables: {
+              locale: FRENCH_FRANCE,
+              ...translationsMapping.fr.params,
+              homeName: 'pix.fr',
+              homeUrl: 'https://pix.fr',
+              resetUrl: `https://app.pix.fr/changer-mot-de-passe/${temporaryKey}`,
+              helpdeskURL: 'https://support.pix.fr/support/tickets/new',
+            },
           },
-        };
-
-        // when
-        await mailService.sendResetPasswordDemandEmail({
-          email: userEmailAddress,
-          locale,
-          temporaryKey,
-        });
-
-        // then
-        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
-      });
-
-      it('should call mailer with locale en', async () => {
-        // given
-        const locale = 'en';
-        const domainOrg = 'pix.org';
-
-        const expectedOptions = {
-          from: senderEmailAddress,
-          fromName: 'PIX - Noreply',
-          to: userEmailAddress,
-          subject: translatedTextsEn['reset-password-demand-email'].subject,
-          template: 'test-password-reset-template-id',
-          variables: {
-            locale,
-            ...translatedTextsEn['reset-password-demand-email'].params,
-            homeName: `${domainOrg}`,
-            homeUrl: `https://${domainOrg}/en-gb/`,
-            resetUrl: `https://app.${domainOrg}/changer-mot-de-passe/${temporaryKey}/?lang=en`,
+        },
+        {
+          locale: FRENCH_SPOKEN,
+          expectedTranslationLanguage: FRENCH_SPOKEN,
+          expectedOptions: {
+            from,
+            to,
+            template,
+            fromName: 'PIX - Ne pas répondre',
+            subject: translationsMapping.fr.subject,
+            variables: {
+              locale: FRENCH_SPOKEN,
+              ...translationsMapping.fr.params,
+              homeName: 'pix.org',
+              homeUrl: 'https://pix.org/fr/',
+              resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=fr`,
+            },
           },
-        };
+        },
+        {
+          locale: ENGLISH_SPOKEN,
+          expectedTranslationLanguage: ENGLISH_SPOKEN,
+          expectedOptions: {
+            from,
+            to,
+            template,
+            fromName: 'PIX - Noreply',
+            subject: translationsMapping.en.subject,
+            variables: {
+              locale: ENGLISH_SPOKEN,
+              ...translationsMapping.en.params,
+              homeName: 'pix.org',
+              homeUrl: 'https://pix.org/en-gb/',
+              resetUrl: `https://app.pix.org/changer-mot-de-passe/${temporaryKey}/?lang=en`,
+            },
+          },
+        },
+      ];
 
-        // when
-        await mailService.sendResetPasswordDemandEmail({
-          email: userEmailAddress,
-          locale,
-          temporaryKey,
+      testCases.forEach((testCase) => {
+        it(`should call mailer with ${testCase.expectedTranslationLanguage} translated texts if locale is ${testCase.locale}`, async () => {
+          // when
+          await mailService.sendResetPasswordDemandEmail({
+            email: userEmailAddress,
+            locale: testCase.locale,
+            temporaryKey,
+          });
+
+          // then
+          expect(mailer.sendEmail).to.have.been.calledWithExactly(testCase.expectedOptions);
         });
-
-        // then
-        expect(mailer.sendEmail).to.have.been.calledWithExactly(expectedOptions);
       });
     });
   });
@@ -300,7 +303,6 @@ describe('Unit | Service | MailService', () => {
     const code = 'ABCDEFGH01';
 
     it('should call sendEmail with from, to, organizationName', async () => {
-
       // given
       const locale = undefined;
 
@@ -387,7 +389,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'fr',
+            locale: FRENCH_SPOKEN,
             expected: {
               fromName: 'Pix Orga - Ne pas répondre',
               subject: 'Invitation à rejoindre Pix Orga',
@@ -402,7 +404,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'fr-fr',
+            locale: FRENCH_FRANCE,
             expected: {
               fromName: 'Pix Orga - Ne pas répondre',
               subject: 'Invitation à rejoindre Pix Orga',
@@ -417,7 +419,7 @@ describe('Unit | Service | MailService', () => {
             },
           },
           {
-            locale: 'en',
+            locale: ENGLISH_SPOKEN,
             expected: {
               fromName: 'Pix Orga - Noreply',
               subject: 'Invitation to join Pix Orga',
@@ -435,7 +437,6 @@ describe('Unit | Service | MailService', () => {
 
         testCases.forEach((testCase) => {
           it(`when locale is ${testCase.locale}`, async () => {
-
             // when
             await mailService.sendOrganizationInvitationEmail({
               email: userEmailAddress, organizationName, organizationInvitationId, code, locale: testCase.locale,
@@ -448,11 +449,8 @@ describe('Unit | Service | MailService', () => {
             expect(options.variables).to.include(testCase.expected.variables);
           });
         });
-
       });
-
     });
-
   });
 
   describe('#sendScoOrganizationInvitationEmail', () => {
@@ -484,7 +482,7 @@ describe('Unit | Service | MailService', () => {
           pixHomeName,
           pixHomeUrl,
           pixOrgaHomeUrl: pixOrgaUrl,
-          locale: 'fr-fr',
+          locale: FRENCH_FRANCE,
           redirectionUrl: `${pixOrgaUrl}/rejoindre?invitationId=${organizationInvitationId}&code=${code}`,
         },
         tags: null,
@@ -504,4 +502,3 @@ describe('Unit | Service | MailService', () => {
   });
 
 });
-

--- a/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
+++ b/api/tests/unit/domain/usecases/create-password-reset-demand_test.js
@@ -67,7 +67,7 @@ describe('Unit | UseCase | create-password-reset-demand', () => {
       shouldChangePassword: false,
     });
     expect(mailService.sendResetPasswordDemandEmail)
-      .to.have.been.calledWithExactly(email, locale, temporaryKey);
+      .to.have.been.calledWithExactly({ email, locale, temporaryKey });
   });
 
   it('should throw UserNotFoundError if user email does not exist', async () => {

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,5 +1,29 @@
 {
   "current-lang" : "en",
+  "campaign" : {
+    "common" :{
+      "yes": "Yes",
+      "no": "No",
+      "not-available": "NA"
+    },
+    "profiles-collection" : {
+      "campaign-id": "Campaign ID",
+      "campaign-name": "Campaign's name",
+      "certifiable-skills": "Number of skills eligible for certification",
+      "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
+      "is-certifiable" :"Eligible for certification (Y/N)",
+      "is-sent": "Sent (Y/N)",
+      "participant-division": "Class",
+      "participant-firstname": "Participant's first name",
+      "participant-lastname": "Participant's last name",
+      "participant-student-number": "Student number",
+      "organization-name": "Organisation’s name",
+      "pix-score": "Total pix score",
+      "sent-on": "Sent on",
+      "skill-level": "Level reached in the skill {{name}}",
+      "skill-ranking": "Pix score for the skill {{name}}"
+    }
+  },
   "organization-invitation-email": {
     "title": "You are invited to join Pix Orga",
     "subtitle": "With the Pix Orga platform, create and manage testing campaigns and monitor the progress of your participants.",
@@ -23,28 +47,19 @@
     "doNotAnswer": "This is an automated email message, please do not reply.",
     "askForHelp": "Any questions? We’re here to help, contact us"
   },
-  "campaign" : {
-    "common" :{
-      "yes": "Yes",
-      "no": "No",
-      "not-available": "NA"  
-    },
-    "profiles-collection" : {
-      "campaign-id": "Campaign ID",
-      "campaign-name": "Campaign's name",
-      "certifiable-skills": "Number of skills eligible for certification",
-      "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable" :"Eligible for certification (Y/N)",
-      "is-sent": "Sent (Y/N)",
-      "participant-division": "Class",
-      "participant-firstname": "Participant's first name",
-      "participant-lastname": "Participant's last name",
-      "participant-student-number": "Student number",
-      "organization-name": "Organisation’s name",
-      "pix-score": "Total pix score",
-      "sent-on": "Sent on",
-      "skill-level": "Level reached in the skill {{name}}",
-      "skill-ranking": "Pix score for the skill {{name}}"
+  "reset-password-demand-email": {
+    "subject": "Pix password reset request",
+    "params": {
+      "title": "Reset your password",
+      "weCannotSendYourPassword": "Hello, for security reasons, we cannot send your password by email.",
+      "clickOnTheButton": "Click on the button below to choose a new password.",
+      "resetMyPassword": "Reset my password",
+      "linkValidFor": "This link is valid for 24 hours. If you did not request to change your password, please ignore this email.",
+      "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
+      "moreOn": "More on",
+      "doNotAnswer": "This is an automated email message, please do not reply. Have questions? We're here to help, ",
+      "contactUs": "contact us here",
+      "helpdeskURL": "http://pix.org/en-gb/help-form"
     }
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,5 +1,29 @@
 {
   "current-lang": "fr",
+  "campaign": {
+    "common" : {
+      "yes": "Oui",
+      "no": "Non",
+      "not-available": "NA"
+    },
+    "profiles-collection" : {
+      "campaign-id": "ID Campagne",
+      "campaign-name": "Nom de la campagne",
+      "certifiable-skills": "Nombre de compétences certifiables",
+      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
+      "is-certifiable" :"Certifiable (O/N)",
+      "is-sent": "Envoi (O/N)",
+      "organization-name": "Nom de l'organisation",
+      "participant-division": "Classe",
+      "participant-firstname": "Prénom du Participant",
+      "participant-lastname": "Nom du Participant",
+      "participant-student-number": "Numéro Étudiant",
+      "pix-score": "Nombre de pix total",
+      "sent-on": "Date de l'envoi",
+      "skill-level": "Niveau pour la compétence {{name}}",
+      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+    }
+  },
   "organization-invitation-email": {
     "title": "Vous êtes invité(e) à rejoindre Pix Orga",
     "subtitle": "La plateforme Pix Orga vous permet de créer, gérer des campagnes de test et suivre la progression de vos participants.",
@@ -23,28 +47,19 @@
     "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
     "askForHelp": "Besoin d’aide, contactez-nous"
   },
-  "campaign": {
-    "common" : {
-      "yes": "Oui",
-      "no": "Non",
-      "not-available": "NA"
-    },
-    "profiles-collection" : {
-      "campaign-id": "ID Campagne",
-      "campaign-name": "Nom de la campagne",
-      "certifiable-skills": "Nombre de compétences certifiables",
-      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable" :"Certifiable (O/N)",
-      "is-sent": "Envoi (O/N)",
-      "organization-name": "Nom de l'organisation",
-      "participant-division": "Classe",
-      "participant-firstname": "Prénom du Participant",
-      "participant-lastname": "Nom du Participant",
-      "participant-student-number": "Numéro Étudiant",
-      "pix-score": "Nombre de pix total",
-      "sent-on": "Date de l'envoi",
-      "skill-level": "Niveau pour la compétence {{name}}",
-      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+  "reset-password-demand-email": {
+    "subject": "Demande de réinitialisation de mot de passe Pix",
+    "params": {
+      "title": "Réinitialisation de votre mot de passe",
+      "weCannotSendYourPassword": "Bonjour, pour des raisons de sécurité, nous ne vous envoyons pas votre mot de passe par e-mail.",
+      "clickOnTheButton": "Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.",
+      "resetMyPassword": "Définir un nouveau mot de passe",
+      "linkValidFor": "Ce lien est valide 24 heures. Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer cet e-mail.",
+      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "moreOn": "En savoir plus sur",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre. Besoin d’aide, ",
+      "contactUs": "contactez-nous ici",
+      "helpdeskURL": "https://pix.org/fr/formulaire-aide"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Aujourd’hui, la traduction des e-mails transactionnels est géré grâce à des structures conditionnelles dans le template des e-mails et s’appuie sur la locale qui est envoyé à l’API de Sendinblue.
Cette façon de faire rend l'évolution des templates des e-mails extrêmement compliqué.

L'e-mail correspondant à la demande de réinitialisation d'un mot de passe, dans Pix App, va être traité dans ce ticket.

## :robot: Solution
* Création des clés et traductions relatives à l'e-mail de demande de réinitialisation de mot de passe
* Envoi des variables à Sendinblue lors de l’envoi de l’e-mail
* Création du template d'e-mail, afin qu’il se base sur les variables envoyées

## :rainbow: Remarques
Le numéro du template de l'e-mail passe de 73 à 96

## :100: Pour tester
Tester la demande de réinitialisation de mot de passe dans Pix App
* Locale = fr-fr : https://app-pr2660.review.pix.fr/mot-de-passe-oublie
* Locale = fr : https://app-pr2660.review.pix.org/mot-de-passe-oublie?lang=fr
* Locale = en : https://app-pr2660.review.pix.org/mot-de-passe-oublie?lang=en
