### PR TITLE
[FEATURE] Ajout d'un lien vers une documentation au sujet des résultats de certification (PIX-2338)

### DIFF
--- a/orga/app/controllers/authenticated/certifications.js
+++ b/orga/app/controllers/authenticated/certifications.js
@@ -37,15 +37,15 @@ export default class AuthenticatedCertificationsController extends Controller {
 
       await this.fileSaver.save({ url, token });
     } catch (error) {
-      let errorMessage = error.message;
-
       if (_isErrorNotFound(error)) {
-        errorMessage = this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision });
+        this.notifications.info(
+          this.intl.t('pages.certifications.errors.no-results', { selectedDivision: this.selectedDivision }),
+          { autoClear: false },
+        );
+      } else {
+        this.notifications.error(error.message, { autoClear: false });
       }
 
-      this.notifications.error(errorMessage, {
-        autoClear: false,
-      });
     }
   }
 

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -1,7 +1,6 @@
 .certifications-page {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
   padding: 16px 0 0 16px;
   width: 100%;
   margin-bottom: 20px;
@@ -28,22 +27,30 @@
     min-width: 100%;
     margin-bottom: 40px;
 
-    button {
-      height: 44px;
-      line-height: 36px;
-      margin-left: 8px;
-    }
-
     label {
       color: $grey-90;
       margin-left: 2px;
       min-width: 100%;
       padding: 4px 0;
     }
+
+    .pix-select {
+      margin-right: 8px;
+      margin-bottom: 6px;
+    }
+
+    button {
+      height: inherit;
+      min-height: 44px;
+      line-height: inherit;
+      padding: 8px 20px;
+      margin-bottom: 6px;
+    }
+
   }
 
   .pix-message {
-    width: max-content;
+    max-width: max-content;
   }
 }
 

--- a/orga/app/styles/pages/authenticated/certifications.scss
+++ b/orga/app/styles/pages/authenticated/certifications.scss
@@ -16,7 +16,8 @@
     font-family: $roboto;
     margin: 2px 0 32px 0;
     font-size: 1rem;
-    line-height: 1.375rem;
+    line-height: 1.45rem;
+    color: $grey-60;
   }
 
   &__action {
@@ -25,20 +26,24 @@
     flex-wrap: wrap;
     align-items: center;
     min-width: 100%;
+    margin-bottom: 40px;
 
     button {
-      height: 36px;
+      height: 44px;
       line-height: 36px;
       margin-left: 8px;
     }
 
     label {
-      font-size: 0.875rem;
       color: $grey-90;
       margin-left: 2px;
       min-width: 100%;
       padding: 4px 0;
     }
+  }
+
+  .pix-message {
+    width: max-content;
   }
 }
 

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -1,12 +1,9 @@
 <div class="certifications-page">
   <h1 class="page__title page-title">{{t 'pages.certifications.title'}}</h1>
   <p class="certifications-page__text">
-    {{t 'pages.certifications.description'}}
+    {{t 'pages.certifications.description' htmlSafe=true}}
   </p>
-  <PixMessage>
-    {{t 'pages.certifications.documentation-link-notice'}}
-    <a href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8">{{t 'pages.certifications.documentation-link-label'}}</a>
-  </PixMessage>
+
   <form class="certifications-page__action" {{on 'submit' this.downloadSessionResultFile}}>
     <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
     <PixSelect id="certifications-page-action__select" 
@@ -23,4 +20,9 @@
       {{t 'pages.certifications.download-button'}}
     </button>
   </form>
+
+  <PixMessage @withIcon={{true}}>
+    {{t 'pages.certifications.documentation-link-notice'}}
+    <a href={{t 'pages.certifications.documentation-link'}}>{{t 'pages.certifications.documentation-link-label'}}</a>
+  </PixMessage>
 </div>

--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -3,6 +3,10 @@
   <p class="certifications-page__text">
     {{t 'pages.certifications.description'}}
   </p>
