### PR TITLE
[BUGFIX] Mettre le score à 0 pour un certificat validé non publié (PIX-2396)

### DIFF
--- a/api/lib/domain/read-models/livret-scolaire/Certificate.js
+++ b/api/lib/domain/read-models/livret-scolaire/Certificate.js
@@ -53,9 +53,10 @@ class Certificate {
     competenceResultsJson,
   } = {}) {
     const isValidated = _isValidated(status);
+    const displayScore = _displayScore({ isPublished, isValidated });
     const updatedStatus = (isPublished) ? status : PENDING;
-    const updatedScore = isValidated ? pixScore : 0;
-    const competenceResults = _getExtractValidatedCompetenceResults(isValidated, competenceResultsJson);
+    const updatedScore = displayScore ? pixScore : 0;
+    const competenceResults = displayScore ? _getExtractValidatedCompetenceResults(competenceResultsJson) : [];
 
     return new Certificate({ id,
       firstName,
@@ -82,11 +83,12 @@ function _isValidated(status) {
   return status === VALIDATED;
 }
 
-function _getExtractValidatedCompetenceResults(isValidated, competenceResultsJson) {
-  if (isValidated) {
-    const competenceResults = JSON.parse(competenceResultsJson);
-    return sortBy(competenceResults, 'competenceId');
-  }
-  return [];
+function _getExtractValidatedCompetenceResults(competenceResultsJson) {
+  const competenceResults = JSON.parse(competenceResultsJson);
+  return sortBy(competenceResults, 'competenceId');
+}
+
+function _displayScore({ isPublished, isValidated }) {
+  return isPublished && isValidated;
 }
 

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -30,6 +30,7 @@ describe('Integration | Repository | Certification-ls ', () => {
   describe('#getCertificatesByOrganizationUAI', () => {
 
     it('should return validated certification results for a given UAI', async () => {
+      // given
       const organizationId = buildOrganization(uai).id;
       const { schoolingRegistration, session, certificationCourse } = buildValidatedPublishedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks });
 
@@ -56,53 +57,72 @@ describe('Integration | Repository | Certification-ls ', () => {
         ],
       };
 
+      // when
       const certificationResults = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
       expect(certificationResults).to.deep.equal([expected]);
     });
 
     it('should return rejected certification results for a given UAI', async () => {
+      // given
       const organizationId = buildOrganization(uai).id;
       buildRejectedPublishedCertificationData({ organizationId, competenceMarks });
 
       await databaseBuilder.commit();
 
+      // when
       const [certificationResult] = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
       expect(certificationResult.status).to.equal(status.REJECTED);
       expect(certificationResult.pixScore).to.equal(0);
       expect(certificationResult.competenceResults).to.be.empty;
     });
 
     it('should return pending (error) certification results for a given UAI', async () => {
+      // given
       const organizationId = buildOrganization(uai).id;
       buildErrorUnpublishedCertificationData({ organizationId });
 
       await databaseBuilder.commit();
 
+      // when
       const [certificationResult] = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
       expect(certificationResult.status).to.equal(status.PENDING);
       expect(certificationResult.pixScore).to.equal(0);
       expect(certificationResult.competenceResults).to.be.empty;
     });
 
     it('should return pending (validated) certification results for a given UAI', async () => {
+      // given
       const organizationId = buildOrganization(uai).id;
       buildValidatedUnpublishedCertificationData({ organizationId });
 
       await databaseBuilder.commit();
 
+      // when
       const [certificationResult] = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
       expect(certificationResult.status).to.equal(status.PENDING);
       expect(certificationResult.pixScore).to.equal(0);
       expect(certificationResult.competenceResults).to.be.empty;
     });
 
     it('should return no certification results if no competence-marks for a given UAI', async () => {
+      // given
       const organizationId = buildOrganization(uai).id;
       buildCertificationDataWithNoCompetenceMarks({ organizationId });
 
       await databaseBuilder.commit();
 
+      // when
       const certificationResult = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
       expect(certificationResult).to.be.empty;
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -92,15 +92,15 @@ function buildOrganization(uai) {
   return databaseBuilder.factory.buildOrganization({ externalId: uai });
 }
 
-const buildValidatedPublishedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks }) {
+function buildValidatedPublishedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks }) {
   return _buildValidatedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks, isPublished: true });
-};
+}
 
-const buildValidatedUnpublishedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks }) {
+function buildValidatedUnpublishedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks }) {
   return _buildValidatedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks, isPublished: false });
-};
+}
 
