### PR TITLE
[FEATURE] Traduire en anglais la page "Mon équipe / Invitations" dans Pix Orga (PIX-2225).

### DIFF
--- a/orga/app/components/routes/authenticated/team/invitations.hbs
+++ b/orga/app/components/routes/authenticated/team/invitations.hbs
@@ -4,15 +4,15 @@
       <table id="table-invitations">
         <thead>
         <tr>
-          <th>Adresse e-mail</th>
-          <th>Date de dernier envoi</th>
+          <th>{{t 'pages.team-invitations.table.column.email-address'}}</th>
+          <th>{{t 'pages.team-invitations.table.column.pending-invitation'}}</th>
         </tr>
         </thead>
         <tbody>
         {{#each @organizationInvitations as |organizationInvitation|}}
-          <tr aria-label="Invitation en attente">
+          <tr aria-label="{{t 'pages.team-invitations.table.row.aria-label'}}">
             <td>{{organizationInvitation.email}}</td>
-            <td colspan="3">Dernière invitation envoyée le {{moment-format organizationInvitation.updatedAt 'DD/MM/YYYY [à] HH:mm' locale='fr'}}</td>
+            <td colspan="3">{{t 'pages.team-invitations.table.row.message'}} {{moment-format organizationInvitation.updatedAt 'DD/MM/YYYY [-] HH:mm' locale='fr'}}</td>
           </tr>
         {{/each}}
         </tbody>

--- a/orga/app/templates/authenticated/team/list.hbs
+++ b/orga/app/templates/authenticated/team/list.hbs
@@ -12,7 +12,7 @@
     </LinkTo>
 
     <LinkTo @route="authenticated.team.list.invitations" class="navbar-item">
-      Invitations ({{@model.organization.organizationInvitations.length}})
+      {{t 'pages.team-list.tabs.invitation'}} ({{@model.organization.organizationInvitations.length}})
     </LinkTo>
   </nav>
 

--- a/orga/tests/integration/components/routes/authenticated/team/invitations-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/invitations-test.js
@@ -1,11 +1,12 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
+import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/authenticated/team | invitations', function(hooks) {
-  setupRenderingTest(hooks);
+
+  setupIntlRenderingTest(hooks);
 
   test('it should list the pending team invitations', async function(assert) {
     // given
@@ -19,13 +20,15 @@ module('Integration | Component | routes/authenticated/team | invitations', func
     await render(hbs`<Routes::Authenticated::Team::Invitations @organizationInvitations={{organizationInvitations}}/>`);
 
     // then
-    assert.dom('[aria-label="Invitation en attente"]').exists({ count: 2 });
+    assert.dom(`[aria-label="${this.intl.t('pages.team-invitations.table.row.aria-label')}"]`).exists({ count: 2 });
   });
 
   test('it should display email and creation date of invitation', async function(assert) {
     // given
+    const pendingInvitationDate = moment('2019-10-08T10:50:00Z').utcOffset(2);
+
     const organizationInvitations = [
-      { email: 'gigi@example.net', updatedAt: moment('2019-10-08T10:50:00Z').utcOffset(2) },
+      { email: 'gigi@example.net', updatedAt: pendingInvitationDate },
     ];
     this.set('organizationInvitations', organizationInvitations);
 
@@ -34,6 +37,6 @@ module('Integration | Component | routes/authenticated/team | invitations', func
 
     // then
     assert.contains('gigi@example.net');
-    assert.contains('Dernière invitation envoyée le 08/10/2019 à 12:50');
+    assert.contains(`${this.intl.t('pages.team-invitations.table.row.message')} ${moment(pendingInvitationDate).format('DD/MM/YYYY - HH:mm')}`);
   });
 });

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -535,6 +535,18 @@
         "empty": "No members yet"
       }
     },
+    "team-invitations": {
+      "table": {
+        "column": {
+          "email-address": "Email address",
+          "pending-invitation": "Pending invitation"
+        },
+        "row": {
+          "aria-label": "Pending invitation",
+          "message": "Sent on"
+        }
+      }
+    },
     "team-new": {
       "title": "Invite a member",
       "email-requirement": "Enter here the email address of the member you want to invite.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -522,7 +522,8 @@
       "title": "My team",
       "add-member-button": "Invite a member",
       "tabs": {
-        "member": "Members"
+        "member": "Members",
+        "invitation": "Invitations"
       }
     },
     "team-members": {

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -535,6 +535,18 @@
         "empty": "En attente de membres"
       }
     },
+    "team-invitations": {
+      "table": {
+        "column": {
+          "email-address": "Adresse e-mail",
+          "pending-invitation": "Date de dernier envoi"
+        },
+        "row": {
+          "aria-label": "Invitation en attente",
+          "message": "Dernière invitation envoyée le"
+        }
+      }
+    },
     "team-new": {
       "title": "Inviter un membre",
       "email-requirement": "Saisissez ici l'adresse e-mail du membre que vous souhaitez inviter.",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -522,7 +522,8 @@
       "title": "Mon équipe",
       "add-member-button": "Inviter un membre",
       "tabs": {
-        "member": "Membres"
+        "member": "Membres",
+        "invitation": "Invitations"
       }
     },
     "team-members": {


### PR DESCRIPTION
## :unicorn: Problème
Dans Pix Orga, les textes de la page Mon Equipe/Invitations sont en français, et implémentés "en dur" dans le code.
On veut ajouter la version anglaise.

## :robot: Solution
Externaliser dans des fichiers dédiés la version française et anglaise des textes de cette page

## :100: Pour tester
Vérifier la bonne traduction dans la page mon Equipe, onglet Invitations.

<img width="344" alt="Capture d’écran 2021-03-22 à 11 20 24" src="https://user-images.githubusercontent.com/58915422/111975247-a639d180-8b00-11eb-89d2-df45c09d0ed2.png">
<img width="656" alt="Capture d’écran 2021-03-22 à 11 20 37" src="https://user-images.githubusercontent.com/58915422/111975251-a89c2b80-8b00-11eb-8995-cd88d26a8a0c.png">