+  <PixMessage>
+    {{t 'pages.certifications.documentation-link-notice'}}
+    <a href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8">{{t 'pages.certifications.documentation-link-label'}}</a>
+  </PixMessage>
   <form class="certifications-page__action" {{on 'submit' this.downloadSessionResultFile}}>
     <label for="certifications-page-action__select">{{t 'pages.certifications.select-label'}}</label>
     <PixSelect id="certifications-page-action__select" 
@@ -12,7 +16,9 @@
       @isSearchable={{true}}
       @isValidationActive={{true}}
       placeholder={{this.firstTwoDivisions}}
-      required={{true}} />
+      required={{true}}
+      autocomplete="off"
+    />
     <button class="button" type="submit">
       {{t 'pages.certifications.download-button'}}
     </button>

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -48,6 +48,14 @@ module('Acceptance | Certifications page', function(hooks) {
         assert.dom('.information-banner').doesNotExist();
         assert.dom('.pix-banner').doesNotExist();
       });
+
+      test('should show documentation about certification results link', async function(assert) {
+        // given / when
+        await visit('/certifications');
+
+        // then
+        assert.dom('a[href="https://cloud.pix.fr/s/cRaeKT4ErrXs4X8"]').exists();
+      });
     });
   });
 });

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -34,7 +34,7 @@ module('Acceptance | Certifications page', function(hooks) {
         await visit('/certifications');
 
         // then
-        assert.contains('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.');
+        assert.dom('.certifications-page__text').containsText('Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv. Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.');
         assert.contains('Exporter les résultats');
         assert.contains('Certifications');
         assert.contains('Classe');

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -301,6 +301,9 @@
       "download-button": "Export the results",
       "select-label": "Class",
       "title": "Certifications",
+      "documentation-link-notice": "TODO",
+      "documentation-link-label": "TODO",
+      "documentation-link": "TODO",
       "errors": {
         "no-results": "No certification results for the class {selectedDivision}.",
         "invalid-division": "The class {selectedDivision} does not exist."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -301,6 +301,9 @@
       "download-button": "Exporter les résultats",
       "select-label": "Classe",
       "title": "Certifications",
+      "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats :",
+      "documentation-link-label": "Interprétation des résultats prescripteur.",
+      "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
       "errors": {
         "no-results": "Aucun résultat de certification pour la classe {selectedDivision}.",
         "invalid-division": "La classe {selectedDivision} n'existe pas."

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -297,7 +297,7 @@
       "waiting-results": "En attente de résultats"
     },
     "certifications": {
-      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.",
+      "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.<br> Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
       "download-button": "Exporter les résultats",
       "select-label": "Classe",
       "title": "Certifications",


### PR DESCRIPTION
## :unicorn: Problème
Les admin Pix Orga SCO qui gèrent une liste d'élèves peuvent télécharger les résultats de certification de leurs élèves depuis Pix Orga.
Cependant le fichier CSV des résultats n'est pas clair, et il arrive souvent que les utilisateurs n'arrivent pas à comprendre son contenu.

## :robot: Solution
Depuis la page “Certifications” dans Pix Orga, ajouter un lien vers la documentation existante d’aide à l’interprétation des résultats : afficher la phrase suivante sous la phrase “Sélectionnez…” : 

- “Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : Interprétation des résultats prescripteur.”
- Le lien : https://cloud.pix.fr/s/cRaeKT4ErrXs4X8

## :rainbow: Remarques
Est-ce qu'on devrait mettre le lien dans le fichiers de traduction ? Même si cette phrase n'est uniquement que pour le SCO ?

## :100: Pour tester
- Lancer l'api avec le toggle : `FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true npm start`
- Lancer Pix Orga : npm start
- Se connecter avec un compte SCO : `sco.admin@example.net` 
- Aller sur l'onglet "Certifications" 
- Constater l'affichage d'une nouvelle information : "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : Interprétation des résultats prescripteur."
- Cliquer sur le lien redirige vers la doc
