### PR TITLE
[BUGFIX] Envoyer une réponse sur une épreuve en preview

### DIFF
--- a/api/lib/domain/usecases/correct-answer-then-update-assessment.js
+++ b/api/lib/domain/usecases/correct-answer-then-update-assessment.js
@@ -38,8 +38,9 @@ module.exports = async function correctAnswerThenUpdateAssessment(
 
   const challenge = await challengeRepository.get(answer.challengeId);
   const correctedAnswer = _evaluateAnswer(challenge, answer);
-  const lastQuestionDate = assessment.lastQuestionDate;
-  correctedAnswer.setTimeSpentFrom({ now: dateUtils.getNowDate(), lastQuestionDate });
+  const now = dateUtils.getNowDate();
+  const lastQuestionDate = assessment.lastQuestionDate || now;
+  correctedAnswer.setTimeSpentFrom({ now, lastQuestionDate });
 
   let scorecardBeforeAnswer = null;
   if (correctedAnswer.result.isOK() && assessment.hasKnowledgeElements()) {


### PR DESCRIPTION
## :unicorn: Problème

Lors d'un preview, la soumission de réponse tombe en erreur.
Cela est dû qu'au moment de l'affichage de la preview, un nouvel assessment est créé avec `lastQuestionDate=null`.
Or, lorsqu'une nouvelle answer est sauvegardé, on calcule le temps passé sur une épreuve à partir de `lastQuestionDate`. Comme celle-ci est null, on a une erreur sur le calcul.

## :robot: Solution
Au moment du calcul du temps passé sur une épreuve, si lastQuestionDate est null, alors on lui attribue la date `now`.
Le calcul du temps passé étant `lastQuestionDate - now`, on obtient alors 0.
Ce temps passé à 0 permet de le distinguer des épreuves non en PREVIEW.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- se rendre sur une épreuve en preview (ex: recof08UKgjNtIO25)
- vérifier que l'assessment créé à lastQuestionDate à null
- répondre à l'épreuve
-  vérifier que l'answer créé à timeSpent à 0
