### PR TITLE
[TECH] Ajout de test d'accessibilité dans nos tests E2E.

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/demo.feature
@@ -7,6 +7,7 @@ Fonctionnalité: Demo
     Alors je suis redirigé vers une page d'épreuve
     Et le titre sur l'épreuve est "Démo essentiels"
     Lorsque je vois l'épreuve "Combien font 2 + 2 ?"
+    Alors l'accessibilité de la page est correcte
     Et je clique sur "Je passe"
     Et je vois l'épreuve "Quel mot est synonyme de « regarder » ?"
     Et je choisis la réponse "radio_3"

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -4,6 +4,14 @@ Fonctionnalité: Connexion - Déconnexion
   Contexte:
     Étant donné que tous les comptes sont créés
 
+  Scénario: Je vérifie l'accessibilité des pages de connexion et d'inscription
+    Étant donné que je vais sur Pix
+    Et que je suis redirigé vers la page "/connexion"
+    Alors je vérifie l'accessibilité
+    Et je clique sur "Créez un compte"
+    Alors je suis redirigé vers la page "/inscription"
+    Et je vérifie l'accessibilité
+
   Scénario: Je me connecte puis je me déconnecte en fin de session
     Étant donné que je vais sur Pix
     Lorsque je me connecte avec le compte "daenerys.targaryen@pix.fr"

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -7,10 +7,10 @@ Fonctionnalité: Connexion - Déconnexion
   Scénario: Je vérifie l'accessibilité des pages de connexion et d'inscription
     Étant donné que je vais sur Pix
     Et que je suis redirigé vers la page "/connexion"
-    Alors je vérifie l'accessibilité
+    Alors l'accessibilité de la page est correcte
     Lorsque je clique sur "Créez un compte"
     Et que je suis redirigé vers la page "/inscription"
-    Alors je vérifie l'accessibilité
+    Alors l'accessibilité de la page est correcte
 
   Scénario: Je me connecte puis je me déconnecte en fin de session
     Étant donné que je vais sur Pix
@@ -32,7 +32,7 @@ Fonctionnalité: Connexion - Déconnexion
     Alors je suis redirigé vers la page d'accueil de "Daenerys"
     Lorsque je me déconnecte
     Alors je suis redirigé vers la page "/nonconnecte"
-    Et je vérifie l'accessibilité
+    Et l'accessibilité de la page est correcte
 
   Scénario: Je me connecte via un organisme externe alors qu'il y a une personne déjà connectée puis je me déconnecte
     Étant donné que je suis connecté à Pix en tant que "John Snow"

--- a/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/login-logout-app.feature
@@ -8,9 +8,9 @@ Fonctionnalité: Connexion - Déconnexion
     Étant donné que je vais sur Pix
     Et que je suis redirigé vers la page "/connexion"
     Alors je vérifie l'accessibilité
-    Et je clique sur "Créez un compte"
-    Alors je suis redirigé vers la page "/inscription"
-    Et je vérifie l'accessibilité
+    Lorsque je clique sur "Créez un compte"
+    Et que je suis redirigé vers la page "/inscription"
+    Alors je vérifie l'accessibilité
 
   Scénario: Je me connecte puis je me déconnecte en fin de session
     Étant donné que je vais sur Pix
@@ -32,6 +32,7 @@ Fonctionnalité: Connexion - Déconnexion
     Alors je suis redirigé vers la page d'accueil de "Daenerys"
     Lorsque je me déconnecte
     Alors je suis redirigé vers la page "/nonconnecte"
+    Et je vérifie l'accessibilité
 
   Scénario: Je me connecte via un organisme externe alors qu'il y a une personne déjà connectée puis je me déconnecte
     Étant donné que je suis connecté à Pix en tant que "John Snow"

