### PR TITLE
[FEATURE] Ajout du markdown sur le champ réponses des QROC (PIX-2291).

### DIFF
--- a/mon-pix/app/initializers/register-showdown-extensions.js
+++ b/mon-pix/app/initializers/register-showdown-extensions.js
@@ -1,0 +1,16 @@
+import showdown from 'showdown';
+
+export function initialize() {
+  showdown.extension('remove-paragraph-tags', function() {
+    return [{
+      type: 'html',
+      regex: /<\/?p[^>]*>/g,
+      replace: '',
+    }];
+  });
+}
+
+export default {
+  name: 'register-showdown-extensions',
+  initialize,
+};

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -76,6 +76,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/qcm-solution-panel';
 @import 'components/qcu-proposals';
 @import 'components/qcu-solution-panel';
+@import 'components/qroc-proposals';
 @import 'components/qroc-solution-panel';
 @import 'components/qrocm-solution-panel';
 @import 'components/reached-stage';

--- a/mon-pix/app/styles/components/_qroc-proposals.scss
+++ b/mon-pix/app/styles/components/_qroc-proposals.scss
@@ -1,0 +1,12 @@
+.qroc-proposal {
+
+  .qroc_input-label {
+    display: inline;
+  }
+
+  ul,
+  ol,
+  p {
+    margin: 0;
+  }
+}

--- a/mon-pix/app/templates/components/qroc-proposal.hbs
+++ b/mon-pix/app/templates/components/qroc-proposal.hbs
@@ -2,7 +2,11 @@
   {{#each this._blocks as |block|}}
 
     {{#if block.text}}
-      <label for="qroc_input">{{block.text}}</label>
+      <label for="qroc_input">
+        <MarkdownToHtml class="qroc_input-label"
+                        @extensions="remove-paragraph-tags"
+                        @markdown={{block.text}} />
+      </label>
     {{/if}}
 
     {{#if block.input}}

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -69,7 +69,7 @@ export default Factory.extend({
   QROC: trait({
     type: 'QROC',
     instruction: 'Un QROC est une question ouverte avec un simple champ texte libre pour répondre',
-    proposals: 'Entrez le prénom de B. Gates : ${firstname#prénom} (en toutes lettres)\nSVP',
+    proposals: 'Entrez le *prénom* de B. Gates : ${firstname#prénom} (en toutes lettres)\nSVP',
   }),
 
   withAutoReply: trait({

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -91,6 +91,8 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
         expect(find('.challenge-response__proposal').disabled).to.be.false;
 
+        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('<p>Entrez le <em>prénom</em> de B. Gates :</p>');
+
         expect(find('.alert')).to.not.exist;
 
       });
@@ -265,6 +267,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
         expect(find('.challenge-response__proposal').disabled).to.be.false;
+        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('<p>Entrez le <em>prénom</em> de B. Gates :</p>');
 
         expect(find('.alert')).to.not.exist;
 

--- a/mon-pix/tests/acceptance/challenge-qroc-test.js
+++ b/mon-pix/tests/acceptance/challenge-qroc-test.js
@@ -91,7 +91,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
         expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
         expect(find('.challenge-response__proposal').disabled).to.be.false;
 
-        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('<p>Entrez le <em>prénom</em> de B. Gates :</p>');
+        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('Entrez le <em>prénom</em> de B. Gates :');
 
         expect(find('.alert')).to.not.exist;
 
@@ -267,7 +267,7 @@ describe('Acceptance | Displaying a QROC challenge', () => {
 
         expect(findAll('.challenge-response__proposal')).to.have.lengthOf(1);
         expect(find('.challenge-response__proposal').disabled).to.be.false;
-        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('<p>Entrez le <em>prénom</em> de B. Gates :</p>');
+        expect(findAll('.qroc_input-label')[0].innerHTML).to.contain('Entrez le <em>prénom</em> de B. Gates :');
 
         expect(find('.alert')).to.not.exist;
 


### PR DESCRIPTION
## :unicorn: Problème

Les épreuves QROC proposent de simples réponses, on ne peut pas y insérer de liens ou images.

## :robot: Solution (non-définitive, voir section remarques ci-après)

- Utiliser le component `MarkdownToHtml` pour afficher les propositions des QROC.
- Ajout de CSS pour supprimer des `margin` trop importantes liées au problème
- Suppression des balises `<p>` créées par le composant `MarkdownToHtml`

## :rainbow: Remarques

Suite à l'utilisation de ce composant `MarkdownToHtml` dans le fichier `qcu-proposals.hbs`, nous remarquons que : 

- Le champ des réponses est rendu dans le template par un `{{#each}}`, créant une séparation des différents éléments passés en paramètres en `blocks` créés par la fonction `proposalsAsBlocks` indépendants les uns des autres.

Il nous est donc impossible via ce procédé d'obtenir un bloc de `code` unique, puisque les ` ``` ` délimitant la section sont comptés comme des lignes uniques.

--> Ainsi, nous obtenons des listes comme ressemblant à la capture d'écran ci-dessous.

<img width="377" alt="Capture d’écran 2021-03-23 à 14 25 39" src="https://user-images.githubusercontent.com/36371437/112153540-a8289100-8be3-11eb-9515-b9bb22e2ae3a.png">

Via la capture d'écran ci-dessous, nous remarquons que cela engendre des problèmes d'accessibilité, de par l'utilisation de plusieurs `label` identiques, malgré la présence d'un seul input puisqu'il s'agit d'épreuves de type `QROC`.

Un autre problème que nous rencontrons est le manque d'informations quant à l'usage du markdown qui sera fait par les équipes contenu sur ce type d'épreuves, et en particulier de l'utilisation (ou non) du bloc `code`.

A partir de là, nous avons la possibilité de : 
 
- Garder l'implémentation en l'état, et ne pas.
- Garder ce qui a été fait sur cette PR (plus les possibles retours qui lui seront faits), et acquérir de la dette dont on se débarrassera lors de la refonte des épreuves (comprenant la suppression du `{{#each}}` de `qcu-proposals.hbs` mentionné auparavant.

D'autres idées ? 🙂

## :100: Pour tester

Réaliser l'épreuve suivante : https://app-pr2755.review.pix.fr/challenges/rec25cYBOmREZy7lM/preview