### PR TITLE
[FEATURE] Changer le wording sur la page Certification dans Pix Orga (PIX-2378)

### DIFF
--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -300,9 +300,9 @@
       "description": "Sélectionnez la classe pour laquelle vous souhaitez exporter les résultats de certification au format csv.<br> Vous pouvez filtrer cette liste en renseignant le nom de la classe directement dans le champ.",
       "download-button": "Exporter les résultats",
       "select-label": "Classe",
-      "title": "Certifications",
-      "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats :",
-      "documentation-link-label": "Interprétation des résultats prescripteur.",
+      "title": "Résultats de certification",
+      "documentation-link-notice": "Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : ",
+      "documentation-link-label": "Interprétation des résultats.",
       "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
       "errors": {
         "no-results": "Aucun résultat de certification pour la classe {selectedDivision}.",


### PR DESCRIPTION
## :unicorn: Problème
Suite à un retour utilisateur, la page "Certifications" n'est pas encore très claire pour certaines formulations. 
Notamment pour le terme "prescripteur", qui pour nos utilisateurs SCO n'est pas adapté.

## :robot: Solution
- Modifier le nom de la page en “Résultats de certification” - uniquement le nom de la page, le libellé du menu “Certifications” ne change pas ! 

- Modifier le texte du lien vers la doc d’interprétation des résultats : “Vous trouverez en suivant ce lien quelques éléments pour interpréter les résultats : Interprétation des résultats.”

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Lancer Pix Orga et l'api avec le feature toggle : `FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED=true`
- Aller dans l'onglet Certif
- Constater les nouvelles formulations du titre et du lien vers la doc.
