### PR TITLE
[FEATURE] Permettre la suppression d'un membre depuis Pix Orga (PIX-404).

### DIFF
--- a/admin/app/adapters/membership.js
+++ b/admin/app/adapters/membership.js
@@ -5,7 +5,8 @@ export default class MembershipAdapter extends ApplicationAdapter {
   updateRecord(store, type, snapshot) {
     if (snapshot.adapterOptions && snapshot.adapterOptions.disable) {
       const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/disable';
-      return this.ajax(url, 'POST');
+      const data = this.serialize(snapshot);
+      return this.ajax(url, 'POST', { data });
     }
     return super.updateRecord(...arguments);
   }

--- a/admin/tests/unit/adapters/membership-test.js
+++ b/admin/tests/unit/adapters/membership-test.js
@@ -22,10 +22,11 @@ module('Unit | Adapter | membership', function(hooks) {
 
       test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
         // when
-        await adapter.updateRecord({}, { modelName: 'membership' }, { id: 1, adapterOptions: { disable: true } });
+        const data = Symbol('membership');
+        await adapter.updateRecord({}, { modelName: 'membership' }, { id: 1, adapterOptions: { disable: true }, serialize: sinon.stub().returns(data) });
 
         // then
-        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/disable', 'POST');
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/disable', 'POST', { data });
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/api/lib/application/memberships/index.js
+++ b/api/lib/application/memberships/index.js
@@ -61,8 +61,8 @@ exports.register = async function(server) {
       path: '/api/memberships/{id}/disable',
       config: {
         pre: [{
-          method: securityPreHandlers.checkUserHasRolePixMaster,
-          assign: 'hasRolePixMaster',
+          method: securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster,
+          assign: 'isAdminInOrganizationOrHasRolePixMaster',
         }],
         validate: {
           params: Joi.object({

--- a/api/tests/integration/application/memberships/membership-controller_test.js
+++ b/api/tests/integration/application/memberships/membership-controller_test.js
@@ -140,7 +140,7 @@ describe('Integration | Application | Memberships | membership-controller', () =
       beforeEach(() => {
         membershipId = domainBuilder.buildMembership().id;
         usecases.disableMembership.resolves();
-        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response(true));
+        securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => h.response(true));
       });
 
       it('should return a 200 HTTP response', async () => {
@@ -154,10 +154,10 @@ describe('Integration | Application | Memberships | membership-controller', () =
 
     context('Error cases', () => {
 
-      context('when user has not pix master role', () => {
+      context('when user is not admin of the organization nor has pix master role', () => {
 
         beforeEach(() => {
-          securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
+          securityPreHandlers.checkUserIsAdminInOrganizationOrHasRolePixMaster.callsFake((request, h) => {
             return Promise.resolve(h.response().code(403).takeover());
           });
         });

--- a/orga/app/adapters/membership.js
+++ b/orga/app/adapters/membership.js
@@ -11,4 +11,13 @@ export default class MembershipAdapter extends ApplicationAdapter {
     }
     return super.urlForQuery(...arguments);
   }
+
+  updateRecord(store, type, snapshot) {
+    if (snapshot.adapterOptions && snapshot.adapterOptions.disable) {
+      const url = this.urlForUpdateRecord(snapshot.id, type.modelName, snapshot) + '/disable';
+      const data = this.serialize(snapshot);
+      return this.ajax(url, 'POST', { data });
+    }
+    return super.updateRecord(...arguments);
+  }
 }

--- a/orga/app/components/modal/dialog.hbs
+++ b/orga/app/components/modal/dialog.hbs
@@ -4,7 +4,7 @@
     @targetAttachment="none"
     @wrapperClass="modal-wrapper"
     @overlayClass="modal-overlay"
-    @containerClass="modal-dialog"
+    @containerClass="{{this.containerClass}}"
     @onClose={{@close}}
   >
     <div class="modal__container" role="dialog" aria-labelledby={{this.labelId}} aria-modal="true" ...attributes>

--- a/orga/app/components/modal/dialog.js
+++ b/orga/app/components/modal/dialog.js
@@ -8,6 +8,10 @@ export default class Dialog extends Component {
     document.addEventListener('keyup', this.closeOnEscape);
   }
 
+  get containerClass() {
+    return `modal-dialog ${this.args.additionalContainerClass}`;
+  }
+
   willDestroy() {
     super.willDestroy(...arguments);
     document.removeEventListener('keyup', this.closeOnEscape);

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -14,6 +14,9 @@
           <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}} aria-label="Modifier le rôle">
             Modifier le rôle
           </Dropdown::Item>
+          <Dropdown::Item @onClick={{fn this.displayRemoveMembershipModal @membership}} aria-label="Supprimer le membre">
+            Supprimer
+          </Dropdown::Item>
         </Dropdown::IconTrigger>
       </td>
     {{else}}
@@ -51,3 +54,17 @@
     </td>
   {{/if}}
 </tr>
+
+<Modal::Dialog class="remove-membership-modal" @title="Confirmez-vous la suppression ?" @display={{this.isRemoveMembershipModalDisplayed}} @close={{this.closeRemoveMembershipModal}} @additionalContainerClass="modal-dialog__large">
+  <Modal::Body class="remove-membership-modal__content">
+    <p class="content-text">
+      {{@membership.user.firstName}} {{@membership.user.lastName}} n'aura plus accès à cet espace Pix Orga.
+      <br>
+      Ses campagnes restent accessibles au reste de l'équipe.
+    </p>
+  </Modal::Body>
+  <Modal::Footer class="remove-membership-modal__actions">
+    <button type="button" class="button button--grey button--regular" {{on 'click' this.closeRemoveMembershipModal}}>Annuler</button>
+    <button type="button" class="button button--red" data-test-modal-remove-button {{on 'click' this.onRemoveButtonClicked}}>Oui, supprimer le membre</button>
+  </Modal::Footer>
+</Modal::Dialog>

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -5,13 +5,16 @@
   {{#unless this.isEditionMode }}
     <td>{{@membership.displayRole}}</td>
     {{#if (not-eq @membership.user.id this.currentUser.prescriber.id) }}
-      <td>
-        <div class="zone-edit-role">
-          <button id='edit-organization-role' class="button button--light-grey button--thin"
-                  type="button" {{on 'click' (fn this.editRoleOfMember @membership)}}>
+      <td class="zone-edit-role">
+        <Dropdown::IconTrigger
+                @icon="ellipsis-v"
+                @dropdownButtonClass="zone-edit-role__dropdown-button"
+                @dropdownContentClass="zone-edit-role__dropdown-content"
+        >
+          <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}} aria-label="Modifier le rôle">
             Modifier le rôle
-          </button>
-        </div>
+          </Dropdown::Item>
+        </Dropdown::IconTrigger>
       </td>
     {{else}}
       <td></td>

--- a/orga/app/components/routes/authenticated/team/items.js
+++ b/orga/app/components/routes/authenticated/team/items.js
@@ -10,11 +10,13 @@ const memberOption = { value: 'MEMBER', label: 'Membre', disabled: false };
 export default class Items extends Component {
 
   @service currentUser;
+  @service notifications;
 
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
   @tracked selectedNewRole = null;
   @tracked currentRole = null;
+  @tracked isRemoveMembershipModalDisplayed = false;
 
   constructor() {
     super(...arguments);
@@ -51,6 +53,32 @@ export default class Items extends Component {
   cancelUpdateRoleOfMember() {
     this.isEditionMode = false;
     this._clearState();
+  }
+
+  @action
+  displayRemoveMembershipModal() {
+    this.isRemoveMembershipModalDisplayed = true;
+  }
+
+  @action
+  closeRemoveMembershipModal() {
+    this.isRemoveMembershipModalDisplayed = false;
+  }
+
+  @action
+  async onRemoveButtonClicked() {
+    try {
+      const membership = this.args.membership;
+      const memberFirstName = membership.user.get('firstName');
+      const memberLastName = membership.user.get('lastName');
+
+      await this.args.removeMembership(membership);
+      this.notifications.success(`${memberFirstName} ${memberLastName} a été supprimé avec succès de votre équipe Pix Orga.`);
+    } catch (e) {
+      this.notifications.error('Une erreur est survenue lors de la désactivation du membre.');
+    } finally {
+      this.closeRemoveMembershipModal();
+    }
   }
 
   _clearState() {

--- a/orga/app/components/routes/authenticated/team/members.hbs
+++ b/orga/app/components/routes/authenticated/team/members.hbs
@@ -12,7 +12,7 @@
       {{#if @memberships}}
         <tbody>
         {{#each @memberships as |membership|}}
-          <Routes::Authenticated::Team::Items @membership={{membership}}/>
+          <Routes::Authenticated::Team::Items @membership={{membership}} @removeMembership={{@removeMembership}} />
         {{/each}}
         </tbody>
       {{/if}}

--- a/orga/app/controllers/authenticated/team/list/members.js
+++ b/orga/app/controllers/authenticated/team/list/members.js
@@ -1,0 +1,15 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class MembersController extends Controller {
+
+  @service currentUser;
+
+  @action
+  async removeMembership(membership) {
+    membership.organization = this.currentUser.organization;
+    await membership.save({ adapterOptions: { disable: true } });
+    this.send('refreshModel');
+  }
+}

--- a/orga/app/routes/authenticated/team/list.js
+++ b/orga/app/routes/authenticated/team/list.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
+import { action } from '@ember/object';
 
 export default class ListRoute extends Route {
   queryParams = {
@@ -33,5 +34,10 @@ export default class ListRoute extends Route {
       controller.pageNumber = 1;
       controller.pageSize = 10;
     }
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/orga/app/styles/components/modal.scss
+++ b/orga/app/styles/components/modal.scss
@@ -12,6 +12,10 @@
     width: 500px;
     padding: 0;
 
+    &__large {
+      width: 600px;
+    }
+
     @include device-is('mobile') {
       width: 80%;
     }

--- a/orga/app/styles/globals/buttons.scss
+++ b/orga/app/styles/globals/buttons.scss
@@ -57,6 +57,15 @@
     }
   }
 
+  &--red {
+    background-color: $red;
+    color: $white;
+
+    &:hover, &:active, &:focus {
+      background-color: $red-hover;
+    }
+  }
+
   &--no-color {
     background-color: transparent;
     color: $grey-100;

--- a/orga/app/styles/globals/colors.scss
+++ b/orga/app/styles/globals/colors.scss
@@ -16,6 +16,8 @@ $green: #038A25;
 $green-hover: darken($green, 4%);
 $orga: #00DDFF;
 $purple: #8A49FF;
+$red: #D63F00;
+$red-hover: darken($red, 4%);
 // gradients
 $pix-orga-old-gradient: linear-gradient(0deg, #0D7DC4 0%, #213371 100%);
 $pix-yellow-gradient: linear-gradient(135deg, #FFBE00 0%, #FF9F00 100%);
@@ -52,7 +54,7 @@ $communication-dark: #3D68FF;
 $communication-light: #12A3FF;
 $content-dark: #1A8C89;
 $content-light: #52D987;
-$information-dark: #F24645;
+$information-dark: #f24645;
 $information-light: #F1A141;
 $security-dark: #AC008D;
 $security-light: #FF3F94;

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -1,3 +1,5 @@
+$margin-right: 32px;
+
 .list-team-page {
   display: flex;
   flex-direction: column;
@@ -30,11 +32,21 @@
 }
 
 .zone-edit-role {
+  align-items: center;
   box-sizing: border-box;
   display: flex;
   height: inherit;
   justify-content: flex-end;
   padding-right: 25px;
+
+  &__dropdown-button {
+    margin-right: $margin-right;
+  }
+
+  &__dropdown-content {
+    width: 200px;
+    right: $margin-right;
+  }
 }
 
 .zone-save-cancel-role {

--- a/orga/app/styles/pages/authenticated/team/list.scss
+++ b/orga/app/styles/pages/authenticated/team/list.scss
@@ -17,6 +17,10 @@ $margin-right: 32px;
     border-bottom: 1px solid $grey-20;
     margin-bottom: 16px;
   }
+
+  .modal-dialog-width {
+    width: 600px;
+  }
 }
 
 .list-team-page-header {
@@ -62,3 +66,30 @@ $margin-right: 32px;
     margin-left: 10px;
   }
 }
+
+.remove-membership-modal {
+
+  .content-text {
+    color: $grey-90;
+    line-height: 26px;
+  }
+
+  &__content, &__actions {
+    background: $grey-10;
+  }
+
+  &__content{
+    padding-top: 32px;
+    padding-bottom: 24px;
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: space-between;
+
+    button:first-child {
+      margin-right: 25px;
+    }
+  }
+}
+

--- a/orga/app/templates/authenticated/team/list/members.hbs
+++ b/orga/app/templates/authenticated/team/list/members.hbs
@@ -1,1 +1,1 @@
-<Routes::Authenticated::Team::Members @memberships={{@model}}/>
+<Routes::Authenticated::Team::Members @memberships={{@model}} @removeMembership={{this.removeMembership}} />

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -321,4 +321,13 @@ export default function() {
   this.get('/organizations/:id/divisions', (schema, _) => {
     return schema.divisions.all();
   });
+
+  this.post('/memberships/:id/disable', (schema, request) => {
+    const membershipId = request.params.id;
+
+    const membership = schema.memberships.find(membershipId);
+    membership.destroy();
+
+    return new Response(204);
+  });
 }

--- a/orga/tests/acceptance/remove-membership-test.js
+++ b/orga/tests/acceptance/remove-membership-test.js
@@ -1,0 +1,54 @@
+import { module, test } from 'qunit';
+import { click, visit } from '@ember/test-helpers';
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+import {
+  createPrescriberByUser, createUserMembershipWithRole,
+} from '../helpers/test-init';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+async function createAuthenticatedSession() {
+  const user = createUserMembershipWithRole('ADMIN');
+  createPrescriberByUser(user);
+
+  await authenticateSession({
+    user_id: user.id,
+    access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+    expires_in: 3600,
+    token_type: 'Bearer token type',
+  });
+
+  return user;
+}
+
+module('Acceptance | Remove membership', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  let user;
+
+  hooks.beforeEach(async function() {
+    const adminUser = await createAuthenticatedSession();
+    const organizationId = adminUser.memberships.models.firstObject.organizationId;
+
+    user = server.create('user', { firstName: 'John', lastName: 'Doe' });
+    server.create('membership', { userId: user.id, organizationId, organizationRole: 'MEMBER' });
+  });
+
+  test('should remove the membership', async (assert) => {
+    // given
+    await visit('/equipe');
+    await clickByLabel('Afficher les actions');
+    await clickByLabel('Supprimer');
+
+    // when
+    await click('button[data-test-modal-remove-button]');
+
+    // then
+    assert.notContains(user.firstName);
+    assert.notContains(user.lastName);
+  });
+});

--- a/orga/tests/integration/components/modal/dialog-test.js
+++ b/orga/tests/integration/components/modal/dialog-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | modal', function(hooks) {
       this.set('close', close);
       this.set('title', 'Mon titre');
 
-      return render(hbs`<Modal::Dialog @display={{display}} @title={{title}} @close={{close}}>Mon contenu</Modal::Dialog>`);
+      return render(hbs`<Modal::Dialog @display={{display}} @title={{title}} @close={{close}} @additionalContainerClass={{additionalContainerClass}}>Mon contenu</Modal::Dialog>`);
     });
 
     test('should render title and content', async function(assert) {
@@ -63,6 +63,14 @@ module('Integration | Component | modal', function(hooks) {
       assert.dom('[role="dialog"]').exists();
       assert.dom('[aria-labelledby="modal_mon_titre_label"]').exists();
       assert.dom('#modal_mon_titre_label').exists();
+    });
+
+    test('should add additional container class', async function(assert) {
+      const additionalContainerClass = 'a_class';
+      this.set('display', true);
+      this.set('additionalContainerClass', additionalContainerClass);
+
+      assert.dom('.modal-dialog').hasClass(additionalContainerClass);
     });
   });
 });

--- a/orga/tests/integration/components/routes/authenticated/team/items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/items-test.js
@@ -120,4 +120,54 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       sinon.assert.called(adminMembership.save);
     });
   });
+
+  module('When remove member button is clicked', (hooks) => {
+
+    let removeMembershipStub;
+
+    hooks.beforeEach(async function() {
+      // given
+      removeMembershipStub = sinon.stub();
+      memberMembership.user.get = (attr) => {
+        return attr === 'firstName' ? memberMembership.user.firstName : memberMembership.user.lastName;
+      };
+      this.set('membership', memberMembership);
+      this.set('removeMembership', removeMembershipStub);
+
+      // when
+      await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}} @removeMembership={{removeMembership}} />`);
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Supprimer');
+    });
+
+    test('should display a confirmation modal', (assert) => {
+      // then
+      assert.contains('Confirmez-vous la suppression ?');
+      assert.contains('Annuler');
+      assert.contains('Supprimer');
+    });
+
+    test('should display the membership first name and last name in the modal', (assert) => {
+      // then
+      assert.contains(memberMembership.user.firstName);
+      assert.contains(memberMembership.user.lastName);
+    });
+
+    test('should close the modal by clicking on cancel button', async (assert) => {
+      // when
+      await clickByLabel('Annuler');
+
+      // then
+      assert.notContains('Supprimer de l\'équipe');
+    });
+
+    test('should call removeMembership and close modal by clicking on remove button', async (assert) => {
+      // when
+      await click('button[data-test-modal-remove-button]');
+
+      // then
+      sinon.assert.calledWith(removeMembershipStub, memberMembership);
+      assert.notContains('Supprimer de l\'équipe');
+    });
+  });
 });

--- a/orga/tests/integration/components/routes/authenticated/team/items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/items-test.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 
 module('Integration | Component | routes/authenticated/team | list-items | items', function(hooks) {
 
@@ -36,7 +37,7 @@ module('Integration | Component | routes/authenticated/team | list-items | items
     };
   });
 
-  test('For an admin, it should display an administrator firstName, lastName, role and edit button', async function(assert) {
+  test('it should display an administrator firstName, lastName, role and edit button', async function(assert) {
     // given
     this.set('membership', adminMembership);
 
@@ -47,21 +48,7 @@ module('Integration | Component | routes/authenticated/team | list-items | items
     assert.contains('La Terreur');
     assert.contains('Gigi');
     assert.contains('Administrateur');
-    assert.contains('Modifier le rôle');
-  });
-
-  test('For a member, it should display a firstName, lastName, role and edit button', async function(assert) {
-    // given
-    this.set('membership', memberMembership);
-
-    // when
-    await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}}/>`);
-
-    // then
-    assert.contains('La Panique');
-    assert.contains('Jojo');
-    assert.contains('Membre');
-    assert.contains('Modifier le rôle');
+    assert.dom('button[aria-label="Afficher les actions"]').exists;
   });
 
   module('When edit organization role button is clicked', function() {
@@ -73,7 +60,8 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}}/>`);
 
       // when
-      await click('#edit-organization-role');
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Modifier le rôle');
 
       // then
       assert.dom('.zone-save-cancel-role').exists({ count: 1 });
@@ -87,7 +75,8 @@ module('Integration | Component | routes/authenticated/team | list-items | items
 
       await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}}/>`);
 
-      await click('#edit-organization-role');
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Modifier le rôle');
 
       // when
       await click('#cancel-update-organization-role');
@@ -102,7 +91,8 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       this.set('membership', memberMembership);
 
       await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}}/>`);
-      await click('#edit-organization-role');
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Modifier le rôle');
 
       // when
       await fillIn('select', 'ADMIN');
@@ -118,7 +108,8 @@ module('Integration | Component | routes/authenticated/team | list-items | items
       this.set('membership', adminMembership);
 
       await render(hbs`<Routes::Authenticated::Team::Items @membership={{membership}}/>`);
-      await click('#edit-organization-role');
+      await clickByLabel('Afficher les actions');
+      await clickByLabel('Modifier le rôle');
 
       // when
       await fillIn('select', 'MEMBER');

--- a/orga/tests/unit/adapters/membership-test.js
+++ b/orga/tests/unit/adapters/membership-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
 
 module('Unit | Adapter | membership', function(hooks) {
   setupTest(hooks);
@@ -8,6 +9,11 @@ module('Unit | Adapter | membership', function(hooks) {
 
   hooks.beforeEach(function() {
     adapter = this.owner.lookup('adapter:membership');
+    sinon.stub(adapter, 'ajax').resolves();
+  });
+
+  hooks.afterEach(function() {
+    adapter.ajax.restore();
   });
 
   module('#urlForQuery', () => {
@@ -21,4 +27,19 @@ module('Unit | Adapter | membership', function(hooks) {
     });
   });
 
+  module('#updateRecord', function() {
+
+    module('when disabled adapter option is provided', function() {
+
+      test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
+        // when
+        const data = Symbol('membership');
+        await adapter.updateRecord({}, { modelName: 'membership' }, { id: 1, adapterOptions: { disable: true }, serialize: sinon.stub().returns(data) });
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, 'http://localhost:3000/api/memberships/1/disable', 'POST', { data });
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
 });

--- a/orga/tests/unit/controllers/authenticated/team/list/members-test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members-test.js
@@ -1,0 +1,63 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Controller | authenticated/team/list/members', function(hooks) {
+  setupTest(hooks);
+  const currentUser = { organization: { id: 1 } };
+  let controller;
+
+  hooks.beforeEach(function() {
+    controller = this.owner.lookup('controller:authenticated/team/list/members');
+    controller.send = sinon.stub();
+    controller.currentUser = currentUser;
+  });
+
+  module('#removeMembership', () => {
+
+    test('should set current organization to the membership ', async (assert) => {
+      // given
+      const saveStub = sinon.stub();
+      const membership = {
+        save: saveStub,
+      };
+
+      // when
+      await controller.removeMembership(membership);
+
+      // then
+      assert.equal(membership.organization, currentUser.organization);
+    });
+
+    test('should call disable membership endpoint', async (assert) => {
+      // given
+      const saveStub = sinon.stub();
+      const membership = {
+        save: saveStub,
+      };
+      const expectedAdapterOptions = { adapterOptions: { disable: true } };
+
+      // when
+      await controller.removeMembership(membership);
+
+      // then
+      sinon.assert.calledWith(saveStub, expectedAdapterOptions);
+      assert.ok(true);
+    });
+
+    test('should call route\'s refreshModel action', async (assert) => {
+      // given
+      const saveStub = sinon.stub();
+      const membership = {
+        save: saveStub,
+      };
+
+      // when
+      await controller.removeMembership(membership);
+
+      // then
+      sinon.assert.calledWith(controller.send, 'refreshModel');
+      assert.ok(true);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Il est impossible aujourd'hui, pour un utilisateur de Pix Orga ayant le rôle Admin, de supprimer l'un des membres d'une organisation. Le seul recours possible est de contacter le support Pix.

## :robot: Solution
Ajouter la fonctionnalité de suppression d'un membre d'une organisation.

## :rainbow: Remarques
La fonctionnalité était déjà présente depuis Pix Admin, il a donc fallu faire évoluer les autorisations d'accès à la route existante. Pour cela, l'envoi du membre afin de récupérer l'organisation à laquelle il appartient était nécessaire.

Textes et design revus par Manu.

## :100: Pour tester
- Se connecter à Pix Orga et accéder à la page équipe.
- Le bouton de suppression se trouve dans le menu situé à droite, dans chaque ligne du tableau.