### PR TITLE
[FEATURE] Ajout du Markdown dans le champ réponses des QCM (PIX-2290).

### DIFF
--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -8,6 +8,7 @@
 }
 
 input.qcm-panel__proposal-checkbox {
+  display: inline-block;
   margin-right: 10px;
 }
 
@@ -17,10 +18,16 @@ input.qcm-panel__proposal-checkbox {
 }
 
 .qcm-proposal-label__oracle[data-goodness='good'] {
+  display: inline-block;
   color: $green;
   font-weight: $font-heavy;
 }
 
 .qcm-proposal-label__oracle[data-goodness='bad'][data-checked='yes'] {
+  display: inline-block;
   text-decoration: line-through;
+}
+
+.qcm-proposal-label__oracle[data-goodness='bad'][data-checked='no'] {
+  display: inline-block;
 }

--- a/mon-pix/app/styles/components/_qcm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qcm-solution-panel.scss
@@ -1,33 +1,39 @@
-.qcm-panel__proposals {
-  margin: 0 0 15px;
-  font-size: 1rem;
-}
-
-.qcm-panel__proposal-item {
-  margin-left: 7px;
-}
-
 input.qcm-panel__proposal-checkbox {
   display: inline-block;
   margin-right: 10px;
 }
 
-.qcm-panel__proposal-label {
-  font-weight: $font-normal;
-  width: 100%;
+.qcm-panel {
+
+  &__proposals {
+    margin: 0 0 15px;
+    font-size: 1rem;
+  }
+
+  &__proposal-item {
+    margin-left: 7px;
+  }
+
+  &__proposal-label {
+    font-weight: $font-normal;
+    width: 100%;
+  }
 }
 
-.qcm-proposal-label__oracle[data-goodness='good'] {
-  display: inline-block;
-  color: $green;
-  font-weight: $font-heavy;
-}
+.qcm-proposal-label {
 
-.qcm-proposal-label__oracle[data-goodness='bad'][data-checked='yes'] {
-  display: inline-block;
-  text-decoration: line-through;
-}
+  &__answer-details[data-goodness='good'] {
+    display: inline-block;
+    color: $green;
+    font-weight: $font-heavy;
+  }
 
-.qcm-proposal-label__oracle[data-goodness='bad'][data-checked='no'] {
-  display: inline-block;
+  &__answer-details[data-goodness='bad'][data-checked='yes'] {
+    display: inline-block;
+    text-decoration: line-through;
+  }
+
+  &__answer-details[data-goodness='bad'][data-checked='no'] {
+    display: inline-block;
+  }
 }

--- a/mon-pix/app/styles/globals/_redesign-inputs.scss
+++ b/mon-pix/app/styles/globals/_redesign-inputs.scss
@@ -178,12 +178,11 @@ input[type=radio]:active::before {
   margin-left: 7px;
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
 }
 
 .proposal-paragraph > input[type=checkbox] {
-  margin-top: 7px;
   flex-shrink: 0;
 }
 

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -12,7 +12,7 @@
 
     <label for="checkbox_{{inc index}}"
             class="label-checkbox-proposal">
-      <span class="proposal-text">{{labeledCheckbox.[0]}}</span>
+      <MarkdownToHtml @class="proposal-text" @markdown={{labeledCheckbox.[0]}} />
     </label>
   </p>
   {{/each}}

--- a/mon-pix/app/templates/components/qcm-proposals.hbs
+++ b/mon-pix/app/templates/components/qcm-proposals.hbs
@@ -1,4 +1,3 @@
-{{!-- template-lint-disable no-action --}}
 <div class="qcm-proposals">
   {{#each this.labeledCheckboxes as |labeledCheckbox index|}}
   <p class="proposal-paragraph">
@@ -7,7 +6,7 @@
            id="checkbox_{{inc index}}"
            @checked={{labeledCheckbox.[1]}}
            name="{{inc index}}"
-           onclick={{action "checkboxClicked" (inc index)}}
+           {{on 'click' (fn this.checkboxClicked (inc index))}}
            disabled={{if @answer true}} />
 
     <label for="checkbox_{{inc index}}"

--- a/mon-pix/app/templates/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcm-solution-panel.hbs
@@ -7,7 +7,7 @@
           <input type="checkbox" class="qcm-panel__proposal-checkbox" checked={{if labeledCheckbox.[1] 'checked' ''}} disabled="disabled">
 
           <MarkdownToHtml
-            @class="qcm-proposal-label__oracle"
+            @class="qcm-proposal-label__answer-details"
             @markdown={{labeledCheckbox.[0]}}
             data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
             data-checked={{if labeledCheckbox.[1] 'yes' 'no'}}

--- a/mon-pix/app/templates/components/qcm-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qcm-solution-panel.hbs
@@ -6,11 +6,12 @@
 
           <input type="checkbox" class="qcm-panel__proposal-checkbox" checked={{if labeledCheckbox.[1] 'checked' ''}} disabled="disabled">
 
-          <span class="qcm-proposal-label__oracle"
-                data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
-                data-checked={{if labeledCheckbox.[1] 'yes' 'no'}}>
-            {{labeledCheckbox.[0]}}
-          </span>
+          <MarkdownToHtml
+            @class="qcm-proposal-label__oracle"
+            @markdown={{labeledCheckbox.[0]}}
+            data-goodness="{{if (get this.solutionArray (concat index)) 'good' 'bad'}}"
+            data-checked={{if labeledCheckbox.[1] 'yes' 'no'}}
+          />
         </label>
       </p>
     {{/each}}

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -49,9 +49,9 @@ export default Factory.extend({
     instruction: 'Un QCM propose plusieurs choix, l\'utilisateur peut en choisir plusieurs',
     attachments: ['http://example_of_url'],
     'illustration-url': 'http://fakeimg.pl/350x200/?text=PictureOfQCM',
-    proposals: '- possibilite 1, et/ou' +
-      '\n - possibilite 2, et/ou' +
-      '\n - possibilite 3, et/ou' +
+    proposals: '- *possibilite* 1, et/ou' +
+      '\n - [possibilite 2](data:test), et/ou' +
+      '\n - ![possibilite 3](/images/pix-logo-blanc.svg), et/ou' +
       '\n - possibilite 4',
   }),
 

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -27,14 +27,16 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcmChallenge.instruction);
 
       expect(findAll('input[type="checkbox"]')).to.have.lengthOf(4);
-      const proposals = findAll('.proposal-text');
-      expect(proposals[0].textContent.trim()).to.equal('possibilite 1, et/ou');
-      expect(proposals[1].textContent.trim()).to.equal('possibilite 2, et/ou');
-      expect(proposals[2].textContent.trim()).to.equal('possibilite 3, et/ou');
-      expect(proposals[3].textContent.trim()).to.equal('possibilite 4');
+
+      const proposalsText = findAll('.proposal-text');
+      expect(proposalsText[0].innerHTML).to.equal('<p><em>possibilite</em> 1, et/ou</p>\n');
+      expect(proposalsText[1].textContent.trim()).to.equal('possibilite 2, et/ou');
+      expect(proposalsText[1].innerHTML).to.equal('<p><a href="data:test" rel="noopener noreferrer" target="_blank">possibilite 2</a>, et/ou</p>\n');
+      expect(proposalsText[2].textContent.trim()).to.equal(', et/ou');
+      expect(proposalsText[2].innerHTML).to.equal('<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3">, et/ou</p>\n');
+      expect(proposalsText[3].textContent.trim()).to.equal('possibilite 4');
 
       expect(find('.alert')).to.not.exist;
-
     });
 
     it('should display the alert box if user validates without checking a checkbox', async () => {

--- a/mon-pix/tests/acceptance/challenge-qcm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qcm-test.js
@@ -141,8 +141,8 @@ describe('Acceptance | Displaying a QCM challenge', () => {
       expect(find('.comparison-window__title-text').textContent.trim()).to.equal('Vous n’avez pas la bonne réponse');
       expect(find('.challenge-statement__instruction').textContent.trim()).to.equal(qcmChallenge.instruction);
 
-      const goodAnswer = findAll('.qcm-proposal-label__oracle')[0];
-      const badAnswerFromUserResult = findAll('.qcm-proposal-label__oracle')[1];
+      const goodAnswer = findAll('.qcm-proposal-label__answer-details')[0];
+      const badAnswerFromUserResult = findAll('.qcm-proposal-label__answer-details')[1];
       expect(goodAnswer.getAttribute('data-goodness')).to.equal('good');
       expect(goodAnswer.getAttribute('data-checked')).to.equal('no');
       expect(badAnswerFromUserResult.getAttribute('data-goodness')).to.equal('bad');

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -55,10 +55,11 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
+        const labels = findAll('.qcm-proposal-label__oracle');
+        expect(labels[1].getAttribute('data-checked')).to.equal('yes');
         expect(findAll('input[type=checkbox]')[1].getAttribute('disabled')).to.equal('disabled');
-        expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-goodness')).to.equal('good');
-        expect(findAll('.qcm-proposal-label__oracle')[1].innerHTML).to.equal(
+        expect(labels[1].getAttribute('data-goodness')).to.equal('good');
+        expect(labels[1].innerHTML).to.equal(
           '<p><a href="data:test" rel="noopener noreferrer" target="_blank">possibilite 2</a></p>\n',
         );
       });
@@ -73,9 +74,11 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
-        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
-        expect(findAll('.qcm-proposal-label__oracle')[0].innerHTML).to.equal('<p><em>possibilite</em> 1</p>\n');
+        const labels = findAll('.qcm-proposal-label__oracle');
+
+        expect(labels[0].getAttribute('data-checked')).to.equal('no');
+        expect(labels[0].getAttribute('data-goodness')).to.equal('bad');
+        expect(labels[0].innerHTML).to.equal('<p><em>possibilite</em> 1</p>\n');
       });
 
       it('should display at least one of the correct answers as not ticked', async function() {
@@ -90,9 +93,11 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('no');
-        expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-goodness')).to.equal('good');
-        expect(findAll('.qcm-proposal-label__oracle')[2].innerHTML).to.equal(
+        const labels = findAll('.qcm-proposal-label__oracle');
+
+        expect(labels[2].getAttribute('data-checked')).to.equal('no');
+        expect(labels[2].getAttribute('data-goodness')).to.equal('good');
+        expect(labels[2].innerHTML).to.equal(
           '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>\n',
         );
       });
@@ -109,8 +114,10 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('yes');
-        expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
+        const labels = findAll('.qcm-proposal-label__oracle');
+
+        expect(labels[0].getAttribute('data-checked')).to.equal('yes');
+        expect(labels[0].getAttribute('data-goodness')).to.equal('bad');
       });
 
       it('should display no clickable input', async function() {

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -21,7 +21,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
       await render(hbs`<QcmSolutionPanel />`);
 
       expect(find('.qcm-solution-panel')).to.exist;
-      expect(findAll('.qcm-proposal-label__oracle')).to.have.lengthOf(0);
+      expect(findAll('.qcm-proposal-label__answer-details')).to.have.lengthOf(0);
     });
 
     describe('checkbox state', function() {
@@ -55,7 +55,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        const labels = findAll('.qcm-proposal-label__oracle');
+        const labels = findAll('.qcm-proposal-label__answer-details');
         expect(labels[1].getAttribute('data-checked')).to.equal('yes');
         expect(findAll('input[type=checkbox]')[1].getAttribute('disabled')).to.equal('disabled');
         expect(labels[1].getAttribute('data-goodness')).to.equal('good');
@@ -74,7 +74,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        const labels = findAll('.qcm-proposal-label__oracle');
+        const labels = findAll('.qcm-proposal-label__answer-details');
 
         expect(labels[0].getAttribute('data-checked')).to.equal('no');
         expect(labels[0].getAttribute('data-goodness')).to.equal('bad');
@@ -93,7 +93,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        const labels = findAll('.qcm-proposal-label__oracle');
+        const labels = findAll('.qcm-proposal-label__answer-details');
 
         expect(labels[2].getAttribute('data-checked')).to.equal('no');
         expect(labels[2].getAttribute('data-goodness')).to.equal('good');
@@ -114,7 +114,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         await render(hbs`<QcmSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}}/>`);
 
         // Then
-        const labels = findAll('.qcm-proposal-label__oracle');
+        const labels = findAll('.qcm-proposal-label__answer-details');
 
         expect(labels[0].getAttribute('data-checked')).to.equal('yes');
         expect(labels[0].getAttribute('data-goodness')).to.equal('bad');

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -45,7 +45,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         answer = EmberObject.create(correctAnswer);
       });
 
-      it('QCM, la réponse correcte est cochée', async function() {
+      it('should display the correct answer as ticked', async function() {
         // Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -63,7 +63,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         );
       });
 
-      it('QCM, une réponse incorrecte n\'est pas cochée', async function() {
+      it('should display an incorrect answer as not ticked', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);
@@ -78,7 +78,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         expect(findAll('.qcm-proposal-label__oracle')[0].innerHTML).to.equal('<p><em>possibilite</em> 1</p>\n');
       });
 
-      it('QCM, Au moins l\'une des réponses correctes n\'est pas cochée', async function() {
+      it('should display at least one of the correct answers as not ticked', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -97,7 +97,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         );
       });
 
-      it('QCM, au moins l\'une des réponses incorrectes est cochée', async function() {
+      it('should display at least one of the incorrect answers as ticked', async function() {
         //Given
         answer = EmberObject.create(unCorrectAnswer);
 
@@ -113,7 +113,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
       });
 
-      it('Aucune case à cocher n\'est cliquable', async function() {
+      it('should display no clickable input', async function() {
         //Given
         this.set('answer', answer);
         this.set('solution', solution);

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -36,7 +36,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
       before(function() {
         challenge = EmberObject.create({
           id: 'challenge_id',
-          proposals: '-foo\n- bar\n- qix\n- yon',
+          proposals: '-*possibilite* 1\n-[possibilite 2](data:test)\n- ![possibilite 3](/images/pix-logo-blanc.svg)\n- yon',
           type: 'QCM',
         });
 
@@ -58,6 +58,9 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-checked')).to.equal('yes');
         expect(findAll('input[type=checkbox]')[1].getAttribute('disabled')).to.equal('disabled');
         expect(findAll('.qcm-proposal-label__oracle')[1].getAttribute('data-goodness')).to.equal('good');
+        expect(findAll('.qcm-proposal-label__oracle')[1].innerHTML).to.equal(
+          '<p><a href="data:test" rel="noopener noreferrer" target="_blank">possibilite 2</a></p>\n',
+        );
       });
 
       it('QCM, une réponse incorrecte n\'est pas cochée', async function() {
@@ -72,6 +75,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-checked')).to.equal('no');
         expect(findAll('.qcm-proposal-label__oracle')[0].getAttribute('data-goodness')).to.equal('bad');
+        expect(findAll('.qcm-proposal-label__oracle')[0].innerHTML).to.equal('<p><em>possibilite</em> 1</p>\n');
       });
 
       it('QCM, Au moins l\'une des réponses correctes n\'est pas cochée', async function() {
@@ -88,6 +92,9 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
         // Then
         expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-checked')).to.equal('no');
         expect(findAll('.qcm-proposal-label__oracle')[2].getAttribute('data-goodness')).to.equal('good');
+        expect(findAll('.qcm-proposal-label__oracle')[2].innerHTML).to.equal(
+          '<p><img src="/images/pix-logo-blanc.svg" alt="possibilite 3"></p>\n',
+        );
       });
 
       it('QCM, au moins l\'une des réponses incorrectes est cochée', async function() {


### PR DESCRIPTION
## :unicorn: Problème

Les épreuves QCM proposent une liste simple de réponses, on ne peut pas y insérer de liens ou images.

## :robot: Solution

Utiliser le component `MarkdownToHtml` pour afficher les propositions des QCM.

## :rainbow: Remarques

La classe CSS `proposal-paragraph` modifiée dans le premier commit afin de centrer l'image horizontalement avec son champ input associé est également utilisée dans les QCU, mais ne semble pas avoir impacté le rendu visuel de ce type de question.

## :100: Pour tester

https://app-pr2717.review.pix.fr/challenges/rec11vu59MIAUGhya/preview
