### PR TITLE
[CLEANUP] Déplacer le composant feedback dans le composant global des challenges (PIX-2372).

### DIFF
--- a/mon-pix/app/styles/components/_challenge-item.scss
+++ b/mon-pix/app/styles/components/_challenge-item.scss
@@ -1,5 +1,13 @@
 .challenge-item__feedback {
   margin-bottom: 20px;
+  padding: 0 20px;
+  width: 100%;
+  text-align: left;
+  max-width: 990px;
+
+  @include device-is('desktop') {
+    padding: 0;
+  }
 }
 
 .challenge-item .alert {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -22,6 +22,9 @@
     }}
     </main>
   </div>
+  <div class="challenge-item__feedback">
+    <FeedbackPanel @assessment={{@model.assessment}} @challenge={{@model.challenge}}/>
+  </div>
 </div>
 
 {{#if this.showLevelup}}

--- a/mon-pix/app/templates/components/challenge-item-qcm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcm.hbs
@@ -57,8 +57,4 @@
       {{/if}}
     </form>
   {{/if}}
-
-  <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}}/>
-  </div>
 </article>

--- a/mon-pix/app/templates/components/challenge-item-qcu.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qcu.hbs
@@ -58,8 +58,4 @@
       {{/if}}
     </form>
   {{/if}}
-
-  <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}}/>
-  </div>
 </article>

--- a/mon-pix/app/templates/components/challenge-item-qroc.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qroc.hbs
@@ -61,8 +61,4 @@
       {{/if}}
     </form>
   {{/if}}
-
-  <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}}/>
-  </div>
 </article>

--- a/mon-pix/app/templates/components/challenge-item-qrocm.hbs
+++ b/mon-pix/app/templates/components/challenge-item-qrocm.hbs
@@ -58,8 +58,4 @@
       {{/if}}
     </form>
   {{/if}}
-
-  <div class="challenge-item__feedback">
-    <FeedbackPanel @assessment={{@assessment}} @challenge={{@challenge}}/>
-  </div>
 </article>


### PR DESCRIPTION
## :unicorn: Problème
Les composants ChallengeQCU/QCM/Etc... ont beaucoup de code en commun, et notamment les feedback

## :robot: Solution
Remonter l'appel du composant du feedback vers celui global aux épreuves

## :rainbow: Remarques
J'aurais bien aimé tout remonté, mais c'est pas si facile ^^

## :100: Pour tester
Envoyer des feedbacks sur les épreuves et voir en base que tout va bien.