### PR TITLE
[FEATURE] Notifier l'utilisateur de son changement d'email (PIX-2088).

### DIFF
--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -51,12 +51,14 @@ module.exports = {
     const userId = parseInt(request.params.id);
     const authenticatedUserId = request.auth.credentials.userId;
     const { email, password } = request.payload.data.attributes;
+    const locale = extractLocaleFromRequest(request);
 
     await usecases.updateUserEmail({
       email,
       userId,
       authenticatedUserId,
       password,
+      locale,
     });
 
     return h.response({}).code(204);

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -72,6 +72,7 @@ module.exports = (function() {
           organizationInvitationScoTemplateId: process.env.SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID,
           passwordResetTemplateId: process.env.SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID,
           certificationResultTemplateId: process.env.SENDINBLUE_CERTIFICATION_RESULT_TEMPLATE_ID,
+          emailChangeTemplateId: process.env.SENDINBLUE_EMAIL_CHANGE_TEMPLATE_ID,
         },
       },
     },
@@ -202,8 +203,8 @@ module.exports = (function() {
     config.mailing.sendinblue.templates.organizationInvitationTemplateId = 'test-organization-invitation-demand-template-id';
     config.mailing.sendinblue.templates.organizationInvitationScoTemplateId = 'test-organization-invitation-sco-demand-template-id';
     config.mailing.sendinblue.templates.certificationResultTemplateId = 'test-certification-result-template-id';
-
     config.mailing.sendinblue.templates.passwordResetTemplateId = 'test-password-reset-template-id';
+    config.mailing.sendinblue.templates.emailChangeTemplateId = 'test-email-change-template-id';
 
     config.captcha.enabled = false;
     config.captcha.googleRecaptchaSecret = 'test-recaptcha-key';

--- a/api/lib/domain/services/mail-service.js
+++ b/api/lib/domain/services/mail-service.js
@@ -25,6 +25,8 @@ const HELPDESK_EN = 'https://pix.org/en-gb/help-form';
 const ORGANIZATION_INVITATION_EMAIL_SUBJECT_FR = 'Invitation à rejoindre Pix Orga';
 const ORGANIZATION_INVITATION_EMAIL_SUBJECT_EN = 'Invitation to join Pix Orga';
 
+const EMAIL_CHANGE_TAG = 'EMAIL_CHANGE';
+
 function sendAccountCreationEmail(email, locale, redirectionUrl) {
 
   let pixName;
@@ -267,10 +269,58 @@ function sendScoOrganizationInvitationEmail({
   });
 }
 
+function notifyEmailChange({ email, locale }) {
+
+  const options = {
+    from: EMAIL_ADDRESS_NO_RESPONSE,
+    fromName: PIX_NAME_FR,
+    to: email,
+    template: mailer.emailChangeTemplateId,
+    tags: [EMAIL_CHANGE_TAG],
+  };
+
+  if (locale === FRENCH_SPOKEN) {
+
+    options.subject = frTranslations['email-change-email'].subject;
+
+    options.variables = {
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/fr/`,
+      displayNationalLogo: false,
+      ...frTranslations['email-change-email'].body,
+    };
+
+  } else if (locale === FRENCH_FRANCE) {
+
+    options.subject = frTranslations['email-change-email'].subject;
+
+    options.variables = {
+      homeName: `pix${settings.domain.tldFr}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldFr}`,
+      displayNationalLogo: true,
+      ...frTranslations['email-change-email'].body,
+    };
+
+  }
+  else if (locale === ENGLISH_SPOKEN) {
+    options.subject = enTranslations['email-change-email'].subject;
+
+    options.variables = {
+      homeName: `pix${settings.domain.tldOrg}`,
+      homeUrl: `${settings.domain.pix + settings.domain.tldOrg}/en-gb/`,
+      displayNationalLogo: false,
+      ...enTranslations['email-change-email'].body,
+    };
+  }
+
+  return mailer.sendEmail(options);
+}
+
 module.exports = {
   sendAccountCreationEmail,
   sendCertificationResultEmail,
   sendOrganizationInvitationEmail,
   sendScoOrganizationInvitationEmail,
   sendResetPasswordDemandEmail,
+  notifyEmailChange,
 };

--- a/api/lib/domain/usecases/update-user-email.js
+++ b/api/lib/domain/usecases/update-user-email.js
@@ -6,9 +6,11 @@ module.exports = async function updateUserEmail({
   userId,
   authenticatedUserId,
   password,
+  locale,
   userRepository,
   authenticationMethodRepository,
   encryptionService,
+  mailService,
 }) {
   if (userId !== authenticatedUserId) {
     throw new UserNotAuthorizedToUpdateEmailError();
@@ -37,4 +39,5 @@ module.exports = async function updateUserEmail({
 
   await userRepository.isEmailAvailable(email);
   await userRepository.updateEmail({ id: userId, email: email.toLowerCase() });
+  await mailService.notifyEmailChange({ email, locale });
 };

--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -63,6 +63,10 @@ class Mailer {
     return mailing[this._providerName].templates.certificationResultTemplateId;
   }
 
+  get emailChangeTemplateId() {
+    return mailing[this._providerName].templates.emailChangeTemplateId;
+  }
+
 }
 
 module.exports = new Mailer();

--- a/api/lib/infrastructure/validate-environement-variables.js
+++ b/api/lib/infrastructure/validate-environement-variables.js
@@ -11,6 +11,7 @@ const schema = Joi.object({
   SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID: Joi.number().optional(),
   SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID: Joi.number().optional(),
   SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID: Joi.number().optional(),
+  SENDINBLUE_EMAIL_CHANGE_TEMPLATE_ID: Joi.number().optional(),
   TLD_FR: Joi.string().optional(),
   TLD_ORG: Joi.string().optional(),
   DOMAIN_PIX: Joi.string().optional(),

--- a/api/sample.env
+++ b/api/sample.env
@@ -126,6 +126,16 @@ TEST_DATABASE_URL=postgresql://postgres@localhost/pix_test
 # default: none
 # SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID=
 
+# ID of the template used to notify the user its email has been changed
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_EMAIL_CHANGE_TEMPLATE_ID=
+
 # String for links in emails redirect to a specific domain when user comes from french domain
 #
 # presence: optional

--- a/api/tests/unit/domain/services/mail-service_test.js
+++ b/api/tests/unit/domain/services/mail-service_test.js
@@ -501,4 +501,90 @@ describe('Unit | Service | MailService', () => {
     });
   });
 
+  describe('#notifyEmailChange', () => {
+
+    it('should call sendEmail with from, to, template, tags', async () => {
+
+      // given
+      const locale = FRENCH_FRANCE;
+      const expectedOptions = {
+        from: senderEmailAddress,
+        to: userEmailAddress,
+        subject: 'Vous avez changé votre adresse e-mail',
+        template: 'test-email-change-template-id',
+        tags: ['EMAIL_CHANGE'],
+      };
+
+      // when
+      await mailService.notifyEmailChange({ email: userEmailAddress, locale });
+
+      // then
+      const options = mailer.sendEmail.firstCall.args[0];
+      expect(options).to.deep.include(expectedOptions);
+    });
+
+    context('according to locale', () => {
+
+      const translationsMapping = {
+        'fr': mainTranslationsMapping.fr['email-change-email'],
+        'en': mainTranslationsMapping.en['email-change-email'],
+      };
+
+      context('should call sendEmail with localized variable options', () => {
+
+        const testCases = [
+          {
+            locale: FRENCH_SPOKEN,
+            expected: {
+              subject: translationsMapping.fr.subject,
+              variables: {
+                homeName: 'pix.org',
+                homeUrl: 'https://pix.org/fr/',
+                displayNationalLogo: false,
+                ...translationsMapping.fr.body },
+            },
+          },
+          {
+            locale: FRENCH_FRANCE,
+            expected: {
+              subject: translationsMapping.fr.subject,
+              variables: {
+                homeName: 'pix.fr',
+                homeUrl: 'https://pix.fr',
+                displayNationalLogo: true,
+                ...translationsMapping.fr.body },
+            },
+          },
+          {
+            locale: ENGLISH_SPOKEN,
+            expected: {
+              subject: translationsMapping.en.subject,
+              variables: {
+                homeName: 'pix.org',
+                homeUrl: 'https://pix.org/en-gb/',
+                displayNationalLogo: false,
+                ...translationsMapping.en.body },
+            },
+          },
+        ];
+
+        testCases.forEach((testCase) => {
+          it(`when locale is ${testCase.locale}`, async () => {
+
+            // when
+            await mailService.notifyEmailChange({ email: userEmailAddress, locale: testCase.locale });
+
+            // then
+            const options = mailer.sendEmail.firstCall.args[0];
+            expect(options.subject).to.equal(testCase.expected.subject);
+            expect(options.variables).to.include(testCase.expected.variables);
+          });
+        });
+
+      });
+
+    });
+
+  });
+
 });

--- a/api/tests/unit/domain/usecases/update-user-email_test.js
+++ b/api/tests/unit/domain/usecases/update-user-email_test.js
@@ -10,7 +10,9 @@ describe('Unit | UseCase | update-user-email', () => {
   let userRepository;
   let authenticationMethodRepository;
   let encryptionService;
+  let mailService;
 
+  const locale = undefined;
   const password = 'password123';
   // eslint-disable-next-line no-sync
   const passwordHash = bcrypt.hashSync(password, 1);
@@ -29,6 +31,10 @@ describe('Unit | UseCase | update-user-email', () => {
     encryptionService = {
       checkPassword: sinon.stub().resolves(),
     };
+
+    mailService = {
+      notifyEmailChange: sinon.stub().resolves(),
+    };
   });
 
   it('should call updateEmail', async () => {
@@ -43,15 +49,43 @@ describe('Unit | UseCase | update-user-email', () => {
       authenticatedUserId,
       email: newEmail,
       password,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then
     expect(userRepository.updateEmail).to.have.been.calledWith({
       id: userId,
       email: newEmail,
+    });
+  });
+
+  it('should call notifyEmailChange', async () => {
+    // given
+    const userId = 1;
+    const authenticatedUserId = 1;
+    const newEmail = 'new_email@example.net';
+
+    // when
+    await updateUserEmail({
+      userId,
+      authenticatedUserId,
+      email: newEmail,
+      password,
+      locale,
+      userRepository,
+      authenticationMethodRepository,
+      encryptionService,
+      mailService,
+    });
+
+    // then
+    expect(mailService.notifyEmailChange).to.have.been.calledWith({
+      email: newEmail,
+      locale: undefined,
     });
   });
 
@@ -68,9 +102,11 @@ describe('Unit | UseCase | update-user-email', () => {
       authenticatedUserId,
       email: newEmail,
       password,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then
@@ -93,9 +129,11 @@ describe('Unit | UseCase | update-user-email', () => {
       authenticatedUserId,
       email: newEmail,
       password,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then
@@ -113,9 +151,11 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then
@@ -134,9 +174,11 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then
@@ -155,9 +197,11 @@ describe('Unit | UseCase | update-user-email', () => {
       userId,
       authenticatedUserId,
       email: newEmail,
+      locale,
       userRepository,
       authenticationMethodRepository,
       encryptionService,
+      mailService,
     });
 
     // then

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,6 +1,6 @@
 {
-  "current-lang" : "en",
-  "campaign-export" : {
+  "current-lang": "en",
+  "campaign-export": {
     "assessment": {
       "competence-area": {
         "items-successfully-completed": "Items of the target profile successfully completed in the competence area {{name}}",
@@ -8,7 +8,7 @@
         "total-items": "Number of items of the target profile in the competence area {{name}}"
       },
       "is-shared": "Shared (Y/N)",
-      "mastery-percentage-target-profile":"% of items successfully completed in the target profile",
+      "mastery-percentage-target-profile": "% of items successfully completed in the target profile",
       "progress": "% of progression",
       "shared-on": "Shared on",
       "started-on": "Started on",
@@ -17,7 +17,7 @@
         "ko": "KO",
         "not-tested": "Not tested",
         "ok": "OK"
-      },  
+      },
       "skill": {
         "items-successfully-completed": "Items of the target profile successfully completed in the skill {{name}}",
         "mastery-percentage": "% of items successfully completed in the skill {{name}}",
@@ -26,7 +26,7 @@
       "success-rate": "Success rate (/{{value}})",
       "thematic-result-name": "{{name}} (Y/N)"
     },
-    "common" :{
+    "common": {
       "campaign-id": "Campaign ID",
       "campaign-name": "Campaign's name",
       "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
@@ -37,11 +37,11 @@
       "participant-firstname": "Participant's first name",
       "participant-lastname": "Participant's last name",
       "participant-student-number": "Student number",
-      "yes": "Yes"  
+      "yes": "Yes"
     },
-    "profiles-collection" : {
+    "profiles-collection": {
       "certifiable-skills": "Number of skills eligible for certification",
-      "is-certifiable" :"Eligible for certification (Y/N)",
+      "is-certifiable": "Eligible for certification (Y/N)",
       "is-sent": "Sent (Y/N)",
       "pix-score": "Total pix score",
       "sent-on": "Sent on",
@@ -91,5 +91,18 @@
     "STAGE_TITLE_IS_REQUIRED": "The stage title is required",
     "STAGE_THRESHOLD_IS_REQUIRED": "The stage threshold is required",
     "TARGET_PROFILE_IS_REQUIRED": "The target profile is required"
+  },
+  "email-change-email": {
+    "subject": "Email change confirmation",
+    "body": {
+      "greeting": "Hi,",
+      "context": "You’ve recently changed your email address.",
+      "loginEmail": "You can now log in using the following email address:",
+      "noPasswordChanged": "Your password remains the same.",
+      "signing": "— The Pix Team",
+      "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills.",
+      "moreOn": "More on",
+      "doNotAnswer": "This is an automated email message, please do not reply."
+    }
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -7,7 +7,7 @@
         "total-items": "Nombre d'acquis du profil cible du domaine {{name}}"
       },
       "is-shared": "Partage (O/N)",
-      "mastery-percentage-target-profile":"% maitrise de l'ensemble des acquis du profil",
+      "mastery-percentage-target-profile": "% maitrise de l'ensemble des acquis du profil",
       "progress": "% de progression",
       "shared-on": "Date du partage",
       "started-on": "Date de début",
@@ -16,7 +16,7 @@
         "ko": "KO",
         "not-tested": "Non testé",
         "ok": "OK"
-      },  
+      },
       "skill": {
         "items-successfully-completed": "Acquis maitrisés dans la compétence {{name}}",
         "mastery-percentage": "% de maitrise des acquis de la compétence {{name}}",
@@ -25,7 +25,7 @@
       "success-rate": "Palier obtenu (/{{value}})",
       "thematic-result-name": "{{name}} obtenu (O/N)"
     },
-    "common" : {
+    "common": {
       "campaign-id": "ID Campagne",
       "campaign-name": "Nom de la campagne",
       "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
@@ -38,9 +38,9 @@
       "participant-student-number": "Numéro Étudiant",
       "yes": "Oui"
     },
-    "profiles-collection" : {
+    "profiles-collection": {
       "certifiable-skills": "Nombre de compétences certifiables",
-      "is-certifiable" :"Certifiable (O/N)",
+      "is-certifiable": "Certifiable (O/N)",
       "is-sent": "Envoi (O/N)",
       "pix-score": "Nombre de pix total",
       "sent-on": "Date de l'envoi",
@@ -50,17 +50,17 @@
   },
   "current-lang": "fr",
   "campaign": {
-    "common" : {
+    "common": {
       "yes": "Oui",
       "no": "Non",
       "not-available": "NA"
     },
-    "profiles-collection" : {
+    "profiles-collection": {
       "campaign-id": "ID Campagne",
       "campaign-name": "Nom de la campagne",
       "certifiable-skills": "Nombre de compétences certifiables",
       "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable" :"Certifiable (O/N)",
+      "is-certifiable": "Certifiable (O/N)",
       "is-sent": "Envoi (O/N)",
       "organization-name": "Nom de l'organisation",
       "participant-division": "Classe",
@@ -115,5 +115,18 @@
     "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
     "STAGE_THRESHOLD_IS_REQUIRED": "Le seuil du palier est obligatoire",
     "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire"
+  },
+  "email-change-email": {
+    "subject": "Vous avez changé votre adresse e-mail",
+    "body": {
+      "greeting": "Bonjour,",
+      "context": "Vous avez récemment modifié votre adresse email.",
+      "loginEmail": "Vous pouvez maintenant vous connecter avec l’adresse suivante :",
+      "noPasswordChanged": "Votre mot de passe reste inchangé.",
+      "signing": "— L'équipe Pix",
+      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "moreOn": "En savoir plus sur",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre"
+    }
   }
 }

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -47,14 +47,14 @@ export default Route.extend(ApplicationRouteMixin, {
     const locale = transition.to.queryParams.lang;
 
     await this._loadCurrentUser();
-    await this._handleLanguage(locale);
+    await this._handleLocale(locale);
   },
 
   async sessionAuthenticated() {
     const _super = this._super;
 
     await this._loadCurrentUser();
-    await this._handleLanguage();
+    await this._handleLocale();
 
     const nextURL = this.session.data.nextURL;
     if (nextURL && get(this.session, 'data.authenticated.source') === 'pole_emploi_connect') {
@@ -71,41 +71,42 @@ export default Route.extend(ApplicationRouteMixin, {
   // https://github.com/simplabs/ember-simple-auth/blob/a3d51d65b7d8e3a2e069c0af24aca2e12c7c3a95/addon/mixins/application-route-mixin.js#L132
   sessionInvalidated() {},
 
-  async _handleLanguage(locale = null) {
+  async _handleLocale(localeFromQueryParam = null) {
 
     const isUserConnected = this.session.isAuthenticated;
     const domain = this.currentDomain.getExtension();
     const defaultLocale = 'fr';
 
     if (domain === 'fr') {
-      await this._setLocale(defaultLocale, defaultLocale);
+      await this._setLocale(defaultLocale);
       return;
     }
 
     if (isUserConnected) {
-      if (locale) {
-        this.currentUser.user.lang = locale;
+      if (localeFromQueryParam) {
+        this.currentUser.user.lang = localeFromQueryParam;
         try {
           await this.currentUser.user.save({ adapterOptions: { lang: this.currentUser.user.lang } });
-          await this._setLocale(this.currentUser.user.lang, defaultLocale);
+          await this._setLocale(this.currentUser.user.lang);
         } catch (error) {
           const status = get(error, 'errors[0].status');
           if (status === '400') {
             this.currentUser.user.rollbackAttributes();
-            await this._setLocale(this.currentUser.user.lang, defaultLocale);
+            await this._setLocale(this.currentUser.user.lang);
           } else {
             throw error;
           }
         }
       } else {
-        await this._setLocale(this.currentUser.user.lang, defaultLocale);
+        await this._setLocale(this.currentUser.user.lang);
       }
     } else {
-      await this._setLocale(locale, defaultLocale);
+      await this._setLocale(localeFromQueryParam);
     }
   },
 
-  _setLocale(locale, defaultLocale) {
+  _setLocale(locale) {
+    const defaultLocale = 'fr';
     this.intl.setLocale([locale, defaultLocale]);
     this.moment.setLocale(locale);
   },

--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -101,7 +101,12 @@ export default Route.extend(ApplicationRouteMixin, {
         await this._setLocale(this.currentUser.user.lang);
       }
     } else {
-      await this._setLocale(localeFromQueryParam);
+      if (localeFromQueryParam) {
+        await this._setLocale(localeFromQueryParam);
+      } else {
+        await this._setLocale(defaultLocale);
+      }
+
     }
   },
 

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -49,7 +49,7 @@ describe('Unit | Route | application', function() {
     expect(currentUserStub.called).to.be.true;
   });
 
-  describe('#__handleLanguage', function() {
+  describe('#__handleLocale', function() {
 
     let intlSetLocaleStub;
     let momentSetLocaleStub;
@@ -77,32 +77,68 @@ describe('Unit | Route | application', function() {
 
       describe('when domain is pix.org', function() {
 
-        it('should update locale', async function() {
-          // given
-          route.set('currentDomain', { getExtension() { return 'org'; } });
+        describe('when supplying locale in queryParam', function() {
 
-          // when
-          await route._handleLanguage('en');
+          it('should update locale', async function() {
+            // given
+            route.set('currentDomain', {
+              getExtension() {
+                return 'org';
+              },
+            });
 
-          // then
-          sinon.assert.called(intlSetLocaleStub);
-          sinon.assert.called(momentSetLocaleStub);
-          sinon.assert.calledWith(intlSetLocaleStub, ['en', 'fr']);
-          sinon.assert.calledWith(momentSetLocaleStub, 'en');
+            // when
+            await route._handleLocale('en');
+
+            // then
+            sinon.assert.called(intlSetLocaleStub);
+            sinon.assert.called(momentSetLocaleStub);
+            sinon.assert.calledWith(intlSetLocaleStub, ['en', 'fr']);
+            sinon.assert.calledWith(momentSetLocaleStub, 'en');
+          });
+
+          it('should ignore locale switch when is neither "fr" nor "en"', async function() {
+            // given
+            route.set('currentDomain', {
+              getExtension() {
+                return 'org';
+              },
+            });
+
+            // when
+            await route._handleLocale('bouh');
+
+            // then
+            sinon.assert.called(intlSetLocaleStub);
+            sinon.assert.called(momentSetLocaleStub);
+            sinon.assert.calledWith(intlSetLocaleStub, ['bouh', 'fr']);
+          });
+
         });
 
-        it('should ignore locale switch when is neither "fr" nor "en"', async function() {
-          // given
-          route.set('currentDomain', { getExtension() { return 'org'; } });
+        describe('when supplying no locale in queryParam', function() {
 
-          // when
-          await route._handleLanguage('bouh');
+          it('should set locale to default locale, but does not (bug)', async function() {
+            // given
+            route.set('currentDomain', {
+              getExtension() {
+                return 'org';
+              },
+            });
 
-          // then
-          sinon.assert.called(intlSetLocaleStub);
-          sinon.assert.called(momentSetLocaleStub);
-          sinon.assert.calledWith(intlSetLocaleStub, ['bouh', 'fr']);
+            const locale = undefined;
+            // when
+            await route._handleLocale(locale);
+
+            // then
+            sinon.assert.called(intlSetLocaleStub);
+            sinon.assert.called(momentSetLocaleStub);
+            sinon.assert.calledWith(intlSetLocaleStub, [null, 'fr']);
+            sinon.assert.calledWith(momentSetLocaleStub, null);
+          });
+
         });
+
       });
 
       describe('when domain is pix.fr', function() {
@@ -112,7 +148,7 @@ describe('Unit | Route | application', function() {
           route.set('currentDomain', { getExtension() { return 'fr'; } });
 
           // when
-          await route._handleLanguage('en');
+          await route._handleLocale('en');
 
           // then
           sinon.assert.called(intlSetLocaleStub);
@@ -140,7 +176,7 @@ describe('Unit | Route | application', function() {
           route.set('currentDomain', { getExtension() { return 'org'; } });
 
           // when
-          await route._handleLanguage();
+          await route._handleLocale();
 
           // then
           sinon.assert.called(intlSetLocaleStub);
@@ -167,7 +203,7 @@ describe('Unit | Route | application', function() {
             route.set('currentDomain', { getExtension() { return 'org'; } });
 
             // when
-            await route._handleLanguage('en');
+            await route._handleLocale('en');
 
             // then
             sinon.assert.called(saveStub);
@@ -192,7 +228,7 @@ describe('Unit | Route | application', function() {
             route.set('currentDomain', { getExtension() { return 'org'; } });
 
             // when
-            await route._handleLanguage('bouh');
+            await route._handleLocale('bouh');
 
             // then
             sinon.assert.called(rollbackAttributesStub);
@@ -215,7 +251,7 @@ describe('Unit | Route | application', function() {
           route.set('currentDomain', { getExtension() { return 'fr'; } });
 
           // when
-          await route._handleLanguage();
+          await route._handleLocale();
 
           // then
           sinon.assert.called(intlSetLocaleStub);
@@ -242,7 +278,7 @@ describe('Unit | Route | application', function() {
             route.set('currentDomain', { getExtension() { return 'fr'; } });
 
             // when
-            await route._handleLanguage('en');
+            await route._handleLocale('en');
 
             // then
             sinon.assert.notCalled(saveStub);

--- a/mon-pix/tests/unit/routes/application-test.js
+++ b/mon-pix/tests/unit/routes/application-test.js
@@ -118,7 +118,7 @@ describe('Unit | Route | application', function() {
 
         describe('when supplying no locale in queryParam', function() {
 
-          it('should set locale to default locale, but does not (bug)', async function() {
+          it('should set locale to default locale', async function() {
             // given
             route.set('currentDomain', {
               getExtension() {
@@ -133,8 +133,8 @@ describe('Unit | Route | application', function() {
             // then
             sinon.assert.called(intlSetLocaleStub);
             sinon.assert.called(momentSetLocaleStub);
-            sinon.assert.calledWith(intlSetLocaleStub, [null, 'fr']);
-            sinon.assert.calledWith(momentSetLocaleStub, null);
+            sinon.assert.calledWith(intlSetLocaleStub, ['fr', 'fr']);
+            sinon.assert.calledWith(momentSetLocaleStub, 'fr');
           });
 
         });


### PR DESCRIPTION
## :unicorn: Problème


## :robot: Solution

Envoyer une notification par mail de l'email actuellement utilisé
Localiser le mail (texte + URL de redirection)

J'ai supprimé le cas de la locale `undefined` dans un commit séparé si besoin de revert
Que faire si la locale n'est pas dans  `fr, fr-fr, en` ?

## :rainbow: Remarques

J'ai rajouté l'envoi du tag `EMAIL_CHANGE` pour faciliter la recherche dans SendInBlue

Penser à alimenter la variable d'environnement `SENDINBLUE_EMAIL_CHANGE_TEMPLATE_ID`
* intégration :heavy_check_mark: 
 * recette :heavy_check_mark: 
 * production :heavy_check_mark: 

Ce ticket embarque aussi un bugfix sur l'email de création de compte sur pix.org qui envoyait un email français  
La locale configurée lors du chargement de l'application était incorrecte, ce qui causait l'envoi d'un header `Accept-language` à `undefined` vers l'API, qui prenait la locale par défaut 'fr-fr'

## :100: Pour tester
Etapes:
- [se créer un compte](https://app-pr2679.review.pix.fr/inscription) avec l'email `<PRENOM>.<NOM>@pix.fr`
- se connecter à [Pix app](https://app-pr2679.review.pix.fr/),
- aller dans Mon Compte
- modifier l'email avec `<PRENOM>.<NOM>-new@pix.fr`
- vérifier qu'un mail est reçu sur `<PRENOM>.<NOM>-new@pix.fr`
- faire une recherche dans [SendInBlue](https://app-smtp.sendinblue.com/log) sur le tag  `EMAIL_CHANGE` 

