### PR TITLE
[TECH] Ajout d'un helper front pour pouvoir avoir un choix de langue dans un bloc de text (PIX-2318).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -33,10 +33,10 @@
         {{#if this.showStages}}
           <div class="skill-review-share__stage-congrats">
             <div class="stage-congrats__title">
-              {{this.reachedStage.title}}
+              {{text-with-multiple-lang this.reachedStage.title (t 'current-lang') }}
             </div>
             <div class="stage-congrats__message">
-              <MarkdownToHtml @markdown={{this.reachedStage.message}} />
+              <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message (t 'current-lang') }} />
             </div>
           </div>
         {{else}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -33,10 +33,10 @@
         {{#if this.showStages}}
           <div class="skill-review-share__stage-congrats">
             <div class="stage-congrats__title">
-              {{text-with-multiple-lang this.reachedStage.title (t 'current-lang') }}
+              {{text-with-multiple-lang this.reachedStage.title}}
             </div>
             <div class="stage-congrats__message">
-              <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message (t 'current-lang') }} />
+              <MarkdownToHtml @markdown={{text-with-multiple-lang this.reachedStage.message}} />
             </div>
           </div>
         {{else}}

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -1,0 +1,14 @@
+import { helper } from '@ember/component/helper';
+
+function _clean(text) {
+  return text.replace(/\[\/?(fr|en)\]/g, '');
+}
+export function textWithMultipleLang(params) {
+  const text = params[0];
+  const lang = params[1];
+  const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
+  const textForLang = text.match(regex);
+  return textForLang ? _clean(textForLang[0]) : _clean(text);
+}
+
+export default helper(textWithMultipleLang);

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -6,9 +6,13 @@ function _clean(text) {
 export function textWithMultipleLang(params) {
   const text = params[0];
   const lang = params[1];
-  const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
-  const textForLang = text.match(regex);
-  return textForLang ? _clean(textForLang[0]) : _clean(text);
+  if (text && lang) {
+    const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
+    const textForLang = text.match(regex);
+    return textForLang ? _clean(textForLang[0]) : _clean(text);
+  } else {
+    return text;
+  }
 }
 
 export default helper(textWithMultipleLang);

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -6,9 +6,9 @@ export default class textWithMultipleLang extends Helper {
 
   compute(params) {
     const text = params[0];
-    const lang = params[1];
+    const lang = this.intl.t('current-lang');
     const listOfLocales = this.intl.locales;
-    if (text && lang && listOfLocales.includes(lang)) {
+    if (text && listOfLocales.includes(lang)) {
       const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
       const textForLang = text.match(regex);
       return textForLang ? _clean(textForLang[0], listOfLocales) : _clean(text, listOfLocales);

--- a/mon-pix/app/helpers/text-with-multiple-lang.js
+++ b/mon-pix/app/helpers/text-with-multiple-lang.js
@@ -1,18 +1,24 @@
-import { helper } from '@ember/component/helper';
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
 
-function _clean(text) {
-  return text.replace(/\[\/?(fr|en)\]/g, '');
-}
-export function textWithMultipleLang(params) {
-  const text = params[0];
-  const lang = params[1];
-  if (text && lang) {
-    const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
-    const textForLang = text.match(regex);
-    return textForLang ? _clean(textForLang[0]) : _clean(text);
-  } else {
-    return text;
+export default class textWithMultipleLang extends Helper {
+  @service intl;
+
+  compute(params) {
+    const text = params[0];
+    const lang = params[1];
+    const listOfLocales = this.intl.locales;
+    if (text && lang && listOfLocales.includes(lang)) {
+      const regex = new RegExp(`(\\[${lang}\\]){1}(.|\n)*?(\\[\\/${lang}\\]){1}`);
+      const textForLang = text.match(regex);
+      return textForLang ? _clean(textForLang[0], listOfLocales) : _clean(text, listOfLocales);
+    } else {
+      return _clean(text, listOfLocales);
+    }
   }
 }
 
-export default helper(textWithMultipleLang);
+function _clean(text, listOfLocales) {
+  const regex = new RegExp(`\\[(\\/)?(${listOfLocales.join('|')})\\]`, 'g');
+  return text ? text.replace(regex, '') : text;
+}

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -6,6 +6,7 @@ describe('Unit | Helper | text with multiple lang', function() {
   [
     { text: 'des mots', lang: 'fr', outputText: 'des mots' },
     { text: 'des mots', lang: null, outputText: 'des mots' },
+    { text: null, lang: 'fr', outputText: null },
     { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'en', outputText: 'some words' },

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { textWithMultipleLang } from 'mon-pix/helpers/text-with-multiple-lang';
+
+describe('Unit | Helper | text with multiple lang', function() {
+  [
+    { text: 'des mots', lang: 'fr', outputText: 'des mots' },
+    { text: 'des mots', lang: null, outputText: 'des mots' },
+    { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'en', outputText: 'some words' },
+  ].forEach((expected) => {
+    it(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function() {
+      expect(textWithMultipleLang([expected.text, expected.lang])).to.equal(expected.outputText);
+    });
+  });
+});

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -19,6 +19,8 @@ describe('Unit | Helper | text with multiple lang', function() {
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'notexist', outputText: 'des motssome words' },
   ].forEach((expected) => {
     it(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function() {
+      textWithMultipleLangHelper.intl.t = () => expected.lang;
+
       expect(textWithMultipleLangHelper.compute([expected.text, expected.lang])).to.equal(expected.outputText);
     });
   });

--- a/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
+++ b/mon-pix/tests/unit/helpers/text-with-multiple-lang-test.js
@@ -1,18 +1,25 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { textWithMultipleLang } from 'mon-pix/helpers/text-with-multiple-lang';
+import textWithMultipleLang from 'mon-pix/helpers/text-with-multiple-lang';
 
 describe('Unit | Helper | text with multiple lang', function() {
+  let textWithMultipleLangHelper;
+
+  beforeEach(function() {
+    textWithMultipleLangHelper = new textWithMultipleLang();
+    textWithMultipleLangHelper.intl = { locales: ['fr', 'en'] };
+  });
   [
     { text: 'des mots', lang: 'fr', outputText: 'des mots' },
     { text: 'des mots', lang: null, outputText: 'des mots' },
     { text: null, lang: 'fr', outputText: null },
     { text: '[fr]des mots', lang: 'fr', outputText: 'des mots' },
     { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
-    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'en', outputText: 'some words' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'fr', outputText: 'des mots' },
+    { text: '[fr]des mots[/fr][en]some words[/en]', lang: 'notexist', outputText: 'des motssome words' },
   ].forEach((expected) => {
     it(`should return the text "${expected.outputText}" if the text is "${expected.text}" in lang ${expected.lang}`, function() {
-      expect(textWithMultipleLang([expected.text, expected.lang])).to.equal(expected.outputText);
+      expect(textWithMultipleLangHelper.compute([expected.text, expected.lang])).to.equal(expected.outputText);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Pour les paliers, les RT, etc. il n'y a qu'un seul champ texte pour les messages, titres ou autre. 
Or, au sein d'une même campagne, il peut y avoir des anglophones et des francophones.

## :robot: Solution
Pour éviter de dupliquer des colonnes pour chaque langue, je propose un genre de markdown pour les langues, via un helper front.


## :rainbow: Remarques
- Pour tester, je l'ai mis sur les paliers (qui étaient la demande faite par Anne-Laure)

## :100: Pour tester
L'idée serait d'avoir des champs textes  : `[fr]Bien joué ![/fr][en]Good job![/en]` et de les afficher coté front avec `{{text-with-multiple-lang @message (t 'current-lang') }}`
- Aller sur https://app-pr2666.review.pix.org/ (vous pouvez prendre le compte userPixAile)
- Aller sur la campagne AZERTY123
- Changer de langue via `?lang=en`
