### PR TITLE
[FIX] Le bouton "Annuler" doit rediriger vers la page de présentation de la campagne (PIX-2336)

### DIFF
--- a/mon-pix/app/routes/campaigns/start-or-resume.js
+++ b/mon-pix/app/routes/campaigns/start-or-resume.js
@@ -114,8 +114,10 @@ export default class StartOrResumeRoute extends Route.extend(SecuredRouteMixin) 
     const hasUserCompletedRestrictedCampaignAssociation = this._handleQueryParamBoolean(queryParams.associationDone, this.state.hasUserCompletedRestrictedCampaignAssociation);
     const isCampaignForNoviceUser = get(campaign, 'isForAbsoluteNovice', this.state.isCampaignForNoviceUser);
     const hasUserSeenJoinPage = this._handleQueryParamBoolean(queryParams.hasUserSeenJoinPage, this.state.hasUserSeenJoinPage);
-    const hasUserNotSeenLandingPage = queryParams.hasUserSeenLandingPage == null ? null : !queryParams.hasUserSeenLandingPage;
-    const shouldDisplayLandingPage = isCampaignForNoviceUser ? false : this._handleQueryParamBoolean(hasUserNotSeenLandingPage, this.state.shouldDisplayLandingPage);
+
+    const hasUserNotSeenLandingPage = queryParams.hasUserSeenLandingPage == null ? this.state.shouldDisplayLandingPage : !this._handleQueryParamBoolean(queryParams.hasUserSeenLandingPage, false);
+    const shouldDisplayLandingPage = isCampaignForNoviceUser ? false : hasUserNotSeenLandingPage;
+
     this.state = {
       campaignCode: get(campaign, 'code', this.state.campaignCode),
       isCampaignRestricted: get(campaign, 'isRestricted', this.state.isCampaignRestricted),

--- a/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
+++ b/mon-pix/tests/acceptance/start-campaigns-with-type-assessment-test.js
@@ -9,6 +9,7 @@ import {
 import visit from '../helpers/visit';
 import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
+import { clickByLabel } from '../helpers/click-by-label';
 
 const ASSESSMENT = 'ASSESSMENT';
 
@@ -62,10 +63,19 @@ describe('Acceptance | Campaigns | Start Campaigns with type Assessment', funct
           it('should redirect to assessment after completion of external id', async function() {
             // when
             await fillIn('#id-pix-label', 'monmail@truc.fr');
-            await click('.button');
+
+            await clickByLabel('Continuer');
 
             // then
             expect(currentURL()).to.contains('/didacticiel');
+          });
+
+          it('should redirect to campaign presentation after cancel button', async function() {
+            // when
+            await clickByLabel('Annuler');
+
+            // then
+            expect(currentURL()).to.contains(`/campagnes/${campaign.code}/presentation`);
           });
         });
 


### PR DESCRIPTION
## :unicorn: Problème
Le bouton "Annuler" ne redirige plus vers la page de présentation de la campagne

## :robot: Solution
Mettre à jour un condition qui traitait un string comme un boolean

## :rainbow: Remarques
Je découvre start or resume. c'est un petit labyrinthe pour moi. Je suis preneur d'avis si j'ai des contextes que je n'aurai pas vu :)

## :100: Pour tester
se connecter avec pixaile . saisi d'un code campagne azerty123 . arrivée sur la page de saisie d'identifiant entreprise. cliquer sur "annuler", vérifier que l'on revient bien sur la page de présentation de la campagne.