### PR TITLE
[BUGFIX] Réparer l'export des résultats pour les utilisateurs anonymes (PIX-2346).

### DIFF
--- a/api/lib/domain/read-models/CampaignParticipationInfo.js
+++ b/api/lib/domain/read-models/CampaignParticipationInfo.js
@@ -3,8 +3,8 @@ const Joi = require('joi')
 const { validateEntity } = require('../validators/entity-validator');
 
 const validationSchema = Joi.object({
-  participantFirstName: Joi.string().required(),
-  participantLastName: Joi.string().required(),
+  participantFirstName: Joi.string().required().allow(''),
+  participantLastName: Joi.string().required().allow(''),
   participantExternalId: Joi.string().optional().allow(null),
   studentNumber: Joi.string().optional().allow(null),
   userId: Joi.number().integer().required(),

--- a/api/tests/unit/domain/read-models/CampaignParticipationInfo_test.js
+++ b/api/tests/unit/domain/read-models/CampaignParticipationInfo_test.js
@@ -33,12 +33,24 @@ describe('Unit | Domain | Read-models | CampaignParticipationInfo', () => {
         .to.throw(ObjectValidationError);
     });
 
+    it('should not throw an ObjectValidationError when participantFirstname is empty', () => {
+      // when
+      expect(() => new CampaignParticipationInfo({ ...validArguments, participantFirstName: '' }))
+        .not.to.throw(ObjectValidationError);
+    });
+
     it('should throw an ObjectValidationError when participantLastName is not valid', () => {
       // when
       expect(() => new CampaignParticipationInfo({ ...validArguments, participantLastName: 123456 }))
         .to.throw(ObjectValidationError);
       expect(() => new CampaignParticipationInfo({ ...validArguments, participantLastName: undefined }))
         .to.throw(ObjectValidationError);
+    });
+
+    it('should not throw an ObjectValidationError when participantLastName is empty', () => {
+      // when
+      expect(() => new CampaignParticipationInfo({ ...validArguments, participantLastName: '' }))
+        .not.to.throw(ObjectValidationError);
     });
 
     it('should throw an ObjectValidationError when participantExternalId is not valid', () => {


### PR DESCRIPTION
## :unicorn: Problème
L'export csv des résultats d'un parcours à accès simplifié ne fonctionne plus pour les utilisateurs anonymes. En effet, lors de l'export des résultats, une validation Joi est effectué afin de valider, entre autres, les champs nom et prénom et ne permet pas que ces attributs soient vide. Or, un utilisateur anonyme ne possède pas de nom et prénom.  

## :robot: Solution
Permettre l'export de résultats d'un utilisateur anonyme, ne possédant donc pas de nom et prénom.

## :100: Pour tester
Se connecter à Pix Orga avec le compte pro.admin@example.net. Exporter les résultats de la campagne SIMPLFIE (organisation: Médiation Numérique).
