### PR TITLE
[FEATURE] Rechercher une classe lors du téléchargement des résultats de certif (PIX-2306)

### DIFF
--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -33,7 +33,9 @@ export default class AuthenticatedCertificationsController extends Controller {
       await this.fileSaver.save({ url, token });
     } catch (error) {
       if (_isErrorNotFound(error)) {
-        this.notifications.error('Aucun résultat de certification pour cette classe.');
+        this.notifications.error('Aucun résultat de certification pour cette classe.', {
+          autoClear: false,
+        });
       }
     }
   }

--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -8,8 +8,9 @@ export default class AuthenticatedCertificationsController extends Controller {
   @service session;
   @service currentUser;
   @service notifications;
+  @service intl;
 
-  @tracked selectedDivision = this.model.options[0].value ;
+  @tracked selectedDivision = '';
 
   @action
   onSelectDivision(event) {
@@ -17,11 +18,15 @@ export default class AuthenticatedCertificationsController extends Controller {
   }
 
   @action
-  async downloadSessionResultFile() {
-
-    const organizationId = this.currentUser.organization.id;
+  async downloadSessionResultFile(event) {
+    event.preventDefault();
 
     try {
+      if (_isDivisionInvalid(this.selectedDivision, this.model.options)) {
+        throw new Error(this.intl.t('pages.certifications.errors.invalid-division', { selectedDivision: this.selectedDivision }));
+      }
+
+      const organizationId = this.currentUser.organization.id;
       const url = `/api/organizations/${organizationId}/certification-results?division=${this.selectedDivision}`;
 
       let token = '';
@@ -32,13 +37,31 @@ export default class AuthenticatedCertificationsController extends Controller {
 
       await this.fileSaver.save({ url, token });
     } catch (error) {
+      let errorMessage = error.message;
+
       if (_isErrorNotFound(error)) {
-        this.notifications.error('Aucun résultat de certification pour cette classe.', {
-          autoClear: false,
-        });
+        errorMessage = this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision });
       }
+
+      this.notifications.error(errorMessage, {
+        autoClear: false,
+      });
     }
   }
+
+  get firstTwoDivisions() {
+    if (this.model.options.length < 2) {
+      return '';
+    }
+
+    return `${this.model.options[0].label}, ${this.model.options[1].label} …`;
+  }
+}
+
+function _isDivisionInvalid(selectedDivision, divisions) {
+  return !divisions.some(
+    (division) => division.label.toLowerCase() === selectedDivision.toLowerCase(),
+  );
 }
 
 function _isErrorNotFound(error) {

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -1,18 +1,10 @@
-.certifications-layout {
-  display: flex;
-}
-
 .certifications-page {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  padding: 16px 0 0 16px;
   width: 100%;
   margin-bottom: 20px;
-
-  &__header {
-    display: flex;
-    margin: 1em 0em 0em 1em;
-  }
 
   &__tabs {
     display: flex;
@@ -22,42 +14,30 @@
 
   &__text {
     font-family: $roboto;
-    margin: 2px 0 32px 16px;
-    font-size: 16px;
+    margin: 2px 0 32px 0;
+    font-size: 1rem;
     line-height: 1.375rem;
-    p {
-      margin: 0;
-    }
   }
 
   &__action {
     display: flex;
     flex-direction: row;
-    align-items: flex-end;
-    width: 100%;
-    margin-left: 1rem;
+    flex-wrap: wrap;
+    align-items: center;
+    min-width: 100%;
 
     button {
       height: 36px;
       line-height: 36px;
+      margin-left: 8px;
     }
 
-    .certifications-page-action {
-
-      &__select-container {
-
-        label[for^="certifications-page-action__select"] {
-          font-size: 14px;
-          color: $grey-90;
-          margin-left: 2px;
-        }
-
-        .pix-select {
-          margin: 4px 24px 0 0;
-          width: 153px;
-          height: 36px;
-        }
-      }
+    label {
+      font-size: 0.875rem;
+      color: $grey-90;
+      margin-left: 2px;
+      min-width: 100%;
+      padding: 4px 0;
     }
   }
 }

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -1,22 +1,20 @@
-<div class="certifications-layout">
-  <div class="certifications-page">
-    <div class="certifications-page__header">
-      <h1 class="page__title page-title">{{t 'pages.certifications.title'}}</h1>
-    </div>
-    <div class="certifications-page__text">
-      <p>
-        {{t 'pages.certifications.description'}}
-      </p>
-    </div>
-    <div class="certifications-page__action">
-      <div class='certifications-page-action__select-container'>
-        <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
-        <PixSelect id="certifications-page-action__select" @options={{@model.options}}
-          @selectedOption={{this.selectedDivision}} @onChange={{this.onSelectDivision}} />
-      </div>
-      <button class="button" type="button" {{on 'click' this.downloadSessionResultFile}}>
-        {{t 'pages.certifications.download-button'}}
-      </button>
-    </div>
-  </div>
+<div class="certifications-page">
+  <h1 class="page__title page-title">{{t 'pages.certifications.title'}}</h1>
+  <p class="certifications-page__text">
+    {{t 'pages.certifications.description'}}
+  </p>
+  <form class="certifications-page__action" {{on 'submit' this.downloadSessionResultFile}}>
+    <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
+    <PixSelect id="certifications-page-action__select" 
+      @options={{@model.options}}
+      @selectedOption={{this.selectedDivision}}
+      @onChange={{this.onSelectDivision}}
+      @isSearchable={{true}}
+      @isValidationActive={{true}}
+      placeholder={{this.firstTwoDivisions}}
+      required={{true}} />
+    <button class="button" type="submit">
+      {{t 'pages.certifications.download-button'}}
+    </button>
+  </form>
 </div>

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -26183,18 +26183,529 @@
       }
     },
     "pix-ui": {
-      "version": "git://github.com/1024pix/pix-ui.git#dd58e0738b9627223b3093c7ae36cdc7c73d2919",
-      "from": "git://github.com/1024pix/pix-ui.git#v3.0.0",
+      "version": "git://github.com/1024pix/pix-ui.git#6e5e68e3810989f887b659a0264f2e36fb0a80ff",
+      "from": "git://github.com/1024pix/pix-ui.git#v3.2.0",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^7.23.0",
-        "ember-cli-htmlbars": "^5.3.1",
+        "ember-cli-babel": "^7.23.1",
+        "ember-cli-htmlbars": "^5.6.2",
         "ember-cli-sass": "^10.0.1",
         "ember-cli-string-utils": "^1.1.0",
         "ember-click-outside": "^2.0.0",
         "ember-truth-helpers": "^3.0.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+          "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+          "dev": true
+        },
+        "@babel/core": {
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
+          "integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.13.0",
+            "@babel/helper-compilation-targets": "^7.13.8",
+            "@babel/helper-module-transforms": "^7.13.0",
+            "@babel/helpers": "^7.13.0",
+            "@babel/parser": "^7.13.4",
+            "@babel/template": "^7.12.13",
+            "@babel/traverse": "^7.13.0",
+            "@babel/types": "^7.13.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "lodash": "^4.17.19",
+            "semver": "^6.3.0",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/helper-compilation-targets": {
+              "version": "7.13.8",
+              "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+              "integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+              "dev": true,
+              "requires": {
+                "@babel/compat-data": "^7.13.8",
+                "@babel/helper-validator-option": "^7.12.17",
+                "browserslist": "^4.14.5",
+                "semver": "^6.3.0"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+          "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+          "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.12.13",
+            "@babel/template": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+          "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+          "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.13.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+          "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+          "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-replace-supers": "^7.13.0",
+            "@babel/helper-simple-access": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "@babel/template": "^7.12.13",
+            "@babel/traverse": "^7.13.0",
+            "@babel/types": "^7.13.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+          "integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+          "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.13.0",
+            "@babel/helper-optimise-call-expression": "^7.12.13",
+            "@babel/traverse": "^7.13.0",
+            "@babel/types": "^7.13.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+          "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+          "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.12.11",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+          "dev": true
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.12.17",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+          "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+          "dev": true
+        },
+        "@babel/helpers": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+          "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.12.13",
+            "@babel/traverse": "^7.13.0",
+            "@babel/types": "^7.13.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.13.8",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+          "integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+          "integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
+          "dev": true
+        },
+        "@babel/runtime": {
+          "version": "7.13.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
+          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/template": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+          "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/parser": "^7.12.13",
+            "@babel/types": "^7.12.13"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+          "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.12.13",
+            "@babel/generator": "^7.13.0",
+            "@babel/helper-function-name": "^7.12.13",
+            "@babel/helper-split-export-declaration": "^7.12.13",
+            "@babel/parser": "^7.13.0",
+            "@babel/types": "^7.13.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@babel/types": {
+          "version": "7.13.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+          "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "async-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.3",
+            "istextorbinary": "^2.5.1",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "rsvp": "^4.8.5",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "babel-plugin-ember-modules-api-polyfill": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz",
+          "integrity": "sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==",
+          "dev": true,
+          "requires": {
+            "ember-rfc176-data": "^0.3.16"
+          }
+        },
+        "babel-plugin-htmlbars-inline-precompile": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-4.4.4.tgz",
+          "integrity": "sha512-H2EqG91B1Vfzc5caPmMm2G6BioWR3c/0qOvai5NxjAHwhf/BK4N/nQUbUTRA1qeakO8afqOpkNonb2BMEgmmlw==",
+          "dev": true,
+          "requires": {
+            "babel-plugin-ember-modules-api-polyfill": "^3.4.0"
+          }
+        },
+        "broccoli-babel-transpiler": {
+          "version": "7.8.0",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.8.0.tgz",
+          "integrity": "sha512-dv30Td5uL7dO3NzQUqQKQs+Iq7JGKnCNtvc6GBO76uVPqGnRlsQZcYqdBVr33JrctR+ZrpTUf7TjsFKeDRFA8Q==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.0",
+            "@babel/polyfill": "^7.11.5",
+            "broccoli-funnel": "^2.0.2",
+            "broccoli-merge-trees": "^3.0.2",
+            "broccoli-persistent-filter": "^2.2.1",
+            "clone": "^2.1.2",
+            "hash-for-dep": "^1.4.7",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.9",
+            "json-stable-stringify": "^1.0.1",
+            "rsvp": "^4.8.4",
+            "workerpool": "^3.1.1"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.3.0",
+            "merge-trees": "^2.0.0"
+          }
+        },
+        "broccoli-output-wrapper": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/broccoli-output-wrapper/-/broccoli-output-wrapper-3.2.5.tgz",
+          "integrity": "sha512-bQAtwjSrF4Nu0CK0JOy5OZqw9t5U0zzv2555EA/cF8/a8SLDTIetk9UgrtMVw7qKLKdSpOZ2liZNeZZDaKgayw==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "heimdalljs-logger": "^0.1.10",
+            "symlink-or-copy": "^1.2.0"
+          }
+        },
+        "browserslist": {
+          "version": "4.16.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
+          "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001181",
+            "colorette": "^1.2.1",
+            "electron-to-chromium": "^1.3.649",
+            "escalade": "^3.1.1",
+            "node-releases": "^1.1.70"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001197",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
+          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "editions": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+          "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+          "dev": true,
+          "requires": {
+            "errlop": "^2.0.0",
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.682",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.682.tgz",
+          "integrity": "sha512-zok2y37qR00U14uM6qBz/3iIjWHom2eRfC2S1StA0RslP7x34jX+j4mxv80t8OEOHLJPVG54ZPeaFxEI7gPrwg==",
+          "dev": true
+        },
+        "ember-cli-babel": {
+          "version": "7.23.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz",
+          "integrity": "sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.0",
+            "@babel/helper-compilation-targets": "^7.12.0",
+            "@babel/plugin-proposal-class-properties": "^7.10.4",
+            "@babel/plugin-proposal-decorators": "^7.10.5",
+            "@babel/plugin-transform-modules-amd": "^7.10.5",
+            "@babel/plugin-transform-runtime": "^7.12.0",
+            "@babel/plugin-transform-typescript": "^7.12.0",
+            "@babel/polyfill": "^7.11.5",
+            "@babel/preset-env": "^7.12.0",
+            "@babel/runtime": "^7.12.0",
+            "amd-name-resolver": "^1.2.1",
+            "babel-plugin-debug-macros": "^0.3.3",
+            "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+            "babel-plugin-ember-modules-api-polyfill": "^3.2.1",
+            "babel-plugin-module-resolver": "^3.1.1",
+            "broccoli-babel-transpiler": "^7.8.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.1",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.1.2",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "ember-cli-version-checker": "^4.1.0",
+            "ensure-posix-path": "^1.0.2",
+            "fixturify-project": "^1.10.0",
+            "rimraf": "^3.0.1",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-babel-plugin-helpers": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz",
+          "integrity": "sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==",
+          "dev": true
+        },
+        "ember-cli-htmlbars": {
+          "version": "5.6.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.6.4.tgz",
+          "integrity": "sha512-I4zSc6PJpWiDuhru7jozQsodo4tAsNENJP/Ry0LTL0DtlZASEa5cwahPsxBjzEmAnr30oI2AExZhrDcZBryTjQ==",
+          "dev": true,
+          "requires": {
+            "@ember/edition-utils": "^1.2.0",
+            "babel-plugin-htmlbars-inline-precompile": "^4.4.1",
+            "broccoli-debug": "^0.6.5",
+            "broccoli-persistent-filter": "^3.1.2",
+            "broccoli-plugin": "^4.0.3",
+            "common-tags": "^1.8.0",
+            "ember-cli-babel-plugin-helpers": "^1.1.1",
+            "fs-tree-diff": "^2.0.1",
+            "hash-for-dep": "^1.5.1",
+            "heimdalljs-logger": "^0.1.10",
+            "json-stable-stringify": "^1.0.1",
+            "semver": "^7.3.4",
+            "silent-error": "^1.1.1",
+            "strip-bom": "^4.0.0",
+            "walk-sync": "^2.2.0"
+          },
+          "dependencies": {
+            "broccoli-persistent-filter": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.2.tgz",
+              "integrity": "sha512-CbU95RXXVyy+eJV9XTiHUC7NnsY3EvdVrGzp3YgyvO2bzXZFE5/GzDp4X/VQqX+jsk4qyT1HvMOF0sD1DX68TQ==",
+              "dev": true,
+              "requires": {
+                "async-disk-cache": "^2.0.0",
+                "async-promise-queue": "^1.0.3",
+                "broccoli-plugin": "^4.0.3",
+                "fs-tree-diff": "^2.0.0",
+                "hash-for-dep": "^1.5.0",
+                "heimdalljs": "^0.2.1",
+                "heimdalljs-logger": "^0.1.7",
+                "promise-map-series": "^0.2.1",
+                "rimraf": "^3.0.0",
+                "symlink-or-copy": "^1.0.1",
+                "sync-disk-cache": "^2.0.0"
+              }
+            },
+            "broccoli-plugin": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+              "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+              "dev": true,
+              "requires": {
+                "broccoli-node-api": "^1.6.0",
+                "broccoli-output-wrapper": "^3.2.1",
+                "fs-merger": "^3.1.0",
+                "promise-map-series": "^0.2.1",
+                "quick-temp": "^0.1.3",
+                "rimraf": "^3.0.0",
+                "symlink-or-copy": "^1.3.0"
+              }
+            },
+            "semver": {
+              "version": "7.3.4",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+              "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.1.tgz",
+          "integrity": "sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^6.3.0",
+            "silent-error": "^1.1.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
+        },
+        "ember-rfc176-data": {
+          "version": "0.3.16",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.16.tgz",
+          "integrity": "sha512-IYAzffS90r2ybAcx8c2qprYfkxa70G+/UPkxMN1hw55DU5S2aLOX6v3umKDZItoRhrvZMCnzwsdfKSrKdC9Wbg==",
+          "dev": true
+        },
         "ember-truth-helpers": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz",
@@ -26202,6 +26713,141 @@
           "dev": true,
           "requires": {
             "ember-cli-babel": "^7.22.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "gensync": {
+          "version": "1.0.0-beta.2",
+          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+          "dev": true
+        },
+        "istextorbinary": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+          "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+          "dev": true,
+          "requires": {
+            "binaryextensions": "^2.1.2",
+            "editions": "^2.2.0",
+            "textextensions": "^2.5.0"
+          }
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
+          "requires": {
+            "fs-updater": "^1.0.4",
+            "heimdalljs": "^0.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.71",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+          "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+          "dev": true
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "sync-disk-cache": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
+          "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "heimdalljs": "^0.2.6",
+            "mkdirp": "^0.5.0",
+            "rimraf": "^3.0.0",
+            "username-sync": "^1.0.2"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
           }
         }
       }

