### PR TITLE
[FEATURE] Masquer le lien de récupération d'espace Orga sur la page de connexion Pix Orga pour pix.org (PIX-2398).

### DIFF
--- a/orga/app/components/routes/login-form.js
+++ b/orga/app/components/routes/login-form.js
@@ -8,6 +8,7 @@ export default class LoginForm extends Component {
   @service intl;
   @service session;
   @service store;
+  @service url;
 
   @tracked errorMessage = null;
   @tracked isErrorMessagePresent = false;
@@ -24,7 +25,7 @@ export default class LoginForm extends Component {
   }
 
   get displayRecoveryLink() {
-    if (this.intl.t('current-lang') === 'en') {
+    if (this.intl.t('current-lang') === 'en' || !this.url.isFrenchDomainExtension) {
       return false;
     }
     return !this.args.isWithInvitation;

--- a/orga/app/services/url.js
+++ b/orga/app/services/url.js
@@ -2,6 +2,8 @@ import Service, { inject as service } from '@ember/service';
 
 import ENV from 'pix-orga/config/environment';
 
+const FRENCH_DOMAIN_EXTENSION = 'fr';
+
 export default class Url extends Service {
 
   @service currentDomain;
@@ -11,6 +13,10 @@ export default class Url extends Service {
   pixAppUrlWithoutExtension = ENV.APP.PIX_APP_URL_WITHOUT_EXTENSION;
 
   definedHomeUrl = ENV.rootURL;
+
+  get isFrenchDomainExtension() {
+    return this.currentDomain.getExtension() === FRENCH_DOMAIN_EXTENSION;
+  }
 
   get campaignsRootUrl() {
     return this.definedCampaignsRootUrl

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -203,4 +203,42 @@ module('Integration | Component | routes/login-form', function(hooks) {
       assert.dom('.fa-eye').exists();
     });
   });
+
+  module('when domain is pix.org', function() {
+
+    test('should not display recovery link', async function(assert) {
+      //given
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return false;
+        }
+      }
+      this.owner.register('service:url', UrlStub);
+
+      // when
+      await render(hbs`<Routes::LoginForm/>`);
+
+      // then
+      assert.dom('.login-form__recover-access-link').doesNotExist();
+    });
+  });
+
+  module('when domain is pix.fr', function() {
+
+    test('should display recovery link', async function(assert) {
+      //given
+      class UrlStub extends Service {
+        get isFrenchDomainExtension() {
+          return true;
+        }
+      }
+      this.owner.register('service:url', UrlStub);
+
+      // when
+      await render(hbs`<Routes::LoginForm/>`);
+
+      // then
+      assert.dom('.login-form__recover-access-link').exists();
+    });
+  });
 });

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -5,6 +5,30 @@ import sinon from 'sinon';
 module('Unit | Service | url', function(hooks) {
   setupTest(hooks);
 
+  test('should have a frenchDomainExtension when the current domain contains pix.fr', function(assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('fr') };
+
+    // when
+    const domainExtension = service.isFrenchDomainExtension;
+
+    // then
+    assert.equal(domainExtension, true);
+  });
+
+  test('should not have frenchDomainExtension when the current domain contains pix.org', function(assert) {
+    // given
+    const service = this.owner.lookup('service:url');
+    service.currentDomain = { getExtension: sinon.stub().returns('org') };
+
+    // when
+    const domainExtension = service.isFrenchDomainExtension;
+
+    // then
+    assert.equal(domainExtension, false);
+  });
+
   module('#campaignsRootUrl', function() {
 
     test('should get default campaigns root url when is defined', function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Le lien présent dans la page de connexion pour activer ou récupérer son espace Pix Orga était toujours visible dans le domaine pix.org, en français (francophone).
Nous souhaitons le masquer et le rendre visible uniquement sur le domaine pix.fr.

## :robot: Solution
Masquer le lien sur pix.org en français.

## :rainbow: Remarques
Ajout d'une méthode `isFrenchDomainExtension` dans le service url pour obtenir le domaine fr.

## :100: Pour tester
Aller sur la page de connexion et changer de domaine pour vérifier la présence ou non du lien de récupération.

`.fr en français` => visible
`.fr en anglais` => caché
`.org` => caché ( en francophone comme en anglais )
