### PR TITLE
[FEATURE] Traduction des bannières d'information de Pix Orga (PIX-2253).

### DIFF
--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -1,15 +1,13 @@
 {{#if this.displayNewYearSchoolingRegistrationsImportBanner}}
   <PixBanner class="information-banner">
     <FaIcon @icon="exclamation-triangle" class="icon--warning icon--margin"/>
-    Rentrée 2020 : l’<strong>administrateur</strong> doit
-    <LinkTo @route="authenticated.sco-students" class="link link--white link--bold link--underlined">
-      importer ou ré-importer la base élèves</LinkTo>
-    pour initialiser Pix Orga. Plus d’info
-    <a href="https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
-      collège <FaIcon @icon="external-link-alt" /></a>
-    et
-    <a href="https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23" class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
-      lycée (GT et Pro) <FaIcon @icon="external-link-alt" /></a>
+    <TranslateExtended
+      @key='banners.import.message'
+      @options={{hash
+        faIcon=(component 'fa-icon' icon='external-link-alt')
+        linkTo=(component 'link-to' (t 'banners.import.link-to') 'authenticated.sco-students' class="link link--white link--bold link--underlined")
+      }}
+    />
   </PixBanner>
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner class="information-banner">

--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -12,10 +12,12 @@
 {{else if this.displayNewYearCampaignsBanner}}
   <PixBanner class="information-banner">
     <FaIcon @icon="bullhorn" class="icon--margin"/>
-    Il est important de vérifier que les élèves soient <strong>certifiables</strong> avant de les inscrire en session de certification. Vous pouvez faire une
-    <a href={{this.documentationLink}} class="link link--white link--bold link--underlined" target="_blank" rel="noopener noreferrer">
-      campagne de collecte de profils
-      <FaIcon @icon="external-link-alt"/></a>
-    pour vous en assurer.
+    <TranslateExtended
+      @key='banners.campaigns.message'
+      @options={{hash
+        faIcon=(component 'fa-icon' icon='external-link-alt')
+        documentationLink=this.documentationLink
+    }}
+    />
   </PixBanner>
 {{/if}}

--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -6,6 +6,8 @@
       @options={{hash
         faIcon=(component 'fa-icon' icon='external-link-alt')
         linkTo=(component 'link-to' (t 'banners.import.link-to') 'authenticated.sco-students' class="link link--white link--bold link--underlined")
+        middleSchoolDocumentationLink='"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"'
+        highSchoolDocumentationLink='"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23"'
         externalLinkClasses='"link link--white link--bold link--underlined"'
       }}
     />

--- a/orga/app/components/information-banner.hbs
+++ b/orga/app/components/information-banner.hbs
@@ -6,6 +6,7 @@
       @options={{hash
         faIcon=(component 'fa-icon' icon='external-link-alt')
         linkTo=(component 'link-to' (t 'banners.import.link-to') 'authenticated.sco-students' class="link link--white link--bold link--underlined")
+        externalLinkClasses='"link link--white link--bold link--underlined"'
       }}
     />
   </PixBanner>
@@ -17,6 +18,7 @@
       @options={{hash
         faIcon=(component 'fa-icon' icon='external-link-alt')
         documentationLink=this.documentationLink
+        externalLinkClasses='"link link--white link--bold link--underlined"'
     }}
     />
   </PixBanner>

--- a/orga/app/components/translate-extended.hbs
+++ b/orga/app/components/translate-extended.hbs
@@ -1,0 +1,4 @@
+{{!-- template-lint-disable no-triple-curlies --}}
+{{#each this.tokens as |token|}}
+  {{{token}}}
+{{/each}}

--- a/orga/app/components/translate-extended.js
+++ b/orga/app/components/translate-extended.js
@@ -1,0 +1,13 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+/* this component allow us to translate sentences with Ember component wrapped in it.
+`key` is the key for translation and `options` is an object with variables for translation.
+Ember component are passed in variables with the `component` helper used in hbs file. */
+export default class TranslateExtendedComponent extends Component {
+  @service intl;
+
+  get tokens() {
+    return this.intl.t(this.args.key, this.args.options);
+  }
+}

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -3,7 +3,6 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
-import sinon from 'sinon';
 
 module('Integration | Component | information-banner', function(hooks) {
   setupIntlRenderingTest(hooks);
@@ -31,17 +30,6 @@ module('Integration | Component | information-banner', function(hooks) {
       });
 
       module('when prescriber has already imported students', function() {
-        const now = new Date('2020-01-01T05:06:07Z');
-        let clock;
-
-        hooks.beforeEach(() => {
-          clock = sinon.useFakeTimers(now);
-        });
-
-        hooks.afterEach(() => {
-          clock.restore();
-        });
-
         test('should not render the banner', async function(assert) {
           // given
           class CurrentUserStub extends Service {
@@ -115,17 +103,6 @@ module('Integration | Component | information-banner', function(hooks) {
     });
 
     module('when prescriber’s organization is not of type SCO that manages students', function() {
-      const now = new Date('2019-01-01T05:06:07Z');
-      let clock;
-
-      hooks.beforeEach(() => {
-        clock = sinon.useFakeTimers(now);
-      });
-
-      hooks.afterEach(() => {
-        clock.restore();
-      });
-
       test('should not display the campaign banner', async function(assert) {
         // given
         class CurrentUserStub extends Service {

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
 module('Integration | Component | information-banner', function(hooks) {
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   module('Import Banner', () => {
     module('when prescriber’s organization is of type SCO that manages students', function() {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -12,6 +12,9 @@
     "global": "An error occurred. Please try again later."
   },
   "banners": {
+    "campaigns": {
+      "message": "Please note that you must check if the students are '<strong>'eligible to certification'</strong>' before signing them up on certification sessions. You can do a '<'a href={documentationLink} class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\"'>'profile collection campaign {faIcon}'</a>' to be sure."
+    },
     "import": {
       "link-to": "import or reimport the students database",
       "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'middle schools {faIcon}'</a>' and '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'high schools {faIcon}'</a>'"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -17,7 +17,7 @@
     },
     "import": {
       "link-to": "import or reimport the students database",
-      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<'a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
+      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
     }
   },
   "current-lang": "en",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -11,6 +11,12 @@
     },
     "global": "An error occurred. Please try again later."
   },
+  "banners": {
+    "import": {
+      "link-to": "import or reimport the students database",
+      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'middle schools {faIcon}'</a>' and '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'high schools {faIcon}'</a>'"
+    }
+  },
   "current-lang": "en",
   "common": {
     "actions": {

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -13,11 +13,11 @@
   },
   "banners": {
     "campaigns": {
-      "message": "Please note that you must check if the students are '<strong>'eligible to certification'</strong>' before signing them up on certification sessions. You can do a '<'a href={documentationLink} class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\"'>'profile collection campaign {faIcon}'</a>' to be sure."
+      "message": "Please note that you must check if the students are '<strong>'eligible to certification'</strong>' before signing them up on certification sessions. You can do a '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'profile collection campaign {faIcon}'</a>' to be sure."
     },
     "import": {
       "link-to": "import or reimport the students database",
-      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'middle schools {faIcon}'</a>' and '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'high schools {faIcon}'</a>'"
+      "message": "Start of school year: the '<strong>'admin'</strong>' must {linkTo} to start using Pix Orga. Learn more on '<'a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'middle schools {faIcon}'</a>' and '<'a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'high schools {faIcon}'</a>'"
     }
   },
   "current-lang": "en",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -17,7 +17,7 @@
     },
     "import": {
       "link-to": "importer ou ré-importer la base élèves",
-      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
+      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href={middleSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href={highSchoolDocumentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     }
   },
   "current-lang": "fr",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -11,6 +11,12 @@
     },
     "global": "Une erreur est survenue. Veuillez réessayer ultérieurement."
   },
+  "banners": {
+    "import": {
+      "link-to": "importer ou ré-importer la base élèves",
+      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'collège {faIcon}'</a>' et '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'lycée (GT et Pro) {faIcon}'</a>'"
+    }
+  },
   "current-lang": "fr",
   "common": {
     "actions": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -13,11 +13,11 @@
   },
   "banners": {
     "campaigns": {
-      "message": "Il est important de vérifier que les élèves soient '<strong>'certifiables'</strong>' avant de les inscrire en session de certification. Vous pouvez faire une '<'a href={documentationLink} class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\"'>'campagne de collecte de profils {faIcon}'</a>' pour vous en assurer."
+      "message": "Il est important de vérifier que les élèves soient '<strong>'certifiables'</strong>' avant de les inscrire en session de certification. Vous pouvez faire une '<'a href={documentationLink} class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'campagne de collecte de profils {faIcon}'</a>' pour vous en assurer."
     },
     "import": {
       "link-to": "importer ou ré-importer la base élèves",
-      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'collège {faIcon}'</a>' et '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'lycée (GT et Pro) {faIcon}'</a>'"
+      "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<'a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'collège {faIcon}'</a>' et '<'a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class={externalLinkClasses} target=\"_blank\" rel=\"noopener noreferrer\"'>'lycée (GT et Pro) {faIcon}'</a>'"
     }
   },
   "current-lang": "fr",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -12,6 +12,9 @@
     "global": "Une erreur est survenue. Veuillez réessayer ultérieurement."
   },
   "banners": {
+    "campaigns": {
+      "message": "Il est important de vérifier que les élèves soient '<strong>'certifiables'</strong>' avant de les inscrire en session de certification. Vous pouvez faire une '<'a href={documentationLink} class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\"'>'campagne de collecte de profils {faIcon}'</a>' pour vous en assurer."
+    },
     "import": {
       "link-to": "importer ou ré-importer la base élèves",
       "message": "Rentrée 2020 : l’'<strong>'administrateur'</strong>' doit {linkTo} pour initialiser Pix Orga. Plus d’info '<a href=\"https://view.genial.ly/5f295b80302a810d2ff9fa60/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'collège {faIcon}'</a>' et '<a href=\"https://view.genial.ly/5f46390591252c0d5246bb63/?idSlide=cd748a12-ef8e-4683-8139-eb851bd0eb23\" class=\"link link--white link--bold link--underlined\" target=\"_blank\" rel=\"noopener noreferrer\">'lycée (GT et Pro) {faIcon}'</a>'"


### PR DESCRIPTION
## :unicorn: Problème

Les bannières de Pix Orga ne sont pas traduites.

## :robot: Solution

Internationaliser les bannières de Pix Orga.

## :rainbow: Remarques

Le composant `TranslateExtender` a été créé afin de pouvoir rendre des composants Ember dans les chaines internationalisée

## :100: Pour tester
- Se connecter avec sco.admin@example.net
- Aller sur "Collège The Night Watch", vérifier que la bannière de campagne est affichée et traduite en mettant "?lang=en"
- Aller sur "Lycée The Night Watch", vérifier que la bannière d'import est affichée et traduite en mettant "?lang=en"
