### PR TITLE
[BUGFIX] Mettre le markdown sur la bonne réponse des QCU (PIX-2350).

### DIFF
--- a/mon-pix/app/components/qcu-solution-panel.js
+++ b/mon-pix/app/components/qcu-solution-panel.js
@@ -3,11 +3,8 @@ import labeledCheckboxes from 'mon-pix/utils/labeled-checkboxes';
 import valueAsArrayOfBoolean from 'mon-pix/utils/value-as-array-of-boolean';
 import proposalsAsArray from 'mon-pix/utils/proposals-as-array';
 import isEmpty from 'lodash/isEmpty';
-import ENV from 'mon-pix/config/environment';
 
 export default class QcuSolutionPanel extends Component {
-  featureFlagDisplayForWrongAnswers = ENV.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
-
   get solutionArray() {
     const solution = this.args.solution;
     return !isEmpty(solution) ? valueAsArrayOfBoolean(solution) : [];

--- a/mon-pix/app/styles/components/_qcu-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcu-solution-panel.scss
@@ -55,3 +55,10 @@
     }
   }
 }
+
+.qcu-solution-answer-feedback {
+
+  &__expected-answer {
+    font-weight: $font-medium;
+  }
+}

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -27,14 +27,12 @@
     </p>
   {{/each}}
 
