### PR TITLE
[TECH] Réparer la configuration de débogage VSCode.

### DIFF
--- a/.vscode/sample.launch.json
+++ b/.vscode/sample.launch.json
@@ -11,7 +11,8 @@
       "skipFiles": [
         "<node_internals>/**"
       ],
-      "program": "${workspaceFolder}/api/bin/www"
+      "program": "${workspaceFolder}/api/bin/www",
+      "cwd": "${workspaceRoot}/api"
     },
     {
       "type": "node",
@@ -24,7 +25,8 @@
       "internalConsoleOptions": "neverOpen",
       "skipFiles": [
         "<node_internals>/**"
-      ]
+      ],
+      "cwd": "${workspaceRoot}/api"
     },
     {
       "type": "node",

--- a/.vscode/sample.settings.json
+++ b/.vscode/sample.settings.json
@@ -1,4 +1,7 @@
 {
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
     "eslint.format.enable": true,
     "eslint.workingDirectories": [
         "./admin",


### PR DESCRIPTION
## :unicorn: Problème
J'ai rencontré un souci de conf depuis la dernière mise à jour de VS code, le mode debug ne fonctionnait plus. il ne démarre plus l'api via le bon cwd path. du coup le .env n'est pas interpreté. 

## :robot: Solution
J'ai rajouté `cwd` pour les deux `api start & watch`. cela semble corriger le problème

## :rainbow: Remarques
Si quelqu'un a rencontrer le problème et a mieux, je suis preneur

## :100: Pour tester
Tester avec et sans la modif sur la dernière version vsCode 1.54.3