### PR TITLE
[FEATURE] Ne pas montrer de bannière sur la page "Certifications" sur PixOrga (PIX-2296) 

### DIFF
--- a/orga/app/components/information-banner.js
+++ b/orga/app/components/information-banner.js
@@ -3,14 +3,21 @@ import { inject as service } from '@ember/service';
 
 export default class InformationBanner extends Component {
   @service currentUser;
+  @service router;
+
+  get _isOnCertificationsPage() {
+    return this.router.currentRouteName === 'authenticated.certifications';
+  }
+
   get displayNewYearSchoolingRegistrationsImportBanner() {
     return !this.currentUser.prescriber.areNewYearSchoolingRegistrationsImported &&
       this.currentUser.isSCOManagingStudents &&
-      !this.currentUser.isAgriculture;
+      !this.currentUser.isAgriculture &&
+      !this._isOnCertificationsPage;
   }
 
   get displayNewYearCampaignsBanner() {
-    return this.currentUser.isSCOManagingStudents;
+    return this.currentUser.isSCOManagingStudents && !this._isOnCertificationsPage;
   }
 
   get documentationLink() {

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -305,28 +305,34 @@ module('Acceptance | authentication', function(hooks) {
           assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
         });
 
-        module('When feature toggle for exporting certification results is enabled', function() {
+        module('when feature toggle for exporting certification results is enabled', function() {
 
           test('should redirect to certifications page', async function(assert) {
             // given
             server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: true });
 
-            await visit('/');
-
             // when
+            await visit('/');
             await clickByLabel('Certifications');
 
             // then
-            assert.dom('.sidebar-menu').containsText('Campagnes');
             assert.dom('.sidebar-menu').containsText('Certifications');
-            assert.dom('.sidebar-menu').containsText('Équipe');
-            assert.dom('.sidebar-menu').containsText('Élèves');
             assert.dom('.sidebar-menu a:nth-child(2)').hasClass('active');
             assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
-            assert.contains('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.');
-            assert.contains('Exporter les résultats');
-            assert.contains('Certifications');
-            assert.contains('Classe');
+          });
+        });
+
+        module('when feature toggle for exporting certification results is not enabled', function() {
+
+          test('should not show Certifications menu', async function(assert) {
+            // given
+            server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: false });
+
+            // when
+            await visit('/');
+
+            // then
+            assert.notContains('Certifications');
           });
         });
 

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -39,6 +39,15 @@ module('Acceptance | Certifications page', function(hooks) {
         assert.contains('Certifications');
         assert.contains('Classe');
       });
+
+      test('should not show any banner', async function(assert) {
+        // given / when
+        await visit('/certifications');
+
+        // then
+        assert.dom('.information-banner').doesNotExist();
+        assert.dom('.pix-banner').doesNotExist();
+      });
     });
   });
 });

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { createUserManagingStudents, createPrescriberByUser } from '../helpers/test-init';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Acceptance | Certifications page', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async () => {
+    const user = createUserManagingStudents('ADMIN');
+    createPrescriberByUser(user);
+
+    await authenticateSession({
+      user_id: user.id,
+      access_token: 'aaa.' + btoa(`{"user_id":${user.id},"source":"pix","iat":1545321469,"exp":4702193958}`) + '.bbb',
+      expires_in: 3600,
+      token_type: 'Bearer token type',
+    });
+  });
+
+  module('When feature toggle for exporting certification results is enabled', function() {
+    hooks.beforeEach(async () => {
+      server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: true });
+    });
+
+    module('When user arrives on certifications page', function() {
+
+      test('should show Certifications page', async function(assert) {
+        // given / when
+        await visit('/certifications');
+
+        // then
+        assert.contains('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.');
+        assert.contains('Exporter les résultats');
+        assert.contains('Certifications');
+        assert.contains('Classe');
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
## :unicorn: Problème
Le bandeau suivant est visible sur la page “Certifications” dans Pix Orga : 
![image](https://user-images.githubusercontent.com/38167520/110149039-d9305580-7ddd-11eb-9e5f-246a9c5f868f.png)

Ce bandeau n'a pas de lien avec la page "Certifications". Cela peut entrainer des incompréhensions ou frustations pour nos utilisateurs.

## :robot: Solution
Enlever les bandeaux sur la page "certifications".

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
