### PR TITLE
[BUGFIX] Corriger l'erreur renvoyée lors d'un changement de mot de passe pour un utilisateur sans adresse e-mail (PIX-2367). 

### DIFF
--- a/api/lib/domain/usecases/update-user-password.js
+++ b/api/lib/domain/usecases/update-user-password.js
@@ -1,3 +1,5 @@
+const { UserNotAuthorizedToUpdatePasswordError } = require('../errors');
+
 module.exports = async function updateUserPassword({
   userId,
   password,
@@ -9,6 +11,10 @@ module.exports = async function updateUserPassword({
 }) {
   const hashedPassword = await encryptionService.hashPassword(password);
   const user = await userRepository.get(userId);
+
+  if (!user.email) {
+    throw new UserNotAuthorizedToUpdatePasswordError();
+  }
 
   await resetPasswordService.hasUserAPasswordResetDemandInProgress(user.email, temporaryKey);
 

--- a/api/tests/unit/domain/usecases/update-user-password_test.js
+++ b/api/tests/unit/domain/usecases/update-user-password_test.js
@@ -1,7 +1,7 @@
 const { catchErr, expect, sinon } = require('../../../test-helper');
 
 const User = require('../../../../lib/domain/models/User');
-const { PasswordResetDemandNotFoundError } = require('../../../../lib/domain/errors');
+const { PasswordResetDemandNotFoundError, UserNotAuthorizedToUpdatePasswordError } = require('../../../../lib/domain/errors');
 
 const validationErrorSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/validation-error-serializer');
 
@@ -63,6 +63,25 @@ describe('Unit | UseCase | update-user-password', () => {
 
     // then
     expect(userRepository.get).to.have.been.calledWith(userId);
+  });
+
+  it('should throw a UserNotAuthorizedToUpdatePasswordError when user does not have an email', async () => {
+    // given
+    userRepository.get.resolves({ email: undefined });
+
+    // when
+    const error = await catchErr(updateUserPassword)({
+      password,
+      userId,
+      temporaryKey,
+      encryptionService,
+      resetPasswordService,
+      authenticationMethodRepository,
+      userRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(UserNotAuthorizedToUpdatePasswordError);
   });
 
   it('should check if user has a current password reset demand', async () => {

--- a/mon-pix/app/components/reset-password-form.js
+++ b/mon-pix/app/components/reset-password-form.js
@@ -5,13 +5,9 @@ import isPasswordValid from '../utils/password-validator';
 import { tracked } from '@glimmer/tracking';
 import get from 'lodash/get';
 
-const WRONG_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
-const FORBIDDEN_ERROR_MESSAGE = 'Vous n’êtes pas autorisé à faire cette demande.';
-const EXPIRED_DEMAND_ERROR_MESSAGE = 'Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.';
-const UNEXPECTED_ERROR = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
-
 export default class ResetPasswordForm extends Component {
   @service url;
+  @service intl;
 
   @tracked hasSucceeded = false;
   validation = {
@@ -30,7 +26,7 @@ export default class ResetPasswordForm extends Component {
       this._resetValidation();
     } else {
       this.validation.status = 'error';
-      this.validation.message = WRONG_FORMAT_ERROR_MESSAGE;
+      this.validation.message = this.intl.t('pages.reset-password.error.wrong-format');
     }
   }
 
@@ -49,19 +45,19 @@ export default class ResetPasswordForm extends Component {
       this.validation.status = 'error';
       switch (status) {
         case '400':
-          this.validation.message = WRONG_FORMAT_ERROR_MESSAGE;
+          this.validation.message = this.intl.t('pages.reset-password.error.wrong-format');
           break;
         case '403':
-          this.validation.message = FORBIDDEN_ERROR_MESSAGE;
+          this.validation.message = this.intl.t('pages.reset-password.error.forbidden');
           break;
         case '404':
-          this.validation.message = EXPIRED_DEMAND_ERROR_MESSAGE;
+          this.validation.message = this.intl.t('pages.reset-password.error.expired-demand');
           break;
         case '500':
-          this.validation.message = UNEXPECTED_ERROR;
+          this.validation.message = this.intl.t('api-error-messages.internal-server-error');
           break;
         default:
-          this.validation.message = UNEXPECTED_ERROR;
+          this.validation.message = this.intl.t('api-error-messages.internal-server-error');
           break;
       }
     }

--- a/mon-pix/app/routes/reset-password.js
+++ b/mon-pix/app/routes/reset-password.js
@@ -15,7 +15,7 @@ export default class ResetPasswordRoute extends Route {
     } catch (error) {
       const status = get(error, 'errors[0].status');
       if (status && (status === 401 || status && 404)) {
-        this.errors.push(this.intl.t('pages.reset-password.error'));
+        this.errors.push(this.intl.t('pages.reset-password.error.expired-demand'));
         this.replaceWith('password-reset-demand');
       }
     }

--- a/mon-pix/tests/integration/components/reset-password-form-test.js
+++ b/mon-pix/tests/integration/components/reset-password-form-test.js
@@ -80,7 +80,7 @@ describe('Integration | Component | reset password form', function() {
 
         const saveWithRejection = () => {
           isSaveMethodCalled = true;
-          return reject();
+          return reject({ errors: [{ status: '400' }] });
         };
 
         beforeEach(function() {

--- a/mon-pix/tests/unit/components/reset-password-form-test.js
+++ b/mon-pix/tests/unit/components/reset-password-form-test.js
@@ -6,17 +6,10 @@ import { setupTest } from 'ember-mocha';
 import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-const WRONG_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
-const FORBIDDEN_ERROR_MESSAGE = 'Vous n’êtes pas autorisé à faire cette demande.';
-const EXPIRED_DEMAND_ERROR_MESSAGE = 'Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.';
-const UNEXPECTED_ERROR = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
-
 describe('Unit | Component | reset password form', function() {
 
   setupTest();
   setupIntl();
-
-  // component.intl.t('api-error-messages.internal-server-error');
 
   describe('#validatePassword', () => {
 
@@ -103,19 +96,19 @@ describe('Unit | Component | reset password form', function() {
       [
         {
           status: '400',
-          message: WRONG_FORMAT_ERROR_MESSAGE,
+          message: 'pages.reset-password.error.wrong-format',
         },
         {
           status: '403',
-          message: FORBIDDEN_ERROR_MESSAGE,
+          message: 'pages.reset-password.error.forbidden',
         },
         {
           status: '404',
-          message: EXPIRED_DEMAND_ERROR_MESSAGE,
+          message: 'pages.reset-password.error.expired-demand',
         },
         {
           status: '500',
-          message: UNEXPECTED_ERROR,
+          message: 'api-error-messages.internal-server-error',
         },
       ].forEach((testCase) => {
         it(`it should display ${testCase.message} when http status is ${testCase.status}`, async () => {
@@ -133,7 +126,7 @@ describe('Unit | Component | reset password form', function() {
 
           // then
           expect(component.validation.status).to.eql('error');
-          expect(component.validation.message).to.eql(testCase.message);
+          expect(component.validation.message).to.eql(component.intl.t(testCase.message));
         });
       });
     });

--- a/mon-pix/tests/unit/components/reset-password-form-test.js
+++ b/mon-pix/tests/unit/components/reset-password-form-test.js
@@ -3,37 +3,26 @@ import EmberObject from '@ember/object';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
+import setupIntl from 'mon-pix/tests/helpers/setup-intl';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-const ERROR_PASSWORD_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
-
-const VALIDATION_MAP = {
-  default: {
-    status: 'default', message: null,
-  },
-  error: {
-    status: 'error', message: ERROR_PASSWORD_MESSAGE,
-  },
-};
-
-const SUBMISSION_MAP = {
-  default: {
-    status: 'default', message: null,
-  },
-  error: {
-    status: 'error', message: ERROR_PASSWORD_MESSAGE,
-  },
-};
+const WRONG_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+const FORBIDDEN_ERROR_MESSAGE = 'Vous n’êtes pas autorisé à faire cette demande.';
+const EXPIRED_DEMAND_ERROR_MESSAGE = 'Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.';
+const UNEXPECTED_ERROR = 'Une erreur interne est survenue, nos équipes sont en train de résoudre le problème. Veuillez réessayer ultérieurement.';
 
 describe('Unit | Component | reset password form', function() {
 
   setupTest();
+  setupIntl();
+
+  // component.intl.t('api-error-messages.internal-server-error');
 
   describe('#validatePassword', () => {
 
     it('should set validation status to default, when component is rendered', function() {
       const component = createGlimmerComponent('component:reset-password-form');
-      expect(component.validation).to.deep.equal(VALIDATION_MAP['default']);
+      expect(component.validation.status).to.equal('default');
     });
 
     it('should set validation status to error, when there is an validation error on password field', async function() {
@@ -45,10 +34,10 @@ describe('Unit | Component | reset password form', function() {
       await component.validatePassword();
 
       // then
-      expect(component.validation).to.eql(VALIDATION_MAP['error']);
+      expect(component.validation.status).to.eql('error');
     });
 
-    it('should set validation status to success, when password is valid', async function() {
+    it('should set validation status to default, when password is valid', async function() {
       //given
       const userWithGoodPassword = { firstName: 'toto', lastName: 'riri', password: 'Pix123 0 #' };
       const component = createGlimmerComponent('component:reset-password-form', { user: userWithGoodPassword });
@@ -57,7 +46,7 @@ describe('Unit | Component | reset password form', function() {
       await component.validatePassword();
 
       // then
-      expect(component.validation).to.eql(VALIDATION_MAP['default']);
+      expect(component.validation.status).to.eql('default');
     });
 
   });
@@ -72,6 +61,7 @@ describe('Unit | Component | reset password form', function() {
     });
 
     describe('When user password is saved', () => {
+
       it('should update validation with success data', async function() {
         // given
         const component = createGlimmerComponent('component:reset-password-form', { user: userWithGoodPassword });
@@ -80,7 +70,8 @@ describe('Unit | Component | reset password form', function() {
         await component.handleResetPassword();
 
         // then
-        expect(component.validation).to.eql(SUBMISSION_MAP['default']);
+        expect(component.validation.status).to.eql('default');
+        expect(component.validation.message).to.be.null;
       });
 
       it('should update hasSucceeded', async function() {
@@ -109,23 +100,42 @@ describe('Unit | Component | reset password form', function() {
 
     describe('When user password saving fails', () => {
 
-      it('should set validation with errors data', async function() {
-        // given
-        const userWithBadPassword = EmberObject.create({
-          firstName: 'toto',
-          lastName: 'riri',
-          password: 'Pix',
-          save: () => reject(),
+      [
+        {
+          status: '400',
+          message: WRONG_FORMAT_ERROR_MESSAGE,
+        },
+        {
+          status: '403',
+          message: FORBIDDEN_ERROR_MESSAGE,
+        },
+        {
+          status: '404',
+          message: EXPIRED_DEMAND_ERROR_MESSAGE,
+        },
+        {
+          status: '500',
+          message: UNEXPECTED_ERROR,
+        },
+      ].forEach((testCase) => {
+        it(`it should display ${testCase.message} when http status is ${testCase.status}`, async () => {
+          // given
+          const userWithBadPassword = EmberObject.create({
+            firstName: 'toto',
+            lastName: 'riri',
+            password: 'Pix',
+            save: () => reject({ errors: [{ status: testCase.status }] }),
+          });
+          const component = createGlimmerComponent('component:reset-password-form', { user: userWithBadPassword });
+
+          // when
+          await component.handleResetPassword();
+
+          // then
+          expect(component.validation.status).to.eql('error');
+          expect(component.validation.message).to.eql(testCase.message);
         });
-        const component = createGlimmerComponent('component:reset-password-form', { user: userWithBadPassword });
-
-        // when
-        await component.handleResetPassword();
-
-        // then
-        expect(component.validation).to.eql(SUBMISSION_MAP['error']);
       });
     });
-
   });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -750,7 +750,11 @@
                 "submit": "Send",
                 "sign-in": "Log in"
             },
-            "error": "We’re sorry, but your request to reset your password has already been used or has expired. Please start again.",
+            "error": {
+                "expired-demand": "We’re sorry, but your request to reset your password has already been used or has expired. Please start again.",
+                "forbidden": "An error occurred, please contact the support.",
+                "wrong-format": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number."
+            },
             "fields": {
                 "password": {
                     "label": "Password"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -746,19 +746,19 @@
             "explanation": "You already submitted the profile below to the organisation {organization}'<br>'on {date,date,LL} at {hour,time,hhmm}"
         },
         "reset-password": {
-            "title": "Change my password",
-            "fields": {
-                "password": {
-                    "label": "Password"
-                }
-            },
             "actions": {
                 "submit": "Send",
                 "sign-in": "Log in"
             },
             "error": "We’re sorry, but your request to reset your password has already been used or has expired. Please start again.",
+            "fields": {
+                "password": {
+                    "label": "Password"
+                }
+            },
             "instruction": "Enter your new password",
-            "succeed": "Your password has been changed successfully."
+            "succeed": "Your password has been changed successfully.",
+            "title": "Change my password"
         },
         "proposals": {
             "answer": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -746,19 +746,19 @@
             "explanation": "Vous avez déjà envoyé le profil ci-dessous à l'organisation {organization}'<br>'le {date,date,LL} à {hour,time,hhmm}"
         },
         "reset-password": {
-            "title": "Changer mon mot de passe",
-            "fields": {
-                "password": {
-                    "label": "Mot de passe"
-                }
-            },
             "actions": {
                 "submit": "Envoyer",
                 "sign-in": "Connectez-vous"
             },
             "error": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+            "fields": {
+                "password": {
+                    "label": "Mot de passe"
+                }
+            },
             "instruction": "Saisissez votre nouveau mot de passe",
-            "succeed": "Votre mot de passe a été modifié avec succès."
+            "succeed": "Votre mot de passe a été modifié avec succès.",
+            "title": "Changer mon mot de passe"
         },
         "proposals": {
             "answer": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -750,7 +750,11 @@
                 "submit": "Envoyer",
                 "sign-in": "Connectez-vous"
             },
-            "error": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+            "error": {
+                "expired-demand": "Nous sommes désolés, mais votre demande de réinitialisation de mot de passe a déjà été utilisée ou est expirée. Merci de recommencer.",
+                "forbidden": "Une erreur est survenue, veuillez contacter le support.",
+                "wrong-format": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre."
+            },
             "fields": {
                 "password": {
                     "label": "Mot de passe"


### PR DESCRIPTION
## :unicorn: Problème
https://sentry.io/organizations/pix/issues/2205394283/?project=1398749&referrer=slack

## :robot: Solution
- Renvoyer une erreur lorsqu'un utilisateur envoie une requête de changement de mot de passe alors qu'il ne possède pas d'adresse e-mail.
- Améliorer la gestion des erreurs côté Pix App et traduire les messages d'erreur.

## :rainbow: Remarques
Je n'ai pas réussi à reproduire le scénario de l'erreur mais ce ticket permet néanmoins de ne pas obtenir d'erreur de la base de donnée et d'afficher un message à l'utilisateur.

## :100: Pour tester
En absence de scénario IHM pour reproduire, un petit JDD qui permet de valider que l'API renvoie bien un 403.

```
curl 'https://app-pr2734.review.pix.fr/api/users/10000002/password-update?temporary-key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkYXRhIjoiOXNhMTZtVkp6NWpuRFgzVUdBOFVzZz09IiwiaWF0IjoxNjE2MTQ2MDY0LCJleHAiOjE2MTYyMzI0NjR9.A1ha1UuQ9FiAt0FhqQlwDqSUvtzjkKNwip4a0rq4qns' \
  -X 'PATCH' \
  -H 'accept: application/vnd.api+json' \
  -H 'accept-language: fr-fr' \
  -H 'authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxMDAwMDAwMiwic291cmNlIjoicGl4IiwiaWF0IjoxNjE2MTQ2MTA3LCJleHAiOjE2MTY3NTA5MDd9.JC5BShqvf0QmXrhW7A9_XnsQZf8stn4LsLKTQMNnDVg' \
  -H 'content-type: application/vnd.api+json' \
  -H 'origin: https://app-pr2734.review.pix.fr' \
{"errors":[{"status":"403","title":"Forbidden","detail":"L'utilisateur n'est pas autorisé à mettre à jour ce mot de passe."}]}
```