### PR TITLE
[BUGFIX] Ne pas afficher les campagnes pour Novice dans les TDB et pages parcours (PIX-2320).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -242,4 +242,19 @@ function _buildCampaignForPro(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
     idPixLabel: 'identifiant entreprise',
   });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 17,
+    name: 'Pro - Med Num - Parcours novice simplifié',
+    code: 'NOVICE123',
+    type: 'ASSESSMENT',
+    title: 'Pour novice, accès simplifié',
+    customLandingPageText: '',
+    organizationId: PRO_COMPANY_ID,
+    creatorId: 2,
+    targetProfileId: TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
+    idPixLabel: null,
+    isForAbsoluteNovice: true,
+  });
+
 }

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -48,7 +48,8 @@ function _findByUserId({ userId }) {
         .innerJoin('organizations', 'organizations.id', 'campaigns.organizationId')
         .innerJoin('assessments', 'assessments.campaignParticipationId', 'campaign-participations.id')
         .modify(_filterMostRecentAssessments)
-        .where('campaign-participations.userId', userId);
+        .where('campaign-participations.userId', userId)
+        .whereNot('campaigns.isForAbsoluteNovice', true);
     })
     .from('campaign-participation-overviews')
     .orderByRaw(_computeCampaignParticipationOrder())

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-overview-repository_test.js
@@ -253,5 +253,21 @@ describe('Integration | Repository | Campaign Participation Overview', () => {
         });
       });
     });
+
+    context('when some campaigns are for novice so they cannot be shared', () => {
+      it('should not retrieve information about campaign participation, campaign and organization of this campaign', async () => {
+        const { id: organizationId } = databaseBuilder.factory.buildOrganization({ name: 'Organization ABCD' });
+        const { id: campaignId } = databaseBuilder.factory.buildCampaign({ title: 'Campaign ABCD', code: 'ABCD', archivedAt: new Date('2020-01-03'), organizationId, targetProfileId: targetProfile.id, isForAbsoluteNovice: true });
+        const { id: participationId } = databaseBuilder.factory.buildCampaignParticipation({ userId, campaignId, createdAt: new Date('2020-01-01'), sharedAt: new Date('2020-01-02'), validatedSkillsCount: 1 });
+        databaseBuilder.factory.buildAssessment({ campaignParticipationId: participationId, state: Assessment.states.COMPLETED });
+        await databaseBuilder.commit();
+
+        const { campaignParticipationOverviews } = await campaignParticipationOverviewRepository.findByUserIdWithFilters({ userId });
+
+        expect(campaignParticipationOverviews).to.deep.equal([]);
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
La campagne ABCDiag est une campagne `isForAbsoluteNovice`. Cette campagne est aussi une campagne à accès simplifié, "sans compte". Mais cela n'empêche pas des personnes avec leur compte de passer cette campagne. 
La campagne ne pouvant être partagé, si l'utilisateur connecté la passe avec son compte, il la verra comme "A partager" sur son tableau de bord et sur la page Mes parcours. Malheureusement, vu qu'il ne peut pas la partager, elle restera là.

## :robot: Solution
Filtrer les `campaign-participation-overviews` pour ne pas remonter les participations aux campagnes pour novice

## :rainbow: Remarques
Ce cas est normalement à la marge de l'utilisation "normale" de ces campagnes

## :100: Pour tester
Sur la RA : 
- AZERTY123 devient `isForAbsoluteNovice`
- userpix1 a commencé la campagne AZERTY456, visible, et a terminé la campagne `isForAbsoluteNovice` AZERTY123 (visible en remettant le code, mais pas sur les pages)