### PR TITLE
[TECH] Utiliser les couleurs de pix-ui dans mon-pix (PIX-2307).

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -6,6 +6,7 @@
 @import 'ember-burger-menu/animations/push';
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";
+@import 'colors';
 
 /* globals */
 @import 'globals/a11y';

--- a/mon-pix/app/styles/components/_assessment-banner.scss
+++ b/mon-pix/app/styles/components/_assessment-banner.scss
@@ -51,10 +51,10 @@
   font-weight: $font-medium;
   margin-left: auto;
   text-align: right;
-  color: $white;
+  color: $grey-0;
   width: 100px;
 
   &:hover {
-    color: rgb($white, 0.8);
+    color: rgb($grey-0, 0.8);
   }
 }

--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -3,7 +3,7 @@
   min-height: 270px;
   background: $pix-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-  color: $white;
+  color: $grey-0;
 }
 
 .background-banner-wrapper {

--- a/mon-pix/app/styles/components/_background-banner.scss
+++ b/mon-pix/app/styles/components/_background-banner.scss
@@ -1,7 +1,7 @@
 .background-banner {
   width: 100%;
   min-height: 270px;
-  background: $default-gradient;
+  background: $pix-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   color: $white;
 }

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -6,7 +6,7 @@
     align-items: flex-start;
     width: 100%;
     height: 270px;
-    background: $green-gradient;
+    background: $pix-green-gradient;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
     color: $white;
   }

--- a/mon-pix/app/styles/components/_certification-banner.scss
+++ b/mon-pix/app/styles/components/_certification-banner.scss
@@ -8,14 +8,14 @@
     height: 270px;
     background: $pix-green-gradient;
     box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-    color: $white;
