### PR TITLE
[BUGFIX] Pouvoir désactiver l'envoi d'e-mails. 

### DIFF
--- a/api/lib/infrastructure/mailers/mailer.js
+++ b/api/lib/infrastructure/mailers/mailer.js
@@ -21,7 +21,7 @@ class Mailer {
 
   async sendEmail(options) {
     if (!mailing.enabled) {
-      EmailingAttempt.success(options.to);
+      return EmailingAttempt.success(options.to);
     }
 
     try {

--- a/api/tests/unit/infrastructure/mailers/mailer_test.js
+++ b/api/tests/unit/infrastructure/mailers/mailer_test.js
@@ -18,7 +18,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
       it('should resolve immediately and return a skip status', async () => {
         //given
         _disableMailing();
-        _mockMailingProvider();
+        const mailingProvider = _mockMailingProvider();
 
         const options = {
           from: 'bob.dylan@example.net',
@@ -33,6 +33,7 @@ describe('Unit | Infrastructure | Mailers | mailer', () => {
 
         // then
         expect(result).to.deep.equal(EmailingAttempt.success('test@example.net'));
+        expect(mailingProvider.sendEmail).to.have.not.been.called;
       });
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Suite à la PR https://github.com/1024pix/pix/pull/2682, même lorsque la variable d'environnement : `MAILING_ENABLED=false` l'envoie des e-mails se fait.

## :robot: Solution
Ajouter un `return` dans la condition vérifiant si les e-mails sont désactivés. 

## :rainbow: Remarques

## :100: Pour tester

### Comportement actuel 
1. Se baser sur dev 
2. Changer votre `.env` avec `MAILING_ENABLED=false` et `LOG_ENABLED=true`
3. Lancer votre api
4. Jouer cette commande dans un autre terminal : 
```shell
echo '{ "data": { "attributes": { "recaptcha-token": null,  "email": "aie@example.net", "first-name": "FirstName", "last-name": "lastName", "password": "Password123*", "cgu": true }, "type": "users" } }' |
  http POST http://locahost:3000/api/users
```
4. `ctrl + f` et chercher `Could not send email to` dans le terminal qui a l'API lancé. 

### Comportement sur la RA
1. Se créer un compte avec votre e-mail 
2. Constater que vous ne recevez pas d'email 
