### PR TITLE
[FEATURE] Afficher le status du CléA dans le fichier des résultats de certification (PIX-2339)

### DIFF
--- a/api/lib/application/sessions/index.js
+++ b/api/lib/application/sessions/index.js
@@ -319,6 +319,10 @@ exports.register = async (server) => {
         }],
         handler: sessionController.generateSessionResultsDownloadLink,
         tags: ['api', 'sessions'],
+        notes: [
+          'Cette route est restreinte aux utilisateurs ayant le rôle PIXMASTER',
+          'Elle permet de générer un lien permettant de télécharger tous les résultats de certification d\'une session',
+        ],
       },
     },
     {
@@ -329,7 +333,8 @@ exports.register = async (server) => {
         handler: sessionController.getSessionResultsByRecipientEmail,
         tags: ['api', 'sessions', 'results'],
         notes: [
-          'Elle retourne les résultats de certifications d\'une session agrégés par email de destinataire des résultats',
+          'Cette route est accessible via un token envoyé par email lors de l\'envoi automatique des résultats de certification',
+          'Elle retourne les résultats de certifications d\'une session agrégés par email de destinataire des résultats, sous format CSV',
         ],
       },
     },
@@ -341,7 +346,8 @@ exports.register = async (server) => {
         handler: sessionController.getSessionResultsToDownload,
         tags: ['api', 'sessions', 'results'],
         notes: [
-          'Elle retourne les résultats de certifications d\'une session agrégés par email de destinataire des résultats',
+          'Cette route est accessible via un token généré par un utilisateur ayant le rôle PIXMASTER',
+          'Elle retourne tous les résultats de certifications d\'une session, sous format CSV',
         ],
       },
     },

--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -148,6 +148,7 @@ module.exports = {
     const token = request.params.token;
     const { sessionId } = tokenService.extractSessionId(token);
     const { session, certificationResults, fileName } = await usecases.getSessionResults({ sessionId });
+
     const csvResult = await certificationResultUtils.getSessionCertificationResultsCsv({ session, certificationResults });
 
     return h.response(csvResult)

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -145,6 +145,12 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
   return { ...rowWithoutCompetences, ...competencesCells };
 };
 
