### PR TITLE
[BUGFIX] Mauvaise classe dans l'export des résultats d'une campagne de collecte de profils (PIX-2366)

### DIFF
--- a/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
+++ b/api/lib/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream.js
@@ -34,7 +34,7 @@ module.exports = async function startWritingCampaignProfilesCollectionResultsToS
   const [allPixCompetences, organization, campaignParticipationResultDatas] = await Promise.all([
     competenceRepository.listPixCompetencesOnly(i18n.getLocale()),
     organizationRepository.get(campaign.organizationId),
-    campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id, campaign.type),
+    campaignParticipationRepository.findProfilesCollectionResultDataByCampaignId(campaign.id),
   ]);
 
   const campaignProfilCollectionExport = new CampaignProfilCollectionExport(writableStream, organization, campaign, allPixCompetences, translate);

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -80,9 +80,9 @@ module.exports = {
         ])
           .from('campaign-participations')
           .leftJoin('users', 'campaign-participations.userId', 'users.id')
-          .leftJoin('schooling-registrations', 'campaign-participations.userId', 'schooling-registrations.userId')
-          .leftJoin('campaigns', function() {
-            this.on({ 'campaign-participations.campaignId': 'campaigns.id' })
+          .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
+          .leftJoin('schooling-registrations', function() {
+            this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' })
               .andOn({ 'campaigns.organizationId': 'schooling-registrations.organizationId' });
           })
           .where({ campaignId });

--- a/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
+++ b/api/tests/integration/domain/usecases/start-writing-campaign-profiles-collection-results-to-stream_test.js
@@ -196,7 +196,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         organization = databaseBuilder.factory.buildOrganization({ type: 'SCO', isManagingStudents: true });
         databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
-        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, firstName: '@Jean', lastName: '=Bono', division: '3emeG' });
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, firstName: '@Jean', lastName: '=Bono', division: '3emeG', organizationId: organization.id });
 
         campaign = databaseBuilder.factory.buildCampaign({
           name: '@Campagne de Test N°2',
@@ -270,7 +270,7 @@ describe('Integration | Domain | Use Cases | start-writing-profiles-collection-c
         organization = databaseBuilder.factory.buildOrganization({ type: 'SUP', isManagingStudents: true });
         databaseBuilder.factory.buildMembership({ userId: user.id, organizationId: organization.id });
 
-        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, studentNumber: '12345A', firstName: '@Jean', lastName: '=Bono' });
+        schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ userId: participant.id, studentNumber: '12345A', firstName: '@Jean', lastName: '=Bono', organizationId: organization.id });
 
         campaign = databaseBuilder.factory.buildCampaign({
           name: '@Campagne de Test N°2',

--- a/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-participation-info-repository_test.js
@@ -214,6 +214,7 @@ describe('Integration | Repository | Campaign Participation Info', () => {
       it('return the first name and the last name of the correct schooling-registration', async () => {
         const campaignParticipationInfos = await campaignParticipationInfoRepository.findByCampaignId(campaign.id);
 
+        expect(campaignParticipationInfos.length).to.equal(1);
         expect(campaignParticipationInfos[0].participantFirstName).to.equal('John');
         expect(campaignParticipationInfos[0].participantLastName).to.equal('Doe');
       });


### PR DESCRIPTION
## :unicorn: Problème
Quand on exportait les résultats d'une campagne de collecte de profils, on pouvait avoir des participants avec la mauvaise classe. 
C'est parce que ces participants avaient plusieurs schooling-registrations et qu'on ne récupérait pas la bonne.

## :robot: Solution
 

## :rainbow: Remarques


## :100: Pour tester
Aller sur pix orga et faire un export de résultat
