### PR TITLE
[TECH] Mise à jour des dépendances de pix-api.

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2669,9 +2669,9 @@
       }
     },
     "eslint-plugin-mocha": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.0.0.tgz",
-      "integrity": "sha512-n67etbWDz6NQM+HnTwZHyBwz/bLlYPOxUbw7bPuCyFujv7ZpaT/Vn6KTAbT02gf7nRljtYIjWcTxK/n8a57rQQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",
+      "integrity": "sha512-1EgHvXKRl7W3mq3sntZAi5T24agRMyiTPL4bSXe+B4GksYOjAPEWYx+J3eJg4It1l2NMNZJtk0gQyQ6mfiPhQg==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.1.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4792,9 +4792,9 @@
       }
     },
     "mocha": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
-      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.2.tgz",
+      "integrity": "sha512-UdmISwr/5w+uXLPKspgoV7/RXZwKRTiTjJ2/AC5ZiEztIoOYdfKb19+9jNmEInzx5pBsCyJQzarAxqIGBNYJhg==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
@@ -4830,31 +4830,6 @@
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
           "dev": true
         },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "chokidar": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
-          "dev": true,
-          "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.3.1",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.5.0"
-          }
-        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -4884,15 +4859,6 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "dev": true
         },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
         "find-up": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4902,13 +4868,6 @@
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
           }
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
         },
         "glob": {
           "version": "7.1.6",
@@ -4928,12 +4887,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "js-yaml": {
@@ -4978,21 +4931,6 @@
             "p-limit": "^3.0.2"
           }
         },
-        "picomatch": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-          "dev": true
-        },
-        "readdirp": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
-          "dev": true,
-          "requires": {
-            "picomatch": "^2.2.1"
-          }
-        },
         "strip-json-comments": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5006,15 +4944,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         },
         "which": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2498,9 +2498,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
-      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.22.0.tgz",
+      "integrity": "sha512-3VawOtjSJUQiiqac8MQc+w457iGLfuNGLFn8JmF051tTKbh5/x/0vlcEj8OgDCaw7Ysa2Jn8paGshV7x2abKXg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -2520,7 +2520,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
-        "globals": "^12.1.0",
+        "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2528,7 +2528,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -2607,24 +2607,18 @@
           "dev": true
         },
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+          "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "ms": {
@@ -2665,6 +2659,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
         }
       }
     },
@@ -7129,9 +7129,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
-          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.1.tgz",
+          "integrity": "sha512-+nu0HDv7kNSOua9apAVc979qd932rrZeb3WOvoiD31A/p1mIE5/9bN2027pE2rOPYEdS3UHzsvof4hY+lM9/WQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -7168,12 +7168,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "string-width": {
@@ -7630,9 +7624,9 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
-      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "v8flags": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -804,108 +804,76 @@
       }
     },
     "@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.2.tgz",
+      "integrity": "sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.2.tgz",
+      "integrity": "sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.2.tgz",
+      "integrity": "sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
+        "@sentry/hub": "6.2.2",
+        "@sentry/types": "6.2.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/node": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.30.0.tgz",
-      "integrity": "sha512-Br5oyVBF0fZo6ZS9bxbJZG4ApAjRqAnqFFurMVJJdunNb80brh7a5Qva2kjhm+U6r9NJAB5OmDyPkA1Qnt+QVg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.2.tgz",
+      "integrity": "sha512-HmQJx3C2C8cj3oC9piFuXJ7NzM+jW15u4RKcRXxJUgHNbZPR/RsScOOi5TbNZAO4k3A8fSJQD8aPj+dbPx/j/Q==",
       "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/hub": "5.30.0",
-        "@sentry/tracing": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/core": "6.2.2",
+        "@sentry/hub": "6.2.2",
+        "@sentry/tracing": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
         "cookie": "^0.4.1",
         "https-proxy-agent": "^5.0.0",
         "lru_map": "^0.3.3",
         "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
       }
     },
     "@sentry/tracing": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-5.30.0.tgz",
-      "integrity": "sha512-dUFowCr0AIMwiLD7Fs314Mdzcug+gBVo/+NCMyDw8tFxJkwWAKl7Qa2OZxLQ0ZHjakcj1hNKfCQJ9rhyfOl4Aw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.2.tgz",
+      "integrity": "sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.2.tgz",
+      "integrity": "sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ=="
     },
     "@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.2.tgz",
