### PR TITLE
[BUGFIX] Permettre aux étudiants faisant partie d'une orga SCO non isManagingStudents d'entrer en certif (PIX-2388)

### DIFF
--- a/api/lib/domain/models/Organization.js
+++ b/api/lib/domain/models/Organization.js
@@ -75,6 +75,10 @@ class Organization {
   get isMediationNumerique() {
     return Boolean(this.tags.find((tag) => this.isPro && tag.name === Tag.MEDIATION_NUMERIQUE));
   }
+
+  get isScoAndManagingStudents() {
+    return this.isSco && this.isManagingStudents;
+  }
 }
 
 Organization.types = types;

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -46,6 +46,21 @@ module.exports = {
       });
   },
 
+  getBySessionId(sessionId) {
+    return BookshelfCertificationCenter
+      .where({ 'sessions.id': sessionId })
+      .query((qb) => {
+        qb.innerJoin('sessions', 'sessions.certificationCenterId', 'certification-centers.id');
+      })
+      .fetch()
+      .then((certificationCenter) => {
+        if (certificationCenter) {
+          return _toDomain(certificationCenter);
+        }
+        throw new NotFoundError(`Could not find certification center for sessionId ${sessionId}.`);
+      });
+  },
+
   save(certificationCenter) {
     const cleanedCertificationCenter = _.omit(certificationCenter, ['createdAt']);
     return new BookshelfCertificationCenter(cleanedCertificationCenter)

--- a/api/lib/infrastructure/repositories/certification-center-repository.js
+++ b/api/lib/infrastructure/repositories/certification-center-repository.js
@@ -34,50 +34,46 @@ function _setSearchFiltersForQueryBuilder(filters, qb) {
 
 module.exports = {
 
-  get(id) {
-    return BookshelfCertificationCenter
+  async get(id) {
+    const certificationCenterBookshelf = await BookshelfCertificationCenter
       .where({ id })
-      .fetch()
-      .then((certificationCenter) => {
-        if (certificationCenter) {
-          return _toDomain(certificationCenter);
-        }
-        throw new NotFoundError(`Certification center with id: ${id} not found`);
-      });
+      .fetch();
+
+    if (certificationCenterBookshelf) {
+      return _toDomain(certificationCenterBookshelf);
+    }
+    throw new NotFoundError(`Certification center with id: ${id} not found`);
   },
 
-  getBySessionId(sessionId) {
-    return BookshelfCertificationCenter
+  async getBySessionId(sessionId) {
+    const certificationCenterBookshelf = await BookshelfCertificationCenter
       .where({ 'sessions.id': sessionId })
       .query((qb) => {
         qb.innerJoin('sessions', 'sessions.certificationCenterId', 'certification-centers.id');
       })
-      .fetch()
-      .then((certificationCenter) => {
-        if (certificationCenter) {
-          return _toDomain(certificationCenter);
-        }
-        throw new NotFoundError(`Could not find certification center for sessionId ${sessionId}.`);
-      });
+      .fetch();
+
+    if (certificationCenterBookshelf) {
+      return _toDomain(certificationCenterBookshelf);
+    }
+    throw new NotFoundError(`Could not find certification center for sessionId ${sessionId}.`);
   },
 
-  save(certificationCenter) {
+  async save(certificationCenter) {
     const cleanedCertificationCenter = _.omit(certificationCenter, ['createdAt']);
-    return new BookshelfCertificationCenter(cleanedCertificationCenter)
-      .save()
-      .then(_toDomain);
+    const certificationCenterBookshelf = await new BookshelfCertificationCenter(cleanedCertificationCenter)
+      .save();
+    return _toDomain(certificationCenterBookshelf);
   },
 
-  findPaginatedFiltered({ filter, page }) {
-    return BookshelfCertificationCenter
+  async findPaginatedFiltered({ filter, page }) {
+    const certificationCenterBookshelf = await BookshelfCertificationCenter
       .query((qb) => _setSearchFiltersForQueryBuilder(filter, qb))
       .fetchPage({
         page: page.number,
         pageSize: page.size,
-      })
-      .then(({ models, pagination }) => ({
-        models: models.map(_toDomain),
-        pagination,
-      }));
+      });
+    const { models, pagination } = certificationCenterBookshelf;
+    return { models: models.map(_toDomain), pagination };
   },
 };

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -101,16 +101,15 @@ module.exports = {
   },
 
   async getScoOrganizationByExternalId(externalId) {
-    return BookshelfOrganization
+    const organizationBookshelf = await BookshelfOrganization
       .query((qb) => qb.where({ type: Organization.types.SCO })
-        .whereRaw('LOWER("externalId") = ? ', externalId.toLowerCase()))
-      .fetch()
-      .then((organization) => {
-        if (organization) {
-          return _toDomain(organization);
-        }
-        throw new NotFoundError(`Could not find organization for externalId ${externalId}.`);
-      });
+        .whereRaw('LOWER("externalId") = ?', externalId.toLowerCase()))
+      .fetch();
+
+    if (organizationBookshelf) {
+      return _toDomain(organizationBookshelf);
+    }
+    throw new NotFoundError(`Could not find organization for externalId ${externalId}.`);
   },
 
   findByExternalIdsFetchingIdsOnly(externalIds) {

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -100,6 +100,19 @@ module.exports = {
     throw new NotFoundError(`Not found organization for certification center id ${certificationCenterId}`);
   },
 
+  async getScoOrganizationByExternalId(externalId) {
+    return BookshelfOrganization
+      .query((qb) => qb.where({ type: Organization.types.SCO })
+        .whereRaw('LOWER("externalId") = ? ', externalId.toLowerCase()))
+      .fetch()
+      .then((organization) => {
+        if (organization) {
+          return _toDomain(organization);
+        }
+        throw new NotFoundError(`Could not find organization for externalId ${externalId}.`);
+      });
+  },
+
   findByExternalIdsFetchingIdsOnly(externalIds) {
     return BookshelfOrganization
       .where('externalId', 'in', externalIds)

--- a/api/lib/infrastructure/repositories/session-repository.js
+++ b/api/lib/infrastructure/repositories/session-repository.js
@@ -129,14 +129,4 @@ module.exports = {
     publishedSession = await publishedSession.refresh();
     return bookshelfToDomainConverter.buildDomainObject(BookshelfSession, publishedSession);
   },
-
-  async isSco(sessionId) {
-    const session = await BookshelfSession
-      .where({ 'sessions.id': sessionId, 'certification-centers.type': 'SCO' })
-      .query((qb) => {
-        qb.innerJoin('certification-centers', 'certification-centers.id', 'sessions.certificationCenterId');
-      })
-      .fetch({ columns: 'sessions.id' });
-    return Boolean(session);
-  },
 };

--- a/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
+++ b/api/tests/acceptance/application/session/session-controller-create-certification-candidate-participation_test.js
@@ -72,7 +72,9 @@ describe('Acceptance | Controller | session-controller-create-certification-cand
       let sessionId;
 
       beforeEach(() => {
-        sessionId = databaseBuilder.factory.buildSession().id;
+        databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: false, externalId: '123456' });
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({ type: 'SCO', externalId: '123456' }).id;
+        sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
         payload = {
           data: {
             attributes: {

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -1,4 +1,4 @@
-const { expect, knex, databaseBuilder } = require('../../../test-helper');
+const { expect, knex, databaseBuilder, catchErr } = require('../../../test-helper');
 const certificationCenterRepository = require('../../../../lib/infrastructure/repositories/certification-center-repository');
 const CertificationCenter = require('../../../../lib/domain/models/CertificationCenter');
 const { NotFoundError } = require('../../../../lib/domain/errors');
@@ -36,12 +36,13 @@ describe('Integration | Repository | Certification Center', () => {
 
     context('the certification center could not be found', () => {
 
-      it('should throw a NotFound error', () => {
+      it('should throw a NotFound error', async () => {
         // when
         const nonExistentId = 1;
-        const promise = certificationCenterRepository.get(nonExistentId);
+        const error = await catchErr(certificationCenterRepository.get)(nonExistentId);
+
         // then
-        return expect(promise).to.have.been.rejectedWith(NotFoundError);
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });
@@ -84,10 +85,10 @@ describe('Integration | Repository | Certification Center', () => {
         await databaseBuilder.commit();
 
         // when
-        const promise = certificationCenterRepository.getBySessionId(8);
+        const error = await catchErr(certificationCenterRepository.getBySessionId)(8);
 
         // then
-        return expect(promise).to.have.been.rejectedWith(NotFoundError);
+        expect(error).to.be.instanceOf(NotFoundError);
       });
     });
   });
@@ -101,8 +102,10 @@ describe('Integration | Repository | Certification Center', () => {
     it('should save the given certification center', async () => {
       // given
       const certificationCenter = new CertificationCenter({ name: 'CertificationCenterName' });
+
       // when
       const savedCertificationCenter = await certificationCenterRepository.save(certificationCenter);
+
       // then
       expect(savedCertificationCenter).to.be.instanceof(CertificationCenter);
       expect(savedCertificationCenter.id).to.exist;

--- a/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-center-repository_test.js
@@ -8,7 +8,7 @@ describe('Integration | Repository | Certification Center', () => {
 
   describe('#get', () => {
 
-    context('the certification is found', () => {
+    context('the certification center is found', () => {
 
       beforeEach(async () => {
         databaseBuilder.factory.buildCertificationCenter({
@@ -21,7 +21,7 @@ describe('Integration | Repository | Certification Center', () => {
         await databaseBuilder.commit();
       });
 
-      it('should return the certification of the given id with the right properties', async () => {
+      it('should return the certification center of the given id with the right properties', async () => {
         // when
         const certificationCenter = await certificationCenterRepository.get(1);
 
@@ -40,6 +40,52 @@ describe('Integration | Repository | Certification Center', () => {
         // when
         const nonExistentId = 1;
         const promise = certificationCenterRepository.get(nonExistentId);
+        // then
+        return expect(promise).to.have.been.rejectedWith(NotFoundError);
+      });
+    });
+  });
+
+  describe('#getBySessionId', () => {
+
+    context('the certification center is found for a sessionId', () => {
+
+      it('should return the certification center of the given sessionId', async () => {
+        // given
+        const certificationCenterId = databaseBuilder.factory.buildCertificationCenter({
+          externalId: '123456',
+          type: 'SCO',
+        }).id;
+        const sessionId = databaseBuilder.factory.buildSession({ certificationCenterId }).id;
+        await databaseBuilder.commit();
+
+        // when
+        const certificationCenter = await certificationCenterRepository.getBySessionId(sessionId);
+
+        // then
+        expect(certificationCenter).to.be.an.instanceOf(CertificationCenter);
+        expect(certificationCenter.id).to.equal(certificationCenterId);
+        expect(certificationCenter.externalId).to.equal('123456');
+        expect(certificationCenter.type).to.equal('SCO');
+      });
+    });
+
+    context('the certification center could not be found for a sessionId', () => {
+
+      it('should throw a NotFound error', async () => {
+        // given
+        databaseBuilder.factory.buildCertificationCenter({
+          id: 7,
+          name: 'certificationCenterName',
+          createdAt: new Date('2018-01-01T05:43:10Z'),
+          externalId: '123456',
+          type: 'SCO',
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const promise = certificationCenterRepository.getBySessionId(8);
+
         // then
         return expect(promise).to.have.been.rejectedWith(NotFoundError);
       });

--- a/api/tests/integration/infrastructure/repositories/organization-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/organization-repository_test.js
@@ -251,6 +251,56 @@ describe('Integration | Repository | Organization', function() {
     });
   });
 
+  describe('#getScoOrganizationByExternalId', () => {
+
+    describe('when there is an organization with given externalId', () => {
+
+      it('should return the organization', async () => {
+        // given
+        databaseBuilder.factory.buildOrganization({
+          id: 1,
+          type: 'SCO',
+          name: 'organization 1',
+          externalId: '1234567',
+          isManagingStudents: true,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const result = await organizationRepository.getScoOrganizationByExternalId('1234567');
+
+        // then
+        expect(result).to.be.instanceOf(Organization);
+        expect(result.id).to.deep.equal(1);
+        expect(result.type).to.deep.equal('SCO');
+        expect(result.externalId).to.deep.equal('1234567');
+        expect(result.isManagingStudents).to.deep.equal(true);
+      });
+    });
+
+    describe('when there is no organization with given externalId', () => {
+
+      it('should throw an error if the externalId does not match an organization ', async () => {
+        // given
+        databaseBuilder.factory.buildOrganization({
+          id: 1,
+          type: 'SCO',
+          name: 'organization 1',
+          externalId: '1234567',
+          isManagingStudents: true,
+        });
+        await databaseBuilder.commit();
+
+        // when
+        const error = await catchErr(organizationRepository.getScoOrganizationByExternalId)('AAAAAA');
+
+        // then
+        expect(error).to.be.instanceOf(NotFoundError);
+        expect(error.message).to.equal('Could not find organization for externalId AAAAAA.');
+      });
+    });
+  });
+
   describe('#findByExternalIdsFetchingIdsOnly', () => {
     let organizations;
 

--- a/api/tests/integration/infrastructure/repositories/session-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/session-repository_test.js
@@ -452,39 +452,4 @@ describe('Integration | Repository | Session', function() {
     });
   });
 
-  describe('#isSco', () => {
-    it('should be true when the certification center is of type SCO', async () => {
-      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
-        type: 'SCO',
-      });
-      const session = databaseBuilder.factory.buildSession({
-        certificationCenterId: certificationCenter.id,
-      });
-
-      await databaseBuilder.commit();
-
-      const result = await sessionRepository.isSco(session.id);
-
-      expect(result).to.be.true;
-    });
-
-    it('should be false when the certification center is not of type SCO', async () => {
-      // given
-      const certificationCenter = databaseBuilder.factory.buildCertificationCenter({
-        type: 'PRO',
-      });
-      const session = databaseBuilder.factory.buildSession({
-        certificationCenterId: certificationCenter.id,
-      });
-
-      await databaseBuilder.commit();
-
-      // when
-      const result = await sessionRepository.isSco(session.id);
-
-      // then
-      expect(result).to.be.false;
-    });
-  });
-
 });

--- a/api/tests/unit/domain/models/Organization_test.js
+++ b/api/tests/unit/domain/models/Organization_test.js
@@ -300,4 +300,32 @@ describe('Unit | Domain | Models | Organization', () => {
       });
     });
   });
+
+  describe('get#isScoAngManagingStudents', () => {
+
+    it('should return true when organization is of type SCO and is managing student', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true });
+
+      // when / then
+      expect(organization.isScoAndManagingStudents).is.true;
+    });
+
+    it('should return false when organization is not of type SCO', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SUP' });
+
+      // when / then
+      expect(organization.isScoAndManagingStudents).is.false;
+    });
+
+    it('should return false when organization is not managingStudent', () => {
+      // given
+      const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false });
+
+      // when / then
+      expect(organization.isScoAndManagingStudents).is.false;
+    });
+  });
+
 });

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -88,8 +88,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should not create a link and return the matching certification candidate', async () => {
           // given
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: false });
           const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
@@ -102,6 +100,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               resolves: [certificationCandidate],
             });
 
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
           // when
           const result = await linkUserToSessionCertificationCandidate({
             sessionId,
@@ -110,7 +112,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
-            sessionRepository,
+            certificationCenterRepository,
           });
 
           // then
@@ -124,8 +126,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should throw a CertificationCandidateAlreadyLinkedToUserError', async () => {
           // given
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: false });
           const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
@@ -138,6 +138,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               resolves: [certificationCandidate],
             });
 
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
           // when
           const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
@@ -146,7 +150,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
-            sessionRepository,
+            certificationCenterRepository,
           });
 
           // then
@@ -161,8 +165,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should throw a UserAlreadyLinkedToCandidateInSessionError', async () => {
           // given
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: false });
           const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
@@ -176,6 +178,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             })
             .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: 'existingLinkedCandidateToUser' });
 
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
           // when
           const err = await catchErr(linkUserToSessionCertificationCandidate)({
             sessionId,
@@ -184,7 +190,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
-            sessionRepository,
+            certificationCenterRepository,
           });
 
           // then