-const _buildValidatedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks, isPublished }) {
+function _buildValidatedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks, isPublished }) {
   const certificationStatus = status.VALIDATED;
   const {
     schoolingRegistration,
@@ -142,9 +142,9 @@ const _buildValidatedCertificationData = function({ organizationId, verification
     session,
     certificationCourse,
   };
-};
+}
 
-const buildRejectedPublishedCertificationData = function({ organizationId, competenceMarks }) {
+function buildRejectedPublishedCertificationData({ organizationId, competenceMarks }) {
   const certificationStatus = status.REJECTED;
   const { assessmentId } = _buildCertificationData({
     organizationId,
@@ -157,10 +157,9 @@ const buildRejectedPublishedCertificationData = function({ organizationId, compe
     createdAt: createdDate,
     competenceMarks,
   });
+}
 
-};
-
-const buildErrorUnpublishedCertificationData = function({ organizationId, competenceMarks }) {
+function buildErrorUnpublishedCertificationData({ organizationId, competenceMarks }) {
   const certificationStatus = status.REJECTED;
   const { assessmentId } = _buildCertificationData({
     organizationId,
@@ -173,10 +172,9 @@ const buildErrorUnpublishedCertificationData = function({ organizationId, compet
     createdAt: createdDate,
     competenceMarks,
   });
+}
 
-};
-
-const buildCertificationDataWithNoCompetenceMarks = function({ organizationId }) {
+function buildCertificationDataWithNoCompetenceMarks({ organizationId }) {
   const certificationStatus = status.REJECTED;
   const { assessmentId } = _buildCertificationData({
     organizationId,
@@ -188,7 +186,7 @@ const buildCertificationDataWithNoCompetenceMarks = function({ organizationId })
     status: certificationStatus,
     createdAt: beforeBeforeCreatedDate,
   });
-};
+}
 
 function mockLearningContentCompetences() {
 

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -93,6 +93,14 @@ function buildOrganization(uai) {
 }
 
 const buildValidatedPublishedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks }) {
+  return _buildValidatedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks, isPublished: true });
+};
+
+const buildValidatedUnpublishedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks }) {
+  return _buildValidatedCertificationData({ organizationId, verificationCode, pixScore, competenceMarks, isPublished: false });
+};
+
+const _buildValidatedCertificationData = function({ organizationId, verificationCode, pixScore, competenceMarks, isPublished }) {
   const certificationStatus = status.VALIDATED;
   const {
     schoolingRegistration,
@@ -104,7 +112,7 @@ const buildValidatedPublishedCertificationData = function({ organizationId, veri
     verificationCode,
     type,
     pixScore,
-    isPublished: true,
+    isPublished,
   });
 
   _createAssessmentResultWithCompetenceMarks({
@@ -136,7 +144,7 @@ const buildValidatedPublishedCertificationData = function({ organizationId, veri
   };
 };
 
-const buildRejectedPublishedCertificationData = function({ organizationId }) {
+const buildRejectedPublishedCertificationData = function({ organizationId, competenceMarks }) {
   const certificationStatus = status.REJECTED;
   const { assessmentId } = _buildCertificationData({
     organizationId,
@@ -147,11 +155,12 @@ const buildRejectedPublishedCertificationData = function({ organizationId }) {
     assessmentId,
     status: certificationStatus,
     createdAt: createdDate,
+    competenceMarks,
   });
 
 };
 
-const buildErrorUnpublishedCertificationData = function({ organizationId }) {
+const buildErrorUnpublishedCertificationData = function({ organizationId, competenceMarks }) {
   const certificationStatus = status.REJECTED;
   const { assessmentId } = _buildCertificationData({
     organizationId,
@@ -162,6 +171,7 @@ const buildErrorUnpublishedCertificationData = function({ organizationId }) {
     assessmentId,
     status: certificationStatus,
     createdAt: createdDate,
+    competenceMarks,
   });
 
 };
@@ -248,6 +258,7 @@ function mockLearningContentCompetences() {
 
 module.exports = {
   buildValidatedPublishedCertificationData,
+  buildValidatedUnpublishedCertificationData,
   buildRejectedPublishedCertificationData,
   buildErrorUnpublishedCertificationData,
   buildCertificationDataWithNoCompetenceMarks,


### PR DESCRIPTION
🦄 Problème
Le score est renvoyé tel quel pour les certificats livrets scolaire. Cela n'a pas de sens si le certificat n'est pas validé OU NON PUBLIÉ

🤖 Solution
Mettre le score à 0 pour un certificat PENDING ou REJECTED ou **non publié**

💯 Pour tester
Exporter une organisation avec 3 certification course (PENDING/REJECTED/VALIDATED).
Seul le VALIDATED et publié devrait avoir une pixScore > 0