+      "integrity": "sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==",
       "requires": {
-        "@sentry/types": "5.30.0",
+        "@sentry/types": "6.2.2",
         "tslib": "^1.9.3"
       }
     },
@@ -3441,20 +3409,13 @@
       }
     },
     "hapi-sentry": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hapi-sentry/-/hapi-sentry-3.1.0.tgz",
-      "integrity": "sha512-wBXuUx8Z65pu2YYiCcti+GHKh9YdyDR8SM87Wf6hTPt70sbDZfdF1b7VWNMPODV+8v5zWwwLr2Bj31VVUky1Jw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/hapi-sentry/-/hapi-sentry-3.2.0.tgz",
+      "integrity": "sha512-tMmSUoP1jtLLUk8foh2VfFajykkEqZgvBa9ofjsM0Xf5/xxjsXlXIFczJ4h3T2qiAxRPEcmkuWF2QQjrnflezw==",
       "requires": {
         "@hapi/hoek": "^9.1.0",
-        "@sentry/node": "^5.22.3",
+        "@sentry/node": "^6.2.2",
         "joi": "^17.2.1"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "hapi-swagger": {
@@ -3616,6 +3577,30 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/http-status/-/http-status-1.5.0.tgz",
       "integrity": "sha512-wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg=="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "i18n": {
       "version": "0.13.2",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8067,9 +8067,9 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmldom": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath": {
       "version": "0.0.27",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3429,14 +3429,14 @@
       }
     },
     "hapi-i18n": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hapi-i18n/-/hapi-i18n-3.0.0.tgz",
-      "integrity": "sha512-l3X+A9dGTyihr9tyLdesC8ex9tulbrmZIgy6gSouGHr4LuIsfxOP723iMyRAZBwHNu7iAKy4KElXgZyQXkMe2Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-i18n/-/hapi-i18n-3.0.1.tgz",
+      "integrity": "sha512-hWRUXLBChBFKro56TUuBIlkMzgOFrcYYNSY1mY1YcTLIc4C9fxOQDzuuFVvVW2GCvRXr+ak4i/DsvBFdMByOHA==",
       "requires": {
         "@hapi/boom": "^9.0.0",
         "@hapi/hoek": "^9.0.2",
         "accept-language-parser": "^1.5.0",
-        "i18n": "^0.8.5",
+        "i18n": "^0.13.2",
         "lodash": "^4.17.4"
       }
     },
@@ -3618,18 +3618,31 @@
       "integrity": "sha512-wcGvY31MpFNHIkUcXHHnvrE4IKYlpvitJw5P/1u892gMBAM46muQ+RH7UN1d+Ntnfx5apnOnVY6vcLmrWHOLwg=="
     },
     "i18n": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.8.6.tgz",
-      "integrity": "sha512-aMsJq8i1XXrb+BBsgmJBwak9mr69zPEIAUPb6c5yw2G/O4k1Q52lBxL+agZdQDN/RGf1ylQzrCswsOOgIiC1FA==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/i18n/-/i18n-0.13.2.tgz",
+      "integrity": "sha512-PB65bHhQESMBIl/xVNChEAzoxZ5W6FrZ1H9Ma/YcPeSfE7VS9b0sqwBPusa0CfzSKUPSl+uMhRIgyv3jkE7XNw==",
       "requires": {
-        "debug": "*",
-        "make-plural": "^6.0.1",
+        "debug": "^4.1.1",
+        "make-plural": "^6.2.2",
         "math-interval-parser": "^2.0.1",
         "messageformat": "^2.3.0",
-        "mustache": "*",
+        "mustache": "^4.0.1",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "sprintf-js": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -4674,12 +4687,6 @@
           "requires": {
             "minimist": "^1.2.0"
           }
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "optional": true
         }
       }
     },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5112,9 +5112,9 @@
       }
     },
     "nock": {
-      "version": "13.0.10",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.10.tgz",
-      "integrity": "sha512-AvUO/tbiWVBjlC3WsuIutPXltPbPmHWfcLwDSYzykKBJhOeo9eZPczo8n9aV4AHHCgpeL70zBXLwiSE+mzx89g==",
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1803,9 +1803,9 @@
       }
     },
     "chai": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.1.tgz",
