### PR TITLE
[FEATURE][i18n] Traduction des en-têtes csv et du contenu pour les résultats d'une campagne (PIX-2206)

### DIFF
--- a/api/lib/application/campaigns/campaign-controller.js
+++ b/api/lib/application/campaigns/campaign-controller.js
@@ -61,7 +61,7 @@ module.exports = {
 
     const writableStream = new PassThrough();
 
-    const { fileName } = await usecases.startWritingCampaignAssessmentResultsToStream({ userId, campaignId, writableStream });
+    const { fileName } = await usecases.startWritingCampaignAssessmentResultsToStream({ userId, campaignId, writableStream, i18n: request.i18n });
     const escapedFileName = requestResponseUtils.escapeFileName(fileName);
 
     writableStream.headers = {

--- a/api/lib/domain/services/campaign-csv-export-service.js
+++ b/api/lib/domain/services/campaign-csv-export-service.js
@@ -13,6 +13,7 @@ function createOneCsvLine({
   targetProfileWithLearningContent,
   participantKnowledgeElementsByCompetenceId,
   acquiredBadges,
+  translate,
 }) {
   const line = new CampaignAssessmentCsvLine({
     organization,
@@ -22,6 +23,7 @@ function createOneCsvLine({
     participantKnowledgeElementsByCompetenceId,
     acquiredBadges,
     campaignParticipationService,
+    translate,
   });
 
   return csvSerializer.serializeLine(line.toCsvLine());

--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -50,7 +50,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
     throw error;
   });
 
-  const fileName = translate('campaign.profiles-collection.file-name', { name: campaign.name, id: campaign.id, date: moment.utc().format('YYYY-MM-DD-hhmm') });
+  const fileName = translate('campaign-export.common.file-name', { name: campaign.name, id: campaign.id, date: moment.utc().format('YYYY-MM-DD-hhmm') });
 
   return { fileName };
 };

--- a/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
+++ b/api/lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line.js
@@ -13,7 +13,7 @@ class CampaignProfileCollectionResultLine {
     this.placementProfile = placementProfile;
     this.translate = translate;
 
-    this.notShared = translate('campaign.common.not-available');
+    this.notShared = translate('campaign-export.common.not-available');
   }
 
   toCsvLine() {
@@ -82,7 +82,7 @@ class CampaignProfileCollectionResultLine {
   }
 
   _yesOrNo(value) {
-    return this.translate(`campaign.common.${value ? 'yes' : 'no'}`);
+    return this.translate(`campaign-export.common.${value ? 'yes' : 'no'}`);
   }
 
   _competenceColumns() {

--- a/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
+++ b/api/lib/infrastructure/serializers/csv/campaign-profile-collection-export.js
@@ -36,19 +36,19 @@ class CampaignProfileCollectionExport {
     const displayDivision = this.organization.isSco && this.organization.isManagingStudents;
 
     const header = [
-      this.translate('campaign.profiles-collection.organization-name'),
-      this.translate('campaign.profiles-collection.campaign-id'),
-      this.translate('campaign.profiles-collection.campaign-name'),
-      this.translate('campaign.profiles-collection.participant-lastname'),
-      this.translate('campaign.profiles-collection.participant-firstname'),
-      displayDivision && this.translate('campaign.profiles-collection.participant-division'),
-      displayStudentNumber && this.translate('campaign.profiles-collection.participant-student-number'),
+      this.translate('campaign-export.common.organization-name'),
+      this.translate('campaign-export.common.campaign-id'),
+      this.translate('campaign-export.common.campaign-name'),
+      this.translate('campaign-export.common.participant-lastname'),
+      this.translate('campaign-export.common.participant-firstname'),
+      displayDivision && this.translate('campaign-export.common.participant-division'),
+      displayStudentNumber && this.translate('campaign-export.common.participant-student-number'),
       this.idPixLabel,
-      this.translate('campaign.profiles-collection.is-sent'),
-      this.translate('campaign.profiles-collection.sent-on'),
-      this.translate('campaign.profiles-collection.pix-score'),
-      this.translate('campaign.profiles-collection.is-certifiable'),
-      this.translate('campaign.profiles-collection.certifiable-skills'),
+      this.translate('campaign-export.profiles-collection.is-sent'),
+      this.translate('campaign-export.profiles-collection.sent-on'),
+      this.translate('campaign-export.profiles-collection.pix-score'),
+      this.translate('campaign-export.profiles-collection.is-certifiable'),
+      this.translate('campaign-export.profiles-collection.certifiable-skills'),
       ...(this._competenceColumnHeaders()),
     ];
 
@@ -81,8 +81,8 @@ class CampaignProfileCollectionExport {
 
   _competenceColumnHeaders() {
     return _.flatMap(this.competences, (competence) => [
-      this.translate('campaign.profiles-collection.skill-level', { name: competence.name }),
-      this.translate('campaign.profiles-collection.skill-ranking', { name: competence.name }),
+      this.translate('campaign-export.profiles-collection.skill-level', { name: competence.name }),
+      this.translate('campaign-export.profiles-collection.skill-ranking', { name: competence.name }),
     ]);
   }
 }

--- a/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -13,6 +13,7 @@ const badgeAcquisitionRepository = require('../../../../lib/infrastructure/repos
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
 
 const Assessment = require('../../../../lib/domain/models/Assessment');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', () => {
 
@@ -26,6 +27,8 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
     let campaignParticipation;
     let writableStream;
     let csvPromise;
+
+    const i18n = getI18n();
 
     beforeEach(async () => {
       organization = databaseBuilder.factory.buildOrganization();
@@ -156,6 +159,7 @@ describe('Integration | Domain | Use Cases | start-writing-campaign-assessment-r
         userId: user.id,
         campaignId: campaign.id,
         writableStream,
+        i18n,
         campaignRepository,
         userRepository,
         targetProfileWithLearningContentRepository,

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -1,5 +1,5 @@
 const { PassThrough } = require('stream');
-const { expect, mockLearningContent, databaseBuilder, streamToPromise, sinon } = require('../../../test-helper');
+const { expect, mockLearningContent, databaseBuilder, streamToPromise } = require('../../../test-helper');
 
 const startWritingCampaignProfilesCollectionResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream');
 
@@ -9,6 +9,7 @@ const competenceRepository = require('../../../../lib/infrastructure/repositorie
 const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 const placementProfileService = require('../../../../lib/domain/services/placement-profile-service');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Integration | Domain | Use Cases | start-writing-profiles-collection-campaign-results-to-stream', () => {
 
@@ -23,13 +24,9 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
     let writableStream;
     let csvPromise;
 
-    const translate = sinon.stub();
     const createdAt = new Date('2019-02-25T10:00:00Z');
 
-    const i18n = {
-      __: translate,
-      getLocale: sinon.stub(),
-    };
+    const i18n = getI18n();
 
     beforeEach(async () => {
       user = databaseBuilder.factory.buildUser();
@@ -120,23 +117,6 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
 
       writableStream = new PassThrough();
       csvPromise = streamToPromise(writableStream);
-
-      translate.withArgs('campaign.profiles-collection.campaign-id').returns('ID Campagne');
-      translate.withArgs('campaign.profiles-collection.organization-name').returns('Nom de l\'organisation');
-      translate.withArgs('campaign.profiles-collection.campaign-name').returns('Nom de la campagne');
-      translate.withArgs('campaign.profiles-collection.participant-lastname').returns('Nom du Participant');
-      translate.withArgs('campaign.profiles-collection.participant-firstname').returns('Prénom du Participant');
-      translate.withArgs('campaign.profiles-collection.participant-division').returns('Classe');
-      translate.withArgs('campaign.profiles-collection.participant-student-number').returns('Numéro Étudiant');
-      translate.withArgs('campaign.profiles-collection.is-sent').returns('Envoi (O/N)');
-      translate.withArgs('campaign.profiles-collection.sent-on').returns('Date de l\'envoi');
-      translate.withArgs('campaign.profiles-collection.pix-score').returns('Nombre de pix total');
-      translate.withArgs('campaign.profiles-collection.is-certifiable').returns('Certifiable (O/N)');
-      translate.withArgs('campaign.profiles-collection.certifiable-skills').returns('Nombre de compétences certifiables');
-
-      translate.withArgs('campaign.common.no').returns('Non');
-      translate.withArgs('campaign.common.yes').returns('Oui');
-      translate.withArgs('campaign.common.not-available').returns('NA');
     });
 
     context('When the organization is PRO', () => {

--- a/api/tests/tooling/i18n/i18n.js
+++ b/api/tests/tooling/i18n/i18n.js
@@ -1,0 +1,15 @@
+const path = require('path');
+const i18n = require('i18n');
+
+function getI18n() {
+  const directory = path.resolve(path.join(__dirname, '../../../translations'));
+  i18n.configure({
+    locales: ['fr'],
+    defaultLocale: 'fr',
+    directory,
+    objectNotation: true,
+  });
+  return i18n;
+}
+
+module.exports = { getI18n };

--- a/api/tests/tooling/i18n/i18n_test.js
+++ b/api/tests/tooling/i18n/i18n_test.js
@@ -1,0 +1,9 @@
+const { expect } = require('../../test-helper');
+const { getI18n } = require('./i18n');
+
+describe('Unit | Tooling | i18n', () => {
+  it('should translate by default to fr', () => {
+    const i18n = getI18n();
+    expect(i18n.__('current-lang'), 'fr');
+  });
+});

--- a/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
+++ b/api/tests/unit/domain/usecases/start-writing-campaign-assessment-results-to-stream_test.js
@@ -3,6 +3,7 @@ const { expect, sinon, domainBuilder, streamToPromise, catchErr } = require('../
 const startWritingCampaignAssessmentResultsToStream = require('../../../../lib/domain/usecases/start-writing-campaign-assessment-results-to-stream');
 const { UserNotAuthorizedToGetCampaignResultsError } = require('../../../../lib/domain/errors');
 const campaignCsvExportService = require('../../../../lib/domain/services/campaign-csv-export-service');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results-to-stream', () => {
   const campaignRepository = { get: () => undefined };
@@ -14,6 +15,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
   const badgeAcquisitionRepository = { getCampaignAcquiredBadgesByUsers: () => undefined };
   let writableStream;
   let csvPromise;
+
+  const i18n = getI18n();
 
   beforeEach(() => {
     writableStream = new PassThrough();
@@ -36,6 +39,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: notAuthorizedUser.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -71,9 +75,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -105,6 +110,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -128,9 +134,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -156,6 +163,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -178,9 +186,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -208,6 +217,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       writableStream,
       campaignRepository,
       userRepository,
+      i18n,
       targetProfileWithLearningContentRepository,
       organizationRepository,
       campaignParticipationInfoRepository,
@@ -230,9 +240,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -243,8 +254,8 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Date de début";' +
       '"Partage (O/N)";' +
       '"Date du partage";' +
-      '"badge1 obtenu (O/N)";' +
-      '"badge2 obtenu (O/N)";' +
+      `"${badge1.title} obtenu (O/N)";` +
+      `"${badge2.title} obtenu (O/N)";` +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
@@ -259,6 +270,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -281,9 +293,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -307,6 +320,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -334,9 +348,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -361,6 +376,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -383,9 +399,10 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(user.id).resolves(user);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').rejects();
+
     const csvExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -410,6 +427,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: user.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,
@@ -440,7 +458,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(campaignRepository, 'get').withArgs(campaign.id).resolves(campaign);
     sinon.stub(userRepository, 'getWithMemberships').withArgs(admin.id).resolves(admin);
     sinon.stub(organizationRepository, 'get').withArgs(campaign.organization.id).resolves(organization);
-    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id }).resolves(targetProfile);
+    sinon.stub(targetProfileWithLearningContentRepository, 'get').withArgs({ id: targetProfile.id, locale: 'fr' }).resolves(targetProfile);
     sinon.stub(campaignParticipationInfoRepository, 'findByCampaignId').withArgs(campaign.id).resolves([participantInfo]);
     sinon.stub(knowledgeElementRepository, 'findTargetedGroupedByCompetencesForUsers').resolves({
       [participantInfo.userId]: {
@@ -450,6 +468,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
     sinon.stub(badgeAcquisitionRepository, 'getCampaignAcquiredBadgesByUsers').resolves({
       [participantInfo.userId]: [badge],
     });
+
     const csvHeaderExpected = '\uFEFF"Nom de l\'organisation";' +
       '"ID Campagne";' +
       '"Nom de la campagne";' +
@@ -460,7 +479,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       '"Date de début";' +
       '"Partage (O/N)";' +
       '"Date du partage";' +
-      '"badge sup obtenu (O/N)";' +
+      `"${badge.title} obtenu (O/N)";` +
       '"% maitrise de l\'ensemble des acquis du profil";' +
       `"% de maitrise des acquis de la compétence ${targetProfile.competences[0].name}";` +
       `"Nombre d'acquis du profil cible dans la compétence ${targetProfile.competences[0].name}";` +
@@ -469,6 +488,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       `"Nombre d'acquis du profil cible du domaine ${targetProfile.areas[0].title}";` +
       `"Acquis maitrisés du domaine ${targetProfile.areas[0].title}";` +
       `"${targetProfile.skills[0].name}"`;
+
     const csvParticipantResultExpected = `"${organization.name}";` +
       `${campaign.id};` +
       `"${campaign.name}";` +
@@ -494,6 +514,7 @@ describe('Unit | Domain | Use Cases | start-writing-campaign-assessment-results
       userId: admin.id,
       campaignId: campaign.id,
       writableStream,
+      i18n,
       campaignRepository,
       userRepository,
       targetProfileWithLearningContentRepository,

--- a/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
+++ b/api/tests/unit/infrastructure/exports/campaigns/campaign-profile-collection-result-line_test.js
@@ -2,12 +2,13 @@ const { domainBuilder, expect, sinon } = require('../../../../test-helper');
 
 const CampaignProfileCollectionResultLine = require('../../../../../lib/infrastructure/exports/campaigns/campaign-profile-collection-result-line');
 const PlacementProfile = require('../../../../../lib/domain/models/PlacementProfile');
+const { getI18n } = require('../../../../tooling/i18n/i18n');
 
 describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', () => {
   describe('#toCsvLine', () => {
     let organization, campaign, competences;
 
-    const translate = sinon.stub();
+    const translate = getI18n().__;
 
     const placementProfile = new PlacementProfile({
       userId: 123,
@@ -25,10 +26,6 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-result-line', ()
     beforeEach(() => {
       const listSkills1 = domainBuilder.buildSkillCollection({ name: '@web', minLevel: 1, maxLevel: 5 });
       const listSkills2 = domainBuilder.buildSkillCollection({ name: '@url', minLevel: 1, maxLevel: 2 });
-
-      translate.withArgs('campaign.common.no').returns('Non');
-      translate.withArgs('campaign.common.yes').returns('Oui');
-      translate.withArgs('campaign.common.not-available').returns('NA');
 
       organization = {};
       campaign = {};

--- a/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/campaign-profile-collection-export_test.js
@@ -2,6 +2,7 @@ const { PassThrough } = require('stream');
 const { domainBuilder, expect, sinon, streamToPromise } = require('../../../../test-helper');
 
 const CampaignProfileCollectionExport = require('../../../../../lib/infrastructure/serializers/csv/campaign-profile-collection-export');
+const { getI18n } = require('../../../../tooling/i18n/i18n');
 
 describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
   describe('#export', () => {
@@ -11,7 +12,7 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
       getPlacementProfilesWithSnapshotting: sinon.stub(),
     };
 
-    const translate = sinon.stub();
+    const translate = getI18n().__;
 
     beforeEach(() => {
       writableStream = new PassThrough();
@@ -37,26 +38,6 @@ describe('Unit | Serializer | CSV | campaign-profile-collection-export', () => {
           skillIds: listSkills2.map((skill) => skill.id),
         },
       ];
-
-      translate.withArgs('campaign.profiles-collection.campaign-id').returns('ID Campagne');
-      translate.withArgs('campaign.profiles-collection.organization-name').returns('Nom de l\'organisation');
-      translate.withArgs('campaign.profiles-collection.campaign-name').returns('Nom de la campagne');
-      translate.withArgs('campaign.profiles-collection.participant-lastname').returns('Nom du Participant');
-      translate.withArgs('campaign.profiles-collection.participant-firstname').returns('Prénom du Participant');
-      translate.withArgs('campaign.profiles-collection.participant-division').returns('Classe');
-      translate.withArgs('campaign.profiles-collection.participant-student-number').returns('Numéro Étudiant');
-      translate.withArgs('campaign.profiles-collection.is-sent').returns('Envoi (O/N)');
-      translate.withArgs('campaign.profiles-collection.sent-on').returns('Date de l\'envoi');
-      translate.withArgs('campaign.profiles-collection.pix-score').returns('Nombre de pix total');
-      translate.withArgs('campaign.profiles-collection.is-certifiable').returns('Certifiable (O/N)');
-      translate.withArgs('campaign.profiles-collection.certifiable-skills').returns('Nombre de compétences certifiables');
-
-      translate.withArgs('campaign.profiles-collection.skill-level', { name: competences[0].name }).returns(`Niveau pour la compétence ${competences[0].name}`);
-      translate.withArgs('campaign.profiles-collection.skill-ranking', { name: competences[0].name }).returns(`Nombre de pix pour la compétence ${competences[0].name}`);
-
-      translate.withArgs('campaign.profiles-collection.skill-level', { name: competences[1].name }).returns(`Niveau pour la compétence ${competences[1].name}`);
-      translate.withArgs('campaign.profiles-collection.skill-ranking', { name: competences[1].name }).returns(`Nombre de pix pour la compétence ${competences[1].name}`);
-
     });
 
     it('should display common header parts of csv', async () => {

--- a/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
+++ b/api/tests/unit/infrastructure/utils/CampaignAssessmentCsvLine_test.js
@@ -2,6 +2,7 @@ const { expect, domainBuilder } = require('../../../test-helper');
 const CampaignAssessmentCsvLine = require('../../../../lib/infrastructure/utils/CampaignAssessmentCsvLine');
 const campaignParticipationService = require('../../../../lib/domain/services/campaign-participation-service');
 const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
   const studentNumberPresenceModifier = (organization.type === 'SUP' && organization.isManagingStudents) ? 1 : 0;
@@ -32,6 +33,7 @@ function _computeExpectedColumnsIndex(campaign, organization, badges, stages) {
 }
 
 describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
+  const translate = getI18n().__;
 
   describe('#toCsvLine', () => {
 
@@ -50,6 +52,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           [targetProfileWithLearningContent.competences[0].id]: [],
         },
         campaignParticipationService,
+        translate,
       });
 
       // when
@@ -84,6 +87,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             [targetProfileWithLearningContent.competences[0].id]: [],
           },
           campaignParticipationService,
+          translate,
         });
 
         // when
@@ -113,6 +117,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             [targetProfileWithLearningContent.competences[0].id]: [],
           },
           campaignParticipationService,
+          translate,
         });
 
         // when
@@ -141,6 +146,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             [targetProfileWithLearningContent.competences[0].id]: [],
           },
           campaignParticipationService,
+          translate,
         });
 
         // when
@@ -170,6 +176,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             [targetProfileWithLearningContent.competences[0].id]: [],
           },
           campaignParticipationService,
+          translate,
         });
 
         // when
@@ -207,6 +214,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             [targetProfileWithLearningContent.competences[0].id]: [knowledgeElement],
           },
           campaignParticipationService,
+          translate,
         });
 
         // when
@@ -283,6 +291,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -306,11 +315,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           // First area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(0.33);
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(3);
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(1);
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal(1);
           // Second area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(1);
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(2);
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(2);
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal(2);
           // Target profile skills
           expect(csvLine[currentColumn++], 'statut acquis').to.equal('OK');
           expect(csvLine[currentColumn++], 'statut acquis').to.equal('Non testé');
@@ -384,6 +393,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -407,11 +417,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           // First area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal('NA');
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal('NA');
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal('NA');
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal('NA');
           // Second area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal('NA');
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal('NA');
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal('NA');
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal('NA');
           // Target profile skills
           expect(csvLine[currentColumn++], 'statut acquis').to.equal('NA');
           expect(csvLine[currentColumn++], 'statut acquis').to.equal('NA');
@@ -487,6 +497,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -510,11 +521,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           // First area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(0.33);
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(3);
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(1);
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal(1);
           // Second area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal(1);
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal(2);
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal(2);
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal(2);
 
           expect(csvLine).to.have.lengthOf(currentColumn);
         });
@@ -582,6 +593,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             stages: [],
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -605,11 +617,11 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
           // First area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal('NA');
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal('NA');
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal('NA');
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal('NA');
           // Second area
           expect(csvLine[currentColumn++], '% maitrise du domaine').to.equal('NA');
           expect(csvLine[currentColumn++], 'nb acquis domaine').to.equal('NA');
-          expect(csvLine[currentColumn++], 'nb acquis validés dans le domaine').to.equal('NA');
+          expect(csvLine[currentColumn++], 'nb acquis validés du domaine').to.equal('NA');
 
           expect(csvLine).to.have.lengthOf(currentColumn);
         });
@@ -631,6 +643,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
               [targetProfileWithLearningContent.competences[0].id]: [],
             },
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -663,6 +676,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             },
             acquiredBadges: [badge],
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -700,6 +714,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             },
             acquiredBadges: [badge.title],
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -734,6 +749,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             },
             acquiredBadges: [],
             campaignParticipationService,
+            translate,
           });
 
           // when
