### PR TITLE
[FIX] Ignorer les liens pole emploi connect dans le Doc Link Checker

### DIFF
--- a/docs/link--check-config.json
+++ b/docs/link--check-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://martinfowler.com/"
+    },
+    {
+      "pattern": "^https://peconnect.pole-emploi.fr/"
     }
   ]
 }


### PR DESCRIPTION
## :unicorn: Problème

La CI échoue à cause d'un test KO sur la commande `npm run lint:docs`
Cette commande semble vérifier que les liens des docs (ADR...) ne soient pas morts.
Apparement il y a le lien https://peconnect.pole-emploi.fr (pôle emploi) dans le document `./docs/adr/0014-utiliser-type-stockage-JSONB-base-de-donnees.md`. Je pensais enlever le lien de la doc, car on a pas vraiment le controle sur ce type de lien

## :robot: Solution

Ignorer le lien pole emploi dans le checker.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

La CI doit passer :)