### PR TITLE
[TECH] Ajout de traductions sur la page "Certifications" dans Pix-Orga (PIX-2391)

### DIFF
--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -303,9 +303,9 @@
       "description": "Please select the class for which you would like to export the certification results in a csv file.",
       "download-button": "Export the results",
       "select-label": "Class",
-      "title": "Certifications",
-      "documentation-link-notice": "TODO",
-      "documentation-link-label": "TODO",
+      "title": "Certification results",
+      "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
+      "documentation-link-label": "Interpreting the results.",
       "documentation-link": "TODO",
       "errors": {
         "no-results": "No certification results for the class {selectedDivision}.",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -306,7 +306,7 @@
       "title": "Certification results",
       "documentation-link-notice": "Follow this link to find indications on how to interpret the results: ",
       "documentation-link-label": "Interpreting the results.",
-      "documentation-link": "TODO",
+      "documentation-link": "https://cloud.pix.fr/s/cRaeKT4ErrXs4X8",
       "errors": {
         "no-results": "No certification results for the class {selectedDivision}.",
         "invalid-division": "The class {selectedDivision} does not exist."


### PR DESCRIPTION
## :unicorn: Problème
Traduction incomplète / modifiée sur la page Certifications de PixOrga.

## :robot: Solution
Ajout de traductions pour :
- titre de la page
- notif de lien vers la doc

## :rainbow: Remarques
Le lien de la doc n'étant toujours pas traduit, j'ai laissé un lien cassé.

## :100: Pour tester
Se connecter sur sco.admin@example.net, passer en langage anglais (ajouter ?lang=en à la fin de l'URL), vérifier la traduction en allant dans le menu Certifications
