### PR TITLE
[FEATURE] Publier des sessions en masse (PIX-2041)

### DIFF
--- a/admin/app/adapters/to-be-published-session.js
+++ b/admin/app/adapters/to-be-published-session.js
@@ -10,4 +10,10 @@ export default class ToBePublishedSessionAdapter extends ApplicationAdapter {
   urlForUpdateRecord(id) {
     return `${this.host}/${this.namespace}/sessions/${id}`;
   }
+
+  publishSessionInBatch(sessionIds) {
+    const url = `${this.host}/${this.namespace}/sessions/publish-in-batch`;
+    const payload = { data: { data: { attributes: { ids: sessionIds } } } };
+    return this.ajax(url, 'POST', payload);
+  }
 }

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -24,19 +24,18 @@ export default class SessionToBePublishedController extends Controller {
     const sessionIdsToBePublished = this.model.map((session) => session.id);
     const adapter = this.store.adapterFor('to-be-published-session');
     try {
-      await adapter.publishSessionInBatch(sessionIdsToBePublished);
-      this.hideConfirmModal();
-      this._removePublishedSessionsFromStore(this.model);
-      this.notifications.success('Les sessions ont été publiées avec succès');
-    } catch (err) {
-      if (this._batchPublicationFailed(err)) {
-        this._notifyPublicationFailure(err);
+      const result = await adapter.publishSessionInBatch(sessionIdsToBePublished);
+      if (this._batchPublicationFailed(result)) {
+        this._notifyPublicationFailure(result);
+        this.send('refreshModel');
       } else {
-        this.notifications.error(err);
+        this._removePublishedSessionsFromStore(this.model);
+        this.notifications.success('Les sessions ont été publiées avec succès');
       }
-      this.hideConfirmModal();
-      this.send('refreshModel');
+    } catch (err) {
+      this.notifications.error(err);
     }
+    this.hideConfirmModal();
   }
 
   @action

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -2,7 +2,6 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
 import get from 'lodash/get';
 
 export default class SessionToBePublishedController extends Controller {

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -55,7 +55,7 @@ export default class SessionToBePublishedController extends Controller {
   }
 
   _batchPublicationFailed(error) {
-    return get(error, 'errors[0].code') === 'SESSION_BATCH_PUBLICATION_FAILED';
+    return get(error, 'errors[0].code') === 'SESSION_PUBLICATION_BATCH_PARTIALLY_FAILED';
   }
 
   _removePublishedSessionsFromStore(sessions) {

--- a/admin/app/controllers/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/controllers/authenticated/sessions/list/to-be-published.js
@@ -1,10 +1,13 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
 import get from 'lodash/get';
 
 export default class SessionToBePublishedController extends Controller {
   @service notifications;
+  @tracked shouldShowModal = false;
 
   @action
   async publishSession(toBePublishedSession) {
@@ -14,5 +17,50 @@ export default class SessionToBePublishedController extends Controller {
       const finalErr = get(err, 'errors[0].detail', err);
       this.notifications.error(finalErr);
     }
+  }
+
+  @action
+  async batchPublishSessions() {
+    const sessionIdsToBePublished = this.model.map((session) => session.id);
+    const adapter = this.store.adapterFor('to-be-published-session');
+    try {
+      await adapter.publishSessionInBatch(sessionIdsToBePublished);
+      this.hideConfirmModal();
+      this._removePublishedSessionsFromStore(this.model);
+      this.notifications.success('Les sessions ont été publiées avec succès');
+    } catch (err) {
+      if (this._batchPublicationFailed(err)) {
+        this._notifyPublicationFailure(err);
+      } else {
+        this.notifications.error(err);
+      }
+      this.hideConfirmModal();
+      this.send('refreshModel');
+    }
+  }
+
+  @action
+  showConfirmModal() {
+    this.shouldShowModal = true;
+  }
+
+  @action
+  hideConfirmModal() {
+    this.shouldShowModal = false;
+  }
+
+  _notifyPublicationFailure(error) {
+    this.notifications.error(
+      'Une ou plusieurs erreurs se sont produites, veuillez conserver la référence suivante pour investigation auprès de l\'équipe technique : ' + get(error, 'errors[0].detail'),
+      { autoClear: false },
+    );
+  }
+
+  _batchPublicationFailed(error) {
+    return get(error, 'errors[0].code') === 'SESSION_BATCH_PUBLICATION_FAILED';
+  }
+
+  _removePublishedSessionsFromStore(sessions) {
+    sessions.map((session) => session.unloadRecord());
   }
 }

--- a/admin/app/routes/authenticated/sessions/list/to-be-published.js
+++ b/admin/app/routes/authenticated/sessions/list/to-be-published.js
@@ -1,7 +1,13 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
 export default class AuthenticatedSessionsListToBePublishedRoute extends Route {
   model() {
     return this.store.query('to-be-published-session', {});
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/admin/app/styles/authenticated/sessions/list.scss
+++ b/admin/app/styles/authenticated/sessions/list.scss
@@ -32,3 +32,12 @@
     text-align: center;
   }
 }
+
+.session-to-be-publish {
+  &__publish-all {
+    width: 100%;
+    display: flex;
+    flex-direction: row-reverse;
+    margin-bottom: 16px;
+  }
+}

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -8,10 +8,9 @@
 
 <ToBePublishedSessions::ListItems @toBePublishedSessions={{@model}} @publishSession={{this.publishSession}} />
 
-
 <ConfirmPopup
-  @message='Vous vous apprêtez à publier {{@model.length}} session(s) de certification, souhaitez vous poursuivre ?' 
+  @message='Vous vous apprêtez à publier {{@model.length}} session(s) de certification, souhaitez vous poursuivre ?'
   @confirm={{this.batchPublishSessions}}
-  @cancel={{this.hideConfirmModal}} 
+  @cancel={{this.hideConfirmModal}}
   @show={{this.shouldShowModal}}
 />

--- a/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
+++ b/admin/app/templates/authenticated/sessions/list/to-be-published.hbs
@@ -1,4 +1,17 @@
-<ToBePublishedSessions::ListItems
-  @toBePublishedSessions={{@model}}
-  @publishSession={{this.publishSession}}
+{{#if @model.length}}
+<div class="session-to-be-publish__publish-all">
+  <button class="btn btn-primary" type="button" {{on 'click' this.showConfirmModal}}>
+    Publier toutes les sessions
+  </button>
+</div>
+{{/if}}
+
+<ToBePublishedSessions::ListItems @toBePublishedSessions={{@model}} @publishSession={{this.publishSession}} />
+
+
+<ConfirmPopup
+  @message='Vous vous apprêtez à publier {{@model.length}} session(s) de certification, souhaitez vous poursuivre ?' 
+  @confirm={{this.batchPublishSessions}}
+  @cancel={{this.hideConfirmModal}} 
+  @show={{this.shouldShowModal}}
 />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -24,7 +24,7 @@ export default function() {
     return withRequiredActionSessions;
   });
   this.patch('/admin/sessions/:id/publish', () => {
-    return new Response(200);
+    return new Response(204);
   });
   this.get('/admin/sessions/:id');
   this.get('/admin/sessions/:id/jury-certification-summaries', getJuryCertificationSummariesBySessionId);
@@ -33,6 +33,10 @@ export default function() {
     const session = schema.sessions.findBy({ id: sessionId });
     session.update({ resultsSentToPrescriberAt: new Date() });
     return session;
+  });
+
+  this.post('/admin/sessions/publish-in-batch', () => {
+    return new Response(200);
   });
 
   this.get('/users');

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
@@ -9,11 +9,15 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
+  const SESSIONS_TO_BE_PUBLISHED_LIST_PAGE = '/sessions/list/to-be-published';
+
+  const PUBLISH_ALL_SESSIONS_BUTTON_SELECTOR = '.session-to-be-publish__publish-all .btn-primary';
+
   module('When user is not logged in', function() {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
-      await visit('/sessions/list/to-be-published');
+      await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
       // then
       assert.equal(currentURL(), '/login');
@@ -29,10 +33,10 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
 
     test('visiting /sessions/list/to-be-published', async function(assert) {
       // when
-      await visit('/sessions/list/to-be-published');
+      await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
       // then
-      assert.equal(currentURL(), '/sessions/list/to-be-published');
+      assert.equal(currentURL(), SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
     });
 
     test('it should display sessions to publish informations', async function(assert) {
@@ -56,15 +60,12 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
       });
 
       // when
-      await visit('/sessions/list/to-be-published');
+      await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
 
       // then
-      assert.contains('Centre SCO des Anne-Étoiles');
-      assert.contains('Centre SUP et rieur');
-      assert.contains('1');
-      assert.contains('2');
-      assert.contains('01/01/2021 à 17:00:00');
-      assert.contains('01/02/2021');
+
+      _assertSessionInformationsAreDisplayed(assert);
+      _assertPublishAllSessionsButtonDisplayed(assert);
     });
 
     test('it should publish a session', async function(assert) {
@@ -86,15 +87,80 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
         sessionDate,
         sessionTime,
       });
-      await visit('/sessions/list/to-be-published');
+      await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
       await click('[aria-label="Publier la session numéro 2"]');
 
       // when
-      await click('.btn-primary');
+      await click('.modal-footer .btn-primary');
 
       // then
-      assert.contains('1');
-      assert.notContains('2');
+      _assertFirstSessionIsDisplayed(assert);
+      _assertSecondSessionIsNotDisplayed(assert);
+    });
+
+    test('it should publish a batch of sessions', async function(assert) {
+      // given
+      const sessionDate = '2021-01-01';
+      const sessionTime = '17:00:00';
+      const finalizedAt = new Date('2021-02-01T03:00:00Z');
+      server.create('to-be-published-session', {
+        id: '1',
+        certificationCenterName: 'Centre SCO des Anne-Étoiles',
+        finalizedAt,
+        sessionDate,
+        sessionTime,
+      });
+      server.create('to-be-published-session', {
+        id: '2',
+        certificationCenterName: 'Centre SUP et rieur',
+        finalizedAt,
+        sessionDate,
+        sessionTime,
+      });
+
+      await visit(SESSIONS_TO_BE_PUBLISHED_LIST_PAGE);
+      await click(PUBLISH_ALL_SESSIONS_BUTTON_SELECTOR);
+
+      // when
+      await click('.modal-footer .btn-primary');
+
+      // then
+      _assertPublishAllSessionsButtonHidden(assert);
+      _assertNoSessionInList(assert);
+      _assertConfirmModalIsClosed(assert);
     });
   });
 });
