### PR TITLE
[ADMIN] Organiser les compétences par rapport à leur index (Pix-2341)

### DIFF
--- a/admin/app/components/target-profiles/details.js
+++ b/admin/app/components/target-profiles/details.js
@@ -5,15 +5,20 @@ import ENV from 'pix-admin/config/environment';
 export default class TargetProfileDetails extends Component {
   get competenceList() {
     const { areas } = this.args.targetProfile;
-    return areas.toArray().flatMap((area) => this._buildCompetencesOfArea(area));
+
+    return areas.toArray()
+      .flatMap((area) => this._buildCompetencesOfArea(area))
+      .sort((a, b) => a.index - b.index);
   }
 
   _buildCompetencesOfArea(area) {
     const { competences } = this.args.targetProfile;
+
     return competences
       .filter((competence) => competence.areaId === area.id)
       .map((competence) => ({
         name: competence.name,
+        index: competence.index,
         area,
         tubes: this._buildTubeOfCompetence(competence.id),
       }));

--- a/admin/app/models/competence.js
+++ b/admin/app/models/competence.js
@@ -3,4 +3,5 @@ import Model, { attr } from '@ember-data/model';
 export default class Competence extends Model {
   @attr('string') name;
   @attr('string') areaId;
+  @attr('string') index;
 }

--- a/admin/tests/unit/components/target-profiles/details-test.js
+++ b/admin/tests/unit/components/target-profiles/details-test.js
@@ -28,8 +28,8 @@ module('Unit |  Component | Target Profiles | details', function(hooks) {
           { id: 'area2', title: 'Area 2' },
         ],
         competences: [
-          { id: 'competence1', name: 'Competence 1', areaId: 'area1' },
-          { id: 'competence2', name: 'Competence 2', areaId: 'area2' },
+          { id: 'competence2', name: 'Competence 2', areaId: 'area2', index: '1.2' },
+          { id: 'competence1', name: 'Competence 1', areaId: 'area1', index: '1.1' },
         ],
         tubes: [
           { id: 'tube1', practicalTitle: 'Tube 1', competenceId: 'competence1' },
@@ -48,6 +48,7 @@ module('Unit |  Component | Target Profiles | details', function(hooks) {
     assert.deepEqual(component.competenceList, [
       {
         name: 'Competence 1',
+        index: '1.1',
         area: { id: 'area1', title: 'Area 1' },
         tubes: [{
           practicalTitle: 'Tube 1',
@@ -60,6 +61,7 @@ module('Unit |  Component | Target Profiles | details', function(hooks) {
       },
       {
         name: 'Competence 2',
+        index: '1.2',
         area: { id: 'area2', title: 'Area 2' },
         tubes: [{
           practicalTitle: 'Tube 2',

--- a/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer.js
@@ -17,7 +17,7 @@ module.exports = {
       competences: {
         ref: 'id',
         included: true,
-        attributes: ['name', 'areaId'],
+        attributes: ['name', 'areaId', 'index'],
       },
       areas: {
         ref: 'id',

--- a/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/target-profile-with-learning-content-serializer_test.js
@@ -18,7 +18,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
         ownerOrganizationId: 12,
         skills: [buildTargetedSkill({ id: 'rec1', name: '@url4', tubeId: 'rec2' })],
         tubes: [{ id: 'rec2', practicalTitle: 'Url', competenceId: 'rec3' }],
-        competences: [{ id: 'rec3', name: 'Comprendre', areaId: 'rec4' }],
+        competences: [{ id: 'rec3', name: 'Comprendre', areaId: 'rec4', index: '1.1' }],
         areas: [{ id: 'rec4', title: 'Connaître', color: 'blue' }],
         organizations: [{ id: 42 }],
       });
@@ -104,6 +104,7 @@ describe('Unit | Serializer | JSONAPI | target-profile-with-learning-content-ser
             attributes: {
               'name': targetProfileWithLearningContent.competences[0].name,
               'area-id': targetProfileWithLearningContent.competences[0].areaId,
+              'index': targetProfileWithLearningContent.competences[0].index,
             },
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
Les compétences dans pix admin ne sont pas trié par rapport à leur index ( 1.1 1.2 etc...)

## :robot: Solution
Exposer l'index via l'API et l'utiliser dans pixAdmin pour effectuer le tri

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter dans pix Admin et vérifier que l'ordre est bien ascendant pour les index