### PR TITLE
[FEATURE] Ouvrir le lien de la documentation vers un nouvel onglet (PIX-2338)

### DIFF
--- a/orga/app/templates/authenticated/certifications.hbs
+++ b/orga/app/templates/authenticated/certifications.hbs
@@ -23,6 +23,6 @@
 
   <PixMessage @withIcon={{true}}>
     {{t 'pages.certifications.documentation-link-notice'}}
-    <a href={{t 'pages.certifications.documentation-link'}}>{{t 'pages.certifications.documentation-link-label'}}</a>
+    <a href={{t 'pages.certifications.documentation-link'}} target="_blank" rel="noopener noreferrer">{{t 'pages.certifications.documentation-link-label'}}</a>
   </PixMessage>
 </div>


### PR DESCRIPTION
## :unicorn: Problème
Aujourd'hui, une grande majorité de nos liens s'ouvre dans un nouvel onglet. Ce comportement est donc récurrent dans nos applications , et nos utilisateurs y sont habitués.
Il peut être embêtant pour nos utilisateurs de Pix Orga de voir leur page Pix Orga être remplacée par le lien sur lequel ils viennent de cliquer.

## :robot: Solution
Ouvrir le lien de la documentation sur les résultats de certification dans un nouvel onglet.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Lancer l'api avec :
- FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true npm start
Lancer Pix Orga :
- aller dans l'onglet Certifications
- cliquer sur le lien vers la doc
- constater que la doc s'ouvre dans un nouvel onglet       