@@ -196,8 +202,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
         it('should create a link with between the candidate and the user and return the linked certification candidate', async () => {
           // given
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: false });
           const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
           const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
@@ -212,6 +216,10 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
             .withLinkToUser({});
 
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SUP' });
+          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+
           // when
           const result = await linkUserToSessionCertificationCandidate({
             sessionId,
@@ -220,7 +228,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
             lastName,
             birthdate,
             certificationCandidateRepository,
-            sessionRepository,
+            certificationCenterRepository,
           });
 
           // then
@@ -234,18 +242,185 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
     });
   });
 
-  context('when the session is of type SCO', () => {
+  context('when the organization behind this session is of type SCO', () => {
 
-    context('when the user does not match with a session candidate and its schooling registration', () => {
+    context('when the organization is also managing students', () => {
 
-      it('throws MatchingReconciledStudentNotFoundError', async () => {
-        // given
-        const certificationCandidate = domainBuilder.buildCertificationCandidate({
-          userId: null,
-          firstName, lastName, birthdate,
+      context('when the user does not match with a session candidate and its schooling registration', () => {
+
+        it('throws MatchingReconciledStudentNotFoundError', async () => {
+          // given
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({
+            userId: null,
+            firstName, lastName, birthdate,
+          });
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+            .withFindBySessionIdAndPersonalInfo({
+              args: {
+                sessionId,
+                firstName,
+                lastName,
+                birthdate,
+              },
+              resolves: [certificationCandidate] });
+
+          const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+          const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+            .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+          const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+          const organizationRepository = _buildFakeOrganizationRepository()
+            .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+          const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
+              args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
+              resolves: false,
+            });
+
+          // when
+          const err = await catchErr(linkUserToSessionCertificationCandidate)({
+            sessionId,
+            userId,
+            firstName,
+            lastName,
+            birthdate,
+            certificationCandidateRepository,
+            schoolingRegistrationRepository,
+            certificationCenterRepository,
+            organizationRepository,
+          });
+
+          // then
+          expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
         });
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: true });
+      });
+
+      context('when the user matches with a session candidate and its schooling registration', () => {
+
+        context('when no other candidates is already linked to that user', () => {
+
+          it('should create a link between the candidate and the user and return an event to notify it, ', async () => {
+            // given
+            const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({
+              userId: null,
+              firstName, lastName, birthdate,
+              schoolingRegistrationId: schoolingRegistration.id,
+            });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              })
+              .withFindOneBySessionIdAndUserId({
+                args: {
+                  sessionId,
+                  userId,
+                },
+                resolves: null,
+              });
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+            const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+            const organizationRepository = _buildFakeOrganizationRepository()
+              .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+            const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+              .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
+
+            // when
+            const event = await linkUserToSessionCertificationCandidate({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              certificationCandidateRepository,
+              schoolingRegistrationRepository,
+              certificationCenterRepository,
+              organizationRepository,
+            });
+
+            // then
+            expect(certificationCandidateRepository.linkToUser).to.have.been.calledWith({
+              id: certificationCandidate.id,
+              userId,
+            });
+            expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
+              .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
+            expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
+          });
+        });
+
+        context('when another candidates is already linked to that user', () => {
+
+          it('throws UserAlreadyLinkedToCandidateInSessionError', async () => {
+            // given
+            const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
+            const certificationCandidate = domainBuilder.buildCertificationCandidate({
+              userId: null,
+              firstName, lastName, birthdate,
+              schoolingRegistrationId: schoolingRegistration.id,
+            });
+            const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+              .withFindBySessionIdAndPersonalInfo({
+                args: {
+                  sessionId,
+                  firstName,
+                  lastName,
+                  birthdate,
+                },
+                resolves: [certificationCandidate],
+              })
+              .withFindOneBySessionIdAndUserId({ args: {
+                sessionId,
+                userId,
+              }, resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }) });
+
+            const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+            const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+              .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+            const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: true, externalId: '123456' });
+            const organizationRepository = _buildFakeOrganizationRepository()
+              .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
+
+            const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
+              .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
+
+            // when
+            const error = await catchErr(linkUserToSessionCertificationCandidate)({
+              sessionId,
+              userId,
+              firstName,
+              lastName,
+              birthdate,
+              certificationCandidateRepository,
+              schoolingRegistrationRepository,
+              certificationCenterRepository,
+              organizationRepository,
+            });
+
+            // then
+            expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization)
+              .to.have.been.calledWith({ userId, schoolingRegistrationId: schoolingRegistration.id });
+            expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
+          });
+        });
+      });
+    });
+
+    context('when the organization is not managing students', () => {
+
+      it('should return the linked certification candidate', async () => {
+        // given
+        const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
         const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
           .withFindBySessionIdAndPersonalInfo({
             args: {
@@ -254,143 +429,62 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
               lastName,
               birthdate,
             },
-            resolves: [certificationCandidate] });
+            resolves: [certificationCandidate],
+          })
+          .withFindOneBySessionIdAndUserId({ args: { sessionId, userId }, resolves: undefined })
+          .withLinkToUser({});
+
+        const certificationCenter = domainBuilder.buildCertificationCenter({ sessionId, type: 'SCO', externalId: '123456' });
+        const certificationCenterRepository = _buildFakeCertificationCenterRepository()
+          .withGetBySessionId({ args: sessionId, resolves: certificationCenter });
+        const organization = domainBuilder.buildOrganization({ type: 'SCO', isManagingStudents: false, externalId: '123456' });
+        const organizationRepository = _buildFakeOrganizationRepository()
+          .withGetScoOrganizationByExternalId({ args: '123456', resolves: organization });
 
         const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
           .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({
             args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId },
-            resolves: false,
+            resolves: true,
           });
 
         // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
+        const result = await linkUserToSessionCertificationCandidate({
           sessionId,
           userId,
           firstName,
           lastName,
           birthdate,
           certificationCandidateRepository,
+          certificationCenterRepository,
+          organizationRepository,
           schoolingRegistrationRepository,
-          sessionRepository,
         });
 
         // then
-        expect(err).to.be.instanceOf(MatchingReconciledStudentNotFoundError);
-      });
-    });
-
-    context('when the user matches with a session candidate and its schooling registration', () => {
-
-      context('when no other candidates is already linked to that user', () => {
-
-        it('should create a link between the candidate and the user and return an event to notify it, ', async () => {
-          // given
-          const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            userId: null,
-            firstName, lastName, birthdate,
-            schoolingRegistrationId: schoolingRegistration.id,
-          });
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: true });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate],
-            })
-            .withFindOneBySessionIdAndUserId({
-              args: {
-                sessionId,
-                userId,
-              },
-              resolves: null,
-            });
-
-          const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
-
-          // when
-          const event = await linkUserToSessionCertificationCandidate({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-            schoolingRegistrationRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(certificationCandidateRepository.linkToUser).to.have.been.calledWith({
-            id: certificationCandidate.id,
-            userId,
-          });
-          expect(event).to.be.instanceOf(UserLinkedToCertificationCandidate);
-        });
-      });
-
-      context('when another candidates is already linked to that user', () => {
-
-        it('throws UserAlreadyLinkedToCandidateInSessionError', async () => {
-          // given
-          const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
-          const certificationCandidate = domainBuilder.buildCertificationCandidate({
-            userId: null,
-            firstName, lastName, birthdate,
-            schoolingRegistrationId: schoolingRegistration.id,
-          });
-          const sessionRepository = _buildFakeSessionRepository()
-            .withIsSco({ args: sessionId, resolves: true });
-          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-            .withFindBySessionIdAndPersonalInfo({
-              args: {
-                sessionId,
-                firstName,
-                lastName,
-                birthdate,
-              },
-              resolves: [certificationCandidate],
-            })
-            .withFindOneBySessionIdAndUserId({ args: {
-              sessionId,
-              userId,
-            }, resolves: domainBuilder.buildCertificationCandidate({ id: 'another candidate' }) });
-
-          const schoolingRegistrationRepository = _buildFakeSchoolingRegistrationRepository()
-            .withIsSchoolingRegistrationIdLinkedToUserAndSCOOrganization({ args: { userId, schoolingRegistrationId: certificationCandidate.schoolingRegistrationId }, resolves: true });
-
-          // when
-          const error = await catchErr(linkUserToSessionCertificationCandidate)({
-            sessionId,
-            userId,
-            firstName,
-            lastName,
-            birthdate,
-            certificationCandidateRepository,
-            schoolingRegistrationRepository,
-            sessionRepository,
-          });
-
-          // then
-          expect(error).to.be.an.instanceof(UserAlreadyLinkedToCandidateInSessionError);
-        });
+        expect(schoolingRegistrationRepository.isSchoolingRegistrationIdLinkedToUserAndSCOOrganization).to.be.not.called;
+        expect(result).to.be.an.instanceof(UserLinkedToCertificationCandidate);
       });
     });
   });
 });
 
