### PR TITLE
[BUGFIX] Soucis visuel sur les checkbox (PIX-2325).

### DIFF
--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -185,10 +185,6 @@ input[type=radio]:active::before {
 .proposal-paragraph > input[type=checkbox] {
   margin-top: 7px;
   flex-shrink: 0;
-
-  &::before {
-    margin-top: -5px;
-  }
 }
 
 /* cursor: pointer is disabled here */


### PR DESCRIPTION
## :unicorn: Problème
Un soucis visuel sur les QCM : https://app.recette.pix.fr/challenges/rec020dj8z3EgFP0A/preview

## :robot: Solution
Retirer du css qui avait été mis par erreur

## :rainbow: Remarques

## :100: Pour tester
https://app-pr2686.review.pix.fr/challenges/rec020dj8z3EgFP0A/preview