### PR TITLE
[FEATURE][i18n] Ajout de l'internationalisation dans le modèle d'import SUP (PIX-2309).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -139,7 +139,7 @@ module.exports = {
   async importHigherSchoolingRegistrations(request, h) {
     const organizationId = parseInt(request.params.id);
     const buffer = request.payload;
-    const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId);
+    const higherSchoolingRegistrationParser = new HigherSchoolingRegistrationParser(buffer, organizationId, request.i18n);
     await usecases.importHigherSchoolingRegistrations({ organizationId, higherSchoolingRegistrationParser });
     return h.response(null).code(204);
   },
@@ -164,10 +164,10 @@ module.exports = {
     const organizationId = parseInt(request.params.id);
     const token = request.query.accessToken;
     const userId = tokenService.extractUserId(token);
-    const template = await usecases.getSchoolingRegistrationsCsvTemplate({ userId, organizationId });
+    const template = await usecases.getSchoolingRegistrationsCsvTemplate({ userId, organizationId, i18n: request.i18n });
 
     return h.response(template)
       .header('Content-Type', 'text/csv;charset=utf-8')
-      .header('Content-Disposition', 'attachment; filename=modele-import.csv');
+      .header('Content-Disposition', `attachment; filename=${request.i18n.__('higher-schooling-registration-csv.template-name')}.csv`);
   },
 };

