### PR TITLE
[BUGFIX] Considérer les campagnes pour novice terminé comme celle partagé en front (PIX-2320).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -222,4 +222,19 @@ function _buildCampaignForPro(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
     idPixLabel: 'identifiant entreprise',
   });
+
+  databaseBuilder.factory.buildCampaign({
+    id: 17,
+    name: 'Med Num : Campagne pour Novice',
+    code: 'NOVICE123',
+    type: 'ASSESSMENT',
+    title: 'Pour novice, accès simplifié',
+    customLandingPageText: '',
+    organizationId: PRO_COMPANY_ID,
+    creatorId: 2,
+    targetProfileId: TARGET_PROFILE_SIMPLIFIED_ACCESS_ID,
+    idPixLabel: null,
+    isForAbsoluteNovice: true,
+  });
+
 }

--- a/api/lib/domain/read-models/CampaignParticipationOverview.js
+++ b/api/lib/domain/read-models/CampaignParticipationOverview.js
@@ -13,6 +13,7 @@ class CampaignParticipationOverview {
     campaignCode,
     campaignTitle,
     campaignArchivedAt,
+    campaignIsForAbsoluteNovice,
     targetProfile,
   } = {}) {
     this.id = id;
@@ -27,6 +28,7 @@ class CampaignParticipationOverview {
     this.campaignCode = campaignCode;
     this.campaignTitle = campaignTitle;
     this.campaignArchivedAt = campaignArchivedAt;
+    this.campaignIsForAbsoluteNovice = campaignIsForAbsoluteNovice;
     this.targetProfile = targetProfile;
   }
 

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -36,6 +36,7 @@ function _findByUserId({ userId }) {
         validatedSkillsCount: 'campaign-participations.validatedSkillsCount',
         campaignCode: 'campaigns.code',
         campaignTitle: 'campaigns.title',
+        campaignIsForAbsoluteNovice: 'campaigns.isForAbsoluteNovice',
         targetProfileId: 'campaigns.targetProfileId',
         campaignArchivedAt: 'campaigns.archivedAt',
         organizationName: 'organizations.name',

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer.js
@@ -10,7 +10,7 @@ module.exports = {
   serialize(campaignParticipationOverview, meta) {
     return new Serializer('campaign-participation-overview',
       {
-        attributes: ['isShared', 'sharedAt', 'createdAt', 'organizationName', 'assessmentState', 'campaignCode', 'campaignTitle', 'campaignArchivedAt', 'masteryPercentage', 'validatedStagesCount', 'totalStagesCount'],
+        attributes: ['isShared', 'campaignIsForAbsoluteNovice', 'sharedAt', 'createdAt', 'organizationName', 'assessmentState', 'campaignCode', 'campaignTitle', 'campaignArchivedAt', 'masteryPercentage', 'validatedStagesCount', 'totalStagesCount'],
         meta,
       }).serialize(campaignParticipationOverview);
   },

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-participation-overview-serializer_test.js
@@ -28,6 +28,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
       assessmentState: 'started',
       campaignCode: '1234',
       campaignTitle: 'My campaign',
+      campaignIsForAbsoluteNovice: true,
       campaignArchivedAt: new Date('2021-01-01'),
       targetProfile,
     });
@@ -47,6 +48,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
             'assessment-state': 'started',
             'campaign-code': '1234',
             'campaign-title': 'My campaign',
+            'campaign-is-for-absolute-novice': true,
             'campaign-archived-at': new Date('2021-01-01'),
             'mastery-percentage': 50,
             'validated-stages-count': 1,
@@ -81,6 +83,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignCode: '4567',
           campaignTitle: 'My campaign 1',
           campaignArchivedAt: null,
+          campaignIsForAbsoluteNovice: false,
           targetProfile,
         }),
         new CampaignParticipationOverview({
@@ -93,6 +96,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
           campaignCode: '4567',
           campaignTitle: 'My campaign 2',
           campaignArchivedAt: null,
+          campaignIsForAbsoluteNovice: true,
           targetProfile,
         }),
       ];