-  <div class="qcu-solution-panel__answer-feedback">
-    {{#if this.isAnswerValid}}
-      <div class="qcu-solution-answer-feedback__correct-answer">{{t 'pages.comparison-window.results.feedback.correct'}}</div>
-    {{else}}
-      <MarkdownToHtml
-              class="qcu-solution-answer-feedback__expected-answer"
-              @markdown="{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}} {{this.solutionAsText}}" />
-    {{/if}}
-  </div>
+  {{#if this.isAnswerValid}}
+    <div data-test-correct-answer>{{t 'pages.comparison-window.results.feedback.correct'}}</div>
+  {{else}}
+    <MarkdownToHtml
+            class="qcu-solution-answer-feedback__expected-answer"
+            @markdown="{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}} {{this.solutionAsText}}" />
+  {{/if}}
 </div>
 

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -27,13 +27,13 @@
     </p>
   {{/each}}
 
-  <div class="qcu-panel-proposals__answer-feedback">
+  <div class="qcu-solution-panel__answer-feedback">
     {{#if this.isAnswerValid}}
-      <div class="answer-feedback__correct-answer">{{t 'pages.comparison-window.results.feedback.correct'}}</div>
+      <div class="qcu-solution-answer-feedback__correct-answer">{{t 'pages.comparison-window.results.feedback.correct'}}</div>
     {{else}}
-      <div class="answer-feedback__wrong-answer">{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}}
-        <strong class="wrong-answer__expected-answer">{{this.solutionAsText}}</strong>
-      </div>
+      <MarkdownToHtml
+              class="qcu-solution-answer-feedback__expected-answer"
+              @markdown="{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}} {{this.solutionAsText}}" />
     {{/if}}
   </div>
 </div>

--- a/mon-pix/app/templates/components/qcu-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcu-solution-panel.hbs
@@ -27,16 +27,14 @@
     </p>
   {{/each}}
 
-  {{#if this.featureFlagDisplayForWrongAnswers}}
-    <div class="qcu-panel-proposals__answer-feedback">
-      {{#if this.isAnswerValid}}
-        <div class="answer-feedback__correct-answer">{{t 'pages.comparison-window.results.feedback.correct'}}</div>
-      {{else}}
-        <div class="answer-feedback__wrong-answer">{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}}
-          <strong class="wrong-answer__expected-answer">{{this.solutionAsText}}</strong>
-        </div>
-      {{/if}}
-    </div>
-  {{/if}}
+  <div class="qcu-panel-proposals__answer-feedback">
+    {{#if this.isAnswerValid}}
+      <div class="answer-feedback__correct-answer">{{t 'pages.comparison-window.results.feedback.correct'}}</div>
+    {{else}}
+      <div class="answer-feedback__wrong-answer">{{t 'pages.comparison-window.results.feedback.wrong' htmlSafe=true}}
+        <strong class="wrong-answer__expected-answer">{{this.solutionAsText}}</strong>
+      </div>
+    {{/if}}
+  </div>
 </div>
 

--- a/mon-pix/config/environment.js
+++ b/mon-pix/config/environment.js
@@ -65,7 +65,6 @@ module.exports = function(environment) {
       MAX_CONCURRENT_AJAX_CALLS: _getEnvironmentVariableAsNumber({ environmentVariableName: 'MAX_CONCURRENT_AJAX_CALLS', defaultValue: 8, minValue: 1 }),
       BANNER_CONTENT: process.env.BANNER_CONTENT || '',
       BANNER_TYPE: process.env.BANNER_TYPE || '',
-      FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU: process.env.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU || false,
       FRENCH_NEW_LEVEL_MESSAGE: process.env.FRENCH_NEW_LEVEL_MESSAGE || '',
       ENGLISH_NEW_LEVEL_MESSAGE: process.env.ENGLISH_NEW_LEVEL_MESSAGE || '',
       IS_PROD_ENVIRONMENT: (process.env.REVIEW_APP === 'false' && environment === 'production') || false,

--- a/mon-pix/tests/acceptance/challenge-qcu-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcu-test.js
@@ -147,7 +147,8 @@ describe('Acceptance | Displaying a QCU challenge', () => {
       expect(badAnswerFromUserResult.getAttribute('data-goodness')).to.equal('bad');
       expect(badAnswerFromUserResult.getAttribute('data-checked')).to.equal('yes');
 
-      expect(find('.wrong-answer__expected-answer').textContent).to.contains(1);
+      expect(find('.qcu-solution-answer-feedback__expected-answer').textContent).to.contains(1);
+      expect(find('.qcu-solution-answer-feedback__expected-answer').innerHTML).to.contains('1ere <em>possibilite</em>');
 
       expect(find('.tutorial-panel__hint-container').textContent).to.contains(correction.hint);
 

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -5,7 +5,6 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, findAll, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import times from 'lodash/times';
-import config from '../../../config/environment';
 
 const assessment = {};
 let challenge = null;
@@ -24,250 +23,214 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
     id: 'answer_id', assessment, challenge, value: '3',
   };
 
-  context('When toggle for improving wrong answers display is true', function() {
+  it('Should render', async function() {
+    await render(hbs`<QcuSolutionPanel/>`);
+    expect(find('.qcu-solution-panel')).to.exist;
+  });
 
-    let configurationForImprovingDisplayForWrongAnswers;
+  describe('Radio state', function() {
 
     before(function() {
-      configurationForImprovingDisplayForWrongAnswers = config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
-      config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = true;
+      challenge = EmberObject.create({
+        id: 'challenge_id',
+        proposals: '-foo\n- bar\n- qix\n- yon',
+        type: 'QCU',
+      });
+
+      solution = '2';
+
+      answer = {
+        id: 'answer_id',
+        assessment,
+        challenge,
+        value: '2',
+      };
     });
 
-    after(function() {
-      config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = configurationForImprovingDisplayForWrongAnswers;
+    it('Should display only user answer', async function() {
+      // Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+
+      // Then
+      expect(findAll('[data-goodness=good]').length).to.equal(1);
     });
 
-    it('Should render', async function() {
-      await render(hbs`<QcuSolutionPanel/>`);
-      expect(find('.qcu-solution-panel')).to.exist;
-    });
+    it('should not be editable', async function() {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
 
-    describe('Radio state', function() {
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-      before(function() {
-        challenge = EmberObject.create({
-          id: 'challenge_id',
-          proposals: '-foo\n- bar\n- qix\n- yon',
-          type: 'QCU',
-        });
-
-        solution = '2';
-
-        answer = {
-          id: 'answer_id',
-          assessment,
-          challenge,
-          value: '2',
-        };
-      });
-
-      it('Should display only user answer', async function() {
-        // Given
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-        // When
-        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-        // Then
-        expect(findAll('[data-goodness=good]').length).to.equal(1);
-      });
-
-      it('should not be editable', async function() {
-        //Given
-        this.set('answer', answer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-        // Then
-        times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
-          expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
-        });
-      });
-    });
-
-    describe('When answer is correct', function() {
-
-      before(function() {
-        challenge = EmberObject.create({
-          id: 'challenge_id',
-          proposals: '-foo\n- bar\n- qix\n- yon',
-          type: 'QCU',
-        });
-
-        solution = '2';
-      });
-
-      it('should inform that the answer is correct', async function() {
-        //Given
-        this.set('answer', correctAnswer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-        // Then
-        expect(find('.answer-feedback__correct-answer')).to.exist;
-      });
-    });
-
-    describe('When answer is wrong', function() {
-      before(function() {
-        challenge = EmberObject.create({
-          id: 'challenge_id',
-          proposals: '-foo\n- bar\n- qix\n- yon',
-          type: 'QCU',
-        });
-
-        solution = '2';
-        solutionAsText = 'bar';
-      });
-
-      it('should inform that the answer is wrong', async function() {
-        //Given
-        this.set('answer', unCorrectAnswer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-        // Then
-        expect(find('.answer-feedback__wrong-answer')).to.exist;
-      });
-
-      it('should inform the user of the correct answer', async function() {
-        // Given
-        this.set('answer', unCorrectAnswer);
-        this.set('solution', solution);
-        this.set('challenge', challenge);
-
-        // When
-        await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-        // Then
-        const correctAnswer = find('.wrong-answer__expected-answer');
-        expect(correctAnswer).to.exist;
-        expect(correctAnswer.innerText).to.equal(solutionAsText);
+      // Then
+      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
+        expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
       });
     });
   });
 
-  context('When toggle for improving wrong answers display is false', function() {
-    describe('#Component should render: ', function() {
+  describe('When answer is correct', function() {
 
-      let configurationForImprovingDisplayForWrongAnswers;
-
-      before(function() {
-        configurationForImprovingDisplayForWrongAnswers = config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU;
-        config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = false;
+    before(function() {
+      challenge = EmberObject.create({
+        id: 'challenge_id',
+        proposals: '-foo\n- bar\n- qix\n- yon',
+        type: 'QCU',
       });
 
-      after(function() {
-        config.APP.FT_IMPROVE_DISPLAY_FOR_WRONG_ANSWERS_FOR_QCU = configurationForImprovingDisplayForWrongAnswers;
+      solution = '2';
+    });
+
+    it('should inform that the answer is correct', async function() {
+      //Given
+      this.set('answer', correctAnswer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+
+      // Then
+      expect(find('.answer-feedback__correct-answer')).to.exist;
+    });
+  });
+
+  describe('When answer is wrong', function() {
+    before(function() {
+      challenge = EmberObject.create({
+        id: 'challenge_id',
+        proposals: '-foo\n- bar\n- qix\n- yon',
+        type: 'QCU',
       });
 
-      it('Should render', async function() {
-        await render(hbs`<QcuSolutionPanel/>`);
-        expect(find('.qcu-solution-panel')).to.exist;
-        expect(findAll('.qcu-solution-panel__proposition')).to.have.lengthOf(0);
+      solution = '2';
+      solutionAsText = 'bar';
+    });
+
+    it('should inform that the answer is wrong', async function() {
+      //Given
+      this.set('answer', unCorrectAnswer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+
+      // Then
+      expect(find('.answer-feedback__wrong-answer')).to.exist;
+    });
+
+    it('should inform the user of the correct answer', async function() {
+      // Given
+      this.set('answer', unCorrectAnswer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+
+      // Then
+      const correctAnswer = find('.wrong-answer__expected-answer');
+      expect(correctAnswer).to.exist;
+      expect(correctAnswer.innerText).to.equal(solutionAsText);
+    });
+  });
+
+  describe('All Radio states', function() {
+
+    before(function() {
+      challenge = EmberObject.create({
+        id: 'challenge_id',
+        proposals: '-foo\n- bar\n- qix\n- yon',
+        type: 'QCM',
       });
 
-      describe('Radio state', function() {
+      solution = '2';
 
-        before(function() {
-          challenge = EmberObject.create({
-            id: 'challenge_id',
-            proposals: '-foo\n- bar\n- qix\n- yon',
-            type: 'QCM',
-          });
+      answer = EmberObject.create(correctAnswer);
+    });
 
-          solution = '2';
+    it('QCU, correct answer is checked', async function() {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-          answer = EmberObject.create(correctAnswer);
-        });
+      // Then
+      expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked')).to.equal('yes');
+      expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness')).to.equal('good');
+      expect(findAll('.qcu-solution-panel__radio-button')[1].innerHTML).to.contains('Votre réponse');
+    });
 
-        it('QCU,la réponse correcte est cochée', async function() {
-          //Given
-          this.set('answer', answer);
-          this.set('solution', solution);
-          this.set('challenge', challenge);
-          // When
-          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+    it('QCU, correct answer is not checked', async function() {
+      //Given
+      answer = EmberObject.create(unCorrectAnswer);
 
-          // Then
-          expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked')).to.equal('yes');
-          expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness')).to.equal('good');
-          expect(findAll('.qcu-solution-panel__radio-button')[1].innerHTML).to.contains('Votre réponse');
-        });
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
 
-        it('QCU, la réponse correcte n\'est pas cochée', async function() {
-          //Given
-          answer = EmberObject.create(unCorrectAnswer);
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-          this.set('answer', answer);
-          this.set('solution', solution);
-          this.set('challenge', challenge);
+      // Then
+      expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked')).to.equal('no');
+      expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness')).to.equal('good');
+      expect(findAll('.qcu-solution-panel__radio-button')[1].innerHTML).to.contains('Autre proposition');
+    });
 
-          // When
-          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+    it('QCU, incorrect answer is not checked', async function() {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
 
-          // Then
-          expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-checked')).to.equal('no');
-          expect(findAll('.qcu-solution-panel__proposition')[1].getAttribute('data-goodness')).to.equal('good');
-          expect(findAll('.qcu-solution-panel__radio-button')[1].innerHTML).to.contains('Autre proposition');
-        });
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-        it('QCU, la réponse incorrecte n\'est pas cochée', async function() {
-          //Given
-          this.set('answer', answer);
-          this.set('solution', solution);
-          this.set('challenge', challenge);
+      // Then
+      expect(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-checked')).to.equal('no');
+      expect(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-goodness')).to.equal('bad');
+      expect(findAll('.qcu-solution-panel__radio-button')[0].innerHTML).to.contains('Autre proposition');
+    });
 
-          // When
-          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+    it('QCU, incorrect answer is checked', async function() {
+      //Given
+      answer = EmberObject.create(unCorrectAnswer);
 
-          // Then
-          expect(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-checked')).to.equal('no');
-          expect(findAll('.qcu-solution-panel__proposition')[0].getAttribute('data-goodness')).to.equal('bad');
-          expect(findAll('.qcu-solution-panel__radio-button')[0].innerHTML).to.contains('Autre proposition');
-        });
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
 
-        it('QCU,la réponse incorrecte est cochée', async function() {
-          //Given
-          answer = EmberObject.create(unCorrectAnswer);
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-          this.set('answer', answer);
-          this.set('solution', solution);
-          this.set('challenge', challenge);
+      // Then
+      expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-checked')).to.equal('yes');
+      expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-goodness')).to.equal('bad');
+      expect(findAll('.qcu-solution-panel__radio-button')[2].innerHTML).to.contains('Votre réponse');
+    });
 
-          // When
-          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
+    it('Should avoid click on radio button', async function() {
+      //Given
+      this.set('answer', answer);
+      this.set('solution', solution);
+      this.set('challenge', challenge);
 
-          // Then
-          expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-checked')).to.equal('yes');
-          expect(findAll('.qcu-solution-panel__proposition')[2].getAttribute('data-goodness')).to.equal('bad');
-          expect(findAll('.qcu-solution-panel__radio-button')[2].innerHTML).to.contains('Votre réponse');
-        });
+      // When
+      await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
-        it('Aucune case à cocher n\'est cliquable', async function() {
-          //Given
-          this.set('answer', answer);
-          this.set('solution', solution);
-          this.set('challenge', challenge);
-
-          // When
-          await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
-
-          // Then
-          times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
-            expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
-          });
-        });
+      // Then
+      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
+        expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
       });
     });
   });

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -97,7 +97,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
       // Then
-      expect(find('.answer-feedback__correct-answer')).to.exist;
+      expect(find('.qcu-solution-answer-feedback__correct-answer')).to.exist;
     });
   });
 
@@ -123,7 +123,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
       // Then
-      expect(find('.answer-feedback__wrong-answer')).to.exist;
+      expect(find('.qcu-solution-answer-feedback__expected-answer')).to.exist;
     });
 
     it('should inform the user of the correct answer', async function() {
@@ -136,9 +136,9 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
       // Then
-      const correctAnswer = find('.wrong-answer__expected-answer');
+      const correctAnswer = find('.qcu-solution-answer-feedback__expected-answer');
       expect(correctAnswer).to.exist;
-      expect(correctAnswer.innerText).to.equal(solutionAsText);
+      expect(correctAnswer.innerText).to.equal('Réponse incorrecte.\nLa bonne réponse est la réponse : ' + solutionAsText);
     });
   });
 

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -97,7 +97,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
       // Then
-      expect(find('.qcu-solution-answer-feedback__correct-answer')).to.exist;
+      expect(find('div[data-test-correct-answer]')).to.exist;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lors de la mise en place du markdown sur les QCU, on avait oublié le texte qui s'affiche pour préciser la bonne réponse en cas de mauvaises réponses.

## :robot: Solution
- Ajouter le markdown à cette endroit
- Retirer le FT qui n'est plus utile

## :rainbow: Remarques
- Suppression des tests en double

## :100: Pour tester
Ne pas réussir une épreuve QCU avec markdown : rec2lr5dke7hm34Kc