-function _buildFakeSessionRepository() {
-  const isSco = sinon.stub();
+function _buildFakeCertificationCenterRepository() {
+  const getBySessionId = sinon.stub();
   return {
-    isSco,
-    withIsSco({ args, resolves }) {
-      this.isSco.withArgs(args).resolves(resolves);
+    getBySessionId,
+    withGetBySessionId({ args, resolves }) {
+      this.getBySessionId.withArgs(args).resolves(resolves);
+      return this;
+    },
+  };
+}
+
+function _buildFakeOrganizationRepository() {
+  const getScoOrganizationByExternalId = sinon.stub();
+  return {
+    getScoOrganizationByExternalId,
+    withGetScoOrganizationByExternalId({ args, resolves }) {
+      this.getScoOrganizationByExternalId.withArgs(args).resolves(resolves);
       return this;
     },
   };

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -23,8 +23,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidateByPersonalInfoNotFoundError', async () => {
         // given
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: false });
         const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
           .withFindBySessionIdAndPersonalInfo({
             args: {
@@ -44,7 +42,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
-          sessionRepository,
         });
 
         // then
@@ -56,8 +53,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
 
       it('should throw a CertificationCandidateByPersonalInfoTooManyMatchesError', async () => {
         // given
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: false });
         const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
           .withFindBySessionIdAndPersonalInfo({
             args: {
@@ -77,7 +72,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           lastName,
           birthdate,
           certificationCandidateRepository,
-          sessionRepository,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -5,8 +5,6 @@ const {
   CertificationCandidateByPersonalInfoNotFoundError,
   MatchingReconciledStudentNotFoundError,
   CertificationCandidateByPersonalInfoTooManyMatchesError,
-  CertificationCandidatePersonalInfoFieldMissingError,
-  CertificationCandidatePersonalInfoWrongFormat,
   UserAlreadyLinkedToCandidateInSessionError,
 } = require('../../../../lib/domain/errors');
 const UserLinkedToCertificationCandidate = require('../../../../lib/domain/events/UserLinkedToCertificationCandidate');
@@ -27,54 +25,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   });
 
   context('when there is a problem with the personal info', () => {
-
-    context('when a field is missing from the provided personal info', () => {
-
-      it('should throw a CertificationCandidatePersonalInfoFieldMissingError', async () => {
-        // given
-        firstName = undefined;
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: false });
-
-        // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-          sessionRepository,
-        });
-
-        // then
-        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoFieldMissingError);
-      });
-    });
-
-    context('when a field is in the wrong format', () => {
-
-      it('should throw a CertificationCandidatePersonalInfoWrongFormat', async () => {
-        // given
-        birthdate = 'invalid format';
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: false });
-
-        // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-          sessionRepository,
-        });
-
-        // then
-        expect(err).to.be.instanceOf(CertificationCandidatePersonalInfoWrongFormat);
-      });
-    });
 
     context('when no certification candidates match with the provided personal info', () => {
 

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -13,16 +13,9 @@ const UserAlreadyLinkedToCertificationCandidate = require('../../../../lib/domai
 describe('Unit | Domain | Use Cases | link-user-to-session-certification-candidate', () => {
   const sessionId = 42;
   const userId = 'userId';
-  let firstName;
-  let lastName;
-  let birthdate;
-  let certificationCandidateRepository;
-
-  beforeEach(() => {
-    firstName = 'Charlie';
-    lastName = 'Bideau';
-    birthdate = '2010-10-10';
-  });
+  const firstName = 'Charlie';
+  const lastName = 'Bideau';
+  const birthdate = '2010-10-10';
 
   context('when there is a problem with the personal info', () => {
 
@@ -32,7 +25,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         // given
         const sessionRepository = _buildFakeSessionRepository()
           .withIsSco({ args: sessionId, resolves: false });
-        certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
           .withFindBySessionIdAndPersonalInfo({
             args: {
               sessionId,
@@ -65,7 +58,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
         // given
         const sessionRepository = _buildFakeSessionRepository()
           .withIsSco({ args: sessionId, resolves: false });
-        certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
           .withFindBySessionIdAndPersonalInfo({
             args: {
               sessionId,
@@ -94,7 +87,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   });
 
   context('when there is exactly one certification candidate that matches with the provided personal info', () => {
-    let certificationCandidate;
 
     context('when the matching certification candidate is already linked to a user', () => {
 
@@ -104,8 +96,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           // given
           const sessionRepository = _buildFakeSessionRepository()
             .withIsSco({ args: sessionId, resolves: false });
-          certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
-          certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId });
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
               args: {
                 sessionId,
@@ -140,8 +132,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           // given
           const sessionRepository = _buildFakeSessionRepository()
             .withIsSco({ args: sessionId, resolves: false });
-          certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
-          certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: 'otherUserId' });
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
               args: {
                 sessionId,
@@ -177,8 +169,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           // given
           const sessionRepository = _buildFakeSessionRepository()
             .withIsSco({ args: sessionId, resolves: false });
-          certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
-          certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null });
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
               args: {
                 sessionId,
@@ -212,8 +204,8 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
           // given
           const sessionRepository = _buildFakeSessionRepository()
             .withIsSco({ args: sessionId, resolves: false });
-          certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
-          certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
+          const certificationCandidate = domainBuilder.buildCertificationCandidate({ userId: null, id: 'candidateId' });
+          const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
             .withFindBySessionIdAndPersonalInfo({
               args: {
                 sessionId,
@@ -251,6 +243,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   context('when the session is of type SCO', () => {
 
     context('when the user does not match with a session candidate and its schooling registration', () => {
+
       it('throws MatchingReconciledStudentNotFoundError', async () => {
         // given
         const certificationCandidate = domainBuilder.buildCertificationCandidate({
@@ -293,7 +286,9 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
     });
 
     context('when the user matches with a session candidate and its schooling registration', () => {
+
       context('when no other candidates is already linked to that user', () => {
+
         it('should create a link between the candidate and the user and return an event to notify it, ', async () => {
           // given
           const schoolingRegistration = domainBuilder.buildSchoolingRegistration();
@@ -347,6 +342,7 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
       });
 
       context('when another candidates is already linked to that user', () => {
+
         it('throws UserAlreadyLinkedToCandidateInSessionError', async () => {
           // given
           const schoolingRegistration = domainBuilder.buildSchoolingRegistration();

--- a/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
+++ b/api/tests/unit/domain/usecases/link-user-to-session-certification-candidate_test.js
@@ -299,37 +299,6 @@ describe('Unit | Domain | Use Cases | link-user-to-session-certification-candida
   });
 
   context('when the session is of type SCO', () => {
-    context('when the user does not match with a session candidate', () => {
-      it('throws CertificationCandidateByPersonalInfoNotFoundError', async () => {
-        // given
-        const certificationCandidateRepository = _buildFakeCertificationCandidateRepository()
-          .withFindBySessionIdAndPersonalInfo({
-            args: {
-              sessionId,
-              firstName,
-              lastName,
-              birthdate,
-            },
-            resolves: [],
-          });
-        const sessionRepository = _buildFakeSessionRepository()
-          .withIsSco({ args: sessionId, resolves: true });
-
-        // when
-        const err = await catchErr(linkUserToSessionCertificationCandidate)({
-          sessionId,
-          userId,
-          firstName,
-          lastName,
-          birthdate,
-          certificationCandidateRepository,
-          sessionRepository,
-        });
-
-        // then
-        expect(err).to.be.instanceOf(CertificationCandidateByPersonalInfoNotFoundError);
-      });
-    });
 
     context('when the user does not match with a session candidate and its schooling registration', () => {
       it('throws MatchingReconciledStudentNotFoundError', async () => {


### PR DESCRIPTION
## :unicorn: Problème
Il existe 2 types d'établissements SCO : ceux important leurs élèves depuis leur fichier SIECLE (aussi appelés "isManagingStudent") et ceux n'important pas leurs élèves (et donc n'ayant pas de "gestion d'élèves").

En ce qui concerne Pix Certif, nous avons aménagé l'ajout des candidats pour les établissements SCO et "isManagingStudent" afin qu'ils puisse rajouter leurs élèves via la liste de leurs élèves déjà importés dans nos bases de données. Pour les établissements SCO et non "isManagingStudent" , les membres de Pix Certif profitent de la même interface que les centres de certification non SCO, c'est à dire avec un imports de candidats via un fichier CSV.

Pour l'application Mon-pix, lorsqu'un candidat venant du SCO tente de rejoindre une session de certification, nous faisons en sorte de vérifier si le candidat est bien connecté avec le même compte que celui avec lequel il a passé ses campagnes (passées via son établissement). Cette étape de réconciliation permet de vérifier le lien entre un candidat (certification-candidate) et un étudiant (schooling-registration).

**Un étudiant venant d'un établissement SCO et non "isManagingStudent" ne peux pas se connecter à sa certification à cause de la vérification de réconciliation.**

## :robot: Solution
Permettre aux étudiants venant des établissements "SCO" et non "isManagingStudent" de rejoindre une certification. Soit enlever la vérification de réconciliation vers un étudiant de base SIECLE pour ce genre de cas. 

## :rainbow: Remarques
Est-ce qu'on devrait déplacer la liaison entre un centre de certif et une orga dans la couche domain au lieu de laisser les repo vérifier ça ? 

## :100: Pour tester
- Lancer l'API et toutes les app
- Créer un organization SCO et non isManagingStudent (PixAdmin)
- Créer un centre de certif avec le même externalId que cette orga (PixAdmin)
- Créer un membre pour ce centre (PixAdmin)
- Créer une session (PixCertif)
- Inscrire 1 candidat de certification (PixCertif)
- Tenter de rejoindre la session avec un compte certifiable (PixApp)
- Ca devrait fonctionner (on doit pouvoir rejoindre le test de certif)