+    color: $grey-0;
   }
 }
 
 .certification-number {
   margin-left: auto;
   text-align: right;
-  color: $white;
+  color: $grey-0;
   width: 150px;
 
   &__label {

--- a/mon-pix/app/styles/components/_certification-result.scss
+++ b/mon-pix/app/styles/components/_certification-result.scss
@@ -7,7 +7,7 @@
   width: 100%;
   margin: -150px auto;
   line-height: 1.875rem;
-  background-color: $white;
+  background-color: $grey-0;
   padding-top: 10px;
 
   @include device-is('tablet') {
@@ -72,7 +72,7 @@
   display: block;
   font-size: 1rem;
   text-align: center;
-  color: $white;
+  color: $grey-0;
   padding: 6px 15px;
   background: $blue;
   border-radius: 5px;
@@ -83,7 +83,7 @@
   cursor: pointer;
 
   &:hover {
-    color: $white;
+    color: $grey-0;
     text-decoration: none;
   }
 
@@ -99,5 +99,5 @@
 
 .result-content__logout-button,
 .result-content__logout-button:hover {
-  color: $white;
+  color: $grey-0;
 }

--- a/mon-pix/app/styles/components/_challenge-actions.scss
+++ b/mon-pix/app/styles/components/_challenge-actions.scss
@@ -85,7 +85,7 @@
   height: 46px;
   border-radius: 23px;
   background-color: $green;
-  color: $white;
+  color: $grey-0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -165,7 +165,7 @@
   border-radius: 23px;
   background-color: $blue;
   font-family: $font-roboto;
-  color: $white;
+  color: $grey-0;
 
   @include button-background-transition();
 

--- a/mon-pix/app/styles/components/_challenge-statement.scss
+++ b/mon-pix/app/styles/components/_challenge-statement.scss
@@ -88,7 +88,7 @@
   padding: 15px;
   width: 430px;
   height: auto;
-  background-color: $white;
+  background-color: $grey-0;
   box-shadow: 1px 1px 1px 0 rgba(0, 0, 0, 0.1);
   border: solid 1px $grey-20;
   position: absolute;
@@ -174,14 +174,14 @@
   height: 46px;
   border-radius: 23px;
   background-color: $blue;
-  color: $white;
+  color: $grey-0;
   cursor: pointer;
   text-align: center;
 }
 
 .challenge-statement__action-link:hover,
 .challenge-statement__action-link:focus {
-  color: $white;
+  color: $grey-0;
 }
 
 .challenge-statement__action-help {

--- a/mon-pix/app/styles/components/_checkpoint.scss
+++ b/mon-pix/app/styles/components/_checkpoint.scss
@@ -42,7 +42,7 @@
 .checkpoint-caption {
   font-size: 0.813rem;
   font-weight: $font-light;
-  color: $white;
+  color: $grey-0;
   margin: 6px 0;
   letter-spacing: 0.4px;
   text-transform: uppercase;

--- a/mon-pix/app/styles/components/_communication-banner.scss
+++ b/mon-pix/app/styles/components/_communication-banner.scss
@@ -1,6 +1,6 @@
 .communication-banner {
   text-align: center;
-  color: $white;
+  color: $grey-0;
   height: 56px;
   font-family: $font-open-sans;
   font-weight: 400;
@@ -21,7 +21,7 @@
   }
 
   a {
-    color: $white;
+    color: $grey-0;
     text-decoration: underline;
   }
 

--- a/mon-pix/app/styles/components/_comparison-window.scss
+++ b/mon-pix/app/styles/components/_comparison-window.scss
@@ -52,7 +52,7 @@
   font-size: 0.875rem;
   border: none;
   background-color: transparent;
-  color: $white;
+  color: $grey-0;
 }
 
 /* Modal Header */

--- a/mon-pix/app/styles/components/_competence-card-default.scss
+++ b/mon-pix/app/styles/components/_competence-card-default.scss
@@ -91,7 +91,7 @@
   }
 
   .competence-card__link:hover {
-    border: 12px solid rgba($white, 0.4);
+    border: 12px solid rgba($grey-0, 0.4);
   }
 
   .competence-card__link:hover .competence-card__score-details {
@@ -159,11 +159,11 @@
   }
 
   .competence-card__score-label--congrats {
-    color: $white;
+    color: $grey-0;
   }
 
   .competence-card__score-value--congrats {
-    color: $white;
+    color: $grey-0;
     font-size: 2.813rem;
     font-weight: $font-bold;
   }

--- a/mon-pix/app/styles/components/_competence-card-mobile.scss
+++ b/mon-pix/app/styles/components/_competence-card-mobile.scss
@@ -17,14 +17,14 @@
 
   & a {
     text-decoration: none;
-    color: $white;
+    color: $grey-0;
   }
 }
 
 .competence-card__title {
   display: flex;
   flex-direction: column;
-  color: $white;
+  color: $grey-0;
   height: 100%;
   position: relative;
   transition: height 0.2s cubic-bezier(0.265, 0.075, 0.025, 0.99);
@@ -89,7 +89,7 @@
   justify-content: center;
   align-items: center;
   margin: 10px;
-  border: 0 solid rgba($white, 0.4);
+  border: 0 solid rgba($grey-0, 0.4);
   transition: border 0.1s ease-in;
   z-index: 1;
   height: 80px;
@@ -106,9 +106,9 @@
   display: flex;
   align-items: center;
   padding: 5px;
-  background-color: $white;
+  background-color: $grey-0;
   background-clip: padding-box;
-  border: 0 solid rgba($white, 0.4);
+  border: 0 solid rgba($grey-0, 0.4);
   border-radius: 50%;
   transition: border 0.1s ease-in;
   z-index: 1;
@@ -125,7 +125,7 @@
   font-size: 2.188rem;
 
   &--congrats {
-    color: $white;
+    color: $grey-0;
     font-weight: $font-bold;
   }
 }
@@ -147,5 +147,5 @@
 }
 
 .competence-card__score-label--congrats {
-  color: $white;
+  color: $grey-0;
 }

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -1,6 +1,6 @@
 .congratulations-banner {
   text-rendering: optimizeLegibility;
-  background: $green-gradient;
+  background: $pix-green-gradient;
   position: relative;
   color: $grey-10;
   border-radius: 6px;

--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -13,7 +13,7 @@
 }
 
 .congratulations-banner__icon {
-  color: $white;
+  color: $grey-0;
   position: absolute;
   top: 12px;
   right: 12px;

--- a/mon-pix/app/styles/components/_feedback-panel.scss
+++ b/mon-pix/app/styles/components/_feedback-panel.scss
@@ -62,7 +62,7 @@
 .feedback-panel__field {
   width: 100%;
   border-radius: 3px;
-  background-color: $white;
+  background-color: $grey-0;
   border: solid 1px $grey-20;
   box-sizing: border-box;
   padding: 8px;
@@ -91,7 +91,7 @@
   margin-top: 20px;
   font-weight: bold;
   word-break: break-word;
-  background-color: $white;
+  background-color: $grey-0;
   padding: 20px;
   border: dashed $grey-70;
 

--- a/mon-pix/app/styles/components/_form-textfield.scss
+++ b/mon-pix/app/styles/components/_form-textfield.scss
@@ -37,7 +37,7 @@
   border-radius: 3px;
   align-items: center;
   border: 2px solid $grey-20;
-  background-color: $white;
+  background-color: $grey-0;
   width: 100%;
 
   &:hover {

--- a/mon-pix/app/styles/components/_hexagon-score.scss
+++ b/mon-pix/app/styles/components/_hexagon-score.scss
@@ -63,7 +63,7 @@
 
 .hexagon-score__information {
   position: absolute;
-  background-color: $white;
+  background-color: $grey-0;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.2);
   border-radius: 3px;
   z-index: 300;

--- a/mon-pix/app/styles/components/_navbar-burger-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-burger-menu.scss
@@ -24,13 +24,13 @@
   &__item {
     margin: 5px 0;
     padding: 6px 32px;
-    color: $white;
+    color: $grey-0;
     font-size: 1rem;
     font-family: $font-open-sans;
 
     &.active,
     &:hover {
-      color: $white;
+      color: $grey-0;
       text-decoration: none;
     }
   }
@@ -61,7 +61,7 @@
     margin: 10px 0;
 
     &:hover {
-      color: $white;
+      color: $grey-0;
       text-decoration: underline;
     }
   }

--- a/mon-pix/app/styles/components/_navbar-desktop-menu.scss
+++ b/mon-pix/app/styles/components/_navbar-desktop-menu.scss
@@ -68,7 +68,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $white;
+    color: $grey-0;
     text-decoration: none;
     background-color: $blue;
   }
@@ -81,7 +81,7 @@
   &:hover,
   &:focus,
   &:active {
-    color: $white;
+    color: $grey-0;
     background-color: $blue;
   }
 }

