### PR TITLE
[BUGFIX] Les Résultats Thématiques sont illisibles sous IE (PIX-2303).

### DIFF
--- a/mon-pix/app/styles/components/_badge-acquired-card.scss
+++ b/mon-pix/app/styles/components/_badge-acquired-card.scss
@@ -1,20 +1,12 @@
 .badge-acquired-container {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
-  grid-column-gap: 32px;
-  grid-row-gap: 24px;
-  padding: 0 14px 48px;
-
-  @include device-is('tablet') {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto;
-    grid-gap: 32px;
-    padding: 0 0 48px;
-  }
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
 }
 
 .badge-acquired-card {
+  flex: 1 1 90%;
+  margin: 10px;
   display: flex;
   flex-direction: row;
   box-shadow: $box-shadow-competence-cards;
@@ -22,12 +14,27 @@
   justify-content: space-between;
   border-radius: 10px;
   overflow: hidden;
+  word-break: break-word;
+
+  @include device-is('desktop') {
+    flex: 1 1 40%;
+    min-width: 420px;
+    max-width: 420px;
+    min-height: 200px;
+  }
 
   &__text {
     display: flex;
     flex-direction: column;
     padding: 24px;
     padding-right: 16px;
+    max-width: 70%;
+
+    @include device-is('desktop') {
+      flex: 1 1 40%;
+      min-width: 300px;
+      max-width: 300px;
+    }
   }
 
   &-text {
@@ -45,7 +52,7 @@
       margin-bottom: 0;
       color: $grey-45;
       font-family: $font-roboto;
-      font-size: 0.75rem;
+      font-size: 0.85rem;
       font-weight: $font-normal;
       letter-spacing: 0.0093rem;
       line-height: 1.2rem;


### PR DESCRIPTION
## :unicorn: Problème
Les RT sont illisibles sous IE.
La cause : grid est très mal géré avec IE, difficile de trouver un bon polyfill

## :robot: Solution
Faire du flex ! 

## :rainbow: Remarques
La taille est bloqué pour éviter que le texte s'étale sous IE et déplace tout

## :100: Pour tester
Terminer une campagne avec des RT, les voir sous les différents navigateurs.