### PR TITLE
[FEATURE] Ajout du markdown sur le champ réponses des QROCm (PIX-2292).

### DIFF
--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -77,6 +77,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/qcu-proposals';
 @import 'components/qcu-solution-panel';
 @import 'components/qroc-proposals';
+@import 'components/qrocm-proposals';
 @import 'components/qroc-solution-panel';
 @import 'components/qrocm-solution-panel';
 @import 'components/reached-stage';

--- a/mon-pix/app/styles/components/_qrocm-proposals.scss
+++ b/mon-pix/app/styles/components/_qrocm-proposals.scss
@@ -1,0 +1,6 @@
+.qrocm-proposal {
+
+  &__label {
+    display: inline-block;
+  }
+}

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -55,3 +55,10 @@
     }
   }
 }
+
+.correction-qrocm-text {
+
+  &__label {
+    display: inline-block;
+  }
+}

--- a/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-dep-solution-panel.hbs
@@ -1,29 +1,38 @@
-{{!-- template-lint-disable no-triple-curlies --}}
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each this.inputFields as |field|}}
-      {{{field.label}}}
+    {{#each this.blocks as |block|}}
+      {{#if block.text}}
+        <MarkdownToHtml @markdown={{block.text}}
+                        @extensions="remove-paragraph-tags"
+                        class="correction-qrocm-text__label" />
+      {{/if}}
 
-      {{#if (eq @challenge.format 'paragraphe')}}
-        <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
-                  rows="5"
-                  value="{{field.answer}}"
-                  id="{{field.label}}"
-                  disabled>
-        </textarea>
-      {{else if (eq @challenge.format 'phrase')}}
-        <input value="{{field.answer}}"
-               class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
-               id="{{field.label}}"
-               disabled>
-      {{else}}
-        <div class="correction-qrocm__answer-wrapper">
-          <input value="{{field.answer}}"
-                 size="{{get-qroc-input-size @challenge.format}}"
-                 class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
-                 id="{{field.label}}"
+      {{#if block.input}}
+        {{#if (eq @challenge.format 'paragraphe')}}
+          <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{block.inputClass}}"
+                    rows="5"
+                    value="{{block.answer}}"
+                    id="{{block.input}}"
+                    disabled>
+          </textarea>
+        {{else if (eq @challenge.format 'phrase')}}
+          <input value="{{block.answer}}"
+                 class="correction-qrocm__answer correction-qrocm__answer--sentence {{block.inputClass}}"
+                 id="{{block.input}}"
                  disabled>
-        </div>
+        {{else}}
+          <div class="correction-qrocm__answer-wrapper">
+            <input value="{{block.answer}}"
+                   size="{{get-qroc-input-size @challenge.format}}"
+                   class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}"
+                   id="{{block.input}}"
+                   disabled>
+          </div>
+        {{/if}}
+      {{/if}}
+
+      {{#if block.breakline}}
+        <br>
       {{/if}}
     {{/each}}
     {{#unless this.answerIsCorrect}}

--- a/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
+++ b/mon-pix/app/templates/components/qrocm-ind-solution-panel.hbs
@@ -1,48 +1,65 @@
-{{!-- template-lint-disable no-triple-curlies --}}
 <div class="qrocm-solution-panel rounded-panel">
   <div class="rounded-panel__row correction-qrocm__text">
-    {{#each this.inputFields as |field|}}
-      {{{field.label}}}
+    {{#each this.blocks as |block|}}
+      {{#if block.showText}}
+        <MarkdownToHtml @markdown={{block.text}}
+                        @extensions="remove-paragraph-tags"
+                        class="correction-qrocm-text__label" />
+      {{/if}}
 
-      {{#if (eq @challenge.format 'paragraphe')}}
-        <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{field.inputClass}}"
-                  rows="5"
-                  value="{{field.answer}}"
-                  id="{{field.label}}"
-                  disabled>
-        </textarea>
-        {{#if field.emptyOrWrongAnswer}}
-            <div class="correction-qrocm__solution">
-                <img class="correction-qrocm__solution-img" src="/images/icons/comparison-window/icon-arrow-right.svg" alt="" role="none">
-                <div class="correction-qrocm__solution-text">{{field.solution}}</div>
-            </div>
+      {{#if block.input}}
+        {{#if block.text}}
+          <label for="{{block.input}}">
+            <MarkdownToHtml @markdown={{block.text}}
+                            @extensions="remove-paragraph-tags"
+                            class="correction-qrocm-text__label" />
+          </label>
         {{/if}}
-      {{else if (eq @challenge.format 'phrase')}}
-        <input value="{{field.answer}}"
-               size="{{get-qroc-input-size @challenge.format}}"
-               class="correction-qrocm__answer correction-qrocm__answer--sentence {{field.inputClass}}"
-               id="{{field.label}}"
-               disabled>
-        {{#if field.emptyOrWrongAnswer}}
-          <div class="correction-qrocm__solution">
-            <img class="correction-qrocm__solution-img" src="/images/icons/comparison-window/icon-arrow-right.svg" alt="" role="none">
-            <div class="correction-qrocm__solution-text">{{field.solution}}</div>
-          </div>
-        {{/if}}
-      {{else}}
-        <div class="correction-qrocm__answer-wrapper">
-          <input value="{{field.answer}}"
+
+        {{#if (eq @challenge.format 'paragraphe')}}
+          <textarea class="correction-qrocm__answer correction-qrocm__answer--paragraph {{block.inputClass}}"
+                    rows="5"
+                    value="{{block.answer}}"
+                    id="{{block.input}}"
+                    disabled>
+          </textarea>
+          {{#if block.emptyOrWrongAnswer}}
+              <div class="correction-qrocm__solution">
+                  <img class="correction-qrocm__solution-img" src="/images/icons/comparison-window/icon-arrow-right.svg" alt="" role="none">
+                  <div class="correction-qrocm__solution-text">{{block.solution}}</div>
+              </div>
+          {{/if}}
+        {{else if (eq @challenge.format 'phrase')}}
+          <input value="{{block.answer}}"
                  size="{{get-qroc-input-size @challenge.format}}"
-                 class="correction-qrocm__answer correction-qrocm__answer--input {{field.inputClass}}"
-                 id="{{field.label}}"
+                 class="correction-qrocm__answer correction-qrocm__answer--sentence {{block.inputClass}}"
+                 id="{{block.input}}"
                  disabled>
-          {{#if field.emptyOrWrongAnswer}}
+          {{#if block.emptyOrWrongAnswer}}
             <div class="correction-qrocm__solution">
               <img class="correction-qrocm__solution-img" src="/images/icons/comparison-window/icon-arrow-right.svg" alt="" role="none">
-              <div class="correction-qrocm__solution-text">{{field.solution}}</div>
+              <div class="correction-qrocm__solution-text">{{block.solution}}</div>
             </div>
           {{/if}}
-        </div>
+        {{else}}
+          <div class="correction-qrocm__answer-wrapper">
+            <input value="{{block.answer}}"
+                   size="{{get-qroc-input-size @challenge.format}}"
+                   class="correction-qrocm__answer correction-qrocm__answer--input {{block.inputClass}}"
+                   id="{{block.input}}"
+                   disabled>
+            {{#if block.emptyOrWrongAnswer}}
+              <div class="correction-qrocm__solution">
+                <img class="correction-qrocm__solution-img" src="/images/icons/comparison-window/icon-arrow-right.svg" alt="" role="none">
+                <div class="correction-qrocm__solution-text">{{block.solution}}</div>
+              </div>
+            {{/if}}
+          </div>
+        {{/if}}
+      {{/if}}
+
+      {{#if block.breakline}}
+        <br>
       {{/if}}
 
     {{/each}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -1,14 +1,19 @@
 {{!-- template-lint-disable no-implicit-this no-action require-input-label --}}
 <div class="qrocm-proposal">
-  {{#each proposalBlocks as |block|}}
+  {{#each proposalBlocks as |block index|}}
 
     {{#if block.showText}}
-      <span>{{block.text}}</span>
+      <MarkdownToHtml @markdown={{block.text}}
+                      @extensions="remove-paragraph-tags"/>
     {{/if}}
 
     {{#if block.input}}
       {{#if block.text}}
-        <label for="{{block.input}}">{{block.text}}</label>
+        <label for="{{block.input}}">
+          <MarkdownToHtml @markdown={{block.text}}
+                          @extensions="remove-paragraph-tags"
+                          data-test="qrocm-label-{{index}}" />
+        </label>
       {{/if}}
 
       {{#if (eq @format 'paragraphe')}}

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -4,7 +4,8 @@
 
     {{#if block.showText}}
       <MarkdownToHtml @markdown={{block.text}}
-                      @extensions="remove-paragraph-tags"/>
+                      @extensions="remove-paragraph-tags"
+                      class="qrocm-proposal__label" />
     {{/if}}
 
     {{#if block.input}}
@@ -12,6 +13,7 @@
         <label for="{{block.input}}">
           <MarkdownToHtml @markdown={{block.text}}
                           @extensions="remove-paragraph-tags"
+                          class="qrocm-proposal__label"
                           data-test="qrocm-label-{{index}}" />
         </label>
       {{/if}}

--- a/mon-pix/mirage/factories/challenge.js
+++ b/mon-pix/mirage/factories/challenge.js
@@ -95,7 +95,7 @@ export default Factory.extend({
   QROCMDep: trait({
     type: 'QROCM-dep',
     instruction: 'Aurélie est montée dans le métro après avoir pris cette photo sur le quai.\n A quelle station peut-elle descendre ?',
-    proposals: 'Station 1 : ${station1}\n' + 'Station 2 : ${station2}',
+    proposals: 'Station **1** : ${station1}\n' + 'Station *2* : ${station2}',
   }),
 
   timed: trait({

--- a/mon-pix/package-lock.json
+++ b/mon-pix/package-lock.json
@@ -15238,9 +15238,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001203",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001203.tgz",
-      "integrity": "sha512-/I9tvnzU/PHMH7wBPrfDMSuecDeUKerjCPX7D0xBbaJZPxoT9m+yYxt0zCTkcijCkjTdim3H56Zm0i5Adxch4w==",
+      "version": "1.0.30001204",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz",
+      "integrity": "sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==",
       "dev": true
     },
     "capture-exit": {

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -29,9 +29,10 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       expect(findAll('.challenge-response__proposal')).to.have.lengthOf(2);
       expect(findAll('.challenge-response__proposal')[0].disabled).to.be.false;
       expect(findAll('.challenge-response__proposal')[1].disabled).to.be.false;
+      expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
+      expect(find('div[data-test="qrocm-label-2"]').innerHTML).to.contains('Station <em>2</em> :');
 
       expect(find('.alert')).to.not.exist;
-
     });
 
     it('should display the alert box if user validates without write an answer for each input', async () => {
@@ -86,6 +87,8 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
     it('should set the input text with previous answers and propose to continue', async () => {
       // then
+      expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
+      expect(find('div[data-test="qrocm-label-2"]').innerHTML).to.contains('Station <em>2</em> :');
       expect(findAll('.challenge-response__proposal')[0].value).to.equal('Republique');
       expect(findAll('.challenge-response__proposal')[1].value).to.equal('Chatelet');
 
@@ -100,6 +103,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
 
   describe('When challenge is already answered and user wants to see answers', () => {
     let correctionDep, correctionInd, tutorial, learningMoreTutorial, qrocmIndChallenge;
+
     beforeEach(async () => {
       // given
       qrocmIndChallenge = server.create('challenge', 'forCompetenceEvaluation', 'QROCMind');

--- a/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qrocm-ind-solution-panel-test.js
@@ -23,7 +23,7 @@ describe('Integration | Component | QROCm ind solution panel', function() {
   const assessment = EmberObject.create({ id: 'assessment_id' });
   const challenge = EmberObject.create({
     id: 'challenge_id',
-    proposals: 'blabla : ${key1}\nCarte mémoire (SD) : ${key2}\nanswer : ${key3}',
+    proposals: '**blabla** : ${key1}\nCarte mémoire (SD) : ${key2}\nanswer : ${key3}',
     format: 'petit',
   });
   const answer = EmberObject.create({
@@ -57,6 +57,11 @@ describe('Integration | Component | QROCm ind solution panel', function() {
           @answer={{this.answer}}
           @solution={{this.solution}}
           @challenge={{this.challenge}} />`);
+      });
+
+      it('should dqrocm-ind-solution-panel-test.jsisplay the labels', function() {
+        const labels = findAll('.correction-qrocm-text__label');
+        expect(labels.length).to.equal(3);
       });
 
       describe('When the answer is correct', function() {

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -155,7 +155,7 @@ describe('Integration | Component | QROCm proposal', function() {
           expect(allLabelElements.length).to.be.equal(allInputElements.length);
           expect(allLabelElements.length).to.be.equal(data.expectedLabel.length);
           allLabelElements.forEach((element, index) => {
-            expect(element.textContent).to.equal(data.expectedLabel[index]);
+            expect(element.textContent.trim()).to.equal(data.expectedLabel[index]);
           });
         });
 

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
@@ -10,7 +10,7 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
   setupTest();
   setupIntl();
 
-  describe('#inputFields', function() {
+  describe('#blocks', function() {
 
     it('should return an array with data to display', function() {
       //Given
@@ -19,21 +19,29 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
       const component = createGlimmerComponent('component:qrocm-dep-solution-panel', { challenge, answer });
 
-      const expectedFieldsData = [{
-        label: 'content : ',
-        answer: ':)',
+      const expectedBlocksData = [{
+        input: 'smiley1',
+        text: 'content :',
+        ariaLabel: null,
         inputClass: '',
+        answer: ':)',
+        placeholder: undefined,
       }, {
-        label: '<br>triste : ',
-        answer: 'Pas de réponse',
+        breakline: true,
+      }, {
+        input: 'smiley2',
+        text: 'triste :',
+        ariaLabel: null,
         inputClass: 'correction-qroc-box-answer--aband',
+        answer: 'Pas de réponse',
+        placeholder: undefined,
       }];
 
       //when
-      const inputFields = component.inputFields;
+      const blocks = component.blocks;
 
       //Then
-      expect(inputFields).to.be.deep.equal(expectedFieldsData);
+      expect(blocks).to.be.deep.equal(expectedBlocksData);
     });
 
   });
@@ -71,7 +79,6 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
       const component = createGlimmerComponent('component:qrocm-dep-solution-panel', {
         challenge,
         answer: { result: 'ko' },
-        inputFields: [1, 2],
         solution: 'groupe 1:\n- horizontalité\n- organisation plate\ngroupe 2:\n- cadre',
       });
 
@@ -88,7 +95,6 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
       const component = createGlimmerComponent('component:qrocm-dep-solution-panel', {
         challenge,
         answer: { result: 'ko' },
-        inputFields: [1, 2],
         solution: 'groupe 1:\n- tag\n- slogan\ngroupe 2:\n- marche\n- sitting\ngroupe 3:\n- masque',
       });
 

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -10,7 +10,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
   setupTest();
   setupIntl();
 
-  describe('#inputFields', function() {
+  describe('#blocks', function() {
 
     let challenge;
     let answer;
@@ -28,18 +28,29 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       answer = { value: 'smiley1: \':)\' smiley2: \':(\'', resultDetails: 'smiley1: true\nsmiley2: true' };
       solution = 'smiley1: \n - :-)\n - :)\n - :-D\n - :D\n - :))\n\nsmiley2:\n - :-(\n - :(\n - :((';
 
-      const expectedFieldsData = [{
-        label: 'content : ',
+      const expectedBlocksData = [{
+        input: 'smiley1',
+        text: 'content :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--correct',
         answer: ':)',
         solution: ':-)',
         emptyOrWrongAnswer: false,
-        inputClass: 'correction-qroc-box-answer--correct',
+        placeholder: undefined,
       }, {
-        label: '<br>triste : ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'smiley2',
+        text: 'triste :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--correct',
         answer: ':(',
         solution: ':-(',
         emptyOrWrongAnswer: false,
-        inputClass: 'correction-qroc-box-answer--correct',
+        placeholder: undefined,
       }];
 
       //When
@@ -50,7 +61,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(expectedFieldsData);
+      expect(component.blocks).to.be.deep.equal(expectedBlocksData);
     });
 
     it('should return an array with data to display (case when there is wrong answers)', function() {
@@ -59,17 +70,28 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       answer = { value: 'num1: \'1\' num2: \'2\'', resultDetails: 'num1: false\nnum2: false' };
       solution = 'num1: \n - 2\n\nnum2:\n - 1';
       const result = [{
-        label: 'Clé USB : ',
+        input: 'num1',
+        text: 'Clé USB :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }, {
-        label: '<br>Carte mémoire (SD) : ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'num2',
+        text: 'Carte mémoire (SD) :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }];
 
       //When
@@ -80,7 +102,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (case when there is some empty answer)', function() {
@@ -90,17 +112,28 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       solution = 'num1: \n - 2\n\nnum2:\n - 1';
 
       const result = [{
-        label: 'Clé USB : ',
+        input: 'num1',
+        text: 'Clé USB :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--aband',
+        placeholder: undefined,
       }, {
-        label: '<br>Carte mémoire (SD) : ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'num2',
+        text: 'Carte mémoire (SD) :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }];
 
       //When
@@ -111,54 +144,41 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (proposals contains a dash ("-"))', function() {
       // given
-      challenge = EmberObject.create({ proposals: '- alain@pix.fr : ${num1}\n\n- leonie@pix.fr : ${num2}\n\n- Programme_Pix.pdf : ${num3}\n\n- lucie@pix.fr : ${num4}\n\n- Programme du festival Pix : ${num5}\n\n- jeremy@pix.fr : ${num6}' });
+      challenge = EmberObject.create({ proposals: '- alain@pix.fr : ${num1}\n\n- leonie@pix.fr : ${num2}' });
       answer = {
-        value: 'num1: \'1\' num2: \'2\' num3: \'3\' num4: \'4\' num5: \'5\' num6: \'6\'',
-        resultDetails: 'num1: false\nnum2: false\nnum3: false\nnum4: false\nnum5: true\nnum6: false',
+        value: 'num1: \'1\' num2: \'2\'',
+        resultDetails: 'num1: false\nnum2: false',
       };
-      solution = 'num1: \n - 2\n\nnum2:\n - 3\n - 4\n\nnum3:\n - 6\n\nnum4:\n - 1\n\nnum5:\n - 5\n\nnum6:\n - 2';
+      solution = 'num1: \n - 2\n\nnum2:\n - 3';
 
       const result = [{
-        label: '- alain@pix.fr : ',
+        input: 'num1',
+        text: '- alain@pix.fr :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }, {
-        label: '<br>- leonie@pix.fr : ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'num2',
+        text: '- leonie@pix.fr :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '3',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
-      }, {
-        label: '<br>- Programme_Pix.pdf : ',
-        answer: '3',
-        solution: '6',
-        emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
-      }, {
-        label: '<br>- lucie@pix.fr : ',
-        answer: '4',
-        solution: '1',
-        emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
-      }, {
-        label: '<br>- Programme du festival Pix : ',
-        answer: '5',
-        solution: '5',
-        emptyOrWrongAnswer: false,
-        inputClass: 'correction-qroc-box-answer--correct',
-      }, {
-        label: '<br>- jeremy@pix.fr : ',
-        answer: '6',
-        solution: '2',
-        emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }];
 
       //When
@@ -169,7 +189,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
     it('should return an array with data to display (proposals are questions)', function() {
@@ -179,17 +199,28 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       solution = 'Num1:\n - 1\n\nNum2:\n - 6';
 
       const result = [{
-        label: '- Combien le dossier "projet PIX" contient-il de dossiers ? ',
+        input: 'Num1',
+        text: '- Combien le dossier "projet PIX" contient-il de dossiers ?',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }, {
-        label: '<br>- Combien le dossier "images" contient-il de fichiers ? ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'Num2',
+        text: '- Combien le dossier "images" contient-il de fichiers ?',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--wrong',
         answer: '3',
         solution: '6',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--wrong',
+        placeholder: undefined,
       }];
 
       //When
@@ -200,7 +231,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
     it('it should return "Pas de réponse" in each answer if the question was passed', function() {
@@ -210,17 +241,28 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       solution = 'num1: \n - 2\n\nnum2:\n - 1';
 
       const result = [{
-        label: 'Clé USB : ',
+        input: 'num1',
+        text: 'Clé USB :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--aband',
+        placeholder: undefined,
       }, {
-        label: '<br>Carte mémoire (SD) : ',
+        breakline: true,
+        showText: undefined,
+      }, {
+        input: 'num2',
+        text: 'Carte mémoire (SD) :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '1',
         emptyOrWrongAnswer: true,
-        inputClass: 'correction-qroc-box-answer--aband',
+        placeholder: undefined,
       }];
 
       //When
@@ -231,7 +273,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
     /**
@@ -245,11 +287,15 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       solution = 'num1: \n - 2';
 
       const result = [{
-        label: 'Clé USB : ',
+        input: 'num1',
+        text: 'Clé USB :',
+        ariaLabel: null,
+        showText: false,
+        inputClass: 'correction-qroc-box-answer--correct',
         answer: '2',
         solution: '2',
         emptyOrWrongAnswer: false,
-        inputClass: 'correction-qroc-box-answer--correct',
+        placeholder: undefined,
       }];
 
       //When
@@ -260,7 +306,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       });
 
       //Then
-      expect(component.inputFields).to.be.deep.equal(result);
+      expect(component.blocks).to.be.deep.equal(result);
     });
 
   });


### PR DESCRIPTION
## :unicorn: Problème
Les épreuves QROCM proposent une liste simple de réponses, on ne peut pas y insérer de liens ou images.

## :robot: Solution
- Utiliser le component MarkdownToHtml pour afficher les propositions des QROC.
- Suppression des balises `<p>` créées par le composant MarkdownToHtml

## :rainbow: Remarques
Cette branche se base sur #2755 pour pourvoir utiliser l'extension showdown qui supprime les balises `<p>`.

Un refacto a été fait pour réutiliser `proposalAsBlocks` dans les solutions.

Cela permet de:
- utiliser la même manière d'afficher les "blocs" dans l'affichage de l'épreuve et l'affichage de sa solution
- corriger l'affichage sur les qrocm qui n'affichaient pas le dernier bout de texte après un input (ex: épreuve recopA530N2rlxYLt)
- pouvoir mettre du markdown sur le label des QROCM-ind car on a besoin de reconnaître si le bloc est un label ou simplement du texte pour l'encapsuler dans un `<label>` ou non

## :100: Pour tester
Tester avec des épreuves QROCM. Par ex:
- [rec1bFPhXfeFkChFW](https://app-pr2759.review.pix.fr/challenges/rec1bFPhXfeFkChFW/preview)
- [rec29winoupJLR418](https://app-pr2759.review.pix.fr/challenges/rec29winoupJLR418/preview)
- [recKhozPtS1kqYuZ0](https://app-pr2759.review.pix.fr/challenges/recKhozPtS1kqYuZ0/preview)