-      "integrity": "sha512-JClPZFGRcSl7X8dYzlCJY7v+X1fBA+9Y339Y8EqhBVfp0QC1hTnaf7nMfR+XZ74clkBC64b0iEw2cWKHt3EVqA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -993,9 +993,9 @@
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
     },
     "@types/node": {
-      "version": "14.14.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
     "@types/readable-stream": {
       "version": "2.3.9",
@@ -2946,9 +2946,9 @@
       }
     },
     "file-type": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
-      "integrity": "sha512-1Wwww3mmZCMmLjBfslCluwt2mxH80GsAXYrvPnfQ42G1EGWag336kB1iyCgyn7UXiKY3cJrNykXPrCwA7xb5Ag==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.3.0.tgz",
+      "integrity": "sha512-ZA0hV64611vJT42ltw0T9IDwHApQuxRdrmQZWTeDmeAUtZBBVSQW3nSQqhhW1cAgpXgqcJvm410BYHXJQ9AymA==",
       "requires": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.0.3",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -394,13 +394,6 @@
       "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
       "requires": {
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/boom": {
@@ -434,6 +427,11 @@
         }
       }
     },
+    "@hapi/bourne": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+      "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
+    },
     "@hapi/call": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
@@ -441,13 +439,6 @@
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/catbox": {
@@ -459,13 +450,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/podium": "4.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/catbox-memory": {
@@ -475,13 +459,6 @@
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/content": {
@@ -506,9 +483,9 @@
       "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
     },
     "@hapi/hapi": {
-      "version": "20.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.0.tgz",
-      "integrity": "sha512-DocLxRpPlHV0jEZw7FHfF/Y+tiRLNOXMcqEDGWdqfbQkDKo8ca3TLHRO4w91BKq1TDcM27w+MHZ1sINTDZyGRw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.1.1.tgz",
+      "integrity": "sha512-FvszZ51i/mlTUyhqL/Be2bjmJcEiVzEcKCM9Z3fiyEYKfnilidhNjso/VgqmVTyEqv2uzRBQ6G4zjeD//j13jg==",
       "requires": {
         "@hapi/accept": "^5.0.1",
         "@hapi/ammo": "^5.0.1",
@@ -528,21 +505,6 @@
         "@hapi/teamwork": "5.x.x",
         "@hapi/topo": "5.x.x",
         "@hapi/validate": "^1.1.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        },
-        "@hapi/topo": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
-          "requires": {
-            "@hapi/hoek": "^9.0.0"
-          }
-        }
       }
     },
     "@hapi/heavy": {
@@ -553,13 +515,6 @@
         "@hapi/boom": "9.x.x",
         "@hapi/hoek": "9.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/hoek": {
@@ -597,18 +552,6 @@
         "@hapi/bourne": "2.x.x",
         "@hapi/cryptiles": "5.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
-        },
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/mimos": {
@@ -618,13 +561,6 @@
       "requires": {
         "@hapi/hoek": "9.x.x",
         "mime-db": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/nigel": {
@@ -634,13 +570,6 @@
       "requires": {
         "@hapi/hoek": "^9.0.4",
         "@hapi/vise": "^4.0.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/pez": {
@@ -653,13 +582,6 @@
         "@hapi/content": "^5.0.2",
         "@hapi/hoek": "9.x.x",
         "@hapi/nigel": "4.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/podium": {
@@ -670,13 +592,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/teamwork": "5.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/shot": {
@@ -686,13 +601,6 @@
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/somever": {
@@ -702,13 +610,6 @@
       "requires": {
         "@hapi/bounce": "2.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/statehood": {
@@ -723,18 +624,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/iron": "6.x.x",
         "@hapi/validate": "1.x.x"
-      },
-      "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
-        },
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/subtext": {
@@ -749,18 +638,6 @@
         "@hapi/hoek": "9.x.x",
         "@hapi/pez": "^5.0.1",
         "@hapi/wreck": "17.x.x"
-      },
-      "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
-        },
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/teamwork": {
@@ -806,13 +683,6 @@
       "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
       "requires": {
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@hapi/vision": {
@@ -841,18 +711,6 @@
         "@hapi/boom": "9.x.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/hoek": "9.x.x"
-      },
-      "dependencies": {
-        "@hapi/bourne": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-          "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
-        },
-        "@hapi/hoek": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
-          "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
-        }
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/api/package.json
+++ b/api/package.json
@@ -43,7 +43,7 @@
     "good-console": "^8.0.0",
     "good-squeeze": "^5.1.0",
     "hapi-i18n": "^3.0.1",
-    "hapi-sentry": "^3.1.0",
+    "hapi-sentry": "^3.2.0",
     "hapi-swagger": "^14.1.0",
     "hash-int": "^1.0.0",
     "iconv-lite": "^0.6.2",

--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^8.3.2",
     "mocha-junit-reporter": "^2.0.0",
-    "nock": "^13.0.10",
+    "nock": "^13.0.11",
     "nodemon": "^2.0.7",
     "nyc": "^15.1.0",
     "sinon": "^9.2.4",

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/1024pix/pix#readme",
   "dependencies": {
     "@hapi/accept": "^5.0.2",
-    "@hapi/hapi": "^20.1.0",
+    "@hapi/hapi": "^20.1.1",
     "@hapi/inert": "^6.0.3",
     "@hapi/vision": "^6.0.1",
     "@joi/date": "^2.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -38,7 +38,7 @@
     "dotenv": "^8.2.0",
     "faker": "^4.1.0",
     "fast-levenshtein": "^3.0.0",
-    "file-type": "^16.2.0",
+    "file-type": "^16.3.0",
     "good": "^8.1.2",
     "good-console": "^8.0.0",
     "good-squeeze": "^5.1.0",

--- a/api/package.json
+++ b/api/package.json
@@ -85,7 +85,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-sorted": "^0.2.0",
     "eslint": "^7.22.0",
-    "eslint-plugin-mocha": "^8.0.0",
+    "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^8.3.0",
     "mocha-junit-reporter": "^2.0.0",
     "nock": "^13.0.10",

--- a/api/package.json
+++ b/api/package.json
@@ -75,7 +75,7 @@
     "xlsx": "^0.16.1",
     "xml-buffer-tostring": "^0.2.0",
     "xml2js": "^0.4.23",
-    "xmldom": "^0.4.0",
+    "xmldom": "^0.5.0",
     "xregexp": "^5.0.1",
     "yamljs": "^0.3.0",
     "yargs": "^16.2.0"

--- a/api/package.json
+++ b/api/package.json
@@ -81,7 +81,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "chai": "^4.3.1",
+    "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-sorted": "^0.2.0",
     "eslint": "^7.21.0",

--- a/api/package.json
+++ b/api/package.json
@@ -42,7 +42,7 @@
     "good": "^8.1.2",
     "good-console": "^8.0.0",
     "good-squeeze": "^5.1.0",
-    "hapi-i18n": "^3.0.0",
+    "hapi-i18n": "^3.0.1",
     "hapi-sentry": "^3.1.0",
     "hapi-swagger": "^14.1.0",
     "hash-int": "^1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "chai-sorted": "^0.2.0",
     "eslint": "^7.22.0",
     "eslint-plugin-mocha": "^8.1.0",
-    "mocha": "^8.3.0",
+    "mocha": "^8.3.2",
     "mocha-junit-reporter": "^2.0.0",
     "nock": "^13.0.10",
     "nodemon": "^2.0.7",

--- a/api/package.json
+++ b/api/package.json
@@ -84,7 +84,7 @@
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-sorted": "^0.2.0",
-    "eslint": "^7.21.0",
+    "eslint": "^7.22.0",
     "eslint-plugin-mocha": "^8.0.0",
     "mocha": "^8.3.0",
     "mocha-junit-reporter": "^2.0.0",


### PR DESCRIPTION
## :unicorn: Problème
Certaines dépendances de pix-api ne sont pas à jour.

## :robot: Solution
Mettre à jour les dépendances avec [npm-bump](https://github.com/VincentHardouin/npm-bump).

Package|Old|New
-|-|-
xmldom|0.4.0|0.5.0
@hapi/hapi|20.1.0|20.1.1
chai|4.3.1|4.3.4
eslint|7.21.0|7.22.0
eslint-plugin-mocha|8.0.0|8.1.0
file-type|16.2.0|16.3.0
hapi-i18n|3.0.0|3.0.1
hapi-sentry|3.1.0|3.2.0
mocha|8.3.0|8.3.2
nock|13.0.10|13.0.11

## :rainbow: Remarques
Utilisation du nouveau paramètre ` -e knex,node-cron,faker,xlsx` de npm-bump afin d'exclure des dépendances que l'on ne veut pas mettre à jour. Elles seront réalisées dans des PRs dédiées.

## :100: Pour tester
Lancer les tests et vérifier le comportement.
