### PR TITLE
[TECH] Recommander l'usage des arrow function dans les tests.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -15,3 +15,4 @@ rules:
         message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
      -  selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
         message: "Use only faker.internet.exampleEmail()"
+  mocha/prefer-arrow-callback: error

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 /* eslint-disable-next-line no-sync */
-require('fs').readdirSync(__dirname).forEach(function(file) {
+require('fs').readdirSync(__dirname).forEach((file) => {
   if (file === 'index.js') return;
 
   module.exports[path.basename(file, '.js')] = require(path.join(__dirname, file));

--- a/api/lib/domain/services/challenge-service.js
+++ b/api/lib/domain/services/challenge-service.js
@@ -2,7 +2,7 @@
 const _ = require('../../infrastructure/utils/lodash-utils');
 
 function _countResult(about, desiredResult) {
-  return _.reduce(about, function(sum, o) {
+  return _.reduce(about, (sum, o) => {
     return sum + (o.result === desiredResult ? 1 : 0);
   }, 0);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -19,7 +19,7 @@ module.exports = {
 
   deserialize(json) {
     return new Deserializer()
-      .deserialize(json, function(err, feedback) {
+      .deserialize(json, (err, feedback) => {
         feedback.assessmentId = json.data.relationships.assessment.data.id;
         feedback.challengeId = json.data.relationships.challenge.data.id;
       })

--- a/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
@@ -22,7 +22,7 @@ function _buildEntirePayloadError(message) {
 function serialize(validationErrors) {
   const errors = [];
 
-  Object.keys(validationErrors.data).forEach(function(field) {
+  Object.keys(validationErrors.data).forEach((field) => {
 
     validationErrors.data[field].forEach((message) => {
 

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -13,7 +13,7 @@ url.pathname = '/postgres';
 const client = new PgClient(url.href);
 
 client.query_and_log(`CREATE DATABASE ${DB_TO_CREATE_NAME};`)
-  .then(function() {
+  .then(() => {
     console.log('Database created');
     client.end();
     process.exit(0);

--- a/api/scripts/recompute-assessment-results.js
+++ b/api/scripts/recompute-assessment-results.js
@@ -39,7 +39,7 @@ function main() {
   });
 
   const listOfAssessmentIdsToRecompute = [];
-  lineReader.on('line', function(line) {
+  lineReader.on('line', (line) => {
     listOfAssessmentIdsToRecompute.push(line);
   });
 

--- a/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
+++ b/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
@@ -121,7 +121,7 @@ async function main() {
     assertFileValidity(filePath);
     console.log('Test de validité du fichier : OK');
 
-    fs.readFile(filePath, 'utf8', async function(err, data) {
+    fs.readFile(filePath, 'utf8', async (err, data) => {
       console.log('\nMise à jour des organizations...');
 
       // We delete the BOM UTF8 at the beginning of the CSV,

--- a/api/tests/acceptance/scripts/import-certifications-from-csv_test.js
+++ b/api/tests/acceptance/scripts/import-certifications-from-csv_test.js
@@ -167,7 +167,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody);
         })
         .reply(200, {});
@@ -255,21 +255,21 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .reply(200, {});
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -359,7 +359,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error');
@@ -367,7 +367,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
@@ -375,7 +375,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -491,7 +491,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error 1');
@@ -499,7 +499,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .replyWithError('Error 2');
@@ -507,7 +507,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});

--- a/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
+++ b/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
@@ -132,7 +132,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody);
         })
         .reply(200, {});
@@ -194,21 +194,21 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .reply(200, {});
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -272,7 +272,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error');
@@ -280,7 +280,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
@@ -288,7 +288,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -368,7 +368,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error 1');
@@ -376,7 +376,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .replyWithError('Error 2');
@@ -384,7 +384,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -129,7 +129,7 @@ function compareDatabaseObject(evaluatedObject, expectedObject) {
 
 }
 
-chai.use(function(chai) {
+chai.use((chai) => {
   const Assertion = chai.Assertion;
 
   Assertion.addMethod('exactlyContain', function(expectedElements) {
@@ -138,7 +138,7 @@ chai.use(function(chai) {
   });
 });
 
-chai.use(function(chai) {
+chai.use((chai) => {
   const Assertion = chai.Assertion;
 
   Assertion.addMethod('exactlyContainInOrder', function(expectedElements) {

--- a/api/tests/unit/domain/services/deactivations-service_test.js
+++ b/api/tests/unit/domain/services/deactivations-service_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.isDefault(caze.deactivations)).to.equal(caze.output);
       });
@@ -49,7 +49,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1(caze.deactivations)).to.equal(caze.output);
       });
@@ -75,7 +75,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2(caze.deactivations)).to.equal(caze.output);
       });
@@ -101,7 +101,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT3(caze.deactivations)).to.equal(caze.output);
       });
@@ -127,7 +127,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T2(caze.deactivations)).to.equal(caze.output);
       });
@@ -153,7 +153,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T3(caze.deactivations)).to.equal(caze.output);
       });
@@ -179,7 +179,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2T3(caze.deactivations)).to.equal(caze.output);
       });
@@ -205,7 +205,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: true, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasT1T2T3(caze.deactivations)).to.equal(caze.output);
       });

--- a/api/tests/unit/domain/services/email-validator_test.js
+++ b/api/tests/unit/domain/services/email-validator_test.js
@@ -17,7 +17,7 @@ describe('Unit | Service | email-validator', function() {
     'INVALID_EMAIL@pix.',
     '@pix.fr',
     '@pix',
-  ].forEach(function(badEmail) {
+  ].forEach((badEmail) => {
     it(`should return false when email is invalid: ${badEmail}`, function() {
       expect(service.emailIsValid(badEmail)).to.be.false;
     });
@@ -33,7 +33,7 @@ describe('Unit | Service | email-validator', function() {
     'follower+beta@pix.fr',
     'follower+beta@pix.gouv.fr',
     'follower+beta@pix.beta.gouv.fr',
-  ].forEach(function(validEmail) {
+  ].forEach((validEmail) => {
     it(`should return true if provided email is valid: ${validEmail}`, function() {
       expect(service.emailIsValid(validEmail)).to.be.true;
     });

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | SolutionService', function() {
 
     it('If the answer is timedout, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(timedout_answer)).then(function(foundAnswer) {
+      service.revalidate(new Answer(timedout_answer)).then((foundAnswer) => {
         expect(foundAnswer.id).equals(timedout_answer.id);
         expect(foundAnswer.attributes.value).equals(timedout_answer.value);
         expect(foundAnswer.attributes.result).equals(timedout_answer.result);
@@ -34,7 +34,7 @@ describe('Unit | Service | SolutionService', function() {
 
     it('If the answer is aband, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(aband_answer)).then(function(foundAnswer) {
+      service.revalidate(new Answer(aband_answer)).then((foundAnswer) => {
         expect(foundAnswer.id).equals(aband_answer.id);
         expect(foundAnswer.attributes.value).equals(aband_answer.value);
         expect(foundAnswer.attributes.result).equals(aband_answer.result);

--- a/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
@@ -25,7 +25,7 @@ describe('Unit | Service | SolutionService', function() {
 
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ', should return ' + caze.output + ' when preresult is "' + caze.preresult + '" and timeout is "' + caze.timeout + '"', function() {
         expect(service._timedOut(caze.preresult, caze.timeout)).to.deep.equal(caze.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -35,7 +35,7 @@ describe('Unit | Service | SolutionServiceQCM ', function() {
       { answer: '1, 2, 3', solution: '1, 2, 3' },
     ];
 
-    successfulCases.forEach(function(testCase) {
+    successfulCases.forEach((testCase) => {
       it('should return "ok" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);
@@ -51,7 +51,7 @@ describe('Unit | Service | SolutionServiceQCM ', function() {
       { answer: '3, 1', solution: '1, 2' },
     ];
 
-    failedCases.forEach(function(testCase) {
+    failedCases.forEach((testCase) => {
       it('should return "ko" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -56,7 +56,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case: '(multiple solutions) answer is 0.25 away from the closest solution', answer: 'quak', solution: 'qvak\nqwak\nanything\n' },
     ];
 
-    successfulCases.forEach(function(data) {
+    successfulCases.forEach((data) => {
       it(data.case + ', should return "ok" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         const result = service.match({ answer: data.answer, solution: data.solution });
         expect(result).to.deep.equal(ANSWER_OK);
@@ -75,7 +75,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case: '(multiple solutions) answer is minimum 0.4 away from a solution', answer: 'quaks', solution: 'qvakes\nqwakes\nanything\n' },
     ];
 
-    failingCases.forEach(function(data) {
+    failingCases.forEach((data) => {
       it(data.case + ', should return "ko" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution })).to.deep.equal(ANSWER_KO);
       });
@@ -101,7 +101,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: {} },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -126,7 +126,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -151,7 +151,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t2: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -176,7 +176,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -201,7 +201,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t2: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -226,7 +226,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -251,7 +251,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t2: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -276,7 +276,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t2: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -106,7 +106,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    maximalScoreCases.forEach(function(testCase) {
+    maximalScoreCases.forEach((testCase) => {
       it(`Should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution)).to.deep.equal(ANSWER_OK);
       });
@@ -145,7 +145,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    maximalScoreCases.forEach(function(testCase) {
+    maximalScoreCases.forEach((testCase) => {
       it(`should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_OK);
       });
@@ -172,7 +172,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    partialScoreCases.forEach(function(testCase) {
+    partialScoreCases.forEach((testCase) => {
 
       it(`should return "partially" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_PARTIALLY);
@@ -207,7 +207,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    failedCases.forEach(function(testCase) {
+    failedCases.forEach((testCase) => {
       it(`should return "ko" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_KO);
       });
@@ -324,7 +324,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(`${testCase.when}, should return ${testCase.output} when answer is "${testCase.answer}" and solution is "${testCase.solution}"`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -440,7 +440,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -556,7 +556,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -672,7 +672,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -788,7 +788,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -904,7 +904,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -1020,7 +1020,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -216,7 +216,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
     },
     ];
 
-    successfulCases.forEach(function(testCase) {
+    successfulCases.forEach((testCase) => {
       it(testCase.case + ', should return "ok" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -281,7 +281,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    failingCases.forEach(function(testCase) {
+    failingCases.forEach((testCase) => {
       it(testCase.case + ', should return "ko" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -385,7 +385,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         const actual = service.match(testCase.answer, testCase.solution, testCase.enabledTreatments);
         expect(actual).to.deep.equal(testCase.output);
@@ -489,7 +489,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -592,7 +592,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -695,7 +695,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -798,7 +798,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -901,7 +901,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -1004,7 +1004,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -1107,7 +1107,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });

--- a/api/tests/unit/domain/services/string-comparison-service_test.js
+++ b/api/tests/unit/domain/services/string-comparison-service_test.js
@@ -20,7 +20,7 @@ describe('Unit | Service | Validation Comparison', function() {
         { should: 'If they have two different characters', arg1: 'book', arg2: ['back'], output: 2 },
       ];
 
-      successfulCases.forEach(function(testCase) {
+      successfulCases.forEach((testCase) => {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(testCase.arg2)} => ${testCase.output}`, function() {
           expect(getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });
@@ -39,7 +39,7 @@ describe('Unit | Service | Validation Comparison', function() {
         { should: 'If the difference is 2 for all elements', arg1: 'book', arg2: ['back', 'buck'], output: 2 },
       ];
 
-      successfulCases.forEach(function(testCase) {
+      successfulCases.forEach((testCase) => {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(testCase.arg2)} => ${testCase.output}`, function() {
           expect(getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -59,7 +59,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
       });
     });
 
-    EMPTY_BLANK_AND_NULL.forEach(function(examinerComment) {
+    EMPTY_BLANK_AND_NULL.forEach((examinerComment) => {
       it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
         // given
         jsonCertificationCourse.data.attributes['examiner-comment'] = examinerComment;

--- a/api/tests/unit/infrastructure/utils/lodash-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/lodash-utils_test.js
@@ -97,7 +97,7 @@ describe('Unit | Utils | lodash-utils', function() {
       '\t',
       '\r\n',
       '\n',
-    ].forEach(function(string) {
+    ].forEach((string) => {
       it(`should return true if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.true;
       });
@@ -109,7 +109,7 @@ describe('Unit | Utils | lodash-utils', function() {
       'a ',
       ' a ',
       '\ta\ta',
-    ].forEach(function(string) {
+    ].forEach((string) => {
       it(`should return false if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.false;
       });

--- a/api/tests/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/request-response-utils_test.js
@@ -64,7 +64,7 @@ describe('Unit | Utils | Request Utils', function() {
       { header: 'en', expectedLocale: ENGLISH_SPOKEN },
       { header: 'de', expectedLocale: FRENCH_FRANCE },
       { header: 'fr-BE', expectedLocale: FRENCH_FRANCE },
-    ].forEach(function(data) {
+    ].forEach((data) => {
 
       it(`should return ${data.expectedLocale} locale when header is ${data.header}`, function() {
         // given


### PR DESCRIPTION
## :unicorn: Problème
Le choix d'implémentation des tests est laissé au développeur:
- fonction `it('should foo', function(`
- arrow-function `it('should foo', ()=>(`

Dans la plupart des cas, les syntaxes sont équivalentes, mais cela amène de l'hétérogénéité dans le code.

Les [avantages](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/prefer-arrow-callback.md#rule-overview) mis en avant pour les arrow-function lors des discussions sont:
- code concis
- réduit la complexité inhérente au `this`

## :robot: Solution
Recommander l'usage des arrow-function en: 
- dans le code existant, remplacer toutes les occurences de fonction par des arrow là où c'est possible (option `--fix`)
- ajouter la règle eslint [prefer-arrow-callback](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/prefer-arrow-callback.md) 

Ce changement sera expérimenté dans l'API pour démarrer.

## :rainbow: Remarques
Dans le cas où un accès au tests runner est nécessaire, par exemple pour [modifier le timeout](https://mochajs.org/#timeouts), une fonction native peut être utilisée.

Si les arguments ne vous semblent pas convaincants ou méritent d'être explicités, je peux créer une ADR.

## :100: Pour tester
Remplacer une arrow-function prar une function, vérifier qu'une erreur de lint `prefer-arrow-callback`  apparaît
Rajouter un `this.setTimeout(500);` dans le corps de la fonction et vérifier que l'erreur de lint disparaît.

