### PR TITLE
[FEATURE] Traduire en anglais la page Inviter un membre dans Pix Orga (PIX-2220).

### DIFF
--- a/orga/app/components/routes/authenticated/team/new-item.hbs
+++ b/orga/app/components/routes/authenticated/team/new-item.hbs
@@ -1,25 +1,31 @@
 <form {{on 'submit' @createOrganizationInvitation}} class="form">
 
   <div class="form__field">
-    <label for="email" class="label">Adresse(s) e-mail</label>
+    <label for="email" class="label">{{t 'pages.team-new-item.input-label'}}</label>
     <Input
-      @type="email"
       @id="email"
-      @name="email"
-      @class="input"
+      @type="email"
       @value={{@organizationInvitation.email}}
-      @multiple={{true}}
-      @aria-required="true"
-      @required="required"
+      name="email"
+      class="input"
+      multiple={{true}}
+      aria-required="true"
+      required="required"
     />
   </div>
 
   <div class="form__validation">
-    <button type="button" class="button button--no-color" {{on 'click' @cancel}}>Annuler</button>
+    <button type="button" class="button button--no-color" {{on 'click' @cancel}}>
+      {{t 'pages.team-new-item.cancel-button'}}
+    </button>
     {{#if @isLoading}}
-      <button type="button" disabled class="button button--regular"><span class="loader-in-button">&nbsp;</span></button>
+      <button type="button" disabled class="button button--regular">
+        <span class="loader-in-button">&nbsp;</span>
+      </button>
     {{else}}
-      <button type="submit" class="button button--regular">Inviter</button>
+      <button type="submit" class="button button--regular">
+        {{t 'pages.team-new-item.invite-button'}}
+      </button>
     {{/if}}
   </div>
 

--- a/orga/app/routes/authenticated/team/new.js
+++ b/orga/app/routes/authenticated/team/new.js
@@ -14,4 +14,9 @@ export default class NewRoute extends Route {
       organizationInvitation: this.store.createRecord('organizationInvitation', { organizationId: organization.id }),
     });
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    controller.initErrorMessages();
+  }
 }

--- a/orga/app/templates/authenticated/team/new.hbs
+++ b/orga/app/templates/authenticated/team/new.hbs
@@ -1,14 +1,19 @@
 <div class="new-team-page">
 
-  <h1 class="page__title page-title">Inviter un membre</h1>
+  <h1 class="page__title page-title">{{t 'pages.team-new.title'}}</h1>
 
   <p class="paragraph new-team-page__text">
-    Saisissez ici l'adresse e-mail du membre que vous souhaitez inviter.
+    {{t 'pages.team-new.email-requirement'}}
     <br>
-    Vous pouvez inviter plusieurs membres en séparant les adresses e-mails par des virgules.
+    {{t 'pages.team-new.several-email-requirement'}}
     <br><br>
-    À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.
+    {{t 'pages.team-new.invited-members'}}
   </p>
 