--- a/high-level-tests/e2e/cypress/support/index.js
+++ b/high-level-tests/e2e/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import 'cypress-axe'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/high-level-tests/e2e/cypress/support/step_definitions/accessibility.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/accessibility.js
@@ -20,7 +20,11 @@ function callback(violations) {
 
 Then('l\'accessibilité de la page est correcte', () => {
   cy.injectAxe();
-  cy.checkA11y(null,   {
+  cy.checkA11y(
+    {
+      exclude: ['.challenge-response__proposal']
+    },
+    {
       rules: {
         'html-lang-valid': { enabled: false },
       },

--- a/high-level-tests/e2e/cypress/support/step_definitions/accessibility.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/accessibility.js
@@ -1,0 +1,30 @@
+function callback(violations) {
+  violations.forEach(violation => {
+    const nodes = Cypress.$(violation.nodes.map(node=> node.target).join(','));
+    Cypress.log({
+      name: `Erreur ${violation.impact} : `,
+      consoleProps: () => violation,
+      $el: nodes,
+      message: `[${violation.help}](${violation.helpUrl})`
+    });
+    violation.nodes.forEach(({target})=> {
+      Cypress.log({
+        name: 'Noeuds bloquants : ',
+        consoleProps: () => violation,
+        $el: Cypress.$(target.join(',')),
+        message: target
+      });
+    });
+  });
+}
+
+Then('l\'accessibilité de la page est correcte', () => {
+  cy.injectAxe();
+  cy.checkA11y(null,   {
+      rules: {
+        'html-lang-valid': { enabled: false },
+      },
+    },
+    callback
+  )
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/assessment.js
@@ -6,6 +6,10 @@ When(`je lance la preview du challenge {string}`, (challengeId) => {
   cy.visitMonPix(`/challenges/${challengeId}/preview`);
 });
 
+When(`je clique sur Signaler un problème`, () => {
+  cy.get('.feedback-panel__open-button').click();
+});
+
 Then(`je suis redirigé vers une page d'épreuve`, () => {
   cy.get('.assessment-challenge').should('exist');
 });
@@ -41,3 +45,4 @@ Then(`j'ai bien répondu à {string}`, (challenge) => {
   cy.contains('.result-item', challenge).find('.result-item__icon svg')
     .should('have.class', 'fa-check-circle').and('have.class', 'result-item__icon--green');
 });
+

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -91,3 +91,14 @@ Then(`la page {string} est correctement affichée`, (pageName) => {
 Then(`je vois {string} comme {string}`, (value, label) => {
   cy.contains(label).parent().within(() => cy.contains(value));
 });
+
+
+Then('je vérifie l\'accessibilité', () => {
+  cy.injectAxe();
+  cy.checkA11y(null,   {
+      rules: {
+        'html-lang-valid': { enabled: false },
+      },
+    },
+  )
+});

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -91,14 +91,3 @@ Then(`la page {string} est correctement affichée`, (pageName) => {
 Then(`je vois {string} comme {string}`, (value, label) => {
   cy.contains(label).parent().within(() => cy.contains(value));
 });
-
-
-Then('l\'accessibilité de la page est correcte', () => {
-  cy.injectAxe();
-  cy.checkA11y(null,   {
-      rules: {
-        'html-lang-valid': { enabled: false },
-      },
-    },
-  )
-});

--- a/high-level-tests/e2e/cypress/support/step_definitions/index.js
+++ b/high-level-tests/e2e/cypress/support/step_definitions/index.js
@@ -93,7 +93,7 @@ Then(`je vois {string} comme {string}`, (value, label) => {
 });
 
 
-Then('je vérifie l\'accessibilité', () => {
+Then('l\'accessibilité de la page est correcte', () => {
   cy.injectAxe();
   cy.checkA11y(null,   {
       rules: {

--- a/high-level-tests/e2e/package-lock.json
+++ b/high-level-tests/e2e/package-lock.json
@@ -1366,6 +1366,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz",
+      "integrity": "sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==",
+      "dev": true
+    },
     "babel-plugin-add-module-exports": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.2.tgz",
@@ -2469,6 +2475,12 @@
           "dev": true
         }
       }
+    },
+    "cypress-axe": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.12.2.tgz",
+      "integrity": "sha512-gn+rVJ2JnvUWhBshbZ/8dkJdANaEB96zgtAEClJ7vNvDgmqAYb+HhQpW0GM04EqtIiPhenqUeKNQDoqrquY5+w==",
+      "dev": true
     },
     "cypress-cucumber-preprocessor": {
       "version": "4.0.1",

--- a/high-level-tests/e2e/package.json
+++ b/high-level-tests/e2e/package.json
@@ -33,7 +33,9 @@
     "start:certif": "cd ../../certif && npm start"
   },
   "devDependencies": {
+    "axe-core": "^4.1.3",
     "cypress": "^5.6.0",
+    "cypress-axe": "^0.12.2",
     "cypress-cucumber-preprocessor": "^4.0.1",
     "cypress-visual-regression": "^1.5.7",
     "eslint": "^7.20.0",

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -10,9 +10,8 @@
     {{/if}}
   </div>
 
-  <div class="assessment-challenge__content rounded-panel--over-background-banner">
+  <main class="assessment-challenge__content rounded-panel--over-background-banner">
     <ProgressBar @assessment={{@model.assessment}} @answerId={{@model.answer.id}}/>
-    <main>
       {{component (get-challenge-component-class @model.challenge)
                 challenge=@model.challenge
                 answer=@model.answer
@@ -22,9 +21,8 @@
                 answerValidated=(route-action "saveAnswerAndNavigate")
                 resumeAssessment=(route-action "resumeAssessment")
     }}
-    </main>
-  </div>
-  <div class="challenge-item__feedback">
+  </main>
+  <div class="challenge-item__feedback" role="complementary">
     <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}}/>
   </div>
 </div>

--- a/mon-pix/app/templates/components/progress-bar.hbs
+++ b/mon-pix/app/templates/components/progress-bar.hbs
@@ -1,11 +1,11 @@
 {{#if this.showProgressBar}}
   <div class="progress-bar-container">
-    <h2 class="sr-only">{{t 'pages.challenge.parts.progress'}}</h2>
     <div class="progress-bar-stepnums"
          role="progressbar"
          aria-valuenow={{this.currentStepNumber}}
          aria-valuemin="1"
          aria-valuemax="5"
+         aria-label="{{t 'pages.challenge.parts.progress'}}"
       >
       {{#each this.steps as |step|}}
         <div class="progress-bar-stepnum {{step.status}}">{{step.stepnum}}</div>
@@ -23,7 +23,7 @@
     </div>
   </div>
 {{else}}
-  <div class="assessment-progress">
+  <div class="assessment-progress" role="progressbar" aria-label="{{t 'pages.challenge.parts.progress'}}">
     <div class="assessment-progress__label">{{t "pages.challenge.progress-bar.label"}}</div>
     <div class="assessment-progress__value">
       {{this.currentStepNumber}} / {{this.maxStepsNumber}}

--- a/mon-pix/app/templates/not-connected.hbs
+++ b/mon-pix/app/templates/not-connected.hbs
@@ -1,10 +1,10 @@
 {{page-title (t 'pages.not-connected.title')}}
-<div class="not-connected">
+<main class="not-connected">
   <div class="rounded-panel not-connected__container">
     <img class="pix-logo__image not-connected__logo" src="/images/pix-logo.svg" alt="Pix">
-
+    <h1 class="sr-only">{{t 'pages.not-connected.title' }}</h1>
     <p class="not-connected__text-block">
-    {{t 'pages.not-connected.message' htmlSafe=true}}
+      {{t 'pages.not-connected.message' htmlSafe=true}}
     </p>
   </div>
-</div>
+</main>


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons rien actuellement pour tester l'accessibilité automatiquement

## :robot: Solution
- Ajout de cypress-axe
- Ajout d'un step pour vérifier l'accessibilité
- Ajout sur quelques pages avec des correctifs

## :rainbow: Remarques
Ces tests ne sont pas suffisants pour dire qu'une page est accessible.

## :100: Pour tester
Lancer les tests cypress