### PR TITLE
[FEATURE] Création de paliers depuis l'admin (PIX-1968)

### DIFF
--- a/admin/app/adapters/badge.js
+++ b/admin/app/adapters/badge.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class BadgeAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/adapters/stage.js
+++ b/admin/app/adapters/stage.js
@@ -1,0 +1,5 @@
+import ApplicationAdapter from './application';
+
+export default class StageAdapter extends ApplicationAdapter {
+  namespace = 'api/admin';
+}

--- a/admin/app/components/organization-target-profiles-section.hbs
+++ b/admin/app/components/organization-target-profiles-section.hbs
@@ -27,16 +27,16 @@
     <div class="table-admin">
       <table>
         <thead>
-        <tr>
-          <th>ID</th>
-          <th>Nom du profil cible</th>
-        </tr>
+          <tr>
+            <th>ID</th>
+            <th>Nom du profil cible</th>
+          </tr>
         </thead>
 
         {{#if @targetProfiles}}
           <tbody>
           {{#each @targetProfiles as |targetProfile|}}
-            <tr aria-label="Profil cible">
+            <tr aria-label="Profil cible" role="button" {{on "click" (fn @goToTargetProfilePage targetProfile.id)}} class="tr--clickable">
               <td>{{targetProfile.id}}</td>
               <td>{{targetProfile.name}}</td>
             </tr>

--- a/admin/app/components/target-profiles/create-target-profile-form.hbs
+++ b/admin/app/components/target-profiles/create-target-profile-form.hbs
@@ -1,10 +1,10 @@
 <form class="form create-target-profile" {{on "submit" @onSubmit}}>
   
   <section class="form-section">
-      <span class="form__instructions">
-        Les champs marqués de <abbr title="obligatoire" class="mandatory-mark">*</abbr> sont
-        obligatoires.
-      </span>
+    <span class="form__instructions">
+      Les champs marqués de <abbr title="obligatoire" class="mandatory-mark">*</abbr> sont
+      obligatoires.
+    </span>
 
     <div class="form-field form-group">
       <label class="form-field__label" for="targetProfileName">Nom <abbr title="obligatoire" class="mandatory-mark">*</abbr> : </label>

--- a/admin/app/components/target-profiles/insight.hbs
+++ b/admin/app/components/target-profiles/insight.hbs
@@ -10,7 +10,7 @@
     <h2 class="insight-section__title">Paliers</h2>
     <TargetProfiles::Stages
             @stages={{@model.stages}}
-            @targetProfileImageUrl={{@model.targetProfileImageUrl}}/>
+            @targetProfile={{@model.targetProfile}}/>
   </section>
 
 </section>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -1,93 +1,112 @@
 <div class="content-text content-text--small">
-  {{#if this.hasStages}}
-    <div class="table-admin">
-      <table>
-        <thead>
-          <tr>
-            <th class="stages-table__id">ID</th>
-            <th class="stages-table__image">Image</th>
-            <th class="stages-table__threshold">Threshold</th>
-            <th class="stages-table__title">Titre</th>
-            <th>Message</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#each @stages as |stage|}}
+  <form class="form" {{on "submit" this.createStages}}>
+    {{#if this.hasStages}}
+      <div class="table-admin">
+        <table>
+          <thead>
             <tr>
-              <td>{{stage.id}}</td>
-              <td class="stages-table__image">
-              <img src={{@targetProfile.imageUrl}} alt="" role="presentation" />
-            </td>
-              <td>
-                {{#if stage.isNew}}
-                  <Input class="form-control"
-                   type="number"
-                   @required="true"
-                   @value={{stage.threshold}} />
-                {{else}}
-                  {{stage.threshold}}
-                {{/if}}
-              </td>
-              <td>
-                {{#if stage.isNew}}
-                  <Input class="form-control"
-                   @required="true"
-                   @value={{stage.title}} />
-                {{else}}
-                  {{stage.title}}
-                {{/if}}
-              </td>
-              <td>
-                {{#if stage.isNew}}
-                  <Input class="form-control"
-                   @required="true"
-                   @value={{stage.message}} />
-                {{else}}
-                  {{stage.message}}
-                {{/if}}
-              </td>
-              <td>
-                {{#if stage.isNew}}
-                  <PixButton class="stages-remove-stage"
-                             @backgroundColor="transparent"
-                             @border="squircle-small"
-                             aria-label="Supprimer palier"
-                             @triggerAction={{fn this.removeNewStage stage}}>
-                    <FaIcon @icon="minus"></FaIcon>
-                  </PixButton>
-                {{/if}}
-              </td>
+              <th class="stages-table__id">ID</th>
+              <th class="stages-table__image">Image</th>
+              <th class="stages-table__threshold">Threshold</th>
+              <th class="stages-table__title">Titre</th>
+              <th>Message</th>
+              <th>Actions</th>
             </tr>
-          {{/each}}
-        </tbody>
-      </table>
-    </div>
-  {{else}}
-    <div class="table__empty content-text">Aucun palier associé</div>
-  {{/if}}
+          </thead>
+          <tbody>
+            {{#each @stages as |stage|}}
+              <tr>
+                <td>{{stage.id}}</td>
+                <td class="stages-table__image">
+                <img src={{@targetProfile.imageUrl}} alt="" role="presentation" />
+              </td>
+                <td>
+                  {{#if stage.isNew}}
+                    <div class="form-field">
+                      <Input class={{if stage.errors.threshold "form-control is-invalid" "form-control"}}
+                             type="number"
+                             @required="true"
+                             @value={{stage.threshold}} />
+                      {{#if stage.errors.threshold}}
+                        <div class="form-field__error">
+                          {{stage.errors.threshold.[0].message}}
+                        </div>
+                      {{/if}}
+                    </div>
+                  {{else}}
+                    {{stage.threshold}}
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if stage.isNew}}
+                    <div class="form-field">
+                      <Input class={{if stage.errors.title "form-field__text form-control is-invalid" "form-field__text form-control"}}
+                             @required="true"
+                             @value={{stage.title}} />
+                      {{#if stage.errors.title}}
+                        <div class="form-field__error">
+                          {{stage.errors.title.[0].message}}
+                        </div>
+                      {{/if}}
+                    </div>
+                  {{else}}
+                    {{stage.title}}
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if stage.isNew}}
+                    <div class="form-field">
+                      <Input class="form-control"
+                             @required="true"
+                             @value={{stage.message}} />
+                    </div>
+                  {{else}}
+                    {{stage.message}}
+                  {{/if}}
+                </td>
+                <td>
+                  {{#if stage.isNew}}
+                    <PixButton class="stages-remove-stage"
+                               @backgroundColor="transparent"
+                               @border="squircle-small"
+                               aria-label="Supprimer palier"
+                               @triggerAction={{fn this.removeNewStage stage}}>
+                      <FaIcon @icon="minus"></FaIcon>
+                    </PixButton>
+                  {{/if}}
+                </td>
+              </tr>
+            {{/each}}
+          </tbody>
+        </table>
+      </div>
+    {{else}}
+      <div class="table__empty content-text">Aucun palier associé</div>
+    {{/if}}
 
-  <PixButton class="stages-new-stage"
-             @backgroundColor="transparent"
-             @border="squircle-small"
-             data-test="Nouveau palier"
-             @triggerAction={{this.addStage}}>
-    <FaIcon @icon="plus"></FaIcon>&nbsp;Nouveau palier
-  </PixButton>
+    <PixButton class="stages-new-stage"
+               @backgroundColor="transparent"
+               @border="squircle-small"
+               data-test="Nouveau palier"
+               @triggerAction={{this.addStage}}>
+      <FaIcon @icon="plus"></FaIcon>&nbsp;Nouveau palier
+    </PixButton>
 
-  {{#if this.hasNewStage}}
-    <div class="stages-actions">
-      <PixButton
-        class="form-action form-action--cancel"
-        @backgroundColor="transparent"
-        @border="squircle-small"
-        @triggerAction={{this.cancelStagesCreation}}>Annuler</PixButton>
-      <PixButton
-        class="form-action form-action--submit"
-        @backgroundColor="green"
-        @border="squircle-small"
-        @isDisabled={{@isDisabled}}
-        @triggerAction={{this.createStages}}>Enregistrer</PixButton>
-    </div>
-  {{/if}}
+    {{#if this.hasNewStage}}
+      <div class="stages-actions">
+        <PixButton
+          class="form-action form-action--cancel"
+          @backgroundColor="transparent"
+          @border="squircle-small"
+          @triggerAction={{this.cancelStagesCreation}}>Annuler</PixButton>
+        <PixButton
+          class="form-action form-action--submit"
+          @type="submit"
+          @backgroundColor="green"
+          @border="squircle-small"
+          @triggerAction={{this.createStages}}>Enregistrer</PixButton>
+      </div>
+    {{/if}}
+  </form>
+
 </div>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -15,7 +15,7 @@
               <th class="stages-table__threshold">Threshold</th>
               <th class="stages-table__title">Titre</th>
               <th>Message</th>
-              <th>Actions</th>
+              <th class="stages-table__actions">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -3,30 +3,79 @@
     <div class="table-admin">
       <table>
         <thead>
-        <tr>
-          <th class="stages-table__id">ID</th>
-          <th class="stages-table__image">Image</th>
-          <th class="stages-table__threshold">Threshold</th>
-          <th class="stages-table__title">Titre</th>
-          <th>Message</th>
-        </tr>
+          <tr>
+            <th class="stages-table__id">ID</th>
+            <th class="stages-table__image">Image</th>
+            <th class="stages-table__threshold">Threshold</th>
+            <th class="stages-table__title">Titre</th>
+            <th>Message</th>
+          </tr>
         </thead>
         <tbody>
-        {{#each @stages as |stage|}}
-          <tr>
-            <td>{{stage.id}}</td>
-            <td class="stages-table__image">
-              <img src={{@targetProfileImageUrl}} alt="" role="presentation" />
+          {{#each @stages as |stage|}}
+            <tr>
+              <td>{{stage.id}}</td>
+              <td class="stages-table__image">
+              <img src={{@targetProfile.imageUrl}} alt="" role="presentation" />
             </td>
-            <td>{{stage.threshold}}</td>
-            <td>{{stage.title}}</td>
-            <td>{{stage.message}}</td>
-          </tr>
-        {{/each}}
+              <td>
+                {{#if stage.isNew}}
+                  <Input class="form-control"
+                   type="number"
+                   @required="true"
+                   @value={{stage.threshold}} />
+                {{else}}
+                  {{stage.threshold}}
+                {{/if}}
+              </td>
+              <td>
+                {{#if stage.isNew}}
+                  <Input class="form-control"
+                   @required="true"
+                   @value={{stage.title}} />
+                {{else}}
+                  {{stage.title}}
+                {{/if}}
+              </td>
+              <td>
+                {{#if stage.isNew}}
+                  <Input class="form-control"
+                   @required="true"
+                   @value={{stage.message}} />
+                {{else}}
+                  {{stage.message}}
+                {{/if}}
+              </td>
+            </tr>
+          {{/each}}
         </tbody>
       </table>
     </div>
   {{else}}
     <div class="table__empty content-text">Aucun palier associé</div>
+  {{/if}}
+
+  <PixButton class="stages-new-stage"
+             @backgroundColor="transparent"
+             @border="squircle-small"
+             data-test="Nouveau palier"
+             @triggerAction={{this.addStage}}>
+    <FaIcon @icon="plus"></FaIcon>&nbsp;Nouveau palier
+  </PixButton>
+
+  {{#if this.hasNewStage}}
+    <div class="stages-actions">
+      <PixButton
+        class="form-action form-action--cancel"
+        @backgroundColor="transparent"
+        @border="squircle-small"
+        @triggerAction={{this.cancelStagesCreation}}>Annuler</PixButton>
+      <PixButton
+        class="form-action form-action--submit"
+        @backgroundColor="green"
+        @border="squircle-small"
+        @isDisabled={{@isDisabled}}
+        @triggerAction={{this.createStages}}>Enregistrer</PixButton>
+    </div>
   {{/if}}
 </div>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -9,6 +9,7 @@
             <th class="stages-table__threshold">Threshold</th>
             <th class="stages-table__title">Titre</th>
             <th>Message</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -44,6 +45,17 @@
                    @value={{stage.message}} />
                 {{else}}
                   {{stage.message}}
+                {{/if}}
+              </td>
+              <td>
+                {{#if stage.isNew}}
+                  <PixButton class="stages-remove-stage"
+                             @backgroundColor="transparent"
+                             @border="squircle-small"
+                             aria-label="Supprimer palier"
+                             @triggerAction={{fn this.removeNewStage stage}}>
+                    <FaIcon @icon="minus"></FaIcon>
+                  </PixButton>
                 {{/if}}
               </td>
             </tr>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -7,7 +7,7 @@
         </PixMessage>
       {{/if}}
       <div class="table-admin">
-        <table>
+        <table class="stages-table">
           <thead>
             <tr>
               <th class="stages-table__id">ID</th>

--- a/admin/app/components/target-profiles/stages.hbs
+++ b/admin/app/components/target-profiles/stages.hbs
@@ -1,6 +1,11 @@
 <div class="content-text content-text--small">
   <form class="form" {{on "submit" this.createStages}}>
     {{#if this.hasStages}}
+      {{#if this.displayNoThresholdZero}}
+        <PixMessage @type='warning'>
+          Attention ! Il n'y a pas de palier à 0
+        </PixMessage>
+      {{/if}}
       <div class="table-admin">
         <table>
           <thead>

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -1,9 +1,36 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
 
 export default class Stages extends Component {
+  @service store;
 
   get hasStages() {
     const stages = this.args.stages;
     return stages && stages.length > 0;
+  }
+
+  get hasNewStage() {
+    return this.args.stages.any((stage) => stage.isNew);
+  }
+
+  get newStages() {
+    return this.args.stages.filter((stage) => stage.isNew);
+  }
+
+  @action
+  addStage() {
+    this.store.createRecord('stage', { targetProfile: this.args.targetProfile });
+  }
+
+  @action
+  async createStages(event) {
+    event.preventDefault();
+    await Promise.all(this.newStages.map((stage) => stage.save()));
+  }
+
+  @action
+  cancelStagesCreation() {
+    this.newStages.forEach((stage) => stage.deleteRecord());
   }
 }

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class Stages extends Component {
   @service store;
+  @service notifications;
 
   get hasStages() {
     const stages = this.args.stages;
@@ -24,8 +25,14 @@ export default class Stages extends Component {
   }
 
   @action
-  async createStages() {
-    await Promise.all(this.newStages.map((stage) => stage.save()));
+  async createStages(event) {
+    event.preventDefault();
+
+    try {
+      await Promise.all(this.newStages.map((stage) => stage.save()));
+    } catch (_error) {
+      this.notifications.error('Une erreur est survenue.');
+    }
   }
 
   @action

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -24,9 +24,13 @@ export default class Stages extends Component {
   }
 
   @action
-  async createStages(event) {
-    event.preventDefault();
+  async createStages() {
     await Promise.all(this.newStages.map((stage) => stage.save()));
+  }
+
+  @action
+  removeNewStage(stage) {
+    stage.deleteRecord();
   }
 
   @action

--- a/admin/app/components/target-profiles/stages.js
+++ b/admin/app/components/target-profiles/stages.js
@@ -19,6 +19,10 @@ export default class Stages extends Component {
     return this.args.stages.filter((stage) => stage.isNew);
   }
 
+  get displayNoThresholdZero() {
+    return this.hasStages && !this.args.stages.any((stage) => stage.threshold === 0);
+  }
+
   @action
   addStage() {
     this.store.createRecord('stage', { targetProfile: this.args.targetProfile });

--- a/admin/app/controllers/authenticated/organizations/get/target-profiles.js
+++ b/admin/app/controllers/authenticated/organizations/get/target-profiles.js
@@ -22,6 +22,11 @@ export default class GetTargetProfilesController extends Controller {
     }
   }
 
+  @action
+  goToTargetProfilePage(targetProfileId) {
+    this.transitionToRoute('authenticated.target-profiles.target-profile', targetProfileId);
+  }
+
   _handleResponseError({ errors }) {
     if (!errors) {
       return this.notifications.error('Une erreur est survenue.');

--- a/admin/app/models/badge.js
+++ b/admin/app/models/badge.js
@@ -1,6 +1,8 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Badge extends Model {
+  @belongsTo('target-profile') targetProfile;
+
   @attr() key;
   @attr() title;
   @attr() message;

--- a/admin/app/models/stage.js
+++ b/admin/app/models/stage.js
@@ -1,6 +1,8 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class Stage extends Model {
+  @belongsTo('target-profile') targetProfile;
+
   @attr('number') threshold;
   @attr('string') title;
   @attr('string') message;

--- a/admin/app/routes/authenticated/target-profiles/target-profile/insight.js
+++ b/admin/app/routes/authenticated/target-profiles/target-profile/insight.js
@@ -9,7 +9,7 @@ export default class TargetProfileInsightRoute extends Route {
     return {
       badges,
       stages,
-      targetProfileImageUrl: targetProfile.imageUrl,
+      targetProfile,
     };
   }
 }

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -18,6 +18,10 @@
       width: 90px;
     }
   }
+
+  &__actions {
+    width: 100px;
+  }
 }
 .stages-table .form-field {
   margin-bottom: 0;

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -1,6 +1,6 @@
 .stages-table {
   &__id {
-    width: 100px;
+    width: 110px;
   }
 
   &__threshold {

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -19,3 +19,10 @@
     }
   }
 }
+
+.stages-new-stage {
+  margin: 10px 0;
+}
+.stages-actions {
+  text-align: right;
+}

--- a/admin/app/styles/components/target-profiles/stages.scss
+++ b/admin/app/styles/components/target-profiles/stages.scss
@@ -19,7 +19,9 @@
     }
   }
 }
-
+.stages-table .form-field {
+  margin-bottom: 0;
+}
 .stages-new-stage {
   margin: 10px 0;
 }

--- a/admin/app/templates/authenticated/organizations/get/target-profiles.hbs
+++ b/admin/app/templates/authenticated/organizations/get/target-profiles.hbs
@@ -1,4 +1,5 @@
 <OrganizationTargetProfilesSection @targetProfiles={{@model.targetProfiles}}
                                    @targetProfilesToAttach={{this.targetProfilesToAttach}}
                                    @attachTargetProfiles={{this.attachTargetProfiles}}
+                                   @goToTargetProfilePage={{this.goToTargetProfilePage}}
 />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -1,9 +1,18 @@
 import { Response } from 'ember-cli-mirage';
 import { createMembership } from './handlers/memberships';
-import { attachTargetProfiles, attachTargetProfileToOrganizations, getOrganizationTargetProfiles, findPaginatedTargetProfileOrganizations, updateTargetProfileName } from './handlers/target-profiles';
+import {
+  attachTargetProfiles,
+  attachTargetProfileToOrganizations,
+  getOrganizationTargetProfiles,
+  findPaginatedTargetProfileOrganizations,
+  updateTargetProfileName,
+  findTargetProfileBadges,
+  findTargetProfileStages,
+} from './handlers/target-profiles';
 import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findPaginatedOrganizationMemberships } from './handlers/organizations';
+import { createStage } from './handlers/stages';
 
 export default function() {
   this.logging = true;
@@ -88,7 +97,11 @@ export default function() {
   this.patch('/admin/target-profiles/:id');
   this.get('/admin/target-profiles/:id/organizations', findPaginatedTargetProfileOrganizations);
   this.post('/admin/target-profiles/:id/attach-organizations', attachTargetProfileToOrganizations);
+  this.get('/admin/target-profiles/:id/badges', findTargetProfileBadges);
+  this.get('/admin/target-profiles/:id/stages', findTargetProfileStages);
   this.patch('/admin/target-profiles/:id', updateTargetProfileName);
+
+  this.post('/admin/stages', createStage);
 
   this.get('/admin/certifications/:id');
   this.get('/admin/certifications/:id/certified-profile', (schema, request) => {

--- a/admin/mirage/handlers/stages.js
+++ b/admin/mirage/handlers/stages.js
@@ -1,0 +1,6 @@
+function createStage(schema, request) {
+  const params = JSON.parse(request.requestBody);
+  return schema.stages.create(params.data.attributes);
+}
+
+export { createStage };

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -42,6 +42,14 @@ function findPaginatedTargetProfileOrganizations(schema, request) {
   return json;
 }
 
+function findTargetProfileBadges(schema) {
+  return schema.badges.all();
+}
+
+function findTargetProfileStages(schema) {
+  return schema.stages.all();
+}
+
 function _getPaginationFromQueryParams(queryParams) {
   return {
     pageSize: parseInt(_get(queryParams, 'page[size]', 10)),
@@ -64,7 +72,6 @@ function updateTargetProfileName(schema, request) {
   const targetProfile = schema.targetProfiles.find(id);
   targetProfile.update({ name: newName });
   return new Response(204);
-
 }
 
 export {
@@ -72,5 +79,7 @@ export {
   attachTargetProfileToOrganizations,
   getOrganizationTargetProfiles,
   findPaginatedTargetProfileOrganizations,
+  findTargetProfileBadges,
+  findTargetProfileStages,
   updateTargetProfileName,
 };

--- a/admin/mirage/serializers/target-profile.js
+++ b/admin/mirage/serializers/target-profile.js
@@ -4,4 +4,15 @@ const _includes = ['areas', 'competences', 'tubes', 'skills'];
 
 export default ApplicationSerializer.extend({
   include: _includes,
+
+  links(targetProfile) {
+    return {
+      badges: {
+        related: `/api/admin/target-profiles/${targetProfile.id}/badges`,
+      },
+      stages: {
+        related: `/api/admin/target-profiles/${targetProfile.id}/stages`,
+      },
+    };
+  },
 });

--- a/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
@@ -56,7 +56,6 @@ module('Acceptance | authenticated/targets-profile/target-profile/insight', func
   });
 
   test('should reset stage creation data after cancellation', async function(assert) {
-
     // when
     await visit(`/target-profiles/${targetProfile.id}/insight`);
     const stageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
@@ -67,5 +66,19 @@ module('Acceptance | authenticated/targets-profile/target-profile/insight', func
     // then
     const newStageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
     assert.equal(newStageCount, 1);
+  });
+
+  test('should remove one line of a new stage', async function(assert) {
+    // when
+    await visit(`/target-profiles/${targetProfile.id}/insight`);
+    const stageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(stageCount, 1);
+    await click('button[data-test=\'Nouveau palier\']');
+    await click('button[data-test=\'Nouveau palier\']');
+    await click('button[aria-label=\'Supprimer palier\']');
+
+    // then
+    const newStageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(newStageCount, 2);
   });
 });

--- a/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
@@ -1,0 +1,71 @@
+import { click, fillIn, findAll, visit } from '@ember/test-helpers';
+import { module, test, setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { createAuthenticateSession } from '../../../helpers/test-init';
+
+module('Acceptance | authenticated/targets-profile/target-profile/insight', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let currentUser;
+  let targetProfile;
+
+  hooks.beforeEach(async function() {
+    currentUser = server.create('user');
+    await createAuthenticateSession({ userId: currentUser.id });
+
+    targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
+    this.server.create('badge', { title: 'My badge' });
+    this.server.create('badge', { title: 'My badge 2' });
+
+    this.server.create('stage', { title: 'My stage' });
+  });
+
+  test('should list badges and stages', async function(assert) {
+    await visit(`/target-profiles/${targetProfile.id}/insight`);
+
+    assert.contains('My badge');
+    assert.contains('My stage');
+  });
+
+  test('should be able to add a new stage', async function(assert) {
+    await visit(`/target-profiles/${targetProfile.id}/insight`);
+
+    const stageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(stageCount, 1);
+
+    assert.notContains('Enregistrer');
+
+    await click('button[data-test=\'Nouveau palier\']');
+
+    assert.contains('Enregistrer');
+    assert.contains('Annuler');
+    const newTableRowCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(newTableRowCount, 2);
+
+    fillIn('.insight__section:nth-child(2) tbody tr td:nth-child(3) input', '0');
+    fillIn('.insight__section:nth-child(2) tbody tr td:nth-child(4) input', 'My stage title');
+    fillIn('.insight__section:nth-child(2) tbody tr td:nth-child(5) input', 'My stage message');
+
+    await click('button.form-action--submit');
+    assert.notContains('Enregistrer');
+
+    const newStageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(newStageCount, 2);
+  });
+
+  test('should reset stage creation data after cancellation', async function(assert) {
+
+    // when
+    await visit(`/target-profiles/${targetProfile.id}/insight`);
+    const stageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(stageCount, 1);
+    await click('button[data-test=\'Nouveau palier\']');
+    await click('button.form-action--cancel');
+
+    // then
+    const newStageCount = findAll('.insight__section:nth-child(2) tbody tr').length;
+    assert.equal(newStageCount, 1);
+  });
+});

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insight-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insight-test.js
@@ -7,10 +7,21 @@ module('Integration | Component | routes/authenticated/target-profiles/target-pr
 
   setupRenderingTest(hooks);
 
-  module('section rendering', function() {
+  module('section rendering', function(hooks) {
+    let model;
+    hooks.beforeEach(() => {
+      model = {
+        badges: [],
+        stages: [],
+      };
+    });
+
     test('it should display the badges title and an empty list', async function(assert) {
+      // given
+      this.set('model', model);
+
       // when
-      await render(hbs`<TargetProfiles::Insight/>`);
+      await render(hbs`<TargetProfiles::Insight @model={{this.model}}/>`);
 
       // then
       assert.contains('Résultats thématiques');
@@ -18,8 +29,11 @@ module('Integration | Component | routes/authenticated/target-profiles/target-pr
     });
 
     test('it should display the stages title and an empty list', async function(assert) {
+      // given
+      this.set('model', model);
+
       // when
-      await render(hbs`<TargetProfiles::Insight/>`);
+      await render(hbs`<TargetProfiles::Insight @model={{this.model}}/>`);
 
       // then
       assert.contains('Paliers');

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
@@ -42,8 +42,6 @@ module('Integration | Component | TargetProfiles::CreateTargetProfileForm', func
   });
 
   test('it should display the items', async function(assert) {
-    // given
-
     // when
     await render(hbs`<TargetProfiles::CreateTargetProfileForm
       @targetProfile={{this.targetProfile}}

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -30,6 +30,7 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
     assert.contains('Threshold');
     assert.contains('Titre');
     assert.contains('Message');
+    assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
     assert.equal(find('tbody tr td:first-child').textContent.trim(), '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -16,10 +16,10 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
       message: 'My message',
     });
     this.set('stages', [stage]);
-    this.set('targetProfileImageUrl', 'data:,');
+    this.set('targetProfile', { imageUrl: 'data:,' });
 
     // when
-    await render(hbs`<TargetProfiles::Stages @stages={{this.stages}} @targetProfileImageUrl={{this.targetProfileImageUrl}}/>`);
+    await render(hbs`<TargetProfiles::Stages @stages={{this.stages}} @targetProfile={{this.targetProfile}}/>`);
 
     // then
     assert.dom('table').exists();
@@ -31,12 +31,12 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
     assert.contains('Titre');
     assert.contains('Message');
     assert.dom('tbody tr').exists({ count: 1 });
-    assert.equal(find('tbody tr td:first-child').textContent, '1');
+    assert.equal(find('tbody tr td:first-child').textContent.trim(), '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();
     assert.equal(find('tbody tr td:nth-child(2) img').getAttribute('src'), 'data:,');
-    assert.equal(find('tbody tr td:nth-child(3)').textContent, '100');
-    assert.equal(find('tbody tr td:nth-child(4)').textContent, 'My title');
-    assert.equal(find('tbody tr td:nth-child(5)').textContent, 'My message');
+    assert.equal(find('tbody tr td:nth-child(3)').textContent.trim(), '100');
+    assert.equal(find('tbody tr td:nth-child(4)').textContent.trim(), 'My title');
+    assert.equal(find('tbody tr td:nth-child(5)').textContent.trim(), 'My message');
     assert.notContains('Aucun résultat thématique associé');
   });
 

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -52,4 +52,33 @@ module('Integration | Component | TargetProfiles::Stages', function(hooks) {
     assert.dom('table').doesNotExist();
     assert.contains('Aucun palier associé');
   });
+
+  test('it should display a message when there is no stages with threshold 0', async function(assert) {
+    // given
+    this.set('stages', []);
+
+    // when
+    await render(hbs`<TargetProfiles::Stages @stages={{this.stages}} />`);
+
+    // then
+    assert.dom('table').doesNotExist();
+    assert.contains('Aucun palier associé');
+  });
+
+  test('it should display a warning when there is no threshold at 0', async function(assert) {
+    // given
+    const stage = EmberObject.create({
+      id: 1,
+      threshold: '100',
+      title: 'My title',
+      message: 'My message',
+    });
+    this.set('stages', [stage]);
+
+    // when
+    await render(hbs`<TargetProfiles::Stages @stages={{this.stages}} />`);
+
+    // then
+    assert.contains('Attention ! Il n\'y a pas de palier à 0');
+  });
 });

--- a/admin/tests/unit/components/target-profiles/stages_test.js
+++ b/admin/tests/unit/components/target-profiles/stages_test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import createComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit |  Component | Target Profiles | stages', function(hooks) {
+  setupTest(hooks);
+
+  module('#displayNoThresholdZero', function() {
+    test('returns false if there a stage with a threshold value at 0', function(assert) {
+      const component = createComponent('component:target-profiles/stages');
+      component.args = {
+        stages: [
+          { threshold: 0 },
+        ],
+      };
+
+      assert.notOk(component.displayNoThresholdZero);
+    });
+
+    test('returns true if there is no stage with a threshold value at 0', function(assert) {
+      const component = createComponent('component:target-profiles/stages');
+      component.args = {
+        stages: [
+          { threshold: 45 },
+        ],
+      };
+
+      assert.ok(component.displayNoThresholdZero);
+    });
+
+    test('returns false if there is no stage', function(assert) {
+      const component = createComponent('component:target-profiles/stages');
+      component.args = {
+        stages: [],
+      };
+
+      assert.notOk(component.displayNoThresholdZero);
+    });
+  });
+});

--- a/api/lib/application/pre-response-utils.js
+++ b/api/lib/application/pre-response-utils.js
@@ -6,7 +6,7 @@ function handleDomainAndHttpErrors(request, h) {
   const response = request.response;
 
   if (response instanceof DomainError || response instanceof BaseHttpError) {
-    return errorManager.handle(h, response);
+    return errorManager.handle(request, h, response);
   }
 
   return h.continue;

--- a/api/lib/application/stages/index.js
+++ b/api/lib/application/stages/index.js
@@ -1,0 +1,21 @@
+const securityPreHandlers = require('../security-pre-handlers');
+const stagesController = require('./stages-controller');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'POST',
+      path: '/api/admin/stages',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: stagesController.create,
+        tags: ['api', 'stages'],
+      },
+    },
+  ]);
+};
+
+exports.name = 'badges-api';

--- a/api/lib/application/stages/stages-controller.js
+++ b/api/lib/application/stages/stages-controller.js
@@ -1,0 +1,10 @@
+const usecases = require('../../domain/usecases');
+const stageSerializer = require('../../infrastructure/serializers/jsonapi/stage-serializer');
+
+module.exports = {
+  async create(request, h) {
+    const stage = stageSerializer.deserialize(request.payload);
+    const newStage = await usecases.createStage({ stage });
+    return h.response(stageSerializer.serialize(newStage)).created();
+  },
+};

--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -7,6 +7,7 @@ class Stage {
     threshold,
     prescriberTitle,
     prescriberDescription,
+    targetProfileId,
   } = {}) {
     this.id = id;
     this.title = title;
@@ -14,6 +15,7 @@ class Stage {
     this.threshold = threshold;
     this.prescriberTitle = prescriberTitle;
     this.prescriberDescription = prescriberDescription;
+    this.targetProfileId = targetProfileId;
   }
 
   getMinSkillsCountToReachStage(totalSkills) {

--- a/api/lib/domain/usecases/create-stage.js
+++ b/api/lib/domain/usecases/create-stage.js
@@ -1,4 +1,7 @@
+const stageValidator = require('../validators/stage-validator');
 
 module.exports = function createStage({ stage, stageRepository }) {
+  stageValidator.validate({ stage });
+
   return stageRepository.create(stage);
 };

--- a/api/lib/domain/usecases/create-stage.js
+++ b/api/lib/domain/usecases/create-stage.js
@@ -1,0 +1,4 @@
+
+module.exports = function createStage({ stage, stageRepository }) {
+  return stageRepository.create(stage);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -136,6 +136,7 @@ module.exports = injectDependencies({
   createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
   createPasswordResetDemand: require('./create-password-reset-demand'),
   createSession: require('./create-session'),
+  createStage: require('./create-stage'),
   createTargetProfile: require('./create-target-profile'),
   createUser: require('./create-user'),
   createUserFromPoleEmploi: require('./create-user-from-pole-emploi'),

--- a/api/lib/domain/validators/stage-validator.js
+++ b/api/lib/domain/validators/stage-validator.js
@@ -9,15 +9,18 @@ const stageValidationJoiSchema = Joi.object({
     .required()
     .messages({
       'string.base': 'STAGE_TITLE_IS_REQUIRED',
+      'string.empty': 'STAGE_TITLE_IS_REQUIRED',
     }),
 
   threshold: Joi.number()
     .integer()
+    .required()
     .messages({
       'number.base': 'STAGE_THRESHOLD_IS_REQUIRED',
     }),
 
   targetProfileId: Joi.number()
+    .required()
     .integer()
     .messages({
       'number.base': 'TARGET_PROFILE_IS_REQUIRED',

--- a/api/lib/domain/validators/stage-validator.js
+++ b/api/lib/domain/validators/stage-validator.js
@@ -1,0 +1,35 @@
+const Joi = require('joi');
+const { EntityValidationError } = require('../errors');
+
+const validationConfiguration = { abortEarly: false, allowUnknown: true };
+
+const stageValidationJoiSchema = Joi.object({
+
+  title: Joi.string()
+    .required()
+    .messages({
+      'string.base': 'STAGE_TITLE_IS_REQUIRED',
+    }),
+
+  threshold: Joi.number()
+    .integer()
+    .messages({
+      'number.base': 'STAGE_THRESHOLD_IS_REQUIRED',
+    }),
+
+  targetProfileId: Joi.number()
+    .integer()
+    .messages({
+      'number.base': 'TARGET_PROFILE_IS_REQUIRED',
+    }),
+});
+
+module.exports = {
+  validate({ stage }) {
+    const { error } = stageValidationJoiSchema.validate(stage, { ...validationConfiguration });
+    if (error) {
+      throw EntityValidationError.fromJoiErrors(error.details);
+    }
+    return true;
+  },
+};

--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -1,5 +1,6 @@
 const BookshelfStage = require('../../infrastructure/data/stage');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const _ = require('lodash');
 
 module.exports = {
   async findByCampaignId(campaignId) {
@@ -18,5 +19,16 @@ module.exports = {
       .orderBy('threshold')
       .fetchAll({ require: false })
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfStage, results));
+  },
+
+  async create(stage) {
+    const stageAttributes = _.pick(stage, [
+      'title',
+      'message',
+      'threshold',
+      'targetProfileId',
+    ]);
+    const createdStage = await (new BookshelfStage(stageAttributes).save());
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfStage, createdStage);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/stage-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/stage-serializer.js
@@ -1,10 +1,19 @@
+const Stage = require('../../../domain/models/Stage');
 const { Serializer } = require('jsonapi-serializer');
 
 module.exports = {
-  serialize(badge = {}) {
+  serialize(stage = {}) {
     return new Serializer('stage', {
       ref: 'id',
       attributes: ['message', 'threshold', 'title'],
-    }).serialize(badge);
+    }).serialize(stage);
+  },
+  deserialize(json) {
+    return new Stage({
+      title: json.data.attributes.title,
+      message: json.data.attributes.message,
+      threshold: json.data.attributes.threshold,
+      targetProfileId: json.data.relationships['target-profile'].data.id,
+    });
   },
 };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -3,6 +3,7 @@ module.exports = [
   require('./application/assessment-results'),
   require('./application/assessments'),
   require('./application/authentication'),
+  require('./application/stages'),
   require('./application/cache'),
   require('./application/campaign-participation-results'),
   require('./application/campaign-participations'),

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -1,5 +1,7 @@
-const { expect, databaseBuilder } = require('../../../test-helper');
+const { expect, databaseBuilder, knex } = require('../../../test-helper');
+const Stage = require('../../../../lib/domain/models/Stage');
 const stageRepository = require('../../../../lib/infrastructure/repositories/stage-repository');
+const _ = require('lodash');
 
 describe('Integration | Repository | StageRepository', () => {
 
@@ -60,6 +62,40 @@ describe('Integration | Repository | StageRepository', () => {
       // then
       expect(stages.length).to.equal(2);
       expect(stages[0].threshold).to.equal(0);
+    });
+  });
+
+  describe('#create', () => {
+    let targetProfileId;
+
+    beforeEach(async () => {
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+
+      await databaseBuilder.commit();
+
+      targetProfileId = targetProfile.id;
+    });
+
+    afterEach(() => {
+      return knex('stages').delete();
+    });
+
+    it('create a stage on a target profile', async () => {
+      // given
+      const stageToSave = {
+        title: 'My title',
+        message: 'My message',
+        threshold: 42,
+        targetProfileId,
+      };
+
+      // when
+      const savedStage = await stageRepository.create(stageToSave);
+
+      // then
+      expect(savedStage).to.be.instanceof(Stage);
+      expect(savedStage.id).to.exist;
+      expect(savedStage).to.deep.include(_.pick(stageToSave, ['title', 'message', 'threshold']));
     });
   });
 });

--- a/api/tests/unit/application/error-manager_test.js
+++ b/api/tests/unit/application/error-manager_test.js
@@ -1,0 +1,106 @@
+const { expect, hFake } = require('../../test-helper');
+const { EntityValidationError } = require('../../../lib/domain/errors');
+
+const { handle: errorManager } = require('../../../lib/application/error-manager');
+
+describe('Unit | Application | ErrorManager', () => {
+
+  describe('#handle', () => {
+    it('should translate EntityValidationError', async () => {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [
+          { attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' },
+        ],
+      });
+
+      // when
+      const response = await errorManager(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'The stage title is required',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
+    it('should translate EntityValidationError to french', async () => {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'fr-fr',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [
+          { attribute: 'name', message: 'STAGE_TITLE_IS_REQUIRED' },
+        ],
+      });
+
+      // when
+      const response = await errorManager(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'Le titre du palier est obligatoire',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+
+    it('should fallback to the message if the translation is not found', async () => {
+      // given
+      const request = {
+        headers: {
+          'accept-language': 'en',
+        },
+      };
+      const error = new EntityValidationError({
+        invalidAttributes: [
+          { attribute: 'name', message: 'message' },
+        ],
+      });
+
+      // when
+      const response = await errorManager(request, hFake, error);
+
+      // then
+      expect(response.statusCode).to.equal(422);
+      expect(response.source).to.deep.equal({
+        errors: [
+          {
+            detail: 'message',
+            source: {
+              pointer: '/data/attributes/name',
+            },
+            status: '422',
+            title: 'Invalid data attribute "name"',
+          },
+        ],
+      });
+    });
+  });
+
+});

--- a/api/tests/unit/application/pre-response-utils_test.js
+++ b/api/tests/unit/application/pre-response-utils_test.js
@@ -40,7 +40,7 @@ describe('Unit | Application | PreResponse-utils', () => {
       await handleDomainAndHttpErrors(request, hFake);
 
       // then
-      expect(errorManager.handle).to.have.been.calledWithExactly(hFake, request.response);
+      expect(errorManager.handle).to.have.been.calledWithExactly(request, hFake, request.response);
     });
 
     it('should manage BaseHttpError', async () => {
@@ -52,7 +52,7 @@ describe('Unit | Application | PreResponse-utils', () => {
       await handleDomainAndHttpErrors(request, hFake);
 
       // then
-      expect(errorManager.handle).to.have.been.calledWithExactly(hFake, request.response);
+      expect(errorManager.handle).to.have.been.calledWithExactly(request, hFake, request.response);
     });
   });
 

--- a/api/tests/unit/application/stages/index_test.js
+++ b/api/tests/unit/application/stages/index_test.js
@@ -1,0 +1,39 @@
+const { expect, sinon, HttpTestServer } = require('../../../test-helper');
+
+const securityPreHandlers = require('../../../../lib/application/security-pre-handlers');
+const stagesController = require('../../../../lib/application/stages/stages-controller');
+const moduleUnderTest = require('../../../../lib/application/stages');
+
+let httpTestServer;
+
+function startServer() {
+  return new HttpTestServer(moduleUnderTest);
+}
+
+describe('Unit | Router | stages-router', () => {
+
+  describe('POST /api/admin/stages', () => {
+
+    const method = 'POST';
+
+    beforeEach(() => {
+      sinon.stub(securityPreHandlers, 'checkUserIsAuthenticated').callsFake((request, h) => {
+        h.continue({ credentials: { accessToken: 'jwt.access.token' } });
+      });
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      sinon.stub(stagesController, 'create').returns('ok');
+      httpTestServer = startServer();
+    });
+
+    it('should exist', async () => {
+      // given
+      const url = '/api/admin/stages';
+
+      // when
+      const response = await httpTestServer.request(method, url);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+  });
+});

--- a/api/tests/unit/application/stages/stages-controller_test.js
+++ b/api/tests/unit/application/stages/stages-controller_test.js
@@ -1,0 +1,49 @@
+const { sinon, expect, hFake } = require('../../../test-helper');
+
+const usecases = require('../../../../lib/domain/usecases');
+
+const stageSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/stage-serializer');
+
+const stagesController = require('../../../../lib/application/stages/stages-controller');
+
+describe('Unit | Controller | stages-controller', () => {
+
+  describe('#create', () => {
+    const userId = '1';
+
+    beforeEach(() => {
+      sinon.stub(stageSerializer, 'serialize');
+      sinon.stub(stageSerializer, 'deserialize');
+      sinon.stub(usecases, 'createStage');
+    });
+
+    it('should return a newly created stage', async function() {
+      // given
+      const requestPayload = {};
+      const request = {
+        auth: {
+          credentials: {
+            userId: userId,
+          },
+        },
+        payload: requestPayload,
+      };
+      const deserializedStage = {
+        title: 'My stage',
+      };
+      const createdStage = {};
+      stageSerializer.deserialize.returns(deserializedStage);
+      usecases.createStage.resolves(createdStage);
+
+      // when
+      const response = await stagesController.create(request, hFake);
+
+      // then
+      expect(response.statusCode).to.equal(201);
+      expect(stageSerializer.deserialize.calledWith(requestPayload)).to.be.true;
+      expect(usecases.createStage.calledWith({ stage: deserializedStage })).to.be.true;
+      expect(stageSerializer.serialize.calledWith(createdStage)).to.be.true;
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/create-stage-test.js
+++ b/api/tests/unit/domain/usecases/create-stage-test.js
@@ -1,0 +1,21 @@
+const { expect, sinon } = require('../../../test-helper');
+const createStage = require('../../../../lib/domain/usecases/create-stage');
+
+describe('Unit | UseCase | create-stage', () => {
+  beforeEach(() => {
+  });
+
+  it.only('should call the stage repository', async () => {
+    // given
+    const stageCreated = {};
+    const stageRepository = { create: sinon.stub().returns(stageCreated) };
+    const stage = { title: 'My stage' };
+
+    // when
+    const result = await createStage({ stage, stageRepository });
+
+    // then
+    expect(stageRepository.create.calledWith(stage)).to.be.true;
+    expect(result).to.equal(stageCreated);
+  });
+});

--- a/api/tests/unit/domain/usecases/create-stage-test.js
+++ b/api/tests/unit/domain/usecases/create-stage-test.js
@@ -1,11 +1,25 @@
-const { expect, sinon } = require('../../../test-helper');
+const { expect, sinon, catchErr } = require('../../../test-helper');
 const createStage = require('../../../../lib/domain/usecases/create-stage');
+const stageValidator = require('../../../../lib/domain/validators/stage-validator');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | UseCase | create-stage', () => {
   beforeEach(() => {
+    sinon.stub(stageValidator, 'validate');
   });
 
-  it.only('should call the stage repository', async () => {
+  it('should throw an EntityValidationError if stage is not valid', async () => {
+    // given
+    stageValidator.validate.throws(new EntityValidationError({ invalidAttributes: [] }));
+
+    // when
+    const error = await catchErr(createStage)({ });
+
+    // then
+    expect(error).to.be.instanceOf(EntityValidationError);
+  });
+
+  it('should call the stage repository', async () => {
     // given
     const stageCreated = {};
     const stageRepository = { create: sinon.stub().returns(stageCreated) };

--- a/api/tests/unit/domain/validators/stage-validator_test.js
+++ b/api/tests/unit/domain/validators/stage-validator_test.js
@@ -1,0 +1,92 @@
+/* eslint-disable mocha/no-identical-title */
+const { expect } = require('../../../test-helper');
+
+const Stage = require('../../../../lib/domain/models/Stage');
+const { EntityValidationError } = require('../../../../lib/domain/errors');
+
+const stageValidator = require('../../../../lib/domain/validators/stage-validator');
+
+const MISSING_VALUE = '';
+
+function _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError) {
+  expect(entityValidationErrors).to.be.instanceOf(EntityValidationError);
+  expect(entityValidationErrors.invalidAttributes).to.have.lengthOf(1);
+  expect(entityValidationErrors.invalidAttributes[0]).to.deep.equal(expectedError);
+}
+
+describe('Unit | Domain | Validators | stage-validator', () => {
+  describe('#validate', () => {
+    let stage;
+
+    beforeEach(() => {
+      stage = new Stage({
+        title: 'My title',
+        threshold: 42,
+        targetProfileId: 3,
+      });
+    });
+
+    context('when validation is successful ', () => {
+      it('should not throw any error', () => {
+        expect(stageValidator.validate({ stage })).to.be.true;
+      });
+    });
+
+    context('when stage data validation fails', () => {
+      it('should reject with error when title is missing', () => {
+        // given
+        const expectedError = {
+          attribute: 'title',
+          message: 'STAGE_TITLE_IS_REQUIRED',
+        };
+        stage.title = MISSING_VALUE;
+
+        // when
+        try {
+          stageValidator.validate({ stage });
+          expect.fail('should have thrown an error');
+        } catch (errors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(errors, expectedError);
+        }
+      });
+
+      it('should reject with error when threshold is missing', () => {
+        // given
+        const expectedError = {
+          attribute: 'threshold',
+          message: 'STAGE_THRESHOLD_IS_REQUIRED',
+        };
+        stage.threshold = MISSING_VALUE;
+
+        // when
+        try {
+          stageValidator.validate({ stage });
+          expect.fail('should have thrown an error');
+        } catch (errors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(errors, expectedError);
+        }
+      });
+
+      it('should reject with error when targetProfileId is missing', () => {
+        // given
+        const expectedError = {
+          attribute: 'targetProfileId',
+          message: 'TARGET_PROFILE_IS_REQUIRED',
+        };
+        stage.targetProfileId = MISSING_VALUE;
+
+        // when
+        try {
+          stageValidator.validate({ stage });
+          expect.fail('should have thrown an error');
+
+        } catch (entityValidationErrors) {
+          // then
+          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
+        }
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/validators/stage-validator_test.js
+++ b/api/tests/unit/domain/validators/stage-validator_test.js
@@ -1,5 +1,5 @@
 /* eslint-disable mocha/no-identical-title */
-const { expect } = require('../../../test-helper');
+const { expect, catchErr } = require('../../../test-helper');
 
 const Stage = require('../../../../lib/domain/models/Stage');
 const { EntityValidationError } = require('../../../../lib/domain/errors');
@@ -33,7 +33,7 @@ describe('Unit | Domain | Validators | stage-validator', () => {
     });
 
     context('when stage data validation fails', () => {
-      it('should reject with error when title is missing', () => {
+      it('should reject with error when title is missing', async () => {
         // given
         const expectedError = {
           attribute: 'title',
@@ -42,16 +42,13 @@ describe('Unit | Domain | Validators | stage-validator', () => {
         stage.title = MISSING_VALUE;
 
         // when
-        try {
-          stageValidator.validate({ stage });
-          expect.fail('should have thrown an error');
-        } catch (errors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(errors, expectedError);
-        }
+        const errors = await catchErr(stageValidator.validate)({ stage });
+
+        // then
+        _assertErrorMatchesWithExpectedOne(errors, expectedError);
       });
 
-      it('should reject with error when threshold is missing', () => {
+      it('should reject with error when threshold is missing', async () => {
         // given
         const expectedError = {
           attribute: 'threshold',
@@ -60,16 +57,28 @@ describe('Unit | Domain | Validators | stage-validator', () => {
         stage.threshold = MISSING_VALUE;
 
         // when
-        try {
-          stageValidator.validate({ stage });
-          expect.fail('should have thrown an error');
-        } catch (errors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(errors, expectedError);
-        }
+        const errors = await catchErr(stageValidator.validate)({ stage });
+
+        // then
+        _assertErrorMatchesWithExpectedOne(errors, expectedError);
       });
 
-      it('should reject with error when targetProfileId is missing', () => {
+      it('should reject with error when threshold is a string', async () => {
+        // given
+        const expectedError = {
+          attribute: 'threshold',
+          message: 'STAGE_THRESHOLD_IS_REQUIRED',
+        };
+        stage.threshold = 'test';
+
+        // when
+        const errors = await catchErr(stageValidator.validate)({ stage });
+
+        // then
+        _assertErrorMatchesWithExpectedOne(errors, expectedError);
+      });
+
+      it('should reject with error when targetProfileId is missing', async () => {
         // given
         const expectedError = {
           attribute: 'targetProfileId',
@@ -78,14 +87,10 @@ describe('Unit | Domain | Validators | stage-validator', () => {
         stage.targetProfileId = MISSING_VALUE;
 
         // when
-        try {
-          stageValidator.validate({ stage });
-          expect.fail('should have thrown an error');
+        const errors = await catchErr(stageValidator.validate)({ stage });
 
-        } catch (entityValidationErrors) {
-          // then
-          _assertErrorMatchesWithExpectedOne(entityValidationErrors, expectedError);
-        }
+        // then
+        _assertErrorMatchesWithExpectedOne(errors, expectedError);
       });
     });
   });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/stage-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/stage-serializer_test.js
@@ -1,0 +1,72 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const Stage = require('../../../../../lib/domain/models/Stage');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/stage-serializer');
+
+describe('Unit | Serializer | JSONAPI | stage-serializer', function() {
+
+  describe('#serialize', function() {
+
+    it('should convert a Stage model object into JSON API data', function() {
+      // given
+      const stage = domainBuilder.buildStage({
+        id: '1',
+        message: 'Congrats, you won a banana stage',
+        targetProfileId: '1',
+        threshold: 42,
+        title: 'Banana',
+      });
+
+      const expectedSerializedStage = {
+        data: {
+          attributes: {
+            message: 'Congrats, you won a banana stage',
+            threshold: 42,
+            title: 'Banana',
+          },
+          id: '1',
+          type: 'stages',
+        },
+      };
+
+      // when
+      const json = serializer.serialize(stage);
+
+      // then
+      expect(json).to.deep.equal(expectedSerializedStage);
+    });
+  });
+
+  describe('#deserialize', function() {
+    it('should create JSON API date into a Stage model', () => {
+      // given
+      const targetProfileId = 43;
+      const jsonStage = {
+        data: {
+          type: 'stages',
+          attributes: {
+            title: 'My stage title',
+            message: 'My stage message',
+            threshold: 42,
+          },
+          relationships: {
+            'target-profile': {
+              data: {
+                type: 'target-profiles',
+                id: targetProfileId,
+              },
+            },
+          },
+        },
+      };
+      // when
+      const stage = serializer.deserialize(jsonStage);
+
+      // then
+      expect(stage).to.be.an.instanceOf(Stage);
+      expect(stage.title).to.equal('My stage title');
+      expect(stage.message).to.equal('My stage message');
+      expect(stage.threshold).to.equal(42);
+      expect(stage.targetProfileId).to.equal(targetProfileId);
+    });
+  });
+});

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -61,5 +61,10 @@
       "contactUs": "contact us here",
       "helpdeskURL": "http://pix.org/en-gb/help-form"
     }
+  },
+  "entity-validation-errors": {
+    "STAGE_TITLE_IS_REQUIRED": "The stage title is required",
+    "STAGE_THRESHOLD_IS_REQUIRED": "The stage threshold is required",
+    "TARGET_PROFILE_IS_REQUIRED": "The target profile is required"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -61,5 +61,10 @@
       "contactUs": "contactez-nous ici",
       "helpdeskURL": "https://pix.org/fr/formulaire-aide"
     }
+  },
+  "entity-validation-errors": {
+    "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
+    "STAGE_THRESHOLD_IS_REQUIRED": "Le seuil du palier est obligatoire",
+    "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire"
   }
 }

--- a/api/translations/index.js
+++ b/api/translations/index.js
@@ -1,0 +1,4 @@
+const fr = require('./fr');
+const en = require('./en');
+
+module.exports = { fr, en };


### PR DESCRIPTION
## :unicorn: Problème PIX-1968
La création de paliers depuis l'interface d'admin n'est pas possible actuellement.

## :robot: Solution
Ajouter la possibilité de créer un palier depuis l'interface d'admin

## :rainbow: Remarques
J'ai mis en place un nouveau système de traduction des erreurs de validation qui pourrait l'intéresser l'équipe prescription. Je compte bien refactorer pour que ce soit utilisé partout.

## :100: Pour tester

1. Se connecter en tant que pixmaster
2. Aller sur un profil cible
3. Cliquer sur Clés de lecture
4. Cliquer sur ajouter un palier
5. Remplir le palier et enregistrer (vous pouvez ajouter plusieurs paliers d'un coup)

https://user-images.githubusercontent.com/86659/110522332-1152d380-8111-11eb-88b9-a6bc0a648f82.mp4