@@ -121,6 +125,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'shared-at': new Date('2018-02-07T17:15:44Z'),
               'mastery-percentage': null,
               'campaign-archived-at': null,
+              'campaign-is-for-absolute-novice': false,
               'validated-stages-count': null,
               'total-stages-count': 0,
             },
@@ -138,6 +143,7 @@ describe('Unit | Serializer | JSONAPI | campaign-participation-overview-serializ
               'shared-at': new Date('2018-02-10T17:30:44Z'),
               'mastery-percentage': null,
               'campaign-archived-at': null,
+              'campaign-is-for-absolute-novice': true,
               'validated-stages-count': null,
               'total-stages-count': 0,
             },

--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -11,6 +11,7 @@ export default class CampaignParticipationOverviews extends Model {
   @attr('string') campaignCode;
   @attr('string') campaignTitle;
   @attr('date') campaignArchivedAt;
+  @attr('boolean') campaignIsForAbsoluteNovice;
   @attr('number') masteryPercentage;
   @attr('number') totalStagesCount;
   @attr('number') validatedStagesCount;

--- a/mon-pix/app/models/campaign-participation-overview.js
+++ b/mon-pix/app/models/campaign-participation-overview.js
@@ -18,7 +18,7 @@ export default class CampaignParticipationOverviews extends Model {
 
   get status() {
     if (this.campaignArchivedAt) return 'ARCHIVED';
-    else if (this.isShared) return 'ENDED';
+    else if (this.isShared || (this.assessmentState === 'completed' && this.campaignIsForAbsoluteNovice)) return 'ENDED';
     else if (this.assessmentState === 'completed') return 'TO_SHARE';
     else return 'ONGOING';
   }

--- a/mon-pix/tests/unit/models/campaign-participation-overview-test.js
+++ b/mon-pix/tests/unit/models/campaign-participation-overview-test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 
-describe('Unit | Model | Campaign-Participation-Overview', function() {
+describe.only('Unit | Model | Campaign-Participation-Overview', function() {
   setupTest();
 
   let store;
@@ -61,6 +61,31 @@ describe('Unit | Model | Campaign-Participation-Overview', function() {
         });
         // when / then
         expect(model.status).to.equal('ARCHIVED');
+      });
+    });
+
+    context('when the campaign is for absolute novice"', () => {
+      it('should return the status "ONGOING" if not finished', function() {
+        // given
+        const model = store.createRecord('campaign-participation-overview', {
+          assessmentState: 'started',
+          isShared: false,
+          campaignIsForAbsoluteNovice: true,
+          campaignArchivedAt: null,
+        });
+        // when / then
+        expect(model.status).to.equal('ONGOING');
+      });
+      it('should return the status "ENDED" if the assessment is finished', function() {
+        // given
+        const model = store.createRecord('campaign-participation-overview', {
+          assessmentState: 'completed',
+          isShared: false,
+          campaignIsForAbsoluteNovice: true,
+          campaignArchivedAt: null,
+        });
+        // when / then
+        expect(model.status).to.equal('ENDED');
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
La campagne ABCDiag est une campagne `isForAbsoluteNovice`. Cette campagne est aussi une campagne à accès simplifié, "sans compte". Mais cela n'empêche pas des personnes avec leur compte de passer cette campagne. 
La campagne ne pouvant être partagé, si l'utilisateur connecté la passe avec son compte, il la verra comme "A partager" sur son tableau de bord et sur la page Mes parcours. Malheureusement, vu qu'il ne peut pas la partager, elle restera là.

## :robot: Solution
Remonter l'info "isForAbsoluteNovice" et considérer en front que si l'assessment est terminé, alors la campaign participation aussi.

## :rainbow: Remarques
Ce cas est normalement à la marge de l'utilisation "normale" de ces campagnes

## :100: Pour tester
Sur la RA : 
- Etre connecté
- Faire la Campagne NOVICE12