### PR TITLE
[FEATURE] Trier la liste des classes sur la page "Certifications" (PIX-2324)

### DIFF
--- a/api/lib/domain/usecases/find-divisions-by-organization.js
+++ b/api/lib/domain/usecases/find-divisions-by-organization.js
@@ -1,8 +1,11 @@
 
-module.exports = function findDivisionsByOrganization({
+module.exports = async function findDivisionsByOrganization({
   organizationId,
   divisionRepository,
 }) {
-  return divisionRepository.findByOrganizationId({ organizationId });
+  const divisionsOrderedByPostgres = await divisionRepository.findByOrganizationId({ organizationId });
+  const divisionsOrderedByName = divisionsOrderedByPostgres.sort((divisionA, divisionB) =>
+    divisionA.name.localeCompare(divisionB.name, 'fr'),
+  );
+  return divisionsOrderedByName;
 };
-

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -16,9 +16,11 @@ async function findByCampaignId(campaignId) {
 }
 
 async function findByOrganizationId({ organizationId }) {
+  const BEGINNING_OF_THE_2020_SCHOOL_YEAR = '2020-08-15';
   const divisionRows = await knex('schooling-registrations')
     .distinct('division')
     .where('organizationId', organizationId)
+    .where('updatedAt', '>', BEGINNING_OF_THE_2020_SCHOOL_YEAR)
     .orderBy('division', 'asc');
 
   return divisionRows.map(({ division }) => _toDomain(division));

--- a/api/lib/infrastructure/repositories/division-repository.js
+++ b/api/lib/infrastructure/repositories/division-repository.js
@@ -19,7 +19,7 @@ async function findByOrganizationId({ organizationId }) {
   const divisionRows = await knex('schooling-registrations')
     .distinct('division')
     .where('organizationId', organizationId)
-    .orderBy('division', 'desc');
+    .orderBy('division', 'asc');
 
   return divisionRows.map(({ division }) => _toDomain(division));
 }

--- a/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
+++ b/api/scripts/data-generation/add-many-students-to-sco-certification-center.js
@@ -6,12 +6,28 @@ const { SchoolingRegistrationsCouldNotBeSavedError } = require('../../lib/domain
 const { knex } = require('../../lib/infrastructure/bookshelf');
 const DomainTransaction = require('../../lib/infrastructure/DomainTransaction');
 
+function _generateRandomDivisionWithSpecialSymbols() {
+  let divisionName = '';
+  const charactersPossibleInDivisions = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghijklmnopqrstuvwxyz-0123456789';
+  const divisionLength = faker.random.number(4) + 2;
+
+  for (let i = 0; i < divisionLength; i++) {
+    const randomNumber = Math.floor(Math.random() * (charactersPossibleInDivisions.length - 1));
+    divisionName = divisionName + charactersPossibleInDivisions[randomNumber];
+  }
+
+  const underscorePrefix = faker.random.number(3) === 1 ? '_' : '';
+  divisionName = underscorePrefix + divisionName;
+  return divisionName;
+}
+
 function _buildSchoolingRegistration() {
+  const division = _generateRandomDivisionWithSpecialSymbols();
   return new SchoolingRegistration({
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
     birthdate: faker.date.past(),
-    division: faker.lorem.word(),
+    division,
     organizationId: SCO_MIDDLE_SCHOOL_ID,
   });
 }

--- a/api/tests/acceptance/application/certification-center-controller_test.js
+++ b/api/tests/acceptance/application/certification-center-controller_test.js
@@ -251,7 +251,7 @@ describe('Acceptance | API | Certification Center', () => {
 
       // then
       expect(response.statusCode).to.equal(200);
-      expect(_.map(response.result.data, 'id')).to.deep.equal(['2ndB', '2ndA']);
+      expect(_.map(response.result.data, 'id')).to.deep.equal(['2ndA', '2ndB']);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/division-repository_test.js
@@ -113,5 +113,34 @@ describe('Integration | Repository | Division', () => {
         { name: 't1' },
       ]);
     });
+
+    it('should omit old divisions', async () => {
+      // given
+      const organization = databaseBuilder.factory.buildOrganization();
+
+      databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: organization.id,
+        division: '5A',
+        updatedAt: new Date('2021-01-01'),
+      });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: organization.id,
+        division: '5A',
+        updatedAt: new Date('2019-01-01'),
+      });
+      databaseBuilder.factory.buildSchoolingRegistration({
+        organizationId: organization.id,
+        division: 'very-old-division',
+        updatedAt: new Date('2019-01-01'),
+      });
+
+      await databaseBuilder.commit();
+
+      // when
+      const divisions = await divisionRepository.findByOrganizationId({ organizationId: organization.id });
+
+      // then
+      expect(divisions).to.deep.equal([{ name: '5A' }]);
+    });
   });
 });

