### PR TITLE
[FEATURE] Traduire en anglais la double mire dans Pix Orga (PIX-2227).

### DIFF
--- a/api/lib/domain/usecases/create-user.js
+++ b/api/lib/domain/usecases/create-user.js
@@ -9,7 +9,7 @@ const passwordValidator = require('../validators/password-validator');
 const { getCampaignUrl } = require('../../infrastructure/utils/url-builder');
 
 function _manageEmailAvailabilityError(error) {
-  return _manageError(error, AlreadyRegisteredEmailError, 'email', 'Cette adresse e-mail est déjà enregistrée, connectez-vous.');
+  return _manageError(error, AlreadyRegisteredEmailError, 'email', 'ALREADY_REGISTERED_EMAIL');
 }
 
 function _manageError(error, errorType, attribute, message) {

--- a/api/lib/domain/validators/user-validator.js
+++ b/api/lib/domain/validators/user-validator.js
@@ -9,30 +9,30 @@ const userValidationJoiSchema = Joi.object({
     .required()
     .max(255)
     .messages({
-      'string.empty': 'Votre prénom n’est pas renseigné.',
-      'string.max': 'Votre prénom ne doit pas dépasser les 255 caractères.',
+      'string.empty': 'EMPTY_FIRST_NAME',
+      'string.max': 'MAX_SIZE_FIRST_NAME',
     }),
 
   lastName: Joi.string()
     .required()
     .max(255)
     .messages({
-      'string.empty': 'Votre nom n’est pas renseigné.',
-      'string.max': 'Votre nom ne doit pas dépasser les 255 caractères.',
+      'string.empty': 'EMPTY_LAST_NAME',
+      'string.max': 'MAX_SIZE_LAST_NAME',
     }),
 
   email: Joi.string()
     .max(255)
     .email({ ignoreLength: true })
     .messages({
-      'string.empty': 'Votre adresse e-mail n’est pas renseignée.',
-      'string.max': 'Votre adresse e-mail ne doit pas dépasser les 255 caractères.',
-      'string.email': 'Le format de l\'adresse e-mail est incorrect.',
+      'string.empty': 'EMPTY_EMAIL',
+      'string.max': 'MAX_SIZE_EMAIL',
+      'string.email': 'WRONG_EMAIL_FORMAT',
     }),
 
   username: Joi.string()
     .messages({
-      'string.empty': 'Votre identifiant n’est pas renseigné.',
+      'string.empty': 'EMPTY_USERNAME',
     }),
 
   cgu: Joi.boolean()
@@ -43,8 +43,8 @@ const userValidationJoiSchema = Joi.object({
     })
     .valid(true)
     .messages({
-      'boolean.base': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
-      'any.only': 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
+      'boolean.base': 'ACCEPT_CGU',
+      'any.only': 'ACCEPT_CGU',
     }),
 
   mustValidateTermsOfService: Joi.boolean(),
@@ -54,8 +54,8 @@ const userValidationJoiSchema = Joi.object({
 }).xor('username', 'email')
   .required()
   .messages({
-    'any.required': 'Aucun champ n\'est renseigné.',
-    'object.missing': 'Vous devez renseigner une adresse e-mail et/ou un identifiant.',
+    'any.required': 'EMPTY_INPUT',
+    'object.missing': 'FILL_USERNAME_OR_EMAIL',
   });
 
 module.exports = {

--- a/api/tests/integration/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
+++ b/api/tests/integration/domain/usecases/create-and-reconcile-user-to-schooling-registration_test.js
@@ -175,7 +175,7 @@ describe('Integration | UseCases | create-and-reconcile-user-to-schooling-regist
             invalidAttributes: [
               {
                 attribute: 'email',
-                message: 'Votre adresse e-mail n’est pas renseignée.',
+                message: 'EMPTY_EMAIL',
               },
               {
                 attribute: 'password',

--- a/api/tests/unit/domain/usecases/create-user_test.js
+++ b/api/tests/unit/domain/usecases/create-user_test.js
@@ -132,7 +132,7 @@ describe('Unit | UseCase | create-user', () => {
         const expectedValidationError = new EntityValidationError({
           invalidAttributes: [{
             attribute: 'email',
-            message: 'Cette adresse e-mail est déjà enregistrée, connectez-vous.',
+            message: 'ALREADY_REGISTERED_EMAIL',
           }],
         });
 

--- a/api/tests/unit/domain/validators/user-validator_test.js
+++ b/api/tests/unit/domain/validators/user-validator_test.js
@@ -44,7 +44,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: undefined,
-            message: 'Aucun champ n\'est renseigné.',
+            message: 'EMPTY_INPUT',
           };
 
           // when
@@ -61,7 +61,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'firstName',
-            message: 'Votre prénom n’est pas renseigné.',
+            message: 'EMPTY_FIRST_NAME',
           };
           user.firstName = MISSING_VALUE;
 
@@ -79,7 +79,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'lastName',
-            message: 'Votre nom n’est pas renseigné.',
+            message: 'EMPTY_LAST_NAME',
           };
           user.lastName = MISSING_VALUE;
 
@@ -97,7 +97,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'cgu',
-            message: 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.',
+            message: 'ACCEPT_CGU',
           };
           user.cgu = 'false';
 
@@ -115,7 +115,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'email',
-            message: 'Votre adresse e-mail n’est pas renseignée.',
+            message: 'EMPTY_EMAIL',
           };
           user.email = MISSING_VALUE;
 
@@ -133,7 +133,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'email',
-            message: 'Le format de l\'adresse e-mail est incorrect.',
+            message: 'WRONG_EMAIL_FORMAT',
           };
           user.email = 'invalid_email';
 
@@ -151,7 +151,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: undefined,
-            message: 'Vous devez renseigner une adresse e-mail et/ou un identifiant.',
+            message: 'FILL_USERNAME_OR_EMAIL',
           };
 
           user.email = undefined;
@@ -183,15 +183,15 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedFirstNameError = {
             attribute: 'firstName',
-            message: 'Votre prénom ne doit pas dépasser les 255 caractères.',
+            message: 'MAX_SIZE_FIRST_NAME',
           };
           const expectedLastNameError = {
             attribute: 'lastName',
-            message: 'Votre nom ne doit pas dépasser les 255 caractères.',
+            message: 'MAX_SIZE_LAST_NAME',
           };
           const expectedMaxLengthEmailError = {
             attribute: 'email',
-            message: 'Votre adresse e-mail ne doit pas dépasser les 255 caractères.',
+            message: 'MAX_SIZE_EMAIL',
           };
 
           user = {
@@ -271,7 +271,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: undefined,
-            message: 'Aucun champ n\'est renseigné.',
+            message: 'EMPTY_INPUT',
           };
 
           // when
@@ -288,7 +288,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'firstName',
-            message: 'Votre prénom n’est pas renseigné.',
+            message: 'EMPTY_FIRST_NAME',
           };
           user.firstName = MISSING_VALUE;
 
@@ -306,7 +306,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'lastName',
-            message: 'Votre nom n’est pas renseigné.',
+            message: 'EMPTY_LAST_NAME',
           };
           user.lastName = MISSING_VALUE;
 
