### PR TITLE
[FEATURE] Permettre dans pix Admin de marquer comme obsolète un profil cible (Pix-2309).

### DIFF
--- a/admin/app/components/confirm-popup.hbs
+++ b/admin/app/components/confirm-popup.hbs
@@ -2,7 +2,7 @@
   @title={{this.title}}
   @closeTitle={{this.closeTitle}}
   @submitTitle={{this.submitTitle}}
-  @size={{null}}
+  @size={{this.size}}
   @fade={{false}}
   @open={{@show}}
   @position="center"

--- a/admin/app/components/confirm-popup.js
+++ b/admin/app/components/confirm-popup.js
@@ -13,4 +13,8 @@ export default class ConfirmPopup extends Component {
   get submitTitle() {
     return this.args.submitTitle || 'Confirmer';
   }
+
+  get size() {
+    return this.args.size || null;
+  }
 }

--- a/admin/app/components/target-profiles/update-target-profile-name.js
+++ b/admin/app/components/target-profiles/update-target-profile-name.js
@@ -1,9 +1,9 @@
-import Component from '@glimmer/component';
 import Object, { action } from '@ember/object';
-import { tracked } from '@glimmer/tracking';
-import { validator, buildValidations } from 'ember-cp-validations';
+import { buildValidations, validator } from 'ember-cp-validations';
+import Component from '@glimmer/component';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 
 const Validations = buildValidations({
   name: {

--- a/admin/app/controllers/authenticated/target-profiles/target-profile.js
+++ b/admin/app/controllers/authenticated/target-profiles/target-profile.js
@@ -1,8 +1,12 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
 export default class TargetProfileController extends Controller {
+  @service notifications;
+
   @tracked isEditMode = false;
+  @tracked displayConfirm = false;
 
   get isPublic() {
     return this.model.isPublic ? 'Oui' : 'Non';
@@ -17,4 +21,34 @@ export default class TargetProfileController extends Controller {
     this.isEditMode = !this.isEditMode;
   }
 
+  @action
+  toggleDisplayConfirm() {
+    this.displayConfirm = !this.displayConfirm;
+  }
+
+  @action
+  async outdate() {
+    this.toggleDisplayConfirm();
+    try {
+      await this.model.outdate();
+
+      return this.notifications.success('Profil cible marqué comme obsolète.');
+    } catch (responseError) {
+      this._handleResponseError(responseError);
+    }
+  }
+
+  _handleResponseError({ errors }) {
+    if (!errors) {
+      return this.notifications.error('Une erreur est survenue.');
+    }
+    errors.forEach((error) => {
+      if (['404', '412'].includes(error.status)) {
+        this.notifications.error(error.detail);
+      }
+      if (error.status === '400') {
+        this.notifications.error('Une erreur est survenue.');
+      }
+    });
+  }
 }

--- a/admin/app/models/target-profile.js
+++ b/admin/app/models/target-profile.js
@@ -28,4 +28,12 @@ export default class TargetProfile extends Model {
       this.reload();
     },
   });
+
+  outdate = memberAction({
+    path: 'outdate',
+    type: 'put',
+    after() {
+      this.reload();
+    },
+  });
 }

--- a/admin/app/templates/authenticated/target-profiles/target-profile.hbs
+++ b/admin/app/templates/authenticated/target-profiles/target-profile.hbs
@@ -20,12 +20,15 @@
       ID : {{@model.id}}<br>
       Date de création : {{format-date @model.createdAt}}<br>
       Public : {{this.isPublic}}<br>
-      Archivé : {{this.isOutdated}}<br>
+      Obsolète : {{this.isOutdated}}<br>
       Organisation de référence : <LinkTo @route="authenticated.organizations.get" @model={{@model.ownerOrganizationId}}>
         {{@model.ownerOrganizationId}} </LinkTo><br>
     </div>
     <br>
     <button type="button" class="btn btn-outline-default" {{on "click" this.toggleEditMode}}>Editer</button>
+    {{#unless @model.outdated}}
+      <button type="button" class="btn btn-danger" {{on "click" this.toggleDisplayConfirm}}>Marquer comme obsolète</button>
+    {{/unless}}
   </section>
 
   {{/if}}
@@ -43,4 +46,13 @@
   </nav>
 
   {{outlet}}
+
+  <ConfirmPopup @message="Marquer comme obsolète ce profil cible entraînera l'impossibilité de l'utiliser dans toutes les organisations qui lui sont rattachées."
+              @title="Etes-vous sûr de vouloir marquer comme obsolète le profil cible {{@model.name}} ?"
+              @submitTitle="Oui, marquer comme obsolète"
+              @closeTitle="Non, annuler"
+              @size="lg"
+              @confirm={{this.outdate}}
+              @cancel={{this.toggleDisplayConfirm}}
+              @show={{this.displayConfirm}}/>
 </main>

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -1,18 +1,20 @@
-import { Response } from 'ember-cli-mirage';
-import { createMembership } from './handlers/memberships';
 import {
-  attachTargetProfiles,
   attachTargetProfileToOrganizations,
-  getOrganizationTargetProfiles,
+  attachTargetProfiles,
   findPaginatedTargetProfileOrganizations,
-  updateTargetProfileName,
   findTargetProfileBadges,
   findTargetProfileStages,
+  getOrganizationTargetProfiles,
+  outdate,
+  updateTargetProfileName,
 } from './handlers/target-profiles';
-import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
+
+import { Response } from 'ember-cli-mirage';
+import { createMembership } from './handlers/memberships';
+import { createStage } from './handlers/stages';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findPaginatedOrganizationMemberships } from './handlers/organizations';
-import { createStage } from './handlers/stages';
+import { getJuryCertificationSummariesBySessionId } from './handlers/get-jury-certification-summaries-by-session-id';
 
 export default function() {
   this.logging = true;
@@ -94,12 +96,12 @@ export default function() {
   this.post('/admin/target-profiles');
   this.get('/admin/target-profiles');
   this.get('/admin/target-profiles/:id');
-  this.patch('/admin/target-profiles/:id');
   this.get('/admin/target-profiles/:id/organizations', findPaginatedTargetProfileOrganizations);
   this.post('/admin/target-profiles/:id/attach-organizations', attachTargetProfileToOrganizations);
   this.get('/admin/target-profiles/:id/badges', findTargetProfileBadges);
   this.get('/admin/target-profiles/:id/stages', findTargetProfileStages);
   this.patch('/admin/target-profiles/:id', updateTargetProfileName);
+  this.put('/admin/target-profiles/:id/outdate', outdate);
 
   this.post('/admin/stages', createStage);
 

--- a/admin/mirage/handlers/target-profiles.js
+++ b/admin/mirage/handlers/target-profiles.js
@@ -74,6 +74,14 @@ function updateTargetProfileName(schema, request) {
   return new Response(204);
 }
 
+function outdate(schema, request) {
+  const id = request.params.id;
+
+  const targetProfile = schema.targetProfiles.find(id);
+  targetProfile.update({ outdated: true });
+  return new Response(204);
+}
+
 export {
   attachTargetProfiles,
   attachTargetProfileToOrganizations,
@@ -82,4 +90,5 @@ export {
   findTargetProfileBadges,
   findTargetProfileStages,
   updateTargetProfileName,
+  outdate,
 };

--- a/admin/tests/acceptance/target-profiles-details-test.js
+++ b/admin/tests/acceptance/target-profiles-details-test.js
@@ -1,8 +1,9 @@
+import { click, currentURL, fillIn, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
-import { currentURL, click, visit, fillIn } from '@ember/test-helpers';
-import { setupApplicationTest } from 'ember-qunit';
-import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Acceptance | Target Profile Details', function(hooks) {
@@ -52,7 +53,7 @@ module('Acceptance | Target Profile Details', function(hooks) {
       assert.contains('Profil Cible Fantastix');
       assert.dom('section').containsText('ID : 1');
       assert.dom('section').containsText('Public : Oui');
-      assert.dom('section').containsText('Archivé : Non');
+      assert.dom('section').containsText('Obsolète : Non');
       assert.dom('section').containsText('Organisation de référence : 456');
     });
 
@@ -114,10 +115,40 @@ module('Acceptance | Target Profile Details', function(hooks) {
 
       // when
       await visit('/target-profiles/1');
-      await click('button[type=button]');
+      await clickByLabel('Editer');
 
       // then
       assert.dom('Editer').doesNotExist();
+
+    });
+
+    test('it should outdate target profile', async function(assert) {
+      // given
+      server.create('target-profile', { id: 1, name: 'Profil Cible Fantastix', isPublic: true, outdated: false, ownerOrganizationId: 456 });
+
+      // when
+      await visit('/target-profiles/1');
+      await clickByLabel('Marquer comme obsolète');
+
+      await clickByLabel('Oui, marquer comme obsolète');
+
+      // then
+      assert.dom('section').containsText('Obsolète : Oui');
+
+    });
+
+    test('it should not outdate target profile', async function(assert) {
+      // given
+      server.create('target-profile', { id: 1, name: 'Profil Cible Fantastix', isPublic: true, outdated: false, ownerOrganizationId: 456 });
+
+      // when
+      await visit('/target-profiles/1');
+      await clickByLabel('Marquer comme obsolète');
+
+      await clickByLabel('Non, annuler');
+
+      // then
+      assert.dom('section').containsText('Obsolète : Non');
 
     });
 
@@ -136,6 +167,5 @@ module('Acceptance | Target Profile Details', function(hooks) {
       assert.contains('Profil Cible Fantastix Edited');
       assert.dom('Enregistrer').doesNotExist();
     });
-
   });
 });

--- a/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/click-by-label.js
@@ -1,0 +1,35 @@
+import { click, findAll } from '@ember/test-helpers';
+
+export default function clickByLabel(labelText) {
+  const clickableElement = _findClickableElementForLabel(labelText);
+
+  if (!clickableElement) {
+    throw new Error(`Cannot find clickable element labelled "${labelText}".`);
+  }
+
+  return click(clickableElement);
+}
+
+function _findClickableElementForLabel(labelText) {
+  const clickableSelectors = ['button', 'a[href]', '[role="button"]', 'input[type="radio"]', 'input[type="checkbox"]', 'label[for]'];
+  return findAll(clickableSelectors.join(',')).find(_matchesLabel(labelText));
+}
+
+function _matchesLabel(labelText) {
+  return (element) => _matchesInnerText(element, labelText) ||
+                      _matchesTitle(element, labelText) ||
+                      _matchesAriaLabel(element, labelText);
+}
+
+function _matchesInnerText(element, labelText) {
+  return element.innerText.includes(labelText);
+}
+
+function _matchesTitle(element, labelText) {
+  return element.title && element.title.includes(labelText);
+}
+
+function _matchesAriaLabel(element, labelText) {
+  const ariaLabel = element.getAttribute('aria-label');
+  return ariaLabel && ariaLabel.includes(labelText);
+}

--- a/admin/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
+++ b/admin/tests/helpers/extended-ember-test-helpers/fill-in-by-label.js
@@ -1,0 +1,36 @@
+import { fillIn, findAll, find } from '@ember/test-helpers';
+
+export default function fillInByLabel(labelText, value) {
+  const control = _findControlForLabel(labelText);
+
+  return fillIn(control, value);
+}
+
+function _findControlForLabel(labelText) {
+  const label = _findLabel(labelText);
+  if (label && label.control) return label.control;
+
+  const control = _findControl(labelText);
+  if (control) return control;
+
+  if (label && !label.control) {
+    throw new Error(`Found label "${labelText}" but no associated form control.`);
+  }
+  throw new Error(`Cannot find form control labelled "${labelText}".`);
+}
+
+function _findLabel(labelText) {
+  return findAll('label').find((label) => label.innerText.includes(labelText));
+}
+
+function _findControl(labelText) {
+  const selectors = [];
+
+  for (const tag of ['input', 'textarea', 'select']) {
+    for (const attr of ['aria-label', 'title']) {
+      selectors.push(`${tag}[${attr}="${labelText}"]`);
+    }
+  }
+
+  return find(selectors.join(','));
+}

--- a/api/lib/application/target-profiles/index.js
+++ b/api/lib/application/target-profiles/index.js
@@ -144,6 +144,27 @@ exports.register = async (server) => {
       },
     },
     {
+      method: 'PUT',
+      path: '/api/admin/target-profiles/{id}/outdate',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.targetProfileId,
+          }),
+        },
+        handler: targetProfileController.outdateTargetProfile,
+        tags: ['api', 'target-profiles'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de marquer un profil cible comme obsolète',
+        ],
+      },
+    },
+    {
       method: 'PATCH',
       path: '/api/admin/target-profiles/{id}',
       config: {
@@ -163,7 +184,7 @@ exports.register = async (server) => {
             },
           }).options({ allowUnknown: true }),
         },
