### PR TITLE
[FEATURE] Afficher la titre et la description prescripteur d'un palier dans la liste des participants d'une campagne d'évaluation de Pix Orga (PIX-2315).

### DIFF
--- a/api/db/seeds/data/stages-builder.js
+++ b/api/db/seeds/data/stages-builder.js
@@ -7,11 +7,11 @@ module.exports = function stagesBuilder({ databaseBuilder }) {
 
 function _buildStagesForTargetProfileId(databaseBuilder, targetProfileId) {
   const stages = [
-    { title: 'palier 1', message: 'Tu as le palier 1', threshold: 0, targetProfileId },
-    { title: 'palier 2', message: 'Tu as le palier 2', threshold: 5, targetProfileId },
-    { title: 'palier 3', message: 'Tu as le palier 3', threshold: 40, targetProfileId },
-    { title: 'palier 4', message: 'Tu as le palier 4', threshold: 60, targetProfileId },
-    { title: 'palier 5', message: 'Tu as le palier 5', threshold: 80, targetProfileId },
+    { title: 'Bravo !', message: 'Tu as le palier 1', prescriberDescription: 'palier 1 c’est nul', threshold: 0, targetProfileId },
+    { title: 'Félicitations !', message: 'Tu as le palier 2', prescriberTitle: 'palier 2', prescriberDescription: 'Maîtrise partielle', threshold: 5, targetProfileId },
+    { title: 'Bien joué !', message: 'Tu as le palier 3', prescriberTitle: 'palier 3', prescriberDescription: 'Maîtrise complète', threshold: 40, targetProfileId },
+    { title: 'Trop fort(e) !', message: 'Tu as le palier 4', prescriberTitle: 'palier 4', prescriberDescription: 'Maîtrise experte', threshold: 60, targetProfileId },
+    { title: 'Quel(le) expert(e) !', message: 'Tu as le palier 5', prescriberDescription: 'Maîtrise absolue', threshold: 80, targetProfileId },
   ];
 
   stages.forEach((stage) => databaseBuilder.factory.buildStage(stage));

--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -5,11 +5,15 @@ class Stage {
     title,
     message,
     threshold,
+    prescriberTitle,
+    prescriberDescription,
   } = {}) {
     this.id = id;
     this.title = title;
     this.message = message;
     this.threshold = threshold;
+    this.prescriberTitle = prescriberTitle;
+    this.prescriberDescription = prescriberDescription;
   }
 
   getMinSkillsCountToReachStage(totalSkills) {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-report-serializer.js
@@ -16,7 +16,7 @@ module.exports = {
       stages: {
         ref: 'id',
         included: true,
-        attributes: ['title', 'message', 'threshold'],
+        attributes: ['prescriberTitle', 'prescriberDescription', 'threshold'],
       },
       badges: {
         ref: 'id',

--- a/api/tests/tooling/domain-builder/factory/build-stage.js
+++ b/api/tests/tooling/domain-builder/factory/build-stage.js
@@ -6,6 +6,8 @@ module.exports = function buildStage({
   title = faker.company.catchPhrase(),
   message = faker.company.catchPhrase(),
   threshold = 1,
+  prescriberTitle,
+  prescriberDescription,
 } = {}) {
 
   return new Stage({
@@ -13,5 +15,7 @@ module.exports = function buildStage({
     title,
     message,
     threshold,
+    prescriberTitle,
+    prescriberDescription,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-report-serializer_test.js
@@ -13,8 +13,8 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
         sharedParticipationsCount: 2,
         stages: [{
           id: 1,
-          title: 'stage1',
-          message: 'stageMessage',
+          prescriberTitle: 'stage1',
+          prescriberDescription: 'description',
           threshold: 30,
         }],
         badges: [{
@@ -87,9 +87,9 @@ describe('Unit | Serializer | JSONAPI | campaign-report-serializer', function() 
         included: [
           {
             attributes: {
-              message: report.stages[0].message,
+              'prescriber-description': report.stages[0].prescriberDescription,
               threshold: report.stages[0].threshold,
-              title: report.stages[0].title,
+              'prescriber-title': report.stages[0].prescriberTitle,
             },
             id: report.stages[0].id.toString(),
             type: 'stages',

--- a/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/list.hbs
@@ -40,6 +40,8 @@
                   <StageStars
                     @result={{participation.masteryPercentage}}
                     @stages={{@campaign.stages}}
+                    @withTooltip={{true}}
+                    @tooltipPosition="bottom-left"
                   />
                 {{else}}
                   <span class="participant-list__mastery-percentage">

--- a/orga/app/components/stage-stars.hbs
+++ b/orga/app/components/stage-stars.hbs
@@ -1,7 +1,19 @@
-<PixStars 
-	@count={{this.starsAcquired}}
-	@total={{this.starsTotal}}
-	@alt={{this.altMessage}}
-	@color="blue"
-	class="stage-stars"
-/>
+<div class="stage-stars__container">
+  <PixStars
+    @count={{this.starsAcquired}}
+    @total={{this.starsTotal}}
+    @alt={{this.altMessage}}
+    @color="blue"
+    class="stage-stars"
+  />
+  {{#if this.displayTooltip}}
+    <PixTooltip
+      role="tooltip"
+      @text={{this.tooltipText}}
+      @position={{@tooltipPosition}}
+      @isWide={{true}}
+      @isLight={{true}}>
+      <FaIcon @icon="info-circle" class="stage-stars__info-icon"/>
+    </PixTooltip>
+  {{/if}}
+</div>

--- a/orga/app/components/stage-stars.js
+++ b/orga/app/components/stage-stars.js
@@ -1,5 +1,8 @@
+import _maxBy from 'lodash/maxBy';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/string';
 
 const _isStageReached = (result, stage) => result >= stage.threshold;
 
@@ -7,6 +10,14 @@ const _hasStars = (stage) => stage.threshold > 0;
 
 export default class StageStars extends Component {
   @service intl;
+
+  @tracked withTooltip = this.args.withTooltip || false;
+
+  get reachedStage() {
+    const { result, stages } = this.args;
+    const stagesReached = stages.filter((stage) => _hasStars(stage) && _isStageReached(result, stage));
+    return _maxBy(stagesReached, 'threshold');
+  }
 
   get starsAcquired() {
     const { result, stages } = this.args;
@@ -20,5 +31,15 @@ export default class StageStars extends Component {
 
   get altMessage() {
     return this.intl.t('pages.assessment-individual-results.stages.value', { count: this.starsAcquired, total: this.starsTotal });
+  }
+
+  get displayTooltip() {
+    return Boolean(this.withTooltip && this.reachedStage && (this.reachedStage.prescriberTitle || this.reachedStage.prescriberDescription));
+  }
+
+  get tooltipText() {
+    let text = this.reachedStage.prescriberTitle ? `<strong>${this.reachedStage.prescriberTitle}</strong>` : '';
+    text += this.reachedStage.prescriberDescription ? `<p>${this.reachedStage.prescriberDescription}</p>` : '';
+    return htmlSafe(text);
   }
 }

--- a/orga/app/models/stage.js
+++ b/orga/app/models/stage.js
@@ -1,7 +1,7 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class Stage extends Model {
-  @attr('string') message;
-  @attr('string') title;
+  @attr('string') prescriberTitle;
+  @attr('string') prescriberDescription;
   @attr('number') threshold;
 }

--- a/orga/app/styles/components/stage-stars.scss
+++ b/orga/app/styles/components/stage-stars.scss
@@ -3,4 +3,17 @@
     width: 18px;
     height: 18px;
   }
+
+  &__container {
+    display: inline-flex;
+
+    p {
+      margin: 0;
+    }
+  }
+
+  &__info-icon {
+    color: $grey-40;
+    margin: 0 8px;
+  }
 }

--- a/orga/tests/integration/components/stage-stars-test.js
+++ b/orga/tests/integration/components/stage-stars-test.js
@@ -51,4 +51,76 @@ module('Integration | Component | stage-stars', function(hooks) {
     // then
     assert.equal(srOnly.textContent.trim(), '1 étoiles sur 2');
   });
+
+  test('should not display tooltip by default', async function(assert) {
+    // given
+    this.set('result', 50);
+    this.set('stages', [{ threshold: 20 }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').doesNotExist();
+  });
+
+  test('should not display tooltip when no stage has been reached yet', async function(assert) {
+    // given
+    this.set('result', undefined);
+    this.set('stages', [{ threshold: 20 }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').doesNotExist();
+  });
+
+  test('should render tooltip with reached stage prescriber title', async function(assert) {
+    // given
+    this.set('result', 50);
+    this.set('stages', [{ threshold: 20, prescriberTitle: 'title' }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}} @withTooltip={{true}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').hasText('title');
+  });
+
+  test('should render tooltip with reached stage prescriber description', async function(assert) {
+    // given
+    this.set('result', 50);
+    this.set('stages', [{ threshold: 20, prescriberDescription: 'description' }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}} @withTooltip={{true}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').hasText('description');
+  });
+
+  test('should render tooltip with reached stage prescriber title and description', async function(assert) {
+    // given
+    this.set('result', 50);
+    this.set('stages', [{ threshold: 20, prescriberTitle: 'title', prescriberDescription: 'description' }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}} @withTooltip={{true}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').hasText('titledescription');
+  });
+
+  test('should not display tooltip when reached stage has no prescriber title nor description', async function(assert) {
+    // given
+    this.set('result', 50);
+    this.set('stages', [{ threshold: 20 }, { threshold: 70 }]);
+
+    // when
+    await render(hbs`<StageStars @result={{this.result}} @stages={{this.stages}} @withTooltip={{true}}/>`);
+
+    // then
+    assert.dom('[role="tooltip"]').doesNotExist();
+  });
 });

--- a/orga/tests/unit/controllers/authenticated/certifications-test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications-test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module.only('Unit | Controller | authenticated/certifications', function(hooks) {
+module('Unit | Controller | authenticated/certifications', function(hooks) {
   setupIntlRenderingTest(hooks);
 
   module('#onSelectDivision', function() {


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs ont besoin d'avoir plus de contexte sur les paliers, pour mieux accompagner leurs prescrits.

## :robot: Solution
Créer un titre et une description spéciale prescripteur (déjà fait #2619), et l'afficher dans la liste des participants d'une campagne d'évaluation de Pix Orga.
![image](https://user-images.githubusercontent.com/23451175/110620430-49055e00-8199-11eb-8eda-5ee88970c3c5.png)

## :rainbow: Remarques
Le contenu est prévu grand exprès (paramètre "wide") puisque la description est prévue d'être une description explicite et donc grande.

## :100: Pour tester
Se connecter avec pro.admin@example.net, et choisir la campagne d'évaluation avec des participants et des paliers. Vérifier que dans la liste des participants, on affiche un petit "i", avec le titre et/ou la description lorsqu'il y en a.