+const cleaStatusLabelsForCSV = {
+  ['not_passed']: 'Non passée',
+  ['validated']: 'Validée',
+  ['rejected']: 'Rejetée',
+}
+
 const _getRowItemsFromSessionAndResultsWithCleaStatus = (session) => (certificationResult) => {
   const rowWithoutCompetences = {
     [_headers.CERTIFICATION_NUMBER]: certificationResult.id,
@@ -153,7 +159,7 @@ const _getRowItemsFromSessionAndResultsWithCleaStatus = (session) => (certificat
     [_headers.BIRTHDATE]: _formatDate(certificationResult.birthdate),
     [_headers.BIRTHPLACE]: certificationResult.birthplace,
     [_headers.EXTERNAL_ID]: certificationResult.externalId,
-    [_headers.CLEA_STATUS]: certificationResult.cleaCertificationStatus,
+    [_headers.CLEA_STATUS]: cleaStatusLabelsForCSV[certificationResult.cleaCertificationStatus],
     [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
     [_headers.SESSION_ID]: session.id,
     [_headers.CERTIFICATION_CENTER]: session.certificationCenter,

--- a/api/lib/infrastructure/utils/csv/certification-results.js
+++ b/api/lib/infrastructure/utils/csv/certification-results.js
@@ -22,6 +22,16 @@ async function getSessionCertificationResultsCsv({
   return getCsvContent({ data, fileHeaders });
 }
 
+async function getSessionCertificationResultsCsvWithCleaStatus({
+  session,
+  certificationResults,
+}) {
+  const data = _buildCertificationResultsFileDataWithCertificationCenterNameAndCleaStatus({ session, certificationResults });
+  const fileHeaders = _buildCertificationResultsFileHeadersWithCertificationCenterNameAndCleaStatus();
+
+  return getCsvContent({ data, fileHeaders });
+}
+
 function _buildCertificationResultsFileDataWithoutCertificationCenterName({ certificationResults }) {
   return certificationResults.map(_getRowItemsFromResults);
 }
@@ -68,6 +78,10 @@ function _buildCertificationResultsFileHeadersWithoutCertificationCenterName() {
   );
 }
 
+function _buildCertificationResultsFileDataWithCertificationCenterNameAndCleaStatus({ session, certificationResults }) {
+  return certificationResults.map(_getRowItemsFromSessionAndResultsWithCleaStatus(session));
+}
+
 function _buildCertificationResultsFileDataWithCertificationCenterName({ session, certificationResults }) {
   return certificationResults.map(_getRowItemsFromSessionAndResults(session));
 }
@@ -81,6 +95,27 @@ function _buildCertificationResultsFileHeadersWithCertificationCenterName() {
       _headers.BIRTHDATE,
       _headers.BIRTHPLACE,
       _headers.EXTERNAL_ID,
+      _headers.PIX_SCORE,
+    ],
+    _competenceIndexes,
+    [
+      _headers.SESSION_ID,
+      _headers.CERTIFICATION_CENTER,
+      _headers.CERTIFICATION_DATE,
+    ],
+  );
+}
+
+function _buildCertificationResultsFileHeadersWithCertificationCenterNameAndCleaStatus() {
+  return _.concat(
+    [
+      _headers.CERTIFICATION_NUMBER,
+      _headers.FIRSTNAME,
+      _headers.LASTNAME,
+      _headers.BIRTHDATE,
+      _headers.BIRTHPLACE,
+      _headers.EXTERNAL_ID,
+      _headers.CLEA_STATUS,
       _headers.PIX_SCORE,
     ],
     _competenceIndexes,
@@ -109,6 +144,25 @@ const _getRowItemsFromSessionAndResults = (session) => (certificationResult) => 
   const competencesCells = _getCompetenceCells(certificationResult);
   return { ...rowWithoutCompetences, ...competencesCells };
 };
+
+const _getRowItemsFromSessionAndResultsWithCleaStatus = (session) => (certificationResult) => {
+  const rowWithoutCompetences = {
+    [_headers.CERTIFICATION_NUMBER]: certificationResult.id,
+    [_headers.FIRSTNAME]: certificationResult.firstName,
+    [_headers.LASTNAME]: certificationResult.lastName,
+    [_headers.BIRTHDATE]: _formatDate(certificationResult.birthdate),
+    [_headers.BIRTHPLACE]: certificationResult.birthplace,
+    [_headers.EXTERNAL_ID]: certificationResult.externalId,
+    [_headers.CLEA_STATUS]: certificationResult.cleaCertificationStatus,
+    [_headers.PIX_SCORE]: _formatPixScore(certificationResult),
+    [_headers.SESSION_ID]: session.id,
+    [_headers.CERTIFICATION_CENTER]: session.certificationCenter,
+    [_headers.CERTIFICATION_DATE]: _formatDate(certificationResult.createdAt),
+  };
+
+  const competencesCells = _getCompetenceCells(certificationResult);
+  return { ...rowWithoutCompetences, ...competencesCells };
+}
 
 function _formatPixScore(certificationResult) {
   return _isCertificationRejected(certificationResult) ? '0' : certificationResult.pixScore;
@@ -179,6 +233,7 @@ const _headers = {
   BIRTHDATE: 'Date de naissance',
   BIRTHPLACE: 'Lieu de naissance',
   EXTERNAL_ID: 'Identifiant Externe',
+  CLEA_STATUS: 'Certification CléA numérique',
   PIX_SCORE: 'Nombre de Pix',
   SESSION_ID: 'Session',
   CERTIFICATION_CENTER: 'Centre de certification',
@@ -187,5 +242,6 @@ const _headers = {
 
 module.exports = {
   getSessionCertificationResultsCsv,
+  getSessionCertificationResultsCsvWithCleaStatus,
   getDivisionCertificationResultsCsv,
 };

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -1,66 +1,67 @@
 const { expect, domainBuilder, databaseBuilder } = require('../../../../test-helper');
-const { getSessionCertificationResultsCsv, getSessionCertificationResultsCsvWithCleaStatus, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
+const { getSessionCertificationResultsCsv, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
 const { statuses: cleaStatuses } = require('../../../../../lib/infrastructure/repositories/clea-certification-status-repository');
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', () => {
 
   describe('#getSessionCertificationResultsCsv', () => {
 
-    it('should return correct csvContent', async () => {
-      // given
-      const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
-      const session = databaseBuilder.factory.buildSession({ certificationCenterId });
+    describe('when no certification has passed clea', () => {
 
-      const birthdate = new Date('1990-01-01');
-      const createdAt = new Date('2020-01-01');
+      it('should return correct csvContent without clea informations', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+        const session = databaseBuilder.factory.buildSession({ certificationCenterId });
 
-      const competencesWithMark1 = [
-        { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
-        { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
-      ];
-      const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+        const birthdate = new Date('1990-01-01');
+        const createdAt = new Date('2020-01-01');
 
-      const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
-        status: 'validated',
-        competenceMarks: competencesWithMark1,
+        const competencesWithMark1 = [
+          { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+          { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+        ];
+        const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+
+        const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark1,
+        });
+        const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+          status: 'rejected',
+          competenceMarks: competencesWithMark2,
+        });
+
+        const certifResult1 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult1,
+          firstName: 'Lili',
+          birthdate,
+          createdAt,
+        });
+        const certifResult2 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult2,
+          firstName: 'Tom',
+          birthdate,
+          createdAt,
+          cleaCertificationStatus: cleaStatuses.NOT_PASSED,
+        });
+
+        const certificationResults = [ certifResult1, certifResult2 ];
+
+        // when
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
+
+        // then
+        const expectedBirthDate = '01/01/1990';
+        const expectedCreatedAt = '01/01/2020';
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+        expect(result).to.deep.equal(expectedResult);
       });
-      const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
-        status: 'rejected',
-        competenceMarks: competencesWithMark2,
-      });
-
-      const certifResult1 = domainBuilder.buildCertificationResult({
-        lastAssessmentResult: lastAssessmentResult1,
-        firstName: 'Lili',
-        birthdate,
-        createdAt,
-      });
-      const certifResult2 = domainBuilder.buildCertificationResult({
-        lastAssessmentResult: lastAssessmentResult2,
-        firstName: 'Tom',
-        birthdate,
-        createdAt,
-      });
-
-      const certificationResults = [ certifResult1, certifResult2 ];
-
-      // when
-      const result = await getSessionCertificationResultsCsv({ session, certificationResults });
-
-      // then
-      const expectedBirthDate = '01/01/1990';
-      const expectedCreatedAt = '01/01/2020';
-      const expectedResult = '\uFEFF' +
-        '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-        `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-        `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
-      expect(result).to.deep.equal(expectedResult);
     });
-  });
 
-  describe('#getSessionCertificationResultsCsvWithCleaStatus', () => {
-
-    describe('when at least one certification has passed CleA certification', () => {
+    describe('when at least one candidate has passed CleA certification', () => {
 
       it('should return correct csvContent with the CleA information', async () => {
         // given
@@ -97,25 +98,25 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
           firstName: 'Tom',
           birthdate,
           createdAt,
-          cleaCertificationStatus: cleaStatuses.REJECTED,
+          cleaCertificationStatus: cleaStatuses.ACQUIRED,
         });
 
         const certificationResults = [ certifResult1, certifResult2 ];
 
         // when
-        const result = await getSessionCertificationResultsCsvWithCleaStatus({ session, certificationResults });
+        const result = await getSessionCertificationResultsCsv({ session, certificationResults });
 
         // then
         const expectedBirthDate = '01/01/1990';
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
-          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+            '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+            `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+            `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"Validée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.deep.equal(expectedResult);
       });
     });
-  })
+  });
 
   describe('#getDivisionCertificationResultsCsv', () => {
 

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -110,8 +110,8 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
         const expectedCreatedAt = '01/01/2020';
         const expectedResult = '\uFEFF' +
           '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
-          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};"not_passed";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
-          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"rejected";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};"Non passée";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"Rejetée";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
         expect(result).to.deep.equal(expectedResult);
       });
     });

