### PR TITLE
[FEATURE] Script de création d'organisations PRO en masse depuis un fichier CSV (PIX-2278).

### DIFF
--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -48,6 +48,12 @@ class AuthenticationMethodNotFoundError extends DomainError {
   }
 }
 
+class OrganizationAlreadyExistError extends DomainError {
+  constructor(message = 'L\'organisation existe déjà.') {
+    super(message);
+  }
+}
+
 class OrganizationNotFoundError extends DomainError {
   constructor(message = 'Organisation non trouvée.') {
     super(message);
@@ -625,6 +631,12 @@ class TargetProfileInvalidError extends DomainError {
   }
 }
 
+class OrganizationTagNotFound extends DomainError {
+  constructor(message = 'Le tag de l’organization n’existe pas.') {
+    super(message);
+  }
+}
+
 class UserAlreadyLinkedToCandidateInSessionError extends DomainError {
   constructor(message = 'Cet utilisateur est déjà lié à un candidat de certification au sein de cette session.') {
     super(message);
@@ -800,6 +812,8 @@ module.exports = {
   NotFoundError,
   NotImplementedError,
   ObjectValidationError,
+  OrganizationTagNotFound,
+  OrganizationAlreadyExistError,
   OrganizationNotFoundError,
   OrganizationWithoutEmailError,
   PasswordNotMatching,

--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -6,6 +6,11 @@ const types = {
   PRO: 'PRO',
 };
 
+const defaultValues = {
+  credit: 0,
+  canCollectProfiles: false,
+};
+
 class Organization {
 
   constructor({
@@ -16,8 +21,8 @@ class Organization {
     externalId,
     provinceCode,
     isManagingStudents,
-    credit,
-    canCollectProfiles,
+    credit = defaultValues.credit,
+    canCollectProfiles = defaultValues.canCollectProfiles,
     email,
     targetProfileShares = [],
     students = [],
@@ -82,4 +87,5 @@ class Organization {
 }
 
 Organization.types = types;
+Organization.defaultValues = defaultValues;
 module.exports = Organization;

--- a/api/lib/domain/services/organization-invitation-service.js
+++ b/api/lib/domain/services/organization-invitation-service.js
@@ -33,6 +33,30 @@ const createOrganizationInvitation = async ({
   return organizationInvitation;
 };
 
+const createProOrganizationInvitation = async ({
+  organizationInvitationRepository, organizationId, email, locale, tags, name,
+}) => {
+  let organizationInvitation = await organizationInvitationRepository.findOnePendingByOrganizationIdAndEmail({ organizationId, email });
+
+  if (!organizationInvitation) {
+    const code = _generateCode();
+    organizationInvitation = await organizationInvitationRepository.create({ organizationId, email, code });
+  }
+
+  await mailService.sendOrganizationInvitationEmail({
+    email,
+    name,
+    organizationInvitationId: organizationInvitation.id,
+    code: organizationInvitation.code,
+    locale,
+    tags,
+  });
+
+  await organizationInvitationRepository.updateModificationDate(organizationInvitation.id);
+
+  return organizationInvitation;
+};
+
 const createScoOrganizationInvitation = async ({
   organizationRepository, organizationInvitationRepository, organizationId, firstName, lastName, email, locale, tags,
 }) => {
@@ -65,4 +89,5 @@ const createScoOrganizationInvitation = async ({
 module.exports = {
   createOrganizationInvitation,
   createScoOrganizationInvitation,
+  createProOrganizationInvitation,
 };

--- a/api/lib/domain/usecases/create-pro-organizations-with-tags.js
+++ b/api/lib/domain/usecases/create-pro-organizations-with-tags.js
@@ -1,0 +1,105 @@
+const { isEmpty, map, uniqBy } = require('lodash');
+const bluebird = require('bluebird');
+const Organization = require('../models/Organization');
+const OrganizationTag = require('../models/OrganizationTag');
+const { ManyOrganizationsFoundError, OrganizationAlreadyExistError, OrganizationTagNotFound, ObjectValidationError } = require('../errors');
+const ORGANIZATION_TAG_SEPARATOR = '_';
+const organizationInvitationService = require('../../domain/services/organization-invitation-service');
+
+module.exports = async function createProOrganizationsWithTags({
+  organizations,
+  domainTransaction,
+  organizationRepository,
+  tagRepository,
+  organizationTagRepository,
+  organizationInvitationRepository,
+}) {
+
+  _checkIfOrganizationsDataAreNotEmptyAndUnique(organizations);
+
+  await _checkIfOrganizationsAlreadyExistInDatabase(organizations, organizationRepository);
+
+  const organizationsData = _validateAndMapOrganizationsData(organizations);
+
+  const allTags = await tagRepository.findAll();
+
+  let createdOrganizations = null;
+
+  await domainTransaction.execute(async (domainTransaction) => {
+
+    const organizationsToCreate = Array.from(organizationsData.values()).map((data) => data.organization);
+
+    createdOrganizations = await organizationRepository.batchCreateProOrganizations(organizationsToCreate, domainTransaction);
+    const organizationsTags = createdOrganizations
+      .flatMap(({ id, externalId }) => {
+        return organizationsData.get(externalId).tags
+          .map((tagName) => {
+            const foundTag = allTags.find((tagInDB) => tagInDB.name === tagName.toUpperCase());
+            if (foundTag) {
+              return new OrganizationTag({ organizationId: id, tagId: foundTag.id });
+            } else {
+              throw new OrganizationTagNotFound();
+            }
+          });
+      });
+    await organizationTagRepository.batchCreate(organizationsTags, domainTransaction);
+  });
+
+  const createdOrganizationsWithEmail = createdOrganizations.filter((organization) => !!organization.email);
+
+  await bluebird.mapSeries(createdOrganizationsWithEmail, (organization) => {
+    const locale = organizationsData.get(organization.externalId).locale;
+    return organizationInvitationService.createProOrganizationInvitation({
+      organizationRepository,
+      organizationInvitationRepository,
+      organizationId: organization.id,
+      name: organization.name,
+      email: organization.email,
+      locale,
+    });
+  });
+  return createdOrganizations;
+};
+
+function _checkIfOrganizationsDataAreNotEmptyAndUnique(organizations) {
+
+  if (!organizations) {
+    throw new ObjectValidationError('Les organisations ne sont pas renseignées.');
+  }
+  const uniqOrganizations = uniqBy(organizations, 'externalId');
+
+  if (uniqOrganizations.length !== organizations.length) {
+    throw new ManyOrganizationsFoundError('Une organisation apparaît plusieurs fois.');
+  }
+}
+
+async function _checkIfOrganizationsAlreadyExistInDatabase(organizations, organizationRepository) {
+
+  const organizationIds = await organizationRepository.findByExternalIdsFetchingIdsOnly(map(organizations, 'externalId'));
+  if (!isEmpty(organizationIds)) {
+    throw new OrganizationAlreadyExistError();
+  }
+}
+
+function _validateAndMapOrganizationsData(organizations) {
+  const mapOrganizationByExternalId = new Map();
+
+  for (const organization of organizations) {
+    if (!organization.externalId) {
+      throw new ObjectValidationError('L’externalId de l’organisation n’est pas présent.');
+    }
+    if (!organization.name) {
+      throw new ObjectValidationError('Le nom de l’organisation n’est pas présent.');
+    }
+
+    mapOrganizationByExternalId.set(organization.externalId, {
+      organization: new Organization({
+        ...organization,
+        type: Organization.types.PRO,
+      }),
+      tags: organization.tags.split(ORGANIZATION_TAG_SEPARATOR),
+      locale: organization.locale,
+    });
+  }
+  return mapOrganizationByExternalId;
+}

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -135,6 +135,7 @@ module.exports = injectDependencies({
   createOrganizationInvitations: require('./create-organization-invitations'),
   createOrUpdateUserOrgaSettings: require('./create-or-update-user-orga-settings'),
   createPasswordResetDemand: require('./create-password-reset-demand'),
+  createProOrganizations: require('./create-pro-organizations-with-tags'),
   createSession: require('./create-session'),
   createStage: require('./create-stage'),
   createTargetProfile: require('./create-target-profile'),

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -60,7 +60,7 @@ module.exports = {
       .then(_toDomain);
   },
 
-  async batchCreate(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
+  async batchCreateProOrganizations(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
     const organizationsRawData = organizations.map((organization) => _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'credit']));
     return Bookshelf.knex.batchInsert('organizations', organizationsRawData).transacting(domainTransaction.knexTransaction).returning(['id', 'externalId', 'email', 'name']);
   },

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -1,8 +1,10 @@
 const _ = require('lodash');
 const { NotFoundError } = require('../../domain/errors');
+const Bookshelf = require('../bookshelf');
 const BookshelfOrganization = require('../data/organization');
 const Organization = require('../../domain/models/Organization');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../DomainTransaction');
 
 const DEFAULT_PAGE_SIZE = 10;
 const DEFAULT_PAGE_NUMBER = 1;
@@ -56,6 +58,11 @@ module.exports = {
     return new BookshelfOrganization()
       .save(organizationRawData)
       .then(_toDomain);
+  },
+
+  async batchCreate(organizations, domainTransaction = DomainTransaction.emptyTransaction()) {
+    const organizationsRawData = organizations.map((organization) => _.pick(organization, ['name', 'type', 'logoUrl', 'externalId', 'provinceCode', 'email', 'isManagingStudents', 'canCollectProfiles', 'credit']));
+    return Bookshelf.knex.batchInsert('organizations', organizationsRawData).transacting(domainTransaction.knexTransaction).returning(['id', 'externalId', 'email', 'name']);
   },
 
   update(organization) {

--- a/api/lib/infrastructure/repositories/organization-tag-repository.js
+++ b/api/lib/infrastructure/repositories/organization-tag-repository.js
@@ -1,8 +1,10 @@
 const BookshelfOrganizationTag = require('../data/organization-tag');
+const Bookshelf = require('../bookshelf');
 const bookshelfUtils = require('../utils/knex-utils');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const { AlreadyExistingEntityError } = require('../../domain/errors');
-const omit = require('lodash/omit');
+const { omit } = require('lodash');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
 
@@ -17,6 +19,10 @@ module.exports = {
       }
       throw err;
     }
+  },
+
+  async batchCreate(organizationsTags, domainTransaction = DomainTransaction.emptyTransaction()) {
+    return Bookshelf.knex.batchInsert('organization-tags', organizationsTags).transacting(domainTransaction.knexTransaction);
   },
 
   async isExistingByOrganizationIdAndTagId({ organizationId, tagId }) {

--- a/api/lib/infrastructure/repositories/tag-repository.js
+++ b/api/lib/infrastructure/repositories/tag-repository.js
@@ -26,4 +26,10 @@ module.exports = {
 
     return bookshelfToDomainConverter.buildDomainObject(BookshelfTag, tag);
   },
+
+  async findAll() {
+    const allTags = await BookshelfTag.fetchAll();
+    return bookshelfToDomainConverter.buildDomainObjects(BookshelfTag, allTags);
+
+  },
 };

--- a/api/scripts/create-pro-organizations-with-tags.js
+++ b/api/scripts/create-pro-organizations-with-tags.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-console */
+// Usage: node create-pro-organizations-with-tags.js path/file.csv
+// To use on file with columns |externalId, name, provinceCode, canCollectProfiles, credit, email, locale, tags|
+
+'use strict';
+require('dotenv').config();
+
+const { parseCsvWithHeader } = require('./helpers/csvHelpers');
+
+const createProOrganizationsWithTags = require('../lib/domain/usecases/create-pro-organizations-with-tags');
+const domainTransaction = require('../lib/infrastructure/DomainTransaction');
+const organizationInvitationRepository = require('../lib/infrastructure/repositories/organization-invitation-repository');
+const organizationRepository = require('../lib/infrastructure/repositories/organization-repository');
+const organizationTagRepository = require('../lib/infrastructure/repositories/organization-tag-repository');
+const tagRepository = require('../lib/infrastructure/repositories/tag-repository');
+
+async function main() {
+  console.log('Starting creating PRO organizations.');
+
+  try {
+    const filePath = process.argv[2];
+
+    console.log('Reading and parsing csv data file... ');
+    const organizations = await parseCsvWithHeader(filePath);
+
+    console.log('Creating PRO organizations...');
+    const createdOrganizations = await createProOrganizationsWithTags({
+      organizations,
+      domainTransaction,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+    console.log('\nDone.');
+
+    createdOrganizations.forEach((createdOrganization) => {
+      console.log(`${createdOrganization.id},${createdOrganization.name}`);
+    });
+  } catch (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
+++ b/api/tests/integration/domain/usecases/create-pro-organization-with-tags_test.js
@@ -1,0 +1,177 @@
+const { catchErr, expect, databaseBuilder, knex } = require('../../../test-helper');
+const { omit } = require('lodash');
+
+const domainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const organizationInvitationRepository = require('../../../../lib/infrastructure/repositories/organization-invitation-repository');
+const organizationRepository = require('../../../../lib/infrastructure/repositories/organization-repository');
+const organizationTagRepository = require('../../../../lib/infrastructure/repositories/organization-tag-repository');
+const tagRepository = require('../../../../lib/infrastructure/repositories/tag-repository');
+const { OrganizationTagNotFound, ObjectValidationError, ManyOrganizationsFoundError } = require('../../../../lib/domain/errors');
+const createProOrganizationsWithTags = require('../../../../lib/domain/usecases/create-pro-organizations-with-tags');
+
+describe('Integration | UseCases | create-pro-organization', () => {
+
+  beforeEach(async () => {
+    databaseBuilder.factory.buildTag({ name: 'TAG1' });
+    databaseBuilder.factory.buildTag({ name: 'TAG2' });
+    databaseBuilder.factory.buildTag({ name: 'TAG3' });
+    await databaseBuilder.commit();
+  });
+
+  afterEach(async () => {
+    await knex('organization-invitations').delete();
+    await knex('organization-tags').delete();
+    await knex('organizations').delete();
+
+  });
+
+  it('should create pro organizations with tags when tags already exists  ', async () => {
+    // given
+    const organizationsWithTagsAlreadyExist = [
+      { externalId: 'b200', name: 'Youness et Fils', provinceCode: '123', canCollectProfiles: false, credit: 0, email: 'youness@example.net', locale: 'fr-fr', tags: 'Tag1_Tag2' },
+      { externalId: 'b300', name: 'Andreia & Co', provinceCode: '345', canCollectProfiles: true, credit: 10, email: 'andreia@example.net', locale: 'fr-fr', tags: 'Tag2_Tag3' },
+      { externalId: 'b400', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'Tag1_Tag3' },
+    ];
+
+    // when
+    await createProOrganizationsWithTags({
+      domainTransaction,
+      organizations: organizationsWithTagsAlreadyExist,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+
+    // then
+    const organizationsInDB = await knex('organizations').select();
+    expect(organizationsInDB.length).to.equal(3);
+    const organizationTagsInDB = await knex('organization-tags').select();
+    expect(organizationTagsInDB.length).to.equal(6);
+
+    for (const organization of organizationsWithTagsAlreadyExist) {
+      const organizationInDB = await knex('organizations').first('id', 'externalId', 'name', 'provinceCode', 'canCollectProfiles', 'credit', 'email').where({ externalId: organization.externalId });
+      expect(omit(organizationInDB, 'id')).to.be.deep.equal(omit(organization, 'locale', 'tags'));
+      const organizationTagInDB = await knex('organization-tags').select().where({ organizationId: organizationInDB.id });
+      expect(organizationTagInDB.length).to.equal(2);
+
+      organizationTagInDB.forEach((value) => {
+        expect(value.organizationId).to.be.equal(organizationInDB.id);
+      });
+    }
+
+  });
+
+  it('should rollback create pro organizations with tags when tags not found', async () => {
+    // given
+    const organizationsWithTagsNotExists = [
+      { externalId: 'b200', name: 'Youness et Fils', provinceCode: '123', canCollectProfiles: false, credit: 0, email: 'youness@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b300', name: 'Andreia & Co', provinceCode: '345', canCollectProfiles: true, credit: 10, email: 'andreia@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b400', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+    ];
+
+    // when
+    const error = await catchErr(createProOrganizationsWithTags)({
+      domainTransaction,
+      organizations: organizationsWithTagsNotExists,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(OrganizationTagNotFound);
+    expect(error.message).to.be.equal('Le tag de l’organization n’existe pas.');
+    const organizationsInDB = await knex('organizations').select();
+    expect(organizationsInDB.length).to.equal(0);
+    const organizationTagsInDB = await knex('organization-tags').select();
+    expect(organizationTagsInDB.length).to.equal(0);
+
+  });
+
+  it('should rollback create pro organizations with tags and throw an error when an externalId is missing', async () => {
+    //given
+    const organizationsWithTagsWithOneMissingExternalId = [
+      { externalId: 'b200', name: 'Youness et Fils', provinceCode: '123', canCollectProfiles: false, credit: 0, email: 'youness@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: '', name: 'Andreia & Co', provinceCode: '345', canCollectProfiles: true, credit: 10, email: 'andreia@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b201', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+    ];
+
+    // when
+    const error = await catchErr(createProOrganizationsWithTags)({
+      domainTransaction,
+      organizations: organizationsWithTagsWithOneMissingExternalId,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(ObjectValidationError);
+    expect(error.message).to.be.equal('L’externalId de l’organisation n’est pas présent.');
+    const organizationsInDB = await knex('organizations').select();
+    expect(organizationsInDB.length).to.equal(0);
+    const organizationTagsInDB = await knex('organization-tags').select();
+    expect(organizationTagsInDB.length).to.equal(0);
+
+  });
+
+  it('should rollback create pro organizations with tags and throw an error when an organization name is missing', async () => {
+    // given
+    const organizationsWithTagsWithOneMissingName = [
+      { externalId: 'b200', name: 'Youness et Fils', provinceCode: '123', canCollectProfiles: false, credit: 0, email: 'youness@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b201', name: '', provinceCode: '345', canCollectProfiles: true, credit: 10, email: 'andreia@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b202', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+    ];
+
+    // when
+    const error = await catchErr(createProOrganizationsWithTags)({
+      domainTransaction,
+      organizations: organizationsWithTagsWithOneMissingName,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(ObjectValidationError);
+    expect(error.message).to.be.equal('Le nom de l’organisation n’est pas présent.');
+    const organizationsInDB = await knex('organizations').select();
+    expect(organizationsInDB.length).to.equal(0);
+    const organizationTagsInDB = await knex('organization-tags').select();
+    expect(organizationTagsInDB.length).to.equal(0);
+
+  });
+
+  it('should rollback create pro organizations with tags and throw an error when there is more than one occurrence of the same organization', async () => {
+    // given
+    const tooManyOccurencesOfTheSameorganizationWithTags = [
+      { externalId: 'b200', name: 'Youness et Fils', provinceCode: '123', canCollectProfiles: false, credit: 0, email: 'youness@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b202', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+      { externalId: 'b202', name: 'Mathieu Bâtiment', provinceCode: '567', canCollectProfiles: false, credit: 20, email: 'mathieu@example.net', locale: 'fr-fr', tags: 'TagNotFound' },
+    ];
+
+    // when
+    const error = await catchErr(createProOrganizationsWithTags)({
+      domainTransaction,
+      organizations: tooManyOccurencesOfTheSameorganizationWithTags,
+      organizationRepository,
+      tagRepository,
+      organizationTagRepository,
+      organizationInvitationRepository,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(ManyOrganizationsFoundError);
+    expect(error.message).to.be.equal('Une organisation apparaît plusieurs fois.');
+    const organizationsInDB = await knex('organizations').select();
+    expect(organizationsInDB.length).to.equal(0);
+    const organizationTagsInDB = await knex('organization-tags').select();
+    expect(organizationTagsInDB.length).to.equal(0);
+
+  });
+
+});

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -51,6 +51,26 @@ describe('Integration | Repository | Organization', function() {
       expect(organizationSaved.externalId).to.equal(organization.externalId);
       expect(organizationSaved.provinceCode).to.equal(organization.provinceCode);
     });
+
+    it('should insert default value for canCollectProfiles (false), credit (0) when not defined', async () => {
+
+      // given
+      const organization = new Organization({
+        name: 'organization',
+        externalId: 'b400',
+        type: 'PRO',
+      });
+
+      // when
+      const organizationSaved = await organizationRepository.create(organization);
+
+      // then
+      expect(organizationSaved.canCollectProfiles).to.equal(Organization.defaultValues['canCollectProfiles']);
+      expect(organizationSaved.credit).to.equal(Organization.defaultValues['credit']);
+      expect(organizationSaved.email).to.be.null;
+
+    });
+
   });
 
   describe('#update', () => {
@@ -874,7 +894,11 @@ describe('Integration | Repository | Organization', function() {
     });
   });
 
-  describe('#batchCreate', () => {
+  describe('#batchCreateProOrganizations', () => {
+
+    afterEach(async () => {
+      await knex('organizations').delete();
+    });
 
     it('should add rows in the table "organizations"', async () => {
       // given
@@ -882,7 +906,7 @@ describe('Integration | Repository | Organization', function() {
       const organization2 = domainBuilder.buildOrganization();
 
       // when
-      await organizationRepository.batchCreate([organization1, organization2]);
+      await organizationRepository.batchCreateProOrganizations([organization1, organization2]);
 
       // then
       const foundOrganizations = await knex('organizations').select();

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -873,4 +873,21 @@ describe('Integration | Repository | Organization', function() {
       });
     });
   });
+
+  describe('#batchCreate', () => {
+
+    it('should add rows in the table "organizations"', async () => {
+      // given
+      const organization1 = domainBuilder.buildOrganization();
+      const organization2 = domainBuilder.buildOrganization();
+
+      // when
+      await organizationRepository.batchCreate([organization1, organization2]);
+
+      // then
+      const foundOrganizations = await knex('organizations').select();
+      expect(foundOrganizations.length).to.equal(2);
+    });
+
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-tag-repository_test.js
@@ -78,4 +78,33 @@ describe('Integration | Repository | OrganizationTagRepository', () => {
     });
   });
 
+  describe('#batchCreate', () => {
+
+    afterEach(async () => {
+      await knex('organization-tags').delete();
+    });
+
+    it('should add rows in the table "organizations-tags"', async () => {
+      // given
+      const organizationId1 = databaseBuilder.factory.buildOrganization().id;
+      const organizationId2 = databaseBuilder.factory.buildOrganization().id;
+
+      const tagId1 = databaseBuilder.factory.buildTag().id;
+      const tagId2 = databaseBuilder.factory.buildTag().id;
+
+      await databaseBuilder.commit();
+
+      const organizationTag1 = domainBuilder.buildOrganizationTag({ organizationId: organizationId1, tagId: tagId1 });
+      const organizationTag2 = domainBuilder.buildOrganizationTag({ organizationId: organizationId2, tagId: tagId2 });
+
+      // when
+      await organizationTagRepository.batchCreate([organizationTag1, organizationTag2]);
+
+      // then
+      const foundOrganizations = await knex('organization-tags').select();
+      expect(foundOrganizations.length).to.equal(2);
+    });
+
+  });
+
 });

--- a/api/tests/integration/infrastructure/repositories/tag-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/tag-repository_test.js
@@ -5,11 +5,11 @@ const tagRepository = require('../../../../lib/infrastructure/repositories/tag-r
 
 describe('Integration | Repository | TagRepository', () => {
 
-  describe('#create', () => {
+  afterEach(async () => {
+    await knex('tags').delete();
+  });
 
-    afterEach(async () => {
-      await knex('tags').delete();
-    });
+  describe('#create', () => {
 
     it('should create a Tag', async () => {
       // given
@@ -63,6 +63,34 @@ describe('Integration | Repository | TagRepository', () => {
 
       // then
       expect(result).to.be.null;
+    });
+  });
+
+  describe('#findAll', () => {
+
+    it('should return all the tags', async () => {
+      // given
+      const tagNameA = 'PUBLIC';
+      databaseBuilder.factory.buildTag({ id: 100000, name: tagNameA });
+      const tagNameB = 'PRIVE';
+      databaseBuilder.factory.buildTag({ id: 100001, name: tagNameB });
+      await databaseBuilder.commit();
+      const expectedResult = [
+        {
+          'id': 100000,
+          'name': 'PUBLIC',
+        },
+        {
+          'id': 100001,
+          'name': 'PRIVE',
+        },
+      ];
+
+      // when
+      const result = await tagRepository.findAll();
+
+      // then
+      expect(result).to.be.deep.equal(expectedResult);
     });
   });
 

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -45,6 +45,20 @@ describe('Unit | Domain | Models | Organization', () => {
       expect(organization.targetProfileShares.length).to.equal(1);
     });
 
+    it('should build an Organization with default values for credit, canCollectProfiles when not specified', () => {
+      // given
+      const rawData = {
+        id: 1,
+        name: 'Lycée Jean Rostand',
+        type: 'SCO',
+      };
+      // when
+      const organization = new Organization(rawData);
+      // then
+      expect(organization.credit).to.equal(0);
+      expect(organization.canCollectProfiles).to.equal(false);
+    });
+
   });
 
   describe('get#isSco', () => {

--- a/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
+++ b/api/tests/unit/domain/usecases/create-pro-organizations-with-tags_test.js
@@ -1,0 +1,242 @@
+const { expect, catchErr, sinon, domainBuilder } = require('../../../test-helper');
+const Organization = require('../../../../lib/domain/models/Organization');
+const OrganizationTag = require('../../../../lib/domain/models/OrganizationTag');
+const domainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
+const createProOrganizations = require('../../../../lib/domain/usecases/create-pro-organizations-with-tags');
+const organizationInvitationService = require('../../../../lib/domain/services/organization-invitation-service');
+const { ManyOrganizationsFoundError, ObjectValidationError, OrganizationAlreadyExistError, OrganizationTagNotFound } = require('../../../../lib/domain/errors');
+
+describe('Unit | UseCase | create-pro-organizations-with-tags', () => {
+
+  let organizationRepositoryStub;
+  let organizationTagRepositoryStub;
+  let organizationInvitationRepositoryStub;
+
+  const allTags = [{ id: 1, name: 'TAG1' }, { id: 2, name: 'TAG2' }, { id: 3, name: 'TAG3' }];
+
+  let tagRepositoryStub;
+
+  beforeEach(() => {
+    organizationRepositoryStub = {
+      findByExternalIdsFetchingIdsOnly: sinon.stub(),
+      batchCreateProOrganizations: sinon.stub(),
+    };
+    organizationTagRepositoryStub = {
+      batchCreate: sinon.stub(),
+    };
+    tagRepositoryStub = {
+      findAll: sinon.stub(),
+    };
+    organizationInvitationRepositoryStub = {};
+
+    domainTransaction.execute = (lambda) => { return lambda(Symbol()); };
+
+    sinon.stub(organizationInvitationService, 'createProOrganizationInvitation').resolves();
+
+  });
+
+  it('should throw an ObjectValidationError if organizations are undefined', async() => {
+    // given
+    const organizations = undefined;
+
+    // when
+    const error = await catchErr(createProOrganizations)({ organizations });
+
+    // then
+    expect(error).to.be.an.instanceOf(ObjectValidationError);
+    expect(error.message).to.be.equals('Les organisations ne sont pas renseignées.');
+
+  });
+
+  it('should throw an error if the same organization appears twice', async() => {
+    // given
+    const organizations = [{ externalId: 'externalId' }, { externalId: 'externalId' }];
+
+    // when
+    const error = await catchErr(createProOrganizations)({ organizations });
+
+    // then
+    expect(error).to.be.an.instanceOf(ManyOrganizationsFoundError);
+  });
+
+  context('when an organization already exists in database', () => {
+
+    it('should throw an error', async() => {
+      // given
+      const organizations = [{ externalId: 'externalId' }];
+      organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([{ id: 'id', externalId: 'externalId' }]);
+
+      // when
+      const error = await catchErr(createProOrganizations)({ organizations, organizationRepository: organizationRepositoryStub });
+
+      // then
+      expect(error).to.be.an.instanceOf(OrganizationAlreadyExistError);
+    });
+  });
+
+  it('should throw an ObjectValidationError if name is empty or undefined', async () => {
+    // given
+    const organizations = [{ name: '', externalId: 'externalId' }];
+
+    // when
+    const error = await catchErr(createProOrganizations)({ organizations, organizationRepository: organizationRepositoryStub });
+
+    // then
+    expect(error).to.be.an.instanceOf(ObjectValidationError);
+    expect(error.message).to.be.equals('Le nom de l’organisation n’est pas présent.');
+  });
+
+  it('should throw an ObjectValidationError if externalId is empty or undefined', async () => {
+    // given
+    const organizations = [{ name: 'name', externalId: '' }];
+
+    // when
+    const error = await catchErr(createProOrganizations)({ organizations, organizationRepository: organizationRepositoryStub });
+
+    // then
+    expect(error).to.be.an.instanceOf(ObjectValidationError);
+    expect(error.message).to.be.equals('L’externalId de l’organisation n’est pas présent.');
+  });
+
+  it('should add organizations into database', async () => {
+    // given
+    const organization = { id: 1, name: 'organization A', externalId: 'externalId A', tags: 'Tag1_Tag2_Tag3' };
+
+    const expectedProOrganizationToInsert = [new Organization({ ...organization, type: 'PRO' })];
+    tagRepositoryStub.findAll.resolves(allTags);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([organization]);
+
+    // when
+    await createProOrganizations({
+      domainTransaction,
+      organizations: [organization],
+      organizationRepository: organizationRepositoryStub,
+      tagRepository: tagRepositoryStub,
+      organizationTagRepository: organizationTagRepositoryStub,
+    });
+
+    // then
+    expect(organizationRepositoryStub.batchCreateProOrganizations).to.be.calledWith(expectedProOrganizationToInsert);
+  });
+
+  it('should add organization tags when exists', async ()=> {
+    // given
+    const firstOrganization = { id: 1, name: 'organization A', externalId: 'externalId A', tags: 'Tag1' };
+    const secondOrganization = { id: 2, name: 'organization B', externalId: 'externalId B', tags: 'Tag1_Tag2' };
+
+    const expectedOrganizationTag1ToInsert = new OrganizationTag({ organizationId: firstOrganization.id, tagId: 1 });
+    const expectedOrganizationTag2ToInsert = new OrganizationTag({ organizationId: secondOrganization.id, tagId: 1 });
+    const expectedOrganizationTag3ToInsert = new OrganizationTag({ organizationId: secondOrganization.id, tagId: 2 });
+    const expectedOrganizationTagsToInsert = [expectedOrganizationTag1ToInsert, expectedOrganizationTag2ToInsert, expectedOrganizationTag3ToInsert];
+
+    organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
+    tagRepositoryStub.findAll.resolves(allTags);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([
+      domainBuilder.buildOrganization(firstOrganization),
+      domainBuilder.buildOrganization(secondOrganization),
+    ]);
+
+    // when
+    await createProOrganizations({
+      domainTransaction,
+      organizations: [firstOrganization, secondOrganization],
+      organizationRepository: organizationRepositoryStub,
+      tagRepository: tagRepositoryStub,
+      organizationTagRepository: organizationTagRepositoryStub,
+    });
+
+    // then
+    expect(organizationTagRepositoryStub.batchCreate).to.be.calledWith(expectedOrganizationTagsToInsert);
+  });
+
+  it('should throw an error when organization tags not exists', async ()=> {
+    // given
+    const firstOrganization = { id: 1, name: 'organization A', externalId: 'externalId A', tags: 'TagNotFound' };
+    const secondOrganization = { id: 2, name: 'organization B', externalId: 'externalId B', tags: 'Tag1_Tag2' };
+
+    organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
+    tagRepositoryStub.findAll.resolves(allTags);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([
+      domainBuilder.buildOrganization(firstOrganization),
+      domainBuilder.buildOrganization(secondOrganization),
+    ]);
+
+    // when
+    const error = await catchErr(createProOrganizations)({
+      domainTransaction,
+      organizations: [firstOrganization, secondOrganization],
+      organizationRepository: organizationRepositoryStub,
+      tagRepository: tagRepositoryStub,
+      organizationTagRepository: organizationTagRepositoryStub,
+    });
+
+    // then
+    expect(error).to.be.instanceOf(OrganizationTagNotFound);
+    expect(error.message).to.be.equal('Le tag de l’organization n’existe pas.');
+  });
+
+  it('should create invitation for organizations with email', async () => {
+    // given
+    const firstOrganization = { id: 1, name: 'organization A', externalId: 'externalId A', tags: 'Tag1', email: 'organizationA@exmaple.net', locale: 'en' };
+    const secondOrganization = { id: 2, name: 'organization B', externalId: 'externalId B', tags: 'Tag2', email: 'organizationB@exmaple.net' };
+
+    organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
+    tagRepositoryStub.findAll.resolves(allTags);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([
+      domainBuilder.buildOrganization(firstOrganization),
+      domainBuilder.buildOrganization(secondOrganization),
+    ]);
+
+    // when
+    await createProOrganizations({
+      domainTransaction,
+      organizations: [firstOrganization, secondOrganization],
+      organizationRepository: organizationRepositoryStub,
+      tagRepository: tagRepositoryStub,
+      organizationTagRepository: organizationTagRepositoryStub,
+      organizationInvitationRepository: organizationInvitationRepositoryStub,
+    });
+
+    // then
+    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWith({
+      organizationRepository: organizationRepositoryStub,
+      organizationInvitationRepository: organizationInvitationRepositoryStub,
+      organizationId: firstOrganization.id,
+      name: firstOrganization.name,
+      email: firstOrganization.email,
+      locale: firstOrganization.locale,
+    });
+    expect(organizationInvitationService.createProOrganizationInvitation).to.have.been.calledWith({
+      organizationRepository: organizationRepositoryStub,
+      organizationInvitationRepository: organizationInvitationRepositoryStub,
+      organizationId: secondOrganization.id,
+      name: secondOrganization.name,
+      email: secondOrganization.email,
+      locale: secondOrganization.locale,
+    });
+  });
+
+  it('should not create invitation if organization email is empty', async () => {
+    // given
+    const organizationWithoutEmail = { id: 1, name: 'organization A', externalId: 'externalId A', tags: 'TAG1', email: null };
+
+    organizationRepositoryStub.findByExternalIdsFetchingIdsOnly.resolves([]);
+    tagRepositoryStub.findAll.resolves(allTags);
+    organizationRepositoryStub.batchCreateProOrganizations.resolves([
+      domainBuilder.buildOrganization(organizationWithoutEmail),
+    ]);
+
+    // when
+    await createProOrganizations({
+      domainTransaction,
+      organizations: [organizationWithoutEmail],
+      organizationRepository: organizationRepositoryStub,
+      tagRepository: tagRepositoryStub,
+      organizationTagRepository: organizationTagRepositoryStub,
+      organizationInvitationRepository: organizationInvitationRepositoryStub,
+    });
+
+    // then
+    expect(organizationInvitationService.createProOrganizationInvitation).to.not.have.been.called;
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
L'équipe PRO doit créer les organisations PRO une par une. L'action devient très couteuse en temps lorsqu'il y en a plusieurs milliers.

## :robot: Solution
Ajouter un script qui permet de les créer en les important depuis un fichier csv en mode batch.

## :rainbow: Remarques
-Les données du fichier sont validées avant d'être insérées en base de donnée.
En cas d'erreur rencontrée, un rollback est effectuée afin ne pas corrompre les données (Utilisation du domainTransaction).
-La colonne tags contient des valeurs multiples séparées par un '_'.
-Pour optimiser le traitement, une recherche de tous les tags est effectuée une fois afin d'éviter les appels multiples de vérification unitaire de l'existence des tags.
-Deux appels en mode batch qui créent les organisations dans un premier temps, récupérés leurs identifiants afin de créer des organisations tags dans un second temps. Les deux appels séquentiels sont englobées dans une seule transaction.
❤️  mob team acces

## :100: Pour tester
Créer un fichier csv qui contient des lignes correspondantes aux informations de l'organisation.
Les colonnes correspondent respectivement au champs ci-dessous:
[ external Id, name, province Code, boolean canCollectProfiles, credit, email, locale, tags ]

Exemple:
b200;Entreprise pro;123;false;0;test@example.net;fr-fr;PUBLIC_AGRICULTURE

Vérifier la création de l'organisation ainsi que ses tags associés.

