### PR TITLE
[TECH] Envoi les résultats de test des tests e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,6 +340,8 @@ jobs:
           environment:
             DATABASE_URL: 'postgres://circleci@localhost:5432/circleci'
           command: npx wait-on http://localhost:3000/api http://localhost:4200 http://localhost:4201 http://localhost:4203 && npm run cy:run:ci
+      - store_test_results:
+          path: /home/circleci/test-results
 
   algo_test:
     docker:

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -17,7 +17,7 @@
     "cy:open": "npm run db:initialize && cypress open",
     "cy:open:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:open",
     "cy:run": "npm run db:initialize && cypress run --browser=chrome && exit",
-    "cy:run:ci": "npm run db:initialize && npx cypress run --browser=chrome --parallel --record --group e2e-tests && exit",
+    "cy:run:ci": "npm run db:initialize && npx cypress run --browser=chrome --parallel --record --group e2e-tests --reporter junit --reporter-options 'mochaFile=/home/circleci/test-results/cypress.xml' && exit",
     "cy:run:local": "DATABASE_URL=postgresql://postgres@localhost/pix_test npm run cy:run",
     "cy:run:base": "cypress run --env type=base --config screenshotsFolder=cypress/snapshots/base",
     "cy:test": "run-p start:api start:mon-pix start:orga start:certif cy:run",


### PR DESCRIPTION
## :unicorn: Problème
Similaire a https://github.com/1024pix/pix/pull/2695, on peut avoir des tests flacky sur les tests end to end mais on n'en garde pas trace.

## :robot: Solution
Utiliser le reporteur junit dans cypress et envoyer le fichier xml a circleci.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Vérifier que l'onglet tests dans circleci https://app.circleci.com/pipelines/github/1024pix/pix/22798/workflows/aa5475fa-50a0-42a6-9236-f6eaf84a9915/jobs/190078/tests affiche le nombre de test et potentiellement ceux en erreurs.
