### PR TITLE
[INFRA] Ajout d'un status de réussite ou d'échec à la méthode d'envoi d'email

### DIFF
--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -12,27 +12,43 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
 
   describe('#sendEmail', () => {
 
-    const recipient = 'test@example.net';
+    context('when mailing is disabled', () => {
+
+      it('should resolve immediately and return a skip status', async () => {
+        //given
+        _disableMailing();
+        _mockMailingProvider();
+
+        const options = {
+          from: 'bob.dylan@example.net',
+          to: 'test@example.net',
+          fromName: 'Ne Pas Repondre',
+          subject: 'Creation de compte',
+          template: '129291',
+        };
+
+        // when
+        const result = await mailer.sendEmail(options);
+
+        // then
+        expect(result).to.equal(mailer.EMAIL_SKIPPED);
+      });
+    });
 
     context('when mailing is enabled', () => {
 
-      beforeEach(() => {
-        sinon.stub(mailing, 'enabled').value(true);
-        const mailingProvider = { sendEmail: sinon.stub() };
-        sinon.stub(mailer, '_provider').value(mailingProvider);
-      });
+      const recipient = 'test@example.net';
 
       context('when email check succeed', () => {
 
-        beforeEach(() => {
-          sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
-        });
-
-        it('should called email provider method _doSendEmail', async () => {
+        it('should send email and return a success status', async () => {
           // given
-          const from = 'no-reply@example.net';
-          mailer._provider.sendEmail.resolves();
+          _enableMailing();
+          _mailAddressIsValid(recipient);
 
+          const mailingProvider = _mockMailingProvider();
+
+          const from = 'no-reply@example.net';
           const options = {
             from,
             to: recipient,
@@ -42,53 +58,80 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
           };
 
           // when
-          await mailer.sendEmail(options);
+          const result = await mailer.sendEmail(options);
 
           // then
-          sinon.assert.calledWith(mailer._provider.sendEmail, options);
+          sinon.assert.calledWith(mailingProvider.sendEmail, options);
+          expect(result).to.equal(mailer.EMAIL_SENT);
         });
       });
 
-      context('when email check fails', () => {
-        let error;
+      context('when email is invalid', () => {
 
-        beforeEach(() => {
-          error = new Error('fail');
-          sinon.stub(mailCheck, 'checkMail').rejects(error);
+        it('should log a warning, and return an error status', async () => {
+          // given
+          _enableMailing();
+          _mockMailingProvider();
+
+          const expectedError = new Error('fail');
+          _mailAddressIsInvalid(recipient, expectedError);
+
           sinon.stub(logger, 'warn');
-        });
 
-        it('should log a warning, not send email and resolve', async () => {
           // when
-          await mailer.sendEmail({ to: recipient });
+          const result = await mailer.sendEmail({ to: recipient });
 
           // then
-          expect(logger.warn).to.have.been.calledWith({ err: error }, 'Email is not valid \'test@example.net\'');
+          expect(logger.warn).to.have.been.calledWith({ err: expectedError }, 'Email is not valid \'test@example.net\'');
+          expect(result).to.equal(mailer.ERROR_INVALID_EMAIL);
         });
       });
 
       context('when emailing fails', () => {
 
-        let error;
-
-        beforeEach(() => {
-          error = new Error('fail');
-          sinon.stub(mailCheck, 'checkMail').resolves();
-          sinon.stub(logger, 'warn');
-        });
-
-        it('should log a warning', async () => {
+        it('should log a warning and return an error status', async () => {
           // given
-          mailer._provider.sendEmail.rejects(error);
+          _enableMailing();
+          _mailAddressIsValid(recipient);
+          const mailingProvider = _mockMailingProvider();
+          const error = new Error('fail');
+          mailingProvider.sendEmail.rejects(error);
+
+          sinon.stub(logger, 'warn');
 
           // when
-          await mailer.sendEmail({ to: recipient });
+          const result = await mailer.sendEmail({ to: recipient });
 
           // then
-          expect(logger.warn).to.have.been.calledWith({ err: error }, 'Could not send email to \'test@example.net\'');
+          expect(logger.warn).to.have.been.calledOnceWith({ err: error }, 'Could not send email to \'test@example.net\'');
+          expect(result).to.equal(mailer.ERROR_EMAIL_FAILED);
         });
       });
     });
   });
 
 });
+
+function _disableMailing() {
+  sinon.stub(mailing, 'enabled').value(false);
+}
+
+function _enableMailing() {
+  sinon.stub(mailing, 'enabled').value(true);
+}
+
+function _mailAddressIsValid(recipient) {
+  sinon.stub(mailCheck, 'checkMail').withArgs(recipient).resolves();
+}
+
+function _mailAddressIsInvalid(recipient, expectedError) {
+  sinon.stub(mailCheck, 'checkMail').withArgs(recipient).rejects(expectedError);
+}
+
+function _mockMailingProvider() {
+  const mailingProvider = { sendEmail: sinon.stub() };
+  mailingProvider.sendEmail.resolves();
+  mailer._provider = mailingProvider;
+
+  return mailingProvider;
+}


### PR DESCRIPTION
## :unicorn: Problème

Avec la méthode d'envoi d'email actuel, du point de vue de l'appelant il n'y a pas de moyen de savoir si il y a eu une erreur lors de l'envoi.

Or pour l'envoi des résultats de certification on souhaite afficher un message d'erreur quand il y a une erreur lors de l'envoi d'email.

## :robot: Solution

Ajouter un status de retour à cette méthode.

## :rainbow: Remarques

On a d'abord pensé ajouter une méthode "unsafe" qui renverrait une exception lors d'une erreur d'envoi.

Puis on s'est dit qu'ajouter un statut de retour permet de rendre le résultat observable sans ajouter de méthode supplémentaire, sans dupliquer les tests et sans changer le comportement existant.

## :100: Pour tester

Tester que les envois d'email fonctionnent toujours.