### PR TITLE
[TECH] Mise à jour de la DB browserlist pour toutes les applications front (PIX-2383)

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -7187,9 +7187,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001148",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
-      "integrity": "sha512-E66qcd0KMKZHNJQt9hiLZGE3J4zuTqE1OnU53miEVtylFbwOEmeA5OsRu90noZful+XGSQOni1aT2tiqu/9yYw==",
+      "version": "1.0.30001203",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==",
       "dev": true
     },
     "capture-exit": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -103,5 +103,6 @@
   },
   "ember": {
     "edition": "octane"
-  }
+  },
+  "dependencies": {}
 }

--- a/certif/package-lock.json
+++ b/certif/package-lock.json
@@ -7197,9 +7197,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001166",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001166.tgz",
-      "integrity": "sha512-nCL4LzYK7F4mL0TjEMeYavafOGnBa98vTudH5c8lW9izUjnB99InG6pmC1ElAI1p0GlyZajv4ltUdFXvOHIl1A==",
+      "version": "1.0.30001203",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==",
       "dev": true
     },
     "capture-exit": {

--- a/certif/package.json
+++ b/certif/package.json
@@ -91,5 +91,6 @@
     "sass": "^1.26.3",
     "stylelint": "^13.7.2",
     "stylelint-config-standard": "^20.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -15238,9 +15238,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001161",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001161.tgz",
-      "integrity": "sha512-JharrCDxOqPLBULF9/SPa6yMcBRTjZARJ6sc3cuKrPfyIk64JN6kuMINWqA99Xc8uElMFcROliwtz0n9pYej+g==",
+      "version": "1.0.30001203",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==",
       "dev": true
     },
     "capture-exit": {
@@ -16065,12 +16065,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.67"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001165",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001165.tgz",
-          "integrity": "sha512-8cEsSMwXfx7lWSUMA2s08z9dIgsnR5NAqjXP23stdsU3AUWkCr/rr4s4OFtHXn5XXr6+7kam3QFVoYyXNPdJPA==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.619",

--- a/mon-pix/package.json
+++ b/mon-pix/package.json
@@ -116,5 +116,6 @@
     "showdown": "^1.9.1",
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^20.0.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/orga/package-lock.json
+++ b/orga/package-lock.json
@@ -149,12 +149,6 @@
             "node-releases": "^1.1.69"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001180",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
-          "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.647",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.647.tgz",
@@ -4124,12 +4118,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.69"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001180",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001180.tgz",
-          "integrity": "sha512-n8JVqXuZMVSPKiPiypjFtDTXc4jWIdjxull0f92WLo7e1MSi3uJ3NvveakSh/aCl1QKFAvIz3vIj0v+0K+FrXw==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.8.3",
@@ -8162,12 +8150,6 @@
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001151",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz",
-          "integrity": "sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==",
-          "dev": true
-        },
         "postcss-value-parser": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
@@ -10929,9 +10911,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001081",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001081.tgz",
-      "integrity": "sha512-iZdh3lu09jsUtLE6Bp8NAbJskco4Y3UDtkR3GTCJGsbMowBU5IWDFF79sV2ws7lSqTzWyKazxam2thasHymENQ==",
+      "version": "1.0.30001203",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
+      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==",
       "dev": true
     },
     "capture-exit": {
@@ -25097,12 +25079,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001197",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
-          "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
-          "dev": true
         },
         "debug": {
           "version": "4.3.1",

--- a/orga/package.json
+++ b/orga/package.json
@@ -92,5 +92,6 @@
     "query-string": "^6.13.6",
     "qunit-dom": "^1.6.0",
     "sass": "^1.27.0"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
## :unicorn: Problème
Comme mentionné dans la PR https://github.com/1024pix/pix/pull/2200, la db (présente en fait dans le package-lock.json de chaque appli) de la browserlist doit être mis à jour de temps en temps, faute de quoi on voit le mot de warning suivant lors du build :
`Browserslist: caniuse-lite is outdated. Please run next command npm update`

## :robot: Solution
Pour chaque dossier front, exécuter :
`npx browserslist@latest --update-db`

## :rainbow: Remarques
Trouver un moyen d'automatiser le process ?

## :100: Pour tester
Non rég
