### PR TITLE
[FEATURE] Afficher la titre et la description prescripteur d'un palier dans le détail d'un participant d'une campagne d'évaluation de Pix Orga (PIX-2316).

### DIFF
--- a/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
+++ b/orga/app/components/routes/authenticated/campaign/assessment/details.hbs
@@ -61,7 +61,12 @@
           </li>
           {{#if @campaign.hasStages}}
             <li aria-label={{t 'pages.assessment-individual-results.stages.label'}} class="panel-header-data__content panel-header-data-content__stages">
-              <StageStars @result={{@campaignAssessmentParticipation.masteryPercentage}} @stages={{@campaign.stages}}/>
+              <StageStars
+                @result={{@campaignAssessmentParticipation.masteryPercentage}}
+                @stages={{@campaign.stages}}
+                @withTooltip={{true}}
+                @tooltipPosition="bottom-left"
+              />
             </li>
           {{else}}
             <li class="panel-header-data__content value-text value-text--highlight panel-header-data-content__mastery-percentage">


### PR DESCRIPTION
## :unicorn: Problème
Les prescripteurs ont besoin d'avoir plus de contexte sur les paliers, pour mieux accompagner leurs prescrits.

## :robot: Solution
Créer un titre et une description spéciale prescripteur (déjà fait #2619), et l'afficher dans le détail d'un participant d'une campagne d'évaluation de Pix Orga.

## :rainbow: Remarques
Le contenu est prévu grand exprès (paramètre "wide") puisque la description est prévue d'être une description explicite et donc grande.

## :100: Pour tester
Se connecter avec pro.admin@example.net, et choisir la campagne d'évaluation avec des participants et des paliers. Vérifier que dans le détail d'un participant, on affiche un petit "i", avec le titre et/ou la description lorsqu'il y en a.