### PR TITLE
[TECH] Tri les paliers par ordre de seuil

### DIFF
--- a/api/lib/infrastructure/repositories/stage-repository.js
+++ b/api/lib/infrastructure/repositories/stage-repository.js
@@ -15,6 +15,7 @@ module.exports = {
   findByTargetProfileId(targetProfileId) {
     return BookshelfStage
       .where({ targetProfileId })
+      .orderBy('threshold')
       .fetchAll({ require: false })
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfStage, results));
   },

--- a/api/tests/integration/infrastructure/repositories/stage-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/stage-repository_test.js
@@ -28,7 +28,7 @@ describe('Integration | Repository | StageRepository', () => {
   });
 
   describe('#findByTargetProfileId', () => {
-    it('should retrieve stage given campaignId', async () => {
+    it('should retrieve stage given targetProfileId', async () => {
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile();
       const anotherTargetProfile = databaseBuilder.factory.buildTargetProfile();
@@ -43,6 +43,23 @@ describe('Integration | Repository | StageRepository', () => {
 
       // then
       expect(stages.length).to.equal(1);
+    });
+
+    it('should retrieve stages sorted by threshold', async () => {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 24 });
+      databaseBuilder.factory.buildStage({ targetProfileId: targetProfile.id, threshold: 0 });
+
+      await databaseBuilder.commit();
+
+      // when
+      const stages = await stageRepository.findByTargetProfileId(targetProfile.id);
+
+      // then
+      expect(stages.length).to.equal(2);
+      expect(stages[0].threshold).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Les paliers dans l'interface d'administration n'étaient pas trié par seuil, ce qui rend la lecture difficile

## :robot: Solution
Trier les paliers par seuil.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
1. Se connecter en tant que pixmaster sur l'admin
2. Se rendre sur un profil cible, onglet "Clé de lecture"
3. La liste des paliers doit êre trié par seuil

![Screenshot_2021-03-11 Pix Admin](https://user-images.githubusercontent.com/86659/110798438-75dd7200-827a-11eb-920f-7d4b5ce87b69.png)

