### PR TITLE
[FEATURE] PixScore = 0 pour certificats Livret-scolaire non validés (PIX-2362)

### DIFF
--- a/api/lib/domain/read-models/livret-scolaire/Certificate.js
+++ b/api/lib/domain/read-models/livret-scolaire/Certificate.js
@@ -1,3 +1,6 @@
+const { VALIDATED, PENDING } = require('./CertificateStatus');
+const sortBy = require('lodash/sortBy');
+
 class Certificate {
 
   constructor({
@@ -31,6 +34,59 @@ class Certificate {
     this.certificationCenter = certificationCenter;
     this.verificationCode = verificationCode;
   }
+
+  static from({
+    id,
+    firstName,
+    middleName,
+    thirdName,
+    lastName,
+    birthdate,
+    nationalStudentId,
+    isPublished,
+    status,
+    pixScore,
+    verificationCode,
+    date,
+    deliveredAt,
+    certificationCenter,
+    competenceResultsJson,
+  } = {}) {
+    const isValidated = _isValidated(status);
+    const updatedStatus = (isPublished) ? status : PENDING;
+    const updatedScore = isValidated ? pixScore : 0;
+    const competenceResults = _getExtractValidatedCompetenceResults(isValidated, competenceResultsJson);
+
+    return new Certificate({ id,
+      firstName,
+      middleName,
+      thirdName,
+      lastName,
+      birthdate,
+      nationalStudentId,
+      isPublished,
+      status: updatedStatus,
+      pixScore: updatedScore,
+      verificationCode,
+      date,
+      deliveredAt,
+      certificationCenter,
+      competenceResults,
+    });
+  }
 }
 
 module.exports = Certificate;
+
+function _isValidated(status) {
+  return status === VALIDATED;
+}
+
+function _getExtractValidatedCompetenceResults(isValidated, competenceResultsJson) {
+  if (isValidated) {
+    const competenceResults = JSON.parse(competenceResultsJson);
+    return sortBy(competenceResults, 'competenceId');
+  }
+  return [];
+}
+

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -40,7 +40,9 @@ module.exports = {
     return result.map((certificate) => {
       const competenceResults = sortBy(_extractValidatedCompetenceResults(certificate), 'competenceId');
       return new Certificate({
-        ...certificate, competenceResults,
+        ...certificate,
+        competenceResults,
+        pixScore: _getPixScoreFromStatus(certificate),
       });
     });
 
@@ -55,6 +57,14 @@ function _filterMostRecentAssessments(queryBuilder) {
     });
 }
 
-function _extractValidatedCompetenceResults(certificate) {
-  return certificate.status === VALIDATED ? JSON.parse(certificate.competenceResults) : [];
+function _extractValidatedCompetenceResults({ status, competenceResults }) {
+  return _isValidated(status) ? JSON.parse(competenceResults) : [];
+}
+
+function _getPixScoreFromStatus({ status, pixScore }) {
+  return _isValidated(status) ? pixScore : 0;
+}
+
+function _isValidated(status) {
+  return status === VALIDATED;
 }

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -1,7 +1,5 @@
 const Certificate = require('../../domain/read-models/livret-scolaire/Certificate');
-const { PENDING, VALIDATED } = require('../../domain/read-models/livret-scolaire/CertificateStatus');
 const { knex } = require('../bookshelf');
-const sortBy = require('lodash/sortBy');
 
 module.exports = {
 
@@ -19,11 +17,11 @@ module.exports = {
         verificationCode: 'certification-courses.verificationCode',
         deliveredAt: 'sessions.publishedAt',
         certificationCenter: 'sessions.certificationCenter',
-        // eslint-disable-next-line no-restricted-syntax
-        status: knex.raw('CASE WHEN "isPublished" THEN "assessment-results".status ELSE ? END', PENDING),
+        isPublished: 'certification-courses.isPublished',
+        status: 'assessment-results.status',
         pixScore: 'assessment-results.pixScore',
       })
-      .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResults"'))
+      .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResultsJson"'))
       .from('certification-courses')
       .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
       .innerJoin('organizations', 'schooling-registrations.organizationId', 'organizations.id')
@@ -37,14 +35,7 @@ module.exports = {
       .orderBy('lastName', 'ASC')
       .orderBy('firstName', 'ASC');
 
-    return result.map((certificate) => {
-      const competenceResults = sortBy(_extractValidatedCompetenceResults(certificate), 'competenceId');
-      return new Certificate({
-        ...certificate,
-        competenceResults,
-        pixScore: _getPixScoreFromStatus(certificate),
-      });
-    });
+    return result.map(Certificate.from);
 
   },
 };
@@ -55,16 +46,4 @@ function _filterMostRecentAssessments(queryBuilder) {
       this.on('last-assessment-results.assessmentId', 'assessments.id')
         .andOn('assessment-results.createdAt', '<', knex.ref('last-assessment-results.createdAt'));
     });
-}
-
-function _extractValidatedCompetenceResults({ status, competenceResults }) {
-  return _isValidated(status) ? JSON.parse(competenceResults) : [];
-}
-
-function _getPixScoreFromStatus({ status, pixScore }) {
-  return _isValidated(status) ? pixScore : 0;
-}
-
-function _isValidated(status) {
-  return status === VALIDATED;
 }

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -62,6 +62,7 @@ describe('Integration | Repository | Certification-ls ', () => {
 
       const [certificationResult] = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
       expect(certificationResult.status).to.equal(status.REJECTED);
+      expect(certificationResult.pixScore).to.equal(0);
       expect(certificationResult.competenceResults).to.be.empty;
     });
 
@@ -73,6 +74,7 @@ describe('Integration | Repository | Certification-ls ', () => {
 
       const [certificationResult] = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
       expect(certificationResult.status).to.equal(status.PENDING);
+      expect(certificationResult.pixScore).to.equal(0);
       expect(certificationResult.competenceResults).to.be.empty;
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Le score est renvoyé tel quel pour les certificats livrets scolaire. Cela n'a pas de sens si le certificat n'est pas validé

## :robot: Solution
Mettre le score à 0 pour un certificat _PENDING_ ou _REJECTED_

## :100: Pour tester
Exporter une organisation avec 3 certification course (PENDING/REJECTED/VALIDATED).
Seul le VALIDATED devrait avoir une pixScore > 0
