### PR TITLE
[FEATURE] Traduire en anglais la page "Mon Equipe" et la modale de suppression dans Pix Orga (PIX-2222).

### DIFF
--- a/orga/app/components/dropdown/icon-trigger.hbs
+++ b/orga/app/components/dropdown/icon-trigger.hbs
@@ -1,7 +1,7 @@
 <div id="icon-trigger" class="dropdown" ...attributes>
   <PixIconButton
     @icon={{@icon}}
-    aria-label="Afficher les actions"
+    aria-label="{{t 'dropdown.arial-label'}}"
     class="{{@dropdownButtonClass}}"
     @triggerAction={{this.toggle}}
     @size="small"

--- a/orga/app/components/routes/authenticated/team/items.hbs
+++ b/orga/app/components/routes/authenticated/team/items.hbs
@@ -1,9 +1,9 @@
-<tr aria-label="Membre">
+<tr aria-label="{{t 'pages.team-items.row.aria-label'}}">
   <td>{{@membership.user.lastName}}</td>
   <td>{{@membership.user.firstName}}</td>
 
   {{#unless this.isEditionMode }}
-    <td>{{@membership.displayRole}}</td>
+    <td>{{this.displayRole}}</td>
     {{#if (not-eq @membership.user.id this.currentUser.prescriber.id) }}
       <td class="zone-edit-role">
         <Dropdown::IconTrigger
@@ -11,11 +11,15 @@
                 @dropdownButtonClass="zone-edit-role__dropdown-button"
                 @dropdownContentClass="zone-edit-role__dropdown-content"
         >
-          <Dropdown::Item @onClick={{fn this.editRoleOfMember @membership}} aria-label="Modifier le rôle">
-            Modifier le rôle
+          <Dropdown::Item
+                  @onClick={{fn this.editRoleOfMember @membership}}
+                  aria-label="{{t 'pages.team-items.actions.edit-organization-membership-role.aria-label'}}">
+            {{t 'pages.team-items.actions.edit-organization-membership-role.label'}}
           </Dropdown::Item>
-          <Dropdown::Item @onClick={{fn this.displayRemoveMembershipModal @membership}} aria-label="Supprimer le membre">
-            Supprimer
+          <Dropdown::Item
+                  @onClick={{fn this.displayRemoveMembershipModal @membership}}
+                  aria-label="{{t 'pages.team-items.actions.remove-membership.aria-label'}}">
+            {{t 'pages.team-items.actions.remove-membership.label'}}
           </Dropdown::Item>
         </Dropdown::IconTrigger>
       </td>
@@ -28,43 +32,46 @@
     <td>
       <div id="selectOrganizationRole">
         <SelectInput
-          class="table__input"
-          @onChange={{this.setRoleSelection}}
-          @options={{this.organizationRoles}}
-          @selectedOption={{@membership.organizationRole}}
-          @placeholder="Sélectionner un rôle"
-          @ariaLabel="Sélectionner un rôle"
+                class="table__input"
+                @onChange={{this.setRoleSelection}}
+                @options={{this.organizationRoles}}
+                @selectedOption={{@membership.organizationRole}}
+                @placeholder="{{t 'pages.team-items.select-input.placeholder'}}"
+                @ariaLabel="{{t 'pages.team-items.select-input.aria-label'}}"
         />
       </div>
     </td>
     <td>
       <div class="zone-save-cancel-role">
         <button id='save-organization-role' type="button" class="button button--thin" {{on 'click' (fn this.updateRoleOfMember @membership)}}>
-          Enregistrer
+          {{t 'pages.team-items.save-button'}}
         </button>
         <PixIconButton
-          @icon="times"
-          id='cancel-update-organization-role'
-          aria-label="Annuler"
-          @triggerAction={{this.cancelUpdateRoleOfMember}}
-          @withBackground={{false}}
-          @color="dark-grey"
+                @icon="times"
+                id='cancel-update-organization-role'
+                aria-label="{{t 'pages.team-items.cancel-button.aria-label'}}"
+                @triggerAction={{this.cancelUpdateRoleOfMember}}
+                @withBackground={{false}}
+                @color="dark-grey"
         />
       </div>
     </td>
   {{/if}}
 </tr>
 
-<Modal::Dialog class="remove-membership-modal" @title="Confirmez-vous la suppression ?" @display={{this.isRemoveMembershipModalDisplayed}} @close={{this.closeRemoveMembershipModal}} @additionalContainerClass="modal-dialog__large">
+<Modal::Dialog
+        class="remove-membership-modal"
+        @title="{{t 'pages.team-items.remove-membership-modal.title'}}"
+        @display={{this.isRemoveMembershipModalDisplayed}}
+        @close={{this.closeRemoveMembershipModal}}
+        @additionalContainerClass="modal-dialog__large">
   <Modal::Body class="remove-membership-modal__content">
     <p class="content-text">
-      {{@membership.user.firstName}} {{@membership.user.lastName}} n'aura plus accès à cet espace Pix Orga.
-      <br>
-      Ses campagnes restent accessibles au reste de l'équipe.
+      {{@membership.user.firstName}} {{@membership.user.lastName}} {{t 'pages.team-items.remove-membership-modal.message' htmlSafe=true}}
     </p>
   </Modal::Body>
   <Modal::Footer class="remove-membership-modal__actions">
-    <button type="button" class="button button--grey button--regular" {{on 'click' this.closeRemoveMembershipModal}}>Annuler</button>
-    <button type="button" class="button button--red" data-test-modal-remove-button {{on 'click' this.onRemoveButtonClicked}}>Oui, supprimer le membre</button>
+    <button type="button" class="button button--grey button--regular" {{on 'click' this.closeRemoveMembershipModal}}>{{t 'pages.team-items.remove-membership-modal.cancel-button'}}</button>
+    <button type="button" class="button button--red" data-test-modal-remove-button {{on 'click' this.onRemoveButtonClicked}}>{{t 'pages.team-items.remove-membership-modal.remove-button'}}</button>
   </Modal::Footer>
 </Modal::Dialog>

--- a/orga/app/components/routes/authenticated/team/items.js
+++ b/orga/app/components/routes/authenticated/team/items.js
@@ -3,14 +3,14 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-const adminOption = { value: 'ADMIN', label: 'Administrateur', disabled: false };
-
-const memberOption = { value: 'MEMBER', label: 'Membre', disabled: false };
+const ARIA_LABEL_MEMBER_TRANSLATION = 'pages.team-items.select-input.options.member-label';
+const ARIA_LABEL_ADMIN_TRANSLATION = 'pages.team-items.select-input.options.admin-label';
 
 export default class Items extends Component {
 
   @service currentUser;
   @service notifications;
+  @service intl;
 
   @tracked organizationRoles = null;
   @tracked isEditionMode = false;
@@ -18,9 +18,30 @@ export default class Items extends Component {
   @tracked currentRole = null;
   @tracked isRemoveMembershipModalDisplayed = false;
 
+  adminOption = {
+    value: 'ADMIN',
+    label: this.intl.t(ARIA_LABEL_ADMIN_TRANSLATION),
+    disabled: false,
+  };
+
+  memberOption = {
+    value: 'MEMBER',
+    label: this.intl.t(ARIA_LABEL_MEMBER_TRANSLATION),
+    disabled: false,
+  };
+
+  displayRoleByOrganizationRole = {
+    ADMIN: this.intl.t(ARIA_LABEL_ADMIN_TRANSLATION),
+    MEMBER: this.intl.t(ARIA_LABEL_MEMBER_TRANSLATION),
+  };
+
   constructor() {
     super(...arguments);
-    this.organizationRoles = [adminOption, memberOption];
+    this.organizationRoles = [this.adminOption, this.memberOption];
+  }
+
+  get displayRole() {
+    return this.displayRoleByOrganizationRole[this.args.membership.organizationRole];
   }
 
   @action
@@ -73,9 +94,9 @@ export default class Items extends Component {
       const memberLastName = membership.user.get('lastName');
 
       await this.args.removeMembership(membership);
-      this.notifications.success(`${memberFirstName} ${memberLastName} a été supprimé avec succès de votre équipe Pix Orga.`);
+      this.notifications.success(this.intl.t('pages.team-items.notifications.success', { memberFirstName, memberLastName }));
     } catch (e) {
-      this.notifications.error('Une erreur est survenue lors de la désactivation du membre.');
+      this.notifications.error(this.intl.t('pages.team-items.notifications.error'));
     } finally {
       this.closeRemoveMembershipModal();
     }

--- a/orga/app/components/routes/authenticated/team/members.hbs
+++ b/orga/app/components/routes/authenticated/team/members.hbs
@@ -3,23 +3,25 @@
     <table id="table-members">
       <thead>
       <tr>
-        <th>Nom</th>
-        <th>Prénom</th>
-        <th>Rôle</th>
+        <th>{{t 'pages.team-members.table.column.last-name'}}</th>
+        <th>{{t 'pages.team-members.table.column.first-name'}}</th>
+        <th>{{t 'pages.team-members.table.column.organization-membership-role'}}</th>
         <th></th>
       </tr>
       </thead>
       {{#if @memberships}}
         <tbody>
         {{#each @memberships as |membership|}}
-          <Routes::Authenticated::Team::Items @membership={{membership}} @removeMembership={{@removeMembership}} />
+          <Routes::Authenticated::Team::Items
+                  @membership={{membership}}
+                  @removeMembership={{@removeMembership}} />
         {{/each}}
         </tbody>
       {{/if}}
     </table>
 
     {{#unless @memberships}}
-      <div class="table__empty content-text">En attente de membres</div>
+      <div class="table__empty content-text">{{t 'pages.team-members.table.empty'}}</div>
     {{/unless}}
   </div>
 </div>

--- a/orga/app/models/membership.js
+++ b/orga/app/models/membership.js
@@ -1,10 +1,5 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
-const organizationRoleToDisplayRole = {
-  ADMIN: 'Administrateur',
-  MEMBER: 'Membre',
-};
-
 export default class Membership extends Model {
   @belongsTo('user') user;
   @belongsTo('organization') organization;
@@ -12,9 +7,5 @@ export default class Membership extends Model {
 
   get isAdmin() {
     return this.organizationRole === 'ADMIN';
-  }
-
-  get displayRole() {
-    return organizationRoleToDisplayRole[this.organizationRole];
   }
 }

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -1,14 +1,14 @@
 <div class="list-team-page">
   <div class="list-team-page__header">
-    <div class="page__title page-title">Mon équipe</div>
+    <div class="page__title page-title">{{t 'pages.team-list.title'}}</div>
     <div class="list-team-page-header__add-member-button">
-      <LinkTo @route="authenticated.team.new" class="button button--link">Inviter un membre</LinkTo>
+      <LinkTo @route="authenticated.team.new" class="button button--link">{{t 'pages.team-list.add-member-button'}}</LinkTo>
     </div>
   </div>
 
   <nav class="navbar list-team-page__tabs">
     <LinkTo @route="authenticated.team.list.members" class="navbar-item">
-      Membres ({{@model.memberships.meta.rowCount}})
+      {{t 'pages.team-list.tabs.member'}} ({{@model.memberships.meta.rowCount}})
     </LinkTo>
 
     <LinkTo @route="authenticated.team.list.invitations" class="navbar-item">

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -96,6 +96,8 @@ module('Acceptance | Team Creation', function(hooks) {
 
       test('it should allow to invite a prescriber and redirect to team page', async function(assert) {
         // given
+        const ariaLabelMember = this.intl.t('pages.team-items.row.aria-label');
+
         const code = 'ABCDEFGH01';
         server.create('user', {
           firstName: 'Gigi',
@@ -116,7 +118,7 @@ module('Acceptance | Team Creation', function(hooks) {
         assert.equal(organizationInvitation.status, 'PENDING');
         assert.equal(organizationInvitation.code, code);
         assert.equal(currentURL(), '/equipe/membres');
-        assert.dom('[aria-label="Membre"]').exists({ count: 1 });
+        assert.dom(`[aria-label="${ariaLabelMember}"]`).exists({ count: 1 });
       });
 
       test('it should not allow to invite a prescriber when an email is not given', async function(assert) {

--- a/orga/tests/integration/components/dropdown/icon-trigger-test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
+import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
 
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('should display actions menu', async function(assert) {
     // when

--- a/orga/tests/integration/components/routes/authenticated/team/items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/items-test.js
@@ -1,13 +1,13 @@
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { setupRenderingTest } from 'ember-qunit';
 import { click, fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/team | list-items | items', function(hooks) {
 
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
   let adminMembership;
   let memberMembership;
 

--- a/orga/tests/integration/components/routes/authenticated/team/members-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/members-test.js
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+
 module('Integration | Component | routes/authenticated/team | members', function(hooks) {
 
-  setupRenderingTest(hooks);
+  setupIntlRenderingTest(hooks);
 
   test('it should list the team members', async function(assert) {
     //given

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -419,6 +419,43 @@
       },
       "title": "Students"
     },
+    "team-items": {
+      "row": {
+        "aria-label": "Member"
+      },
+      "actions": {
+        "edit-organization-membership-role": {
+          "aria-label": "Change role",
+          "label": "Change role"
+        },
+        "remove-membership": {
+          "aria-label": "Remove the member",
+          "label": "Remove"
+        }
+      },
+      "select-input": {
+        "placeholder": "Select a role",
+        "aria-label": "Select a role",
+        "options": {
+          "admin-label": "Administrator",
+          "member-label": "Member"
+        }
+      },
+      "save-button": "Save",
+      "cancel-button": {
+        "aria-label": "Cancel"
+      },
+      "remove-membership-modal": {
+        "title": "Are you sure you want to remove this member?",
+        "message": "will no longer have access to this Pix Orga workspace.<br>The campaigns created by this member will still be accessible to the rest of the team.",
+        "cancel-button": "Cancel",
+        "remove-button": "Yes, remove the member"
+      },
+      "notifications": {
+        "success": "{memberFirstName} {memberLastName} has successfully been removed from your Pix Orga team.",
+        "error": "An error occurred while removing this member."
+      }
+    },
     "team-members": {
       "table": {
         "column": {
@@ -449,5 +486,8 @@
       "cancel-button": "Cancel",
       "invite-button": "Invite"
     }
+  },
+  "dropdown": {
+    "arial-label": "Manage"
   }
 }

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -419,6 +419,16 @@
       },
       "title": "Students"
     },
+    "team-members": {
+      "table": {
+        "column": {
+          "first-name": "First name",
+          "last-name": "Last name",
+          "organization-membership-role": "Role"
+        },
+        "empty": "No members yet"
+      }
+    },
     "team-new": {
       "title": "Invite a member",
       "email-requirement": "Enter here the email address of the member you want to invite.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -456,6 +456,13 @@
         "error": "An error occurred while removing this member."
       }
     },
+    "team-list": {
+      "title": "My team",
+      "add-member-button": "Invite a member",
+      "tabs": {
+        "member": "Members"
+      }
+    },
     "team-members": {
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -419,6 +419,43 @@
       },
       "title": "Étudiants"
     },
+    "team-items": {
+      "row": {
+        "aria-label": "Membre"
+      },
+      "actions": {
+        "edit-organization-membership-role": {
+          "aria-label": "Modifier le rôle",
+          "label": "Modifier le rôle"
+        },
+        "remove-membership": {
+          "aria-label": "Supprimer le membre",
+          "label": "Supprimer"
+        }
+      },
+      "select-input": {
+        "placeholder": "Sélectionner un rôle",
+        "aria-label": "Sélectionner un rôle",
+        "options": {
+          "admin-label": "Administrateur",
+          "member-label": "Membre"
+        }
+      },
+      "save-button": "Enregistrer",
+      "cancel-button": {
+        "aria-label": "Annuler"
+      },
+      "remove-membership-modal": {
+        "title": "Confirmez-vous la suppression ?",
+        "message": "n'aura plus accès à cet espace Pix Orga.<br>Ses campagnes restent accessibles au reste de l'équipe.",
+        "cancel-button": "Annuler",
+        "remove-button": "Oui, supprimer le membre"
+      },
+      "notifications": {
+        "success": "{memberFirstName} {memberLastName} a été supprimé avec succès de votre équipe Pix Orga.",
+        "error": "Une erreur est survenue lors de la désactivation du membre."
+      }
+    },
     "team-members": {
       "table": {
         "column": {
@@ -449,5 +486,8 @@
       "cancel-button": "Annuler",
       "invite-button": "Inviter"
     }
+  },
+  "dropdown": {
+    "arial-label": "Afficher les actions"
   }
 }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -456,6 +456,13 @@
         "error": "Une erreur est survenue lors de la désactivation du membre."
       }
     },
+    "team-list": {
+      "title": "Mon équipe",
+      "add-member-button": "Inviter un membre",
+      "tabs": {
+        "member": "Membres"
+      }
+    },
     "team-members": {
       "table": {
         "column": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -419,6 +419,16 @@
       },
       "title": "Étudiants"
     },
+    "team-members": {
+      "table": {
+        "column": {
+          "first-name":"Prénom",
+          "last-name":"Nom",
+          "organization-membership-role":"Rôle"
+        },
+        "empty": "En attente de membres"
+      }
+    },
     "team-new": {
       "title": "Inviter un membre",
       "email-requirement": "Saisissez ici l'adresse e-mail du membre que vous souhaitez inviter.",


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, les textes de la page Mon Equipe ( et la modale de suppression d'un membre ) sont en français, et implémentés "en dur" dans le code.
On veut ajouter la version anglaise.

## :robot: Solution
- Externaliser dans des fichiers dédiés la version française et anglaise des textes de cette page
## :rainbow: Remarques
Déplacement du getter displayRole() présent dans le model membership, dans le composant items pour faire la traduction des rôles de chaque membre de l'organisation.

## :100: Pour tester
Vérifier la bonne traduction de la page [Mon équipe](https://orga-pr2702.review.pix.fr/equipe/membres) en français et en anglais.

Cliquer sur les 3 points pour : 
- modifier le rôle d'un membre et vérifier la bonne traduction du sélécteur, des boutons.
- supprimer un membre
<img width="207" alt="Capture d’écran 2021-03-12 à 17 05 11" src="https://user-images.githubusercontent.com/58915422/110966028-2455e580-8355-11eb-856c-2bcd7914e9b8.png">

Vérifier la bonne traduction de la modale de suppression d'un membre. ( Ainsi que la notification de succès et d'erreur )