--- a/mon-pix/app/styles/components/_navbar-header.scss
+++ b/mon-pix/app/styles/components/_navbar-header.scss
@@ -1,6 +1,6 @@
 .navbar-header {
   float: none;
   width: 100%;
-  background-color: $white;
+  background-color: $grey-0;
   color: $grey-50;
 }

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -41,7 +41,7 @@
   }
 
   &--blue-gradient-background {
-    background-image: $default-gradient;
+    background-image: $pix-gradient;
     background-color: rgb(5, 108, 255);
   }
 

--- a/mon-pix/app/styles/components/_new-information.scss
+++ b/mon-pix/app/styles/components/_new-information.scss
@@ -46,7 +46,7 @@
   }
 
   &--white-text {
-    color: $white;
+    color: $grey-0;
   }
 
   &--black-text {
@@ -134,7 +134,7 @@
 
       &:focus span,
       &:hover span {
-        border-bottom: 1px solid $white;
+        border-bottom: 1px solid $grey-0;
       }
     }
   }

--- a/mon-pix/app/styles/components/_progress-bar.scss
+++ b/mon-pix/app/styles/components/_progress-bar.scss
@@ -18,7 +18,7 @@
 
   &.active {
     opacity: 1;
-    color: $white;
+    color: $grey-0;
   }
 }
 