+
+function _assertPublishAllSessionsButtonDisplayed(assert) {
+  assert.contains('Publier toutes les sessions');
+}
+
+function _assertSessionInformationsAreDisplayed(assert) {
+  assert.contains('Centre SCO des Anne-Étoiles');
+  assert.contains('Centre SUP et rieur');
+  assert.contains('1');
+  assert.contains('2');
+  assert.contains('01/01/2021 à 17:00:00');
+  assert.contains('01/02/2021');
+}
+
+function _assertFirstSessionIsDisplayed(assert) {
+  assert.contains('Centre SCO des Anne-Étoiles');
+}
+
+function _assertSecondSessionIsNotDisplayed(assert) {
+  assert.notContains('Centre SUP et rieur');
+}
+
+function _assertPublishAllSessionsButtonHidden(assert) {
+  assert.notContains('Publier toutes les sessions');
+}
+
+function _assertNoSessionInList(assert) {
+  assert.contains('Aucun résultat');
+}
+
+function _assertConfirmModalIsClosed(assert) {
+  assert.notContains('Merci de confirmer');
+}

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -104,7 +104,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       assert.ok(true);
     });
 
-    test('should notify error on notifications service when publication fail', async function(assert) {
+    test('should notify error on notifications service when publication fails', async function(assert) {
       // given
       const errorMock = sinon.stub();
       class NotificationsStub extends Service {
@@ -115,14 +115,14 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
 
       const unloadRecord = sinon.stub().resolves();
       const sessions = [EmberObject.create({ id: 1, unloadRecord }), EmberObject.create({ id: 2, unloadRecord }) ];
-      const error = {
+      const response = {
         errors: [
           { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
         ],
       };
       const store = {
         adapterFor: sinon.stub().returns({
-          publishSessionInBatch: sinon.stub().resolves(error),
+          publishSessionInBatch: sinon.stub().resolves(response),
         }),
       };
 
@@ -138,7 +138,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       // then
       sinon.assert.calledWith(send, 'refreshModel');
       sinon.assert.calledWith(errorMock,
-        `Une ou plusieurs erreurs se sont produites, veuillez conserver la référence suivante pour investigation auprès de l'équipe technique : ${error.errors[0].detail}`,
+        `Une ou plusieurs erreurs se sont produites, veuillez conserver la référence suivante pour investigation auprès de l'équipe technique : ${response.errors[0].detail}`,
       );
       assert.ok(true);
     });

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -117,7 +117,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       const sessions = [EmberObject.create({ id: 1, unloadRecord }), EmberObject.create({ id: 2, unloadRecord }) ];
       const response = {
         errors: [
-          { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
+          { code: 'SESSION_PUBLICATION_BATCH_PARTIALLY_FAILED', details: 'Erreur dans la publication' },
         ],
       };
       const store = {

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -115,14 +115,14 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
 
       const unloadRecord = sinon.stub().resolves();
       const sessions = [EmberObject.create({ id: 1, unloadRecord }), EmberObject.create({ id: 2, unloadRecord }) ];
-      const publishError = { error: {
+      const error = {
         errors: [
           { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
         ],
-      } };
+      };
       const store = {
         adapterFor: sinon.stub().returns({
-          publishSessionInBatch: sinon.stub().rejects(publishError),
+          publishSessionInBatch: sinon.stub().resolves(error),
         }),
       };
 
@@ -138,11 +138,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
       // then
       sinon.assert.calledWith(send, 'refreshModel');
       sinon.assert.calledWith(errorMock,
-        { error: {
-          errors: [
-            { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
-          ],
-        } },
+        `Une ou plusieurs erreurs se sont produites, veuillez conserver la référence suivante pour investigation auprès de l'équipe technique : ${error.errors[0].detail}`,
       );
       assert.ok(true);
     });

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import sinon from 'sinon';
+import EmberObject from '@ember/object';
 
 module('Unit | Controller | authenticated/sessions/list/to-be-published', function(hooks) {
   setupTest(hooks);
@@ -45,6 +46,104 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
 
       // then
       sinon.assert.calledWith(errorMock, publishError);
+      assert.ok(true);
+    });
+  });
+
+  module('#showConfirmModal', function() {
+    test('should change shouldShowModal to true', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
+
+      // when
+      await controller.showConfirmModal();
+
+      // then
+      assert.ok(controller.shouldShowModal);
+    });
+  });
+
+  module('#hideConfirmModal', function() {
+    test('should change shouldShowModal to false', async function(assert) {
+      // given
+      const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
+
+      // when
+      await controller.hideConfirmModal();
+
+      // then
+      assert.notOk(controller.shouldShowModal);
+    });
+  });
+
+  module('#batchPublishSessions', function() {
+    test('should publish several sessions', async function(assert) {
+      // given
+      const successMock = sinon.stub();
+      class NotificationsStub extends Service {
+        success = successMock;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+      const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
+      const unloadRecord = sinon.stub().resolves();
+      const sessions = [EmberObject.create({ id: 1, unloadRecord }), EmberObject.create({ id: 2, unloadRecord }) ];
+      const store = {
+        adapterFor: sinon.stub().returns({
+          publishSessionInBatch: sinon.stub().resolves(),
+        }),
+      };
+      controller.set('model', sessions);
+      controller.set('store', store);
+
+      // when
+      await controller.batchPublishSessions();
+
+      // then
+      sinon.assert.calledTwice(unloadRecord);
+      sinon.assert.calledOnce(successMock);
+      assert.ok(true);
+    });
+
+    test('should notify error on notifications service when publication fail', async function(assert) {
+      // given
+      const errorMock = sinon.stub();
+      class NotificationsStub extends Service {
+        error = errorMock;
+      }
+      this.owner.register('service:notifications', NotificationsStub);
+      const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
+
+      const unloadRecord = sinon.stub().resolves();
+      const sessions = [EmberObject.create({ id: 1, unloadRecord }), EmberObject.create({ id: 2, unloadRecord }) ];
+      const publishError = { error: {
+        errors: [
+          { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
+        ],
+      } };
+      const store = {
+        adapterFor: sinon.stub().returns({
+          publishSessionInBatch: sinon.stub().rejects(publishError),
+        }),
+      };
+
+      const send = sinon.stub().resolves();
+
+      controller.set('send', send);
+      controller.set('model', sessions);
+      controller.set('store', store);
+
+      // when
+      await controller.batchPublishSessions();
+
+      // then
+      sinon.assert.calledWith(send, 'refreshModel');
+      sinon.assert.calledWith(errorMock,
+        { error: {
+          errors: [
+            { code: 'SESSION_BATCH_PUBLICATION_FAILED', details: 'Erreur dans la publication' },
+          ],
+        } },
+      );
       assert.ok(true);
     });
   });

--- a/api/db/seeds/data/certification/certification-candidates-builder.js
+++ b/api/db/seeds/data/certification/certification-candidates-builder.js
@@ -23,8 +23,8 @@ const FAILURE_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID = 6;
 const STARTED_CANDIDATE_IN_PROBLEMS_FINALIZED_SESSION_ID = 7;
 const SUCCESS_CANDIDATE_IN_PUBLISHED_SESSION_ID = 8;
 const FAILURE_CANDIDATE_IN_PUBLISHED_SESSION_ID = 9;
-const CANDIDATE_DATA_SUCCESS = { firstName: 'anne', lastName: 'success', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: 'destinaire-des-resulats@orga.com' };
-const CANDIDATE_DATA_FAILURE = { firstName: 'anne', lastName: 'failure', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: 'destinaire-des-resulats@orga.com' };
+const CANDIDATE_DATA_SUCCESS = { firstName: 'anne', lastName: 'success', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: 'destinaire-des-resulats@example.net' };
+const CANDIDATE_DATA_FAILURE = { firstName: 'anne', lastName: 'failure', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: 'destinaire-des-resulats@example.net' };
 const CANDIDATE_DATA_MISSING = { firstName: 'anne', lastName: 'missing', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: null };
 const CANDIDATE_DATA_STARTED = { firstName: 'AnneNormale5', lastName: 'Certif5', birthdate: '2000-01-01', birthCity: 'Ici', resultRecipientEmail: null };
 

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -113,7 +113,7 @@ class SessionPublicationBatchError extends BaseHttpError {
   constructor(batchId) {
     super(`${batchId}`);
     this.title = 'One or more error occurred while publishing session in batch';
-    this.code = 'SESSION_BATCH_PUBLICATION_FAILED',
+    this.code = 'SESSION_PUBLICATION_BATCH_PARTIALLY_FAILED',
     this.status = 207;
   }
 }

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -114,7 +114,7 @@ class SessionPublicationBatchError extends BaseHttpError {
     super(`${batchId}`);
     this.title = 'One or more error occurred while publishing session in batch';
     this.code = 'SESSION_BATCH_PUBLICATION_FAILED',
-    this.status = 503;
+    this.status = 207;
   }
 }
 

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -109,6 +109,15 @@ class PayloadTooLargeError extends BaseHttpError {
   }
 }
 
+class SessionPublicationBatchError extends BaseHttpError {
+  constructor(batchId) {
+    super(`${batchId}`);
+    this.title = 'One or more error occurred while publishing session in batch';
+    this.code = 'SESSION_BATCH_PUBLICATION_FAILED',
+    this.status = 503;
+  }
+}
+
 function sendJsonApiError(httpError, h) {
   const jsonApiError = new JSONAPIError({
     status: httpError.status.toString(),
@@ -133,4 +142,5 @@ module.exports = {
   ServiceUnavailableError,
   UnauthorizedError,
   UnprocessableEntityError,
+  SessionPublicationBatchError,
 };

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -407,6 +407,31 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/sessions/publish-in-batch',
+      config: {
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                ids: Joi.array().items(identifiersType.sessionId),
+              },
+            },
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: sessionController.publishInBatch,
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
+          '- Publie plusieurs sessions d\'un coup',
+        ],
+        tags: ['api', 'session', 'publication'],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/sessions/{id}/unpublish',
       config: {

--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -425,8 +425,8 @@ exports.register = async (server) => {
         }],
         handler: sessionController.publishInBatch,
         notes: [
-          '- **Cette route est restreinte aux utilisateurs authentifiés**\n' +
-          '- Publie plusieurs sessions d\'un coup',
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle PixMaster**\n' +
+          '- Permet de publier plusieurs sessions sans problème d\'un coup',
         ],
         tags: ['api', 'session', 'publication'],
       },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -277,12 +277,14 @@ module.exports = {
 };
 
 function _logSessionBatchPublicationErrors(result) {
-  const dtoToBeLogged = {
-    batchId: result.batchId,
-  };
+  logger.warn(`One or more error occurred when publishing session in batch ${result.batchId}`);
+
   const sessionAndError = result.publicationErrors;
   for (const sessionId in sessionAndError) {
-    dtoToBeLogged[sessionId] = sessionAndError[sessionId].message;
+    logger.warn({
+      batchId: result.batchId,
+      sessionId,
+      message: sessionAndError[sessionId].message,
+    });
   }
-  logger.warn(dtoToBeLogged, `One or more error occurred when publishing session in batch ${result.batchId}`);
 }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -626,6 +626,12 @@ class SessionAlreadyFinalizedError extends DomainError {
   }
 }
 
+class SessionAlreadyPublishedError extends DomainError {
+  constructor(message = 'La session est déjà publiée.') {
+    super(message);
+  }
+}
+
 class TargetProfileInvalidError extends DomainError {
   constructor(message = 'Le profil cible ne possède aucun acquis ciblé.') {
     super(message);
@@ -810,6 +816,7 @@ module.exports = {
   SchoolingRegistrationsCouldNotBeSavedError,
   SendingEmailToResultRecipientError,
   SessionAlreadyFinalizedError,
+  SessionAlreadyPublishedError,
   TargetProfileInvalidError,
   TargetProfileCannotBeCreated,
   UnexpectedUserAccount,

--- a/api/lib/domain/models/EmailingAttempt.js
+++ b/api/lib/domain/models/EmailingAttempt.js
@@ -1,0 +1,27 @@
+module.exports = class EmailingAttempt {
+  constructor(recipientEmail, status) {
+    this.recipientEmail = recipientEmail;
+    this.status = status;
+  }
+
+  hasFailed() {
+    return this.status === AttemptStatus.FAILURE;
+  }
+
+  hasSucceeded() {
+    return this.status === AttemptStatus.SUCCESS;
+  }
+
+  static success(recipientEmail) {
+    return new EmailingAttempt(recipientEmail, AttemptStatus.SUCCESS);
+  }
+
+  static failure(recipientEmail) {
+    return new EmailingAttempt(recipientEmail, AttemptStatus.FAILURE);
+  }
+};
+
+const AttemptStatus = {
+  SUCCESS: 'SUCCESS',
+  FAILURE: 'FAILURE',
+};

--- a/api/lib/domain/models/Session.js
+++ b/api/lib/domain/models/Session.js
@@ -67,6 +67,10 @@ class Session {
     }
     return statuses.CREATED;
   }
+
+  isPublished() {
+    return this.publishedAt !== null;
+  }
 }
 
 module.exports = Session;

--- a/api/lib/domain/models/SessionPublicationBatchResult.js
+++ b/api/lib/domain/models/SessionPublicationBatchResult.js
@@ -1,0 +1,18 @@
+class SessionPublicationBatchResult {
+  constructor(batchId) {
+    this.batchId = batchId;
+    this.publicationErrors = {};
+  }
+
+  hasPublicationErrors() {
+    return Boolean(Object.keys(this.publicationErrors).length);
+  }
+
+  addPublicationError(sessionId, error) {
+    this.publicationErrors[sessionId] = error;
+  }
+}
+
+module.exports = {
+  SessionPublicationBatchResult,
+};

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -72,7 +72,7 @@ function _someHaveFailed(emailingAttempts) {
 
 function _failedAttemptsRecipients(emailingAttempts) {
   return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed())
-    .map((emailAttempt) => emailAttempt.recipient);
+    .map((emailAttempt) => emailAttempt.recipientEmail);
 }
 
 module.exports = {

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -1,4 +1,4 @@
-const { SendingEmailToResultRecipientError } = require('../../domain/errors');
+const { SendingEmailToResultRecipientError, SessionAlreadyPublishedError } = require('../../domain/errors');
 const mailService = require('../../domain/services/mail-service');
 const uniqBy = require('lodash/uniqBy');
 const some = require('lodash/some');
@@ -11,6 +11,9 @@ async function publishSession({
   publishedAt = new Date(),
 }) {
   const session = await sessionRepository.getWithCertificationCandidates(sessionId);
+  if (session.isPublished()) {
+    throw new SessionAlreadyPublishedError();
+  }
 
   await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
 

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -1,0 +1,79 @@
+const { SendingEmailToResultRecipientError } = require('../../domain/errors');
+const mailService = require('../../domain/services/mail-service');
+const uniqBy = require('lodash/uniqBy');
+const some = require('lodash/some');
+
+async function publishSession({
+  sessionId,
+  certificationRepository,
+  finalizedSessionRepository,
+  sessionRepository,
+  publishedAt = new Date(),
+}) {
+  const session = await sessionRepository.getWithCertificationCandidates(sessionId);
+
+  await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
+
+  let publishedSession = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
+
+  await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
+
+  const emailingAttempts = await _sendPrescriberEmails(session);
+  if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
+    publishedSession = await sessionRepository.flagResultsAsSentToPrescriber({
+      id: sessionId,
+      resultsSentToPrescriberAt: publishedAt,
+    });
+  }
+  if (_someHaveFailed(emailingAttempts)) {
+    const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
+    throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
+  }
+
+  return publishedSession;
+}
+
+async function _sendPrescriberEmails(session) {
+  const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);
+
+  const emailingAttempts = [];
+  for (const recipientEmail of recipientEmails) {
+    const emailingAttempt = await mailService.sendCertificationResultEmail({
+      email: recipientEmail,
+      sessionId: session.id,
+      sessionDate: session.date,
+      certificationCenterName: session.certificationCenter,
+      resultRecipientEmail: recipientEmail,
+      daysBeforeExpiration: 30,
+    });
+    emailingAttempts.push(emailingAttempt);
+  }
+  return emailingAttempts;
+}
+
+function _distinctCandidatesResultRecipientEmails(certificationCandidates) {
+  return uniqBy(certificationCandidates, 'resultRecipientEmail')
+    .map((candidate) => candidate.resultRecipientEmail)
+    .filter(Boolean);
+}
+
+function _someHaveSucceeded(emailingAttempts) {
+  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasSucceeded());
+}
+
+function _noneHaveFailed(emailingAttempts) {
+  return !some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
+}
+
+function _someHaveFailed(emailingAttempts) {
+  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
+}
+
+function _failedAttemptsRecipients(emailingAttempts) {
+  return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed())
+    .map((emailAttempt) => emailAttempt.recipient);
+}
+
+module.exports = {
+  publishSession,
+};

--- a/api/lib/domain/services/session-publication-service.js
+++ b/api/lib/domain/services/session-publication-service.js
@@ -14,13 +14,13 @@ async function publishSession({
 
   await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
 
-  let publishedSession = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
+  await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
 
   await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
 
   const emailingAttempts = await _sendPrescriberEmails(session);
   if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
-    publishedSession = await sessionRepository.flagResultsAsSentToPrescriber({
+    await sessionRepository.flagResultsAsSentToPrescriber({
       id: sessionId,
       resultsSentToPrescriberAt: publishedAt,
     });
@@ -29,8 +29,6 @@ async function publishSession({
     const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
     throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
   }
-
-  return publishedSession;
 }
 
 async function _sendPrescriberEmails(session) {

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -77,6 +77,7 @@ const dependencies = {
   scorecardService: require('../../domain/services/scorecard-service'),
   scoringCertificationService: require('../../domain/services/scoring/scoring-certification-service'),
   sessionAuthorizationService: require('../../domain/services/session-authorization-service'),
+  sessionPublicationService: require('../../domain/services/session-publication-service'),
   sessionRepository: require('../../infrastructure/repositories/session-repository'),
   settings: require('../../config'),
   skillRepository: require('../../infrastructure/repositories/skill-repository'),

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -256,6 +256,7 @@ module.exports = injectDependencies({
   updateOrganizationInformation: require('./update-organization-information'),
   publishSession: require('./publish-session'),
   unpublishSession: require('./unpublish-session'),
+  publishSessionsInBatch: require('./publish-sessions-in-batch'),
   updateSchoolingRegistrationDependentUserPassword: require('./update-schooling-registration-dependent-user-password'),
   updateSession: require('./update-session'),
   updateStudentNumber: require('./update-student-number'),

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -7,11 +7,13 @@ module.exports = async function publishSession({
   publishedAt = new Date(),
 }) {
 
-  return sessionPublicationService.publishSession({
+  await sessionPublicationService.publishSession({
     sessionId,
     certificationRepository,
     finalizedSessionRepository,
     sessionRepository,
     publishedAt,
   });
+
+  return sessionRepository.get(sessionId);
 };

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -1,75 +1,17 @@
-const { SendingEmailToResultRecipientError } = require('../../domain/errors');
-const mailService = require('../../domain/services/mail-service');
-const uniqBy = require('lodash/uniqBy');
-const some = require('lodash/some');
-
 module.exports = async function publishSession({
   sessionId,
   certificationRepository,
   finalizedSessionRepository,
   sessionRepository,
+  sessionPublicationService,
   publishedAt = new Date(),
 }) {
-  const session = await sessionRepository.getWithCertificationCandidates(sessionId);
 
-  await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
-
-  let publishedSession = await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
-
-  await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
-
-  const emailingAttempts = await _sendPrescriberEmails(session);
-  if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
-    publishedSession = await sessionRepository.flagResultsAsSentToPrescriber({
-      id: sessionId,
-      resultsSentToPrescriberAt: publishedAt,
-    });
-  }
-  if (_someHaveFailed(emailingAttempts)) {
-    const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
-    throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
-  }
-
-  return publishedSession;
+  return sessionPublicationService.publishSession({
+    sessionId,
+    certificationRepository,
+    finalizedSessionRepository,
+    sessionRepository,
+    publishedAt,
+  });
 };
-
-async function _sendPrescriberEmails(session) {
-  const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);
-
-  const emailingAttempts = [];
-  for (const recipientEmail of recipientEmails) {
-    const emailingAttempt = await mailService.sendCertificationResultEmail({
-      email: recipientEmail,
-      sessionId: session.id,
-      sessionDate: session.date,
-      certificationCenterName: session.certificationCenter,
-      resultRecipientEmail: recipientEmail,
-      daysBeforeExpiration: 30,
-    });
-    emailingAttempts.push(emailingAttempt);
-  }
-  return emailingAttempts;
-}
-
-function _distinctCandidatesResultRecipientEmails(certificationCandidates) {
-  return uniqBy(certificationCandidates, 'resultRecipientEmail')
-    .map((candidate) => candidate.resultRecipientEmail)
-    .filter(Boolean);
-}
-
-function _someHaveSucceeded(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasSucceeded());
-}
-
-function _noneHaveFailed(emailingAttempts) {
-  return !some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
-}
-
-function _someHaveFailed(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
-}
-
-function _failedAttemptsRecipients(emailingAttempts) {
-  return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed())
-    .map((emailAttempt) => emailAttempt.recipient);
-}

--- a/api/lib/domain/usecases/publish-session.js
+++ b/api/lib/domain/usecases/publish-session.js
@@ -38,19 +38,15 @@ async function _sendPrescriberEmails(session) {
 
   const emailingAttempts = [];
   for (const recipientEmail of recipientEmails) {
-    try {
-      await mailService.sendCertificationResultEmail({
-        email: recipientEmail,
-        sessionId: session.id,
-        sessionDate: session.date,
-        certificationCenterName: session.certificationCenter,
-        resultRecipientEmail: recipientEmail,
-        daysBeforeExpiration: 30,
-      });
-      emailingAttempts.push(EmailingAttempt.success(recipientEmail));
-    } catch (error) {
-      emailingAttempts.push(EmailingAttempt.failure(recipientEmail));
-    }
+    const emailingAttempt = await mailService.sendCertificationResultEmail({
+      email: recipientEmail,
+      sessionId: session.id,
+      sessionDate: session.date,
+      certificationCenterName: session.certificationCenter,
+      resultRecipientEmail: recipientEmail,
+      daysBeforeExpiration: 30,
+    });
+    emailingAttempts.push(emailingAttempt);
   }
   return emailingAttempts;
 }
@@ -60,34 +56,6 @@ function _distinctCandidatesResultRecipientEmails(certificationCandidates) {
     .map((candidate) => candidate.resultRecipientEmail)
     .filter(Boolean);
 }
-
-class EmailingAttempt {
-  constructor(recipientEmail, status) {
-    this.recipientEmail = recipientEmail;
-    this.status = status;
-  }
-
-  hasFailed() {
-    return this.status === AttemptStatus.FAILURE;
-  }
-
-  hasSucceeded() {
-    return this.status === AttemptStatus.SUCCESS;
-  }
-
-  static success(recipientEmail) {
-    return new EmailingAttempt(recipientEmail, AttemptStatus.SUCCESS);
-  }
-
-  static failure(recipientEmail) {
-    return new EmailingAttempt(recipientEmail, AttemptStatus.FAILURE);
-  }
-}
-
-const AttemptStatus = {
-  SUCCESS: 'SUCCESS',
-  FAILURE: 'FAILURE',
-};
 
 function _someHaveSucceeded(emailingAttempts) {
   return some(emailingAttempts, (emailAttempt) => emailAttempt.hasSucceeded());

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,13 +1,8 @@
-const some = require('lodash/some');
-const uniqBy = require('lodash/uniqBy');
-
-const { SendingEmailToResultRecipientError } = require('../../domain/errors');
-const mailService = require('../../domain/services/mail-service');
-
 module.exports = async function publishSessionsInBatch({
   sessionIds,
   certificationRepository,
   finalizedSessionRepository,
+  sessionPublicationService,
   sessionRepository,
   publishedAt = new Date(),
 }) {
@@ -15,69 +10,16 @@ module.exports = async function publishSessionsInBatch({
 
   for (const sessionId of sessionIds) {
     try {
-      const session = await sessionRepository.getWithCertificationCandidates(sessionId);
-
-      await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
-
-      await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
-
-      await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
-
-      const emailingAttempts = await _sendPrescriberEmails(session);
-      if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
-        await sessionRepository.flagResultsAsSentToPrescriber({
-          id: sessionId,
-          resultsSentToPrescriberAt: publishedAt,
-        });
-      }
-      if (_someHaveFailed(emailingAttempts)) {
-        const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
-        throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
-      }
+      await sessionPublicationService.publishSession({
+        sessionId,
+        certificationRepository,
+        finalizedSessionRepository,
+        sessionRepository,
+        publishedAt,
+      });
     }
     catch (error) {
       publicationErrors.push(error);
     }
   }
 };
-
-async function _sendPrescriberEmails(session) {
-  const recipientEmails = _distinctCandidatesResultRecipientEmails(session.certificationCandidates);
-
-  const emailingAttempts = [];
-  for (const recipientEmail of recipientEmails) {
-    const emailingAttempt = await mailService.sendCertificationResultEmail({
-      email: recipientEmail,
-      sessionId: session.id,
-      sessionDate: session.date,
-      certificationCenterName: session.certificationCenter,
-      resultRecipientEmail: recipientEmail,
-      daysBeforeExpiration: 30,
-    });
-    emailingAttempts.push(emailingAttempt);
-  }
-  return emailingAttempts;
-}
-
-function _distinctCandidatesResultRecipientEmails(certificationCandidates) {
-  return uniqBy(certificationCandidates, 'resultRecipientEmail')
-    .map((candidate) => candidate.resultRecipientEmail)
-    .filter(Boolean);
-}
-
-function _someHaveSucceeded(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasSucceeded());
-}
-
-function _noneHaveFailed(emailingAttempts) {
-  return !some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
-}
-
-function _someHaveFailed(emailingAttempts) {
-  return some(emailingAttempts, (emailAttempt) => emailAttempt.hasFailed());
-}
-
-function _failedAttemptsRecipients(emailingAttempts) {
-  return emailingAttempts.filter((emailAttempt) => emailAttempt.hasFailed())
-    .map((emailAttempt) => emailAttempt.recipient);
-}

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,4 +1,5 @@
 const uuidv4 = require('uuid/v4');
+const { SessionPublicationBatchResult } = require('../models/SessionPublicationBatchResult');
 
 module.exports = async function publishSessionsInBatch({
   sessionIds,
@@ -25,16 +26,3 @@ module.exports = async function publishSessionsInBatch({
   }
   return result;
 };
-
-class SessionPublicationBatchResult {
-  constructor(batchId) {
-    this.batchId = batchId;
-    this.publicationErrors = {};
-  }
-  hasPublicationErrors() {
-    return Boolean(Object.keys(this.publicationErrors).length);
-  }
-  addPublicationError(sessionId, error) {
-    this.publicationErrors[sessionId] = error;
-  }
-}

--- a/api/lib/domain/usecases/publish-sessions-in-batch.js
+++ b/api/lib/domain/usecases/publish-sessions-in-batch.js
@@ -1,7 +1,9 @@
+const bluebird = require('bluebird');
+const some = require('lodash/some');
+const uniqBy = require('lodash/uniqBy');
+
 const { SendingEmailToResultRecipientError } = require('../../domain/errors');
 const mailService = require('../../domain/services/mail-service');
-const uniqBy = require('lodash/uniqBy');
-const some = require('lodash/some');
 
 module.exports = async function publishSessionsInBatch({
   sessionIds,
@@ -10,29 +12,34 @@ module.exports = async function publishSessionsInBatch({
   sessionRepository,
   publishedAt = new Date(),
 }) {
-  // Attention, ce n'est pas une implémentation à conserver, c'est un squelette
-  // à changer
-  return Promise.all(sessionIds.map(async (sessionId) => {
-    const session = await sessionRepository.getWithCertificationCandidates(sessionId);
+  const publicationErrors = [];
 
-    await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
+  for (const sessionId of sessionIds) {
+    try {
+      const session = await sessionRepository.getWithCertificationCandidates(sessionId);
 
-    await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
+      await certificationRepository.publishCertificationCoursesBySessionId(sessionId);
 
-    await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
+      await sessionRepository.updatePublishedAt({ id: sessionId, publishedAt });
 
-    const emailingAttempts = await _sendPrescriberEmails(session);
-    if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
-      await sessionRepository.flagResultsAsSentToPrescriber({
-        id: sessionId,
-        resultsSentToPrescriberAt: publishedAt,
-      });
+      await finalizedSessionRepository.updatePublishedAt({ sessionId, publishedAt });
+
+      const emailingAttempts = await _sendPrescriberEmails(session);
+      if (_someHaveSucceeded(emailingAttempts) && _noneHaveFailed(emailingAttempts)) {
+        await sessionRepository.flagResultsAsSentToPrescriber({
+          id: sessionId,
+          resultsSentToPrescriberAt: publishedAt,
+        });
+      }
+      if (_someHaveFailed(emailingAttempts)) {
+        const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
+        throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
+      }
     }
-    if (_someHaveFailed(emailingAttempts)) {
-      const failedEmailsRecipients = _failedAttemptsRecipients(emailingAttempts);
-      throw new SendingEmailToResultRecipientError(failedEmailsRecipients);
+    catch (error) {
+      publicationErrors.push(error);
     }
-  }));
+  }
 };
 
 async function _sendPrescriberEmails(session) {

--- a/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
+++ b/api/tests/acceptance/application/session/session-controller-patch-publish-session_test.js
@@ -78,7 +78,7 @@ describe('PATCH /api/admin/sessions/:id/publish', () => {
         const date = new Date('2000-01-01T10:00:00Z');
 
         beforeEach(() => {
-          sessionId = databaseBuilder.factory.buildSession({ publishedAt: date }).id;
+          sessionId = databaseBuilder.factory.buildSession({ publishedAt: null }).id;
           databaseBuilder.factory.buildFinalizedSession({ sessionId });
           options.url = `/api/admin/sessions/${sessionId}/publish`;
           certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;

--- a/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
@@ -1,0 +1,110 @@
+const {
+  expect, generateValidRequestAuthorizationHeader, databaseBuilder, knex,
+} = require('../../../test-helper');
+const createServer = require('../../../../server');
+
+describe('POST /api/admin/sessions/publish-in-batch', () => {
+  let server;
+  const options = {
+    method: 'POST',
+    url: '/api/admin/sessions/publish-in-batch',
+  };
+  let userId;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  context('when user does not have the role PIX MASTER', () => {
+
+    beforeEach(() => {
+      userId = databaseBuilder.factory.buildUser().id;
+      return databaseBuilder.commit();
+    });
+
+    it('should return a 403 error code', async () => {
+      // given
+      options.payload = { data: { attributes: { ids: [1] } } };
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+  });
+
+  context('when user has role PixMaster', () => {
+
+    beforeEach(() => {
+      // given
+      userId = databaseBuilder.factory.buildUser.withPixRolePixMaster().id;
+      options.headers = { authorization: generateValidRequestAuthorizationHeader(userId) };
+      return databaseBuilder.commit();
+    });
+
+    context('when a session id has an invalid format', () => {
+
+      it('should return a 400 error code', async () => {
+        // given
+        options.payload = { data: { attributes: { ids: ['any'] } } };
+
+        // when
+        const response = await server.inject(options);
+
+        // then
+        expect(response.statusCode).to.equal(400);
+      });
+    });
+
+    context('when the session id is a number', () => {
+
+      context('when a session does not exist', () => {
+
+        it('should return a 207 error code', async () => {
+          // given
+          options.payload = { data: { attributes: { ids: [1] } } };
+
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(207);
+          expect(response.result).to.nested.include({ 'errors[0].code': 'SESSION_BATCH_PUBLICATION_FAILED' });
+        });
+      });
+
+      context('when all the sessions exists', () => {
+        let sessionId;
+        let certificationId;
+
+        beforeEach(() => {
+          sessionId = databaseBuilder.factory.buildSession({ publishedAt: null }).id;
+          databaseBuilder.factory.buildFinalizedSession({ sessionId });
+          options.payload = { data: { attributes: { ids: [sessionId] } } };
+          certificationId = databaseBuilder.factory.buildCertificationCourse({ sessionId, isPublished: false }).id;
+          return databaseBuilder.commit();
+        });
+
+        it('should return a 204 status code', async () => {
+          // when
+          const response = await server.inject(options);
+
+          // then
+          expect(response.statusCode).to.equal(204);
+        });
+
+        it('should update the isPublished field in certification course', async () => {
+          // when
+          await server.inject(options);
+
+          // then
+          const certificationCourses = await knex('certification-courses').where({ id: certificationId });
+          expect(certificationCourses[0].isPublished).to.be.true;
+        });
+      });
+    });
+  });
+});

--- a/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
+++ b/api/tests/acceptance/application/session/session-controller-publish-session-in-batch_test.js
@@ -32,7 +32,7 @@ describe('POST /api/admin/sessions/publish-in-batch', () => {
 
         // then
         expect(response.statusCode).to.equal(207);
-        expect(response.result).to.nested.include({ 'errors[0].code': 'SESSION_BATCH_PUBLICATION_FAILED' });
+        expect(response.result).to.nested.include({ 'errors[0].code': 'SESSION_PUBLICATION_BATCH_PARTIALLY_FAILED' });
       });
     });
 

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -386,6 +386,14 @@ describe('Integration | API | Controller Error', () => {
       expect(responseDetail(response)).to.equal('Erreur, tentatives de finalisation multiples de la session.');
     });
 
+    it('responds Bad Request when a SessionAlreadyPublishedError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.SessionAlreadyPublishedError());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(BAD_REQUEST_ERROR);
+      expect(responseDetail(response)).to.equal('La session est déjà publiée.');
+    });
+
     it('responds Bad Request when a UserOrgaSettingsCreationError error occurs', async () => {
       routeHandler.throws(new DomainErrors.UserOrgaSettingsCreationError('Erreur lors de la création des paramètres utilisateur relatifs à Pix Orga.'));
       const response = await server.inject(options);

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -291,7 +291,26 @@ describe('Unit | Application | Sessions | Routes', () => {
   });
 
   describe('POST /api/admin/sessions/publish-in-batch', () => {
-    it('should exist', async () => {
+
+    it('is protected by a prehandler checking the Pix Master role', async () => {
+      // given
+      securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => h.response().code(403).takeover());
+      const payload = {
+        data: {
+          attributes: {
+            ids: [1, 2, 3],
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+      // then
+      expect(response.statusCode).to.equal(403);
+    });
+
+    it('should succeed with valid session ids', async () => {
       // given
       const payload = {
         data: {

--- a/api/tests/unit/application/session/index_test.js
+++ b/api/tests/unit/application/session/index_test.js
@@ -43,6 +43,7 @@ describe('Unit | Application | Sessions | Routes', () => {
     sinon.stub(sessionController, 'flagResultsAsSentToPrescriber').returns('ok');
     sinon.stub(sessionController, 'assignCertificationOfficer').returns('ok');
     sinon.stub(sessionController, 'enrollStudentsToSession').returns('ok');
+    sinon.stub(sessionController, 'publishInBatch').returns('ok');
     sinon.stub(finalizedSessionController, 'findFinalizedSessionsToPublish').returns('ok');
     sinon.stub(finalizedSessionController, 'findFinalizedSessionsWithRequiredAction').returns('ok');
 
@@ -286,6 +287,42 @@ describe('Unit | Application | Sessions | Routes', () => {
 
       // then
       expect(response.statusCode).to.equal(200);
+    });
+  });
+
+  describe('POST /api/admin/sessions/publish-in-batch', () => {
+    it('should exist', async () => {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            ids: [1, 2, 3],
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should validate the session ids in payload', async () => {
+      // given
+      const payload = {
+        data: {
+          attributes: {
+            ids: ['an invalid session id'],
+          },
+        },
+      };
+
+      // when
+      const response = await httpTestServer.request('POST', '/api/admin/sessions/publish-in-batch', payload);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -803,14 +803,19 @@ describe('Unit | Controller | sessionController', () => {
       await catchErr(sessionController.publishInBatch)(request, hFake);
 
       // then
-      expect(logger.warn).to.have.been.calledWithExactly(
-        {
-          batchId: 'batchId',
-          sessionId1: 'an error',
-          sessionId2: 'another error',
-        },
-        'One or more error occurred when publishing session in batch batchId',
-      );
+      expect(logger.warn).to.have.been.calledWithExactly('One or more error occurred when publishing session in batch batchId');
+
+      expect(logger.warn).to.have.been.calledWithExactly({
+        batchId: 'batchId',
+        sessionId: 'sessionId1',
+        message: 'an error',
+      });
+
+      expect(logger.warn).to.have.been.calledWithExactly({
+        batchId: 'batchId',
+        sessionId: 'sessionId2',
+        message: 'another error',
+      });
     });
 
     it('returns the serialized batch id', async () => {

--- a/api/tests/unit/domain/models/Session_test.js
+++ b/api/tests/unit/domain/models/Session_test.js
@@ -1,6 +1,7 @@
 const Session = require('../../../../lib/domain/models/Session');
 const { expect } = require('../../../test-helper');
 const _ = require('lodash');
+const { domainBuilder } = require('../../../test-helper');
 
 const SESSION_PROPS = [
   'id',
@@ -143,6 +144,28 @@ describe('Unit | Domain | Models | Session', () => {
           });
         });
       });
+    });
+  });
+
+  context('#isPublished', () => {
+    it('returns true when the session is published', () => {
+      // given
+      const session = domainBuilder.buildSession({ publishedAt: new Date() });
+      // when
+      const isPublished = session.isPublished();
+
+      // then
+      expect(isPublished).to.be.true;
+    });
+
+    it('returns false when the session is not published', () => {
+      // given
+      const session = domainBuilder.buildSession({ publishedAt: null });
+      // when
+      const isPublished = session.isPublished();
+
+      // then
+      expect(isPublished).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -5,10 +5,10 @@ const {
   catchErr,
 } = require('../../../test-helper');
 
-const publishSession = require('../../../../lib/domain/usecases/publish-session');
+const { publishSession } = require('../../../../lib/domain/services/session-publication-service');
+
 const { SendingEmailToResultRecipientError } = require('../../../../lib/domain/errors');
 const mailService = require('../../../../lib/domain/services/mail-service');
-const sessionPublicationService = require('../../../../lib/domain/services/session-publication-service');
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 
 describe('Unit | UseCase | publish-session', () => {
@@ -89,7 +89,6 @@ describe('Unit | UseCase | publish-session', () => {
           finalizedSessionRepository,
           sessionRepository,
           publishedAt: now,
-          sessionPublicationService,
         });
 
         // then
@@ -111,7 +110,6 @@ describe('Unit | UseCase | publish-session', () => {
           certificationRepository,
           finalizedSessionRepository,
           sessionRepository,
-          sessionPublicationService,
         });
 
         // then
@@ -146,7 +144,6 @@ describe('Unit | UseCase | publish-session', () => {
           certificationRepository,
           finalizedSessionRepository,
           sessionRepository,
-          sessionPublicationService,
         });
 
         // then
@@ -177,7 +174,6 @@ describe('Unit | UseCase | publish-session', () => {
             certificationRepository,
             finalizedSessionRepository,
             sessionRepository,
-            sessionPublicationService,
           });
 
           // then
@@ -211,7 +207,6 @@ describe('Unit | UseCase | publish-session', () => {
             finalizedSessionRepository,
             sessionRepository,
             publishedAt: now,
-            sessionPublicationService,
           });
 
           // then
@@ -237,7 +232,6 @@ describe('Unit | UseCase | publish-session', () => {
           finalizedSessionRepository,
           sessionRepository,
           publishedAt,
-          sessionPublicationService,
         });
 
         // then

--- a/api/tests/unit/domain/services/session-publication-service_test.js
+++ b/api/tests/unit/domain/services/session-publication-service_test.js
@@ -11,7 +11,7 @@ const { SendingEmailToResultRecipientError } = require('../../../../lib/domain/e
 const mailService = require('../../../../lib/domain/services/mail-service');
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 
-describe('Unit | UseCase | publish-session', () => {
+describe('Unit | UseCase | session-publication-service', () => {
 
   const sessionId = 123;
   let certificationRepository;
@@ -83,7 +83,7 @@ describe('Unit | UseCase | publish-session', () => {
         mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
 
         // when
-        const session = await publishSession({
+        await publishSession({
           sessionId,
           certificationRepository,
           finalizedSessionRepository,
@@ -92,7 +92,6 @@ describe('Unit | UseCase | publish-session', () => {
         });
 
         // then
-        expect(session).to.deep.equal(updatedSessionWithResultSent);
         expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId, publishedAt: now });
       });
 

--- a/api/tests/unit/domain/usecases/publish-session_test.js
+++ b/api/tests/unit/domain/usecases/publish-session_test.js
@@ -1,266 +1,47 @@
 const {
-  domainBuilder,
   sinon,
   expect,
-  catchErr,
 } = require('../../../test-helper');
 
 const publishSession = require('../../../../lib/domain/usecases/publish-session');
-const { SendingEmailToResultRecipientError } = require('../../../../lib/domain/errors');
-const mailService = require('../../../../lib/domain/services/mail-service');
-const sessionPublicationService = require('../../../../lib/domain/services/session-publication-service');
-const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 
 describe('Unit | UseCase | publish-session', () => {
 
-  const sessionId = 123;
-  let certificationRepository;
-  let sessionRepository;
-  let finalizedSessionRepository;
-  const now = new Date('2019-01-01T05:06:07Z');
-  const sessionDate = '2020-05-08';
-  let clock;
+  it('delegates the action to the session-publication-service and return the session', async () => {
+    // given
+    const sessionId = Symbol('a session id');
+    const session = Symbol('a session');
+    const certificationRepository = Symbol('the certification repository');
+    const finalizedSessionRepository = Symbol('the finalizedSessionRepository');
+    const publishedAt = Symbol('a publication date');
 
-  beforeEach(() => {
-    clock = sinon.useFakeTimers(now);
-    certificationRepository = {
-      publishCertificationCoursesBySessionId: sinon.stub(),
+    const sessionRepository = {
+      get: sinon.stub(),
     };
-    sessionRepository = {
-      updatePublishedAt: sinon.stub(),
-      getWithCertificationCandidates: sinon.stub(),
+    sessionRepository.get.resolves(session);
+
+    const sessionPublicationService = {
+      publishSession: sinon.stub(),
     };
-    finalizedSessionRepository = {
-      updatePublishedAt: sinon.stub().resolves(),
-    };
-    sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
-    mailService.sendCertificationResultEmail = sinon.stub();
+
+    // when
+    const result = await publishSession({
+      sessionId,
+      certificationRepository,
+      finalizedSessionRepository,
+      sessionRepository,
+      sessionPublicationService,
+      publishedAt,
+    });
+
+    // then
+    expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
+      sessionId,
+      certificationRepository,
+      finalizedSessionRepository,
+      sessionRepository,
+      publishedAt,
+    });
+    expect(result).to.equal(session);
   });
-
-  afterEach(() => {
-    clock.restore();
-  });
-
-  context('when the session exists', () => {
-    const recipient1 = 'email1@example.net';
-    const recipient2 = 'email2@example.net';
-    const certificationCenter = 'certificationCenter';
-    const candidateWithRecipient1 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient1,
-    });
-    const candidateWithRecipient2 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient2,
-    });
-    const candidate2WithRecipient2 = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: recipient2,
-    });
-    const candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
-      resultRecipientEmail: null,
-    });
-    const originalSession = domainBuilder.buildSession({
-      id: sessionId,
-      certificationCenter,
-      date: sessionDate,
-      certificationCandidates: [
-        candidateWithRecipient1, candidateWithRecipient2, candidate2WithRecipient2, candidateWithNoRecipient,
-      ],
-    });
-
-    beforeEach(() => {
-      sessionRepository.getWithCertificationCandidates.withArgs(sessionId).resolves(originalSession);
-    });
-
-    context('When we publish the session', () => {
-
-      it('should update the published date', async () => {
-        // given
-        const updatedSessionWithPublishedAt = { ...originalSession, publishedAt: now };
-        const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-        sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
-        sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
-
-        // when
-        const session = await publishSession({
-          sessionId,
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionRepository,
-          publishedAt: now,
-          sessionPublicationService,
-        });
-
-        // then
-        expect(session).to.deep.equal(updatedSessionWithResultSent);
-        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId, publishedAt: now });
-      });
-
-      it('should send result emails', async () => {
-        // given
-        const updatedSession = { ...originalSession, publishedAt: now };
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-        sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSession);
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
-
-        // when
-        await publishSession({
-          sessionId,
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionRepository,
-          sessionPublicationService,
-        });
-
-        // then
-        function getCertificationResultArgs(recipientEmail) {
-          return {
-            email: recipientEmail,
-            sessionId: sessionId,
-            sessionDate,
-            certificationCenterName: certificationCenter,
-          };
-        }
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledTwice;
-        expect(mailService.sendCertificationResultEmail.firstCall)
-          .to.have.been.calledWithMatch(getCertificationResultArgs(recipient1));
-        expect(mailService.sendCertificationResultEmail.secondCall)
-          .to.have.been.calledWithMatch(getCertificationResultArgs(recipient2));
-      });
-
-      it('should generate links for certification results for each unique recipient', async () => {
-        // given
-        const updatedSession = { ...originalSession, publishedAt: now };
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-        sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSession);
-        mailService.sendCertificationResultEmail.withArgs({ sessionId, resultRecipientEmail: 'email1@example.net', daysBeforeExpiration: 30 }).returns('token-1');
-        mailService.sendCertificationResultEmail.withArgs({ sessionId, resultRecipientEmail: 'email2@example.net', daysBeforeExpiration: 30 }).returns('token-2');
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
-
-        // when
-        await publishSession({
-          sessionId,
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionRepository,
-          sessionPublicationService,
-        });
-
-        // then
-        expect(mailService.sendCertificationResultEmail.firstCall).to.have.been.calledWithMatch(
-          { sessionId, resultRecipientEmail: 'email1@example.net', daysBeforeExpiration: 30 },
-        );
-        expect(mailService.sendCertificationResultEmail.secondCall).to.have.been.calledWithMatch(
-          { sessionId, resultRecipientEmail: 'email2@example.net', daysBeforeExpiration: 30 },
-        );
-      });
-
-      context('when there is at least one results recipient', () => {
-
-        it('should set session results as sent now', async () => {
-          // given
-          const now = new Date();
-          const updatedSessionWithPublishedAt = { ...originalSession, publishedAt: now };
-          const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
-          certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-          sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
-          sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
-          mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipient1));
-          mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipient2));
-
-          // when
-          await publishSession({
-            sessionId,
-            certificationRepository,
-            finalizedSessionRepository,
-            sessionRepository,
-            sessionPublicationService,
-          });
-
-          // then
-          expect(sessionRepository.flagResultsAsSentToPrescriber).to.have.been.calledWith({ id: sessionId, resultsSentToPrescriberAt: now });
-        });
-      });
-
-      context('when there is no results recipient', () => {
-        it('should leave resultSentToPrescriberAt untouched', async () => {
-          // given
-          const candidateWithNoRecipient = domainBuilder.buildCertificationCandidate({
-            resultRecipientEmail: null,
-          });
-          const sessionWithoutResultsRecipient = domainBuilder.buildSession({
-            id: sessionId,
-            certificationCenter,
-            date: sessionDate,
-            certificationCandidates: [ candidateWithNoRecipient ],
-          });
-          sessionRepository.getWithCertificationCandidates.withArgs(sessionId).resolves(sessionWithoutResultsRecipient);
-
-          const now = new Date();
-          const updatedSessionWithPublishedAt = { ...sessionWithoutResultsRecipient, publishedAt: now };
-          certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-          sessionRepository.updatePublishedAt.withArgs({ id: sessionId, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
-
-          // when
-          await publishSession({
-            sessionId,
-            certificationRepository,
-            finalizedSessionRepository,
-            sessionRepository,
-            publishedAt: now,
-            sessionPublicationService,
-          });
-
-          // then
-          expect(sessionRepository.flagResultsAsSentToPrescriber).to.not.have.been.called;
-        });
-      });
-    });
-
-    context('When at least one of the e-mail sending fails', () => {
-
-      it('should throw an error and leave the session unpublished', async () => {
-        // given
-        const publishedAt = new Date();
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId).resolves();
-        sessionRepository.updatePublishedAt.resolves({ ...originalSession, publishedAt: publishedAt });
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.failure('\'email1@example.net\''));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success('\'email2@example.net\''));
-
-        // when
-        const error = await catchErr(publishSession)({
-          sessionId,
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionRepository,
-          publishedAt,
-          sessionPublicationService,
-        });
-
-        // then
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWith({
-          sessionId,
-          resultRecipientEmail: 'email1@example.net',
-          daysBeforeExpiration: 30,
-          certificationCenterName: 'certificationCenter',
-          sessionDate: originalSession.date,
-          email: 'email1@example.net',
-        });
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWith({
-          sessionId,
-          resultRecipientEmail: 'email2@example.net',
-          daysBeforeExpiration: 30,
-          certificationCenterName: 'certificationCenter',
-          sessionDate: originalSession.date,
-          email: 'email2@example.net',
-        });
-        expect(sessionRepository.flagResultsAsSentToPrescriber).to.not.have.been.called;
-        expect(error).to.be.an.instanceOf(SendingEmailToResultRecipientError);
-      });
-    });
-  });
-
 });

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -1,6 +1,7 @@
 const { domainBuilder, sinon, expect } = require('../../../test-helper');
 
 const publishSessionSessionsInBatch = require('../../../../lib/domain/usecases/publish-sessions-in-batch');
+const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 const mailService = require('../../../../lib/domain/services/mail-service');
 
 describe('Unit | UseCase | publish-sessions-in-batch', () => {
@@ -84,6 +85,8 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
         certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId1).resolves();
         sessionRepository.updatePublishedAt.withArgs({ id: sessionId1, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
         sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId1, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
+        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipientSession1));
+        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipientSession2));
 
         // when
         await publishSessionSessionsInBatch({
@@ -99,12 +102,95 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
         expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId: sessionId2, publishedAt: now });
       });
 
-      it.skip('should send result emails', async () => {
-        // pas besoin de retester ?
-      });
+      it('should send result emails', async () => {
+        // given
+        const recipientSession1 = 'email1@example.net';
+        const certificationCenter1 = 'certificationCenter1';
+        const candidate1 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession1,
+        });
+        const candidate2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession1,
+        });
 
-      it.skip('should generate links for certification results for each unique recipient', async () => {
-        // pas besoin de retester ?
+        const sessionId1 = 123001;
+        const sessionDate1 = '2020-01-01';
+        const originalSession1 = domainBuilder.buildSession({
+          id: sessionId1,
+          certificationCenter1,
+          date: sessionDate1,
+          certificationCandidates: [
+            candidate1, candidate2,
+          ],
+        });
+
+        const recipientSession2 = 'email2@example.net';
+        const candidate1Session2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession2,
+        });
+        const candidate2Session2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession2,
+        });
+
+        const sessionId2 = 123002;
+        const sessionDate2 = '2020-01-02';
+        const certificationCenter2 = 'certificationCenter2';
+        const originalSession2 = domainBuilder.buildSession({
+          id: sessionId2,
+          certificationCenter2,
+          date: sessionDate2,
+          certificationCandidates: [
+            candidate1Session2, candidate2Session2,
+          ],
+        });
+
+        const sessionRepository = {
+          updatePublishedAt: sinon.stub(),
+          getWithCertificationCandidates: sinon.stub(),
+        };
+        sessionRepository.getWithCertificationCandidates.withArgs(sessionId1).resolves(originalSession1);
+        sessionRepository.getWithCertificationCandidates.withArgs(sessionId2).resolves(originalSession2);
+        sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
+
+        const certificationRepository = {
+          publishCertificationCoursesBySessionId: sinon.stub(),
+        };
+        const finalizedSessionRepository = {
+          updatePublishedAt: sinon.stub(),
+        };
+        mailService.sendCertificationResultEmail = sinon.stub();
+
+        const updatedSessionWithPublishedAt = { ...originalSession1, publishedAt: now };
+        const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
+
+        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId1).resolves();
+        sessionRepository.updatePublishedAt.withArgs({ id: sessionId1, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
+        sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId1, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
+        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipientSession1));
+        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipientSession2));
+
+        // when
+        await publishSessionSessionsInBatch({
+          sessionIds: [sessionId1, sessionId2],
+          certificationRepository,
+          finalizedSessionRepository,
+          sessionRepository,
+          publishedAt: now,
+        });
+
+        // then
+        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithMatch({
+          email: recipientSession1,
+          sessionId: sessionId1,
+          resultRecipientEmail: 'email1@example.net',
+          daysBeforeExpiration: 30,
+        });
+        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithMatch({
+          email: recipientSession2,
+          sessionId: sessionId2,
+          resultRecipientEmail: 'email2@example.net',
+          daysBeforeExpiration: 30,
+        });
       });
 
       context('when there is at least one results recipient', () => {

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -1,0 +1,142 @@
+const { domainBuilder, sinon, expect } = require('../../../test-helper');
+
+const publishSessionSessionsInBatch = require('../../../../lib/domain/usecases/publish-sessions-in-batch');
+const mailService = require('../../../../lib/domain/services/mail-service');
+
+describe('Unit | UseCase | publish-sessions-in-batch', () => {
+
+  const now = new Date('2020-02-01T12:00:00Z');
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(now);
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  context('when the sessions exist', () => {
+
+    context('When we publish the sessions', () => {
+
+      it('should update the published date', async () => {
+        // given
+        const recipientSession1 = 'email1@example.net';
+        const certificationCenter1 = 'certificationCenter1';
+        const candidate1 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession1,
+        });
+        const candidate2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession1,
+        });
+
+        const sessionId1 = 123001;
+        const sessionDate1 = '2020-01-01';
+        const originalSession1 = domainBuilder.buildSession({
+          id: sessionId1,
+          certificationCenter1,
+          date: sessionDate1,
+          certificationCandidates: [
+            candidate1, candidate2,
+          ],
+        });
+
+        const recipientSession2 = 'email2@example.net';
+        const candidate1Session2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession2,
+        });
+        const candidate2Session2 = domainBuilder.buildCertificationCandidate({
+          resultRecipientEmail: recipientSession2,
+        });
+
+        const sessionId2 = 123002;
+        const sessionDate2 = '2020-01-02';
+        const certificationCenter2 = 'certificationCenter2';
+        const originalSession2 = domainBuilder.buildSession({
+          id: sessionId2,
+          certificationCenter2,
+          date: sessionDate2,
+          certificationCandidates: [
+            candidate1Session2, candidate2Session2,
+          ],
+        });
+
+        const sessionRepository = {
+          updatePublishedAt: sinon.stub(),
+          getWithCertificationCandidates: sinon.stub(),
+        };
+        sessionRepository.getWithCertificationCandidates.withArgs(sessionId1).resolves(originalSession1);
+        sessionRepository.getWithCertificationCandidates.withArgs(sessionId2).resolves(originalSession2);
+        sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
+
+        const certificationRepository = {
+          publishCertificationCoursesBySessionId: sinon.stub(),
+        };
+        const finalizedSessionRepository = {
+          updatePublishedAt: sinon.stub(),
+        };
+        mailService.sendCertificationResultEmail = sinon.stub();
+
+        const updatedSessionWithPublishedAt = { ...originalSession1, publishedAt: now };
+        const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
+
+        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId1).resolves();
+        sessionRepository.updatePublishedAt.withArgs({ id: sessionId1, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
+        sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId1, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
+
+        // when
+        await publishSessionSessionsInBatch({
+          sessionIds: [sessionId1, sessionId2],
+          certificationRepository,
+          finalizedSessionRepository,
+          sessionRepository,
+          publishedAt: now,
+        });
+
+        // then
+        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId: sessionId1, publishedAt: now });
+        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId: sessionId2, publishedAt: now });
+      });
+
+      it.skip('should send result emails', async () => {
+        // pas besoin de retester ?
+      });
+
+      it.skip('should generate links for certification results for each unique recipient', async () => {
+        // pas besoin de retester ?
+      });
+
+      context('when there is at least one results recipient', () => {
+
+        it.skip('should set session results as sent now', async () => {
+          // pas besoin de retester ?
+        });
+      });
+
+      context('when there is no results recipient', () => {
+        it.skip('should leave resultSentToPrescriberAt untouched', async () => {
+          // pas besoin de retester ?
+        });
+      });
+    });
+
+    context('When at least one of the e-mail sending fails', () => {
+
+      it.skip('should throw an error and leave the session unpublished', async () => {
+        // pas besoin de retester ?
+      });
+    });
+  });
+
+  context('when one or many sessions are already published', () => {
+    it.skip('should ignore the published sessions', () => {
+    });
+  });
+
+  context('when one or many sessions dont exist', () => {
+    it.skip('should ignore the non existing session', () => {
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -18,9 +18,9 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
 
   context('when the sessions exist', () => {
 
-    context('When we publish the sessions', () => {
+    context('When we publish the sessions in batch', () => {
 
-      it('should update the published date', async () => {
+      it('should update the published dates', async () => {
         // given
         const recipientSession1 = 'email1@example.net';
         const certificationCenter1 = 'certificationCenter1';
@@ -131,11 +131,14 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
 
   context('when one or many sessions are already published', () => {
     it.skip('should ignore the published sessions', () => {
+      // est-ce qu'on loggue ?
+      // envoi des résultats ?
     });
   });
 
   context('when one or many sessions dont exist', () => {
     it.skip('should ignore the non existing session', () => {
+      // est-ce qu'on loggue ?
     });
   });
 

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -1,235 +1,116 @@
-const { domainBuilder, sinon, expect } = require('../../../test-helper');
+const { sinon, expect } = require('../../../test-helper');
 
-const publishSessionSessionsInBatch = require('../../../../lib/domain/usecases/publish-sessions-in-batch');
-const sessionPublicationService = require('../../../../lib/domain/services/session-publication-service');
-
-const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
-const mailService = require('../../../../lib/domain/services/mail-service');
+const publishSessionsInBatch = require('../../../../lib/domain/usecases/publish-sessions-in-batch');
 
 describe('Unit | UseCase | publish-sessions-in-batch', () => {
 
-  const now = new Date('2020-02-01T12:00:00Z');
-  let clock;
+  const dependencies = {
+    certificationRepository: Symbol('certificationRepository'),
+    finalizedSessionRepository: Symbol('finalizedSessionRepository'),
+    sessionRepository: Symbol('sessionRepository'),
+  };
 
-  beforeEach(() => {
-    clock = sinon.useFakeTimers(now);
-  });
+  it('delegates to the publish session service', async () => {
+    // given
+    const sessionId1 = Symbol('first session id');
+    const sessionId2 = Symbol('second session id');
+    const publishedAt = Symbol('a publication date');
 
-  afterEach(() => {
-    clock.restore();
-  });
+    const sessionPublicationService = {
+      publishSession: sinon.stub(),
+    };
 
-  context('when the sessions exist', () => {
-
-    context('When we publish the sessions in batch', () => {
-
-      it('should update the published dates', async () => {
-        // given
-        const recipientSession1 = 'email1@example.net';
-        const certificationCenter1 = 'certificationCenter1';
-        const candidate1 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession1,
-        });
-        const candidate2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession1,
-        });
-
-        const sessionId1 = 123001;
-        const sessionDate1 = '2020-01-01';
-        const originalSession1 = domainBuilder.buildSession({
-          id: sessionId1,
-          certificationCenter1,
-          date: sessionDate1,
-          certificationCandidates: [
-            candidate1, candidate2,
-          ],
-        });
-
-        const recipientSession2 = 'email2@example.net';
-        const candidate1Session2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession2,
-        });
-        const candidate2Session2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession2,
-        });
-
-        const sessionId2 = 123002;
-        const sessionDate2 = '2020-01-02';
-        const certificationCenter2 = 'certificationCenter2';
-        const originalSession2 = domainBuilder.buildSession({
-          id: sessionId2,
-          certificationCenter2,
-          date: sessionDate2,
-          certificationCandidates: [
-            candidate1Session2, candidate2Session2,
-          ],
-        });
-
-        const sessionRepository = {
-          updatePublishedAt: sinon.stub(),
-          getWithCertificationCandidates: sinon.stub(),
-        };
-        sessionRepository.getWithCertificationCandidates.withArgs(sessionId1).resolves(originalSession1);
-        sessionRepository.getWithCertificationCandidates.withArgs(sessionId2).resolves(originalSession2);
-        sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
-
-        const certificationRepository = {
-          publishCertificationCoursesBySessionId: sinon.stub(),
-        };
-        const finalizedSessionRepository = {
-          updatePublishedAt: sinon.stub(),
-        };
-        mailService.sendCertificationResultEmail = sinon.stub();
-
-        const updatedSessionWithPublishedAt = { ...originalSession1, publishedAt: now };
-        const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
-
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId1).resolves();
-        sessionRepository.updatePublishedAt.withArgs({ id: sessionId1, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
-        sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId1, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipientSession1));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipientSession2));
-
-        // when
-        await publishSessionSessionsInBatch({
-          sessionIds: [sessionId1, sessionId2],
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionPublicationService,
-          sessionRepository,
-          publishedAt: now,
-        });
-
-        // then
-        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId: sessionId1, publishedAt: now });
-        expect(finalizedSessionRepository.updatePublishedAt).to.have.been.calledWith({ sessionId: sessionId2, publishedAt: now });
-      });
-
-      it('should send result emails', async () => {
-        // given
-        const recipientSession1 = 'email1@example.net';
-        const certificationCenter1 = 'certificationCenter1';
-        const candidate1 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession1,
-        });
-        const candidate2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession1,
-        });
-
-        const sessionId1 = 123001;
-        const sessionDate1 = '2020-01-01';
-        const originalSession1 = domainBuilder.buildSession({
-          id: sessionId1,
-          certificationCenter1,
-          date: sessionDate1,
-          certificationCandidates: [
-            candidate1, candidate2,
-          ],
-        });
-
-        const recipientSession2 = 'email2@example.net';
-        const candidate1Session2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession2,
-        });
-        const candidate2Session2 = domainBuilder.buildCertificationCandidate({
-          resultRecipientEmail: recipientSession2,
-        });
-
-        const sessionId2 = 123002;
-        const sessionDate2 = '2020-01-02';
-        const certificationCenter2 = 'certificationCenter2';
-        const originalSession2 = domainBuilder.buildSession({
-          id: sessionId2,
-          certificationCenter2,
-          date: sessionDate2,
-          certificationCandidates: [
-            candidate1Session2, candidate2Session2,
-          ],
-        });
-
-        const sessionRepository = {
-          updatePublishedAt: sinon.stub(),
-          getWithCertificationCandidates: sinon.stub(),
-        };
-        sessionRepository.getWithCertificationCandidates.withArgs(sessionId1).resolves(originalSession1);
-        sessionRepository.getWithCertificationCandidates.withArgs(sessionId2).resolves(originalSession2);
-        sessionRepository.flagResultsAsSentToPrescriber = sinon.stub();
-
-        const certificationRepository = {
-          publishCertificationCoursesBySessionId: sinon.stub(),
-        };
-        const finalizedSessionRepository = {
-          updatePublishedAt: sinon.stub(),
-        };
-        mailService.sendCertificationResultEmail = sinon.stub();
-
-        const updatedSessionWithPublishedAt = { ...originalSession1, publishedAt: now };
-        const updatedSessionWithResultSent = { ...updatedSessionWithPublishedAt, resultsSentToPrescriberAt: now };
-
-        certificationRepository.publishCertificationCoursesBySessionId.withArgs(sessionId1).resolves();
-        sessionRepository.updatePublishedAt.withArgs({ id: sessionId1, publishedAt: now }).resolves(updatedSessionWithPublishedAt);
-        sessionRepository.flagResultsAsSentToPrescriber.withArgs({ id: sessionId1, resultsSentToPrescriberAt: now }).resolves(updatedSessionWithResultSent);
-        mailService.sendCertificationResultEmail.onCall(0).resolves(EmailingAttempt.success(recipientSession1));
-        mailService.sendCertificationResultEmail.onCall(1).resolves(EmailingAttempt.success(recipientSession2));
-
-        // when
-        await publishSessionSessionsInBatch({
-          sessionIds: [sessionId1, sessionId2],
-          certificationRepository,
-          finalizedSessionRepository,
-          sessionPublicationService,
-          sessionRepository,
-          publishedAt: now,
-        });
-
-        // then
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithMatch({
-          email: recipientSession1,
-          sessionId: sessionId1,
-          resultRecipientEmail: 'email1@example.net',
-          daysBeforeExpiration: 30,
-        });
-        expect(mailService.sendCertificationResultEmail).to.have.been.calledWithMatch({
-          email: recipientSession2,
-          sessionId: sessionId2,
-          resultRecipientEmail: 'email2@example.net',
-          daysBeforeExpiration: 30,
-        });
-      });
-
-      context('when there is at least one results recipient', () => {
-
-        it.skip('should set session results as sent now', async () => {
-          // pas besoin de retester ?
-        });
-      });
-
-      context('when there is no results recipient', () => {
-        it.skip('should leave resultSentToPrescriberAt untouched', async () => {
-          // pas besoin de retester ?
-        });
-      });
+    // when
+    await publishSessionsInBatch({
+      ...dependencies,
+      sessionIds: [sessionId1, sessionId2],
+      sessionPublicationService,
+      publishedAt,
+      batchId: 'batch id',
     });
 
-    context('When at least one of the e-mail sending fails', () => {
-
-      it.skip('should throw an error and leave the session unpublished', async () => {
-        // pas besoin de retester ?
-      });
+    // then
+    expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
+      ...dependencies,
+      sessionId: sessionId1,
+      publishedAt,
+    });
+    expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
+      ...dependencies,
+      sessionId: sessionId2,
+      publishedAt,
     });
   });
 
-  context('when one or many sessions are already published', () => {
-    it.skip('should ignore the published sessions', () => {
-      // est-ce qu'on loggue ?
-      // envoi des résultats ?
+  context('when one or many session publication fail', () => {
+    it('should continue', async () => {
+      // given
+      const sessionId1 = Symbol('first session id');
+      const sessionId2 = Symbol('second session id');
+      const publishedAt = Symbol('a publication date');
+
+      const sessionPublicationService = {
+        publishSession: sinon.stub(),
+      };
+      sessionPublicationService.publishSession.withArgs({
+        ...dependencies,
+        sessionId: sessionId1,
+        publishedAt,
+      }).rejects(new Error('an error'));
+
+      // when
+      await publishSessionsInBatch({
+        ...dependencies,
+        sessionIds: [sessionId1, sessionId2],
+        sessionPublicationService,
+        publishedAt,
+        batchId: 'batch id',
+      });
+
+      expect(sessionPublicationService.publishSession).to.have.been.calledWithExactly({
+        ...dependencies,
+        sessionId: sessionId2,
+        publishedAt,
+      });
+    });
+
+    it('should return the errors with a batch id', async () => {
+      // given
+      const sessionId1 = Symbol('first session id');
+      const sessionId2 = Symbol('second session id');
+      const publishedAt = Symbol('a publication date');
+
+      const sessionPublicationService = {
+        publishSession: sinon.stub(),
+      };
+      const error1 = new Error('an error');
+      const error2 = new Error('another error');
+      sessionPublicationService.publishSession.withArgs({
+        ...dependencies,
+        sessionId: sessionId1,
+        publishedAt,
+      }).rejects(error1);
+      sessionPublicationService.publishSession.withArgs({
+        ...dependencies,
+        sessionId: sessionId2,
+        publishedAt,
+      }).rejects(error2);
+
+      // when
+      const result = await publishSessionsInBatch({
+        ...dependencies,
+        sessionIds: [sessionId1, sessionId2],
+        sessionPublicationService,
+        publishedAt,
+        batchId: 'batch id',
+      });
+
+      // then
+      expect(result.batchId).to.equal('batch id');
+      expect(result.publicationErrors).to.deep.equal({
+        [sessionId1]: error1,
+        [sessionId2]: error2,
+      });
     });
   });
-
-  context('when one or many sessions dont exist', () => {
-    it.skip('should ignore the non existing session', () => {
-      // est-ce qu'on loggue ?
-    });
-  });
-
 });

--- a/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
+++ b/api/tests/unit/domain/usecases/publish-sessions-in-batch_test.js
@@ -1,6 +1,8 @@
 const { domainBuilder, sinon, expect } = require('../../../test-helper');
 
 const publishSessionSessionsInBatch = require('../../../../lib/domain/usecases/publish-sessions-in-batch');
+const sessionPublicationService = require('../../../../lib/domain/services/session-publication-service');
+
 const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 const mailService = require('../../../../lib/domain/services/mail-service');
 
@@ -93,6 +95,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
           sessionIds: [sessionId1, sessionId2],
           certificationRepository,
           finalizedSessionRepository,
+          sessionPublicationService,
           sessionRepository,
           publishedAt: now,
         });
@@ -174,6 +177,7 @@ describe('Unit | UseCase | publish-sessions-in-batch', () => {
           sessionIds: [sessionId1, sessionId2],
           certificationRepository,
           finalizedSessionRepository,
+          sessionPublicationService,
           sessionRepository,
           publishedAt: now,
         });

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -3,6 +3,7 @@ const { mailing } = require('../../../../lib/config');
 const mailCheck = require('../../../../lib/infrastructure/mail-check');
 const logger = require('../../../../lib/infrastructure/logger');
 const mailer = require('../../../../lib/infrastructure/mailers/mailer');
+const EmailingAttempt = require('../../../../lib/domain/models/EmailingAttempt');
 
 describe('Unit | Infrastructure | Mailers | mailer', () => {
 
@@ -31,7 +32,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
         const result = await mailer.sendEmail(options);
 
         // then
-        expect(result).to.equal(mailer.EMAIL_SKIPPED);
+        expect(result).to.deep.equal(EmailingAttempt.success('test@example.net'));
       });
     });
 
@@ -62,7 +63,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
 
           // then
           sinon.assert.calledWith(mailingProvider.sendEmail, options);
-          expect(result).to.equal(mailer.EMAIL_SENT);
+          expect(result).to.deep.equal(EmailingAttempt.success('test@example.net'));
         });
       });
 
@@ -83,7 +84,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
 
           // then
           expect(logger.warn).to.have.been.calledWith({ err: expectedError }, 'Email is not valid \'test@example.net\'');
-          expect(result).to.equal(mailer.ERROR_INVALID_EMAIL);
+          expect(result).to.deep.equal(EmailingAttempt.failure('test@example.net'));
         });
       });
 