@@ -799,6 +815,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
               targetProfileWithLearningContent,
               participantKnowledgeElementsByCompetenceId,
               campaignParticipationService,
+              translate,
             });
 
             // when
@@ -861,6 +878,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
               targetProfileWithLearningContent,
               participantKnowledgeElementsByCompetenceId,
               campaignParticipationService,
+              translate,
             });
 
             // when
@@ -923,6 +941,7 @@ describe('Unit | Infrastructure | Utils | CampaignAssessmentCsvLine', () => {
             targetProfileWithLearningContent,
             participantKnowledgeElementsByCompetenceId,
             campaignParticipationService,
+            translate,
           });
 
           // when

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,23 +1,48 @@
 {
   "current-lang" : "en",
-  "campaign" : {
-    "common" :{
-      "yes": "Yes",
-      "no": "No",
-      "not-available": "NA"
+  "campaign-export" : {
+    "assessment": {
+      "competence-area": {
+        "items-successfully-completed": "Items of the target profile successfully completed in the competence area {{name}}",
+        "mastery-percentage": "% of items successfully completed in the competence area {{name}}",
+        "total-items": "Number of items of the target profile in the competence area {{name}}"
+      },
+      "is-shared": "Shared (Y/N)",
+      "mastery-percentage-target-profile":"% of items successfully completed in the target profile",
+      "progress": "% of progression",
+      "shared-on": "Shared on",
+      "started-on": "Started on",
+      "target-profile-name": "Target profile’s name",
+      "status": {
+        "ko": "KO",
+        "not-tested": "Not tested",
+        "ok": "OK"
+      },  
+      "skill": {
+        "items-successfully-completed": "Items of the target profile successfully completed in the skill {{name}}",
+        "mastery-percentage": "% of items successfully completed in the skill {{name}}",
+        "total-items": "Number of items of the target profile in the skill {{name}}"
+      },
+      "success-rate": "Success rate (/{{value}})",
+      "thematic-result-name": "{{name}} (Y/N)"
     },
-    "profiles-collection" : {
+    "common" :{
       "campaign-id": "Campaign ID",
       "campaign-name": "Campaign's name",
-      "certifiable-skills": "Number of skills eligible for certification",
       "file-name": "Results-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable" :"Eligible for certification (Y/N)",
-      "is-sent": "Sent (Y/N)",
+      "no": "No",
+      "not-available": "NA",
+      "organization-name": "Organisation’s name",
       "participant-division": "Class",
       "participant-firstname": "Participant's first name",
       "participant-lastname": "Participant's last name",
       "participant-student-number": "Student number",
-      "organization-name": "Organisation’s name",
+      "yes": "Yes"  
+    },
+    "profiles-collection" : {
+      "certifiable-skills": "Number of skills eligible for certification",
+      "is-certifiable" :"Eligible for certification (Y/N)",
+      "is-sent": "Sent (Y/N)",
       "pix-score": "Total pix score",
       "sent-on": "Sent on",
       "skill-level": "Level reached in the skill {{name}}",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,4 +1,53 @@
 {
+  "campaign-export": {
+    "assessment": {
+      "competence-area": {
+        "items-successfully-completed": "Acquis maitrisés du domaine {{name}}",
+        "mastery-percentage": "% de maitrise des acquis du domaine {{name}}",
+        "total-items": "Nombre d'acquis du profil cible du domaine {{name}}"
+      },
+      "is-shared": "Partage (O/N)",
+      "mastery-percentage-target-profile":"% maitrise de l'ensemble des acquis du profil",
+      "progress": "% de progression",
+      "shared-on": "Date du partage",
+      "started-on": "Date de début",
+      "target-profile-name": "Nom du Profil Cible",
+      "status": {
+        "ko": "KO",
+        "not-tested": "Non testé",
+        "ok": "OK"
+      },  
+      "skill": {
+        "items-successfully-completed": "Acquis maitrisés dans la compétence {{name}}",
+        "mastery-percentage": "% de maitrise des acquis de la compétence {{name}}",
+        "total-items": "Nombre d'acquis du profil cible dans la compétence {{name}}"
+      },
+      "success-rate": "Palier obtenu (/{{value}})",
+      "thematic-result-name": "{{name}} obtenu (O/N)"
+    },
+    "common" : {
+      "campaign-id": "ID Campagne",
+      "campaign-name": "Nom de la campagne",
+      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
+      "no": "Non",
+      "not-available": "NA",
+      "organization-name": "Nom de l'organisation",
+      "participant-division": "Classe",
+      "participant-firstname": "Prénom du Participant",
+      "participant-lastname": "Nom du Participant",
+      "participant-student-number": "Numéro Étudiant",
+      "yes": "Oui"
+    },
+    "profiles-collection" : {
+      "certifiable-skills": "Nombre de compétences certifiables",
+      "is-certifiable" :"Certifiable (O/N)",
+      "is-sent": "Envoi (O/N)",
+      "pix-score": "Nombre de pix total",
+      "sent-on": "Date de l'envoi",
+      "skill-level": "Niveau pour la compétence {{name}}",
+      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+    }
+  },
   "current-lang": "fr",
   "campaign": {
     "common" : {


### PR DESCRIPTION
## :unicorn: Problème
Pix orga s'internationalise petit à petit

## :robot: Solution
Ajouter la detection de langue côté API sur l'export de résultat de campagnes afin d'avoir un export traduit dans la langue souhaité

## :rainbow: Remarques

## :100: Pour tester
Se connecter avec `pro.admin@example.net` , lancer un export . vérifier que tout les champs sont traduits