### PR TITLE
[TECH] Trier les résultats par compétence dans les résultats envoyés pour le livret scolaire.

### DIFF
--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -1,6 +1,7 @@
 const Certificate = require('../../domain/read-models/livret-scolaire/Certificate');
 const { PENDING, VALIDATED } = require('../../domain/read-models/livret-scolaire/CertificateStatus');
 const { knex } = require('../bookshelf');
+const sortBy = require('lodash/sortBy');
 
 module.exports = {
 
@@ -37,7 +38,7 @@ module.exports = {
       .orderBy('firstName', 'ASC');
 
     return result.map((certificate) => {
-      const competenceResults = _extractValidatedCompetenceResults(certificate);
+      const competenceResults = sortBy(_extractValidatedCompetenceResults(certificate), 'competenceId');
       return new Certificate({
         ...certificate, competenceResults,
       });

--- a/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
@@ -201,7 +201,19 @@ describe('Acceptance | API | Certifications', () => {
         // given
         server = await createServer();
         const { schoolingRegistration, session, certificationCourse }
-          = buildValidatedPublishedCertificationData({ organizationId, verificationCode, type, pixScore, competenceMarks: [ { code: '1.1', level: 6 }, { code: '5.2', level: 4 }] });
+          = buildValidatedPublishedCertificationData({
+            organizationId,
+            verificationCode,
+            type,
+            pixScore,
+            competenceMarks: [{
+              code: '5.2',
+              level: 4,
+            }, {
+              code: '1.1',
+              level: 6,
+            }],
+          });
         await databaseBuilder.commit();
 
         options = {


### PR DESCRIPTION
## :unicorn: Problème
Les résultats par compétence ne sont pas triés et sont envoyés dans un ordre aléatoire.
Cela entraine des faux positifs sur la CI. (cf https://app.circleci.com/pipelines/github/1024pix/pix/22478/workflows/ff9c00c1-f4df-439f-98c8-bfaa01950f53/jobs/187625)

## :robot: Solution
Trier les résultats par compétence dans le repository.

## :rainbow: Remarques
RAS

## :100: Pour tester
Vérifier que la CI passe sans flacky tests.
En local, on peut lancer les tests N fois pour s'assurer de la predictivité des résultats:
```
for run in {1..100}; do npm run test:api:acceptance; done
```