-  <Routes::Authenticated::Team::NewItem @organizationInvitation={{@model.organizationInvitation}} @createOrganizationInvitation={{this.createOrganizationInvitation}} @cancel={{this.cancel}} @isLoading={{this.isLoading}} />
+  <Routes::Authenticated::Team::NewItem
+          @organizationInvitation={{@model.organizationInvitation}}
+          @createOrganizationInvitation={{this.createOrganizationInvitation}}
+          @cancel={{this.cancel}}
+          @isLoading={{this.isLoading}}
+  />
 </div>

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -17,6 +17,8 @@ module('Acceptance | Team Creation', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  const email = 'user.to.invite@example.net';
+
   test('it should not be accessible by an unauthenticated prescriber', async function(assert) {
     // when
     await visit('/equipe/creation');
@@ -84,10 +86,13 @@ module('Acceptance | Team Creation', function(hooks) {
 
       test('it should allow to invite a prescriber and redirect to team page', async function(assert) {
         // given
-        const email = 'gigi@labrochette.com';
         const code = 'ABCDEFGH01';
-
-        server.create('user', { firstName: 'Gigi', lastName: 'La Brochette', email, pixOrgaTermsOfServiceAccepted: true });
+        server.create('user', {
+          firstName: 'Gigi',
+          lastName: 'La Brochette',
+          email,
+          pixOrgaTermsOfServiceAccepted: true,
+        });
 
         await visit('/equipe/creation');
         await fillInByLabel('Adresse(s) e-mail', email);
@@ -134,17 +139,14 @@ module('Acceptance | Team Creation', function(hooks) {
       test('it should display error on global form when error 500 is returned from backend', async function(assert) {
         // given
         await visit('/equipe/creation');
-        server.post(`/organizations/${organizationId}/invitations`,
-          {
-            errors: [
-              {
-                detail: '[Object object]',
-                status: '500',
-                title: 'Internal Server Error',
-              },
-            ],
-          }, 500);
-        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
+        server.post(`/organizations/${organizationId}/invitations`, {
+          errors: [{
+            detail: '[Object object]',
+            status: '500',
+            title: 'Internal Server Error',
+          }],
+        }, 500);
+        await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
         await clickByLabel('Inviter');
@@ -152,23 +154,21 @@ module('Acceptance | Team Creation', function(hooks) {
         // then
         assert.equal(currentURL(), '/equipe/creation');
         assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
+        assert.dom('[data-test-notification-message="error"]')
+          .hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
       });
 
       test('it should display error on global form when error 412 is returned from backend', async function(assert) {
         // given
         await visit('/equipe/creation');
-        server.post(`/organizations/${organizationId}/invitations`,
-          {
-            errors: [
-              {
-                detail: '',
-                status: '412',
-                title: 'Precondition Failed',
-              },
-            ],
-          }, 412);
-        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
+        server.post(`/organizations/${organizationId}/invitations`, {
+          errors: [{
+            detail: '',
+            status: '412',
+            title: 'Precondition Failed',
+          }],
+        }, 412);
+        await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
         await clickByLabel('Inviter');
@@ -182,17 +182,14 @@ module('Acceptance | Team Creation', function(hooks) {
       test('it should display error on global form when error 404 is returned from backend', async function(assert) {
         // given
         await visit('/equipe/creation');
-        server.post(`/organizations/${organizationId}/invitations`,
-          {
-            errors: [
-              {
-                detail: '',
-                status: '404',
-                title: 'Not Found',
-              },
-            ],
-          }, 404);
-        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
+        server.post(`/organizations/${organizationId}/invitations`, {
+          errors: [{
+            detail: '',
+            status: '404',
+            title: 'Not Found',
+          }],
+        }, 404);
+        await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
         await clickByLabel('Inviter');
@@ -206,17 +203,14 @@ module('Acceptance | Team Creation', function(hooks) {
       test('it should display error on global form when error 400 is returned from backend', async function(assert) {
         // given
         await visit('/equipe/creation');
-        server.post(`/organizations/${organizationId}/invitations`,
-          {
-            errors: [
-              {
-                detail: '',
-                status: '400',
-                title: 'Bad Request',
-              },
-            ],
-          }, 400);
-        await fillInByLabel('Adresse(s) e-mail', 'fake@email');
+        server.post(`/organizations/${organizationId}/invitations`, {
+          errors: [{
+            detail: '',
+            status: '400',
+            title: 'Bad Request',
+          }],
+        }, 400);
+        await fillInByLabel('Adresse(s) e-mail', email);
 
         // when
         await clickByLabel('Inviter');

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -9,6 +9,7 @@ import {
   createUserMembershipWithRole,
   createPrescriberByUser,
 } from '../helpers/test-init';
+import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
@@ -16,6 +17,7 @@ module('Acceptance | Team Creation', function(hooks) {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  setupIntl(hooks);
 
   const email = 'user.to.invite@example.net';
 
@@ -29,8 +31,8 @@ module('Acceptance | Team Creation', function(hooks) {
 
   module('When prescriber is logged in', function(hooks) {
 
-    let user;
     let organizationId;
+    let user;
 
     hooks.afterEach(function() {
       const notificationMessagesService = this.owner.lookup('service:notifications');
@@ -62,7 +64,11 @@ module('Acceptance | Team Creation', function(hooks) {
 
     module('When prescriber is an admin', function(hooks) {
 
-      hooks.beforeEach(async () => {
+      let inputLabel;
+      let cancelButton;
+      let inviteButton;
+
+      hooks.beforeEach(async function() {
         user = createUserMembershipWithRole('ADMIN');
         createPrescriberByUser(user);
 
@@ -74,6 +80,10 @@ module('Acceptance | Team Creation', function(hooks) {
           expires_in: 3600,
           token_type: 'Bearer token type',
         });
+
+        inputLabel = this.intl.t('pages.team-new-item.input-label');
+        inviteButton = this.intl.t('pages.team-new-item.invite-button');
+        cancelButton = this.intl.t('pages.team-new-item.cancel-button');
       });
 
       test('it should be accessible', async function(assert) {
@@ -95,10 +105,10 @@ module('Acceptance | Team Creation', function(hooks) {
         });
 
         await visit('/equipe/creation');
-        await fillInByLabel('Adresse(s) e-mail', email);
+        await fillInByLabel(inputLabel, email);
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         const organizationInvitation = server.db.organizationInvitations[server.db.organizationInvitations.length - 1];
@@ -112,10 +122,10 @@ module('Acceptance | Team Creation', function(hooks) {
       test('it should not allow to invite a prescriber when an email is not given', async function(assert) {
         // given
         await visit('/equipe/creation');
-        await fillInByLabel('Adresse(s) e-mail', '');
+        await fillInByLabel(inputLabel, '');
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
@@ -123,11 +133,9 @@ module('Acceptance | Team Creation', function(hooks) {
 
       test('should display an empty input field after cancel and before add a team member', async function(assert) {
         // given
-        const email = 'cancel&cancel.com';
-
         await visit('/equipe/creation');
-        await fillInByLabel('Adresse(s) e-mail', email);
-        await clickByLabel('Annuler');
+        await fillInByLabel(inputLabel, email);
+        await clickByLabel(cancelButton);
 
         // when
         await visit('/equipe/creation');
@@ -138,6 +146,8 @@ module('Acceptance | Team Creation', function(hooks) {
 
       test('it should display error on global form when error 500 is returned from backend', async function(assert) {
         // given
+        const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.500');
+
         await visit('/equipe/creation');
         server.post(`/organizations/${organizationId}/invitations`, {
           errors: [{
@@ -146,20 +156,21 @@ module('Acceptance | Team Creation', function(hooks) {
             title: 'Internal Server Error',
           }],
         }, 500);
-        await fillInByLabel('Adresse(s) e-mail', email);
+        await fillInByLabel(inputLabel, email);
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
         assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]')
-          .hasText('Quelque chose s\'est mal passé. Veuillez réessayer.');
+        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 412 is returned from backend', async function(assert) {
         // given
+        const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.412');
+
         await visit('/equipe/creation');
         server.post(`/organizations/${organizationId}/invitations`, {
           errors: [{
@@ -168,19 +179,21 @@ module('Acceptance | Team Creation', function(hooks) {
             title: 'Precondition Failed',
           }],
         }, 412);
-        await fillInByLabel('Adresse(s) e-mail', email);
+        await fillInByLabel(inputLabel, email);
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
         assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText('Ce membre a déjà été ajouté.');
+        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 404 is returned from backend', async function(assert) {
         // given
+        const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.404');
+
         await visit('/equipe/creation');
         server.post(`/organizations/${organizationId}/invitations`, {
           errors: [{
@@ -189,19 +202,21 @@ module('Acceptance | Team Creation', function(hooks) {
             title: 'Not Found',
           }],
         }, 404);
-        await fillInByLabel('Adresse(s) e-mail', email);
+        await fillInByLabel(inputLabel, email);
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
         assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText('Cet email n\'appartient à aucun utilisateur.');
+        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
       });
 
       test('it should display error on global form when error 400 is returned from backend', async function(assert) {
         // given
+        const expectedErrorMessage = this.intl.t('pages.team-new.errors.status.400');
+
         await visit('/equipe/creation');
         server.post(`/organizations/${organizationId}/invitations`, {
           errors: [{
@@ -210,15 +225,15 @@ module('Acceptance | Team Creation', function(hooks) {
             title: 'Bad Request',
           }],
         }, 400);
-        await fillInByLabel('Adresse(s) e-mail', email);
+        await fillInByLabel(inputLabel, email);
 
         // when
-        await clickByLabel('Inviter');
+        await clickByLabel(inviteButton);
 
         // then
         assert.equal(currentURL(), '/equipe/creation');
         assert.dom('[data-test-notification-message="error"]').exists();
-        assert.dom('[data-test-notification-message="error"]').hasText('Le format de l\'adresse e-mail est incorrect.');
+        assert.dom('[data-test-notification-message="error"]').hasText(expectedErrorMessage);
       });
     });
   });

--- a/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
@@ -1,12 +1,17 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
+import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
+import setupIntl from '../../../../../helpers/setup-intl';
+
 module('Integration | Component | routes/authenticated/team/new-item', function(hooks) {
+
   setupRenderingTest(hooks);
+  setupIntl(hooks);
 
   hooks.beforeEach(function() {
     this.set('createOrganizationInvitationSpy', () => {});
@@ -15,7 +20,7 @@ module('Integration | Component | routes/authenticated/team/new-item', function(
 
   test('it should contain email input and validation button', async function(assert) {
     // when
-    await render(hbs`<Routes::Authenticated::Team::NewItem @createOrganizationInvitation={{createOrganizationInvitationSpy}} @cancel={{cancelSpy}}/>`);
+    await render(hbs `<Routes::Authenticated::Team::NewItem @createOrganizationInvitation={{createOrganizationInvitationSpy}} @cancel={{cancelSpy}} />`);
 
     // then
     assert.dom('#email').exists();
@@ -25,11 +30,12 @@ module('Integration | Component | routes/authenticated/team/new-item', function(
 
   test('it should bind organizationInvitation properties with email form input', async function(assert) {
     // given
+    const inputLabel = this.intl.t('pages.team-new-item.input-label');
     this.set('organizationInvitation', EmberObject.create({ organizationInvitation: { email: 'toto@org.fr' } }));
     await render(hbs`<Routes::Authenticated::Team::NewItem @organizationInvitation={{organizationInvitation}} @createOrganizationInvitation={{createOrganizationInvitationSpy}} @cancel={{cancelSpy}}/>`);
 
     // when
-    await fillInByLabel('Adresse(s) e-mail', 'dev@example.net');
+    await fillInByLabel(inputLabel, 'dev@example.net');
 
     // then
     assert.deepEqual(this.organizationInvitation.email, 'dev@example.net');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -329,6 +329,26 @@
         "row-title": "Student"
       },
       "title": "Students"
+    },
+    "team-new": {
+      "title": "Invite a member",
+      "email-requirement": "Enter here the email address of the member you want to invite.",
+      "several-email-requirement": "Invite several members by separating the email addresses with commas.",
+      "invited-members": "By clicking on the link provided in the invitation, the invited members will be able to create an account or log in with an existing Pix account.",
+      "errors": {
+        "default": "The service is temporarily unavailable. Please try again later.",
+        "status" : {
+          "400": "The email address format is invalid.",
+          "412": "This member has already been added.",
+          "404": "This email address doesn't match any Pix user.",
+          "500": "Something went wrong. Please try again."
+        }
+      }
+    },
+    "team-new-item": {
+      "input-label": "Email address(es)",
+      "cancel-button": "Cancel",
+      "invite-button": "Invite"
     }
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -329,6 +329,26 @@
         "row-title": "Étudiant"
       },
       "title": "Étudiants"
+    },
+    "team-new": {
+      "title": "Inviter un membre",
+      "email-requirement": "Saisissez ici l'adresse e-mail du membre que vous souhaitez inviter.",
+      "several-email-requirement": "Vous pouvez inviter plusieurs membres en séparant les adresses e-mails par des virgules.",
+      "invited-members": "À la réception de l'e-mail, les invités pourront choisir de se créer un compte Pix ou de se connecter avec un compte Pix existant.",
+      "errors": {
+        "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
+        "status" : {
+          "400": "Le format de l'adresse e-mail est incorrect.",
+          "412": "Ce membre a déjà été ajouté.",
+          "404": "Cet email n'appartient à aucun utilisateur.",
+          "500": "Quelque chose s'est mal passé. Veuillez réessayer."
+        }
+      }
+    },
+    "team-new-item": {
+      "input-label": "Adresse(s) e-mail",
+      "cancel-button": "Annuler",
+      "invite-button": "Inviter"
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, les textes de la page Inviter un membre sont en français, et implémentés "en dur" dans le code.
On veut ajouter la version anglaise.

## :robot: Solution
* Externaliser dans des fichiers dédiés la version française et anglaise des textes de cette page
* Utiliser l'addon Ember d'internationalisation

## :rainbow: Remarques
* TODO : Forcer ou remplacer la traduction anglaise du champ `input` de type email (cf. [oninvalid](https://stackoverflow.com/questions/10753881/changing-the-language-of-error-message-in-required-field-in-html5-contact-form)).

## :100: Pour tester
* Inviter un membre à rejoindre une organisation, et vérifier que les textes sont bien traduits
  * Se connecter à Pix Orga : `/equipe/creation?lang=fr`
  * Se connecter à Pix Orga : `/equipe/creation?lang=en`
  
* Répéter les mêmes actions, mais en faisant volontairement des erreurs, pour vérifier que les messages d'erreur sont bien traduits.