-        handler: targetProfileController.updateTargetProfile,
+        handler: targetProfileController.updateTargetProfileName,
         tags: ['api', 'target-profiles'],
         notes: [
           '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +

--- a/api/lib/application/target-profiles/target-profile-controller.js
+++ b/api/lib/application/target-profiles/target-profile-controller.js
@@ -42,10 +42,17 @@ module.exports = {
     return h.response({}).code(204);
   },
 
-  updateTargetProfile: async (request, h) => {
+  async updateTargetProfileName(request, h) {
     const id = parseInt(request.params.id);
     const { name } = request.payload.data.attributes;
     await usecases.updateTargetProfileName({ id, name });
+    return h.response({}).code(204);
+  },
+
+  async outdateTargetProfile(request, h) {
+    const id = parseInt(request.params.id);
+
+    await usecases.outdateTargetProfile({ id });
     return h.response({}).code(204);
   },
 

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -112,6 +112,7 @@ module.exports = injectDependencies({
   attachTargetProfilesToOrganization: require('./attach-target-profiles-to-organization'),
   attachOrganizationsToTargetProfile: require('./attach-organizations-to-target-profile'),
   archiveCampaign: require('./archive-campaign'),
+  outdateTargetProfile: require('./outdate-target-profile'),
   assignCertificationOfficerToJurySession: require('./assign-certification-officer-to-jury-session'),
   authenticateAnonymousUser: require('./authenticate-anonymous-user'),
   authenticatePoleEmploiUser: require('./authenticate-pole-emploi-user'),

--- a/api/lib/domain/usecases/outdate-target-profile.js
+++ b/api/lib/domain/usecases/outdate-target-profile.js
@@ -1,0 +1,6 @@
+module.exports = async function outdateTargetProfile({
+  id,
+  targetProfileRepository,
+}) {
+  await targetProfileRepository.update({ id, outdated: true });
+};

--- a/api/lib/domain/usecases/update-target-profile-name.js
+++ b/api/lib/domain/usecases/update-target-profile-name.js
@@ -3,5 +3,5 @@ module.exports = async function updateTargetProfileName({
   name,
   targetProfileRepository,
 }) {
-  await targetProfileRepository.updateName({ id, name });
+  await targetProfileRepository.update({ id, name });
 };

--- a/api/lib/infrastructure/repositories/target-profile-repository.js
+++ b/api/lib/infrastructure/repositories/target-profile-repository.js
@@ -151,14 +151,22 @@ module.exports = {
     return attachedOrganizations.some((e) => e);
   },
 
-  async updateName(targetProfile) {
+  async update(targetProfile) {
+    const editedAttributes = _.pick(targetProfile, [
+      'name',
+      'outdated',
+    ]);
+
     try {
-      await new BookshelfTargetProfile({ id: targetProfile.id })
-        .save({ name: targetProfile.name }, { patch: true });
+      const bookshelfTargetProfile = await BookshelfTargetProfile.where({ id: targetProfile.id })
+        .save(editedAttributes, { patch: true });
+
+      return bookshelfToDomainConverter.buildDomainObject(BookshelfTargetProfile, bookshelfTargetProfile);
     } catch (error) {
       if (error instanceof BookshelfTargetProfile.NoRowsUpdatedError) {
         throw new NotFoundError(`Le profil cible avec l'id ${targetProfile.id} n'existe pas`);
       }
+
       throw new ObjectValidationError;
     }
   },

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -220,6 +220,34 @@ describe('Acceptance | Controller | target-profile-controller', () => {
     });
   });
 
+  describe('PUT /api/admin/target-profiles/{id}/outdate', () => {
+
+    it('should return 204', async () => {
+      const targetProfile = databaseBuilder.factory.buildTargetProfile();
+      const user = databaseBuilder.factory.buildUser.withPixRolePixMaster();
+      await databaseBuilder.commit();
+
+      const options = {
+        method: 'PUT',
+        url: `/api/admin/target-profiles/${targetProfile.id}/outdate`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(user.id) },
+        payload: {
+          data: {
+            attributes: {
+              'outdated': true,
+            },
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+
   describe('GET /api/admin/target-profiles/{id}/badges', () => {
     let user;
     let targetProfileId;

--- a/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/target-profile-repository_test.js
@@ -571,7 +571,7 @@ describe('Integration | Repository | Target-profile', () => {
     });
   });
 
-  describe('#updateName', () => {
+  describe('#update', () => {
 
     it('should update the target profile name', async () => {
       // given
@@ -580,14 +580,28 @@ describe('Integration | Repository | Target-profile', () => {
 
       // when
       targetProfile.name = 'Karam';
-      await targetProfileRepository.updateName(targetProfile);
+      await targetProfileRepository.update(targetProfile);
 
       // then
       const { name } = await knex('target-profiles').select('name').where('id', targetProfile.id).first();
       expect(name).to.equal(targetProfile.name);
     });
 
-    it('should not update the target profile name and throw an error', async () => {
+    it('should outdate the target profile', async () => {
+      // given
+      const targetProfile = databaseBuilder.factory.buildTargetProfile({ outdated: true });
+      await databaseBuilder.commit();
+
+      // when
+      targetProfile.outdate = true;
+      await targetProfileRepository.update(targetProfile);
+
+      // then
+      const { outdated } = await knex('target-profiles').select('outdated').where('id', targetProfile.id).first();
+      expect(outdated).to.equal(targetProfile.outdated);
+    });
+
+    it('should not update the target profile and throw an error while id not existing', async () => {
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ name: 'Arthur' });
       await databaseBuilder.commit();
@@ -595,20 +609,20 @@ describe('Integration | Repository | Target-profile', () => {
       // when
       targetProfile.id = 999999;
       targetProfile.name = 'Karam';
-      const error = await catchErr(targetProfileRepository.updateName)(targetProfile);
+      const error = await catchErr(targetProfileRepository.update)(targetProfile);
 
       // then
       expect(error).to.be.instanceOf(NotFoundError);
     });
 
-    it('should not update the target profile name for an unknown error', async () => {
+    it('should not update the target profile name for an database error', async () => {
       // given
       const targetProfile = databaseBuilder.factory.buildTargetProfile({ name: 'Arthur' });
       await databaseBuilder.commit();
 
       // when
       targetProfile.name = null;
-      const error = await catchErr(targetProfileRepository.updateName)(targetProfile);
+      const error = await catchErr(targetProfileRepository.update)(targetProfile);
 
       // then
       expect(error).to.be.instanceOf(ObjectValidationError);

--- a/api/tests/unit/application/target-profiles/index_test.js
+++ b/api/tests/unit/application/target-profiles/index_test.js
@@ -10,11 +10,12 @@ describe('Integration | Application | Target Profiles | Routes', () => {
 
   beforeEach(() => {
     sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+    sinon.stub(targetProfileController, 'outdateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
+    sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfiles').callsFake((request, h) => h.response('ok').code(200));
     sinon.stub(targetProfileController, 'getTargetProfileDetails').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'findPaginatedFilteredTargetProfileOrganizations').callsFake((request, h) => h.response('ok').code(200));
-    sinon.stub(targetProfileController, 'updateTargetProfile').callsFake((request, h) => h.response('ok').code(204));
-    sinon.stub(targetProfileController, 'createTargetProfile').callsFake((request, h) => h.response('ok').code(200));
+    sinon.stub(targetProfileController, 'updateTargetProfileName').callsFake((request, h) => h.response('ok').code(204));
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
   });
@@ -243,6 +244,7 @@ describe('Integration | Application | Target Profiles | Routes', () => {
       expect(response.statusCode).to.equal(400);
     });
   });
+
   describe('PATCH /api/target-profiles', () => {
 
     it('should exist', async () => {
@@ -305,4 +307,43 @@ describe('Integration | Application | Target Profiles | Routes', () => {
     });
 
   });
+
+  describe('PUT /api/target-profiles/{:id}/outdate', () => {
+
+    it('should exist', async () => {
+      // given
+      const method = 'PUT';
+      const payload = { };
+      const url = '/api/admin/target-profiles/123/outdate';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    describe('when user does not have a Pix Master role', () => {
+
+      const method = 'PUT';
+      const payload = { };
+      const url = '/api/admin/target-profiles/9999999/outdate';
+
+      it('should resolve a 403 HTTP response', async () => {
+        //Given
+        securityPreHandlers.checkUserHasRolePixMaster.callsFake((request, h) => {
+          return Promise.resolve(h.response().code(403).takeover());
+        });
+
+        // when
+        const response = await httpTestServer.request(method, url, payload);
+
+        // then
+        expect(response.statusCode).to.equal(403);
+      });
+
+    });
+
+  });
+
 });

--- a/api/tests/unit/application/target-profiles/target-profile-controller_test.js
+++ b/api/tests/unit/application/target-profiles/target-profile-controller_test.js
@@ -30,7 +30,7 @@ describe('Unit | Controller | target-profile-controller', () => {
 
       it('should succeed', async () => {
         // when
-        const response = await targetProfileController.updateTargetProfile(request, hFake);
+        const response = await targetProfileController.updateTargetProfileName(request, hFake);
 
         // then
         expect(response.statusCode).to.equal(204);
@@ -38,11 +38,46 @@ describe('Unit | Controller | target-profile-controller', () => {
 
       it('should update target profile name', async () => {
         // when
-        await targetProfileController.updateTargetProfile(request, hFake);
+        await targetProfileController.updateTargetProfileName(request, hFake);
 
         // then
         expect(usecases.updateTargetProfileName).to.have.been.calledOnce;
         expect(usecases.updateTargetProfileName).to.have.been.calledWithMatch({ id: 123, name: 'Pixer123' });
+      });
+    });
+  });
+
+  describe('#outdateTargetProfile', () => {
+
+    let request;
+
+    beforeEach(() => {
+
+      sinon.stub(usecases, 'outdateTargetProfile');
+
+      request = {
+        params: {
+          id: 123,
+        },
+      };
+    });
+
+    context('successful case', () => {
+
+      it('should succeed', async () => {
+        // when
+        const response = await targetProfileController.outdateTargetProfile(request, hFake);
+
+        // then
+        expect(response.statusCode).to.equal(204);
+      });
+
+      it('should outdate target profile', async () => {
+        // when
+        await targetProfileController.outdateTargetProfile(request, hFake);
+
+        // then
+        expect(usecases.outdateTargetProfile).to.have.been.calledWithMatch({ id: 123 });
       });
     });
   });

--- a/api/tests/unit/domain/usecases/outdate-target-profile_test.js
+++ b/api/tests/unit/domain/usecases/outdate-target-profile_test.js
@@ -1,0 +1,18 @@
+const { expect, sinon } = require('../../../test-helper');
+const { outdateTargetProfile } = require('../../../../lib/domain/usecases');
+
+describe('Unit | UseCase | outdate-target-profile', () => {
+
+  it('should call repository method to update a target profile name', async () => {
+    //given
+    const targetProfileRepository = {
+      update: sinon.stub(),
+    };
+
+    //when
+    await outdateTargetProfile({ id: 123, outdated: true, targetProfileRepository });
+
+    //then
+    expect(targetProfileRepository.update).to.have.been.calledOnceWithExactly({ id: 123, outdated: true });
+  });
+});

--- a/api/tests/unit/domain/usecases/update-target-profile-name_test.js
+++ b/api/tests/unit/domain/usecases/update-target-profile-name_test.js
@@ -6,14 +6,14 @@ describe('Unit | UseCase | update-target-profile-name', () => {
   it('should call repository method to update a target profile name', async () => {
     //given
     const targetProfileRepository = {
-      updateName: sinon.stub(),
+      update: sinon.stub(),
     };
 
     //when
     await updateTargetProfileName({ id: 123, name: 'Tom', targetProfileRepository });
 
     //then
-    expect(targetProfileRepository.updateName).to.have.been.calledOnceWithExactly({ id: 123, name: 'Tom' });
+    expect(targetProfileRepository.update).to.have.been.calledOnceWithExactly({ id: 123, name: 'Tom' });
 
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Actuellement rendre obsolète un profil cible se faisait seulement en sql.

## :robot: Solution
Ajouter une route pour l'admin permettant de marquer comme obsolète un profil cible

## :rainbow: Remarques

## :100: Pour tester
Se connecter sur Pix Admin. Rendre obsolète un profil cible ayant des orga rattachées.
allez dans Pix Orga et vérifier qu'a la création d'une campagne le profil cible n'est plus disponible.