### PR TITLE
[FEATURE] Traduire en anglais la page de connexion de Pix Orga (PIX-2221).

### DIFF
--- a/api/lib/application/http-errors.js
+++ b/api/lib/application/http-errors.js
@@ -67,6 +67,7 @@ class PasswordShouldChangeError extends BaseHttpError {
     super(message);
     this.title = 'PasswordShouldChange';
     this.status = 401;
+    this.code = 'SHOULD_CHANGE_PASSWORD';
   }
 }
 

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -84,13 +84,12 @@ describe('Acceptance | Controller | authentication-controller', () => {
       });
 
       const expectedResponseError = {
-        errors: [
-          {
-            title: 'PasswordShouldChange',
-            status: '401',
-            detail: 'Erreur, vous devez changer votre mot de passe.',
-          },
-        ],
+        errors: [{
+          code: 'SHOULD_CHANGE_PASSWORD',
+          detail: 'Erreur, vous devez changer votre mot de passe.',
+          status: '401',
+          title: 'PasswordShouldChange',
+        }],
       };
 
       options.payload = querystring.stringify({

--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -66,14 +66,14 @@
           {{t 'pages.login-form.forgot-password'}}
         </a>
       </div>
-      {{#unless @isWithInvitation}}
+      {{#if this.displayRecoverLink}}
         <div>
           <div class="login-form__recover-access-link help-text">
             <LinkTo @route="join-request" class="link">{{t 'pages.login-form.active-or-retrieve'}}</LinkTo>
           </div>
           <div class="login-form__recover-access-message help-text">({{t 'pages.login-form.only-for-admin'}})</div>
         </div>
-      {{/unless}}
+      {{/if}}
     </div>
 
   </form>

--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -66,7 +66,7 @@
           {{t 'pages.login-form.forgot-password'}}
         </a>
       </div>
-      {{#if this.displayRecoverLink}}
+      {{#if this.displayRecoveryLink}}
         <div>
           <div class="login-form__recover-access-link help-text">
             <LinkTo @route="join-request" class="link">{{t 'pages.login-form.active-or-retrieve'}}</LinkTo>

--- a/orga/app/components/routes/login-form.hbs
+++ b/orga/app/components/routes/login-form.hbs
@@ -1,52 +1,49 @@
 <div class="login-form">
 
   {{#unless @isWithInvitation }}
-    <div class="login-form__information">
-      L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.
-    </div>
+    <div class="login-form__information">{{t 'pages.login-form.is-only-accessible'}}</div>
   {{/unless}}
 
   {{#if @hasInvitationError}}
-      <div class="login-form__invitation-error">
-        Cette invitation a déjà été acceptée. Connectez-vous ou contactez l’administrateur de votre espace Pix Orga.
-      </div>
+    <div class="login-form__invitation-error">{{t 'pages.login-form.invitation-already-accepted'}}</div>
   {{/if}}
 
   {{#if this.isErrorMessagePresent}}
-    <div id="login-form-error-message" class="login-form__error-message error-message">{{this.errorMessage}}
+    <div id="login-form-error-message" class="login-form__error-message error-message">
+      {{this.errorMessage}}
     </div>
   {{/if}}
 
   <form {{on 'submit' this.authenticate}}>
 
     <div class="input-container">
-      <label for="login-email" class="label">Adresse e-mail</label>
+      <label for="login-email" class="label">{{t 'pages.login-form.email'}}</label>
       <Input
         @id="login-email"
-        @name="login"
         @type="email"
-        @class="input"
         @value={{this.email}}
-        @autocomplete="username"
-        @required='true'
+        name="login"
+        class="input"
+        autocomplete="username"
+        required={{true}}
       />
     </div>
 
     <div class="input-container">
-      <label for="login-password" class="label">Mot de passe</label>
+      <label for="login-password" class="label">{{t 'pages.login-form.password'}}</label>
       <div class="input-password">
         <Input
           @id="login-password"
-          @name="password"
           @type={{this.passwordInputType}}
-          @class="input"
           @value={{this.password}}
-          @autocomplete="current-password"
-          @required='true'
+          name="password"
+          class="input"
+          autocomplete="current-password"
+          required={{true}}
         />
         <PixIconButton
           @icon="{{if this.isPasswordVisible 'eye' 'eye-slash'}}"
-          aria-label="rendre le mot de passe lisible"
+          aria-label="{{t 'pages.login-form.show-password'}}"
           @triggerAction={{this.togglePasswordVisibility}}
           @withBackground={{false}}
           @color="dark-grey"
@@ -58,20 +55,23 @@
       {{#if this.isLoading}}
         <button type="button" class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button type="submit" class="button login-form__button">Je me connecte</button>
+        <button type="submit" class="button login-form__button">{{t 'pages.login-form.login'}}</button>
       {{/if}}
     </div>
 
     <div>
       <div class="login-form__forgotten-password help-text">
-        <a href="https://app.pix.fr/mot-de-passe-oublie" target="_blank" rel="noopener noreferrer" class="link">Mot de passe oublié ?</a>
+        <a href="{{t 'pages.login-form.forgotten-password-url'}}"
+           target="_blank" rel="noopener noreferrer" class="link">
+          {{t 'pages.login-form.forgot-password'}}
+        </a>
       </div>
       {{#unless @isWithInvitation}}
         <div>
           <div class="login-form__recover-access-link help-text">
-            <LinkTo @route="join-request" class="link">Activez ou récupérez votre espace PixOrga</LinkTo>
+            <LinkTo @route="join-request" class="link">{{t 'pages.login-form.active-or-retrieve'}}</LinkTo>
           </div>
-          <div class="login-form__recover-access-message help-text">(réservé aux personnels de direction des établissements scolaires)</div>
+          <div class="login-form__recover-access-message help-text">({{t 'pages.login-form.only-for-admin'}})</div>
         </div>
       {{/unless}}
     </div>

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -2,19 +2,23 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import get from 'lodash/get';
 
 export default class LoginForm extends Component {
 
+  @service intl;
+  @service notifications;
   @service session;
   @service store;
 
-  email = null;
-  password = null;
+  @tracked isErrorMessagePresent = false;
   @tracked isLoading = false;
   @tracked isPasswordVisible = false;
+
+  email = null;
   errorMessage = null;
-  @tracked isErrorMessagePresent = false;
+  password = null;
+
+  ERROR_MESSAGES;
 
   get passwordInputType() {
     return this.isPasswordVisible ? 'text' : 'password';
@@ -49,16 +53,12 @@ export default class LoginForm extends Component {
 
   _authenticate(password, email) {
     const scope = 'pix-orga';
-    return this.session.authenticate('authenticator:oauth2', email, password, scope)
-      .catch((response) => {
-        this.isErrorMessagePresent = true;
+    this._initErrorMessages();
 
-        const nbErrors = get(response, 'errors.length', 0);
-        if (nbErrors > 0) {
-          this.errorMessage = response.errors[0].detail;
-        } else {
-          this.errorMessage = 'Le service est momentanément indisponible. Veuillez réessayer ultérieurement.';
-        }
+    return this.session.authenticate('authenticator:oauth2', email, password, scope)
+      .catch((errorResponse) => {
+        this.isErrorMessagePresent = true;
+        this.errorMessage = this._handleResponseError(errorResponse);
       })
       .finally(() => {
         this.isLoading = false;
@@ -71,5 +71,35 @@ export default class LoginForm extends Component {
       code: organizationInvitationCode,
       email,
     }).save({ adapterOptions: { organizationInvitationId } });
+  }
+
+  _handleResponseError({ errors }) {
+    if (Array.isArray(errors)) {
+      const error = errors[0];
+      switch (error.status) {
+        case '400':
+          return this.ERROR_MESSAGES.STATUS_400;
+        case '401':
+          return error.code === 'SHOULD_CHANGE_PASSWORD'
+            ? this.ERROR_MESSAGES.STATUS_401_SHOULD_CHANGE_PASSWORD
+            : this.ERROR_MESSAGES.STATUS_401;
+        case '403':
+          return this.ERROR_MESSAGES.STATUS_403;
+        default:
+          return this.ERROR_MESSAGES.DEFAULT;
+      }
+    } else {
+      return this.ERROR_MESSAGES.DEFAULT;
+    }
+  }
+
+  _initErrorMessages() {
+    this.ERROR_MESSAGES = {
+      DEFAULT: this.intl.t('api-errors-messages.default'),
+      STATUS_400: this.intl.t('api-errors-messages.bad-request'),
+      STATUS_401: this.intl.t('pages.login-form.errors.status.401'),
+      STATUS_401_SHOULD_CHANGE_PASSWORD: this.intl.t('pages.login-form.errors.status.401-should-change-password'),
+      STATUS_403: this.intl.t('pages.login-form.errors.status.403'),
+    };
   }
 }

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -6,16 +6,15 @@ import { tracked } from '@glimmer/tracking';
 export default class LoginForm extends Component {
 
   @service intl;
-  @service notifications;
   @service session;
   @service store;
 
+  @tracked errorMessage = null;
   @tracked isErrorMessagePresent = false;
   @tracked isLoading = false;
   @tracked isPasswordVisible = false;
 
   email = null;
-  errorMessage = null;
   password = null;
 
   ERROR_MESSAGES;
@@ -24,7 +23,7 @@ export default class LoginForm extends Component {
     return this.isPasswordVisible ? 'text' : 'password';
   }
 
-  get displayRecoverLink() {
+  get displayRecoveryLink() {
     if (this.intl.t('current-lang') === 'en') {
       return false;
     }
@@ -34,6 +33,7 @@ export default class LoginForm extends Component {
   @action
   async authenticate(event) {
     event.preventDefault();
+
     this.isLoading = true;
     const email = this.email ? this.email.trim() : '';
     const password = this.password;
@@ -60,12 +60,16 @@ export default class LoginForm extends Component {
 
   _authenticate(password, email) {
     const scope = 'pix-orga';
+
+    this.isErrorMessagePresent = false;
+    this.errorMessage = '';
+
     this._initErrorMessages();
 
     return this.session.authenticate('authenticator:oauth2', email, password, scope)
       .catch((errorResponse) => {
-        this.isErrorMessagePresent = true;
         this.errorMessage = this._handleResponseError(errorResponse);
+        this.isErrorMessagePresent = true;
       })
       .finally(() => {
         this.isLoading = false;

--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -24,6 +24,13 @@ export default class LoginForm extends Component {
     return this.isPasswordVisible ? 'text' : 'password';
   }
 
+  get displayRecoverLink() {
+    if (this.intl.t('current-lang') === 'en') {
+      return false;
+    }
+    return !this.args.isWithInvitation;
+  }
+
   @action
   async authenticate(event) {
     event.preventDefault();

--- a/orga/app/routes/application.js
+++ b/orga/app/routes/application.js
@@ -35,7 +35,7 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   async _getUserAndLocale(lang = null) {
     await this._loadCurrentUser();
     await this._updatePrescriberLocale(lang);
-    this._setLocale();
+    this._setLocale(lang);
   }
 
   _updatePrescriberLocale(lang) {
@@ -47,8 +47,8 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
     return prescriber.save({ adapterOptions: { lang } });
   }
 
-  _setLocale() {
-    const locale = get(this.currentUser, 'prescriber.lang', DEFAULT_LOCALE);
+  _setLocale(lang = null) {
+    const locale = lang || get(this.currentUser, 'prescriber.lang', DEFAULT_LOCALE);
     this.intl.setLocale([locale, DEFAULT_LOCALE]);
     this.moment.setLocale(locale);
   }

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -5,6 +5,7 @@ import ENV from 'pix-orga/config/environment';
 export default class Url extends Service {
 
   @service currentDomain;
+  @service intl;
 
   definedCampaignsRootUrl = ENV.APP.CAMPAIGNS_ROOT_URL;
   pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
@@ -18,7 +19,8 @@ export default class Url extends Service {
   }
 
   get homeUrl() {
-    return this.definedHomeUrl;
+    const currentLanguage = this.intl.t('current-lang');
+    return `${this.definedHomeUrl}?lang=${currentLanguage}`;
   }
 
 }

--- a/orga/app/templates/login.hbs
+++ b/orga/app/templates/login.hbs
@@ -3,7 +3,7 @@
     <div class="panel__image">
       <img src="/pix-orga.svg" alt="Pix Orga">
     </div>
-    <h3 class="form-title">Connectez-vous</h3>
+    <h3 class="form-title">{{t 'pages.login.title'}}</h3>
     <Routes::LoginForm @isWithInvitation={{false}} @hasInvitationError={{this.hasInvitationError}} />
   </div>
 </div>

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -1,11 +1,13 @@
 {
   "api-errors-messages": {
+    "bad-request": "The data entered was not in the correct format.",
     "campaign-creation": {
       "external-user-id-required": "Please specify the type of external user ID which the participants will be required to fill when starting the personalised test.",
       "name-required": "Please name your campaign.",
       "purpose-required": "Please select the purpose of your campaign: assess participants or collect their profiles.",
       "target-profile-required": "Please select a target profile for your campaign."
     },
+    "default": "The service is temporarily unavailable. Please try again later.",
     "edit-student-number": {
       "student-number-exists": "The student number entered is already used by {firstName} {lastName}"
     },
@@ -309,6 +311,28 @@
         "invalid-division": "The class {selectedDivision} does not exist."
       }
     },
+    "login": {
+      "title": "Log in"
+    },
+    "login-form": {
+      "active-or-retrieve": "Activate or retrieve your Pix Orga workspace",
+      "email": "Email address",
+      "forgot-password": "Forgot your password?",
+      "forgotten-password-url": "https://app.pix.org/mot-de-passe-oublie?lang=en",
+      "invitation-already-accepted": "This invitation has already been accepted. Please log in or contact the administrator of your Pix Orga workspace.",
+      "is-only-accessible": "Pix Orga is only accessible to invited members. Please contact your Pix Orga administrator in order to be invited.",
+      "login": "Log in",
+      "only-for-admin": "only for school administrations",
+      "password": "Password",
+      "show-password": "Show password",
+      "errors": {
+        "status": {
+          "401": "Missing or invalid credentials",
+          "401-should-change-password": "An error occurred. Please change your password.",
+          "403": "Access to this Pix Orga workspace is limited to invited members. Each Pix Orga workspace is managed by an administrator specific to the organisation using it. Please contact your administrator to get invited."
+        }
+      }
+    },
     "profiles-individual-results": {
       "certifiable": "Eligible for certification",
       "competences-certifiables": "SKILLS ELIGIBLE FOR CERTIFICATION",
@@ -482,8 +506,8 @@
         "default": "The service is temporarily unavailable. Please try again later.",
         "status" : {
           "400": "The email address format is invalid.",
-          "412": "This member has already been added.",
           "404": "This email address doesn't match any Pix user.",
+          "412": "This member has already been added.",
           "500": "Something went wrong. Please try again."
         }
       }

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -1,11 +1,13 @@
 {
   "api-errors-messages": {
+    "bad-request": "Les données que vous avez soumises ne sont pas au bon format.",
     "campaign-creation": {
       "external-user-id-required": "Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.",
       "name-required": "Veuillez donner un nom à votre campagne.",
       "purpose-required": "Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.",
       "target-profile-required": "Veuillez sélectionner un profil cible pour votre campagne."
     },
+    "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
     "edit-student-number": {
       "student-number-exists": "Le numéro étudiant saisi est déjà utilisé par l’étudiant {firstName} {lastName}"
     },
@@ -309,6 +311,28 @@
         "invalid-division": "La classe {selectedDivision} n'existe pas."
       }
     },
+    "login": {
+      "title": "Connectez-vous"
+    },
+    "login-form": {
+      "active-or-retrieve": "Activez ou récupérez votre espace Pix Orga",
+      "email": "Adresse e-mail",
+      "forgot-password": "Mot de passe oublié ?",
+      "forgotten-password-url": "https://app.pix.fr/mot-de-passe-oublie",
+      "invitation-already-accepted": "Cette invitation a déjà été acceptée. Connectez-vous ou contactez l'administrateur de votre espace Pix Orga.",
+      "is-only-accessible": "L'accès à Pix Orga est limité aux membres invités. Contactez l’administrateur Pix Orga de votre organisation pour qu'il vous invite.",
+      "login": "Je me connecte",
+      "only-for-admin": "réservé aux personnels de direction des établissements scolaires",
+      "password": "Mot de passe",
+      "show-password": "rendre le mot de passe lisible",
+      "errors": {
+        "status": {
+          "401": "L'adresse e-mail et/ou le mot de passe saisis sont incorrects.",
+          "401-should-change-password": "Erreur, vous devez changer votre mot de passe.",
+          "403": "L'accès à Pix Orga est limité aux membres invités. Chaque espace est géré par un administrateur Pix Orga propre à l'organisation qui l'utilise. Contactez-le pour qu'il vous y invite."
+        }
+      }
+    },
     "profiles-individual-results": {
       "certifiable": "Certifiable",
       "competences-certifiables": "COMP. CERTIFIABLES",
@@ -482,8 +506,8 @@
         "default": "Le service est momentanément indisponible. Veuillez réessayer ultérieurement.",
         "status" : {
           "400": "Le format de l'adresse e-mail est incorrect.",
-          "412": "Ce membre a déjà été ajouté.",
           "404": "Cet email n'appartient à aucun utilisateur.",
+          "412": "Ce membre a déjà été ajouté.",
           "500": "Quelque chose s'est mal passé. Veuillez réessayer."
         }
       }


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, les textes de la page de connexion en français, et implémentés "en dur" dans le code.
On veut ajouter la version anglaise.

## :robot: Solution
* Externaliser dans des fichiers dédiés la version française et anglaise des textes de cette page
* Utiliser l'addon Ember d'internationalisation

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter à Pix Orga 
* [en français](https://orga-pr2704.review.pix.fr/connexion?lang=fr)
* [en anglais](https://orga-pr2704.review.pix.fr/connexion?lang=en)

Scénarios:
* `is-only-accessible`: pas de connexion nécessaire, affiché au dessus du champ `email`
* `default`: faire renvoyer une erreur par `POST /api/token`
* `bad-request`: modifier la validation Joi de `POST /api/token` en ajoutant un champ obligatoire non envoyé par PixOrga
* aria-label "Voir le mot de passe" : inspecter la source (ex: anglais)
`<button class="pix-icon-button pix-icon-button--big pix-icon-button--dark-grey " aria-label="Show password" type="button">`
* utlisateur inexistant : `jaune.attend@example.org`
* mot de passe invalide : `lasttermsofservice@validated.net` / `foo`
* utilisateur non membre : `userpix1@example.net` / `pix123`
* invitation déjà acceptée
   * [français](https://orga-pr2704.review.pix.org/rejoindre?invitationId=10000000&code=SLEPTJ0312&lang=fr)     
   * [anglais](https://orga-pr2704.review.pix.org/rejoindre?invitationId=10000000&code=SLEPTJ0312&lang=en)    
* mot de passe à changer : requête ci-dessous + `sco.admin@example.net` / `pix123` 

Forcer l'utilisateur à changer son mot de passe
```
UPDATE
     "authentication-methods"
SET
    "authenticationComplement" = jsonb_set("authenticationComplement", '{shouldChangePassword}', '"true"')
WHERE 1=1
    AND "userId" IN (SELECT id FROM users u WHERE u.email = 'pixmaster@example.net')
;
```