--- a/orga/package.json
+++ b/orga/package.json
@@ -88,7 +88,7 @@
     "lodash": "^4.17.20",
     "npm-run-all": "^4.1.5",
     "p-queue": "^6.6.2",
-    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.0.0",
+    "pix-ui": "git://github.com/1024pix/pix-ui.git#v3.2.0",
     "query-string": "^6.13.6",
     "qunit-dom": "^1.6.0",
     "sass": "^1.27.0"

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -272,7 +272,11 @@
       "description": "Please select the class for which you would like to export the certification results in a csv file.",
       "download-button": "Export the results",
       "select-label": "Class",
-      "title": "Certifications"
+      "title": "Certifications",
+      "errors": {
+        "no-results": "No certification results for the class {selectedDivision}.",
+        "invalid-division": "The class {selectedDivision} does not exist."
+      }
     },
     "profiles-individual-results": {
       "certifiable": "Eligible for certification",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -272,7 +272,11 @@
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.",
       "download-button": "Exporter les résultats",
       "select-label": "Classe",
-      "title": "Certifications"
+      "title": "Certifications",
+      "errors": {
+        "no-results": "Aucun résultat de certification pour la classe {selectedDivision}.",
+        "invalid-division": "La classe {selectedDivision} n'existe pas."
+      }
     },
     "profiles-individual-results": {
       "certifiable": "Certifiable",


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'epix "Affichage des résultats sco", le menu de classe peut potentiellement afficher de très nombreuses classes.

## :rainbow: Remarques
Permettre au menu de selection d'une classe de filtrer par nom de classe.

## :100: Pour tester
- Lancer l'api avec `FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true` 
- Se connecter à Pix Orga avec un compte sco & admin (ex: sco.admin@example.net) ayant des résultats de certifications disponibles*
- Cliquer sur l'onglet **Certifications**
- Commencer à taper le nom d'une classe existante (proposée par le placeholder)
- Sélectionner une classe dans les proposition ou taper son nom complet
- Constater que le champ devient vert
- Cliquer sur **Exporter mes résultats** ou appuyer sur la touche Entrée
- Constater que le téléchargement s'effectue

🌻   Pour aller plus loin 🌻
- Entrer le nom d'une classe inexistante
- Cliquer sur **Exporter mes résultats** ou appuyer sur la touche Entrée
- Constater l'affichage d'un message d'erreur

*Note: Pour générer des résultats de certification pour une organisation donnée, utiliser le script :
```shell
./api/scripts/data-generation/generate-certifications-for-organization.js --organizationId  <un id d'orga> --certificationCenterId <un id de centre de certif>
```
