### PR TITLE
[FEATURE] Ne plus filtrer par défaut la liste de "Toutes les sessions" (PIX-2300)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/list/all.js
+++ b/admin/app/controllers/authenticated/sessions/list/all.js
@@ -4,7 +4,6 @@ import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { task, timeout } from 'ember-concurrency';
 import config from 'pix-admin/config/environment';
-import { FINALIZED } from 'pix-admin/models/session';
 import { action } from '@ember/object';
 
 const DEFAULT_PAGE_NUMBER = 1;
@@ -19,7 +18,7 @@ export default class AuthenticatedSessionsListAllController extends Controller {
   @tracked id = null;
   @tracked certificationCenterName = null;
   @tracked certificationCenterType = null;
-  @tracked status = FINALIZED;
+  @tracked status = null;
   @tracked resultsSentToPrescriberAt = null;
   @tracked assignedToSelfOnly = false;
 

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -63,7 +63,7 @@ module('Acceptance | Session List', function(hooks) {
 
           // then
           assert.dom('select#pageSize').hasValue('10');
-          assert.dom('.table-admin tbody tr').exists({ count: 5 });
+          assert.dom('.table-admin tbody tr').exists({ count: 10 });
           assert.dom('div.page-navigation__current-page').hasText('2');
         });
       });
@@ -77,7 +77,7 @@ module('Acceptance | Session List', function(hooks) {
 
           // then
           assert.dom('select#pageSize').hasValue('25');
-          assert.dom('.table-admin tbody tr').exists({ count: 15 });
+          assert.dom('.table-admin tbody tr').exists({ count: 25 });
           assert.dom('div.page-navigation__current-page').hasText('1');
         });
       });


### PR DESCRIPTION
## :unicorn: Problème

La liste “Toutes les sessions” dans Pix Admin avait pour but principal de permettre aux membres du pôle certification d’identifier les sessions à traiter en priorité, ce que permet aujourd’hui la nouvelle liste des “Sessions à traiter”. Il n’est donc plus nécessaire de filtrer par défaut sur les sessions au statut “Finalisée” dans cette liste. La liste de “Toutes les sessions” peut donc récupérer son rôle de liste permettant de visualiser une liste de toutes les sessions, de rechercher une session spécifique etc quelque soit son statut.

## :robot: Solution

Dans la liste de “Toutes les sessions” dans Pix Admin, ne plus filtrer par défaut sur le statut “Finalisée” : le filtre par défaut pour le champ “Statut” doit être “Tous”

## :rainbow: Remarques
*RAS*

## :100: Pour tester

1. Se connecter à Pix Admin
2. Ouvrir la page **Session de certifications**
3. Constater que le filtre de la colonne *Statut* est sur *Tous* par défaut et que toutes les sessions apparaissent