### PR TITLE
[FEATURE] Afficher le nombre de sessions à traiter dans le libellé de l'onglet (PIX-2298)

### DIFF
--- a/admin/app/controllers/authenticated/sessions/list.js
+++ b/admin/app/controllers/authenticated/sessions/list.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class ListController extends Controller {
+  get sessionsWithRequiredActionCount() {
+    return this.model.length;
+  }
+}

--- a/admin/app/routes/authenticated/sessions/list.js
+++ b/admin/app/routes/authenticated/sessions/list.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class AuthenticatedSessionsListRoute extends Route {
+  model() {
+    return this.store.query('with-required-action-session', {});
+  }
+}

--- a/admin/app/routes/authenticated/sessions/list/with-required-action.js
+++ b/admin/app/routes/authenticated/sessions/list/with-required-action.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default class AuthenticatedSessionsWithRequiredActionListRoute extends Route {
   model() {
-    return this.store.query('with-required-action-session', {});
+    return this.modelFor('authenticated.sessions.list');
   }
 }

--- a/admin/app/templates/authenticated/sessions/list.hbs
+++ b/admin/app/templates/authenticated/sessions/list.hbs
@@ -5,7 +5,7 @@
       Sessions à publier
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.with-required-action" class="navbar-item">
-      Sessions à traiter
+      Sessions à traiter ({{ this.sessionsWithRequiredActionCount }})
     </LinkTo>
     <LinkTo @route="authenticated.sessions.list.all" class="navbar-item">
       Toutes les sessions

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -34,6 +34,18 @@ module('Acceptance | Session List', function(hooks) {
       assert.equal(currentURL(), '/sessions/list');
     });
 
+    test('it should display the number of sessions with required actions', async function(assert) {
+      // given
+      server.createList('with-required-action-session', 10);
+
+      // when
+      await visit('/sessions/list');
+
+      // then
+      assert.equal(currentURL(), '/sessions/list');
+      assert.contains('Sessions à traiter (10)');
+    });
+
     module('#Pagination', function(hooks) {
 
       hooks.beforeEach(function() {

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list/with-required-action', function(hooks) {
+module('Unit | Route | authenticated/sessions/list', function(hooks) {
   setupTest(hooks);
 
   let store;
@@ -18,7 +18,7 @@ module('Unit | Route | authenticated/sessions/list/with-required-action', functi
   module('#model', function() {
     test('it should fetch the list of sessions with required action', async function(assert) {
       // given
-      const route = this.owner.lookup('route:authenticated/sessions/list/with-required-action');
+      const route = this.owner.lookup('route:authenticated/sessions/list');
       const sessionsWithRequiredAction = [{
         certificationCenterName: 'Centre SCO des Anne-Solo',
         finalizedAt: '2020-04-15T15:00:34.000Z',
@@ -31,7 +31,10 @@ module('Unit | Route | authenticated/sessions/list/with-required-action', functi
       const result = await route.model();
 
       // then
-      assert.equal(result, sessionsWithRequiredAction);
+      assert.deepEqual(result, [{
+        certificationCenterName: 'Centre SCO des Anne-Solo',
+        finalizedAt: '2020-04-15T15:00:34.000Z',
+      }]);
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Le pôle Certif souhaite connaître le nombre de sessions à traiter car cela leur permet d’organiser leur travail entre leur différentes activités. Ex : si je vois qu’il y a peu de sessions à traiter, je vais me concentrer sur la gestion des demandes d’agréments…

## :robot: Solution
Afficher le nombre de session à traiter entre parenthèses après le libellé de l’onglet "Session à traiter" de la page Sessions de Certifications de Pix Admin
![Onglet avec nombre de session](https://user-images.githubusercontent.com/5627688/111468920-65b80d80-8726-11eb-8ea4-6841133f8c92.png)

## :rainbow: Remarques
- Conséquence de cette modification, due à une limitation technique d'Ember : le contenu de la page "Sessions à traiter" n'est pas rechargée quand on clique sur l'onglet correspondant, uniquement quand on ouvre la page "Sessions de certifications". Il faut recharger manuellement la page.

## :100: Pour tester
1. Se connecter à Pix Admin avec le compte pixmaster@example.net
2. Se rendre sur la page **Sessions de certifications**
3. Constater que le nombre de session à traiter apparaît dans le libellé de l'onglet correspondant