--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -1,11 +1,12 @@
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const { UserNotAuthorizedToAccessEntityError } = require('../errors');
-const HigherSchoolingRegistrationParser = require('../../infrastructure/serializers/csv/higher-schooling-registration-parser');
+const HigherSchoolingRegistrationColumns = require('../../infrastructure/serializers/csv/higher-schooling-registration-columns');
 const SchoolingRegistrationParser = require('../../infrastructure/serializers/csv/schooling-registration-parser');
 
 module.exports = async function getSchoolingRegistrationsCsvTemplate({
   userId,
   organizationId,
+  i18n,
   membershipRepository,
 }) {
   let header = [];
@@ -18,7 +19,8 @@ module.exports = async function getSchoolingRegistrationsCsvTemplate({
   const { isSup, isSco, isAgriculture } = membership.organization;
 
   if (isSup) {
-    header = _getCsvColumns(HigherSchoolingRegistrationParser.COLUMNS);
+    header = _getCsvColumns(new HigherSchoolingRegistrationColumns(i18n).columns);
+
   } else if (isSco && isAgriculture) {
     header = _getCsvColumns(SchoolingRegistrationParser.COLUMNS);
   } else {

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-columns.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-columns.js
@@ -1,0 +1,28 @@
+const { CsvColumn } = require('./csv-registration-parser');
+
+class HigherSchoolingRegistrationColumns {
+  constructor(i18n) {
+    this.translate = i18n.__;
+    this.columns = this.setColumns();
+  }
+
+  setColumns() {
+    return [
+      new CsvColumn({ name: 'firstName', label: this.translate('higher-schooling-registration-csv.firstname'), isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'middleName', label: this.translate('higher-schooling-registration-csv.middle-name') }),
+      new CsvColumn({ name: 'thirdName', label: this.translate('higher-schooling-registration-csv.third-name') }),
+      new CsvColumn({ name: 'lastName', label: this.translate('higher-schooling-registration-csv.lastname'), isRequired: true }),
+      new CsvColumn({ name: 'preferredLastName', label: this.translate('higher-schooling-registration-csv.preferred-lastname') }),
+      new CsvColumn({ name: 'birthdate', label: this.translate('higher-schooling-registration-csv.birthdate'), isRequired: true, isDate: true }),
+      new CsvColumn({ name: 'email', label: this.translate('higher-schooling-registration-csv.email') }),
+      new CsvColumn({ name: 'studentNumber', label: this.translate('higher-schooling-registration-csv.student-number'), isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'department', label: this.translate('higher-schooling-registration-csv.department') }),
+      new CsvColumn({ name: 'educationalTeam', label: this.translate('higher-schooling-registration-csv.educational-team') }),
+      new CsvColumn({ name: 'group', label: this.translate('higher-schooling-registration-csv.group') }),
+      new CsvColumn({ name: 'diploma', label: this.translate('higher-schooling-registration-csv.diploma') }),
+      new CsvColumn({ name: 'studyScheme', label: this.translate('higher-schooling-registration-csv.study-scheme') }),
+    ];
+  }
+}
+
+module.exports = HigherSchoolingRegistrationColumns;

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-parser.js
@@ -1,23 +1,8 @@
 const HigherSchoolingRegistrationSet = require('../../../../lib/domain/models/HigherSchoolingRegistrationSet');
 const { CsvImportError } = require('../../../../lib/domain/errors');
 
-const { CsvRegistrationParser, CsvColumn } = require('./csv-registration-parser');
-
-const COLUMNS = [
-  new CsvColumn({ name: 'firstName', label: 'Premier prénom', isRequired: true, checkEncoding: true }),
-  new CsvColumn({ name: 'middleName', label: 'Deuxième prénom' }),
-  new CsvColumn({ name: 'thirdName', label: 'Troisième prénom' }),
-  new CsvColumn({ name: 'lastName', label: 'Nom de famille', isRequired: true }),
-  new CsvColumn({ name: 'preferredLastName', label: 'Nom d\'usage' }),
-  new CsvColumn({ name: 'birthdate', label: 'Date de naissance (jj/mm/aaaa)', isRequired: true, isDate: true }),
-  new CsvColumn({ name: 'email', label: 'Email' }),
-  new CsvColumn({ name: 'studentNumber', label: 'Numéro étudiant', isRequired: true, checkEncoding: true }),
-  new CsvColumn({ name: 'department', label: 'Composante' }),
-  new CsvColumn({ name: 'educationalTeam', label: 'Équipe pédagogique' }),
-  new CsvColumn({ name: 'group', label: 'Groupe' }),
-  new CsvColumn({ name: 'diploma', label: 'Diplôme' }),
-  new CsvColumn({ name: 'studyScheme', label: 'Régime' }),
-];
+const { CsvRegistrationParser } = require('./csv-registration-parser');
+const HigherSchoolingRegistrationColumns = require('./higher-schooling-registration-columns');
 
 const ERRORS = {
   STUDENT_NUMBER_UNIQUE: 'STUDENT_NUMBER_UNIQUE',
@@ -26,9 +11,12 @@ const ERRORS = {
 
 class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
 
-  constructor(input, organizationId) {
+  constructor(input, organizationId, i18n) {
     const registrationSet = new HigherSchoolingRegistrationSet();
-    super(input, organizationId, COLUMNS, registrationSet);
+
+    const columns = new HigherSchoolingRegistrationColumns(i18n).columns;
+
+    super(input, organizationId, columns, registrationSet);
   }
 
   _handleError(err, index) {
@@ -45,7 +33,4 @@ class HigherSchoolingRegistrationParser extends CsvRegistrationParser {
   }
 }
 
-HigherSchoolingRegistrationParser.COLUMNS = COLUMNS;
-
 module.exports = HigherSchoolingRegistrationParser;
-

--- a/api/lib/plugins.js
+++ b/api/lib/plugins.js
@@ -49,6 +49,7 @@ const plugins = [
       directory: __dirname + '/../translations',
       defaultLocale: 'fr',
       queryParameter: 'lang',
+      languageHeaderField: 'Accept-Language',
       objectNotation: true,
       updateFiles: false,
     },

--- a/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-higher-schooling-registration_test.js
@@ -1,11 +1,14 @@
 const { expect, knex, databaseBuilder, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
 const Membership = require('../../../../lib/domain/models/Membership');
+const HigherSchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-columns');
 
+const { getI18n } = require('../../../../tests/tooling/i18n/i18n');
 const createServer = require('../../../../server');
-const { COLUMNS } = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-parser');
-let server;
 
-const higherSchoolingRegistrationColumns = COLUMNS.map((column) => column.label).join(';');
+const i18n = getI18n();
+const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
+
+let server;
 
 describe('Acceptance | Application | organization-controller-import-higher-schooling-registrations', () => {
 

--- a/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
+++ b/api/tests/integration/domain/usecases/import-higher-schooling-registrations_test.js
@@ -4,8 +4,12 @@ const iconv = require('iconv-lite');
 const importHigherSchoolingRegistration = require('../../../../lib/domain/usecases/import-higher-schooling-registrations');
 const higherSchoolingRegistrationRepository = require('../../../../lib/infrastructure/repositories/higher-schooling-registration-repository');
 const HigherSchoolingRegistrationParser = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-parser');
+const HigherSchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-columns');
+const { getI18n } = require('../../../../tests/tooling/i18n/i18n');
 
-const higherSchoolingRegistrationColumns = HigherSchoolingRegistrationParser.COLUMNS.map((column) => column.label).join(';');
+const i18n = getI18n();
+
+const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
 
 describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
 
@@ -27,7 +31,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
       await importHigherSchoolingRegistration({
         organizationId: organization.id,
         higherSchoolingRegistrationRepository,
-        higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+        higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
       });
 
       const registrations = await knex('schooling-registrations').where({ organizationId: organization.id });
@@ -59,7 +63,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
@@ -96,7 +100,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
@@ -127,7 +131,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
@@ -164,7 +168,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
@@ -201,7 +205,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
@@ -233,7 +237,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const [registration] = await knex('schooling-registrations').where({ organizationId: organization.id });
@@ -277,7 +281,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
@@ -322,7 +326,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
           await importHigherSchoolingRegistration({
             organizationId: organization.id,
             higherSchoolingRegistrationRepository,
-            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+            higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
           });
 
           const registrations = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');
@@ -369,7 +373,7 @@ describe('Integration | UseCase | ImportHigherSchoolingRegistration', () => {
         await importHigherSchoolingRegistration({
           organizationId: organization.id,
           higherSchoolingRegistrationRepository,
-          higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id),
+          higherSchoolingRegistrationParser: new HigherSchoolingRegistrationParser(encodedInput, organization.id, i18n),
         });
 
         const [registration1, registration2] = await knex('schooling-registrations').where({ organizationId: organization.id }).orderBy('createdAt');

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -16,10 +16,12 @@ const targetProfileSerializer = require('../../../../lib/infrastructure/serializ
 const userWithSchoolingRegistrationSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/user-with-schooling-registration-serializer');
 const certificationResultUtils = require('../../../../lib/infrastructure/utils/csv/certification-results');
 const queryParamsUtils = require('../../../../lib/infrastructure/utils/query-params-utils');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Unit | Application | Organizations | organization-controller', () => {
 
   let request;
+  const i18n = getI18n();
 
   describe('#getOrganizationDetails', () => {
 
@@ -656,6 +658,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
 
     it('should return a response with correct headers', async () => {
       // when
+      request.i18n = i18n;
       const response = await organizationController.getSchoolingRegistrationsCsvTemplate(request, hFake);
 
       // then

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -2,12 +2,14 @@ const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper
 const getSchoolingRegistrationsCsvTemplate = require('../../../../lib/domain/usecases/get-schooling-registrations-csv-template');
 const _ = require('lodash');
 const { UserNotAuthorizedToAccessEntityError } = require('../../../../lib/domain/errors');
+const { getI18n } = require('../../../tooling/i18n/i18n');
 
 describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
 
   const userId = Symbol('userId');
   const organizationId = Symbol('organizationId');
   const membershipRepository = { findByUserIdAndOrganizationId: _.noop };
+  const i18n = getI18n();
 
   context('When user is ADMIN in a SUP organization managing students', () => {
     it('should return headers line', async () => {
@@ -17,7 +19,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
 
       // when
-      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository });
+      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository, i18n });
 
       // then
       const csvExpected = '\uFEFF"Premier prénom";' +
@@ -148,4 +150,3 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
   });
 
 });
-

--- a/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/higher-schooling-registration-parser_test.js
@@ -1,9 +1,12 @@
 const iconv = require('iconv-lite');
 const { expect, catchErr } = require('../../../../test-helper');
 const HigherSchoolingRegistrationParser = require('../../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-parser');
+const HigherSchoolingRegistrationColumns = require('../../../../../lib/infrastructure/serializers/csv/higher-schooling-registration-columns');
 const _ = require('lodash');
+const { getI18n } = require('../../../../../tests/tooling/i18n/i18n');
+const i18n = getI18n();
 
-const higherSchoolingRegistrationColumns = HigherSchoolingRegistrationParser.COLUMNS.map((column) => column.label).join(';');
+const higherSchoolingRegistrationColumns = new HigherSchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
 
 describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
   context('when the header is correctly formed', () => {
@@ -11,7 +14,7 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
       it('returns an empty HigherSchoolingRegistrationSet', () => {
         const input = higherSchoolingRegistrationColumns;
         const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new HigherSchoolingRegistrationParser(encodedInput, 123);
+        const parser = new HigherSchoolingRegistrationParser(encodedInput, 123, i18n);
 
         const higherSchoolingRegistrationSet = parser.parse();
 
@@ -25,7 +28,7 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
         O-Ren;;;Ishii;Cottonmouth;01/01/1980;ishii@example.net;789;Assassination Squad;Bill;Deadly Viper Assassination Squad;DUT;;
         `;
         const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new HigherSchoolingRegistrationParser(encodedInput, 456);
+        const parser = new HigherSchoolingRegistrationParser(encodedInput, 456, i18n);
 
         const higherSchoolingRegistrationSet = parser.parse();
         const registrations = higherSchoolingRegistrationSet.registrations;
@@ -39,7 +42,7 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
         `;
         const organizationId = 789;
         const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
+        const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
         const higherSchoolingRegistrationSet = parser.parse();
         const registrations = _.sortBy(higherSchoolingRegistrationSet.registrations, 'preferredLastName');
@@ -89,7 +92,7 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
       Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
       Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
       const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
+      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
       const error = await catchErr(parser.parse, parser)();
 
@@ -102,7 +105,7 @@ describe('Unit | Infrastructure | HigherSchoolingRegistrationParser', () => {
       Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1970;thebride@example.net;123@;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;
       Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1971;thebride@example.net;1234;Assassination Squad;Hattori Hanzo;Deadly Viper Assassination Squad;Master;hello darkness my old friend;`;
       const encodedInput = iconv.encode(input, 'utf8');
-      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId);
+      const parser = new HigherSchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
       const error = await catchErr(parser.parse, parser)();
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -1,5 +1,4 @@
 {
-  "current-lang": "en",
   "campaign-export": {
     "assessment": {
       "competence-area": {
@@ -11,19 +10,19 @@
       "mastery-percentage-target-profile": "% of items successfully completed in the target profile",
       "progress": "% of progression",
       "shared-on": "Shared on",
-      "started-on": "Started on",
-      "target-profile-name": "Target profile’s name",
-      "status": {
-        "ko": "KO",
-        "not-tested": "Not tested",
-        "ok": "OK"
-      },
       "skill": {
         "items-successfully-completed": "Items of the target profile successfully completed in the skill {{name}}",
         "mastery-percentage": "% of items successfully completed in the skill {{name}}",
         "total-items": "Number of items of the target profile in the skill {{name}}"
       },
+      "started-on": "Started on",
+      "status": {
+        "ko": "KO",
+        "not-tested": "Not tested",
+        "ok": "OK"
+      },
       "success-rate": "Success rate (/{{value}})",
+      "target-profile-name": "Target profile’s name",
       "thematic-result-name": "{{name}} (Y/N)"
     },
     "common": {
@@ -49,65 +48,82 @@
       "skill-ranking": "Pix score for the skill {{name}}"
     }
   },
-  "organization-invitation-email": {
-    "subject": "Invitation to join Pix Orga",
-    "params": {
-      "title": "You are invited to join Pix Orga",
-      "subtitle": "With the Pix Orga platform, create and manage testing campaigns and monitor the progress of your participants.",
-      "yourOrganization": "Your organization",
-      "acceptInvitation": "Accept the invitation",
-      "oneTimeLink": "This is a single-use link",
+  "current-lang": "en",
+  "email-change-email": {
+    "body": {
+      "context": "You’ve recently changed your email address.",
+      "doNotAnswer": "This is an automated email message, please do not reply.",
+      "greeting": "Hi,",
+      "loginEmail": "You can now log in using the following email address:",
+      "moreOn": "More on",
+      "noPasswordChanged": "Your password remains the same.",
       "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills.",
-      "moreAbout": "More on",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "needHelp": "Have questions? We’re here to help, contact us",
-      "here": "here"
-    }
-  },
-  "pix-account-creation-email": {
-    "subject": "Your Pix account has been created",
-    "params" : {
-      "title": "Your Pix account has been created !",
-      "subtitle": "You can now start testing your skills.",
-      "goToPix": "Get started",
-      "disclaimer": "If you did not create this account, you can ask its deletion",
-      "helpdeskLinkLabel": "here",
-      "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
-      "moreOn": "More on",
-      "doNotAnswer": "This is an automated email message, please do not reply.",
-      "askForHelp": "Any questions? We’re here to help, contact us"
-    }
-  },
-  "reset-password-demand-email": {
-    "subject": "Pix password reset request",
-    "params": {
-      "title": "Reset your password",
-      "weCannotSendYourPassword": "Hello, for security reasons, we cannot send your password by email.",
-      "clickOnTheButton": "Click on the button below to choose a new password.",
-      "resetMyPassword": "Reset my password",
-      "linkValidFor": "This link is valid for 24 hours. If you did not request to change your password, please ignore this email.",
-      "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
-      "moreOn": "More on",
-      "doNotAnswer": "This is an automated email message, please do not reply. Have questions? We're here to help, ",
-      "contactUs": "contact us here"
-    }
+      "signing": "— The Pix Team"
+    },
+    "subject": "Email change confirmation"
   },
   "entity-validation-errors": {
-    "STAGE_TITLE_IS_REQUIRED": "The stage title is required",
     "STAGE_THRESHOLD_IS_REQUIRED": "The stage threshold is required",
+    "STAGE_TITLE_IS_REQUIRED": "The stage title is required",
     "TARGET_PROFILE_IS_REQUIRED": "The target profile is required"
   },
-  "email-change-email": {
-    "subject": "Email change confirmation",
-    "body": {
-      "greeting": "Hi,",
-      "context": "You’ve recently changed your email address.",
-      "loginEmail": "You can now log in using the following email address:",
-      "noPasswordChanged": "Your password remains the same.",
-      "signing": "— The Pix Team",
+  "higher-schooling-registration-csv": {
+    "birthdate": "Date of birth (DD/MM/YYYY)",
+    "department": "Department",
+    "diploma": "Degree",
+    "educational-team": "Teaching staff",
+    "email": "Email address",
+    "firstname": "First Name",
+    "group": "Group",
+    "lastname": "Last name",
+    "middle-name": "Middle name #1",
+    "preferred-lastname": "Preferred name",
+    "student-number": "Student number",
+    "study-scheme": "Status",
+    "template-name": "import-template",
+    "third-name": "Middle name #2"
+  },
+  "organization-invitation-email": {
+    "params": {
+      "acceptInvitation": "Accept the invitation",
+      "doNotAnswer": "This is an automated email message, please do not reply.",
+      "here": "here",
+      "moreAbout": "More on",
+      "needHelp": "Have questions? We’re here to help, contact us",
+      "oneTimeLink": "This is a single-use link",
       "pixPresentation": "Pix is the online service to assess, develop and certify your digital skills.",
+      "subtitle": "With the Pix Orga platform, create and manage testing campaigns and monitor the progress of your participants.",
+      "title": "You are invited to join Pix Orga",
+      "yourOrganization": "Your organization"
+    },
+    "subject": "Invitation to join Pix Orga"
+  },
+  "pix-account-creation-email": {
+    "params": {
+      "askForHelp": "Any questions? We’re here to help, contact us",
+      "disclaimer": "If you did not create this account, you can ask its deletion",
+      "doNotAnswer": "This is an automated email message, please do not reply.",
+      "goToPix": "Get started",
+      "helpdeskLinkLabel": "here",
       "moreOn": "More on",
-      "doNotAnswer": "This is an automated email message, please do not reply."
-    }
+      "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
+      "subtitle": "You can now start testing your skills.",
+      "title": "Your Pix account has been created !"
+    },
+    "subject": "Your Pix account has been created"
+  },
+  "reset-password-demand-email": {
+    "params": {
+      "clickOnTheButton": "Click on the button below to choose a new password.",
+      "contactUs": "contact us here",
+      "doNotAnswer": "This is an automated email message, please do not reply. Have questions? We're here to help, ",
+      "linkValidFor": "This link is valid for 24 hours. If you did not request to change your password, please ignore this email.",
+      "moreOn": "More on",
+      "pixPresentation": "Pix is the online public service to assess, develop and certify your digital skills.",
+      "resetMyPassword": "Reset my password",
+      "title": "Reset your password",
+      "weCannotSendYourPassword": "Hello, for security reasons, we cannot send your password by email."
+    },
+    "subject": "Pix password reset request"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,4 +1,28 @@
 {
+  "campaign": {
+    "common": {
+      "no": "Non",
+      "not-available": "NA",
+      "yes": "Oui"
+    },
+    "profiles-collection": {
+      "campaign-id": "ID Campagne",
+      "campaign-name": "Nom de la campagne",
+      "certifiable-skills": "Nombre de compétences certifiables",
+      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
+      "is-certifiable": "Certifiable (O/N)",
+      "is-sent": "Envoi (O/N)",
+      "organization-name": "Nom de l'organisation",
+      "participant-division": "Classe",
+      "participant-firstname": "Prénom du Participant",
+      "participant-lastname": "Nom du Participant",
+      "participant-student-number": "Numéro Étudiant",
+      "pix-score": "Nombre de pix total",
+      "sent-on": "Date de l'envoi",
+      "skill-level": "Niveau pour la compétence {{name}}",
+      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
+    }
+  },
   "campaign-export": {
     "assessment": {
       "competence-area": {
@@ -10,19 +34,19 @@
       "mastery-percentage-target-profile": "% maitrise de l'ensemble des acquis du profil",
       "progress": "% de progression",
       "shared-on": "Date du partage",
-      "started-on": "Date de début",
-      "target-profile-name": "Nom du Profil Cible",
-      "status": {
-        "ko": "KO",
-        "not-tested": "Non testé",
-        "ok": "OK"
-      },
       "skill": {
         "items-successfully-completed": "Acquis maitrisés dans la compétence {{name}}",
         "mastery-percentage": "% de maitrise des acquis de la compétence {{name}}",
         "total-items": "Nombre d'acquis du profil cible dans la compétence {{name}}"
       },
+      "started-on": "Date de début",
+      "status": {
+        "ko": "KO",
+        "not-tested": "Non testé",
+        "ok": "OK"
+      },
       "success-rate": "Palier obtenu (/{{value}})",
+      "target-profile-name": "Nom du Profil Cible",
       "thematic-result-name": "{{name}} obtenu (O/N)"
     },
     "common": {
@@ -49,89 +73,81 @@
     }
   },
   "current-lang": "fr",
-  "campaign": {
-    "common": {
-      "yes": "Oui",
-      "no": "Non",
-      "not-available": "NA"
+  "email-change-email": {
+    "body": {
+      "context": "Vous avez récemment modifié votre adresse email.",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre",
+      "greeting": "Bonjour,",
+      "loginEmail": "Vous pouvez maintenant vous connecter avec l’adresse suivante :",
+      "moreOn": "En savoir plus sur",
+      "noPasswordChanged": "Votre mot de passe reste inchangé.",
+      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "signing": "— L'équipe Pix"
     },
-    "profiles-collection": {
-      "campaign-id": "ID Campagne",
-      "campaign-name": "Nom de la campagne",
-      "certifiable-skills": "Nombre de compétences certifiables",
-      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable": "Certifiable (O/N)",
-      "is-sent": "Envoi (O/N)",
-      "organization-name": "Nom de l'organisation",
-      "participant-division": "Classe",
-      "participant-firstname": "Prénom du Participant",
-      "participant-lastname": "Nom du Participant",
-      "participant-student-number": "Numéro Étudiant",
-      "pix-score": "Nombre de pix total",
-      "sent-on": "Date de l'envoi",
-      "skill-level": "Niveau pour la compétence {{name}}",
-      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
-    }
-  },
-  "organization-invitation-email": {
-    "subject": "Invitation à rejoindre Pix Orga",
-    "params": {
-      "title": "Vous êtes invité(e) à rejoindre Pix Orga",
-      "subtitle": "La plateforme Pix Orga vous permet de créer, gérer des campagnes de test et suivre la progression de vos participants.",
-      "yourOrganization": "Votre organisation",
-      "acceptInvitation": "Accepter l’invitation",
-      "oneTimeLink": "Ce lien est à usage unique",
-      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
-      "moreAbout": "En savoir plus sur",
-      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
-      "needHelp": "Besoin d’aide, contactez-nous",
-      "here": "ici"
-    }
-  },
-  "pix-account-creation-email": {
-    "subject": "Votre compte Pix a bien été créé",
-    "params": {
-      "title": "Votre compte Pix a bien été créé !",
-      "subtitle": "Vous pouvez désormais commencer les tests.",
-      "goToPix": "Commencer les tests",
-      "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
-      "helpdeskLinkLabel": "ici",
-      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
-      "moreOn": "En savoir plus sur",
-      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
-      "askForHelp": "Besoin d’aide, contactez-nous"
-    }
-  },
-  "reset-password-demand-email": {
-    "subject": "Demande de réinitialisation de mot de passe Pix",
-    "params": {
-      "title": "Réinitialisation de votre mot de passe",
-      "weCannotSendYourPassword": "Bonjour, pour des raisons de sécurité, nous ne vous envoyons pas votre mot de passe par e-mail.",
-      "clickOnTheButton": "Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.",
-      "resetMyPassword": "Définir un nouveau mot de passe",
-      "linkValidFor": "Ce lien est valide 24 heures. Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer cet e-mail.",
-      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
-      "moreOn": "En savoir plus sur",
-      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre. Besoin d’aide, ",
-      "contactUs": "contactez-nous ici"
-    }
+    "subject": "Vous avez changé votre adresse e-mail"
   },
   "entity-validation-errors": {
-    "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
     "STAGE_THRESHOLD_IS_REQUIRED": "Le seuil du palier est obligatoire",
+    "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
     "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire"
   },
-  "email-change-email": {
-    "subject": "Vous avez changé votre adresse e-mail",
-    "body": {
-      "greeting": "Bonjour,",
-      "context": "Vous avez récemment modifié votre adresse email.",
-      "loginEmail": "Vous pouvez maintenant vous connecter avec l’adresse suivante :",
-      "noPasswordChanged": "Votre mot de passe reste inchangé.",
-      "signing": "— L'équipe Pix",
+  "higher-schooling-registration-csv": {
+    "birthdate": "Date de naissance (jj/mm/aaaa)",
+    "department": "Composante",
+    "diploma": "Diplôme",
+    "educational-team": "Équipe pédagogique",
+    "email": "Email",
+    "firstname": "Premier prénom",
+    "group": "Groupe",
+    "lastname": "Nom de famille",
+    "middle-name": "Deuxième prénom",
+    "preferred-lastname": "Nom d'usage",
+    "student-number": "Numéro étudiant",
+    "study-scheme": "Régime",
+    "template-name": "modele-import",
+    "third-name": "Troisième prénom"
+  },
+  "organization-invitation-email": {
+    "params": {
+      "acceptInvitation": "Accepter l’invitation",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
+      "here": "ici",
+      "moreAbout": "En savoir plus sur",
+      "needHelp": "Besoin d’aide, contactez-nous",
+      "oneTimeLink": "Ce lien est à usage unique",
       "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "subtitle": "La plateforme Pix Orga vous permet de créer, gérer des campagnes de test et suivre la progression de vos participants.",
+      "title": "Vous êtes invité(e) à rejoindre Pix Orga",
+      "yourOrganization": "Votre organisation"
+    },
+    "subject": "Invitation à rejoindre Pix Orga"
+  },
+  "pix-account-creation-email": {
+    "params": {
+      "askForHelp": "Besoin d’aide, contactez-nous",
+      "disclaimer": "Si vous n'êtes pas à l’origine de cette création de compte, vous pouvez en demander la suppression",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre.",
+      "goToPix": "Commencer les tests",
+      "helpdeskLinkLabel": "ici",
       "moreOn": "En savoir plus sur",
-      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre"
-    }
+      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "subtitle": "Vous pouvez désormais commencer les tests.",
+      "title": "Votre compte Pix a bien été créé !"
+    },
+    "subject": "Votre compte Pix a bien été créé"
+  },
+  "reset-password-demand-email": {
+    "params": {
+      "clickOnTheButton": "Cliquez sur le bouton ci-dessous pour choisir un nouveau mot de passe.",
+      "contactUs": "contactez-nous ici",
+      "doNotAnswer": "Ceci est un e-mail automatique, merci de ne pas y répondre. Besoin d’aide, ",
+      "linkValidFor": "Ce lien est valide 24 heures. Si vous n'êtes pas à l'origine de cette demande, merci d'ignorer cet e-mail.",
+      "moreOn": "En savoir plus sur",
+      "pixPresentation": "Pix est le service public en ligne pour évaluer, développer et certifier ses compétences numériques.",
+      "resetMyPassword": "Définir un nouveau mot de passe",
+      "title": "Réinitialisation de votre mot de passe",
+      "weCannotSendYourPassword": "Bonjour, pour des raisons de sécurité, nous ne vous envoyons pas votre mot de passe par e-mail."
+    },
+    "subject": "Demande de réinitialisation de mot de passe Pix"
   }
 }

--- a/orga/app/components/routes/authenticated/sup-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sup-students/list-items.js
@@ -12,7 +12,7 @@ export default class ListItems extends Component {
   @tracked isShowingEditStudentNumberModal = false;
 
   get urlToDownloadCsvTemplate() {
-    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
+    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}&lang=${this.currentUser.prescriber.lang}`;
   }
 
   @action

--- a/orga/app/controllers/authenticated/sup-students/list.js
+++ b/orga/app/controllers/authenticated/sup-students/list.js
@@ -45,6 +45,7 @@ export default class ListController extends Controller {
       await file.uploadBinary(`${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-csv`, {
         headers: {
           Authorization: `Bearer ${access_token}`,
+          'Accept-Language': this.currentUser.prescriber.lang,
         },
       });
 

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
@@ -26,6 +26,9 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
         isAdminInOrganization = true;
+        prescriber = {
+          lang: 'fr',
+        }
       }
       this.owner.register('service:current-user', CurrentUserStub);
     });

--- a/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
   setupTest(hooks);
-  const currentUser = { organization: { id: 1 } };
+  const currentUser = { organization: { id: 1 }, prescriber: { lang: 'fr' } };
   const session = { data: { authenticated: { access_token: 12345 } } };
   let controller;
 
@@ -19,7 +19,7 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
   module('#importStudents', function() {
     test('it sends the chosen file to the API', async function(assert) {
       const importStudentsURL = `${ENV.APP.API_HOST}/api/organizations/${currentUser.organization.id}/schooling-registrations/import-csv`;
-      const headers = { Authorization: `Bearer ${12345}` };
+      const headers = { Authorization: `Bearer ${12345}`, 'Accept-Language': controller.currentUser.prescriber.lang };
       const file = { uploadBinary: sinon.spy() };
 
       controller.session = session;


### PR DESCRIPTION
## :unicorn: Problème
le ficher csv d'import modèle pour l'import des étudiants sur Pix Orga n'est pas internationalisé  

## :robot: Solution
Traduire les columns du fichier csv import modèle en fonction de current language envoyer dans le request. 
- Un module i18n est ajouté dans le request url , puis passé à la où il y a les colonnes de csv à traduire.
- il n'était pas possible de fair passer le module i18n du controller jusqu'au fichier où se trouvaient les colonnes du modèle d'import, donc un nouveau fichier appeler `higher-schooling-registration-columns.js` a été créé pour faire le lien. 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Allez sur pixOrga, étudiante . cliquez sur télécharger le modèle . en fonction du paramètre lang de l'url. les colonnes s'afficheront dans la langue sélectionnée.