@@ -104,7 +105,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
 
           // then
           expect(logger.warn).to.have.been.calledOnceWith({ err: error }, 'Could not send email to \'test@example.net\'');
-          expect(result).to.equal(mailer.ERROR_EMAIL_FAILED);
+          expect(result).to.deep.equal(EmailingAttempt.failure('test@example.net'));
         });
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Certaine sessions de certification sont considérées “sans problème” c’est à dire qu’elles ne nécessitent aucune action du jury avant publication. Toutes ces sessions peuvent donc être publiées en masse.

## :robot: Solution
Permettre au pôle certification de publier en masse plusieurs sessions sans problèmes.

Dans Pix Admin > Sessions de certification > onglet “Sessions à publier” : 

- Ajouter un bouton “Publier” en haut à droite de la page

- Cliquer sur ce bouton affiche une pop-up de confirmation : “Vous vous apprêtez à publier xx sessions de certification, souhaitez vous confirmer ?” avec les boutons “Annuler”/”Confirmer”

cliquer sur “Confirmer” : 

- Ferme la pop-up

- Affiche un message de confirmation “Les sessions ont été correctement publiées.”

- La date de publication des sessions est mise à jour

- La session doit être assignée à “Publication automatique”

## :rainbow: Remarques
![image](https://user-images.githubusercontent.com/37305474/110505520-84068380-80fe-11eb-8bac-495d872c02d5.png)

## :100: Pour tester
- Aller dans Pix-admin
- Aller dans Sessions de certifications > Sessions à publier
- Cliquer sur Publier toutes les sessions
- Constater la notification de succès
- Constater que la liste est vide
 