--- a/api/tests/integration/infrastructure/repositories/division-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/division-repository_test.js
@@ -69,17 +69,17 @@ describe('Integration | Repository | Division', () => {
   });
 
   describe('#findByOrganizationId', () => {
-    it('should return an organization list of divisions', async () => {
+    it('should return list of divisions from an organization ordered by name', async () => {
       // given
       const organization = databaseBuilder.factory.buildOrganization();
 
       databaseBuilder.factory.buildSchoolingRegistration({
         organizationId: organization.id,
-        division: '3b',
+        division: '5A',
       });
       databaseBuilder.factory.buildSchoolingRegistration({
         organizationId: organization.id,
-        division: '3A',
+        division: '_3A',
       });
       databaseBuilder.factory.buildSchoolingRegistration({
         organizationId: organization.id,
@@ -104,20 +104,13 @@ describe('Integration | Repository | Division', () => {
       const divisions = await divisionRepository.findByOrganizationId({ organizationId: organization.id });
 
       // then
-      expect(divisions).to.have.lengthOf(4);
+      expect(divisions).to.have.lengthOf(5);
       expect(divisions).to.deep.equal([
-        {
-          name: 't1',
-        },
-        {
-          name: 'T2',
-        },
-        {
-          name: '3b',
-        },
-        {
-          name: '3A',
-        },
+        { name: '3A' },
+        { name: '5A' },
+        { name: 'T2' },
+        { name: '_3A' },
+        { name: 't1' },
       ]);
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Lors d'un retours d'une démonstration de la nouvelle fonctionnalité des résultats de certif dans Pix Orga, un utilisateur nous a remonté qu'il pouvait être difficile de trouver une classe car la liste des classes n'était pas triée.

De plus, les anciennes classes (des années précédentes) apparaîssent dans la liste, ce qui rends la recherche encore plus complexe.

![image](https://user-images.githubusercontent.com/38167520/110654629-9942e700-81be-11eb-867c-4b0bbdb399dc.png)

![image](https://user-images.githubusercontent.com/38167520/110654659-a233b880-81be-11eb-8756-cb24ba91df41.png)


## :robot: Solution
En réalité, la liste des classes était en fait déjà trié, mais par ordre décroissant (on préférera croissant), et par un tri "spécial postegres". 
Pour plus d'info sur le "désordre" du tris postgres: https://dba.stackexchange.com/questions/115364/why-does-postgres-order-by-seem-to-halfway-ignore-leading-underscores

Afin de trier d'une manière "plus logique" la liste des classes , nous pouvons utiliser la fonction `localeCompare` de js, qui permet de comparer des chaines de caractères avec certaines options.

Pour les anciennes classes, il suffit d'enlever les classes qui contiennent QUE des élèves importés avant le 15/08/2020 (début de l'année scolaire).


## :rainbow: Remarques
Tri de postgres : 
`- < [0-9] < [A-Z] < _[0-9] < _[A-Z] < _[a-z] < [a-z]`
```
[
    Division { name: '3A' },
    Division { name: '5D' },
    Division { name: '6E' },
    Division { name: 'LqdsJk' },
    Division { name: 'Nx-j' },
    Division { name: 'S3OGRy' },
    Division { name: 'WiK' },
    Division { name: '_Y0' },
    Division { name: '_bDR' },
    Division { name: '_tHCe' },
    Division { name: 'bea6d' },
    Division { name: 'j-a' },
    Division { name: 'rMxjd' }
  ]
 ```

Tris JS avec `localeCompare`: 
` _ < [0-9] < [a-Z]`
```
[
    Division { name: '_bDR' },
    Division { name: '_tHCe' },
    Division { name: '_Y0' },
    Division { name: '3A' },
    Division { name: '5D' },
    Division { name: '6E' },
    Division { name: 'bea6d' },
    Division { name: 'j-a' },
    Division { name: 'LqdsJk' },
    Division { name: 'Nx-j' },
    Division { name: 'rMxjd' },
    Division { name: 'S3OGRy' },
    Division { name: 'WiK' }
  ]
  ```
 
 Tris JS avec `localeCompare` avec la locale à `fr` et l'option `{ ignorePunctuation: true }` : 
`[0-9] < [a-Z]`
 ```
 [
    Division { name: '3A' },
    Division { name: '5D' },
    Division { name: '6E' },
    Division { name: '_bDR' },
    Division { name: 'bea6d' },
    Division { name: 'j-a' },
    Division { name: 'LqdsJk' },
    Division { name: 'Nx-j' },
    Division { name: 'rMxjd' },
    Division { name: 'S3OGRy' },
    Division { name: '_tHCe' },
    Division { name: 'WiK' },
    Division { name: '_Y0' }
  ]
  ```


## :100: Pour tester
Rajouter un peu de seeds avec le script qui génère des élèves : 
- cd api/
- node scripts/data-generation/add-many-students-to-sco-certification-center.js 100
Lancer l'api avec le feature toggle des résutlats de certif : 
- `FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true npm start` 
Lancer Orga et se connecter : 
- npm start   +  `sco.admin@example.net` 
- cliquer sur l'onglet "Certifications"
- double cliquer dans le champ ou commencer à taper quelque chose
- constater que les classes sont triées dans un ordre "humain logique"
