### PR TITLE
[BUGFIX] Affichage du burger menu cassé.

### DIFF
--- a/mon-pix/app/templates/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/templates/components/navbar-mobile-header.hbs
@@ -1,4 +1,4 @@
-{{!-- template-lint-disable no-implicit-this no-action no-curly-component-invocation no-invalid-interactive --}}
+{{!-- template-lint-disable no-implicit-this no-action no-curly-component-invocation no-invalid-interactive no-unused-block-params --}}
 <div class="navbar-mobile-header">
   <div class="navbar-mobile-header__container">
     {{#if @burger}}

--- a/mon-pix/app/templates/components/navbar-mobile-header.hbs
+++ b/mon-pix/app/templates/components/navbar-mobile-header.hbs
@@ -11,7 +11,9 @@
           {{/if}}
         </span>
 
-        <NavbarBurgerMenu class="navbar-burger-menu-content"/>
+        {{#@burger.menu as |menu|}}
+          <NavbarBurgerMenu class="navbar-burger-menu-content"/>
+        {{/@burger.menu}}
       {{/if}}
     {{/if}}
 


### PR DESCRIPTION
## :unicorn: Problème
Le burger-menu est cassé, suite à une suppression de ligne pour le linter

## :robot: Solution
Remettre comme avant

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
