### PR TITLE
[BUGFIX] Supprime une faille d'injection SQL 

### DIFF
--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -20,7 +20,7 @@ module.exports = {
         deliveredAt: 'sessions.publishedAt',
         certificationCenter: 'sessions.certificationCenter',
         // eslint-disable-next-line no-restricted-syntax
-        status: knex.raw(`CASE WHEN "isPublished" THEN "assessment-results".status ELSE '${PENDING}' END`),
+        status: knex.raw('CASE WHEN "isPublished" THEN "assessment-results".status ELSE ? END', PENDING),
         pixScore: 'assessment-results.pixScore',
       })
       .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResults"'))
@@ -32,7 +32,7 @@ module.exports = {
       .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
       .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
       .modify(_filterMostRecentAssessments)
-      .whereRaw(`LOWER("organizations"."externalId") = LOWER('${uai}')`)
+      .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
       .andWhereRaw('"last-assessment-results".id is null')
       .orderBy('lastName', 'ASC')
       .orderBy('firstName', 'ASC');


### PR DESCRIPTION
## :unicorn: Problème
Une faille d'injection SQL n'a pas été levé par le linter et peut permettre d'accéder à des données non restreintes

## :robot: Solution
Utiliser la gestion des parametres via knex

## :rainbow: Remarques
Merci @jonathanperret d'avoir linter mieux que le linter

## :100: Pour tester
En local ajouter des certification pour des utilisateurs avec schooling registrations dans une organisation SCO
Eventuellement, désactiver l'authentification sur le endpoint:
un appel 
`http -pb "http://localhost:3000/api/organizations/') or 'x' = ('x/certifications"` renvoi toutes les certifications en base.

Pour l'integration, il y a deja des données, il faut en revanche récupérer un token.
`http -pb "https://integration.pix.fr/api/organizations/') or 'x' = ('x/certifications" "Authorization:Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGllbnRfaWQiOiJsc2wiLCJzb3VyY2UiOiJsc2wiLCJzY29wZSI6Im9yZ2FuaXphdGlvbnMtY2VydGlmaWNhdGlvbnMtcmVzdWx0IiwiaWF0IjoxNjE1MzA0NzQ3LCJleHAiOjE2MTU5MDk1NDd9.T2Cce9uFMundd31JKr1RUOpUZTGGyqFRttA6ZGSe75o"`
