### PR TITLE
[BUGFIX] La tooltip "Copier" dans la page détail d'une campagne n'avait pas de traduction (PIX-2305)

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/details/tab.js
+++ b/orga/app/components/routes/authenticated/campaign/details/tab.js
@@ -10,7 +10,7 @@ export default class Tab extends Component {
   @service url;
   @service intl;
 
-  @tracked tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copy');
+  @tracked tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copy');
 
   get campaignsRootUrl() {
     return `${this.url.campaignsRootUrl}${this.args.campaign.code}`;
@@ -18,12 +18,12 @@ export default class Tab extends Component {
 
   @action
   clipboardSuccess() {
-    this.tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copied');
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copied');
   }
 
   @action
   clipboardOut() {
-    this.tooltipText = this.intl.t('pages.campaign.details.actions.copy-link.copy');
+    this.tooltipText = this.intl.t('pages.campaign-details.actions.copy-link.copy');
   }
 
   @action


### PR DESCRIPTION
## :unicorn: Problème
La tooltip qui sert à copier le lien de la campagne, n'avait pas de traduction. Un message 'missing-translation' s'affichait.

## :robot: Solution
Corriger une faute de frappe dans le nom de la clé de trad.

## :rainbow: Remarques
RAS

## :100: Pour tester
Aller dans PixOrga, aller voir le détail d'une campagne et survoler la tooltip pour copier le lien de la campagne.
