### PR TITLE
[TECH] Pouvoir changer le comportement de l'utilisateur dans les tests d'algo (PIX-2063).

### DIFF
--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -28,6 +28,9 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
     case 'random':
       result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
       break;
+    case '1ok+ko':
+      !allAnswers.length ? result = AnswerStatus.OK : result = AnswerStatus.KO;
+      break;
     default:
       result = AnswerStatus.OK;
   }

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -12,8 +12,26 @@ const Answer = require('../../api/lib/domain/models/Answer');
 const AnswerStatus = require('../../api/lib/domain/models/AnswerStatus');
 const KnowledgeElement = require('../../api/lib/domain/models/KnowledgeElement');
 
+const POSSIBLE_ANSWER_STATUSES = [AnswerStatus.OK, AnswerStatus.KO];
+
 function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult }) {
-  const result = userResult === 'ok' ? AnswerStatus.OK : AnswerStatus.KO;
+
+  let result;
+
+  switch (userResult) {
+    case 'ok':
+      result = AnswerStatus.OK;
+      break;
+    case 'ko':
+      result = AnswerStatus.KO;
+      break;
+    case 'random':
+      result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
+      break;
+    default:
+      result = AnswerStatus.OK;
+  }
+
   const newAnswer = new Answer({ challengeId: challenge.id, result });
 
   const _getSkillsFilteredByStatus = (knowledgeElements, targetSkills, status) => {

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -31,6 +31,9 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
     case '1ok+ko':
       !allAnswers.length ? result = AnswerStatus.OK : result = AnswerStatus.KO;
       break;
+    case '1ko+ok':
+      !allAnswers.length ? result = AnswerStatus.KO : result = AnswerStatus.OK;
+      break;
     default:
       result = AnswerStatus.OK;
   }

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -28,10 +28,10 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
     case 'random':
       result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
       break;
-    case '1ok+ko':
+    case 'firstOKthenKO':
       !allAnswers.length ? result = AnswerStatus.OK : result = AnswerStatus.KO;
       break;
-    case '1ko+ok':
+    case 'firstKOthenOK':
       !allAnswers.length ? result = AnswerStatus.KO : result = AnswerStatus.OK;
       break;
     default:
@@ -182,7 +182,7 @@ async function launchTest(argv) {
         userId: assessment.userId,
         allKnowledgeElements: knowledgeElements,
         targetSkills,
-        userResult
+        userResult,
       });
       allAnswers = updatedAnswers;
       knowledgeElements = updatedKnowledgeElements;

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -17,7 +17,7 @@ const POSSIBLE_ANSWER_STATUSES = [AnswerStatus.OK, AnswerStatus.KO];
 function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult }) {
 
   let result;
-
+  const isFirstAnswer = !allAnswers.length;
   switch (userResult) {
     case 'ok':
       result = AnswerStatus.OK;
@@ -29,10 +29,10 @@ function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targe
       result = POSSIBLE_ANSWER_STATUSES[Math.round(Math.random())];
       break;
     case 'firstOKthenKO':
-      !allAnswers.length ? result = AnswerStatus.OK : result = AnswerStatus.KO;
+      isFirstAnswer ? result = AnswerStatus.OK : result = AnswerStatus.KO;
       break;
     case 'firstKOthenOK':
-      !allAnswers.length ? result = AnswerStatus.KO : result = AnswerStatus.OK;
+      isFirstAnswer ? result = AnswerStatus.KO : result = AnswerStatus.OK;
       break;
     default:
       result = AnswerStatus.OK;

--- a/high-level-tests/test-algo/algo.js
+++ b/high-level-tests/test-algo/algo.js
@@ -12,8 +12,9 @@ const Answer = require('../../api/lib/domain/models/Answer');
 const AnswerStatus = require('../../api/lib/domain/models/AnswerStatus');
 const KnowledgeElement = require('../../api/lib/domain/models/KnowledgeElement');
 
-function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId }) {
-  const newAnswer = new Answer({ challengeId: challenge.id, result: AnswerStatus.OK });
+function answerTheChallenge({ challenge, allAnswers, allKnowledgeElements, targetSkills, userId, userResult }) {
+  const result = userResult === 'ok' ? AnswerStatus.OK : AnswerStatus.KO;
+  const newAnswer = new Answer({ challengeId: challenge.id, result });
 
   const _getSkillsFilteredByStatus = (knowledgeElements, targetSkills, status) => {
     return knowledgeElements
@@ -108,7 +109,7 @@ async function _getChallenge({
 
 async function launchTest(argv) {
 
-  const { competenceId, targetProfileId, locale } = argv;
+  const { competenceId, targetProfileId, locale, userResult } = argv;
 
   let allAnswers = [];
   let knowledgeElements = [];
@@ -157,6 +158,7 @@ async function launchTest(argv) {
         userId: assessment.userId,
         allKnowledgeElements: knowledgeElements,
         targetSkills,
+        userResult
       });
       allAnswers = updatedAnswers;
       knowledgeElements = updatedKnowledgeElements;

--- a/high-level-tests/test-algo/index.js
+++ b/high-level-tests/test-algo/index.js
@@ -24,7 +24,7 @@ async function index() {
     .option('userResult', {
       type: 'string',
       description: 'Choix de réponse pour l\'utilisateur',
-      choices: ['ok', 'ko', 'random', '1ok+ko', '1ko+ok'],
+      choices: ['ok', 'ko', 'random', 'firstOKthenKO', 'firstKOthenOK'],
       default: 'ok',
     })
     .check((argv) => {

--- a/high-level-tests/test-algo/index.js
+++ b/high-level-tests/test-algo/index.js
@@ -21,6 +21,12 @@ async function index() {
       choices: ['fr', 'fr-fr', 'en'],
       default: 'fr',
     })
+    .option('userResult', {
+      type: 'string',
+      description: 'Choix de réponse pour l\'utilisateur',
+      choices: ['ok', 'ko', 'random', '1ok+ko', '1ko+ok'],
+      default: 'ok',
+    })
     .check((argv) => {
       return Boolean(argv.competenceId || argv.targetProfileId);
     })

--- a/high-level-tests/test-algo/tests/algo_test.js
+++ b/high-level-tests/test-algo/tests/algo_test.js
@@ -104,11 +104,12 @@ describe('#answerTheChallenge', () => {
   });
 
   describe('when userResult is "random"', ()=> {
-    previousAnswers = [];
+
     const userResult = 'random';
 
     it('should return the list of answers with some validated and some invalidated', () => {
       // when
+      previousAnswers = [];
       const allResults = [];
       for (let i = 0; i < 50; i++) {
         const result = answerTheChallenge({
@@ -119,7 +120,7 @@ describe('#answerTheChallenge', () => {
           userId: 1,
           userResult,
         });
-        allResults.push(result.updatedAnswers[1].result.status);
+        allResults.push(result.updatedAnswers[0].result.status);
       }
 
       // then
@@ -130,12 +131,12 @@ describe('#answerTheChallenge', () => {
   });
 
   describe('when userResult is first OK then all KO', () => {
-    let previousAnswers = [];
     const userResult = 'firstOKthenKO';
 
     it('should return the list of answers with the first one validated and the rest invalidated', () => {
       // when
       const allResults = [];
+      previousAnswers = [];
       for (let i = 0; i < 10; i++) {
         const result = answerTheChallenge({
           challenge,
@@ -150,7 +151,7 @@ describe('#answerTheChallenge', () => {
       }
 
       // then
-      expect(allResults[0]).to.contains('ok');
+      expect(allResults[0]).to.equal('ok');
       expect(allResults.slice(1)).to.contains('ko');
       expect(allResults.slice(1)).to.not.contains('ok');
     });
@@ -158,12 +159,12 @@ describe('#answerTheChallenge', () => {
   });
 
   describe('when userResult is first K0 then all OK', ()=> {
-    let previousAnswers = [];
     const userResult = 'firstKOthenOK';
 
     it('should return the list of answers with the first one invalidated and the rest validated', () => {
       // when
       const allResults = [];
+      let previousAnswers = [];
       for (let i = 0; i < 10; i++) {
         const result = answerTheChallenge({
           challenge,
@@ -178,7 +179,7 @@ describe('#answerTheChallenge', () => {
       }
 
       // then
-      expect(allResults[0]).to.contains('ko');
+      expect(allResults[0]).to.equal('ko');
       expect(allResults.slice(1)).to.contains('ok');
       expect(allResults.slice(1)).to.not.contains('ko');
     });

--- a/high-level-tests/test-algo/tests/index_test.js
+++ b/high-level-tests/test-algo/tests/index_test.js
@@ -157,6 +157,34 @@ describe('#answerTheChallenge', () => {
 
   });
 
+  context('when userResult is first K0 then all OK', ()=> {
+    let previousAnswers = [];
+    const userResult = '1ko+ok';
+
+    it('should return the list of answers with the first one invalidated and the rest validated', () => {
+      // when
+      const allResults = [];
+      for (let i = 0; i < 10; i++) {
+        const result = answerTheChallenge({
+          challenge,
+          allAnswers: previousAnswers,
+          allKnowledgeElements: previousKE,
+          targetSkills: [],
+          userId: 1,
+          userResult,
+        });
+        previousAnswers = result.updatedAnswers;
+        allResults.push(result.updatedAnswers[i].result.status);
+      }
+
+      // then
+      expect(allResults[0]).to.contains('ko');
+      expect(allResults.slice(1)).to.contains('ok');
+      expect(allResults.slice(1)).to.not.contains('ko');
+    });
+
+  });
+
 });
 
 describe('#_getReferentiel', () => {

--- a/high-level-tests/test-algo/tests/index_test.js
+++ b/high-level-tests/test-algo/tests/index_test.js
@@ -57,7 +57,7 @@ describe('#answerTheChallenge', () => {
     expect(result.updatedKnowledgeElements[1]).to.deep.equal(newKe);
   });
 
-  context('when userResult is "ok"', ()=> {
+  describe('when userResult is "ok"', ()=> {
     const userResult = 'ok';
 
     it('should return the list of answers with the new one validated', () => {
@@ -80,7 +80,7 @@ describe('#answerTheChallenge', () => {
 
   });
 
-  context('when userResult is "ko"', ()=> {
+  describe('when userResult is "ko"', ()=> {
     const userResult = 'ko';
 
     it('should return the list of answers with the new one invalidated', () => {
@@ -103,7 +103,7 @@ describe('#answerTheChallenge', () => {
 
   });
 
-  context('when userResult is "random"', ()=> {
+  describe('when userResult is "random"', ()=> {
     previousAnswers = [];
     const userResult = 'random';
 
@@ -129,9 +129,9 @@ describe('#answerTheChallenge', () => {
 
   });
 
-  context('when userResult is first OK then all KO', ()=> {
+  describe('when userResult is first OK then all KO', () => {
     let previousAnswers = [];
-    const userResult = '1ok+ko';
+    const userResult = 'firstOKthenKO';
 
     it('should return the list of answers with the first one validated and the rest invalidated', () => {
       // when
@@ -157,9 +157,9 @@ describe('#answerTheChallenge', () => {
 
   });
 
-  context('when userResult is first K0 then all OK', ()=> {
+  describe('when userResult is first K0 then all OK', ()=> {
     let previousAnswers = [];
-    const userResult = '1ko+ok';
+    const userResult = 'firstKOthenOK';
 
     it('should return the list of answers with the first one invalidated and the rest validated', () => {
       // when

--- a/high-level-tests/test-algo/tests/index_test.js
+++ b/high-level-tests/test-algo/tests/index_test.js
@@ -103,6 +103,31 @@ describe('#answerTheChallenge', () => {
 
   });
 
+  context('when userResult is "random"', ()=> {
+    const userResult = 'random';
+
+    it('should return the list of answers with some validated and some invalidated', () => {
+      // when
+      const allResults = [];
+      for(let i=0; i<50; i++) {
+        const result = answerTheChallenge({
+          challenge,
+          allAnswers: previousAnswers,
+          allKnowledgeElements: previousKE,
+          targetSkills: [],
+          userId: 1,
+          userResult,
+        });
+        allResults.push(result.updatedAnswers[1].result.status);
+      }
+
+      // then
+      expect(allResults).to.contains('ok');
+      expect(allResults).to.contains('ko');
+    });
+
+  });
+
 });
 
 describe('#_getReferentiel', () => {

--- a/high-level-tests/test-algo/tests/index_test.js
+++ b/high-level-tests/test-algo/tests/index_test.js
@@ -56,6 +56,53 @@ describe('#answerTheChallenge', () => {
     expect(result.updatedKnowledgeElements[0]).to.deep.equal(previousKE[0]);
     expect(result.updatedKnowledgeElements[1]).to.deep.equal(newKe);
   });
+
+  context('when userResult is "ok"', ()=> {
+    const userResult = 'ok';
+
+    it('should return the list of answers with the new one validated', () => {
+      // when
+      const result = answerTheChallenge({
+        challenge,
+        allAnswers: previousAnswers,
+        allKnowledgeElements: previousKE,
+        targetSkills: [],
+        userId: 1,
+        userResult,
+      });
+
+      // then
+      expect(result.updatedAnswers).lengthOf(previousAnswers.length + 1);
+      expect(result.updatedAnswers[0]).to.be.deep.equal(previousAnswers[0]);
+      expect(result.updatedAnswers[1].challengeId).to.be.equal(challenge.id);
+      expect(result.updatedAnswers[1].result).to.be.deep.equal({ status: 'ok' });
+    });
+
+  });
+
+  context('when userResult is "ko"', ()=> {
+    const userResult = 'ko';
+
+    it('should return the list of answers with the new one invalidated', () => {
+      // when
+      const result = answerTheChallenge({
+        challenge,
+        allAnswers: previousAnswers,
+        allKnowledgeElements: previousKE,
+        targetSkills: [],
+        userId: 1,
+        userResult,
+      });
+
+      // then
+      expect(result.updatedAnswers).lengthOf(previousAnswers.length + 1);
+      expect(result.updatedAnswers[0]).to.be.deep.equal(previousAnswers[0]);
+      expect(result.updatedAnswers[1].challengeId).to.be.equal(challenge.id);
+      expect(result.updatedAnswers[1].result).to.be.deep.equal({ status: 'ko' });
+    });
+
+  });
+
 });
 
 describe('#_getReferentiel', () => {

--- a/high-level-tests/test-algo/tests/index_test.js
+++ b/high-level-tests/test-algo/tests/index_test.js
@@ -104,12 +104,13 @@ describe('#answerTheChallenge', () => {
   });
 
   context('when userResult is "random"', ()=> {
+    previousAnswers = [];
     const userResult = 'random';
 
     it('should return the list of answers with some validated and some invalidated', () => {
       // when
       const allResults = [];
-      for(let i=0; i<50; i++) {
+      for (let i = 0; i < 50; i++) {
         const result = answerTheChallenge({
           challenge,
           allAnswers: previousAnswers,
@@ -124,6 +125,34 @@ describe('#answerTheChallenge', () => {
       // then
       expect(allResults).to.contains('ok');
       expect(allResults).to.contains('ko');
+    });
+
+  });
+
+  context('when userResult is first OK then all KO', ()=> {
+    let previousAnswers = [];
+    const userResult = '1ok+ko';
+
+    it('should return the list of answers with the first one validated and the rest invalidated', () => {
+      // when
+      const allResults = [];
+      for (let i = 0; i < 10; i++) {
+        const result = answerTheChallenge({
+          challenge,
+          allAnswers: previousAnswers,
+          allKnowledgeElements: previousKE,
+          targetSkills: [],
+          userId: 1,
+          userResult,
+        });
+        previousAnswers = result.updatedAnswers;
+        allResults.push(result.updatedAnswers[i].result.status);
+      }
+
+      // then
+      expect(allResults[0]).to.contains('ok');
+      expect(allResults.slice(1)).to.contains('ko');
+      expect(allResults.slice(1)).to.not.contains('ok');
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans les tests d'algo, l'utilisateur test ne faisait que répondre correctement.

## :robot: Solution
Ajouter de nouveaux types d'utiliseur, qui vont répondre : 
- ok : toujours ok,
- ko : toujours ko
- random : aléatoirement ok ou ko
- firstOKthenKO : correctement à la première, puis faux aux suivantes
- firstKOthenOK : faux à la première, et correctement aux suivantes

## :rainbow: Remarques
- On fait une boucle pour tester le random

## :100: Pour tester
Tester en local avec : `npm start -- --competenceId RECID --userResult USERRESULT`
Avec USERRESULT = ok, ko, random, firstOKthenKO, firstKOthenOK