@@ -54,7 +54,7 @@
 
 .assessment-progress {
   text-align: right;
-  color: $white;
+  color: $grey-0;
   margin-bottom: 10px;
 
   &__label {

--- a/mon-pix/app/styles/components/_progression-gauge.scss
+++ b/mon-pix/app/styles/components/_progression-gauge.scss
@@ -10,19 +10,19 @@
     background-color: lighten($blue, 15%);
 
     & .progression-gauge__marker {
-      background: $white;
+      background: $grey-0;
     }
 
     & .progression-gauge__tooltip {
-      background: $white;
+      background: $grey-0;
       color: $blue;
       font-family: $font-open-sans;
       font-weight: $font-bold;
       padding: 0;
 
       &::before {
-        color: $white;
-        border-top-color: $white;
+        color: $grey-0;
+        border-top-color: $grey-0;
         margin-top: 18px;
       }
     }
@@ -67,7 +67,7 @@
 .progression-gauge__tooltip {
   position: absolute;
   background: linear-gradient(180deg, $warning 0%, $information-light 100%);
-  color: $white;
+  color: $grey-0;
   border-radius: 5px;
   font-family: $font-roboto;
   font-size: 0.813rem;

--- a/mon-pix/app/styles/components/_qroc-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qroc-solution-panel.scss
@@ -6,7 +6,7 @@
   height: 26px;
   line-height: 1.5rem;
   border-radius: 3px;
-  background-color: $white;
+  background-color: $grey-0;
   box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
   border: solid 1px $grey-20;
   padding: 0 10px;

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -10,7 +10,7 @@
   &__answer {
     line-height: 1.625rem;
     border-radius: 3px;
-    background-color: $white;
+    background-color: $grey-0;
     box-shadow: inset 0 1px 3px 0 rgba(0, 0, 0, 0.15);
     border: solid 1px $grey-20;
     padding: 0 10px;

--- a/mon-pix/app/styles/components/_reached-stage.scss
+++ b/mon-pix/app/styles/components/_reached-stage.scss
@@ -1,7 +1,7 @@
 .reached-stage {
   display: flex;
   flex-direction: column;
-  background: $white;
+  background: $grey-0;
   border: 1px solid rgb(231, 231, 231);
   border-radius: 16px;
   margin: 0 auto;

--- a/mon-pix/app/styles/components/_result-item.scss
+++ b/mon-pix/app/styles/components/_result-item.scss
@@ -8,7 +8,7 @@
   border: none;
   outline: none;
   padding: 8px 0;
-  background-color: $white;
+  background-color: $grey-0;
 
   &:nth-child(odd) {
     background: $grey-10;

--- a/mon-pix/app/styles/components/_rounded-panel.scss
+++ b/mon-pix/app/styles/components/_rounded-panel.scss
@@ -1,5 +1,5 @@
 .rounded-panel {
-  background-color: $white;
+  background-color: $grey-0;
   border-radius: 5px;
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.05);
   margin-bottom: 30px;

--- a/mon-pix/app/styles/components/_timed-challenge-instructions.scss
+++ b/mon-pix/app/styles/components/_timed-challenge-instructions.scss
@@ -79,7 +79,7 @@
     margin-top: 22px;
     border: none;
     background-color: $green-hover;
-    color: $white;
+    color: $grey-0;
     text-transform: uppercase;
     font-size: 0.875rem;
     cursor: pointer;

--- a/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
@@ -3,7 +3,7 @@
   min-height: 270px;
   background: $pix-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
-  color: $white;
+  color: $grey-0;
   position: absolute;
   top: 0;
   left: 0;

--- a/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
+++ b/mon-pix/app/styles/components/_user-certifications-detail-banner.scss
@@ -1,7 +1,7 @@
 .certification-background-banner {
   width: 100%;
   min-height: 270px;
-  background: $default-gradient;
+  background: $pix-gradient;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.1);
   color: $white;
   position: absolute;

--- a/mon-pix/app/styles/components/_user-logged-menu.scss
+++ b/mon-pix/app/styles/components/_user-logged-menu.scss
@@ -63,7 +63,7 @@
   right: 0;
   top: 80px;
   z-index: 999;
-  background-color: $white;
+  background-color: $grey-0;
   max-width: 380px;
   min-width: 240px;
   border-radius: 4px;

--- a/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
+++ b/mon-pix/app/styles/components/campaign-participation-overview/_card.scss
@@ -1,6 +1,6 @@
 .campaign-participation-overview-card {
   height: 273px;
-  background: $white;
+  background: $grey-0;
   box-shadow: 0 2px 0 0 rgba(23, 43, 77, 0.06);
   border-radius: 8px;
   display: flex;

--- a/mon-pix/app/styles/components/dashboard/_content.scss
+++ b/mon-pix/app/styles/components/dashboard/_content.scss
@@ -137,7 +137,7 @@
 
   &__wrapper {
     display: flex;
-    background-color: $white;
+    background-color: $grey-0;
     border-radius: 10px;
     padding: 19px 0;
     box-shadow: 0 1px 0 0 rgba(23, 43, 77, 0.12);

--- a/mon-pix/app/styles/globals/_alert.scss
+++ b/mon-pix/app/styles/globals/_alert.scss
@@ -3,7 +3,7 @@
   border-radius: 0.195em;
   padding: 9px;
   margin-bottom: 11px;
-  color: $white;
+  color: $grey-0;
   text-shadow: none;
   font-size: 0.875rem;
 }

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -6,7 +6,7 @@
   text-align: center;
   border-radius: 5px;
   background-color: $blue;
-  color: $white;
+  color: $grey-0;
   cursor: pointer;
   border: none;
   outline: none;
@@ -25,7 +25,7 @@
     &:hover,
     &:active,
     &:focus {
-      color: $white;
+      color: $grey-0;
       text-decoration: none;
     }
   }
@@ -88,7 +88,7 @@
 
   &--red {
     background: $dark-error;
-    color: $white;
+    color: $grey-0;
 
     &:hover,
     &:active,
@@ -114,7 +114,7 @@
 
   &--dark-grey {
     background-color: $grey-60;
-    color: $white;
+    color: $grey-0;
     font-weight: $font-bold;
     font-size: 0.938rem;
 
@@ -126,7 +126,7 @@
   }
 
   &--white {
-    background-color: $white;
+    background-color: $grey-0;
     color: $grey-200;
 
     &:hover,
@@ -144,7 +144,7 @@
     &:active,
     &:focus {
       background-color: $blue;
-      color: $white;
+      color: $grey-0;
     }
   }
 

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -1,8 +1,3 @@
-// See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
-
-// primary
-$white: #FFFFFF;
-
 // secondary
 $pure-orange: #F45C00;
 $pole-emploi:#1B2E57;

--- a/mon-pix/app/styles/globals/_colors.scss
+++ b/mon-pix/app/styles/globals/_colors.scss
@@ -1,74 +1,21 @@
 // See https://zeroheight.com/8dd127da7/p/839645-couleurs/b/21317a
 
 // primary
-$blue: #3D68FF;
-$blue-zodiac: #505F79;
 $white: #FFFFFF;
 
 // secondary
-$blue-hover: darken($blue, 4%);
-$dark-blue-pro: #1A38A0;
-$green-certif: #1A8C89;
-$dark-orga: #0095C0;
-$orga: #00DDFF;
-$green: #038A25;
-$green-hover: darken($green, 4%);
-$red: #D63F00;
-$red-hover: darken($red, 4%);
-$yellow: #FFBE00;
-$yellow-hover: darken($yellow, 8%);
-$light-blue: #388AFF;
 $pure-orange: #F45C00;
 $pole-emploi:#1B2E57;
-$purple: #8845FF;
+
+// hover
+$blue-hover: darken($blue, 4%);
+$green-hover: darken($green, 4%);
 
 // gradients
-$default-gradient: linear-gradient(135deg, $blue 0%, $purple 100%);
-$green-gradient: linear-gradient(0deg, #52D987 0%, #1A8C89 100%);
-$pix-orga-old-gradient: linear-gradient(0deg, #0D7DC4 0%, #213371 100%);
 $yellow-gradient: linear-gradient(180deg, #FEDC41 0%, #F45C00 100%);
 
-// light
-$grey-5: #FAFBFC;
-$grey-10: #F4F5F7;
-$grey-15: #EAECF0;
-$grey-20: #DFE1E6;
-$grey-22: #C1C7D0;
-$grey-25: #A5ADBA;
-
-// medium
-$grey-30: #97A0AF;
-$grey-35: #8993A4;
-$grey-40: #7A869A;
-$grey-45: #6B778C;
-$grey-50: #5E6C84;
-$grey-60: #505F79;
-
-// dark
-$grey-70: #344563;
-$grey-80: #253858;
-$grey-90: #172B4D;
-$grey-100: #091E42;
-$grey-200: #07142E;
-
-// solids
-$environment-dark: #5E2563;
-$environment-light: #564DA6;
-$communication-dark: #3D68FF;
-$communication-light: #12A3FF;
-$content-dark: #1A8C89;
-$content-light: #52D987;
-$information-dark: #F24645;
-$information-light: #F1A141;
-$security-dark: #AC008D;
-$security-light: #FF3F94;
-
 // status
-$error: #FF4B00;
-$light-red: lighten($error, 8%);
 $dark-error: darken($error, 8%);
-$success: #57C884;
-$warning: #FFBE00;
 
 // box shadows
 $box-shadow-competence-cards: 0 3px 4px 0 rgba(12, 22, 58, 0.1), 0 1px 3px 0 rgba($grey-200, 0.1);

--- a/mon-pix/app/styles/globals/_pix-modal.scss
+++ b/mon-pix/app/styles/globals/_pix-modal.scss
@@ -23,7 +23,7 @@ $pix-modal-border-radius: 5px;
     }
 
     .pix-modal__close-link {
-      color: $white;
+      color: $grey-0;
       background: transparent;
       border: none;
       text-align: right;
@@ -59,7 +59,7 @@ $pix-modal-border-radius: 5px;
       margin: auto;
 
       &--white {
-        background-color: $white;
+        background-color: $grey-0;
       }
 
       &--with-padding {
@@ -69,7 +69,7 @@ $pix-modal-border-radius: 5px;
       }
 
       .pix-modal-header {
-        background: $white;
+        background: $grey-0;
         border-top-left-radius: $pix-modal-border-radius;
         border-top-right-radius: $pix-modal-border-radius;
 
@@ -136,7 +136,7 @@ $pix-modal-border-radius: 5px;
 .pix-modal__input {
   padding: 15px;
   border-radius: $pix-modal-border-radius;
-  background-color: $white;
+  background-color: $grey-0;
   border: 2px solid $grey-20;
   color: $grey-50;
   letter-spacing: 0.125rem;

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -71,7 +71,7 @@ input[type=checkbox]::before {
   border: 2px solid $grey-40;
   content: ' ';
   display: block;
-  background-color: $white;
+  background-color: $grey-0;
   border-radius: 10%;
   box-sizing: border-box;
 }
@@ -87,7 +87,7 @@ input[type=checkbox]:checked::after {
   position: relative;
   top: -21px;
   font-size: 0.875rem;
-  color: $white;
+  color: $grey-0;
   font-weight: $font-bold;
   content: '✓';
   display: block;
@@ -130,7 +130,7 @@ input[type=radio]::before {
   left: -5px;
   border: solid 2px $grey-30;
   border-radius: 10px;
-  background-color: $white;
+  background-color: $grey-0;
 }
 
 input[type=radio]:checked::after {

--- a/mon-pix/app/styles/pages/_assessment-results.scss
+++ b/mon-pix/app/styles/pages/_assessment-results.scss
@@ -13,7 +13,7 @@
   width: 100%;
   padding: 20px;
   padding-left: 12%;
-  background-color: $white;
+  background-color: $grey-0;
 }
 
 .assessment-results__scoring {
@@ -25,7 +25,7 @@
   width: 100%;
   padding: 30px;
   margin-top: -175px;
-  background: $white;
+  background: $grey-0;
   border-radius: 10px;
   box-shadow: 0 7px 14px 0 rgba(12, 22, 58, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.1);
 }
@@ -86,5 +86,5 @@
   font-weight: $font-semi-bold;
   text-align: center;
   font-family: $font-open-sans;
-  color: $white;
+  color: $grey-0;
 }

--- a/mon-pix/app/styles/pages/_competence-results.scss
+++ b/mon-pix/app/styles/pages/_competence-results.scss
@@ -10,7 +10,7 @@
 
     &-result-comment {
       margin: 0;
-      color: $white;
+      color: $grey-0;
       font-size: 3rem;
       font-family: $font-open-sans;
       font-weight: $font-bold;
@@ -89,7 +89,7 @@
   }
 
   &__subtitle {
-    color: $white;
+    color: $grey-0;
     font-family: $font-open-sans;
     font-size: 1.125rem;
     margin-top: 14px;
@@ -158,13 +158,13 @@
 .competence-results-banner-text-results {
 
   &__label {
-    color: $white;
+    color: $grey-0;
     font-family: $font-open-sans;
     font-size: 0.875rem;
   }
 
   &__value {
-    color: $white;
+    color: $grey-0;
     font-family: $font-open-sans;
     font-size: 1.5rem;
     padding: 0 10px;

--- a/mon-pix/app/styles/pages/_join-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_join-restricted-campaign.scss
@@ -120,7 +120,7 @@
     display: flex;
     justify-content: space-between;
     height: 78px;
-    background-color: $white;
+    background-color: $grey-0;
     padding: 20px;
   }
 

--- a/mon-pix/app/styles/pages/_login-or-register-to-access-restricted-campaign.scss
+++ b/mon-pix/app/styles/pages/_login-or-register-to-access-restricted-campaign.scss
@@ -1,5 +1,5 @@
 .login-or-register-to-access-restricted-campaign {
-  background: $default-gradient;
+  background: $pix-gradient;
   display: flex;
   justify-content: center;
   min-height: 100vh;

--- a/mon-pix/app/styles/pages/_not-connected.scss
+++ b/mon-pix/app/styles/pages/_not-connected.scss
@@ -1,5 +1,5 @@
 .not-connected {
-  background: $default-gradient;
+  background: $pix-gradient;
   height: 100vh;
   padding-top: 5%;
 

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -23,7 +23,7 @@
     width: 95%;
     max-width: 609px;
     border-radius: 10px;
-    background-color: $white;
+    background-color: $grey-0;
     margin: 0 auto;
     padding: 20px 10px;
 
@@ -51,7 +51,7 @@
   &__notification-message {
     width: 100%;
     text-align: center;
-    color: $white;
+    color: $grey-0;
     font-size: 1rem;
     font-weight: 400;
     line-height: 1.625rem;
@@ -169,7 +169,7 @@
     border: 2px solid $pole-emploi;
     text-decoration: none;
     background-color: $pole-emploi;
-    color: $white;
+    color: $grey-0;
     padding: 7px 10px 7px 13px;
     font-size: 14px;
     font-weight: bold;

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -1,7 +1,7 @@
 .sign-form-page {
   display: flex;
   justify-content: center;
-  background: $default-gradient;
+  background: $pix-gradient;
   background-size: cover;
   width: 100%;
   height: 100%;

--- a/mon-pix/app/styles/pages/_terms-of-service.scss
+++ b/mon-pix/app/styles/pages/_terms-of-service.scss
@@ -3,7 +3,7 @@
   width: 100%;
   height: 100px;
   min-height: 100vh;
-  background: $default-gradient;
+  background: $pix-gradient;
   align-items: center;
 }
 

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -1,7 +1,7 @@
 .update-expired-password-form-page {
   display: flex;
   justify-content: center;
-  background: $default-gradient;
+  background: $pix-gradient;
   background-size: cover;
   width: 100%;
   height: 100%;

--- a/mon-pix/app/styles/pages/_update-expired-password-form.scss
+++ b/mon-pix/app/styles/pages/_update-expired-password-form.scss
@@ -24,7 +24,7 @@
     max-width: 609px;
     border-radius: 10px;
     padding-top: 10px;
-    background-color: $white;
+    background-color: $grey-0;
     margin: 10px auto;
 
     @include device-is('tablet') {
@@ -61,7 +61,7 @@
     width: 100%;
     text-align: center;
     border-radius: 3px;
-    color: $white;
+    color: $grey-0;
     font-size: 0.875rem;
     padding: 9px;
     margin: 10px 0;

--- a/mon-pix/app/styles/pages/_user-tests.scss
+++ b/mon-pix/app/styles/pages/_user-tests.scss
@@ -40,7 +40,7 @@
     margin: 0 0 8px;
     width: 100%;
     font-size: 3rem;
-    color: $white;
+    color: $grey-0;
   }
 }
 

--- a/mon-pix/app/styles/pages/_user-tutorials.scss
+++ b/mon-pix/app/styles/pages/_user-tutorials.scss
@@ -35,7 +35,7 @@
     margin: 0 0 8px;
     padding-top: 64px;
     font-size: 3rem;
-    color: $white;
+    color: $grey-0;
   }
 
   &__description {

--- a/mon-pix/app/styles/vendor/ember-routable-modal/dialog.scss
+++ b/mon-pix/app/styles/vendor/ember-routable-modal/dialog.scss
@@ -4,7 +4,7 @@
 }
 
 .routable-modal--content {
-  background: $white;
+  background: $grey-0;
 }
 
 .routable-modal--header {

--- a/mon-pix/ember-cli-build.js
+++ b/mon-pix/ember-cli-build.js
@@ -18,6 +18,11 @@ module.exports = function(defaults) {
     autoprefixer: {
       grid: 'autoplace',
     },
+    sassOptions: {
+      includePaths: [
+        'node_modules/pix-ui/addon/styles',
+      ],
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
## :unicorn: Problème
Chaque application front a son propre fichier `colors.scss`.
Le fichier reprend les couleurs du design system en plus de couleurs locales.

## :robot: Solution
Utiliser les couleurs du design-system déclarés dans pix-ui et supprimer les doublons.
Seules les couleurs locales à mon-pix restent dans le `colors.scss`.

## :rainbow: Remarques
- RAF pour cette PR: modifier le package.json pour récupérer la nouvelle version de pix-ui quand https://github.com/1024pix/pix-ui/pull/87 sera mergée et pix-ui déployée
- RAF dans de nouvelles PR: utiliser les couleurs de pix-ui dans les applis certif, orga, admin

## :100: Pour tester
Sur la RA, naviguer et vérifier qu'il n'y a pas de problème de couleur.
