### PR TITLE
[FEATURE] Modifier l'ordre des onglets sur la page "Sessions de certifications" (PIX-2302)

### DIFF
--- a/admin/app/components/menu-bar.hbs
+++ b/admin/app/components/menu-bar.hbs
@@ -24,7 +24,7 @@
     </li>
     <li class="menu-bar__entry">
       <PixTooltip @text='Sessions de certifications' @position='right' @inline={{true}}>
-        <LinkTo @route="authenticated.sessions.list" class="menu-bar__link menu-bar__link--sessions">
+        <LinkTo @route="authenticated.sessions.list.to-be-published" class="menu-bar__link menu-bar__link--sessions">
           <FaIcon @icon="chalkboard-teacher"></FaIcon>
         </LinkTo>
       </PixTooltip>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,14 +1,14 @@
 <header class="session-list">
   <h1 class="page-header page-title session-list__title">Sessions de certifications</h1>
   <nav class="navbar session-list__navbar">
-    <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
-        Toutes les sessions
-    </LinkTo>
     <LinkTo @route="authenticated.sessions.list.to-be-published" class="navbar-item">
-        Sessions à publier
+      Sessions à publier
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
       Sessions à traiter
+    </LinkTo>
+    <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
+      Toutes les sessions
     </LinkTo>
   </nav>
 </header>

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -1,5 +1,5 @@
 <header class="session-list">
-  <h1 class="page-header page-title session-list__title">Toutes les sessions</h1>
+  <h1 class="page-header page-title session-list__title">Sessions de certifications</h1>
   <nav class="navbar session-list__navbar">
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
         Toutes les sessions


### PR DESCRIPTION
## :unicorn: Problème

Il y a une certaine logique dans le traitement des sessions de certification : le pôle certification commence par publier les sessions sans problème, puis se penche sur les sessions à problème. La liste de toutes les sessions permet quant à elle au pôle certification de rechercher et donc visualiser une session spécifique, par exemple suite à une demande du support. Cette logique ne se répercute pas aujourd’hui dans l’ordre des onglets de la page “Sessions de certifications” dans Pix Admin.

## :robot: Solution

- Sur la page “Sessions de certification” dans Pix Admin, afficher les onglets dans l’ordre suivant : "Sessions à publier", "Sessions à traiter", "Toutes les sessions"
- Ouvrir par défaut l'onglet "Sessions à publier" quand on ouvre la page "Sessions de certification"

## :rainbow: Remarques

Le titre de la page (au-dessus des trois onglets) était encore "Toutes les sessions", il a été renommé "Sessions de certifications".

## :100: Pour tester

1. Se connecter à Pix Admin
2. Ouvrir la page **Session de certifications**
3. Constater que l'onglet **Session à publier** s'ouvre par défaut et que le nouvel ordre des onglets
