### PR TITLE
[FEATURE] Change wording for certification page labels (pix-2295)

### DIFF
--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -324,9 +324,9 @@ module('Acceptance | authentication', function(hooks) {
             assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
             assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
             assert.contains('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.');
-            assert.contains('Exporter mes résultats');
-            assert.contains('Mes certifications');
-            assert.contains('Classes');
+            assert.contains('Exporter les résultats');
+            assert.contains('Certifications');
+            assert.contains('Classe');
           });
         });
 

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -269,7 +269,7 @@
       "description": "Please select the class for which you would like to export the certification results in a csv file.",
       "download-button": "Export the results",
       "select-label": "Class",
-      "title": "My certifications"
+      "title": "Certifications"
     },
     "profiles-individual-results": {
       "certifiable": "Eligible for certification",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -267,9 +267,9 @@
     },
     "certifications": {
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.",
-      "download-button": "Exporter mes résultats",
-      "select-label": "Classes",
-      "title": "Mes certifications"
+      "download-button": "Exporter les résultats",
+      "select-label": "Classe",
+      "title": "Certifications"
     },
     "profiles-individual-results": {
       "certifiable": "Certifiable",


### PR DESCRIPTION
## :unicorn: Problème
Des termes utilisés lors de la première version de la page ont été revus lors de la démonstration.

## :robot: Solution
Titre de la page : “Certifications” (on supprime le “mes”)

Bouton : “Exporter les résultats” (et non “mes” résultats)

Libellé du filtre : “Classe” (pas au pluriel mais au singulier car on ne peut sélectionner qu’une classe)

## :100: Pour tester
> Lancer Pix API avec FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true
> Se connecter à Pix Orga avec un compte admin SCO isManagingStudent.
> Se rendre sur la page Certifications depuis le menu de gauche et constater les changements.

<img width="808" alt="Capture d’écran 2021-03-04 à 17 18 22" src="https://user-images.githubusercontent.com/35962680/109994607-c3535f80-7d0d-11eb-85f0-6f27930aac96.png">