@@ -324,7 +324,7 @@ describe('Unit | Domain | Validators | user-validator', () => {
           // given
           const expectedError = {
             attribute: 'username',
-            message: 'Votre identifiant n’est pas renseigné.',
+            message: 'EMPTY_USERNAME',
           };
           user.username = MISSING_VALUE;
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -65,7 +65,19 @@
   "entity-validation-errors": {
     "STAGE_THRESHOLD_IS_REQUIRED": "The stage threshold is required",
     "STAGE_TITLE_IS_REQUIRED": "The stage title is required",
-    "TARGET_PROFILE_IS_REQUIRED": "The target profile is required"
+    "TARGET_PROFILE_IS_REQUIRED": "The target profile is required",
+    "ALREADY_REGISTERED_EMAIL": "This email address is already registered, please log in.",
+    "WRONG_EMAIL_FORMAT": "The email address format is invalid.",
+    "MAX_SIZE_EMAIL": "Your email address must not exceed 255 characters.",
+    "MAX_SIZE_LAST_NAME": "Your last name must not exceed 255 characters.",
+    "MAX_SIZE_FIRST_NAME": "Your first name must not exceed 255 characters.",
+    "EMPTY_EMAIL": "Please enter an email address.",
+    "EMPTY_LAST_NAME": "Please enter a last name.",
+    "EMPTY_FIRST_NAME": "Please enter a first name.",
+    "EMPTY_USERNAME": "Please enter a username.",
+    "EMPTY_INPUT": "Please fill out the fields.",
+    "ACCEPT_CGU": "Please agree to the terms and conditions of use.",
+    "FILL_USERNAME_OR_EMAIL": "Please enter an email address and/or a username."
   },
   "higher-schooling-registration-csv": {
     "birthdate": "Date of birth (DD/MM/YYYY)",

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -89,7 +89,19 @@
   "entity-validation-errors": {
     "STAGE_THRESHOLD_IS_REQUIRED": "Le seuil du palier est obligatoire",
     "STAGE_TITLE_IS_REQUIRED": "Le titre du palier est obligatoire",
-    "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire"
+    "TARGET_PROFILE_IS_REQUIRED": "Le profil cible est obligatoire",
+    "ALREADY_REGISTERED_EMAIL": "Cette adresse e-mail est déjà enregistrée, connectez-vous.",
+    "WRONG_EMAIL_FORMAT": "Le format de l'adresse e-mail est incorrect.",
+    "MAX_SIZE_EMAIL": "Votre adresse e-mail ne doit pas dépasser les 255 caractères.",
+    "MAX_SIZE_LAST_NAME": "Votre nom ne doit pas dépasser les 255 caractères.",
+    "MAX_SIZE_FIRST_NAME": "Votre prénom ne doit pas dépasser les 255 caractères.",
+    "EMPTY_EMAIL": "Votre adresse e-mail n’est pas renseignée.",
+    "EMPTY_LAST_NAME": "Votre nom n’est pas renseignée.",
+    "EMPTY_FIRST_NAME": "Votre prénom n’est pas renseigné.",
+    "EMPTY_USERNAME": "Votre identifiant n’est pas renseigné.",
+    "EMPTY_INPUT": "Aucun champ n'est renseigné.",
+    "ACCEPT_CGU": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
+    "FILL_USERNAME_OR_EMAIL": "Vous devez renseigner une adresse e-mail et/ou un identifiant."
   },
   "higher-schooling-registration-csv": {
     "birthdate": "Date de naissance (jj/mm/aaaa)",

--- a/orga/app/components/routes/login-or-register.hbs
+++ b/orga/app/components/routes/login-or-register.hbs
@@ -3,12 +3,14 @@
     <div>
       <img src="/pix-orga.svg" alt="Pix Orga" class="login-or-register-panel__logo">
     </div>
-    <span class="login-or-register-panel__invitation">Vous êtes invité(e) à rejoindre l'organisation {{@organizationName}}</span>
+    <span class="login-or-register-panel__invitation">{{t 'pages.login-or-register.invitation'}} {{@organizationName}}</span>
     <div class="login-or-register-panel__forms-container">
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">Je m’inscris</h1>
+        <h1 class="form-title">{{t 'pages.login-or-register.register-form.title'}}</h1>
         {{#unless this.displayRegisterForm}}
-          <button type="button" id="register" {{on 'click' this.toggleFormsVisibility}} class="button button--white button--bordered">S'inscrire</button>
+          <button type="button" id="register" {{on 'click' this.toggleFormsVisibility}} class="button button--white button--bordered">
+            {{t 'pages.login-or-register.register-form.button'}}
+          </button>
         {{/unless}}
         <div class={{concat "login-or-register-panel-form__expandable" (if this.displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
           {{#if this.displayRegisterForm}}
@@ -18,9 +20,11 @@
       </div>
       <div class="login-or-register-panel__divider"></div>
       <div class="login-or-register-panel__form">
-        <h1 class="form-title">J’ai déjà un compte</h1>
+        <h1 class="form-title">{{t 'pages.login-or-register.login-form.title'}}</h1>
         {{#if this.displayRegisterForm}}
-          <button type="button" id="login" {{on 'click' this.toggleFormsVisibility}} class="button button--white button--bordered">Se connecter</button>
+          <button type="button" id="login" {{on 'click' this.toggleFormsVisibility}} class="button button--white button--bordered">
+            {{t 'pages.login-or-register.login-form.button'}}
+          </button>
         {{/if}}
         <div class={{concat "login-or-register-panel-form__expandable" (unless this.displayRegisterForm " login-or-register-panel-form__expandable--expanded")}}>
           {{#unless this.displayRegisterForm}}

--- a/orga/app/components/routes/register-form.hbs
+++ b/orga/app/components/routes/register-form.hbs
@@ -3,9 +3,6 @@
 
     <div id="register-firstName-container" class="input-container">
       <label for="register-firstName" class="label">{{t 'pages.login-or-register.register-form.fields.first-name.label'}}</label>
-      {{#if this.validation.firstName.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.firstName.message}}</div>
-      {{/if}}
       <Input
         @id="register-firstName"
         @name="firstName"
@@ -15,13 +12,13 @@
         @autocomplete="firstname"
         {{on "focusout" (fn this.validateInput "firstName" this.user.firstName)}}
       />
+      {{#if this.validation.firstName.hasError}}
+        <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.firstName.message}}</div>
+      {{/if}}
     </div>
 
     <div id="register-lastName-container" class="input-container">
       <label for="register-lastName" class="label">{{t 'pages.login-or-register.register-form.fields.last-name.label'}}</label>
-      {{#if this.validation.lastName.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.lastName.message}}</div>
-      {{/if}}
       <Input
         @id="register-lastName"
         @name="lastName"
@@ -31,13 +28,13 @@
         @autocomplete="lastname"
         {{on "focusout" (fn this.validateInput "lastName" this.user.lastName)}}
       />
+      {{#if this.validation.lastName.hasError}}
+        <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.lastName.message}}</div>
+      {{/if}}
     </div>
 
     <div id="register-email-container" class="input-container">
       <label for="register-email" class="label">{{t 'pages.login-or-register.register-form.fields.email.label'}}</label>
-      {{#if this.validation.email.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.email.message}}</div>
-      {{/if}}
       <Input
         @id="register-email"
         @name="email"
@@ -47,13 +44,13 @@
         @autocomplete="username"
         {{on "focusout" (fn this.validateInput "email" this.user.email)}}
       />
+      {{#if this.validation.email.hasError}}
+        <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.email.message}}</div>
+      {{/if}}
     </div>
 
     <div id="register-password-container" class="input-container">
       <label for="register-password" class="label">{{t 'pages.login-or-register.register-form.fields.password.label'}}</label>
-      {{#if this.validation.password.hasError}}
-        <div class="alert-input alert-input--error" role="alert">{{this.validation.password.message}}</div>
-      {{/if}}
       <div class="input-password {{if this.validation.password.hasError 'input-password--error'}}">
         <Input
           @id="register-password"
@@ -72,6 +69,9 @@
           @color="dark-grey"
         />
       </div>
+      {{#if this.validation.password.hasError}}
+        <div class="alert-input alert-input--error alert-input--left" role="alert">{{this.validation.password.message}}</div>
+      {{/if}}
     </div>
 
     <div id="register-cgu-container" class="input-container">

--- a/orga/app/components/routes/register-form.hbs
+++ b/orga/app/components/routes/register-form.hbs
@@ -2,7 +2,7 @@
   <form {{on 'submit' this.register}}>
 
     <div id="register-firstName-container" class="input-container">
-      <label for="register-firstName" class="label">Prénom</label>
+      <label for="register-firstName" class="label">{{t 'pages.login-or-register.register-form.fields.first-name.label'}}</label>
       {{#if this.validation.firstName.hasError}}
         <div class="alert-input alert-input--error" role="alert">{{this.validation.firstName.message}}</div>
       {{/if}}
@@ -18,7 +18,7 @@
     </div>
 
     <div id="register-lastName-container" class="input-container">
-      <label for="register-lastName" class="label">Nom</label>
+      <label for="register-lastName" class="label">{{t 'pages.login-or-register.register-form.fields.last-name.label'}}</label>
       {{#if this.validation.lastName.hasError}}
         <div class="alert-input alert-input--error" role="alert">{{this.validation.lastName.message}}</div>
       {{/if}}
@@ -34,7 +34,7 @@
     </div>
 
     <div id="register-email-container" class="input-container">
-      <label for="register-email" class="label">Adresse e-mail</label>
+      <label for="register-email" class="label">{{t 'pages.login-or-register.register-form.fields.email.label'}}</label>
       {{#if this.validation.email.hasError}}
         <div class="alert-input alert-input--error" role="alert">{{this.validation.email.message}}</div>
       {{/if}}
@@ -50,7 +50,7 @@
     </div>
 
     <div id="register-password-container" class="input-container">
-      <label for="register-password" class="label">Mot de passe</label>
+      <label for="register-password" class="label">{{t 'pages.login-or-register.register-form.fields.password.label'}}</label>
       {{#if this.validation.password.hasError}}
         <div class="alert-input alert-input--error" role="alert">{{this.validation.password.message}}</div>
       {{/if}}
@@ -80,11 +80,14 @@
           @id="register-cgu"
           @type="checkbox"
           @checked={{this.user.cgu}}
-          aria-label="Accepter les conditions d'utilisation de Pix"
+          aria-label="{{t 'pages.login-or-register.register-form.fields.cgu.aria-label'}}"
           {{on "focusout" (fn this.validateInput "cgu" this.user.cgu)}}
         />
         <span class="register-form__cgu">
-      J'​accepte les <a href="https://pix.fr/conditions-generales-d-utilisation" class="link" target="_blank" rel="noopener noreferrer">conditions d'​utilisation de Pix</a>
+      {{t 'pages.login-or-register.register-form.fields.cgu.accept'}}
+          <a href="{{t 'pages.login-or-register.register-form.fields.cgu.link'}}" class="link" target="_blank" rel="noopener noreferrer">
+            {{t 'pages.login-or-register.register-form.fields.cgu.terms-of-use'}}
+          </a>
     </span>
       </label>
       {{#if this.validation.cgu.hasError}}
@@ -96,18 +99,13 @@
       {{#if this.isLoading}}
         <button type="button" class="button"><span class="loader-in-button">&nbsp;</span></button>
       {{else}}
-        <button type="submit" class="button">Je m'inscris</button>
+        <button type="submit" class="button">{{t 'pages.login-or-register.register-form.fields.button.label'}}</button>
       {{/if}}
     </div>
 
   </form>
 
   <div class="legal-text">
-    Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour
-    permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont
-    destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le
-    cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « informatique et libertés »,
-    vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le
-    Délégué à la Protection des Données de Pix à dpo@pix.fr.
+    {{t 'pages.login-or-register.register-form.legal-text'}}
   </div>
 </div>

--- a/orga/app/components/routes/register-form.js
+++ b/orga/app/components/routes/register-form.js
@@ -13,13 +13,14 @@ export default class RegisterForm extends Component {
 
   @service session;
   @service store;
+  @service intl;
 
   validation = {
-    firstName: new InputValidator(isStringValid, 'Votre prénom n’est pas renseigné.'),
-    lastName: new InputValidator(isStringValid, 'Votre nom n’est pas renseigné.'),
-    email: new InputValidator(isEmailValid, 'Votre email n’est pas valide.'),
-    password: new InputValidator(isPasswordValid, 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.'),
-    cgu: new InputValidator(Boolean, 'Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.'),
+    firstName: new InputValidator(isStringValid, this.intl.t('pages.login-or-register.register-form.fields.first-name.error')),
+    lastName: new InputValidator(isStringValid, this.intl.t('pages.login-or-register.register-form.fields.last-name.error')),
+    email: new InputValidator(isEmailValid, this.intl.t('pages.login-or-register.register-form.fields.email.error')),
+    password: new InputValidator(isPasswordValid, this.intl.t('pages.login-or-register.register-form.fields.password.error')),
+    cgu: new InputValidator(Boolean, this.intl.t('pages.login-or-register.register-form.fields.cgu.error')),
   };
 
   user = null;

--- a/orga/app/styles/globals/errors.scss
+++ b/orga/app/styles/globals/errors.scss
@@ -96,5 +96,6 @@
 
   &--left {
     text-align: left;
+    margin-top: 5px;
   }
 }

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -20,6 +20,12 @@ module('Acceptance | join', function(hooks) {
   setupMirage(hooks);
   setupIntl(hooks);
 
+  let loginOrRegisterButton;
+
+  hooks.beforeEach(function() {
+    loginOrRegisterButton = this.intl.t('pages.login-or-register.login-form.button');
+  });
+
   module('When prescriber tries to go on join page', function() {
 
     test('it should remain on join page when organization-invitation exists', async function(assert) {
@@ -67,7 +73,17 @@ module('Acceptance | join', function(hooks) {
     });
   });
 
-  module('Login', function() {
+  module('Login', function(hooks) {
+
+    let emailInputLabel;
+    let passwordInputLabel;
+    let loginButton;
+
+    hooks.beforeEach(function() {
+      emailInputLabel = this.intl.t('pages.login-form.email');
+      passwordInputLabel = this.intl.t('pages.login-form.password');
+      loginButton = this.intl.t('pages.login-form.login');
+    });
 
     module('When prescriber is logging in but has not accepted terms of service yet', function(hooks) {
 
@@ -91,12 +107,12 @@ module('Acceptance | join', function(hooks) {
       test('it should redirect user to the terms-of-service page', async function(assert) {
         // given
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'secret');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'secret');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.equal(currentURL(), '/cgu');
@@ -108,12 +124,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'secret');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'secret');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -146,12 +162,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'secret');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'secret');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.equal(currentURL(), '/campagnes');
@@ -163,12 +179,12 @@ module('Acceptance | join', function(hooks) {
         server.create('campaign');
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'secret');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'secret');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.ok(currentSession(this.application).get('isAuthenticated'), 'The user is authenticated');
@@ -200,12 +216,12 @@ module('Acceptance | join', function(hooks) {
         }, 401);
 
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'fakepassword');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'fakepassword');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
@@ -242,12 +258,12 @@ module('Acceptance | join', function(hooks) {
           }],
         }, 412);
         await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-        await clickByLabel('Se connecter');
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', 'secret');
+        await clickByLabel(loginOrRegisterButton);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, 'secret');
 
         // when
-        await clickByLabel('Je me connecte');
+        await clickByLabel(loginButton);
 
         // then
         assert.equal(currentURL(), '/cgu');
@@ -256,7 +272,23 @@ module('Acceptance | join', function(hooks) {
     });
   });
 
-  module('Register', function() {
+  module('Register', function(hooks) {
+
+    let firstNameInputLabel;
+    let lastNameInputLabel;
+    let emailInputLabel;
+    let passwordInputLabel;
+    let cguAriaLabel;
+    let registerButtonLabel;
+
+    hooks.beforeEach(function() {
+      firstNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.first-name.label');
+      lastNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.last-name.label');
+      emailInputLabel = this.intl.t('pages.login-or-register.register-form.fields.email.label');
+      passwordInputLabel = this.intl.t('pages.login-or-register.register-form.fields.password.label');
+      cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
+      registerButtonLabel = this.intl.t('pages.login-or-register.register-form.fields.button.label');
+    });
 
     module('When prescriber is registering', function() {
 
@@ -276,14 +308,14 @@ module('Acceptance | join', function(hooks) {
           }).id;
 
           await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-          await fillInByLabel('Prénom', 'pix');
-          await fillInByLabel('Nom', 'pix');
-          await fillInByLabel('Adresse e-mail', 'shi@fu.me');
-          await fillInByLabel('Mot de passe', 'Password4register');
-          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
+          await fillInByLabel(firstNameInputLabel, 'pix');
+          await fillInByLabel(lastNameInputLabel, 'pix');
+          await fillInByLabel(emailInputLabel, 'shi@fu.me');
+          await fillInByLabel(passwordInputLabel, 'Password4register');
+          await clickByLabel(cguAriaLabel);
 
           // when
-          await clickByLabel('Je m\'inscris');
+          await clickByLabel(registerButtonLabel);
 
           // then
           assert.equal(currentURL(), '/cgu');
@@ -317,14 +349,14 @@ module('Acceptance | join', function(hooks) {
           }, 422);
 
           await visit(`/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);
-          await fillInByLabel('Prénom', 'pix');
-          await fillInByLabel('Nom', 'pix');
-          await fillInByLabel('Adresse e-mail', 'alreadyUser@organization.org');
-          await fillInByLabel('Mot de passe', 'Password4register');
-          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
+          await fillInByLabel(firstNameInputLabel, 'pix');
+          await fillInByLabel(lastNameInputLabel, 'pix');
+          await fillInByLabel(emailInputLabel, 'alreadyUser@organization.org');
+          await fillInByLabel(passwordInputLabel, 'Password4register');
+          await clickByLabel(cguAriaLabel);
 
           // when
-          await clickByLabel('Je m\'inscris');
+          await clickByLabel(registerButtonLabel);
 
           // then
           assert.equal(currentURL(), `/rejoindre?invitationId=${organizationInvitationId}&code=${code}`);

--- a/orga/tests/integration/components/routes/login-or-register-test.js
+++ b/orga/tests/integration/components/routes/login-or-register-test.js
@@ -1,11 +1,18 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
 module('Integration | Component | routes/login-or-register', function(hooks) {
-  setupRenderingTest(hooks);
+
+  setupIntlRenderingTest(hooks);
+
+  let loginButton;
+
+  hooks.beforeEach(function() {
+    loginButton = this.intl.t('pages.login-or-register.login-form.button');
+  });
 
   test('it renders', async function(assert) {
     // when
@@ -17,10 +24,12 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
 
   test('it display the organization name the user is invited to', async function(assert) {
     // when
+    const invitationMessage = this.intl.t('pages.login-or-register.invitation');
+
     await render(hbs`<Routes::LoginOrRegister @organizationName='Organization Aztec'/>`);
 
     // then
-    assert.dom('.login-or-register-panel__invitation').hasText('Vous êtes invité(e) à rejoindre l\'organisation Organization Aztec');
+    assert.dom('.login-or-register-panel__invitation').hasText(`${invitationMessage} Organization Aztec`);
   });
 
   test('it toggle the register form by default', async function(assert) {
@@ -36,7 +45,7 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
     await render(hbs`<Routes::LoginOrRegister/>`);
 
     // when
-    await clickByLabel('Se connecter');
+    await clickByLabel(loginButton);
 
     // then
     assert.dom('.login-form').exists();
@@ -44,11 +53,13 @@ module('Integration | Component | routes/login-or-register', function(hooks) {
 
   test('it toggle the register form on click on register button', async function(assert) {
     // given
+    const registerButtonLabel = this.intl.t('pages.login-or-register.register-form.button');
+
     await render(hbs`<Routes::LoginOrRegister/>`);
 
     // when
-    await clickByLabel('Se connecter');
-    await clickByLabel('S\'inscrire');
+    await clickByLabel(loginButton);
+    await clickByLabel(registerButtonLabel);
 
     // then
     assert.dom('.register-form').exists();

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -1,5 +1,4 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 import { render, triggerEvent } from '@ember/test-helpers';
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
@@ -8,22 +7,38 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
+import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
-const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
-const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
-const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
+const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.first-name.error';
+const EMPTY_LASTNAME_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.last-name.error';
+const EMPTY_EMAIL_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.email.error';
+const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'pages.login-or-register.register-form.fields.password.error';
 
 module('Integration | Component | routes/register-form', function(hooks) {
-  setupRenderingTest(hooks);
+
+  setupIntlRenderingTest(hooks);
 
   class SessionStub extends Service {}
   class StoreStub extends Service {}
+
+  let firstNameInputLabel;
+  let lastNameInputLabel;
+  let emailInputLabel;
+  let passwordInputLabel;
+  let cguAriaLabel;
+  let registerButtonLabel;
 
   hooks.beforeEach(function() {
     this.set('user', EmberObject.create({}));
 
     this.owner.register('service:session', SessionStub);
+
+    firstNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.first-name.label');
+    lastNameInputLabel = this.intl.t('pages.login-or-register.register-form.fields.last-name.label');
+    emailInputLabel = this.intl.t('pages.login-or-register.register-form.fields.email.label');
+    passwordInputLabel = this.intl.t('pages.login-or-register.register-form.fields.password.label');
+    cguAriaLabel = this.intl.t('pages.login-or-register.register-form.fields.cgu.aria-label');
+    registerButtonLabel = this.intl.t('pages.login-or-register.register-form.fields.button.label');
   });
 
   test('it renders', async function(assert) {
@@ -62,14 +77,14 @@ module('Integration | Component | routes/register-form', function(hooks) {
       // given
       const sessionServiceObserver = this.owner.lookup('service:session');
       await render(hbs`<Routes::RegisterForm @organizationInvitationId=1 @organizationInvitationCode='C0D3'/>`);
-      await fillInByLabel('Prénom', 'pix');
-      await fillInByLabel('Nom', 'pix');
-      await fillInByLabel('Adresse e-mail', 'shi@fu.me');
-      await fillInByLabel('Mot de passe', 'Mypassword1');
-      await clickByLabel('Accepter les conditions d\'utilisation de Pix');
+      await fillInByLabel(firstNameInputLabel, 'pix');
+      await fillInByLabel(lastNameInputLabel, 'pix');
+      await fillInByLabel(emailInputLabel, 'shi@fu.me');
+      await fillInByLabel(passwordInputLabel, 'Mypassword1');
+      await clickByLabel(cguAriaLabel);
 
       // when
-      await clickByLabel('Je m\'inscris');
+      await clickByLabel(registerButtonLabel);
 
       // then
       assert.dom('.alert-input--error').doesNotExist();
@@ -92,11 +107,11 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillInByLabel('Prénom', stringFilledIn);
+          await fillInByLabel(firstNameInputLabel, stringFilledIn);
           await triggerEvent('#register-firstName', 'focusout');
 
           // then
-          assert.dom('#register-firstName-container .alert-input--error').hasText(EMPTY_FIRSTNAME_ERROR_MESSAGE);
+          assert.dom('#register-firstName-container .alert-input--error').hasText(this.intl.t(EMPTY_FIRSTNAME_ERROR_MESSAGE));
           assert.dom('#register-firstName-container .input--error').exists();
         });
       });
@@ -109,11 +124,11 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillInByLabel('Nom', stringFilledIn);
+          await fillInByLabel(lastNameInputLabel, stringFilledIn);
           await triggerEvent('#register-lastName', 'focusout');
 
           // then
-          assert.dom('#register-lastName-container .alert-input--error').hasText(EMPTY_LASTNAME_ERROR_MESSAGE);
+          assert.dom('#register-lastName-container .alert-input--error').hasText(this.intl.t(EMPTY_LASTNAME_ERROR_MESSAGE));
           assert.dom('#register-lastName-container .input--error').exists();
         });
       });
@@ -128,11 +143,11 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillInByLabel('Adresse e-mail', stringFilledIn);
+          await fillInByLabel(emailInputLabel, stringFilledIn);
           await triggerEvent('#register-email', 'focusout');
 
           // then
-          assert.dom('#register-email-container .alert-input--error').hasText(EMPTY_EMAIL_ERROR_MESSAGE);
+          assert.dom('#register-email-container .alert-input--error').hasText(this.intl.t(EMPTY_EMAIL_ERROR_MESSAGE));
           assert.dom('#register-email-container .input--error').exists();
         });
       });
@@ -148,11 +163,11 @@ module('Integration | Component | routes/register-form', function(hooks) {
           await render(hbs`<Routes::RegisterForm/>`);
 
           // when
-          await fillInByLabel('Mot de passe', stringFilledIn);
+          await fillInByLabel(passwordInputLabel, stringFilledIn);
           await triggerEvent('#register-password', 'focusout');
 
           // then
-          assert.dom('#register-password-container .alert-input--error').hasText(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE);
+          assert.dom('#register-password-container .alert-input--error').hasText(this.intl.t(INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE));
           assert.dom('#register-password-container .input-password--error').exists();
         });
       });
@@ -164,12 +179,12 @@ module('Integration | Component | routes/register-form', function(hooks) {
       let validUser;
 
       const fillForm = async function(user) {
-        await fillInByLabel('Prénom', user.firstName);
-        await fillInByLabel('Nom', user.lastName);
-        await fillInByLabel('Adresse e-mail', user.email);
-        await fillInByLabel('Mot de passe', user.password);
+        await fillInByLabel(firstNameInputLabel, user.firstName);
+        await fillInByLabel(lastNameInputLabel, user.lastName);
+        await fillInByLabel(emailInputLabel, user.email);
+        await fillInByLabel(passwordInputLabel, user.password);
         if (user.cgu) {
-          await clickByLabel('Accepter les conditions d\'utilisation de Pix');
+          await clickByLabel(cguAriaLabel);
         }
       };
 
@@ -200,7 +215,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ firstName: '' } });
 
         // when
-        await clickByLabel('Je m\'inscris');
+        await clickByLabel(registerButtonLabel);
 
         // then
         assert.equal(spy.callCount, 0);
@@ -211,7 +226,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ lastName: '' } });
 
         // when
-        await clickByLabel('Je m\'inscris');
+        await clickByLabel(registerButtonLabel);
 
         // then
         assert.equal(spy.callCount, 0);
@@ -222,7 +237,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ email: '' } });
 
         // when
-        await clickByLabel('Je m\'inscris');
+        await clickByLabel(registerButtonLabel);
 
         // then
         assert.equal(spy.callCount, 0);
@@ -233,7 +248,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ password: '' } });
 
         // when
-        await clickByLabel('Je m\'inscris');
+        await clickByLabel(registerButtonLabel);
 
         // then
         assert.equal(spy.callCount, 0);
@@ -244,7 +259,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         await fillForm({ ...validUser, ...{ cgu: false } });
 
         // when
-        await clickByLabel('Je m\'inscris');
+        await clickByLabel(registerButtonLabel);
 
         // then
         assert.equal(spy.callCount, 0);

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -347,22 +347,22 @@
       }
     },
     "login-or-register": {
-      "invitation": "En cours de traduction",
+      "invitation": "You have been invited to join the organisation",
       "register-form": {
-        "title": "En cours de traduction",
+        "title": "I sign up",
         "button": "Sign up",
         "fields": {
           "first-name": {
             "label":"First name",
-            "error": "Please enter your first name."
+            "error": "Please enter a first name."
           },
           "last-name": {
             "label":"Last name",
-            "error": "Please enter your last name."
+            "error": "Please enter a last name."
           },
           "email": {
             "label": "Email address",
-            "error": "Your email address is invalid."
+            "error": "Please enter a valid email address."
           },
           "password": {
             "label": "Password",
@@ -371,18 +371,18 @@
           "cgu": {
             "accept": "I agree to the",
             "link": "https://pix.org/en-gb/terms-and-conditions/",
-            "terms-of-use": "Pix terms of use",
-            "aria-label": "En cours de traduction",
-            "error": "You must agree to the Pix terms of use to create an account."
+            "terms-of-use": "terms and conditions of use of the Pix platform",
+            "aria-label": "Accept the terms of use of the Pix platform",
+            "error": "Please agree to the terms and conditions of use."
           },
           "button": {
-            "label": "En cours de traduction"
+            "label": "I sign up"
           }
         },
         "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific personalised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
       },
       "login-form": {
-        "title": "En cours de traduction",
+        "title": "I already have an account",
         "button": "Log in"
       }
     },

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -350,7 +350,36 @@
       "invitation": "En cours de traduction",
       "register-form": {
         "title": "En cours de traduction",
-        "button": "Sign up"
+        "button": "Sign up",
+        "fields": {
+          "first-name": {
+            "label":"First name",
+            "error": "Please enter your first name."
+          },
+          "last-name": {
+            "label":"Last name",
+            "error": "Please enter your last name."
+          },
+          "email": {
+            "label": "Email address",
+            "error": "Your email address is invalid."
+          },
+          "password": {
+            "label": "Password",
+            "error": "Your password must contain at least 8 characters and include at least one uppercase letter, one lowercase letter and one number."
+          },
+          "cgu": {
+            "accept": "I agree to the",
+            "link": "https://pix.org/en-gb/terms-and-conditions/",
+            "terms-of-use": "Pix terms of use",
+            "aria-label": "En cours de traduction",
+            "error": "You must agree to the Pix terms of use to create an account."
+          },
+          "button": {
+            "label": "En cours de traduction"
+          }
+        },
+        "legal-text": "The information collected in this form is saved in a computer file by Pix to enable access to the service offered by Pix. They are kept for the duration of use of the service and are intended for Pix. Test results may be communicated to third parties, with your consent, if you have been invited to take a specific personalised test. In accordance with the French law governing computer technology and freedoms (“Informatique et Libertés”), you can exercise the right to access and rectify your data by emailing our Data Protection Officer at dpo@pix.fr."
       },
       "login-form": {
         "title": "En cours de traduction",

--- a/orga/translations/en.json
+++ b/orga/translations/en.json
@@ -346,6 +346,17 @@
         }
       }
     },
+    "login-or-register": {
+      "invitation": "En cours de traduction",
+      "register-form": {
+        "title": "En cours de traduction",
+        "button": "Sign up"
+      },
+      "login-form": {
+        "title": "En cours de traduction",
+        "button": "Log in"
+      }
+    },
     "profiles-individual-results": {
       "certifiable": "Eligible for certification",
       "competences-certifiables": "SKILLS ELIGIBLE FOR CERTIFICATION",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -346,6 +346,17 @@
         }
       }
     },
+    "login-or-register": {
+      "invitation": "Vous êtes invité(e) à rejoindre l'organisation",
+      "register-form": {
+        "title": "Je m’inscris",
+        "button": "S'inscrire"
+      },
+      "login-form": {
+        "title": "J'ai déjà un compte",
+        "button": "Se connecter"
+      }
+    },
     "profiles-individual-results": {
       "certifiable": "Certifiable",
       "competences-certifiables": "COMP. CERTIFIABLES",

--- a/orga/translations/fr.json
+++ b/orga/translations/fr.json
@@ -350,7 +350,36 @@
       "invitation": "Vous êtes invité(e) à rejoindre l'organisation",
       "register-form": {
         "title": "Je m’inscris",
-        "button": "S'inscrire"
+        "button": "S'inscrire",
+        "fields": {
+          "first-name": {
+            "label":"Prénom",
+            "error": "Votre prénom n’est pas renseigné."
+          },
+          "last-name": {
+            "label":"Nom",
+            "error": "Votre nom n’est pas renseigné."
+          },
+          "email": {
+            "label": "Adresse e-mail",
+            "error": "Votre adresse e-mail n’est pas valide."
+          },
+          "password": {
+            "label": "Mot de passe",
+            "error": "Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre."
+          },
+          "cgu": {
+            "accept": "J'accepte les",
+            "link": "https://pix.fr/conditions-generales-d-utilisation",
+            "terms-of-use": "conditions d'utilisation de Pix",
+            "aria-label": "Accepter les conditions d'utilisation de Pix",
+            "error": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte."
+          },
+          "button": {
+            "label": "Je m'inscris"
+          }
+        },
+        "legal-text": "Les informations recueillies sur ce formulaire sont enregistrées dans un fichier informatisé par Pix pour permettre l’accès au service offert. Elles sont conservées pendant la durée d’utilisation du service et sont destinées à Pix. Les résultats des tests pourront être communiqués à des tiers, avec votre consentement, dans le cas où vous avez été invité à suivre un parcours spécifique. Conformément à la loi « Informatique et Libertés », vous pouvez exercer votre droit d'accès aux données vous concernant et les faire rectifier en contactant le Délégué à la Protection des Données de Pix à dpo@pix.fr."
       },
       "login-form": {
         "title": "J'ai déjà un compte",


### PR DESCRIPTION
## :unicorn: Problème
ℹ️ EN ATTENTE DE TRADUCTION ℹ️ 
Dans Pix Orga, les textes de la double mire de connexion sont en français, et implémentés "en dur" dans le code.
On veut ajouter la version anglaise.

## :robot: Solution
Externaliser dans des fichiers dédiés la version française et anglaise des textes de cette page

## :rainbow: Remarques
Déplacement des messages d'erreur sous les champs pour le formulaire de gauche, pour créer un compte.

## :100: Pour tester
Vérifier la bonne traduction dans la double mire :

- Pour y accéder, se connecter avec un compte admin (sco.admin@exemple.net) et s'envoyer une invitation (`nom.prénom+test@pix.fr`).

- Cliquer sur le lien du mail reçu. ( Pour voir la page en anglais, ajouter à la suite de l'URL `&lang=en` )

Si test en local, entrer l'URL suivante `rejoindre?invitationId=100019&code=PY84GN6MQ7` avec `&lang=en` pour l'anglais