--- a/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
+++ b/api/tests/integration/infrastructure/utils/csv/certification-results_test.js
@@ -1,5 +1,6 @@
 const { expect, domainBuilder, databaseBuilder } = require('../../../../test-helper');
-const { getSessionCertificationResultsCsv, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
+const { getSessionCertificationResultsCsv, getSessionCertificationResultsCsvWithCleaStatus, getDivisionCertificationResultsCsv } = require('../../../../../lib/infrastructure/utils/csv/certification-results');
+const { statuses: cleaStatuses } = require('../../../../../lib/infrastructure/repositories/clea-certification-status-repository');
 
 describe('Integration | Infrastructure | Utils | csv | certification-results', () => {
 
@@ -56,6 +57,65 @@ describe('Integration | Infrastructure | Utils | csv | certification-results', (
       expect(result).to.deep.equal(expectedResult);
     });
   });
+
+  describe('#getSessionCertificationResultsCsvWithCleaStatus', () => {
+
+    describe('when at least one certification has passed CleA certification', () => {
+
+      it('should return correct csvContent with the CleA information', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({}).id;
+        const session = databaseBuilder.factory.buildSession({ certificationCenterId });
+
+        const birthdate = new Date('1990-01-01');
+        const createdAt = new Date('2020-01-01');
+
+        const competencesWithMark1 = [
+          { competence_code: '1.1', level: 0 }, { competence_code: '1.2', level: 1 }, { competence_code: '1.3', level: 5 },
+          { competence_code: '5.1', level: 0 }, { competence_code: '5.2', level: -1 },
+        ];
+        const competencesWithMark2 = [ { competence_code: '5.1', level: 3 }, { competence_code: '5.2', level: -1 } ];
+
+        const lastAssessmentResult1 = domainBuilder.buildAssessmentResult({
+          status: 'validated',
+          competenceMarks: competencesWithMark1,
+        });
+        const lastAssessmentResult2 = domainBuilder.buildAssessmentResult({
+          status: 'rejected',
+          competenceMarks: competencesWithMark2,
+        });
+
+        const certifResult1 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult1,
+          firstName: 'Lili',
+          birthdate,
+          createdAt,
+          cleaCertificationStatus: cleaStatuses.NOT_PASSED,
+        });
+        const certifResult2 = domainBuilder.buildCertificationResult({
+          lastAssessmentResult: lastAssessmentResult2,
+          firstName: 'Tom',
+          birthdate,
+          createdAt,
+          cleaCertificationStatus: cleaStatuses.REJECTED,
+        });
+
+        const certificationResults = [ certifResult1, certifResult2 ];
+
+        // when
+        const result = await getSessionCertificationResultsCsvWithCleaStatus({ session, certificationResults });
+
+        // then
+        const expectedBirthDate = '01/01/1990';
+        const expectedCreatedAt = '01/01/2020';
+        const expectedResult = '\uFEFF' +
+          '"Numéro de certification";"Prénom";"Nom";"Date de naissance";"Lieu de naissance";"Identifiant Externe";"Certification CléA numérique";"Nombre de Pix";"1.1";"1.2";"1.3";"2.1";"2.2";"2.3";"2.4";"3.1";"3.2";"3.3";"3.4";"4.1";"4.2";"4.3";"5.1";"5.2";"Session";"Centre de certification";"Date de passage de la certification"\n' +
+          `"${certifResult1.id}";"Lili";"${certifResult1.lastName}";"${expectedBirthDate}";"${certifResult1.birthplace}";${certifResult1.externalId};"not_passed";${certifResult1.pixScore};0;1;5;"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"\n` +
+          `"${certifResult2.id}";"Tom";"${certifResult2.lastName}";"${expectedBirthDate}";"${certifResult2.birthplace}";${certifResult2.externalId};"rejected";"0";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";"-";0;0;${session.id};"${session.certificationCenter}";"${expectedCreatedAt}"`;
+        expect(result).to.deep.equal(expectedResult);
+      });
+    });
+  })
 
   describe('#getDivisionCertificationResultsCsv', () => {
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-result.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-result.js
@@ -16,7 +16,7 @@ module.exports = function buildCertificationResult({
   createdAt = faker.date.past(),
   isPublished = faker.random.boolean(),
   isV2Certification = true,
-  cleaCertificationStatus = faker.random.objectElement(cleaStatuses),
+  cleaCertificationStatus = cleaStatuses.NOT_PASSED,
   hasSeenEndTestScreen = faker.random.boolean(),
   assessmentId,
   sessionId,


### PR DESCRIPTION
## :unicorn: Problème
Les centres de certification agréés “CléA numérique” et Pix ont besoin de savoir si les candidats ayant passé la double certification l’ont obtenu ou pas. En effet, cette information leur permet ensuite de générer les certificats CléA numérique (= parchemin) depuis la plateforme Certif Pro (qui délivre le CléA numérique) pour les candidats l’ayant obtenue.

Bien que les centres de certification peuvent aujourd'hui obtenir les résultats sur les certifications Pix sous format CSV, ils n'ont aucune information le CléA. En effet, cette information n’est pas visible dans le fichier CSV des résultats de certification qui est mis à leur disposition.

Ce besoin ne concerne que les centres de certification agréés "Cléa numérique". Et pour ne pas apporter d'incompréhension aux autres centres, il n'est pas souhaitable d'afficher les résultats du CléA pour les centres non agréés Cléa.

## :robot: Solution
Dans le fichier csv des résultats de certification, UNIQUEMENT pour les sessions ayant au moins 1 candidat qui a tenté de passer la certification CléA numérique : 

- ajouter une colonne “Certification CléA numérique” avec les valeur “Validée”, “Rejetée” ou “Non passée” (si certains candidats de la session n’ont pas passé la double certif)

- colonne à placer après la colonne “Identifiant Externe”

## :rainbow: Remarques
> RAS

## :100: Pour tester
Sur Pix Certif : 
- Créer une session de certification
- Ajouter des candidats ayant obtenu le badge Cléa Numérique (par exemple anne success)
Sur Mon-Pix : 
- Passer la certification normalement avec au moins anne success
Sur Pix Admin : 
- Aller sur le détail de la session et cliquer sur "Télécharger les résultats" ou "Générer un lien de résultats".
- Constater que le CSV obtenu contient une nouvelle colonne "Certification CléA Numérique"

Refaire la même chose avec une session dans laquelle il n'y pas de candidat ayant le badge Cléa (sans anne success)