### PR TITLE
[TECH] Remplacer IE9 par IE11 comme navigateur le plus "vieux" à supporter sur mon-pix (PIX-2375)

### DIFF
--- a/admin/config/targets.js
+++ b/admin/config/targets.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  '> 1%',
 ];
 
 const isCI = Boolean(process.env.CI);

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  '> 1%',
 ];
 
 const isCI = Boolean(process.env.CI);

--- a/certif/config/targets.js
+++ b/certif/config/targets.js
@@ -1,20 +1,17 @@
 'use strict';
 
 const browsers = [
-  'ie 11',
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions',
 ];
 
-/* We override the Ember 3.4 config in order to support IE 11 even in development or integration environment */
-//
-// const isCI = !!process.env.CI;
-// const isProduction = process.env.EMBER_ENV === 'production';
-//
-// if (isCI || isProduction) {
-//   browsers.push('ie 11');
-// }
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
 
 module.exports = {
   browsers,

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -10,7 +10,7 @@ const isCI = Boolean(process.env.CI);
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {
-  browsers.push('ie 9');
+  browsers.push('ie 11');
 }
 
 module.exports = {

--- a/mon-pix/config/targets.js
+++ b/mon-pix/config/targets.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  '> 1%',
 ];
 
 const isCI = Boolean(process.env.CI);

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const browsers = [
-  'last 1 Chrome versions',
-  'last 1 Firefox versions',
-  'last 1 Safari versions',
+  '> 1%',
 ];
 
 const isCI = Boolean(process.env.CI);

--- a/orga/config/targets.js
+++ b/orga/config/targets.js
@@ -1,20 +1,17 @@
 'use strict';
 
 const browsers = [
-  'ie 11',
   'last 1 Chrome versions',
   'last 1 Firefox versions',
   'last 1 Safari versions',
 ];
 
-/* We override the Ember 3.4 config in order to support IE 11 even in development or integration environment */
-//
-// const isCI = !!process.env.CI;
-// const isProduction = process.env.EMBER_ENV === 'production';
-//
-// if (isCI || isProduction) {
-//   browsers.push('ie 11');
-// }
+const isCI = Boolean(process.env.CI);
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
 
 module.exports = {
   browsers,


### PR DESCRIPTION
## :unicorn: Problème
On clame à qui veut bien l'entendre qu'on supporte au minimum IE11, mais dans la configuration du fichier targets.js, qui permet de définir pour le build les navigateurs supportés, on trouve encore mention de IE9 dans le projet mon-pix.

## :robot: Solution
- Remplacer IE9 par IE11 sur la configuration de mon-pix
- Rendre ISO toutes les configurations entre elles en mettant IE11 dans la liste des navigateurs seulement pour la CI et les builds "production"

## :rainbow: Remarques
Le deuxième point n'est pas une régression pour le développement car, que je sache, personne ne teste en local sur IE son travail (non mais franchement). + je rappelle que les déploiements sur les RAs sont effectués en build production, donc si on souhaite éprouver notre travail sur IE, passer par les RAs + LambdaTest est un excellent moyen de le faire. En local, il est possible d'utiliser LambdaTest + un tunnel.


## :100: Pour tester
Tester des fonctionnalités classiques sous IE11 avec LambdaTest

