### PR TITLE
[BUGFIX] Empêcher le téléchargement de résultats non publiés sur orga  (PIX-2293)

### DIFF
--- a/api/lib/domain/usecases/get-sco-certification-results-by-division.js
+++ b/api/lib/domain/usecases/get-sco-certification-results-by-division.js
@@ -12,7 +12,9 @@ module.exports = async function getScoCertificationResultsByDivision({
   const candidateIds = await scoCertificationCandidateRepository.findIdsByOrganizationIdAndDivision({ organizationId, division });
   const certificationCourses = await certificationCourseRepository.findCertificationCoursesByCandidateIds({ candidateIds });
 
-  const certificationResults = await bluebird.mapSeries(certificationCourses,
+  const publishedCertificationCourses = certificationCourses.filter((course) => course.isPublished);
+
+  const certificationResults = await bluebird.mapSeries(publishedCertificationCourses,
     (certificationCourse) => getCertificationResultByCertifCourse({ certificationCourse }),
   );
 

--- a/api/tests/acceptance/application/organizations/organization-controller_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller_test.js
@@ -1373,6 +1373,7 @@ describe('Acceptance | Application | organization-controller', () => {
         const certificationCourse = databaseBuilder.factory.buildCertificationCourse({
           userId: candidate.userId,
           sessionId: candidate.sessionId,
+          isPublished: true,
         });
 
         const assessment = databaseBuilder.factory.buildAssessment({ certificationCourseId: certificationCourse.id });

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -679,9 +679,9 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       };
 
       const certificationResults = [
-        domainBuilder.buildCertificationResult(),
-        domainBuilder.buildCertificationResult(),
-        domainBuilder.buildCertificationResult(),
+        domainBuilder.buildCertificationResult({ isPublished: true }),
+        domainBuilder.buildCertificationResult({ isPublished: true }),
+        domainBuilder.buildCertificationResult({ isPublished: true }),
       ];
 
       sinon.stub(momentProto, 'format');


### PR DESCRIPTION
## :unicorn: Problème
Actuellement il est possible de télécharger des résultats de certification d'une classe même si ceux ci n'ont pas été publié

## :robot: Solution
Empêcher de télécharger des résultats non publiés

## :100: Pour tester
- Lancer l'api avec FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true
- Créer une session de certification sco
- Passer cette certification sans la publier
- Essayer de télécharger les resultats de la classe de la session concernée dans pix-orga
- Constater que les résultats ne sont pas téléchargé
- Publier la session
- Tenter à nouveau de télécharger les résultats dans Pix-orga
- Constater que les resultats sont téléchargés