### PR TITLE
[TECH] Traduction du mot d'aide/erreur lors de la mauvaise saisie du numéro de session lors de l'accès à la certification sur PixApp (PIX-2394)

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -178,7 +178,7 @@
                     "session-number": "Session number"
                 },
                 "fields-validation": {
-                  "session-number-error": "TODO"
+                  "session-number-error": "The session ID must only contain numbers."
                 }
             }
         },


### PR DESCRIPTION
## :unicorn: Problème
PixApp est complètement traduit en anglais. Lorsqu'on ajoute du texte, on doit aussi apporter la traduction. Parfois, cela met du temps avant d'avoir la traduction, donc on l'ajoute après coup.
Ici, c'est le mot d'erreur affiché lorsque le candidat saisi un numéro de session au mauvais format qui n'est pas encore traduit

## :robot: Solution
Le numéro de session est composé uniquement de chiffres. -> The session ID must only contain numbers.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se rendre sur PixApp.org avec une personne certifiable (certif1@example.net par ex.), passer en anglais, essayer d'entrer en session de certification en saisissant un numéro de session au mauvais format.
