### PR TITLE
[CERTIF] Changer le contenu du bandeau sur l'ajout de candidats (PIX-2352)

### DIFF
--- a/certif/app/templates/authenticated/sessions/add-student.hbs
+++ b/certif/app/templates/authenticated/sessions/add-student.hbs
@@ -6,10 +6,9 @@
     class="add-student__return-to">Retour à la session</PixReturnTo>
 
   <h1 class="add-student__title">Ajouter des candidats</h1>
-
   <PixMessage @type='info' @withIcon={{true}} class="add-student__info-message">
     Si certain(e)s élèves n’apparaissent pas dans cette liste,
-    merci de ré-importer le fichier SIECLE dans Pix Orga.<br>
+    merci de ré-importer le fichier élèves dans Pix Orga.<br />
     Si malgré tout des élèves ne sont pas visibles, merci de contacter
     <a href="https://support.pix.fr" target="_blank" rel="noopener noreferrer">support.pix.fr</a>.
   </PixMessage>


### PR DESCRIPTION
## :coffee: Contexte 
Sur Pix Certif, après avoir accédé à la liste des candidats dans une session de certification puis avoir ouvert l'ajout de candidats, un bandeau est présent au-dessus de la liste des élèves pour informer les utilisateurs de la nécessité de réimport si certains élèves ne sont pas visibles dans la liste.

## :unicorn: Problème
Le bandeau fait actuellement référence à la base SIECLE, alors que parmi les orga SCO qui gèrent une liste d'élèves, il y a aussi des établissements de l’AGRI qui utilisent un autre outil pour la gestion de leur liste d'élèves.

## :robot: Solution
Modifier le texte dans le bandeau : 

“Si certain(e)s élèves n’apparaissent pas dans cette liste, merci de ré-importer le fichier élèves dans Pix Orga. Si malgré tout des élèves ne sont pas visibles, merci de contacter support.pix.fr.”

## :100: Pour tester
- Lancer Pix Certif en tant qu'encadrant scolaire.
- Choisir une session.
- Aller sur la page d'ajout d'un candidat.
- Constater le changement de texte dans la bannière.
