### PR TITLE
[FEATURE] Ajout d'un onglet Neutralisation dans le détail d'une certification sur Pix Admin (PIX-2357)

### DIFF
--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -62,6 +62,7 @@ Router.map(function() {
     this.route('certifications', function() {
       this.route('certification', { path: '/:certification_id' }, function() {
         this.route('informations', { path: '/' });
+        this.route('neutralization');
         this.route('details');
         this.route('profile');
       });

--- a/admin/app/routes/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/routes/authenticated/certifications/certification/neutralization.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class CertificationNeutralizationRoute extends Route {
+}

--- a/admin/app/templates/authenticated/certifications/certification.hbs
+++ b/admin/app/templates/authenticated/certifications/certification.hbs
@@ -2,6 +2,9 @@
   <LinkTo @route="authenticated.certifications.certification.informations" @model={{@model.id}} class="navbar-item">
     Informations
   </LinkTo>
+  <LinkTo @route="authenticated.certifications.certification.neutralization" class="navbar-item">
+    Neutralisation<br />(en chantier)
+  </LinkTo>
   <LinkTo @route="authenticated.certifications.certification.details" @model={{@model.id}} class="navbar-item">
     Détails
   </LinkTo>


### PR DESCRIPTION
## ☕ Contexte
Le pôle certification peut aujourd’hui neutraliser une (ou plusieurs) épreuve d’un test de certification depuis l’onglet “Détails” d’une certification dans Pix Admin. 

## :unicorn: Problème
Cette page est complexe à mettre à jour / maintenir. Nous allons donc permettre au pôle certification de neutraliser une ou plusieurs épreuves d’un test de certification dans un onglet spécifique dédié à la neutralisation. L’impact de cette neutralisation se fera alors automatiquement.

## :robot: Solution
Dans Pix Admin > page de détails d’une certification : 

ajouter un onglet “Neutralisation” entre l’onglet “Informations” et “Détails”

## :100: Pour tester
- Démarrer Pix Admin.
- Se rendre sur la page Certifications, renseigner l'ID (par exemple 200) puis charger la certification.
- Constater la présence d'un nouvel onglet neutralisation.
