### PR TITLE
[FEATURE] Traduire les erreurs à l'import des CSV des élèves/étudiants (PIX-2312)

### DIFF
--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -263,7 +263,7 @@ function _mapToHttpError(error) {
     return new HttpErrors.UnprocessableEntityError(error.message);
   }
   if (error instanceof DomainErrors.CsvImportError) {
-    return new HttpErrors.PreconditionFailedError(error.message);
+    return new HttpErrors.PreconditionFailedError(error.message, error.code, error.meta);
   }
   if (error instanceof DomainErrors.TargetProfileInvalidError) {
     return new HttpErrors.PreconditionFailedError(error.message);

--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -16,9 +16,11 @@ class UnprocessableEntityError extends BaseHttpError {
 }
 
 class PreconditionFailedError extends BaseHttpError {
-  constructor(message, title) {
+  constructor(message, code, meta) {
     super(message);
-    this.title = title || 'Precondition Failed';
+    this.title = 'Precondition Failed';
+    this.code = code;
+    this.meta = meta;
     this.status = 412;
   }
 }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -730,8 +730,10 @@ class WrongDateFormatError extends DomainError {
 }
 
 class CsvImportError extends DomainError {
-  constructor(message = 'Quelque chose s’est mal passé. Veuillez réessayer.') {
-    super(message);
+  constructor(code, meta) {
+    super('An error occurred during CSV import');
+    this.code = code;
+    this.meta = meta;
   }
 }
 

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
@@ -19,6 +19,11 @@ const COLUMNS = [
   new CsvColumn({ name: 'studyScheme', label: 'Régime' }),
 ];
 
+const ERRORS = {
+  STUDENT_NUMBER_UNIQUE: 'STUDENT_NUMBER_UNIQUE',
+  STUDENT_NUMBER_FORMAT: 'STUDENT_NUMBER_FORMAT',
+};
+
 class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
 
   constructor(input, organizationId) {
@@ -27,11 +32,14 @@ class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
   }
 
   _handleError(err, index) {
+    const column = this._columns.find((column) => column.name === err.key);
+    const line = index + 2;
+    const field = column.label;
     if (err.why === 'uniqueness') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “Numéro étudiant” doit être unique au sein du fichier.`);
+      throw new CsvImportError(ERRORS.STUDENT_NUMBER_UNIQUE, { line, field });
     }
     if (err.why === 'student_number_format') {
-      throw new CsvImportError(`Ligne ${index + 2} : Le champ “numéro étudiant” ne doit pas avoir de caractères spéciaux.`);
+      throw new CsvImportError(ERRORS.STUDENT_NUMBER_FORMAT, { line, field });
     }
     super._handleError(...arguments);
   }

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -846,7 +846,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
           const schoolingRegistrations = await knex('schooling-registrations').where({ organizationId });
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
-          expect(response.result.errors[0].detail).to.equal('Ligne 3 : Le champ “Nom de famille*” est obligatoire.');
+          expect(response.result.errors[0].code).to.equal('FIELD_REQUIRED');
+          expect(response.result.errors[0].meta.field).to.equal('Nom de famille*');
         });
 
         it('should not save any schooling registration with wrong birthCountryCode', async () => {
@@ -868,7 +869,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
-          expect(response.result.errors[0].detail).to.equal('Ligne 2 : Le champ “Code pays naissance*” n\'est pas au format INSEE.');
+          expect(response.result.errors[0].code).to.equal('INSEE_CODE_INVALID');
+          expect(response.result.errors[0].meta.field).to.equal('Code pays naissance*');
         });
 
         it('should not save any schooling registration with wrong birthCityCode', async () => {
@@ -890,7 +892,8 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
-          expect(response.result.errors[0].detail).to.equal('Ligne 2 : Le champ “Code commune naissance**” n\'est pas au format INSEE.');
+          expect(response.result.errors[0].code).to.equal('INSEE_CODE_INVALID');
+          expect(response.result.errors[0].meta.field).to.equal('Code commune naissance**');
         });
       });
 
@@ -915,7 +918,7 @@ describe('Acceptance | Application | organization-controller-import-schooling-re
 
           expect(schoolingRegistrations).to.have.lengthOf(0);
           expect(response.statusCode).to.equal(412);
-          expect(response.result.errors[0].detail).to.contains('Le champ “Identifiant unique*” de cette ligne est présent plusieurs fois dans le fichier.');
+          expect(response.result.errors[0].code).to.equal('INA_UNIQUE');
         });
       });
     });

--- a/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
@@ -93,7 +93,8 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
 
       const error = await catchErr(parser.parse, parser)();
 
-      expect(error.message).to.contain('Ligne 3 : Le champ “Numéro étudiant” doit être unique au sein du fichier.');
+      expect(error.code).to.equal('STUDENT_NUMBER_UNIQUE');
+      expect(error.meta).to.deep.equal({ line: 3, field: 'Numéro étudiant' });
     });
 
     it('should throw an error if the student number is has an incorrect  format', async () => {
@@ -105,7 +106,8 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
 
       const error = await catchErr(parser.parse, parser)();
 
-      expect(error.message).to.contain('Ligne 2 : Le champ “numéro étudiant” ne doit pas avoir de caractères spéciaux.');
+      expect(error.code).to.equal('STUDENT_NUMBER_FORMAT');
+      expect(error.meta).to.deep.equal({ line: 2, field: 'Numéro étudiant' });
     });
   });
 });

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -9,6 +9,8 @@ export default class ListController extends Controller {
   @service session;
   @service currentUser;
   @service notifications;
+  @service errorMessages;
+  @service intl;
 
   @tracked isLoading = false;
 
@@ -48,17 +50,17 @@ export default class ListController extends Controller {
 
       this.refresh();
       this.isLoading = false;
-      this.notifications.sendSuccess('La liste a été importée avec succès.');
+      this.notifications.sendSuccess(this.intl.t('pages.students-sup.import.global-success'));
 
     } catch (errorResponse) {
       this.isLoading = false;
 
-      const errorPrefix = 'Aucun étudiant n’a été importé.<br/>';
-      const globalErrorMessage = `<div>${errorPrefix} Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d'aide</a></div>`;
+      const globalErrorMessage = this.intl.t('pages.students-sup.import.global-error', { htmlSafe: true });
       if (errorResponse.body.errors) {
         errorResponse.body.errors.forEach((error) => {
           if (error.status === '412' || error.status === '413') {
-            return this.notifications.sendError(`<div>${errorPrefix} <strong>${error.detail}</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>`);
+            const message = this.errorMessages.getErrorMessage(error.code, error.meta) || error.detail;
+            return this.notifications.sendError(this.intl.t('pages.students-sup.import.error-wrapper', { message, htmlSafe: true }));
           }
           return this.notifications.sendError(globalErrorMessage);
         });

--- a/orga/app/helpers/display-campaign-errors.js
+++ b/orga/app/helpers/display-campaign-errors.js
@@ -1,30 +1,11 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-const CAMPAIGN_CREATION_ERRORS = [
-  {
-    i18nKey: 'api-errors-messages.campaign-creation.name-required',
-    message: 'CAMPAIGN_NAME_IS_REQUIRED',
-  },
-  {
-    i18nKey: 'api-errors-messages.campaign-creation.purpose-required',
-    message: 'CAMPAIGN_PURPOSE_IS_REQUIRED',
-  },
-  {
-    i18nKey: 'api-errors-messages.campaign-creation.target-profile-required',
-    message: 'TARGET_PROFILE_IS_REQUIRED',
-  },
-  {
-    i18nKey: 'api-errors-messages.campaign-creation.external-user-id-required',
-    message: 'EXTERNAL_USER_ID_IS_REQUIRED',
-  },
-];
-
 export default class extends Helper {
-  @service intl;
+  @service errorMessages;
 
   compute([errors]) {
     if (!errors.length) return;
-    return this.intl.t(CAMPAIGN_CREATION_ERRORS.find((error) => error.message === errors[0].message).i18nKey);
+    return this.errorMessages.getErrorMessage(errors[0].message);
   }
 }

--- a/orga/app/services/error-messages.js
+++ b/orga/app/services/error-messages.js
@@ -1,0 +1,51 @@
+import Service, { inject as service } from '@ember/service';
+
+const CAMPAIGN_CREATION_ERRORS = {
+  CAMPAIGN_NAME_IS_REQUIRED: 'api-errors-messages.campaign-creation.name-required',
+  CAMPAIGN_PURPOSE_IS_REQUIRED: 'api-errors-messages.campaign-creation.purpose-required',
+  TARGET_PROFILE_IS_REQUIRED: 'api-errors-messages.campaign-creation.target-profile-required',
+  EXTERNAL_USER_ID_IS_REQUIRED: 'api-errors-messages.campaign-creation.external-user-id-required',
+};
+
+const CSV_IMPORT_ERRORS = {
+  ENCODING_NOT_SUPPORTED: 'api-errors-messages.student-csv-import.encoding-not-supported',
+  BAD_CSV_FORMAT: 'api-errors-messages.student-csv-import.bad-csv-format',
+  HEADER_REQUIRED: 'api-errors-messages.student-csv-import.header-required',
+  HEADER_UNKNOWN: 'api-errors-messages.student-csv-import.header-unknown',
+  FIELD_MIN_LENGTH: 'api-errors-messages.student-csv-import.field-min-length',
+  FIELD_MAX_LENGTH: 'api-errors-messages.student-csv-import.field-max-length',
+  FIELD_LENGTH: 'api-errors-messages.student-csv-import.field-length',
+  FIELD_DATE_FORMAT: 'api-errors-messages.student-csv-import.field-date-format',
+  FIELD_EMAIL_FORMAT: 'api-errors-messages.student-csv-import.field-email-format',
+  FIELD_REQUIRED: 'api-errors-messages.student-csv-import.field-required',
+  FIELD_BAD_VALUES: 'api-errors-messages.student-csv-import.field-bad-values',
+  INA_FORMAT: 'api-errors-messages.student-csv-import.ina-format',
+  INA_UNIQUE: 'api-errors-messages.student-csv-import.ina-unique',
+  INSEE_CODE_INVALID: 'api-errors-messages.student-csv-import.insee-code-invalid',
+  STUDENT_NUMBER_UNIQUE: 'api-errors-messages.student-csv-import.student-number-unique',
+  STUDENT_NUMBER_FORMAT: 'api-errors-messages.student-csv-import.student-number-format',
+};
+
+const ERROR_MESSAGES = {
+  ...CAMPAIGN_CREATION_ERRORS,
+  ...CSV_IMPORT_ERRORS,
+};
+
+export default class ErrorMessagesService extends Service {
+  @service intl;
+
+  _formatMeta(meta) {
+    if (!meta) return;
+    if (meta.valids) {
+      meta.valids = meta.valids.join(this.intl.t('api-errors-messages.or-separator'));
+    }
+    return meta;
+  }
+
+  getErrorMessage(code, meta) {
+    if (!code) return;
+    const i18nKey = ERROR_MESSAGES[code];
+    if (!i18nKey) return;
+    return this.intl.t(i18nKey, this._formatMeta(meta));
+  }
+}

--- a/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
@@ -10,6 +10,7 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
   let controller;
 
   hooks.beforeEach(function() {
+    controller = this.owner.lookup('service:intl').setLocale('fr');
     controller = this.owner.lookup('controller:authenticated/sup-students/list');
     controller.send = sinon.stub();
     controller.currentUser = currentUser;
@@ -47,7 +48,8 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
         await controller.importStudents(file);
 
         // then
-        assert.ok(controller.notifications.sendError.calledWith('<div>Aucun étudiant n’a été importé.<br/> Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d\'aide</a></div>'));
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target="_blank" rel="noopener noreferrer" href="https://support.pix.fr/support/tickets/new">le formulaire du centre d’aide</a></div>');
       });
 
       test('notify a detailed error message if 412 error', async function(assert) {
@@ -61,7 +63,8 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
         await controller.importStudents(file);
 
         // then
-        assert.ok(controller.notifications.sendError.calledWith('<div>Aucun étudiant n’a été importé.<br/> <strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'));
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>');
       });
 
       test('notify a detailed error message if 413 error', async function(assert) {
@@ -75,7 +78,8 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
         await controller.importStudents(file);
 
         // then
-        assert.ok(controller.notifications.sendError.calledWith('<div>Aucun étudiant n’a été importé.<br/> <strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>'));
+        const notificationMessage = controller.notifications.sendError.firstCall.firstArg.string;
+        assert.equal(notificationMessage, '<div>Aucun étudiant n’a été importé.<br/><strong>Error message</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>');
       });
     });
   });

--- a/orga/tests/unit/services/error-messages-test.js
+++ b/orga/tests/unit/services/error-messages-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupIntl from '../../helpers/setup-intl';
+
+module('Unit | Service | Error messages', function(hooks) {
+  setupTest(hooks);
+  setupIntl(hooks);
+
+  test('should return undefined when no error code', function(assert) {
+    // Given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    // When
+    const message = errorMessages.getErrorMessage(undefined);
+    // Then
+    assert.equal(message, undefined);
+  });
+
+  test('should return undefined when no error code not found in mapping', function(assert) {
+    // Given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    // When
+    const message = errorMessages.getErrorMessage('UNKNOWN_ERROR_CODE');
+    // Then
+    assert.equal(message, undefined);
+  });
+
+  test('should return the message when error code is found', function(assert) {
+    // Given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    // When
+    const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
+    // Then
+    assert.equal(message, 'Veuillez donner un nom à votre campagne.');
+  });
+
+  test('should return the message with parameters', function(assert) {
+    // Given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    // When
+    const message = errorMessages.getErrorMessage('FIELD_MIN_LENGTH', { line: 1, field: 'Boo', limit: 2 });
+    // Then
+    assert.equal(message, 'Ligne 1 : Le champ “Boo” doit être d’au moins 2 caractères.');
+  });
+
+  test('should concatenate "valids" parameters', function(assert) {
+    // Given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    // When
+    const message = errorMessages.getErrorMessage('FIELD_BAD_VALUES', { line: 1, field: 'Boo', valids: ['A', 'B'] });
+    // Then
+    assert.equal(message, 'Ligne 1 : Le champ “Boo” doit être “A ou B”.');
+  });
+});

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -9,7 +9,26 @@
     "edit-student-number": {
       "student-number-exists": "The student number entered is already used by {firstName} {lastName}"
     },
-    "global": "An error occurred. Please try again later."
+    "global": "An error occurred. Please try again later.",
+    "or-separator": " or ",
+    "student-csv-import": {
+      "bad-csv-format": "The file must be in csv format with comma or semicolon separator.",
+      "encoding-not-supported": "File encoding not supported.",
+      "field-bad-values": "Row {line} : The field “{field}” must be “{valids}”.",
+      "field-date-format": "Row {line} : The field “{field}” must be in the format dd/mm/yyyy.",
+      "field-email-format": "Row {line} : The field “{field}” must be a valid email address.",
+      "field-length": "Row {line} : The field “{field}” must contain {limit} characters.",
+      "field-max-length": "Row {line} : The field “{field}” must contain less than {limit} characters.",
+      "field-min-length": "Row {line} : The field “{field}” must contain at least {limit} characters.",
+      "field-required": "Row {line} : The field “{field}” is mandatory.",
+      "header-required": "The “{field}” is mandatory.",
+      "header-unknown": "Column headers must be identical to the ones on the template.",
+      "ina-format": "Row {line} : The field “{field}” (INA) must contain 10 numbers followed by 1 letter.",
+      "ina-unique": "Row {line} : The field “{field}” of this row is repeated several times within the file.",
+      "insee-code-invalid": "Row {line} : The field “{field}” is not in the INSEE format.",
+      "student-number-format": "Row {line} : The field “{field}” must not contain any special characters.",
+      "student-number-unique": "Row {line} : The field “{field}” must be unique within the file."
+    }
   },
   "banners": {
     "campaigns": {
@@ -319,6 +338,11 @@
         "identifiant": "Username",
         "mediacentre": "Mediacentre"
       },
+      "import": {
+        "error-wrapper": "<div>{message} Please try again or contact us through <a id=\"support-link\" href=\"https://pix.org/en-gb/help-form\">the help form</a>.</div>",
+        "global-error": "Import has failed. Please edit your file and try to import it again.",
+        "global-success": "The list has been successfully imported."
+      },
       "know-more": "Know more",
       "table": {
         "column": {
@@ -364,6 +388,11 @@
           "success": "{firstName} {lastName}'s student number has been successfully edited."
         },
         "title": "Edit a student number"
+      },
+      "import": {
+        "error-wrapper": "<div>Import has failed.<br/><strong>{message}</strong><br/> Please edit your file and try to import it again.</div>",
+        "global-error": "<div>Import has failed.<br/>Please try again or contact us through <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://pix.org/en-gb/help-form\">the help form</a></div>",
+        "global-success": "The list has been successfully imported."
       },
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -9,7 +9,26 @@
     "edit-student-number": {
       "student-number-exists": "Le numéro étudiant saisi est déjà utilisé par l’étudiant {firstName} {lastName}"
     },
-    "global": "Une erreur est survenue. Veuillez réessayer ultérieurement."
+    "global": "Une erreur est survenue. Veuillez réessayer ultérieurement.",
+    "or-separator": " ou ",
+    "student-csv-import": {
+      "bad-csv-format": "Le fichier doit être au format csv avec séparateur virgule ou point-virgule.",
+      "encoding-not-supported": "Encodage du fichier non supporté.",
+      "field-bad-values": "Ligne {line} : Le champ “{field}” doit être “{valids}”.",
+      "field-date-format": "Ligne {line} : Le champ “{field}” doit être au format jj/mm/aaaa.",
+      "field-email-format": "Ligne {line} : Le champ “{field}” doit être une adresse email valide.",
+      "field-length": "Ligne {line} : Le champ “{field}” doit faire {limit} caractères.",
+      "field-max-length": "Ligne {line} : Le champ “{field}” doit être inférieur à {limit} caractères.",
+      "field-min-length": "Ligne {line} : Le champ “{field}” doit être d’au moins {limit} caractères.",
+      "field-required": "Ligne {line} : Le champ “{field}” est obligatoire.",
+      "header-required": "La colonne “{field}” est obligatoire.",
+      "header-unknown": "Les entêtes de colonnes doivent être identiques à celles du modèle.",
+      "ina-format": "Ligne {line} : Le champ “{field}” (INA) doit être de 10 chiffres suivis d’une lettre.",
+      "ina-unique": "Ligne {line} : Le champ “{field}” de cette ligne est présent plusieurs fois dans le fichier.",
+      "insee-code-invalid": "Ligne {line} : Le champ “{field}” n'est pas au format INSEE.",
+      "student-number-format": "Ligne {line} : Le champ “{field}” ne doit pas avoir de caractères spéciaux.",
+      "student-number-unique": "Ligne {line} : Le champ “{field}” doit être unique au sein du fichier."
+    }
   },
   "banners": {
     "campaigns": {
@@ -319,6 +338,11 @@
         "identifiant": "Identifiant",
         "mediacentre": "Mediacentre"
       },
+      "import": {
+        "error-wrapper": "<div>{message} Veuillez réessayer ou nous contacter via <a id=\"support-link\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d'aide</a>.</div>",
+        "global-error": "Quelque chose s'est mal passé. Veuillez réessayer.",
+        "global-success": "La liste a été importée avec succès."
+      },
       "know-more": "En savoir plus",
       "table": {
         "column": {
@@ -364,6 +388,11 @@
           "success": "La modification du numéro étudiant de {firstName} {lastName} a bien été effectué."
         },
         "title": "Édition du numéro étudiant"
+      },
+      "import": {
+        "error-wrapper": "<div>Aucun étudiant n’a été importé.<br/><strong>{message}</strong><br/> Veuillez modifier votre fichier et l’importer à nouveau.</div>",
+        "global-error": "<div>Aucun étudiant n’a été importé.<br/>Veuillez réessayer ou nous contacter via <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://support.pix.fr/support/tickets/new\">le formulaire du centre d’aide</a></div>",
+        "global-success": "La liste a été importée avec succès."
       },
       "table": {
         "column": {


### PR DESCRIPTION
## :unicorn: Problème

A l'import des CSV des élèves ou étudiants, différentes erreurs peuvent être remontées de l'API (status 412) : erreurs d'encodage, de format, de structure du CSV ou des règles de gestion non respectées.

Actuellement l'API remonte les erreurs en Français, or on souhaite internationaliser l'affichage de ces erreurs côté pix-orga.

## :robot: Solution

Au lieu de remonter le détail de l'erreur en Français, l'API renverra un `code` d'erreur associé à des `meta` données représentant des informations supplémentaires liées à l'erreur. Par exemple:
- `line` : ligne du csv en erreur, 
- `field` : le champ en erreur (ex: `birthdate`, `studentNumber`...),
- et/ou autres données relatives à l'erreur.

La signature du constructeur de l'exception `CSVImportError` est désormais:
```js
CSVImportError(code, meta) // avant: CSVImport(message) 
```

Ces codes et paramètres (meta) seront alors associés à des clés de traduction.
Chaque champ du CSV (`field`) doit également avoir une clé de traduction côté front.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

1. Se connecter avec différentes orga : 
  - SCO AGRI (sco.admin@example.net)
  - SUP (sup.admin@example.net)
2. Aller sur l'onglet élèves / étudiants
3. Importer des fichiers CSV en erreur: [csv-files-agri-and-sup-ok-and-ko.zip](https://github.com/1024pix/pix/files/6122232/csv-files-agri-and-sup-ok-and-ko.zip)
