### PR TITLE
[TECH] Imposer l'usage des arrow function (hors callbacks Mocha).

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -81,4 +81,5 @@ rules:
     - error
   no-multi-spaces:
     - error
-    
+  mocha/prefer-arrow-callback:
+    - error

--- a/admin/tests/acceptance/authenticated/certification-centers/get-test.js
+++ b/admin/tests/acceptance/authenticated/certification-centers/get-test.js
@@ -14,7 +14,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import { createAuthenticateSession } from '../../../helpers/test-init';
 
-module('Acceptance | authenticated/certification-centers/get', function(hooks) {
+module('Acceptance | authenticated/certification-centers/get', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -29,7 +29,7 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
   let certificationCenterMembership1;
   let currentUser;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
 
@@ -84,7 +84,7 @@ module('Acceptance | authenticated/certification-centers/get', function(hooks) {
     assert.contains(expectedDate1);
   });
 
-  module('To add certification center membership', function() {
+  module('To add certification center membership', () => {
 
     test('should display elements to add certification center membership', async function(assert) {
       // when

--- a/admin/tests/acceptance/authenticated/certifications/certification/profile-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/profile-test.js
@@ -5,11 +5,11 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authenticated/certifications/certification/profile', function(hooks) {
+module('Acceptance | authenticated/certifications/certification/profile', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // given
@@ -23,7 +23,7 @@ module('Acceptance | authenticated/certifications/certification/profile', functi
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });

--- a/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/to-be-published-test.js
@@ -5,7 +5,7 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authenticated/sessions/list/to be published', function(hooks) {
+module('Acceptance | authenticated/sessions/list/to be published', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -13,7 +13,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
 
   const PUBLISH_ALL_SESSIONS_BUTTON_SELECTOR = '.session-to-be-publish__publish-all .btn-primary';
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -24,7 +24,7 @@ module('Acceptance | authenticated/sessions/list/to be published', function(hook
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       // given

--- a/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
+++ b/admin/tests/acceptance/authenticated/sessions/list/with-required-action-test.js
@@ -5,11 +5,11 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authenticated/sessions/list/with required action', function(hooks) {
+module('Acceptance | authenticated/sessions/list/with required action', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -20,7 +20,7 @@ module('Acceptance | authenticated/sessions/list/with required action', function
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       // given

--- a/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
@@ -3,7 +3,7 @@ import { module, test, setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from '../../../helpers/test-init';
 
-module('Acceptance | authenticated/targets-profile/target-profile/insight', function(hooks) {
+module('Acceptance | authenticated/targets-profile/target-profile/insight', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/organizations-test.js
@@ -3,7 +3,7 @@ import { module, test, setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from '../../../helpers/test-init';
 
-module('Acceptance | authenticated/targets-profile/target-profile/organizations', function(hooks) {
+module('Acceptance | authenticated/targets-profile/target-profile/organizations', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -18,7 +18,7 @@ module('Acceptance | authenticated/targets-profile/target-profile/organizations'
     targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
   });
 
-  module('with multiple organizations', function(hooks) {
+  module('with multiple organizations', (hooks) => {
 
     hooks.beforeEach(async function() {
       this.server.create('organization', { name: 'My organization' });

--- a/admin/tests/acceptance/authenticated/users/get-test.js
+++ b/admin/tests/acceptance/authenticated/users/get-test.js
@@ -4,14 +4,14 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { createAuthenticateSession } from '../../../helpers/test-init';
 
-module('Acceptance | authenticated/users/get', function(hooks) {
+module('Acceptance | authenticated/users/get', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let currentUser;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
   });

--- a/admin/tests/acceptance/certification-center-form--test.js
+++ b/admin/tests/acceptance/certification-center-form--test.js
@@ -7,7 +7,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
-module('Acceptance | Certification-center Form', function(hooks) {
+module('Acceptance | Certification-center Form', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/admin/tests/acceptance/certification-centers-list-test.js
+++ b/admin/tests/acceptance/certification-centers-list-test.js
@@ -6,11 +6,11 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
-module('Acceptance | Certification-centers List', function(hooks) {
+module('Acceptance | Certification-centers List', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -21,7 +21,7 @@ module('Acceptance | Certification-centers List', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });

--- a/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
+++ b/admin/tests/acceptance/flag-results-sent-to-prescriptor-test.js
@@ -6,16 +6,16 @@ import { FINALIZED, statusToDisplayName } from 'pix-admin/models/session';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
-module('Acceptance | Session page', function(hooks) {
+module('Acceptance | Session page', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     const user = server.create('user');
     await createAuthenticateSession({ userId: user.id });
   });
 
-  module('Access', function() {
+  module('Access', () => {
 
     test('Session page should be accessible from /certification/sessions', async function(assert) {
       // when
@@ -26,7 +26,7 @@ module('Acceptance | Session page', function(hooks) {
     });
   });
 
-  module('Rendering', function(hooks) {
+  module('Rendering', (hooks) => {
 
     const STATUS_SECTION = 9;
     const FINALISATION_DATE_SECTION = 10;
@@ -35,7 +35,7 @@ module('Acceptance | Session page', function(hooks) {
     const VALUE_ROW_INDEX = 2;
     const SEND_TO_PRESCRIPTEUR_BUTTON_INDEX = 5;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       await visitSessionsPage();
     });
 

--- a/admin/tests/acceptance/organization-information-management-test.js
+++ b/admin/tests/acceptance/organization-information-management-test.js
@@ -4,15 +4,15 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | organization information management', function(hooks) {
+module('Acceptance | organization information management', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     await createAuthenticateSession({ userId: 1 });
   });
 
-  module('editing organization', function() {
+  module('editing organization', () => {
 
     test('should be able to edit organization information', async function(assert) {
       // given

--- a/admin/tests/acceptance/organization-list-test.js
+++ b/admin/tests/acceptance/organization-list-test.js
@@ -5,12 +5,12 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Organization List', function(hooks) {
+module('Acceptance | Organization List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -21,7 +21,7 @@ module('Acceptance | Organization List', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });
@@ -46,7 +46,7 @@ module('Acceptance | Organization List', function(hooks) {
       assert.dom('.organization-list .table-admin tbody tr').exists({ count: 12 });
     });
 
-    module('when filters are used', function(hooks) {
+    module('when filters are used', (hooks) => {
 
       hooks.beforeEach(async () => {
         server.createList('organization', 12);

--- a/admin/tests/acceptance/organization-memberships-management-test.js
+++ b/admin/tests/acceptance/organization-memberships-management-test.js
@@ -5,7 +5,7 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | organization memberships management', function(hooks) {
+module('Acceptance | organization memberships management', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -24,7 +24,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     assert.equal(currentURL(), `/organizations/${organization.id}/members`);
   });
 
-  module('listing members', function(hooks) {
+  module('listing members', (hooks) => {
     hooks.beforeEach(async () => {
       server.createList('membership', 12);
     });
@@ -62,7 +62,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     });
   });
 
-  module('adding a member', function() {
+  module('adding a member', () => {
 
     test('should create a user membership and display it in the list', async function(assert) {
       // given
@@ -113,7 +113,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     });
   });
 
-  module('inviting a member', function() {
+  module('inviting a member', () => {
 
     test('should create an organization-invitation', async function(assert) {
       // when
@@ -144,7 +144,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     });
   });
 
-  module('editing a member\'s role', function(hooks) {
+  module('editing a member\'s role', (hooks) => {
 
     let membership;
 
@@ -166,7 +166,7 @@ module('Acceptance | organization memberships management', function(hooks) {
     });
   });
 
-  module('deactivating a member', function(hooks) {
+  module('deactivating a member', (hooks) => {
 
     hooks.beforeEach(async function() {
       const user = this.server.create('user', { firstName: 'John', lastName: 'Doe', email: 'user@example.com' });

--- a/admin/tests/acceptance/organization-target-profiles-management-test.js
+++ b/admin/tests/acceptance/organization-target-profiles-management-test.js
@@ -4,11 +4,11 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | organization target profiles management', function(hooks) {
+module('Acceptance | organization target profiles management', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     await createAuthenticateSession({ userId: 1 });
   });
 

--- a/admin/tests/acceptance/routes-protection-test.js
+++ b/admin/tests/acceptance/routes-protection-test.js
@@ -5,7 +5,7 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import { createAuthenticateSession } from '../helpers/test-init';
 
-module('Acceptance | routes protection', function(hooks) {
+module('Acceptance | routes protection', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/admin/tests/acceptance/session-test.js
+++ b/admin/tests/acceptance/session-test.js
@@ -8,11 +8,11 @@ import sinon from 'sinon';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
-module('Acceptance | Session pages', function(hooks) {
+module('Acceptance | Session pages', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -23,7 +23,7 @@ module('Acceptance | Session pages', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     let session;
 
@@ -40,7 +40,7 @@ module('Acceptance | Session pages', function(hooks) {
       });
     });
 
-    module('Informations tab', function(hooks) {
+    module('Informations tab', (hooks) => {
 
       hooks.beforeEach(async () => {
         // when
@@ -52,7 +52,7 @@ module('Acceptance | Session pages', function(hooks) {
         assert.equal(currentURL(), '/sessions/1');
       });
 
-      module('Search section', function() {
+      module('Search section', () => {
 
         test('it should show a header with title and sessionId search', function(assert) {
           // then
@@ -73,7 +73,7 @@ module('Acceptance | Session pages', function(hooks) {
         });
       });
 
-      module('Tabs section', function() {
+      module('Tabs section', () => {
 
         test('tab "Informations" is clickable', async function(assert) {
           // when
@@ -94,7 +94,7 @@ module('Acceptance | Session pages', function(hooks) {
         });
       });
 
-      module('Informations section', function() {
+      module('Informations section', () => {
 
         test('it shows session informations', function(assert) {
           // then
@@ -104,7 +104,7 @@ module('Acceptance | Session pages', function(hooks) {
         });
       });
 
-      module('Buttons section', function() {
+      module('Buttons section', () => {
 
         test('it shows all buttons', function(assert) {
           // then
@@ -115,7 +115,7 @@ module('Acceptance | Session pages', function(hooks) {
           assert.contains('Résultats transmis au prescripteur');
         });
 
-        module('copy link button', function() {
+        module('copy link button', () => {
           test('it should copy \'http://link-to-results.fr\' in navigator clipboard on click', async (assert) => {
             // given
 
@@ -133,7 +133,7 @@ module('Acceptance | Session pages', function(hooks) {
       });
     });
 
-    module('Certifications tab', function(hooks) {
+    module('Certifications tab', (hooks) => {
 
       let juryCertificationSummary;
 
@@ -150,7 +150,7 @@ module('Acceptance | Session pages', function(hooks) {
         await visit('/sessions/1/certifications');
       });
 
-      module('Certification section', function() {
+      module('Certification section', () => {
 
         test('it shows certifications informations', function(assert) {
           // then

--- a/admin/tests/acceptance/sessions-list-test.js
+++ b/admin/tests/acceptance/sessions-list-test.js
@@ -5,11 +5,11 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session List', function(hooks) {
+module('Acceptance | Session List', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -20,7 +20,7 @@ module('Acceptance | Session List', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });
@@ -46,14 +46,14 @@ module('Acceptance | Session List', function(hooks) {
       assert.contains('Sessions à traiter (10)');
     });
 
-    module('#Pagination', function(hooks) {
+    module('#Pagination', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         server.createList('session', 15, 'finalized');
         server.createList('session', 20);
       });
 
-      module('Default display', function() {
+      module('Default display', () => {
 
         test('it should display the first page of finalized sessions', async function(assert) {
           // when
@@ -66,7 +66,7 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('when selecting a different page', function() {
+      module('when selecting a different page', () => {
 
         test('it should display the second page of finalized sessions', async function(assert) {
           // when
@@ -80,7 +80,7 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('when selecting a different pageSize', function() {
+      module('when selecting a different pageSize', () => {
 
         test('it should display all the finalized sessions', async function(assert) {
           // when
@@ -94,7 +94,7 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('when invalid filter value are typed in', function() {
+      module('when invalid filter value are typed in', () => {
 
         test('it should display an empty list', async function(assert) {
           // given
@@ -109,12 +109,12 @@ module('Acceptance | Session List', function(hooks) {
       });
     });
 
-    module('#Filters', function() {
+    module('#Filters', () => {
 
-      module('#id', function(hooks) {
+      module('#id', (hooks) => {
         let expectedSession;
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           expectedSession = server.create('session', 'finalized');
           server.createList('session', 10, 'finalized');
         });
@@ -129,10 +129,10 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('#certificationCenterName', function(hooks) {
+      module('#certificationCenterName', (hooks) => {
         let expectedSession;
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           expectedSession = server.create('session', 'finalized');
           server.createList('session', 10, 'finalized');
         });
@@ -147,9 +147,9 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('#status', function(hooks) {
+      module('#status', (hooks) => {
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           server.createList('session', 5, 'processed');
           server.createList('session', 3, 'finalized');
         });
@@ -164,9 +164,9 @@ module('Acceptance | Session List', function(hooks) {
         });
       });
 
-      module('#resultsSentToPrescriberAt', function(hooks) {
+      module('#resultsSentToPrescriberAt', (hooks) => {
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           server.createList('session', 5, 'withResultsSentToPrescriber', 'finalized');
           server.createList('session', 3, 'finalized');
         });

--- a/admin/tests/acceptance/target-profiles-details-test.js
+++ b/admin/tests/acceptance/target-profiles-details-test.js
@@ -5,12 +5,12 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Target Profile Details', function(hooks) {
+module('Acceptance | Target Profile Details', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // given
@@ -24,7 +24,7 @@ module('Acceptance | Target Profile Details', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });

--- a/admin/tests/acceptance/target-profiles-list-test.js
+++ b/admin/tests/acceptance/target-profiles-list-test.js
@@ -5,12 +5,12 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Target Profiles List', function(hooks) {
+module('Acceptance | Target Profiles List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -21,7 +21,7 @@ module('Acceptance | Target Profiles List', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });
@@ -46,7 +46,7 @@ module('Acceptance | Target Profiles List', function(hooks) {
       assert.dom('[aria-label="Profil cible"]').exists({ count: 12 });
     });
 
-    module('when filters are used', function(hooks) {
+    module('when filters are used', (hooks) => {
 
       hooks.beforeEach(async () => {
         server.createList('target-profile', 12);

--- a/admin/tests/acceptance/tools-page-test.js
+++ b/admin/tests/acceptance/tools-page-test.js
@@ -4,15 +4,15 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | tools page', function(hooks) {
+module('Acceptance | tools page', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     await createAuthenticateSession({ userId: 1 });
   });
 
-  module('Access', function() {
+  module('Access', () => {
 
     test('Tools page should be accessible from /tools', async function(assert) {
       // when
@@ -23,9 +23,9 @@ module('Acceptance | tools page', function(hooks) {
     });
   });
 
-  module('Rendering', function(hooks) {
+  module('Rendering', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       await visit('/tools');
     });
 

--- a/admin/tests/acceptance/user-details-personal-information-test.js
+++ b/admin/tests/acceptance/user-details-personal-information-test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | User details personal information', function(hooks) {
+module('Acceptance | User details personal information', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -32,7 +32,7 @@ module('Acceptance | User details personal information', function(hooks) {
     assert.equal(currentURL(), `/users/${user.id}`);
   });
 
-  module('when administrator click to edit users details', function() {
+  module('when administrator click to edit users details', () => {
 
     test('should update user firstName, lastName and email', async function(assert) {
       // given
@@ -53,7 +53,7 @@ module('Acceptance | User details personal information', function(hooks) {
     });
   });
 
-  module('when administrator click on anonymize button and confirm modal', function() {
+  module('when administrator click on anonymize button and confirm modal', () => {
 
     test('should anonymize the user', async function(assert) {
       // given
@@ -70,7 +70,7 @@ module('Acceptance | User details personal information', function(hooks) {
     });
   });
 
-  module('when administrator click on dissociate button', function() {
+  module('when administrator click on dissociate button', () => {
 
     test('should not display dissociate button after', async function(assert) {
       // given

--- a/admin/tests/acceptance/user-list-test.js
+++ b/admin/tests/acceptance/user-list-test.js
@@ -5,11 +5,11 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | User List', function(hooks) {
+module('Acceptance | User List', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -20,7 +20,7 @@ module('Acceptance | User List', function(hooks) {
     });
   });
 
-  module('When user is logged in', function(hooks) {
+  module('When user is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await createAuthenticateSession({ userId: 1 });

--- a/admin/tests/integration/components/certification-center-form-test.js
+++ b/admin/tests/integration/components/certification-center-form-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
-module('Integration | Component | certification-center-form', function(hooks) {
+module('Integration | Component | certification-center-form', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -23,7 +23,7 @@ module('Integration | Component | certification-center-form', function(hooks) {
     assert.dom('.certification-center-form').exists();
   });
 
-  module('#selectCertificationCenterType', function() {
+  module('#selectCertificationCenterType', () => {
 
     test('should update attribute certificationCenter.type', async function(assert) {
       // given

--- a/admin/tests/integration/components/certification-center-memberships-section-test.js
+++ b/admin/tests/integration/components/certification-center-memberships-section-test.js
@@ -6,7 +6,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | certification-center-memberships-section', function(hooks) {
+module('Integration | Component | certification-center-memberships-section', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/certification-status-test.js
+++ b/admin/tests/integration/components/certification-status-test.js
@@ -4,10 +4,10 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { ERROR, STARTED } from 'pix-admin/models/certification';
 
-module('Integration | Component | certification-status', function(hooks) {
+module('Integration | Component | certification-status', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('#isStatusBlocking', function() {
+  module('#isStatusBlocking', () => {
 
     [
       { status: ERROR },

--- a/admin/tests/integration/components/certification/certification-details-answer-test.js
+++ b/admin/tests/integration/components/certification/certification-details-answer-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
-module('Integration | Component | Certification | CertificationDetailsAnswer', function(hooks) {
+module('Integration | Component | Certification | CertificationDetailsAnswer', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/certification/certification-details-competence-test.js
+++ b/admin/tests/integration/components/certification/certification-details-competence-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 
-module('Integration | Component | <Certification::CertificationDetailsCompetence/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationDetailsCompetence/>', (hooks) => {
   setupRenderingTest(hooks);
 
   const answer = (result) => {

--- a/admin/tests/integration/components/certification/certification-info-competences-test.js
+++ b/admin/tests/integration/components/certification/certification-info-competences-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | <Certification::CertificationCompetenceList/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationCompetenceList/>', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/certification/certification-info-field-test.js
+++ b/admin/tests/integration/components/certification/certification-info-field-test.js
@@ -4,10 +4,10 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { resolve } from 'rsvp';
 
-module('Integration | Component | <Certification::CertificationInfoField/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationInfoField/>', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('[Consultation mode]', async function() {
+  module('[Consultation mode]', async () => {
 
     test('it should be in "consultation (read only) mode" by default when @edition (optional) argument is not provided', async function(assert) {
 
@@ -63,7 +63,7 @@ module('Integration | Component | <Certification::CertificationInfoField/>', fun
     });
   });
 
-  module('[Edition mode]', async function() {
+  module('[Edition mode]', async () => {
 
     test('it should be in "edition (writable) mode" when @edition (optional) argument is set to "true"', async function(assert) {
 

--- a/admin/tests/integration/components/certification/certification-info-published-test.js
+++ b/admin/tests/integration/components/certification/certification-info-published-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | <Certification::CertificationInfoPublished/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationInfoPublished/>', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/certification/certification-list-test.js
+++ b/admin/tests/integration/components/certification/certification-list-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | <Certification::CertificationList/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationList/>', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/certification/certification-status-select-test.js
+++ b/admin/tests/integration/components/certification/certification-status-select-test.js
@@ -4,13 +4,13 @@ import { fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | <Certification::CertificationStatusSelect/>', function(hooks) {
+module('Integration | Component | <Certification::CertificationStatusSelect/>', (hooks) => {
 
   setupRenderingTest(hooks);
 
-  module('when in edition mode', function() {
+  module('when in edition mode', () => {
 
-    module('rendering', function() {
+    module('rendering', () => {
 
       test('it displays a label', async function(assert) {
         // given
@@ -61,7 +61,7 @@ module('Integration | Component | <Certification::CertificationStatusSelect/>', 
       });
     });
 
-    module('behaviour', function() {
+    module('behaviour', () => {
 
       test('it updates the certification status when the selected value changes', async function(assert) {
         // given
@@ -78,7 +78,7 @@ module('Integration | Component | <Certification::CertificationStatusSelect/>', 
     });
   });
 
-  module('when not in edition mode', function() {
+  module('when not in edition mode', () => {
 
     test('it does not render the select', async function(assert) {
       // given

--- a/admin/tests/integration/components/certification/certified-profile-test.js
+++ b/admin/tests/integration/components/certification/certified-profile-test.js
@@ -4,7 +4,7 @@ import { render, find } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | <Certification::CertifiedProfile/>', function(hooks) {
+module('Integration | Component | <Certification::CertifiedProfile/>', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -24,7 +24,7 @@ module('Integration | Component | <Certification::CertifiedProfile/>', function(
     assert.contains('Profil certifié vide.');
   });
 
-  module('when certified profile is not empty', function() {
+  module('when certified profile is not empty', () => {
     test('it should display one column per difficulty levels within a competence', async function(assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/admin/tests/integration/components/confirm-popup-test.js
+++ b/admin/tests/integration/components/confirm-popup-test.js
@@ -4,7 +4,7 @@ import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-module('Integration | Component | confirm-popup', function(hooks) {
+module('Integration | Component | confirm-popup', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/admin/tests/integration/components/login-form-test.js
+++ b/admin/tests/integration/components/login-form-test.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 const NOT_PIXMASTER_MSG = 'Vous n\'avez pas les droits pour vous connecter.';
 
-module('Integration | Component | login-form', function(hooks) {
+module('Integration | Component | login-form', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -30,7 +30,7 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('p.login-form__error').doesNotExist();
   });
 
-  module('Error management', function(hooks) {
+  module('Error management', (hooks) => {
 
     class SessionStub extends Service {
       authenticate = sinon.stub()

--- a/admin/tests/integration/components/member-item-test.js
+++ b/admin/tests/integration/components/member-item-test.js
@@ -6,7 +6,7 @@ import { selectChoose } from 'ember-power-select/test-support/helpers';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-module('Integration | Component | member-item', function(hooks) {
+module('Integration | Component | member-item', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -28,7 +28,7 @@ module('Integration | Component | member-item', function(hooks) {
     assert.contains('Désactiver');
   });
 
-  module('when editing organization\'s role', function(hooks) {
+  module('when editing organization\'s role', (hooks) => {
 
     hooks.beforeEach(async function() {
       // given
@@ -77,7 +77,7 @@ module('Integration | Component | member-item', function(hooks) {
     });
   });
 
-  module('when deactivating membership', function(hooks) {
+  module('when deactivating membership', (hooks) => {
 
     hooks.beforeEach(async function() {
       // given

--- a/admin/tests/integration/components/menu-bar-test.js
+++ b/admin/tests/integration/components/menu-bar-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | menu-bar', function(hooks) {
+module('Integration | Component | menu-bar', (hooks) => {
   setupRenderingTest(hooks);
 
   test('should contain link to "organizations" management page', async function(assert) {

--- a/admin/tests/integration/components/organization-form-test.js
+++ b/admin/tests/integration/components/organization-form-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import { selectChoose } from 'ember-power-select/test-support/helpers';
 
-module('Integration | Component | organization-form', function(hooks) {
+module('Integration | Component | organization-form', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -23,7 +23,7 @@ module('Integration | Component | organization-form', function(hooks) {
     assert.dom('.organization-form').exists();
   });
 
-  module('#selectOrganizationType', function() {
+  module('#selectOrganizationType', () => {
 
     test('should update attribute organization.type', async function(assert) {
       // given

--- a/admin/tests/integration/components/organization-information-section-test.js
+++ b/admin/tests/integration/components/organization-information-section-test.js
@@ -4,7 +4,7 @@ import { click, render, fillIn } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | organization-information-section', function(hooks) {
+module('Integration | Component | organization-information-section', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -43,7 +43,7 @@ module('Integration | Component | organization-information-section', function(ho
     assert.dom('.organization__canCollectProfiles').hasText('Oui');
   });
 
-  module('Edit organization', function(hooks) {
+  module('Edit organization', (hooks) => {
 
     let organization;
 
@@ -242,7 +242,7 @@ module('Integration | Component | organization-information-section', function(ho
     });
   });
 
-  module('When organization is SCO or SUP', function(hooks) {
+  module('When organization is SCO or SUP', (hooks) => {
 
     hooks.beforeEach(function() {
       this.organization = EmberObject.create({ type: 'SCO', isOrganizationSCO: true, isManagingStudents: true });
@@ -278,7 +278,7 @@ module('Integration | Component | organization-information-section', function(ho
     });
   });
 
-  module('When organization is not SCO', function(hooks) {
+  module('When organization is not SCO', (hooks) => {
 
     hooks.beforeEach(function() {
       this.organization = EmberObject.create({ type: 'PRO', isOrganizationSCO: false, isOrganizationSUP: false });

--- a/admin/tests/integration/components/organization-members-section-test.js
+++ b/admin/tests/integration/components/organization-members-section-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | organization-members-section', function(hooks) {
+module('Integration | Component | organization-members-section', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/admin/tests/integration/components/organizations-test.js
+++ b/admin/tests/integration/components/organizations-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-module('Integration | Component | target-profiles organizations', function(hooks) {
+module('Integration | Component | target-profiles organizations', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/pagination-control-test.js
+++ b/admin/tests/integration/components/pagination-control-test.js
@@ -14,7 +14,7 @@ function getMetaForPage(pageNumber) {
   };
 }
 
-module('Integration | Component | pagination-control', function(hooks) {
+module('Integration | Component | pagination-control', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should disable previous button when user is on first page', async function(assert) {

--- a/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certification-centers/list-items-test.js
@@ -4,7 +4,7 @@ import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-module('Integration | Component | routes/authenticated/certification-centers | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/certification-centers | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/certifications/certification/informations-test.js
@@ -5,18 +5,18 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
-module('Integration | Component | routes/authenticated/certifications/certification | informations', function(hooks) {
+module('Integration | Component | routes/authenticated/certifications/certification | informations', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     const user = server.create('user');
     await createAuthenticateSession({ userId: user.id });
   });
 
-  module('certification issue report container', function() {
+  module('certification issue report container', () => {
 
-    module('when there is no certification issue report', function() {
+    module('when there is no certification issue report', () => {
       test('it renders nothing', async function(assert) {
         // given
         const certificationIssueReports = [];
@@ -52,9 +52,9 @@ module('Integration | Component | routes/authenticated/certifications/certificat
       });
     });
 
-    module('when there are certification issue reports', function() {
+    module('when there are certification issue reports', () => {
 
-      module('when there are only certification issue reports with required action', function() {
+      module('when there are only certification issue reports with required action', () => {
 
         test('it renders only certifications issue reports with required action', async function(assert) {
           // given
@@ -97,7 +97,7 @@ module('Integration | Component | routes/authenticated/certifications/certificat
         });
       });
 
-      module('when there are only certification issue reports without required action', function() {
+      module('when there are only certification issue reports without required action', () => {
 
         test('it renders only certifications issue reports without required action', async function(assert) {
           // given

--- a/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/organizations/list-items-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/organizations | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/organizations | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/list-items-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { fillIn, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/sessions | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/sessions | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -53,7 +53,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     assert.dom('table tbody tr:nth-child(2) td:nth-child(9)').hasText(sessions[1].assignedCertificationOfficer.fullName);
   });
 
-  module('Input field for id filtering', function() {
+  module('Input field for id filtering', () => {
 
     test('it should render a input field to filter on id', async function(assert) {
       // when
@@ -64,7 +64,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     });
   });
 
-  module('Input field for certificationCenterName filtering', function() {
+  module('Input field for certificationCenterName filtering', () => {
 
     test('it should render a input field to filter on certificationCenterName', async function(assert) {
       // when
@@ -76,7 +76,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     });
   });
 
-  module('Dropdown menu for certification center type filtering', function() {
+  module('Dropdown menu for certification center type filtering', () => {
 
     test('it should render a dropdown menu to filter sessions on their certification center type', async function(assert) {
       // given
@@ -114,7 +114,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     });
   });
 
-  module('Dropdown menu for status filtering', function() {
+  module('Dropdown menu for status filtering', () => {
 
     test('it should render a dropdown menu to filter sessions on their status', async function(assert) {
       // given
@@ -153,7 +153,7 @@ module('Integration | Component | routes/authenticated/sessions | list-items', f
     });
   });
 
-  module('Dropdown menu for resultsSentToPrescriberAt filtering', function() {
+  module('Dropdown menu for resultsSentToPrescriberAt filtering', () => {
 
     test('it should render a dropdown menu to filter sessions on their results sending', async function(assert) {
       // given

--- a/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
+++ b/admin/tests/integration/components/routes/authenticated/sessions/session-id/informations-test.js
@@ -8,18 +8,18 @@ import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 
 import moment from 'moment';
 
-module('Integration | Component | routes/authenticated/sessions/session | informations', function(hooks) {
+module('Integration | Component | routes/authenticated/sessions/session | informations', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let session;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     const user = server.create('user');
     await createAuthenticateSession({ userId: user.id });
   });
 
-  module('regardless of session status', function() {
+  module('regardless of session status', () => {
 
     test('it renders the details page with correct info', async function(assert) {
       // given
@@ -43,7 +43,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
   });
 
-  module('when the session is created', function() {
+  module('when the session is created', () => {
 
     test('it does not render the examinerGlobalComment row or stats', async function(assert) {
       // given
@@ -59,7 +59,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
     });
   });
 
-  module('when the session is finalized', function() {
+  module('when the session is finalized', () => {
 
     hooks.beforeEach(async function() {
       const sessionData = {
@@ -111,7 +111,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
       assert.equal(find('[data-test-id="session-info__examiner-comment"]'), undefined);
     });
 
-    module('when results have not yet been sent to prescriber', function() {
+    module('when results have not yet been sent to prescriber', () => {
       test('it should display the button to flag results as sent', async function(assert) {
         // given
         session.update({ resultsSentToPrescriberAt: null });
@@ -126,7 +126,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
 
     });
 
-    module('when results have been sent to prescriber', function() {
+    module('when results have been sent to prescriber', () => {
       test('it should not display the button to flag results as sent', async function(assert) {
         // given
         session.update({ resultsSentToPrescriberAt: new Date() });
@@ -141,7 +141,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
     });
   });
 
-  module('when the session results have been sent to the prescriber', function() {
+  module('when the session results have been sent to the prescriber', () => {
 
     test('it renders the resultsSentToPrescriberAt date', async function(assert) {
       // given
@@ -155,7 +155,7 @@ module('Integration | Component | routes/authenticated/sessions/session | inform
     });
   });
 
-  module('when the session is processed', function() {
+  module('when the session is processed', () => {
 
     test('it renders the publishedAt date', async function(assert) {
       // given

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/list-items-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/target-profiles | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/target-profiles | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/details-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/target-profiles/target-profile | details', function(hooks) {
+module('Integration | Component | routes/authenticated/target-profiles/target-profile | details', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insight-test.js
+++ b/admin/tests/integration/components/routes/authenticated/target-profiles/target-profile/insight-test.js
@@ -3,11 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/target-profiles/target-profile | insight', function(hooks) {
+module('Integration | Component | routes/authenticated/target-profiles/target-profile | insight', (hooks) => {
 
   setupRenderingTest(hooks);
 
-  module('section rendering', function(hooks) {
+  module('section rendering', (hooks) => {
     let model;
     hooks.beforeEach(() => {
       model = {

--- a/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/to-be-published-sessions/list-items-test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
 
-module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/to-be-published-sessions | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/routes/authenticated/users/list-items-test.js
+++ b/admin/tests/integration/components/routes/authenticated/users/list-items-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/users | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/users | list-items', (hooks) => {
 
   setupRenderingTest(hooks);
 

--- a/admin/tests/integration/components/stages/stage-test.js
+++ b/admin/tests/integration/components/stages/stage-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | Stages::Stage', function(hooks) {
+module('Integration | Component | Stages::Stage', (hooks) => {
   let stage;
   let isEditMode;
   let toggleEditMode;

--- a/admin/tests/integration/components/stages/update-stage-test.js
+++ b/admin/tests/integration/components/stages/update-stage-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | UpdateStage', function(hooks) {
+module('Integration | Component | UpdateStage', (hooks) => {
   setupRenderingTest(hooks);
 
   let toggleEditMode;

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -4,7 +4,7 @@ import { find, render } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | TargetProfiles::Badges', function(hooks) {
+module('Integration | Component | TargetProfiles::Badges', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should display the items', async function(assert) {

--- a/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
+++ b/admin/tests/integration/components/target-profiles/create-target-profile-form-test.js
@@ -4,7 +4,7 @@ import { click, triggerEvent, render } from '@ember/test-helpers';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | TargetProfiles::CreateTargetProfileForm', function(hooks) {
+module('Integration | Component | TargetProfiles::CreateTargetProfileForm', (hooks) => {
   setupRenderingTest(hooks);
 
   let targetProfile;

--- a/admin/tests/integration/components/target-profiles/stages_test.js
+++ b/admin/tests/integration/components/target-profiles/stages_test.js
@@ -4,7 +4,7 @@ import { find, render } from '@ember/test-helpers';
 import EmberObject from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | TargetProfiles::Stages', function(hooks) {
+module('Integration | Component | TargetProfiles::Stages', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should display the items', async function(assert) {

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -4,11 +4,11 @@ import { click, find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | user-detail-personal-information', function(hooks) {
+module('Integration | Component | user-detail-personal-information', (hooks) => {
 
   setupRenderingTest(hooks);
 
-  module('When the administrator click on user details', async function() {
+  module('When the administrator click on user details', async () => {
 
     test('should display the update button when user is connected by email only', async function(assert) {
       this.set('user', {
@@ -204,7 +204,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       assert.dom('.user__is-authenticated-from-gar').hasText('NON');
     });
 
-    module('When user has no schoolingRegistrations', function() {
+    module('When user has no schoolingRegistrations', () => {
 
       test('should not display dissociate button', async function(assert) {
         // given
@@ -229,7 +229,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
       });
     });
 
-    module('When user has schoolingRegistrations', function() {
+    module('When user has schoolingRegistrations', () => {
 
       test('should display dissociate button', async function(assert) {
         // given
@@ -256,11 +256,11 @@ module('Integration | Component | user-detail-personal-information', function(ho
     });
   });
 
-  module('When the administrator click to update user details', async function() {
+  module('When the administrator click to update user details', async () => {
 
     let user = null;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       user = EmberObject.create({
         lastName: 'Harry',
         firstName: 'John',
@@ -313,11 +313,11 @@ module('Integration | Component | user-detail-personal-information', function(ho
     });
   });
 
-  module('when the administrator click on anonymize button', async function() {
+  module('when the administrator click on anonymize button', async () => {
 
     let user = null;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       user = EmberObject.create({
         lastName: 'Harry',
         firstName: 'John',

--- a/admin/tests/unit/adapters/application-test.js
+++ b/admin/tests/unit/adapters/application-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+module('Unit | Adapters | ApplicationAdapter', (hooks) => {
   setupTest(hooks);
 
   test('should specify /api as the root url', function(assert) {
@@ -13,7 +13,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
-  module('get headers()', function() {
+  module('get headers()', () => {
 
     test('should add header with authentication token when the session is authenticated', function(assert) {
       // Given
@@ -39,7 +39,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     });
   });
 
-  module('ajax()', function() {
+  module('ajax()', () => {
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');

--- a/admin/tests/unit/adapters/certification-center-membership-test.js
+++ b/admin/tests/unit/adapters/certification-center-membership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | certificationCenterMembership', function(hooks) {
+module('Unit | Adapter | certificationCenterMembership', (hooks) => {
 
   setupTest(hooks);
 
@@ -13,7 +13,7 @@ module('Unit | Adapter | certificationCenterMembership', function(hooks) {
     adapter.ajax = sinon.stub().resolves();
   });
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
 
     test('should build query url from certificationCenter id', async function(assert) {
       const query = { filter: { certificationCenterId: '1' } };
@@ -24,9 +24,9 @@ module('Unit | Adapter | certificationCenterMembership', function(hooks) {
     });
   });
 
-  module('#createRecord', function() {
+  module('#createRecord', () => {
 
-    module('when createByEmail is true', function() {
+    module('when createByEmail is true', () => {
 
       test('should call /api/certification-centers/id/certification-center-memberships', async function(assert) {
         // given

--- a/admin/tests/unit/adapters/certification-details-test.js
+++ b/admin/tests/unit/adapters/certification-details-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | certification details', function(hooks) {
+module('Unit | Adapter | certification details', (hooks) => {
   setupTest(hooks);
 
-  module('#urlForFindRecord', function() {
+  module('#urlForFindRecord', () => {
     test('should build get url from certification details id', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:certification-details');

--- a/admin/tests/unit/adapters/certification-test.js
+++ b/admin/tests/unit/adapters/certification-test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | certification details', function(hooks) {
+module('Unit | Adapter | certification details', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -17,11 +17,11 @@ module('Unit | Adapter | certification details', function(hooks) {
     serializer = { serializeIntoHash: sinon.stub() };
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(() => {
     adapter.ajax.restore();
   });
 
-  module('#urlForFindRecord', function() {
+  module('#urlForFindRecord', () => {
     test('should build get url from certification id', function(assert) {
       // when
       const url = adapter.urlForFindRecord(123, 'certification');
@@ -31,7 +31,7 @@ module('Unit | Adapter | certification details', function(hooks) {
     });
   });
 
-  module('#urlForUpdateMarks', function() {
+  module('#urlForUpdateMarks', () => {
     test('should build update marks url from certification id', function(assert) {
       // when
       const url = adapter.urlForUpdateMarks();
@@ -41,7 +41,7 @@ module('Unit | Adapter | certification details', function(hooks) {
     });
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
     test('should build update url from certification details id', function(assert) {
       // when
       const url = adapter.urlForUpdateRecord(123, 'certification');
@@ -51,9 +51,9 @@ module('Unit | Adapter | certification details', function(hooks) {
     });
   });
 
-  module('#updateRecord', function() {
+  module('#updateRecord', () => {
 
-    module('when updateMarks adapter option passed', function() {
+    module('when updateMarks adapter option passed', () => {
 
       test('it should trigger an ajax call with the updateMarks url, data and method', async function(assert) {
         // given
@@ -85,7 +85,7 @@ module('Unit | Adapter | certification details', function(hooks) {
 
     });
 
-    module('when no adapter options is passed', function() {
+    module('when no adapter options is passed', () => {
 
       test('it should trigger an ajax call with the appropriate url, data and method', async function(assert) {
         // given

--- a/admin/tests/unit/adapters/certified-profile-test.js
+++ b/admin/tests/unit/adapters/certified-profile-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | certified profile', function(hooks) {
+module('Unit | Adapter | certified profile', (hooks) => {
   setupTest(hooks);
 
-  module('#urlForFindRecord', function() {
+  module('#urlForFindRecord', () => {
     test('should build URL', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:certified-profile');

--- a/admin/tests/unit/adapters/learning-content-cache-test.js
+++ b/admin/tests/unit/adapters/learning-content-cache-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | learning content cache', function(hooks) {
+module('Unit | Adapter | learning content cache', (hooks) => {
 
   setupTest(hooks);
 
@@ -13,7 +13,7 @@ module('Unit | Adapter | learning content cache', function(hooks) {
     sinon.stub(adapter, 'ajax');
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(() => {
     adapter.ajax.restore();
   });
 

--- a/admin/tests/unit/adapters/membership-test.js
+++ b/admin/tests/unit/adapters/membership-test.js
@@ -2,7 +2,7 @@ import sinon from 'sinon';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | membership', function(hooks) {
+module('Unit | Adapter | membership', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -12,13 +12,13 @@ module('Unit | Adapter | membership', function(hooks) {
     sinon.stub(adapter, 'ajax').resolves();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(() => {
     adapter.ajax.restore();
   });
 
-  module('#updateRecord', function() {
+  module('#updateRecord', () => {
 
-    module('when disabled adapter option is provided', function() {
+    module('when disabled adapter option is provided', () => {
 
       test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
         // when

--- a/admin/tests/unit/adapters/organization-test.js
+++ b/admin/tests/unit/adapters/organization-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import ENV from 'pix-admin/config/environment';
 
-module('Unit | Adapters | organization', function(hooks) {
+module('Unit | Adapters | organization', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -15,7 +15,7 @@ module('Unit | Adapters | organization', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#findHasMany', function() {
+  module('#findHasMany', () => {
     test('should build url with query params when type is membership', async function(assert) {
       // given
       const snapshot = { modelName: 'organization', id: '1', adapterOptions: { 'page[size]': 2 } };

--- a/admin/tests/unit/adapters/session-test.js
+++ b/admin/tests/unit/adapters/session-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | session', function(hooks) {
+module('Unit | Adapter | session', (hooks) => {
   setupTest(hooks);
   let adapter;
 
@@ -10,7 +10,7 @@ module('Unit | Adapter | session', function(hooks) {
     adapter = this.owner.lookup('adapter:session');
   });
 
-  module('#urlForQueryRecord', function() {
+  module('#urlForQueryRecord', () => {
 
     test('should add /jury inside the default query url', function(assert) {
       // when
@@ -21,7 +21,7 @@ module('Unit | Adapter | session', function(hooks) {
     });
   });
 
-  module('#urlForFindRecord', function() {
+  module('#urlForFindRecord', () => {
     test('should add /jury inside the default find record url', function(assert) {
       // when
       const url = adapter.urlForFindRecord(123, 'sessions');
@@ -31,7 +31,7 @@ module('Unit | Adapter | session', function(hooks) {
     });
   });
 
-  module('#urlForUpdateMarks', function() {
+  module('#urlForUpdateMarks', () => {
     test('should add /admin inside the default update record url', function(assert) {
       // when
       const url = adapter.urlForUpdateRecord(123);
@@ -41,9 +41,9 @@ module('Unit | Adapter | session', function(hooks) {
     });
   });
 
-  module('#updateRecord', function() {
+  module('#updateRecord', () => {
 
-    module('when updatePublishedCertification adapterOption is passed', function() {
+    module('when updatePublishedCertification adapterOption is passed', () => {
 
       test('should send a patch request to /publish', function(assert) {
         // when
@@ -70,13 +70,13 @@ module('Unit | Adapter | session', function(hooks) {
       });
     });
 
-    module('when certificationOfficerAssignment adapterOption passed', function(hooks) {
+    module('when certificationOfficerAssignment adapterOption passed', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         sinon.stub(adapter, 'ajax');
       });
 
-      hooks.afterEach(function() {
+      hooks.afterEach(() => {
         adapter.ajax.restore();
       });
 

--- a/admin/tests/unit/adapters/to-be-published-session-test.js
+++ b/admin/tests/unit/adapters/to-be-published-session-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | to be published session', function(hooks) {
+module('Unit | Adapter | to be published session', (hooks) => {
   setupTest(hooks);
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
     test('should return /admin/sessions/to-publish', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:to-be-published-session');
@@ -15,7 +15,7 @@ module('Unit | Adapter | to be published session', function(hooks) {
     });
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
     test('should return /admin/sessions/:id', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:to-be-published-session');

--- a/admin/tests/unit/adapters/user-test.js
+++ b/admin/tests/unit/adapters/user-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | user', function(hooks) {
+module('Unit | Adapter | user', (hooks) => {
 
   setupTest(hooks);
 
@@ -12,7 +12,7 @@ module('Unit | Adapter | user', function(hooks) {
     adapter = this.owner.lookup('adapter:user');
   });
 
-  module('#urlForFindRecord', function() {
+  module('#urlForFindRecord', () => {
     test('should add /admin inside the default find record url', function(assert) {
       // when
       const url = adapter.urlForFindRecord(123, 'users');
@@ -22,7 +22,7 @@ module('Unit | Adapter | user', function(hooks) {
     });
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
     test('should add /admin inside the default update record url', function(assert) {
       // when
       const url = adapter.urlForUpdateRecord(123);
@@ -32,17 +32,17 @@ module('Unit | Adapter | user', function(hooks) {
     });
   });
 
-  module('#updateRecord', function(hooks) {
+  module('#updateRecord', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       sinon.stub(adapter, 'ajax').resolves();
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       adapter.ajax.restore();
     });
 
-    module('when anonymizeUser adapterOptions is passed', function() {
+    module('when anonymizeUser adapterOptions is passed', () => {
 
       test('should send a POST request to user anonymize endpoint', async function(assert) {
         // given
@@ -62,7 +62,7 @@ module('Unit | Adapter | user', function(hooks) {
       });
     });
 
-    module('when dissociate adapterOptions is passed', function() {
+    module('when dissociate adapterOptions is passed', () => {
 
       test('should send a PATCH request to user dissociate endpoint', async function(assert) {
         // given

--- a/admin/tests/unit/adapters/with-required-action-session-test.js
+++ b/admin/tests/unit/adapters/with-required-action-session-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapter | with required action session', function(hooks) {
+module('Unit | Adapter | with required action session', (hooks) => {
   setupTest(hooks);
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
     test('should return /admin/sessions/with-required-action', function(assert) {
       // when
       const adapter = this.owner.lookup('adapter:with-required-action-session');

--- a/admin/tests/unit/components/certification/certification-competence-list-test.js
+++ b/admin/tests/unit/components/certification/certification-competence-list-test.js
@@ -2,12 +2,12 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit | Component | <Certification::CertificationCompetenceList/>', function(hooks) {
+module('Unit | Component | <Certification::CertificationCompetenceList/>', (hooks) => {
   setupTest(hooks);
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:certification/certification-competence-list');
   });
 

--- a/admin/tests/unit/components/certification/certification-details-competence-test.js
+++ b/admin/tests/unit/components/certification/certification-details-competence-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { htmlSafe } from '@ember/string';
 import createGlimmerComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
+module('Unit | Component | <CertificationDetailsCompetence/>', (hooks) => {
   setupTest(hooks);
 
   const answer = (result) => {
@@ -29,11 +29,11 @@ module('Unit | Component | <CertificationDetailsCompetence/>', function(hooks) {
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:certification/certification-details-competence');
   });
 
-  module('#competenceJury', function() {
+  module('#competenceJury', () => {
 
     test('it should not give jury values when no jury rate is set', async function(assert) {
       // given

--- a/admin/tests/unit/components/organization-information-section-test.js
+++ b/admin/tests/unit/components/organization-information-section-test.js
@@ -3,13 +3,13 @@ import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import ENV from 'pix-admin/config/environment';
 
-module('Unit | Component | organization-information-section', function(hooks) {
+module('Unit | Component | organization-information-section', (hooks) => {
 
   setupTest(hooks);
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:organization-information-section');
   });
 

--- a/admin/tests/unit/components/target-profiles/details-test.js
+++ b/admin/tests/unit/components/target-profiles/details-test.js
@@ -5,7 +5,7 @@ import createComponent from '../../../helpers/create-glimmer-component';
 
 const NO_SKILL = undefined;
 
-module('Unit |  Component | Target Profiles | details', function(hooks) {
+module('Unit |  Component | Target Profiles | details', (hooks) => {
   setupTest(hooks);
 
   test('build empty competence list with no target profile', function(assert) {

--- a/admin/tests/unit/components/target-profiles/stages_test.js
+++ b/admin/tests/unit/components/target-profiles/stages_test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 
 import createComponent from '../../../helpers/create-glimmer-component';
 
-module('Unit |  Component | Target Profiles | stages', function(hooks) {
+module('Unit |  Component | Target Profiles | stages', (hooks) => {
   setupTest(hooks);
 
-  module('#displayNoThresholdZero', function() {
+  module('#displayNoThresholdZero', () => {
     test('returns false if there a stage with a threshold value at 0', function(assert) {
       const component = createComponent('component:target-profiles/stages');
       component.args = {

--- a/admin/tests/unit/components/update-stage-test.js
+++ b/admin/tests/unit/components/update-stage-test.js
@@ -3,10 +3,10 @@ import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-module('Unit | Component | update-stage', function(hooks) {
+module('Unit | Component | update-stage', (hooks) => {
   setupTest(hooks);
 
-  module('#updateStage', function() {
+  module('#updateStage', () => {
     test('it should update controller stage fields', async function(assert) {
       // given
       const component = createGlimmerComponent('component:stages/update-stage', { model: {

--- a/admin/tests/unit/components/update-target-profile-name-test.js
+++ b/admin/tests/unit/components/update-target-profile-name-test.js
@@ -3,10 +3,10 @@ import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-module('Unit | Component | update-target-profile-name', function(hooks) {
+module('Unit | Component | update-target-profile-name', (hooks) => {
   setupTest(hooks);
 
-  module('#updateProfileName', function() {
+  module('#updateProfileName', () => {
     test('it should update controller name field', async function(assert) {
       // given
       const component = createGlimmerComponent('component:target-profiles/update-target-profile-name', { model: {

--- a/admin/tests/unit/components/user-detail-personal-information-test.js
+++ b/admin/tests/unit/components/user-detail-personal-information-test.js
@@ -3,13 +3,13 @@ import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import ENV from 'pix-admin/config/environment';
 
-module('Unit | Component | user-detail-personal-information', function(hooks) {
+module('Unit | Component | user-detail-personal-information', (hooks) => {
 
   setupTest(hooks);
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:user-detail-personal-information');
   });
 

--- a/admin/tests/unit/controllers/authenticated/certification-centers/get-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/get-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/certification-centers/get', function(hooks) {
+module('Unit | Controller | authenticated/certification-centers/get', (hooks) => {
 
   setupTest(hooks);
 
@@ -44,7 +44,7 @@ module('Unit | Controller | authenticated/certification-centers/get', function(h
     controller.notifications.error.resolves();
   });
 
-  module('#updateEmailErrorMessage', function() {
+  module('#updateEmailErrorMessage', () => {
 
     test('should set email error message if email syntax is invalid', function(assert) {
       // given
@@ -70,16 +70,16 @@ module('Unit | Controller | authenticated/certification-centers/get', function(h
     });
   });
 
-  module('#addCertificationCenterMembership', function(hooks) {
+  module('#addCertificationCenterMembership', (hooks) => {
 
     let event;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       event = { preventDefault() {} };
       controller.send = sinon.stub();
     });
 
-    module('when email is valid', function() {
+    module('when email is valid', () => {
 
       const emailWithSpaces = ' test@example.net ';
 
@@ -128,7 +128,7 @@ module('Unit | Controller | authenticated/certification-centers/get', function(h
       });
     });
 
-    module('when email is not valid', function() {
+    module('when email is not valid', () => {
 
       test('should be disabled if the email is empty', async function(assert) {
         // given
@@ -164,9 +164,9 @@ module('Unit | Controller | authenticated/certification-centers/get', function(h
       });
     });
 
-    module('when API response is not OK (201)', function() {
+    module('when API response is not OK (201)', () => {
 
-      module('when the response error does not contains any errors property', function() {
+      module('when the response error does not contains any errors property', () => {
 
         test('should send default error notification', async function(assert) {
           // given

--- a/admin/tests/unit/controllers/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/certification-centers/list', function(hooks) {
+module('Unit | Controller | authenticated/certification-centers/list', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -9,9 +9,9 @@ module('Unit | Controller | authenticated/certification-centers/list', function(
     controller = this.owner.lookup('controller:authenticated.certification-centers.list');
   });
 
-  module('#triggerFiltering task', function() {
+  module('#triggerFiltering task', () => {
 
-    module('updating id', function() {
+    module('updating id', () => {
 
       test('it should update controller id field', async function(assert) {
         // given
@@ -26,7 +26,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function(
       });
     });
 
-    module('updating name', function() {
+    module('updating name', () => {
 
       test('it should update controller name field', async function(assert) {
         // given
@@ -41,7 +41,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function(
       });
     });
 
-    module('updating type', function() {
+    module('updating type', () => {
 
       test('it should update controller type field', async function(assert) {
         // given
@@ -56,7 +56,7 @@ module('Unit | Controller | authenticated/certification-centers/list', function(
       });
     });
 
-    module('updating externalId', function() {
+    module('updating externalId', () => {
 
       test('it should update controller externalId field', async function(assert) {
         // given

--- a/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/certification-centers/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/certification-centers/new', function(hooks) {
+module('Unit | Controller | authenticated/certification-centers/new', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/controllers/authenticated/certifications-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/certifications', function(hooks) {
+module('Unit | Controller | authenticated/certifications', (hooks) => {
   setupTest(hooks);
 
   test('#loadCertification', function(assert) {

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/details-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/details-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import EmberObject from '@ember/object';
 
-module('Unit | Controller | authenticated/certifications/certification/details', function(hooks) {
+module('Unit | Controller | authenticated/certifications/certification/details', (hooks) => {
   setupTest(hooks);
 
   const answer = (result) => {
@@ -37,7 +37,7 @@ module('Unit | Controller | authenticated/certifications/certification/details',
     }));
 
     // when
-    run(function() {
+    run(() => {
       controller.send('onUpdateRate');
     });
 
@@ -53,7 +53,7 @@ module('Unit | Controller | authenticated/certifications/certification/details',
     }));
 
     // when
-    run(function() {
+    run(() => {
       controller.send('onUpdateRate');
     });
 

--- a/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/certifications/certification/informations-test.js
@@ -5,7 +5,7 @@ import { getSettledState, settled } from '@ember/test-helpers';
 
 import EmberObject from '@ember/object';
 
-module('Unit | Controller | authenticated/certifications/certification/informations', function(hooks) {
+module('Unit | Controller | authenticated/certifications/certification/informations', (hooks) => {
 
   setupTest(hooks);
 
@@ -210,7 +210,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
 
   module('#onUpdateScore', () => {
 
-    module('when there is a given score', function() {
+    module('when there is a given score', () => {
 
       test('it replaces competence score correctly', async function(assert) {
         // When
@@ -223,7 +223,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       });
     });
 
-    module('when there is no given score and competence has no level', function() {
+    module('when there is no given score and competence has no level', () => {
 
       test('it removes competence correctly (score)', async function(assert) {
         // When
@@ -237,7 +237,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       });
     });
 
-    module('when the competence is not present', function() {
+    module('when the competence is not present', () => {
 
       test('it creates competence score correctly', async function(assert) {
         // When
@@ -253,7 +253,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
 
   module('#onUpdateLevel', () => {
 
-    module('when there is a given level', function() {
+    module('when there is a given level', () => {
 
       test('it replaces competence level correctly', async function(assert) {
         // When
@@ -266,7 +266,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       });
     });
 
-    module('when there is no given level and competence has no score', function() {
+    module('when there is no given level and competence has no score', () => {
 
       test('it removes competence correctly (level)', async function(assert) {
         // When
@@ -280,7 +280,7 @@ module('Unit | Controller | authenticated/certifications/certification/informati
       });
     });
 
-    module('when the competence is not present', function() {
+    module('when the competence is not present', () => {
 
       test('it creates competence level correctly', async function(assert) {
         // When

--- a/admin/tests/unit/controllers/authenticated/organizations/get/members-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/get/members-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Controller | authenticated/organizations/get/members', function(hooks) {
+module('Unit | Controller | authenticated/organizations/get/members', (hooks) => {
   setupTest(hooks);
 
   let controller;
@@ -11,7 +11,7 @@ module('Unit | Controller | authenticated/organizations/get/members', function(h
     controller = this.owner.lookup('controller:authenticated/organizations/get/members');
   });
 
-  module('#createOrganizationInvitation', function() {
+  module('#createOrganizationInvitation', () => {
 
     test('it should create an organization-invitation if the email is valid', function(assert) {
       const saveStub = sinon.stub().resolves();

--- a/admin/tests/unit/controllers/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/organizations/list', function(hooks) {
+module('Unit | Controller | authenticated/organizations/list', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -9,8 +9,8 @@ module('Unit | Controller | authenticated/organizations/list', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.organizations.list');
   });
 
-  module('#updateFilters', function() {
-    module('updating name', function() {
+  module('#updateFilters', () => {
+    module('updating name', () => {
       test('it should update controller name field', async function(assert) {
         // given
         controller.name = 'someName';
@@ -24,7 +24,7 @@ module('Unit | Controller | authenticated/organizations/list', function(hooks) {
       });
     });
 
-    module('updating type', function() {
+    module('updating type', () => {
       test('it should update controller type field', async function(assert) {
         // given
         controller.type = 'someType';
@@ -38,7 +38,7 @@ module('Unit | Controller | authenticated/organizations/list', function(hooks) {
       });
     });
 
-    module('updating externalId', function() {
+    module('updating externalId', () => {
       test('it should update controller externalId field', async function(assert) {
         // given
         controller.externalId = 'someExternalId';

--- a/admin/tests/unit/controllers/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/organizations/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/organizations/new', function(hooks) {
+module('Unit | Controller | authenticated/organizations/new', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/controllers/authenticated/sessions/list/all-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/all-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
+module('Unit | Controller | authenticated/sessions/list/all', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -9,9 +9,9 @@ module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.sessions.list.all');
   });
 
-  module('#triggerFiltering task', function() {
+  module('#triggerFiltering task', () => {
 
-    module('when fieldName is id', function() {
+    module('when fieldName is id', () => {
 
       test('it should update controller id field', async function(assert) {
         // given
@@ -26,7 +26,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when fieldName is certificationCenterName', function() {
+    module('when fieldName is certificationCenterName', () => {
 
       test('it should update controller certificationCenterName field', async function(assert) {
         // given
@@ -41,7 +41,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when fieldName is status', function() {
+    module('when fieldName is status', () => {
 
       test('it should update controller status field', async function(assert) {
         // given
@@ -56,7 +56,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when fieldName is resultsSentToPrescriberAt', function() {
+    module('when fieldName is resultsSentToPrescriberAt', () => {
 
       test('it should update controller resultsSentToPrescriberAt field', async function(assert) {
         // given
@@ -71,7 +71,7 @@ module('Unit | Controller | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when fieldName is certificationCenterType', function() {
+    module('when fieldName is certificationCenterType', () => {
 
       test('should update controller certificationCenterType field', async function(assert) {
         // given

--- a/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/list/to-be-published-test.js
@@ -4,10 +4,10 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 
-module('Unit | Controller | authenticated/sessions/list/to-be-published', function(hooks) {
+module('Unit | Controller | authenticated/sessions/list/to-be-published', (hooks) => {
   setupTest(hooks);
 
-  module('#publishSession', function() {
+  module('#publishSession', () => {
 
     test('should publish session', async function(assert) {
       // given
@@ -50,7 +50,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
     });
   });
 
-  module('#showConfirmModal', function() {
+  module('#showConfirmModal', () => {
     test('should change shouldShowModal to true', async function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
@@ -63,7 +63,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
     });
   });
 
-  module('#hideConfirmModal', function() {
+  module('#hideConfirmModal', () => {
     test('should change shouldShowModal to false', async function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated.sessions.list.to-be-published');
@@ -76,7 +76,7 @@ module('Unit | Controller | authenticated/sessions/list/to-be-published', functi
     });
   });
 
-  module('#batchPublishSessions', function() {
+  module('#batchPublishSessions', () => {
     test('should publish several sessions', async function(assert) {
       // given
       const successMock = sinon.stub();

--- a/admin/tests/unit/controllers/authenticated/sessions/session-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/sessions/session', function(hooks) {
+module('Unit | Controller | authenticated/sessions/session', (hooks) => {
   setupTest(hooks);
 
   test('#loadSession', function(assert) {

--- a/admin/tests/unit/controllers/authenticated/sessions/session/certifications-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/certifications-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/sessions/session/certifications', function(hooks) {
+module('Unit | Controller | authenticated/sessions/session/certifications', (hooks) => {
 
   setupTest(hooks);
   let controller;
@@ -14,7 +14,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
     model = EmberObject.create({ id: Symbol('an id'), certifications: [{}, {}], isPublished: null });
   });
 
-  module('#canPublish', function() {
+  module('#canPublish', () => {
 
     test('should be false when there is a certification in error', async function(assert) {
       // given
@@ -53,13 +53,13 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
     });
   });
 
-  module('#displayCertificationStatusUpdateConfirmationModal', function(hooks) {
+  module('#displayCertificationStatusUpdateConfirmationModal', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller.set('model', model);
     });
 
-    module('when session is not yet published', function() {
+    module('when session is not yet published', () => {
 
       test('should update modal message to publish', async function(assert) {
         // given
@@ -76,7 +76,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       });
     });
 
-    module('when session is published', function() {
+    module('when session is published', () => {
 
       test('should update modal message to unpublish', async function(assert) {
         // given
@@ -93,13 +93,13 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
     });
   });
 
-  module('#toggleSessionPublication', function(hooks) {
+  module('#toggleSessionPublication', (hooks) => {
 
     let notificationsStub;
     let store;
     let isPublishedGetterStub;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       notificationsStub = { success: sinon.stub() };
       store = {
         findRecord: sinon.stub(),
@@ -131,7 +131,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       assert.equal(controller.displayConfirm, false);
     });
 
-    module('when session is not yet published', function() {
+    module('when session is not yet published', () => {
 
       test('should publish all certifications', async function(assert) {
         // given
@@ -148,7 +148,7 @@ module('Unit | Controller | authenticated/sessions/session/certifications', func
       });
     });
 
-    module('when session is published', function() {
+    module('when session is published', () => {
 
       test('should unpublish all certifications', async function(assert) {
         // given

--- a/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/controllers/authenticated/sessions/session/informations-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/sessions/session/informations', function(hooks) {
+module('Unit | Controller | authenticated/sessions/session/informations', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -21,11 +21,11 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     controller.notifications = { success, error };
   });
 
-  module('#downloadSessionResultFile', function() {
+  module('#downloadSessionResultFile', () => {
 
     let url, fileName, validToken;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       url = `/api/admin/sessions/${model.id}/results`;
       fileName = 'resultats-session.csv';
       validToken = Symbol('my super token');
@@ -64,9 +64,9 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
   });
 
-  module('#downloadBeforeJuryFile', function() {
+  module('#downloadBeforeJuryFile', () => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       sinon.stub(store, 'peekRecord');
       store.peekRecord.withArgs('certification', 'juryCertifSummary1').returns('certification1');
       store.peekRecord.withArgs('certification', 'juryCertifSummary2').returns('certification2');
@@ -102,14 +102,14 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
   });
 
-  module('#checkForAssignment', function(hooks) {
+  module('#checkForAssignment', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       const save = sinon.stub();
       controller.model = { save };
     });
 
-    module('when a user is already assigned to session', function() {
+    module('when a user is already assigned to session', () => {
 
       test('it should show the modal', async function(assert) {
         //given
@@ -125,7 +125,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
       });
     });
 
-    module('when a user is not assigned to session', function() {
+    module('when a user is not assigned to session', () => {
 
       test('it should assign user to session', async function(assert) {
         // given
@@ -159,7 +159,7 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
   });
 
-  module('#cancelAssignment', function() {
+  module('#cancelAssignment', () => {
 
     test('it should close the modal', async function(assert) {
       // when
@@ -170,9 +170,9 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
   });
 
-  module('#confirmAssignment', function(hooks) {
+  module('#confirmAssignment', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       const save = sinon.stub();
       save.withArgs({ adapterOptions: { certificationOfficerAssignment: true } }).resolves();
       controller.model = { save };
@@ -207,9 +207,9 @@ module('Unit | Controller | authenticated/sessions/session/informations', functi
     });
   });
 
-  module('#copyResultsDownloadLink', function(hooks) {
+  module('#copyResultsDownloadLink', (hooks) => {
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       sinon.restore();
     });
 

--- a/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/target-profiles/list', function(hooks) {
+module('Unit | Controller | authenticated/target-profiles/list', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -9,9 +9,9 @@ module('Unit | Controller | authenticated/target-profiles/list', function(hooks)
     controller = this.owner.lookup('controller:authenticated.target-profiles.list');
   });
 
-  module('#triggerFiltering task', function() {
+  module('#triggerFiltering task', () => {
 
-    module('updating name', function() {
+    module('updating name', () => {
 
       test('it should update controller name field', async function(assert) {
         // given
@@ -26,7 +26,7 @@ module('Unit | Controller | authenticated/target-profiles/list', function(hooks)
       });
     });
 
-    module('updating id', function() {
+    module('updating id', () => {
 
       test('it should update controller id field', async function(assert) {
         // given

--- a/admin/tests/unit/controllers/authenticated/target-profiles/new-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/new-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/target-profiles/new', function(hooks) {
+module('Unit | Controller | authenticated/target-profiles/new', (hooks) => {
   setupTest(hooks);
 
   let controller;
@@ -11,7 +11,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
     controller = this.owner.lookup('controller:authenticated/target-profiles/new');
   });
 
-  module('#goBackToTargetProfileList', function() {
+  module('#goBackToTargetProfileList', () => {
     test('should delete record and go back target profile list page', async function(assert) {
       controller.store.deleteRecord = sinon.stub();
       controller.transitionToRoute = sinon.stub();
@@ -24,8 +24,8 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
     });
   });
 
-  module('#saveFileObject', function(hooks) {
-    hooks.beforeEach(function() {
+  module('#saveFileObject', (hooks) => {
+    hooks.beforeEach(() => {
       sinon.restore();
     });
 
@@ -54,7 +54,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
 
       let onLoadFunction;
       sinon.stub(FileReader.prototype, 'readAsText');
-      sinon.stub(FileReader.prototype, 'onload').set(function(onload) {
+      sinon.stub(FileReader.prototype, 'onload').set((onload) => {
         onLoadFunction = onload;
       });
 
@@ -76,7 +76,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
 
       let onLoadFunction;
       sinon.stub(FileReader.prototype, 'readAsText');
-      sinon.stub(FileReader.prototype, 'onload').set(function(onload) {
+      sinon.stub(FileReader.prototype, 'onload').set((onload) => {
         onLoadFunction = onload;
       });
 
@@ -89,7 +89,7 @@ module('Unit | Controller | authenticated/target-profiles/new', function(hooks) 
 
   });
 
-  module('#createTargetProfile', function() {
+  module('#createTargetProfile', () => {
     test('it should save model', async function(assert) {
       controller.model = {
         id: 3,

--- a/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/unit/controllers/authenticated/target-profiles/target-profile/organizations-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Controller | authenticated/target-profiles/target-profile/organizations', function(hooks) {
+module('Unit | Controller | authenticated/target-profiles/target-profile/organizations', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -11,8 +11,8 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
     controller = this.owner.lookup('controller:authenticated.target-profiles.target-profile.organizations');
   });
 
-  module('#updateFilters', function() {
-    module('updating name', function() {
+  module('#updateFilters', () => {
+    module('updating name', () => {
       test('it should update controller name field', async function(assert) {
         // given
         controller.name = 'someName';
@@ -26,7 +26,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
       });
     });
 
-    module('updating type', function() {
+    module('updating type', () => {
       test('it should update controller type field', async function(assert) {
         // given
         controller.type = 'someType';
@@ -40,7 +40,7 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
       });
     });
 
-    module('updating externalId', function() {
+    module('updating externalId', () => {
       test('it should update controller externalId field', async function(assert) {
         // given
         controller.externalId = 'someExternalId';
@@ -55,11 +55,11 @@ module('Unit | Controller | authenticated/target-profiles/target-profile/organiz
     });
   });
 
-  module('#attachOrganizations', function(hooks) {
+  module('#attachOrganizations', (hooks) => {
 
     let event;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       event = { preventDefault() {} };
     });
 

--- a/admin/tests/unit/controllers/authenticated/tools-test.js
+++ b/admin/tests/unit/controllers/authenticated/tools-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/tools', function(hooks) {
+module('Unit | Controller | authenticated/tools', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/controllers/authenticated/users/list-test.js
+++ b/admin/tests/unit/controllers/authenticated/users/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/users/list', function(hooks) {
+module('Unit | Controller | authenticated/users/list', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -9,9 +9,9 @@ module('Unit | Controller | authenticated/users/list', function(hooks) {
     controller = this.owner.lookup('controller:authenticated.users.list');
   });
 
-  module('#triggerFiltering task', function() {
+  module('#triggerFiltering task', () => {
 
-    module('updating firstName', function() {
+    module('updating firstName', () => {
 
       test('it should update controller firstName field', async function(assert) {
         // given
@@ -26,7 +26,7 @@ module('Unit | Controller | authenticated/users/list', function(hooks) {
       });
     });
 
-    module('updating lastName', function() {
+    module('updating lastName', () => {
 
       test('it should update controller lastName field', async function(assert) {
         // given
@@ -41,7 +41,7 @@ module('Unit | Controller | authenticated/users/list', function(hooks) {
       });
     });
 
-    module('updating email', function() {
+    module('updating email', () => {
 
       test('it should update controller email field', async function(assert) {
         // given

--- a/admin/tests/unit/controllers/stages/stage-test.js
+++ b/admin/tests/unit/controllers/stages/stage-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/stages/stage', function(hooks) {
+module('Unit | Controller | authenticated/stages/stage', (hooks) => {
   setupTest(hooks);
 
-  module('#toggleEditMode', function() {
+  module('#toggleEditMode', () => {
     test('should change isEditMode to true', async function(assert) {
       //given
       const controller = this.owner.lookup('controller:authenticated.stages.stage');

--- a/admin/tests/unit/helpers/format-date-test.js
+++ b/admin/tests/unit/helpers/format-date-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { formatDate } from 'pix-admin/helpers/format-date';
 
-module('Unit | Helpers | formatDate', function() {
+module('Unit | Helpers | formatDate', () => {
 
   test('it should return null if the given value is null', function(assert) {
     // given

--- a/admin/tests/unit/models/certification-details-test.js
+++ b/admin/tests/unit/models/certification-details-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | certification details', function(hooks) {
+module('Unit | Model | certification details', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/models/certification-issue-report-test.js
+++ b/admin/tests/unit/models/certification-issue-report-test.js
@@ -12,7 +12,7 @@ import {
   subcategoryToCode,
 } from 'pix-admin/models/certification-issue-report';
 
-module('Unit | Model | certification issue report', function(hooks) {
+module('Unit | Model | certification issue report', (hooks) => {
   setupTest(hooks);
 
   test('it should return the right label for the category', function(assert) {

--- a/admin/tests/unit/models/certification-test.js
+++ b/admin/tests/unit/models/certification-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import { ACQUIRED, REJECTED, NOT_PASSED } from 'pix-admin/models/certification';
 
-module('Unit | Model | certification', function(hooks) {
+module('Unit | Model | certification', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -17,7 +17,7 @@ module('Unit | Model | certification', function(hooks) {
     assert.ok(model);
   });
 
-  module('#isCleaCertificationIsAcquired', function() {
+  module('#isCleaCertificationIsAcquired', () => {
 
     const cleaStatusesAndExpectedResult = new Map([
       [ACQUIRED, true],
@@ -25,7 +25,7 @@ module('Unit | Model | certification', function(hooks) {
       [NOT_PASSED, false],
     ]);
     cleaStatusesAndExpectedResult.forEach((expectedResult, cleaStatus) => {
-      module(`when cleaCertificationStatus is ${cleaStatus}`, function() {
+      module(`when cleaCertificationStatus is ${cleaStatus}`, () => {
 
         test(`isCleaCertificationIsAcquired should be ${expectedResult}`, function(assert) {
           // given
@@ -43,7 +43,7 @@ module('Unit | Model | certification', function(hooks) {
     });
   });
 
-  module('#isCleaCertificationIsRejected', function() {
+  module('#isCleaCertificationIsRejected', () => {
 
     const cleaStatusesAndExpectedResult = new Map([
       [ACQUIRED, false],
@@ -51,7 +51,7 @@ module('Unit | Model | certification', function(hooks) {
       [NOT_PASSED, false],
     ]);
     cleaStatusesAndExpectedResult.forEach((expectedResult, cleaStatus) => {
-      module(`when cleaCertificationStatus is ${cleaStatus}`, function() {
+      module(`when cleaCertificationStatus is ${cleaStatus}`, () => {
 
         test(`isCleaCertificationIsRejected should be ${expectedResult}`, function(assert) {
           // given

--- a/admin/tests/unit/models/jury-certification-summary-test.js
+++ b/admin/tests/unit/models/jury-certification-summary-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import { certificationStatuses } from 'pix-admin/models/certification';
 
-module('Unit | Model | jury-certification-summary', function(hooks) {
+module('Unit | Model | jury-certification-summary', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -12,10 +12,10 @@ module('Unit | Model | jury-certification-summary', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#statusLabel', function() {
+  module('#statusLabel', () => {
 
-    certificationStatuses.forEach(function({ value, label }) {
-      module(`when the status is ${value}`, function() {
+    certificationStatuses.forEach(({ value, label }) => {
+      module(`when the status is ${value}`, () => {
 
         test(`statusLabel should return ${label}`, function(assert) {
           // given

--- a/admin/tests/unit/models/membership-test.js
+++ b/admin/tests/unit/models/membership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | organization access', function(hooks) {
+module('Unit | Model | organization access', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/models/session-test.js
+++ b/admin/tests/unit/models/session-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import { STARTED, PROCESSED } from 'pix-admin/models/session';
 
-module('Unit | Model | session', function(hooks) {
+module('Unit | Model | session', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -12,9 +12,9 @@ module('Unit | Model | session', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#isFinalized', function() {
+  module('#isFinalized', () => {
 
-    module('when the status is PROCESSED', function() {
+    module('when the status is PROCESSED', () => {
 
       test('isFinalized should be true', function(assert) {
         // given
@@ -30,7 +30,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when the status is STARTED', function() {
+    module('when the status is STARTED', () => {
 
       test('isFinalized should be false', function(assert) {
         // given
@@ -49,9 +49,9 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#hasExaminerGlobalComment', function() {
+  module('#hasExaminerGlobalComment', () => {
 
-    module('when there is no examinerGlobalComment', function() {
+    module('when there is no examinerGlobalComment', () => {
 
       test('it should return false', function(assert) {
         // given
@@ -65,7 +65,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when there is a examinerGlobalComment with only whitespaces', function() {
+    module('when there is a examinerGlobalComment with only whitespaces', () => {
 
       test('it should also return false', function(assert) {
         // given
@@ -79,7 +79,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when there is an examinerGlobalComment', function() {
+    module('when there is an examinerGlobalComment', () => {
 
       test('it should return true', function(assert) {
         // given
@@ -94,9 +94,9 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#isPublished', function() {
+  module('#isPublished', () => {
 
-    module('when there is no certification', function() {
+    module('when there is no certification', () => {
       let sessionWithoutCertifications;
 
       test('isPublished should be false', function(assert) {
@@ -113,13 +113,13 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when there are multiple certifications', function() {
+    module('when there are multiple certifications', () => {
 
-      module('when all certifications are published', function() {
+      module('when all certifications are published', () => {
 
         let sessionWithAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(async () => {
           sessionWithAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: true });
@@ -133,11 +133,11 @@ module('Unit | Model | session', function(hooks) {
         });
       });
 
-      module('when not all certifications are published', function() {
+      module('when not all certifications are published', () => {
 
         let sessionWithoutAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(async () => {
           sessionWithoutAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: true });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
@@ -150,11 +150,11 @@ module('Unit | Model | session', function(hooks) {
           assert.equal(isPublished, true);
         });
       });
-      module('when all certifications are not published', function() {
+      module('when all certifications are not published', () => {
 
         let sessionWithoutAllCertificationsPublished;
 
-        hooks.beforeEach(async function() {
+        hooks.beforeEach(async () => {
           sessionWithoutAllCertificationsPublished = run(() => {
             const certif1 = store.createRecord('jury-certification-summary', { isPublished: false });
             const certif2 = store.createRecord('jury-certification-summary', { isPublished: false });
@@ -172,11 +172,11 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countCertificationIssueReports', function() {
+  module('#countCertificationIssueReports', () => {
     let sessionWithCertificationIssueReports;
     let sessionWithoutCertificationIssueReport;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       sessionWithCertificationIssueReports = run(() => {
         const certif = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReports: 5 });
         const certif2 = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReports: 1 });
@@ -199,11 +199,11 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countCertificationIssueReportsWithActionRequired', function() {
+  module('#countCertificationIssueReportsWithActionRequired', () => {
     let sessionWithCertificationIssueReports;
     let sessionWithoutCertificationIssueReport;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       sessionWithCertificationIssueReports = run(() => {
         const certif = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 5 });
         const certif2 = store.createRecord('jury-certification-summary', { numberOfCertificationIssueReportsWithRequiredAction: 1 });
@@ -226,12 +226,12 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countNotCheckedEndScreen', function() {
+  module('#countNotCheckedEndScreen', () => {
 
     let sessionWithOneUncheckedEndScreen;
     let sessionWithOneCheckedEndScreen;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       sessionWithOneUncheckedEndScreen = run(() => {
         const certif = store.createRecord('jury-certification-summary', { hasSeenEndTestScreen: false });
         return store.createRecord('session', { juryCertificationSummaries: [certif] });
@@ -255,12 +255,12 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#countNonValidatedCertifications', function() {
+  module('#countNonValidatedCertifications', () => {
 
     let sessionWithOneNotValidatedCertif;
     let sessionWithValidatedCertif;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       sessionWithOneNotValidatedCertif = run(() => {
         const certif = store.createRecord('jury-certification-summary', { status: 'nonValidated' });
         return store.createRecord('session', { juryCertificationSummaries: [certif] });
@@ -284,9 +284,9 @@ module('Unit | Model | session', function(hooks) {
 
   });
 
-  module('#areResultsToBeSentToPrescriber', function() {
+  module('#areResultsToBeSentToPrescriber', () => {
 
-    module('when session is finalized but results were not sent to prescriber yet', function() {
+    module('when session is finalized but results were not sent to prescriber yet', () => {
 
       test('it should return areResultsToBeSentToPrescriber with true value', function(assert) {
         // given
@@ -300,7 +300,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when session is finalized and results has been sent to prescriber', function() {
+    module('when session is finalized and results has been sent to prescriber', () => {
 
       test('it should return areResultsToBeSentToPrescriber with false value', function(assert) {
         // given
@@ -315,9 +315,9 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#displayStatus', function() {
+  module('#displayStatus', () => {
 
-    module('when status is created', function() {
+    module('when status is created', () => {
 
       test('it should display created printable equivalent', function(assert) {
         // given
@@ -331,7 +331,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when status is finalized', function() {
+    module('when status is finalized', () => {
 
       test('it should display finalized printable equivalent', function(assert) {
         // given
@@ -345,7 +345,7 @@ module('Unit | Model | session', function(hooks) {
       });
     });
 
-    module('when status is processed', function() {
+    module('when status is processed', () => {
 
       test('it should display processed printable equivalent', function(assert) {
         // given

--- a/admin/tests/unit/models/to-be-published-session-test.js
+++ b/admin/tests/unit/models/to-be-published-session-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | to be published session', function(hooks) {
+module('Unit | Model | to be published session', (hooks) => {
   setupTest(hooks);
 
-  module('#printableDateAndTime', function() {
+  module('#printableDateAndTime', () => {
     test('it should return a printable version of to be published session date and time', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -21,7 +21,7 @@ module('Unit | Model | to be published session', function(hooks) {
     });
   });
 
-  module('#printableFinalizationDate', function() {
+  module('#printableFinalizationDate', () => {
     test('it should return a printable version of to be published session finalization date', function(assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/admin/tests/unit/models/user-test.js
+++ b/admin/tests/unit/models/user-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | user', function(hooks) {
+module('Unit | Model | user', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -11,7 +11,7 @@ module('Unit | Model | user', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#fullName', function() {
+  module('#fullName', () => {
 
     test('it should return the fullname, combination of last and first name', function(assert) {
       // given

--- a/admin/tests/unit/models/with-required-action-session-test.js
+++ b/admin/tests/unit/models/with-required-action-session-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | with required action session', function(hooks) {
+module('Unit | Model | with required action session', (hooks) => {
   setupTest(hooks);
 
-  module('#printableDateAndTime', function() {
+  module('#printableDateAndTime', () => {
     test('it should return a printable version of session with required action date and time', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -21,7 +21,7 @@ module('Unit | Model | with required action session', function(hooks) {
     });
   });
 
-  module('#printableFinalizationDate', function() {
+  module('#printableFinalizationDate', () => {
     test('it should return a printable version of session with required action finalization date', function(assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/admin/tests/unit/routes/about-test.js
+++ b/admin/tests/unit/routes/about-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | about', function(hooks) {
+module('Unit | Route | about', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/application-test.js
+++ b/admin/tests/unit/routes/application-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | application', function(hooks) {
+module('Unit | Route | application', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated-test.js
+++ b/admin/tests/unit/routes/authenticated-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated', function(hooks) {
+module('Unit | Route | authenticated', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/certification-centers/get-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/get-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/certification-centers/get', function(hooks) {
+module('Unit | Route | authenticated/certification-centers/get', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
+++ b/admin/tests/unit/routes/authenticated/certification-centers/list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/certification-centers/list', function(hooks) {
+module('Unit | Route | authenticated/certification-centers/list', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
     route = this.owner.lookup('route:authenticated/certification-centers/list');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const params = {};
     const expectedQueryArgs = {};
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.query = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
@@ -24,7 +24,7 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
       };
     });
 
-    module('when queryParams filters are falsy', function() {
+    module('when queryParams filters are falsy', () => {
 
       test('it should call store.query with no filters on name, type and externalId', async function(assert) {
         // when
@@ -42,7 +42,7 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
       });
     });
 
-    module('when queryParams filters are  truthy', function() {
+    module('when queryParams filters are  truthy', () => {
 
       test('it should call store.query with filters containing trimmed values', async function(assert) {
         // given
@@ -68,10 +68,10 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
 
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -82,7 +82,7 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -98,7 +98,7 @@ module('Unit | Route | authenticated/certification-centers/list', function(hooks
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/certifications/certification-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/certifications/certification', function(hooks) {
+module('Unit | Route | authenticated/certifications/certification', (hooks) => {
   setupTest(hooks);
 
   test('#setupController', function(assert) {

--- a/admin/tests/unit/routes/authenticated/certifications/certification/details-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/details-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/certifications/certification/details', function(hooks) {
+module('Unit | Route | authenticated/certifications/certification/details', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/certifications/certification/informations-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/informations-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/certifications/certification/informations', function(hooks) {
+module('Unit | Route | authenticated/certifications/certification/informations', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/certifications/certification/profile-test.js
+++ b/admin/tests/unit/routes/authenticated/certifications/certification/profile-test.js
@@ -3,10 +3,10 @@ import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/certifications/certification/profile', function(hooks) {
+module('Unit | Route | authenticated/certifications/certification/profile', (hooks) => {
   setupTest(hooks);
 
-  module('#model', function() {
+  module('#model', () => {
 
     test('it should return certified profile', async function(assert) {
       // given

--- a/admin/tests/unit/routes/authenticated/index-test.js
+++ b/admin/tests/unit/routes/authenticated/index-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/index', function(hooks) {
+module('Unit | Route | authenticated/index', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/organizations/get-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/get-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/organizations/get', function(hooks) {
+module('Unit | Route | authenticated/organizations/get', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/organizations/index-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/index-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/organizations/index', function(hooks) {
+module('Unit | Route | authenticated/organizations/index', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/organizations/list-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/organizations/list', function(hooks) {
+module('Unit | Route | authenticated/organizations/list', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
     route = this.owner.lookup('route:authenticated/organizations/list');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const params = {};
     const expectedQueryArgs = {};
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.query = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
@@ -24,7 +24,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
       };
     });
 
-    module('when queryParams filters are falsy', function() {
+    module('when queryParams filters are falsy', () => {
 
       test('it should call store.query with no filters on id, name, type and externalId', async function(assert) {
         // when
@@ -42,7 +42,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
       });
     });
 
-    module('when queryParams filters are  truthy', function() {
+    module('when queryParams filters are  truthy', () => {
 
       test('it should call store.query with filters containing trimmed values', async function(assert) {
         // given
@@ -68,10 +68,10 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
 
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -82,7 +82,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -98,7 +98,7 @@ module('Unit | Route | authenticated/organizations/list', function(hooks) {
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/organizations/new-test.js
+++ b/admin/tests/unit/routes/authenticated/organizations/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/organizations/new', function(hooks) {
+module('Unit | Route | authenticated/organizations/new', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list', function(hooks) {
+module('Unit | Route | authenticated/sessions/list', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -15,7 +15,7 @@ module('Unit | Route | authenticated/sessions/list', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#model', function() {
+  module('#model', () => {
     test('it should fetch the list of sessions with required action', async function(assert) {
       // given
       const route = this.owner.lookup('route:authenticated/sessions/list');

--- a/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/all-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
+module('Unit | Route | authenticated/sessions/list/all', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
     route = this.owner.lookup('route:authenticated/sessions/list/all');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     let params;
     const expectedQueryArgs = {};
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.query = sinon.stub();
       params = {};
       params.pageNumber = 'somePageNumber';
@@ -25,7 +25,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       };
     });
 
-    module('when queryParams are undefined', function() {
+    module('when queryParams are undefined', () => {
 
       test('it should call store.query with no filters', async function(assert) {
         // when
@@ -45,7 +45,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams id is truthy', function() {
+    module('when queryParams id is truthy', () => {
 
       test('it should call store.query with a filter with trimmed id', async function(assert) {
         // given
@@ -68,7 +68,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams certificationCenterName is truthy', function() {
+    module('when queryParams certificationCenterName is truthy', () => {
 
       test('it should call store.query with a filter with trimmed certificationCenterName', async function(assert) {
         // given
@@ -91,7 +91,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams certificationCenterType is truthy', function() {
+    module('when queryParams certificationCenterType is truthy', () => {
 
       test('it should call store.query with a filter with trimmed certificationCenterType', async function(assert) {
         // given
@@ -114,7 +114,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams status is truthy', function() {
+    module('when queryParams status is truthy', () => {
 
       test('it should call store.query with a filter with status', async function(assert) {
         // given
@@ -137,7 +137,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams resultsSentToPrescriberAt is true', function() {
+    module('when queryParams resultsSentToPrescriberAt is true', () => {
 
       test('it should call store.query with a filter with true resultsSentToPrescriberAt', async function(assert) {
         // given
@@ -160,7 +160,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when queryParams assignedToSelfOnly is truthy', function() {
+    module('when queryParams assignedToSelfOnly is truthy', () => {
 
       test('it should call store.query with a filter with assignedToSelfOnly', async function(assert) {
         // given
@@ -183,7 +183,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when query to the store throws an error', function() {
+    module('when query to the store throws an error', () => {
       test('it should return an empty array of sessions', async function(assert) {
         // given
         route.store.query.rejects();
@@ -196,7 +196,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when query to the store is successful', function() {
+    module('when query to the store is successful', () => {
       test('it should return the result of the store call to query', async function(assert) {
         // given
         route.store.query.resolves('someSessions');
@@ -211,10 +211,10 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
 
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -226,7 +226,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -243,7 +243,7 @@ module('Unit | Route | authenticated/sessions/list/all', function(hooks) {
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/list/to-be-published-test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list/to-be-published', function(hooks) {
+module('Unit | Route | authenticated/sessions/list/to-be-published', (hooks) => {
   setupTest(hooks);
 
   let store;
@@ -15,7 +15,7 @@ module('Unit | Route | authenticated/sessions/list/to-be-published', function(ho
     store = this.owner.lookup('service:store');
   });
 
-  module('#model', function() {
+  module('#model', () => {
     test('it should fetch the list of sessions to be published', async function(assert) {
       // given
       const route = this.owner.lookup('route:authenticated/sessions/list/to-be-published');

--- a/admin/tests/unit/routes/authenticated/sessions/session-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/session', function(hooks) {
+module('Unit | Route | authenticated/sessions/session', (hooks) => {
   setupTest(hooks);
 
   test('#setupController', function(assert) {

--- a/admin/tests/unit/routes/authenticated/sessions/session/certifications-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session/certifications-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/sessions/session/certifications', function(hooks) {
+module('Unit | Route | authenticated/sessions/session/certifications', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/sessions/session/informations-test.js
+++ b/admin/tests/unit/routes/authenticated/sessions/session/informations-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/sessions/session/informations', function(hooks) {
+module('Unit | Route | authenticated/sessions/session/informations', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
+module('Unit | Route | authenticated/target-profiles/list', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
     route = this.owner.lookup('route:authenticated/target-profiles/list');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const params = {};
     const expectedQueryArgs = {};
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.query = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
@@ -24,7 +24,7 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
       };
     });
 
-    module('when queryParams filters are falsy', function() {
+    module('when queryParams filters are falsy', () => {
 
       test('it should call store.query with no filters on name and id', async function(assert) {
         // when
@@ -40,7 +40,7 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
       });
     });
 
-    module('when queryParams filters are truthy', function() {
+    module('when queryParams filters are truthy', () => {
 
       test('it should call store.query with filters containing trimmed values', async function(assert) {
         // given
@@ -62,10 +62,10 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
 
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -74,7 +74,7 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -88,7 +88,7 @@ module('Unit | Route | authenticated/target-profiles/list', function(hooks) {
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations-test.js
+++ b/admin/tests/unit/routes/authenticated/target-profiles/target-profile/organizations-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/target-profiles/target-profile/organizations', function(hooks) {
+module('Unit | Route | authenticated/target-profiles/target-profile/organizations', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -9,10 +9,10 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
     route = this.owner.lookup('route:authenticated/target-profiles/target-profile/organizations');
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -22,7 +22,7 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -37,7 +37,7 @@ module('Unit | Route | authenticated/target-profiles/target-profile/organization
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/authenticated/tools-test.js
+++ b/admin/tests/unit/routes/authenticated/tools-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/tools', function(hooks) {
+module('Unit | Route | authenticated/tools', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/users/index-test.js
+++ b/admin/tests/unit/routes/authenticated/users/index-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/users/index', function(hooks) {
+module('Unit | Route | authenticated/users/index', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/authenticated/users/list-test.js
+++ b/admin/tests/unit/routes/authenticated/users/list-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/users/list', function(hooks) {
+module('Unit | Route | authenticated/users/list', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
     route = this.owner.lookup('route:authenticated/users/list');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const params = {};
     const expectedQueryArgs = {};
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.query = sinon.stub().resolves();
       params.pageNumber = 'somePageNumber';
       params.pageSize = 'somePageSize';
@@ -24,7 +24,7 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
       };
     });
 
-    module('when queryParams filters are falsy', function() {
+    module('when queryParams filters are falsy', () => {
 
       test('it should call store.query with no filters on name, type and externalId', async function(assert) {
         // when
@@ -41,7 +41,7 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
       });
     });
 
-    module('when queryParams filters are  truthy', function() {
+    module('when queryParams filters are  truthy', () => {
 
       test('it should call store.query with filters containing trimmed values', async function(assert) {
         // given
@@ -65,10 +65,10 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
 
   });
 
-  module('#resetController', function(hooks) {
+  module('#resetController', (hooks) => {
     let controller;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       controller = {
         pageNumber: 'somePageNumber',
         pageSize: 'somePageSize',
@@ -78,7 +78,7 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
       };
     });
 
-    module('when route is exiting', function() {
+    module('when route is exiting', () => {
 
       test('it should reset controller', function(assert) {
         // when
@@ -93,7 +93,7 @@ module('Unit | Route | authenticated/users/list', function(hooks) {
       });
     });
 
-    module('when route is not exiting', function() {
+    module('when route is not exiting', () => {
 
       test('it should not reset controller', function(assert) {
         // when

--- a/admin/tests/unit/routes/index-test.js
+++ b/admin/tests/unit/routes/index-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | index', function(hooks) {
+module('Unit | Route | index', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/routes/logout-test.js
+++ b/admin/tests/unit/routes/logout-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | logout', function(hooks) {
+module('Unit | Route | logout', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/admin/tests/unit/serializers/certification-details-test.js
+++ b/admin/tests/unit/serializers/certification-details-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Serializer | certification details', function(hooks) {
+module('Unit | Serializer | certification details', (hooks) => {
   setupTest(hooks);
 
   test('it serializes records', function(assert) {

--- a/admin/tests/unit/serializers/certification-test.js
+++ b/admin/tests/unit/serializers/certification-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Serializer | certification', function(hooks) {
+module('Unit | Serializer | certification', (hooks) => {
   setupTest(hooks);
 
   test('it serializes records', function(assert) {

--- a/admin/tests/unit/serializers/organization-test.js
+++ b/admin/tests/unit/serializers/organization-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Serializer | organization', function(hooks) {
+module('Unit | Serializer | organization', (hooks) => {
   setupTest(hooks);
 
   test('it serializes records', function(assert) {

--- a/admin/tests/unit/services/csv-service-test.js
+++ b/admin/tests/unit/services/csv-service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Service | csv-service', function(hooks) {
+module('Unit | Service | csv-service', (hooks) => {
   setupTest(hooks);
 
   let service;
@@ -10,9 +10,9 @@ module('Unit | Service | csv-service', function(hooks) {
     service = this.owner.lookup('service:csv-service');
   });
 
-  module('#sanitize', function() {
+  module('#sanitize', () => {
 
-    module('when the string is clean', function() {
+    module('when the string is clean', () => {
 
       test('should return the string when string is empty', function(assert) {
         // given
@@ -38,7 +38,7 @@ module('Unit | Service | csv-service', function(hooks) {
 
     });
 
-    module('when the string starts with an illegal character', function() {
+    module('when the string starts with an illegal character', () => {
 
       test('should sanitize when starts with @', function(assert) {
         // given
@@ -89,7 +89,7 @@ module('Unit | Service | csv-service', function(hooks) {
       });
     });
 
-    module('when the value is not a string', function() {
+    module('when the value is not a string', () => {
 
       test('should return the same value', function(assert) {
         // given

--- a/admin/tests/unit/services/current-user-test.js
+++ b/admin/tests/unit/services/current-user-test.js
@@ -4,11 +4,11 @@ import { reject, resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Unit | Service | current-user', function(hooks) {
+module('Unit | Service | current-user', (hooks) => {
 
   setupTest(hooks);
 
-  module('user is authenticated', function() {
+  module('user is authenticated', () => {
 
     test('should load the current user', async function(assert) {
       // Given
@@ -33,7 +33,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user is not authenticated', function() {
+  module('user is not authenticated', () => {
 
     test('should do nothing', async function(assert) {
       // Given
@@ -51,7 +51,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user token is expired', function() {
+  module('user token is expired', () => {
 
     test('should redirect to login', async function(assert) {
       // Given

--- a/admin/tests/unit/services/error-notifier-test.js
+++ b/admin/tests/unit/services/error-notifier-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | error-notifier', function(hooks) {
+module('Unit | Service | error-notifier', (hooks) => {
   setupTest(hooks);
 
   test('it notifies a non-JSONAPI error as a single notification', function(assert) {

--- a/admin/tests/unit/services/file-saver-test.js
+++ b/admin/tests/unit/services/file-saver-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | file-saver', function(hooks) {
+module('Unit | Service | file-saver', (hooks) => {
   setupTest(hooks);
   let fileSaver;
 
@@ -10,7 +10,7 @@ module('Unit | Service | file-saver', function(hooks) {
     fileSaver = this.owner.lookup('service:file-saver');
   });
 
-  module('#save', function() {
+  module('#save', () => {
     const id = 123456;
     const url = `/attestation/${id}`;
     const token = 'mytoken';
@@ -30,7 +30,7 @@ module('Unit | Service | file-saver', function(hooks) {
       downloadFileForModernBrowsersStub = sinon.stub().returns();
     });
 
-    module('when response does have a fileName info in headers', function() {
+    module('when response does have a fileName info in headers', () => {
       test('should give fileName from response', async function(assert) {
         // given
         const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
@@ -53,7 +53,7 @@ module('Unit | Service | file-saver', function(hooks) {
       });
     });
 
-    module('when response does not have a fileName info in headers', function() {
+    module('when response does not have a fileName info in headers', () => {
       test('should give default fileName', async function(assert) {
         // given
         const response = { blob: blobStub };

--- a/admin/tests/unit/services/mark-store-test.js
+++ b/admin/tests/unit/services/mark-store-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Service | mark-store', function(hooks) {
+module('Unit | Service | mark-store', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/admin/tests/unit/services/session-info-service-test.js
+++ b/admin/tests/unit/services/session-info-service-test.js
@@ -5,7 +5,7 @@ import { A } from '@ember/array';
 import Service from '@ember/service';
 import moment from 'moment';
 
-module('Unit | Service | session-info-service', function(hooks) {
+module('Unit | Service | session-info-service', (hooks) => {
 
   setupTest(hooks);
 
@@ -68,7 +68,7 @@ module('Unit | Service | session-info-service', function(hooks) {
     });
   }
 
-  module('#downloadJuryFile', function() {
+  module('#downloadJuryFile', () => {
 
     test('should include certification which status is not "validated"', async function(assert) {
       const session = EmberObject.create({ id: 5 });
@@ -127,7 +127,7 @@ module('Unit | Service | session-info-service', function(hooks) {
         '');
     });
 
-    module('when data start with illegal characters', function() {
+    module('when data start with illegal characters', () => {
 
       test('should sanitize Jury data', async function(assert) {
         // given
@@ -149,14 +149,14 @@ module('Unit | Service | session-info-service', function(hooks) {
     });
   });
 
-  module('#buildSessionExportFileData', function() {
+  module('#buildSessionExportFileData', () => {
 
-    module('when the certif status is rejected', function() {
+    module('when the certif status is rejected', () => {
       let certifRejected;
       let sessionWithRejectedCertif;
       let certifications;
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         const indexedCompetences = { '1.1': { level: 3, score: 2 } };
         certifRejected = buildCertification({ sessionId: 1, status: 'rejected', indexedCompetences });
         sessionWithRejectedCertif = { certificationCenterName: 'Salut' };
@@ -190,13 +190,13 @@ module('Unit | Service | session-info-service', function(hooks) {
 
     });
 
-    module('when the certif status is validated', function() {
+    module('when the certif status is validated', () => {
 
       let certifValidated;
       let sessionWithValidatedCertif;
       let certifications;
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         const indexedCompetences = { '1.1': { level: 3, score: 2 } };
         certifValidated = buildCertification({ sessionId: 1, indexedCompetences });
         sessionWithValidatedCertif = { certificationCenterName: 'Salut' };

--- a/admin/tests/unit/utils/email-validator-test.js
+++ b/admin/tests/unit/utils/email-validator-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import isEmailValid from 'pix-admin/utils/email-validator';
 
-module('Unit | Utils | email validator', function(hooks) {
+module('Unit | Utils | email validator', (hooks) => {
   setupTest(hooks);
 
-  module('Invalid emails', function() {
+  module('Invalid emails', () => {
     [
       '',
       ' ',
@@ -16,14 +16,14 @@ module('Unit | Utils | email validator', function(hooks) {
       'INVALID_EMAIL@pix.',
       '@pix.fr',
       '@pix',
-    ].forEach(function(badEmail) {
+    ].forEach((badEmail) => {
       test(`should return false when email is invalid: ${badEmail}`, function(assert) {
         assert.equal(isEmailValid(badEmail), false);
       });
     });
   });
 
-  module('Valid emails', function() {
+  module('Valid emails', () => {
     [
       'user@pix.fr',
       'user@pix.fr ',
@@ -34,7 +34,7 @@ module('Unit | Utils | email validator', function(hooks) {
       'user+beta@pix.fr',
       'user+beta@pix.gouv.fr',
       'user+beta@pix.beta.gouv.fr',
-    ].forEach(function(validEmail) {
+    ].forEach((validEmail) => {
       test(`should return true if provided email is valid: ${validEmail}`, function(assert) {
         assert.equal(isEmailValid(validEmail), true);
       });

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -15,3 +15,4 @@ rules:
         message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
      -  selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
         message: "Use only faker.internet.exampleEmail()"
+  mocha/prefer-arrow-callback: error

--- a/api/db/migrations/20170105153948_update_answers_timeout.js
+++ b/api/db/migrations/20170105153948_update_answers_timeout.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'answers';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('timeout');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('timeout');
   });
 };

--- a/api/db/migrations/20170329112753_add_elapsedTime_to_answers.js
+++ b/api/db/migrations/20170329112753_add_elapsedTime_to_answers.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'answers';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('elapsedTime');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('elapsedTime');
   });
 };

--- a/api/db/migrations/20170329153349_update_answers--add_column_result_details.js
+++ b/api/db/migrations/20170329153349_update_answers--add_column_result_details.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'answers';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.text('resultDetails');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('resultDetails');
   });
 };

--- a/api/db/migrations/20170418114929_remove_login_from_users.js
+++ b/api/db/migrations/20170418114929_remove_login_from_users.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'users';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('login');
     table.boolean('cgu');
     table.unique('email');
@@ -9,7 +9,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('login').defaultTo('').notNullable();
     table.dropColumn('cgu');
   });

--- a/api/db/migrations/20170703105035_create_link_between_user_and_assessment.js
+++ b/api/db/migrations/20170703105035_create_link_between_user_and_assessment.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'assessments';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.bigInteger('userId').index().references('users.id');
     table.dropColumn('userName');
     table.dropColumn('userEmail');
@@ -9,7 +9,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('userId');
     table.string('userName').notNull();
     table.string('userEmail').notNull();

--- a/api/db/migrations/20170703163243_update_assessment_with_level_and_score.js
+++ b/api/db/migrations/20170703163243_update_assessment_with_level_and_score.js
@@ -1,14 +1,14 @@
 const TABLE_NAME = 'assessments';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('estimatedLevel');
     table.integer('pixScore');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('estimatedLevel');
     table.dropColumn('pixScore');
   });

--- a/api/db/migrations/20170728141316_add_code_to_organization.js
+++ b/api/db/migrations/20170728141316_add_code_to_organization.js
@@ -1,5 +1,5 @@
 exports.up = function(knex) {
-  return knex.schema.table('organizations', function(table) {
+  return knex.schema.table('organizations', (table) => {
     table.string('code', 6).default('').notNullable();
   });
 };

--- a/api/db/migrations/20170829165045_add_completion_percentage_to_snapshot.js
+++ b/api/db/migrations/20170829165045_add_completion_percentage_to_snapshot.js
@@ -1,5 +1,5 @@
 exports.up = function(knex) {
-  return knex.schema.table('snapshots', function(table) {
+  return knex.schema.table('snapshots', (table) => {
     table.string('completionPercentage', 6);
   });
 };

--- a/api/db/migrations/20171113103608_add_type_to_assessments.js
+++ b/api/db/migrations/20171113103608_add_type_to_assessments.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'assessments';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('type');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('type');
   });
 };

--- a/api/db/migrations/20171204102525_add_userId_to_certification_course.js
+++ b/api/db/migrations/20171204102525_add_userId_to_certification_course.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('userId').references('users.id').index();
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('userId');
   });
 };

--- a/api/db/migrations/20171212144653_add_status_to_certification_course.js
+++ b/api/db/migrations/20171212144653_add_status_to_certification_course.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('status');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('status');
   });
 };

--- a/api/db/migrations/20180103152804_add_completed_time_to_certification_course.js
+++ b/api/db/migrations/20180103152804_add_completed_time_to_certification_course.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dateTime('completedAt');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('completedAt');
   });
 };

--- a/api/db/migrations/20180116161332_modify_column_completedPercentage_to_tests_finished_in_snapshots.js
+++ b/api/db/migrations/20180116161332_modify_column_completedPercentage_to_tests_finished_in_snapshots.js
@@ -5,7 +5,7 @@ const MULTIPLICATOR_PERCENTAGE_TO_COMPETENCES = NUMBER_OF_COMPETENCES / 100;
 const MULTIPLICATOR_COMPETENCES_TO_PERCENTAGE = 100 / NUMBER_OF_COMPETENCES;
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('testsFinished');
   }).then(() => {
     return knex(TABLE_NAME)
@@ -14,14 +14,14 @@ exports.up = function(knex) {
         testsFinished: knex.raw('ROUND(CAST(?? as numeric) * ' + MULTIPLICATOR_PERCENTAGE_TO_COMPETENCES + ', 0)', ['completionPercentage']),
       });
   }).then(() => {
-    return knex.schema.table(TABLE_NAME, function(table) {
+    return knex.schema.table(TABLE_NAME, (table) => {
       table.dropColumn('completionPercentage');
     });
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('completionPercentage');
   })
     .then(() => {
@@ -31,7 +31,7 @@ exports.down = function(knex) {
           completionPercentage: knex.raw('CAST(?? as numeric) * ' + MULTIPLICATOR_COMPETENCES_TO_PERCENTAGE, ['testsFinished']),
         });})
     .then(() => {
-      return knex.schema.table(TABLE_NAME, function(table) {
+      return knex.schema.table(TABLE_NAME, (table) => {
         table.dropColumn('testsFinished');
       });
     });

--- a/api/db/migrations/20180216153505_add_user_details_and_rejection_reason_to_certification_courses.js
+++ b/api/db/migrations/20180216153505_add_user_details_and_rejection_reason_to_certification_courses.js
@@ -1,7 +1,7 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('firstName');
     table.string('lastName');
     table.date('birthdate');
@@ -11,7 +11,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropTable('firstName');
     table.dropTable('lastName');
     table.dropTable('birthdate');

--- a/api/db/migrations/20180315164634_add-column-access-code-on-sessions.js
+++ b/api/db/migrations/20180315164634_add-column-access-code-on-sessions.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'sessions';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('accessCode');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('accessCode');
   });
 };

--- a/api/db/migrations/20180315164647_add-column-session-id-on-certifications.js
+++ b/api/db/migrations/20180315164647_add-column-session-id-on-certifications.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-courses';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('sessionId').references('sessions.id').index();
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('sessionId').references('sessions.id').index();
   });
 };

--- a/api/db/migrations/20180405100236_move_status_from_certification_to_assessment.js
+++ b/api/db/migrations/20180405100236_move_status_from_certification_to_assessment.js
@@ -7,7 +7,7 @@ exports.up = function(knex) {
 
   return knex.schema
     // Add Column
-    .table(TABLE_NAME_ASSESSMENTS, function(table) {
+    .table(TABLE_NAME_ASSESSMENTS, (table) => {
       table.text('state');
       table.index('state');
     })
@@ -42,7 +42,7 @@ exports.up = function(knex) {
 
     // Add status to assessments
     .then(() => {
-      return knex.schema.table(TABLE_NAME_CERTIFICATION, function(table) {
+      return knex.schema.table(TABLE_NAME_CERTIFICATION, (table) => {
         table.dropColumn('status');
         table.dropColumn('rejectionReason');
       });
@@ -51,7 +51,7 @@ exports.up = function(knex) {
 
 exports.down = function(knex) {
   // Add Column
-  return knex.schema.table(TABLE_NAME_CERTIFICATION, function(table) {
+  return knex.schema.table(TABLE_NAME_CERTIFICATION, (table) => {
     table.text('status');
     table.text('rejectionReason');
   }).then(() => {
@@ -73,7 +73,7 @@ exports.down = function(knex) {
     });
 
   }).then(() => {
-    return knex.schema.table(TABLE_NAME_ASSESSMENTS, function(table) {
+    return knex.schema.table(TABLE_NAME_ASSESSMENTS, (table) => {
       table.dropColumn('state');
     });
   });

--- a/api/db/migrations/20180405100452_migrate_assessments_info_to_assessment_results.js
+++ b/api/db/migrations/20180405100452_migrate_assessments_info_to_assessment_results.js
@@ -25,7 +25,7 @@ exports.up = function(knex) {
       });
 
     }).then(() => {
-      return knex.schema.table(TABLE_NAME_ASSESSMENTS, function(table) {
+      return knex.schema.table(TABLE_NAME_ASSESSMENTS, (table) => {
         table.dropColumn('pixScore');
         table.dropColumn('estimatedLevel');
       });
@@ -35,7 +35,7 @@ exports.up = function(knex) {
 exports.down = function(knex) {
 
   return knex.schema
-    .table(TABLE_NAME_ASSESSMENTS, function(table) {
+    .table(TABLE_NAME_ASSESSMENTS, (table) => {
       table.integer('pixScore');
       table.integer('estimatedLevel');
     })

--- a/api/db/migrations/20180405100530_link_marks_to_assessment_results.js
+++ b/api/db/migrations/20180405100530_link_marks_to_assessment_results.js
@@ -5,7 +5,7 @@ const TABLE_NAME_MARKS = 'marks';
 
 exports.up = function(knex) {
 
-  return knex.schema.table(TABLE_NAME_MARKS, function(table) {
+  return knex.schema.table(TABLE_NAME_MARKS, (table) => {
     table.integer('assessmentResultId').unsigned();
     table.foreign('assessmentResultId').references('assessment-results.id');
     table.index('assessmentResultId');
@@ -24,7 +24,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME_MARKS, function(table) {
+  return knex.schema.table(TABLE_NAME_MARKS, (table) => {
     table.dropColumn('assessmentResultId');
   });
 };

--- a/api/db/migrations/20180731102046_create_target_profiles_table.js
+++ b/api/db/migrations/20180731102046_create_target_profiles_table.js
@@ -20,14 +20,14 @@ exports.up = function(knex) {
         });
     })
     .then(() => {
-      return knex.schema.table(TABLE_NAME_CAMPAIGNS, function(table) {
+      return knex.schema.table(TABLE_NAME_CAMPAIGNS, (table) => {
         table.integer('targetProfileId').references('target-profiles.id').index();
       });
     });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME_CAMPAIGNS, function(table) {
+  return knex.schema.table(TABLE_NAME_CAMPAIGNS, (table) => {
     table.dropColumn('targetProfileId');
   })
     .then(() => {

--- a/api/db/migrations/20190905120343_alter_table_assessments_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190905120343_alter_table_assessments_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'assessments';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('userId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('userId').alter();
   });
 };

--- a/api/db/migrations/20190906090933_alter_table_certification_center_memberships_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906090933_alter_table_certification_center_memberships_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-center-memberships';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('userId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('userId').alter();
   });
 };

--- a/api/db/migrations/20190906094217_alter_table_certification_center_memberships_column_certification_center_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906094217_alter_table_certification_center_memberships_column_certification_center_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-center-memberships';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('certificationCenterId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('certificationCenterId').alter();
   });
 };

--- a/api/db/migrations/20190906100845_alter_table_certification_challenges_column_course_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906100845_alter_table_certification_challenges_column_course_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'certification-challenges';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('courseId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('courseId').unsigned().alter();
   });
 };

--- a/api/db/migrations/20190906101419_alter_table_memberships_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906101419_alter_table_memberships_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'memberships';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('userId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('userId').alter();
   });
 };

--- a/api/db/migrations/20190906101520_alter_table_memberships_column_organization_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906101520_alter_table_memberships_column_organization_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'memberships';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('organizationId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('organizationId').alter();
   });
 };

--- a/api/db/migrations/20190906101739_alter_table_organizations_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906101739_alter_table_organizations_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'organizations';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('userId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('userId').alter();
   });
 };

--- a/api/db/migrations/20190906101930_alter_table_snapshots_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906101930_alter_table_snapshots_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'snapshots';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('userId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('userId').unsigned().alter();
   });
 };

--- a/api/db/migrations/20190906102015_alter_table_snapshots_column_organization_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906102015_alter_table_snapshots_column_organization_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'snapshots';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('organizationId').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('organizationId').unsigned().alter();
   });
 };

--- a/api/db/migrations/20190906102158_alter_table_users_pix_roles_column_user_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906102158_alter_table_users_pix_roles_column_user_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'users_pix_roles';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('user_id').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('user_id').alter();
   });
 };

--- a/api/db/migrations/20190906102335_alter_table_users_pix_roles_column_pix_role_id_from_bigint_to_integer.js
+++ b/api/db/migrations/20190906102335_alter_table_users_pix_roles_column_pix_role_id_from_bigint_to_integer.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'users_pix_roles';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.integer('pix_role_id').unsigned().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.bigInteger('pix_role_id').alter();
   });
 };

--- a/api/db/migrations/20191008142311_alter_feedback_answer_column_to_text.js
+++ b/api/db/migrations/20191008142311_alter_feedback_answer_column_to_text.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'feedbacks';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.text('answer').alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.string('answer').alter();
   });
 };

--- a/api/db/migrations/20200212135345_fix_indexes_on_table_campaign-participations.js
+++ b/api/db/migrations/20200212135345_fix_indexes_on_table_campaign-participations.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'campaign-participations';
 const CAMPAIGNID_COLUMN = 'campaignId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(CAMPAIGNID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(CAMPAIGNID_COLUMN);
   });
 };

--- a/api/db/migrations/20200212135819_fix_indexes_on_table_certification-candidates.js
+++ b/api/db/migrations/20200212135819_fix_indexes_on_table_certification-candidates.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'certification-candidates';
 const SESSIONID_COLUMN = 'sessionId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(SESSIONID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(SESSIONID_COLUMN);
   });
 };

--- a/api/db/migrations/20200212140202_fix_indexes_on_table_certification-center-memberships.js
+++ b/api/db/migrations/20200212140202_fix_indexes_on_table_certification-center-memberships.js
@@ -3,14 +3,14 @@ const USERID_COLUMN = 'userId';
 const CERTIFICATIONCENTERID_COLUMN = 'certificationCenterId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(USERID_COLUMN);
     table.dropIndex(CERTIFICATIONCENTERID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(USERID_COLUMN);
     table.index(CERTIFICATIONCENTERID_COLUMN);
   });

--- a/api/db/migrations/20200212140810_fix_indexes_on_table_competence-evaluations.js
+++ b/api/db/migrations/20200212140810_fix_indexes_on_table_competence-evaluations.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'competence-evaluations';
 const COMPETENCEID_COLUMN = 'competenceId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(COMPETENCEID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(COMPETENCEID_COLUMN);
   });
 };

--- a/api/db/migrations/20200212141121_fix_indexes_on_table_knowledge-elements.js
+++ b/api/db/migrations/20200212141121_fix_indexes_on_table_knowledge-elements.js
@@ -5,7 +5,7 @@ const ASSESSMENTID_COLUMN = 'assessmentId';
 const COMPETENCEID_COLUMN = 'competenceId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(SKILLID_COLUMN);
     table.dropIndex(ANSWERID_COLUMN);
     table.dropIndex(ASSESSMENTID_COLUMN);
@@ -14,7 +14,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(SKILLID_COLUMN);
     table.index(ANSWERID_COLUMN);
     table.index(ASSESSMENTID_COLUMN);

--- a/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
+++ b/api/db/migrations/20200212141456_fix_indexes_on_table_memberships.js
@@ -7,13 +7,13 @@ const OLD_INDEX_ORGANIZATIONID = 'organizations_accesses_organizationid_index';
 exports.up = async function(knex) {
   await knex.raw(`DROP INDEX IF EXISTS ${OLD_INDEX_USERID}`);
   await knex.raw(`DROP INDEX IF EXISTS ${OLD_INDEX_ORGANIZATIONID}`);
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(ORGANIZATIONID_COLUMN);
   });
 };
 
 exports.down = async function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(ORGANIZATIONID_COLUMN);
     table.index(USERID_COLUMN, OLD_INDEX_USERID);
     table.index(ORGANIZATIONID_COLUMN, OLD_INDEX_ORGANIZATIONID);

--- a/api/db/migrations/20200212141646_fix_indexes_on_table_organizations.js
+++ b/api/db/migrations/20200212141646_fix_indexes_on_table_organizations.js
@@ -5,7 +5,7 @@ const EXTERNALID_COLUMN = 'externalId';
 const CODE_COLUMN = 'code';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(USERID_COLUMN);
     table.dropIndex(PROVINCECODE_COLUMN);
     table.dropIndex(EXTERNALID_COLUMN);
@@ -14,7 +14,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(USERID_COLUMN);
     table.index(PROVINCECODE_COLUMN);
     table.index(EXTERNALID_COLUMN);

--- a/api/db/migrations/20200212142949_fix_indexes_on_table_sessions.js
+++ b/api/db/migrations/20200212142949_fix_indexes_on_table_sessions.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'sessions';
 const ACCESSCODE_COLUMN = 'accessCode';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(ACCESSCODE_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(ACCESSCODE_COLUMN);
   });
 };

--- a/api/db/migrations/20200212143352_fix_indexes_on_table_students.js
+++ b/api/db/migrations/20200212143352_fix_indexes_on_table_students.js
@@ -4,7 +4,7 @@ const ORGANIZATIONID_COLUMN = 'organizationId';
 const NATIONALSTUDENTID_COLUMN = 'nationalStudentId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(NATIONALSTUDENTID_COLUMN);
     table.dropIndex(ORGANIZATIONID_COLUMN);
     table.dropIndex(USERID_COLUMN);
@@ -14,7 +14,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(NATIONALSTUDENTID_COLUMN);
     table.index(ORGANIZATIONID_COLUMN);
     table.index(USERID_COLUMN);

--- a/api/db/migrations/20200225130232_remove-user-id-in-organizations.js
+++ b/api/db/migrations/20200225130232_remove-user-id-in-organizations.js
@@ -8,7 +8,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).unsigned();
   });
 };

--- a/api/db/migrations/20200225133240_remove-code-on-organizations.js
+++ b/api/db/migrations/20200225133240_remove-code-on-organizations.js
@@ -8,7 +8,7 @@ exports.up = function(knex) {
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(COLUMN_NAME, 6).default('').notNullable();
   });
 };

--- a/api/db/migrations/20200320163042_add_functional_key_on_badges_table.js
+++ b/api/db/migrations/20200320163042_add_functional_key_on_badges_table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'badges';
 const COLUMN_KEY = 'key';
 
 exports.up = async (knex) => {
-  await knex.schema.alterTable(TABLE_NAME, function(table) {
+  await knex.schema.alterTable(TABLE_NAME, (table) => {
     table.text(COLUMN_KEY);
   });
 

--- a/api/db/migrations/20200320170707_add-type-to-campaign.js
+++ b/api/db/migrations/20200320170707_add-type-to-campaign.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'campaigns';
 const COLUMN_NAME = 'type';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(COLUMN_NAME).notNullable().defaultTo('');
   }).then(() => {
     return knex(TABLE_NAME)

--- a/api/db/migrations/20200324101353_add-can-collect-profiles-to-organization.js
+++ b/api/db/migrations/20200324101353_add-can-collect-profiles-to-organization.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'organizations';
 const COLUMN_NAME = 'canCollectProfiles';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.boolean(COLUMN_NAME).notNullable().defaultTo(false);
   });
 };

--- a/api/db/migrations/20200608170256_alter_table_badgePartnerCompetences_column_color_from_notNullable_to_nullable.js
+++ b/api/db/migrations/20200608170256_alter_table_badgePartnerCompetences_column_color_from_notNullable_to_nullable.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'badge-partner-competences';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.string('color').nullable().alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.string('color').notNullable().alter();
   });
 };

--- a/api/db/migrations/20200724115030_replace-knowledge-element-snapshots-index-by-unique-index-on-userId-and-snappedAt.js
+++ b/api/db/migrations/20200724115030_replace-knowledge-element-snapshots-index-by-unique-index-on-userId-and-snappedAt.js
@@ -1,14 +1,14 @@
 const TABLE_NAME = 'knowledge-element-snapshots';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex('userId');
     table.unique(['userId', 'snappedAt']);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index('userId');
     table.dropUnique(['userId', 'snappedAt']);
   });

--- a/api/db/migrations/20200814135754_drop-redundant-index-table-tutorial-evaluations-on-column-user-id.js
+++ b/api/db/migrations/20200814135754_drop-redundant-index-table-tutorial-evaluations-on-column-user-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'tutorial-evaluations';
 const USERID_COLUMN = 'userId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(USERID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(USERID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814140251_drop-not-need-index-table-tutorial-evaluations-on-column-tutorial-id.js
+++ b/api/db/migrations/20200814140251_drop-not-need-index-table-tutorial-evaluations-on-column-tutorial-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'tutorial-evaluations';
 const TUTORIALID_COLUMN = 'tutorialId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(TUTORIALID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(TUTORIALID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814141138_drop-unused-index-on-user-id-table-certification-candidates.js
+++ b/api/db/migrations/20200814141138_drop-unused-index-on-user-id-table-certification-candidates.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'certification-candidates';
 const USERID_COLUMN = 'userId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(USERID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(USERID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814142831_drop-redundant-index-table-user-tutorials-on-column-user-id.js
+++ b/api/db/migrations/20200814142831_drop-redundant-index-table-user-tutorials-on-column-user-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'user_tutorials';
 const USERID_COLUMN = 'userId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(USERID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(USERID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814142948_drop-not-needed-index-table-user-tutorials-on-column-tutorial-id.js
+++ b/api/db/migrations/20200814142948_drop-not-needed-index-table-user-tutorials-on-column-tutorial-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'user_tutorials';
 const TUTORIALID_COLUMN = 'tutorialId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(TUTORIALID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(TUTORIALID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814144054_drop-not-needed-index-table-feedbacks-on-column-assessment-id.js
+++ b/api/db/migrations/20200814144054_drop-not-needed-index-table-feedbacks-on-column-assessment-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'feedbacks';
 const ASSESSMENTID_COLUMN = 'assessmentId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(ASSESSMENTID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(ASSESSMENTID_COLUMN);
   });
 };

--- a/api/db/migrations/20200814144606_drop-not-needed-index-table-assessments-on-column-type.js
+++ b/api/db/migrations/20200814144606_drop-not-needed-index-table-assessments-on-column-type.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'assessments';
 const TYPE_COLUMN = 'type';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(TYPE_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(TYPE_COLUMN);
   });
 };

--- a/api/db/migrations/20200814144712_drop-not-needed-index-table-assessments-on-column-state.js
+++ b/api/db/migrations/20200814144712_drop-not-needed-index-table-assessments-on-column-state.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'assessments';
 const TYPE_COLUMN = 'state';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(TYPE_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(TYPE_COLUMN);
   });
 };

--- a/api/db/migrations/20200814144752_drop-not-needed-index-table-assessments-on-column-competence-id.js
+++ b/api/db/migrations/20200814144752_drop-not-needed-index-table-assessments-on-column-competence-id.js
@@ -2,13 +2,13 @@ const TABLE_NAME = 'assessments';
 const COMPETENCEID_COLUMN = 'competenceId';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropIndex(COMPETENCEID_COLUMN);
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.index(COMPETENCEID_COLUMN);
   });
 };

--- a/api/db/migrations/20200929142112_update-constraint-memberships_userid_organizationid_unique.js
+++ b/api/db/migrations/20200929142112_update-constraint-memberships_userid_organizationid_unique.js
@@ -5,14 +5,14 @@ const DISABLEDAT_COLUMN = 'disabledAt';
 const NEW_CONSTRAINT_NAME = 'memberships_userid_organizationid_disabledAt_unique';
 
 exports.up = async function(knex) {
-  await knex.schema.table(TABLE_NAME, function(table) {
+  await knex.schema.table(TABLE_NAME, (table) => {
     table.dropUnique([USERID_COLUMN, ORGANIZATIONID_COLUMN]);
   });
   return knex.raw(`CREATE UNIQUE INDEX ${NEW_CONSTRAINT_NAME} ON ${TABLE_NAME} ("${USERID_COLUMN}", "${ORGANIZATIONID_COLUMN}") WHERE "${DISABLEDAT_COLUMN}" IS NULL;`);
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropUnique(null, NEW_CONSTRAINT_NAME);
     table.unique([USERID_COLUMN, ORGANIZATIONID_COLUMN]);
   });

--- a/api/db/migrations/20201027144304_add_nationalApprenticeId_to_schooling-registrations.js
+++ b/api/db/migrations/20201027144304_add_nationalApprenticeId_to_schooling-registrations.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'schooling-registrations';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string('nationalApprenticeId');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('nationalApprenticeId');
   });
 };

--- a/api/db/migrations/20201117143916_update-stages-message-column-string-to-text.js
+++ b/api/db/migrations/20201117143916_update-stages-message-column-string-to-text.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'stages';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.text('message').alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.string('message').alter();
   });
 };

--- a/api/db/migrations/20201117144053_update-badges-message-column-string-to-text.js
+++ b/api/db/migrations/20201117144053_update-badges-message-column-string-to-text.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'badges';
 
 exports.up = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.text('message').alter();
   });
 };
 
 exports.down = (knex) => {
-  return knex.schema.alterTable(TABLE_NAME, function(table) {
+  return knex.schema.alterTable(TABLE_NAME, (table) => {
     table.string('message').alter();
   });
 };

--- a/api/db/migrations/20201217144235_add-subcategory-column-to-certif-issue-report.js
+++ b/api/db/migrations/20201217144235_add-subcategory-column-to-certif-issue-report.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'certification-issue-reports';
 const COLUMN_NAME = 'subcategory';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(COLUMN_NAME);
   });
 };

--- a/api/db/migrations/20201222163514_add-question-number-column-to-certification-issue-reports-table.js
+++ b/api/db/migrations/20201222163514_add-question-number-column-to-certification-issue-reports-table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'certification-issue-reports';
 const COLUMN_NAME = 'questionNumber';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME).unsigned();
   });
 };

--- a/api/db/migrations/20210115143718_add-column-in-target-profiles-is-simplified-access.js
+++ b/api/db/migrations/20210115143718_add-column-in-target-profiles-is-simplified-access.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'target-profiles';
 const COLUMN_NAME = 'isSimplifiedAccess';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.boolean(COLUMN_NAME).defaultTo(false);
   });
 };

--- a/api/db/migrations/20210119120015_add-validated-skills-count-to-campaign-participations.js
+++ b/api/db/migrations/20210119120015_add-validated-skills-count-to-campaign-participations.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'campaign-participations';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('validatedSkillsCount');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('validatedSkillsCount');
   });
 };

--- a/api/db/migrations/20210119141645_add-column-is-anonymous-to-users.js
+++ b/api/db/migrations/20210119141645_add-column-is-anonymous-to-users.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'users';
 const COLUMN_NAME = 'isAnonymous';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.boolean(COLUMN_NAME).defaultTo(false);
   });
 };

--- a/api/db/migrations/20210203110934_add-publishedAt-in-finalized-session-table.js
+++ b/api/db/migrations/20210203110934_add-publishedAt-in-finalized-session-table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'finalized-sessions';
 const COLUMN_NAME = 'publishedAt';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dateTime(COLUMN_NAME);
   });
 };

--- a/api/db/migrations/20210216141040_add-column-for-absolute-novice-to-campaigns.js
+++ b/api/db/migrations/20210216141040_add-column-for-absolute-novice-to-campaigns.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'campaigns';
 const COLUMN_NAME = 'isForAbsoluteNovice';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.boolean(COLUMN_NAME).defaultTo(false);
   });
 };

--- a/api/db/migrations/20210224170037_add-prescriber-description-and-prescriber-title-to-stages-table.js
+++ b/api/db/migrations/20210224170037_add-prescriber-description-and-prescriber-title-to-stages-table.js
@@ -3,7 +3,7 @@ const PRESCRIBER_TITLE_COLUMN = 'prescriberTitle';
 const PRESCRIBER_DESCRIPTION_COLUMN = 'prescriberDescription';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.string(PRESCRIBER_TITLE_COLUMN);
     table.text(PRESCRIBER_DESCRIPTION_COLUMN);
   });

--- a/api/db/migrations/20210304154309_add-partner-competences-ids-to-badge-criteria-table.js
+++ b/api/db/migrations/20210304154309_add-partner-competences-ids-to-badge-criteria-table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'badge-criteria';
 const NEW_COLUMN = 'partnerCompetenceIds';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.specificType(NEW_COLUMN, 'int[]');
   });
 };

--- a/api/db/migrations/20210310110213_add-last-question-date-in-assesments-table.js
+++ b/api/db/migrations/20210310110213_add-last-question-date-in-assesments-table.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'assessments';
 const COLUMN_NAME = 'lastQuestionDate';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dateTime(COLUMN_NAME);
   });
 };

--- a/api/db/migrations/20210311142327_add-column-timespent-in-answers.js
+++ b/api/db/migrations/20210311142327_add-column-timespent-in-answers.js
@@ -2,7 +2,7 @@ const TABLE_NAME = 'answers';
 const COLUMN_NAME = 'timeSpent';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer(COLUMN_NAME);
   });
 };

--- a/api/db/migrations/20210315154549_drop-elapsedTime-in-answers-table.js
+++ b/api/db/migrations/20210315154549_drop-elapsedTime-in-answers-table.js
@@ -1,13 +1,13 @@
 const TABLE_NAME = 'answers';
 
 exports.up = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.dropColumn('elapsedTime');
   });
 };
 
 exports.down = function(knex) {
-  return knex.schema.table(TABLE_NAME, function(table) {
+  return knex.schema.table(TABLE_NAME, (table) => {
     table.integer('elapsedTime');
   });
 };

--- a/api/lib/domain/models/index.js
+++ b/api/lib/domain/models/index.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 /* eslint-disable-next-line no-sync */
-require('fs').readdirSync(__dirname).forEach(function(file) {
+require('fs').readdirSync(__dirname).forEach((file) => {
   if (file === 'index.js') return;
 
   module.exports[path.basename(file, '.js')] = require(path.join(__dirname, file));

--- a/api/lib/domain/services/challenge-service.js
+++ b/api/lib/domain/services/challenge-service.js
@@ -2,7 +2,7 @@
 const _ = require('../../infrastructure/utils/lodash-utils');
 
 function _countResult(about, desiredResult) {
-  return _.reduce(about, function(sum, o) {
+  return _.reduce(about, (sum, o) => {
     return sum + (o.result === desiredResult ? 1 : 0);
   }, 0);
 }

--- a/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/feedback-serializer.js
@@ -19,7 +19,7 @@ module.exports = {
 
   deserialize(json) {
     return new Deserializer()
-      .deserialize(json, function(err, feedback) {
+      .deserialize(json, (err, feedback) => {
         feedback.assessmentId = json.data.relationships.assessment.data.id;
         feedback.challengeId = json.data.relationships.challenge.data.id;
       })

--- a/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/validation-error-serializer.js
@@ -22,7 +22,7 @@ function _buildEntirePayloadError(message) {
 function serialize(validationErrors) {
   const errors = [];
 
-  Object.keys(validationErrors.data).forEach(function(field) {
+  Object.keys(validationErrors.data).forEach((field) => {
 
     validationErrors.data[field].forEach((message) => {
 

--- a/api/scripts/database/create-database.js
+++ b/api/scripts/database/create-database.js
@@ -13,7 +13,7 @@ url.pathname = '/postgres';
 const client = new PgClient(url.href);
 
 client.query_and_log(`CREATE DATABASE ${DB_TO_CREATE_NAME};`)
-  .then(function() {
+  .then(() => {
     console.log('Database created');
     client.end();
     process.exit(0);

--- a/api/scripts/recompute-assessment-results.js
+++ b/api/scripts/recompute-assessment-results.js
@@ -39,7 +39,7 @@ function main() {
   });
 
   const listOfAssessmentIdsToRecompute = [];
-  lineReader.on('line', function(line) {
+  lineReader.on('line', (line) => {
     listOfAssessmentIdsToRecompute.push(line);
   });
 

--- a/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
+++ b/api/scripts/update-sco-organizations-with-province-code-and-external-id.js
@@ -121,7 +121,7 @@ async function main() {
     assertFileValidity(filePath);
     console.log('Test de validité du fichier : OK');
 
-    fs.readFile(filePath, 'utf8', async function(err, data) {
+    fs.readFile(filePath, 'utf8', async (err, data) => {
       console.log('\nMise à jour des organizations...');
 
       // We delete the BOM UTF8 at the beginning of the CSV,

--- a/api/tests/acceptance/scripts/import-certifications-from-csv_test.js
+++ b/api/tests/acceptance/scripts/import-certifications-from-csv_test.js
@@ -167,7 +167,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody);
         })
         .reply(200, {});
@@ -255,21 +255,21 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .reply(200, {});
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -359,7 +359,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error');
@@ -367,7 +367,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
@@ -375,7 +375,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -491,7 +491,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/1', function(body) {
+        .patch('/api/certification-courses/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error 1');
@@ -499,7 +499,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/2', function(body) {
+        .patch('/api/certification-courses/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .replyWithError('Error 2');
@@ -507,7 +507,7 @@ describe('Acceptance | Scripts | import-certifications-from-csv.js', () => {
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer coucou-je-suis-un-token' },
       })
-        .patch('/api/certification-courses/3', function(body) {
+        .patch('/api/certification-courses/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});

--- a/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
+++ b/api/tests/acceptance/scripts/update-sco-organizations-with-province-code-and-external-id_test.js
@@ -132,7 +132,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody);
         })
         .reply(200, {});
@@ -194,21 +194,21 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .reply(200, {});
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -272,7 +272,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub1 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error');
@@ -280,7 +280,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub2 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .reply(200, {});
@@ -288,7 +288,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       const nockStub3 = nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});
@@ -368,7 +368,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/1', function(body) {
+        .patch('/api/organizations/1', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody1);
         })
         .replyWithError('Error 1');
@@ -376,7 +376,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/2', function(body) {
+        .patch('/api/organizations/2', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody2);
         })
         .replyWithError('Error 2');
@@ -384,7 +384,7 @@ describe('Acceptance | Scripts | update-sco-organizations-with-province-code-and
       nock('http://localhost:3000', {
         reqheaders: { authorization: 'Bearer token-token' },
       })
-        .patch('/api/organizations/3', function(body) {
+        .patch('/api/organizations/3', (body) => {
           return JSON.stringify(body) === JSON.stringify(expectedBody3);
         })
         .reply(200, {});

--- a/api/tests/test-helper.js
+++ b/api/tests/test-helper.js
@@ -129,7 +129,7 @@ function compareDatabaseObject(evaluatedObject, expectedObject) {
 
 }
 
-chai.use(function(chai) {
+chai.use((chai) => {
   const Assertion = chai.Assertion;
 
   Assertion.addMethod('exactlyContain', function(expectedElements) {
@@ -138,7 +138,7 @@ chai.use(function(chai) {
   });
 });
 
-chai.use(function(chai) {
+chai.use((chai) => {
   const Assertion = chai.Assertion;
 
   Assertion.addMethod('exactlyContainInOrder', function(expectedElements) {

--- a/api/tests/unit/domain/services/deactivations-service_test.js
+++ b/api/tests/unit/domain/services/deactivations-service_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.isDefault(caze.deactivations)).to.equal(caze.output);
       });
@@ -49,7 +49,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1(caze.deactivations)).to.equal(caze.output);
       });
@@ -75,7 +75,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2(caze.deactivations)).to.equal(caze.output);
       });
@@ -101,7 +101,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT3(caze.deactivations)).to.equal(caze.output);
       });
@@ -127,7 +127,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T2(caze.deactivations)).to.equal(caze.output);
       });
@@ -153,7 +153,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT1T3(caze.deactivations)).to.equal(caze.output);
       });
@@ -179,7 +179,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: false, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasOnlyT2T3(caze.deactivations)).to.equal(caze.output);
       });
@@ -205,7 +205,7 @@ describe('Unit | Service | DeactivationsService ', function() {
       { when: 'Deactivations has t1, t2, t3 with truthy value', output: true, deactivations: { t1: true, t2: 'other', t3: 'any' } },
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ' : ' + JSON.stringify(caze.deactivations) + '  =>  ' + caze.output, function() {
         expect(service.hasT1T2T3(caze.deactivations)).to.equal(caze.output);
       });

--- a/api/tests/unit/domain/services/email-validator_test.js
+++ b/api/tests/unit/domain/services/email-validator_test.js
@@ -17,7 +17,7 @@ describe('Unit | Service | email-validator', function() {
     'INVALID_EMAIL@pix.',
     '@pix.fr',
     '@pix',
-  ].forEach(function(badEmail) {
+  ].forEach((badEmail) => {
     it(`should return false when email is invalid: ${badEmail}`, function() {
       expect(service.emailIsValid(badEmail)).to.be.false;
     });
@@ -33,7 +33,7 @@ describe('Unit | Service | email-validator', function() {
     'follower+beta@pix.fr',
     'follower+beta@pix.gouv.fr',
     'follower+beta@pix.beta.gouv.fr',
-  ].forEach(function(validEmail) {
+  ].forEach((validEmail) => {
     it(`should return true if provided email is valid: ${validEmail}`, function() {
       expect(service.emailIsValid(validEmail)).to.be.true;
     });

--- a/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-revalidate_test.js
@@ -23,7 +23,7 @@ describe('Unit | Service | SolutionService', function() {
 
     it('If the answer is timedout, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(timedout_answer)).then(function(foundAnswer) {
+      service.revalidate(new Answer(timedout_answer)).then((foundAnswer) => {
         expect(foundAnswer.id).equals(timedout_answer.id);
         expect(foundAnswer.attributes.value).equals(timedout_answer.value);
         expect(foundAnswer.attributes.result).equals(timedout_answer.result);
@@ -34,7 +34,7 @@ describe('Unit | Service | SolutionService', function() {
 
     it('If the answer is aband, resolve to the answer itself, unchanged', function(done) {
       expect(service.revalidate).to.exist;
-      service.revalidate(new Answer(aband_answer)).then(function(foundAnswer) {
+      service.revalidate(new Answer(aband_answer)).then((foundAnswer) => {
         expect(foundAnswer.id).equals(aband_answer.id);
         expect(foundAnswer.attributes.value).equals(aband_answer.value);
         expect(foundAnswer.attributes.result).equals(aband_answer.result);

--- a/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
+++ b/api/tests/unit/domain/services/solution-service-function-timedOut_test.js
@@ -25,7 +25,7 @@ describe('Unit | Service | SolutionService', function() {
 
     ];
 
-    allCases.forEach(function(caze) {
+    allCases.forEach((caze) => {
       it(caze.when + ', should return ' + caze.output + ' when preresult is "' + caze.preresult + '" and timeout is "' + caze.timeout + '"', function() {
         expect(service._timedOut(caze.preresult, caze.timeout)).to.deep.equal(caze.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qcm_test.js
+++ b/api/tests/unit/domain/services/solution-service-qcm_test.js
@@ -35,7 +35,7 @@ describe('Unit | Service | SolutionServiceQCM ', function() {
       { answer: '1, 2, 3', solution: '1, 2, 3' },
     ];
 
-    successfulCases.forEach(function(testCase) {
+    successfulCases.forEach((testCase) => {
       it('should return "ok" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);
@@ -51,7 +51,7 @@ describe('Unit | Service | SolutionServiceQCM ', function() {
       { answer: '3, 1', solution: '1, 2' },
     ];
 
-    failedCases.forEach(function(testCase) {
+    failedCases.forEach((testCase) => {
       it('should return "ko" when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         const answer = buildAnswer(testCase.answer);
         const solution = buildSolution('QCM', testCase.solution);

--- a/api/tests/unit/domain/services/solution-service-qroc_test.js
+++ b/api/tests/unit/domain/services/solution-service-qroc_test.js
@@ -56,7 +56,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case: '(multiple solutions) answer is 0.25 away from the closest solution', answer: 'quak', solution: 'qvak\nqwak\nanything\n' },
     ];
 
-    successfulCases.forEach(function(data) {
+    successfulCases.forEach((data) => {
       it(data.case + ', should return "ok" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         const result = service.match({ answer: data.answer, solution: data.solution });
         expect(result).to.deep.equal(ANSWER_OK);
@@ -75,7 +75,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { case: '(multiple solutions) answer is minimum 0.4 away from a solution', answer: 'quaks', solution: 'qvakes\nqwakes\nanything\n' },
     ];
 
-    failingCases.forEach(function(data) {
+    failingCases.forEach((data) => {
       it(data.case + ', should return "ko" when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution })).to.deep.equal(ANSWER_KO);
       });
@@ -101,7 +101,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: {} },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -126,7 +126,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -151,7 +151,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t2: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -176,7 +176,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -201,7 +201,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_OK, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t2: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -226,7 +226,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -251,7 +251,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t2: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });
@@ -276,7 +276,7 @@ describe('Unit | Service | SolutionServiceQROC ', function() {
       { when: 'reverted levenshtein stress', output: ANSWER_KO, answer: '123456789', solution: '\nvariant1\n0123456789\n', deactivations: { t1: true, t2: true, t3: true } },
     ];
 
-    allCases.forEach(function(data) {
+    allCases.forEach((data) => {
       it(data.when + ', should return ' + data.output + ' when answer is "' + data.answer + '" and solution is "' + escape(data.solution) + '"', function() {
         expect(service.match({ answer: data.answer, solution: data.solution, deactivations: data.deactivations })).to.deep.equal(data.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-dep_test.js
@@ -106,7 +106,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    maximalScoreCases.forEach(function(testCase) {
+    maximalScoreCases.forEach((testCase) => {
       it(`Should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution)).to.deep.equal(ANSWER_OK);
       });
@@ -145,7 +145,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    maximalScoreCases.forEach(function(testCase) {
+    maximalScoreCases.forEach((testCase) => {
       it(`should return "ok" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_OK);
       });
@@ -172,7 +172,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    partialScoreCases.forEach(function(testCase) {
+    partialScoreCases.forEach((testCase) => {
 
       it(`should return "partially" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_PARTIALLY);
@@ -207,7 +207,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    failedCases.forEach(function(testCase) {
+    failedCases.forEach((testCase) => {
       it(`should return "ko" when ${testCase.when}`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring)).to.deep.equal(ANSWER_KO);
       });
@@ -324,7 +324,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(`${testCase.when}, should return ${testCase.output} when answer is "${testCase.answer}" and solution is "${testCase.solution}"`, function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -440,7 +440,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -556,7 +556,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -672,7 +672,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -788,7 +788,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -904,7 +904,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });
@@ -1020,7 +1020,7 @@ describe('Unit | Service | SolutionServiceQROCM-dep ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + testCase.solution + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.scoring, testCase.deactivations)).to.deep.equal(testCase.output);
       });

--- a/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
+++ b/api/tests/unit/domain/services/solution-service-qrocm-ind_test.js
@@ -216,7 +216,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
     },
     ];
 
-    successfulCases.forEach(function(testCase) {
+    successfulCases.forEach((testCase) => {
       it(testCase.case + ', should return "ok" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -281,7 +281,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    failingCases.forEach(function(testCase) {
+    failingCases.forEach((testCase) => {
       it(testCase.case + ', should return "ko" when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -385,7 +385,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         const actual = service.match(testCase.answer, testCase.solution, testCase.enabledTreatments);
         expect(actual).to.deep.equal(testCase.output);
@@ -489,7 +489,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -592,7 +592,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -695,7 +695,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -798,7 +798,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -901,7 +901,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -1004,7 +1004,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });
@@ -1107,7 +1107,7 @@ describe('Unit | Service | SolutionServiceQROCM-ind ', function() {
       },
     ];
 
-    allCases.forEach(function(testCase) {
+    allCases.forEach((testCase) => {
       it(testCase.when + ', should return ' + testCase.output + ' when answer is "' + testCase.answer + '" and solution is "' + escape(testCase.solution) + '"', function() {
         expect(service.match(testCase.answer, testCase.solution, testCase.enabledTreatments)).to.deep.equal(testCase.output);
       });

--- a/api/tests/unit/domain/services/string-comparison-service_test.js
+++ b/api/tests/unit/domain/services/string-comparison-service_test.js
@@ -20,7 +20,7 @@ describe('Unit | Service | Validation Comparison', function() {
         { should: 'If they have two different characters', arg1: 'book', arg2: ['back'], output: 2 },
       ];
 
-      successfulCases.forEach(function(testCase) {
+      successfulCases.forEach((testCase) => {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(testCase.arg2)} => ${testCase.output}`, function() {
           expect(getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });
@@ -39,7 +39,7 @@ describe('Unit | Service | Validation Comparison', function() {
         { should: 'If the difference is 2 for all elements', arg1: 'book', arg2: ['back', 'buck'], output: 2 },
       ];
 
-      successfulCases.forEach(function(testCase) {
+      successfulCases.forEach((testCase) => {
         it(`${testCase.should} for example arg1 ${JSON.stringify(testCase.arg1)} and arg2 ${JSON.stringify(testCase.arg2)} => ${testCase.output}`, function() {
           expect(getSmallestLevenshteinDistance(testCase.arg1, testCase.arg2)).to.equal(testCase.output);
         });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-serializer_test.js
@@ -59,7 +59,7 @@ describe('Unit | Serializer | JSONAPI | certification-serializer', () => {
       });
     });
 
-    EMPTY_BLANK_AND_NULL.forEach(function(examinerComment) {
+    EMPTY_BLANK_AND_NULL.forEach((examinerComment) => {
       it(`should return no examiner comment if comment is "${examinerComment}"`, async function() {
         // given
         jsonCertificationCourse.data.attributes['examiner-comment'] = examinerComment;

--- a/api/tests/unit/infrastructure/utils/lodash-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/lodash-utils_test.js
@@ -97,7 +97,7 @@ describe('Unit | Utils | lodash-utils', function() {
       '\t',
       '\r\n',
       '\n',
-    ].forEach(function(string) {
+    ].forEach((string) => {
       it(`should return true if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.true;
       });
@@ -109,7 +109,7 @@ describe('Unit | Utils | lodash-utils', function() {
       'a ',
       ' a ',
       '\ta\ta',
-    ].forEach(function(string) {
+    ].forEach((string) => {
       it(`should return false if string is "${string}"`, function() {
         expect(_.isBlank(string)).to.be.false;
       });

--- a/api/tests/unit/infrastructure/utils/request-response-utils_test.js
+++ b/api/tests/unit/infrastructure/utils/request-response-utils_test.js
@@ -64,7 +64,7 @@ describe('Unit | Utils | Request Utils', function() {
       { header: 'en', expectedLocale: ENGLISH_SPOKEN },
       { header: 'de', expectedLocale: FRENCH_FRANCE },
       { header: 'fr-BE', expectedLocale: FRENCH_FRANCE },
-    ].forEach(function(data) {
+    ].forEach((data) => {
 
       it(`should return ${data.expectedLocale} locale when header is ${data.header}`, function() {
         // given

--- a/certif/mirage/config.js
+++ b/certif/mirage/config.js
@@ -44,7 +44,7 @@ export default function() {
 
   this.post('/sessions');
 
-  this.get('/sessions/:id', function(schema, request) {
+  this.get('/sessions/:id', (schema, request) => {
     const sessionId = request.params.id;
 
     return schema.sessions.find(sessionId);
@@ -52,17 +52,17 @@ export default function() {
 
   this.patch('/sessions/:id');
 
-  this.get('/sessions/:id/certification-candidates', function(schema, request) {
+  this.get('/sessions/:id/certification-candidates', (schema, request) => {
     const sessionId = request.params.id;
     return schema.certificationCandidates.where({ sessionId });
   });
 
-  this.post('/sessions/:id/certification-candidates', function(schema, request) {
+  this.post('/sessions/:id/certification-candidates', (schema, request) => {
     const sessionId = request.params.id;
     return schema.certificationCandidates.create({ sessionId });
   });
 
-  this.post('/certification-reports/:id/certification-issue-reports', function(schema, request) {
+  this.post('/certification-reports/:id/certification-issue-reports', (schema, request) => {
     const certificationCourseId = request.params.id;
     const requestBody = JSON.parse(request.requestBody);
     const description = requestBody.data.attributes['description'];
@@ -72,7 +72,7 @@ export default function() {
     return schema.certificationIssueReports.create({ certificationReport, description, category });
   });
 
-  this.delete('/certification-issue-reports/:id', function(schema, request) {
+  this.delete('/certification-issue-reports/:id', (schema, request) => {
     const certificationIssueReportId = request.params.id;
     const certificationIssueReport = schema.certificationIssueReports.find(certificationIssueReportId);
 
@@ -80,13 +80,13 @@ export default function() {
     return { data: null };
   });
 
-  this.get('/sessions/:id/certification-reports', function(schema, request) {
+  this.get('/sessions/:id/certification-reports', (schema, request) => {
     const sessionId = request.params.id;
 
     return schema.sessions.find(sessionId).certificationReports;
   });
 
-  this.delete('/sessions/:id/certification-candidates/:candidateId', function(schema, request) {
+  this.delete('/sessions/:id/certification-candidates/:candidateId', (schema, request) => {
     const certificationCandidateId = request.params.candidateId;
     const certificationCandidate = schema.certificationCandidates.find(certificationCandidateId);
     if (certificationCandidate.isLinked) {
@@ -97,7 +97,7 @@ export default function() {
     return { data: null };
   });
 
-  this.post('/sessions/:id/certification-candidates/import', upload(function(schema, request) {
+  this.post('/sessions/:id/certification-candidates/import', upload((schema, request) => {
     const { name } = request.requestBody.file;
     if (name === 'invalid-file') {
       return new Response(422, { some: 'header' }, { errors: [{ status: '422', title: 'Unprocessable Entity', detail: 'Une erreur personnalisée' }] });

--- a/certif/tests/acceptance/authenticated-test.js
+++ b/certif/tests/acceptance/authenticated-test.js
@@ -8,12 +8,12 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authenticated', function(hooks) {
+module('Acceptance | authenticated', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user clicks the sidebar logo', function() {
+  module('When user clicks the sidebar logo', () => {
     test('it should redirect to the sessions list page', async function(assert) {
       // given
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
@@ -29,7 +29,7 @@ module('Acceptance | authenticated', function(hooks) {
     });
   });
 
-  module('When user clicks the sessions sidebar menu entry', function() {
+  module('When user clicks the sessions sidebar menu entry', () => {
     test('it should also redirect to the sessions list page', async function(assert) {
       // given
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();

--- a/certif/tests/acceptance/authentication-test.js
+++ b/certif/tests/acceptance/authentication-test.js
@@ -13,14 +13,14 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authentication', function(hooks) {
+module('Acceptance | authentication', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let certificationPointOfContact;
 
-  module('When certificationPointOfContact is not logged in', function() {
+  module('When certificationPointOfContact is not logged in', () => {
 
     test('it should redirect certificationPointOfContact to login page', async function(assert) {
       // given
@@ -35,7 +35,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logging in but has not accepted terms of service yet', function(hooks) {
+  module('When certificationPointOfContact is logging in but has not accepted terms of service yet', (hooks) => {
 
     hooks.beforeEach(async () => {
       await invalidateSession();
@@ -73,7 +73,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logging in and has accepted terms of service', function(hooks) {
+  module('When certificationPointOfContact is logging in and has accepted terms of service', (hooks) => {
 
     hooks.beforeEach(async () => {
       await invalidateSession();
@@ -110,7 +110,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is already authenticated and has accepted terms of service', function(hooks) {
+  module('When certificationPointOfContact is already authenticated and has accepted terms of service', (hooks) => {
 
     hooks.beforeEach(async () => {
       certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();

--- a/certif/tests/acceptance/session-add-students_test.js
+++ b/certif/tests/acceptance/session-add-students_test.js
@@ -5,7 +5,7 @@ import { createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServic
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Add Sco Students', function(hooks) {
+module('Acceptance | Session Add Sco Students', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -13,7 +13,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
   let certificationPointOfContact;
   let session;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     server.create('feature-toggle', { id: 0, certifPrescriptionSco: true });
     certificationPointOfContact = createScoIsManagingStudentsCertificationPointOfContactWithTermsOfServiceAccepted('SCO');
     session = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
@@ -24,7 +24,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('When certificationPointOfContact is not logged in', function() {
+  module('When certificationPointOfContact is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function(assert) {
       // when
@@ -35,7 +35,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logged in', function(hooks) {
+  module('When certificationPointOfContact is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await authenticateSession(certificationPointOfContact.id);
@@ -60,7 +60,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
       assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
     });
 
-    module('when there are no students', function() {
+    module('when there are no students', () => {
 
       test('it should show a empty list', async function(assert) {
         // when
@@ -71,7 +71,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
       });
     });
 
-    module('when there are some students', function() {
+    module('when there are some students', () => {
 
       const rowSelector = '.add-student-list table tbody tr';
 
@@ -94,7 +94,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
         assert.equal(studentRows.length, 2);
       });
 
-      module('when there are no enrolled students', function() {
+      module('when there are no enrolled students', () => {
         const DEFAULT_PAGE_SIZE = 50;
 
         test('it should show first page of students (with default size)', async function(assert) {
@@ -109,7 +109,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
           assert.equal(allRow.length, DEFAULT_PAGE_SIZE);
         });
 
-        module('when selecting some students', function() {
+        module('when selecting some students', () => {
 
           const checkboxSelector = 'button.checkbox';
           const checkboxCheckedSelector = `${checkboxSelector}.checkbox--checked`;
@@ -151,7 +151,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
             assert.equal(currentURL(), `/sessions/${session.id}/candidats`);
           });
 
-          module('when clicking on "Ajout"', function() {
+          module('when clicking on "Ajout"', () => {
             test('it redirect to previous page', async function(assert) {
               // given
               server.createList('student', DEFAULT_PAGE_SIZE, { isSelected: false, isEnrolled: false });
@@ -191,7 +191,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
         });
       });
 
-      module('when there are enrolled students', function(hooks) {
+      module('when there are enrolled students', (hooks) => {
 
         const rowSelector = '.add-student-list table tbody tr';
         let sessionWithEnrolledStudent;
@@ -235,7 +235,7 @@ module('Acceptance | Session Add Sco Students', function(hooks) {
           assert.dom(candidatesSelectedSelector).includesText('1 candidat(s) sélectionné(s)');
         });
 
-        module('when toggle all click', function() {
+        module('when toggle all click', () => {
           test('it should show "1 candidat sélectionné | 1 candidats déjà ajoutés à la session"', async function(assert) {
             // given
             const candidatesEnrolledSelector = '.bottom-action-bar__informations--candidates-already-added';

--- a/certif/tests/acceptance/session-details-certification-candidates-test.js
+++ b/certif/tests/acceptance/session-details-certification-candidates-test.js
@@ -10,7 +10,7 @@ import { upload } from 'ember-file-upload/test-support';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Details Certification Candidates', function(hooks) {
+module('Acceptance | Session Details Certification Candidates', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -27,7 +27,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
     notificationMessagesService.clearAll();
   });
 
-  module('When certificationPointOfContact is not logged in', function() {
+  module('When certificationPointOfContact is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function(assert) {
       const session = server.create('session');
@@ -40,7 +40,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
     });
   });
 
-  module('when certificationPointOfContact is logged in', function(hooks) {
+  module('when certificationPointOfContact is logged in', (hooks) => {
 
     let certificationPointOfContact;
     let session;
@@ -51,7 +51,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
       await authenticateSession(certificationPointOfContact.id);
     });
 
-    module('when there is no candidates yet', function() {
+    module('when there is no candidates yet', () => {
 
       test('it should display a download button and upload button', async function(assert) {
         // when
@@ -72,12 +72,12 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
       });
     });
 
-    module('when there are some candidates', function() {
+    module('when there are some candidates', () => {
 
       let sessionWithCandidates;
       let candidates;
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         sessionWithCandidates = server.create('session', { certificationCenterId: certificationPointOfContact.certificationCenterId });
         candidates = server.createList('certification-candidate', 3, { sessionId: sessionWithCandidates.id, isLinked: false, resultRecipientEmail: 'recipient@example.com' });
       });
@@ -102,7 +102,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
         assert.contains(`${aCandidate.externalId}`);
       });
 
-      module('on import', function() {
+      module('on import', () => {
 
         test('it should replace the candidates list with the imported ones', async function(assert) {
           // given
@@ -168,14 +168,14 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
 
       module('add candidate', () => {
 
-        module('when certificationPointOfContact is not SCO', function(hooks) {
+        module('when certificationPointOfContact is not SCO', (hooks) => {
 
-          hooks.beforeEach(async function() {
+          hooks.beforeEach(async () => {
             server.create('feature-toggle', { id: 0, certifPrescriptionSco: false });
             await visit(`/sessions/${sessionWithCandidates.id}/candidats`);
           });
 
-          module('when candidate data not valid', function() {
+          module('when candidate data not valid', () => {
 
             test('it should leave the line up for modification', async function(assert) {
               this.server.post('/sessions/:id/certification-candidates', () => ({
@@ -204,7 +204,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
             });
           });
 
-          module('when candidate data is valid', function() {
+          module('when candidate data is valid', () => {
 
             test('it remove the editable line', async function(assert) {
               // when
@@ -250,7 +250,7 @@ module('Acceptance | Session Details Certification Candidates', function(hooks) 
           });
         });
 
-        module('when certificationPointOfContact is SCO managing students', function() {
+        module('when certificationPointOfContact is SCO managing students', () => {
 
           test('it should display the list of students for session', async function(assert) {
             // given

--- a/certif/tests/acceptance/session-details-parameters-test.js
+++ b/certif/tests/acceptance/session-details-parameters-test.js
@@ -10,7 +10,7 @@ import { CREATED, FINALIZED } from 'pix-certif/models/session';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Details Parameters', function(hooks) {
+module('Acceptance | Session Details Parameters', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -20,7 +20,7 @@ module('Acceptance | Session Details Parameters', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('when certificationPointOfContact is logged in', function(hooks) {
+  module('when certificationPointOfContact is logged in', (hooks) => {
 
     let certificationPointOfContact;
 
@@ -29,11 +29,11 @@ module('Acceptance | Session Details Parameters', function(hooks) {
       await authenticateSession(certificationPointOfContact.id);
     });
 
-    module('when looking at the session details', function() {
+    module('when looking at the session details', () => {
 
-      module('when the session is not finalized', function() {
+      module('when the session is not finalized', () => {
 
-        module('when the session is CREATED', function() {
+        module('when the session is CREATED', () => {
 
           test('it should not display the finalize button if no candidat has joined the session', async function(assert) {
             // given
@@ -62,11 +62,11 @@ module('Acceptance | Session Details Parameters', function(hooks) {
         });
       });
 
-      module('when the session is finalized', function(hooks) {
+      module('when the session is finalized', (hooks) => {
 
         let sessionFinalized;
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           sessionFinalized = server.create('session', { status: FINALIZED });
           server.createList('certification-candidate', 3, { isLinked: true, sessionId: sessionFinalized.id });
         });

--- a/certif/tests/acceptance/session-details-test.js
+++ b/certif/tests/acceptance/session-details-test.js
@@ -10,7 +10,7 @@ import config from 'pix-certif/config/environment';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Details', function(hooks) {
+module('Acceptance | Session Details', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -20,7 +20,7 @@ module('Acceptance | Session Details', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('when certificationPointOfContact is not logged in', function() {
+  module('when certificationPointOfContact is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function(assert) {
       // given
@@ -34,7 +34,7 @@ module('Acceptance | Session Details', function(hooks) {
     });
   });
 
-  module('when certificationPointOfContact is logged in', function(hooks) {
+  module('when certificationPointOfContact is logged in', (hooks) => {
 
     let certificationPointOfContact;
     let session;
@@ -68,7 +68,7 @@ module('Acceptance | Session Details', function(hooks) {
       assert.equal(candidateTabElement.innerHTML.trim(), expectedTabContent);
     });
 
-    module('when looking at the header', function() {
+    module('when looking at the header', () => {
 
       test('it should display session details', async function(assert) {
         // given
@@ -90,7 +90,7 @@ module('Acceptance | Session Details', function(hooks) {
         assert.dom('.session-details-header-datetime__time .content-text').hasText('14:00');
       });
 
-      module('when FT_REPORTS_CATEGORISATION is on', function() {
+      module('when FT_REPORTS_CATEGORISATION is on', () => {
 
         test('it should show issue report sheet download button', async function(assert) {
         // given
@@ -106,7 +106,7 @@ module('Acceptance | Session Details', function(hooks) {
         });
       });
 
-      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is on', function(hooks) {
+      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is on', (hooks) => {
 
         const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 
@@ -142,7 +142,7 @@ module('Acceptance | Session Details', function(hooks) {
         });
       });
 
-      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is off', function(hooks) {
+      module('when FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS is off', (hooks) => {
 
         const ft = config.APP.FT_IS_AUTO_SENDING_OF_CERTIF_RESULTS;
 

--- a/certif/tests/acceptance/session-finalization-test.js
+++ b/certif/tests/acceptance/session-finalization-test.js
@@ -5,7 +5,7 @@ import { createCertificationPointOfContactWithTermsOfServiceAccepted, authentica
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Finalization', function(hooks) {
+module('Acceptance | Session Finalization', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -13,7 +13,7 @@ module('Acceptance | Session Finalization', function(hooks) {
   let certificationPointOfContact;
   let session;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
     const certificationCenterId = certificationPointOfContact.certificationCenterId;
     session = server.create('session', { certificationCenterId });
@@ -27,7 +27,7 @@ module('Acceptance | Session Finalization', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('When certificationPointOfContact is not logged in', function() {
+  module('When certificationPointOfContact is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated certificationPointOfContact', async function(assert) {
       // when
@@ -38,7 +38,7 @@ module('Acceptance | Session Finalization', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact is logged in', function(hooks) {
+  module('When certificationPointOfContact is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       await authenticateSession(certificationPointOfContact.id);
@@ -52,9 +52,9 @@ module('Acceptance | Session Finalization', function(hooks) {
       assert.equal(currentURL(), `/sessions/${session.id}/finalisation`);
     });
 
-    module('When certificationPointOfContact click on "Finaliser" button', function() {
+    module('When certificationPointOfContact click on "Finaliser" button', () => {
 
-      module('when there is no certification issue reports', function() {
+      module('when there is no certification issue reports', () => {
         test('it should show "Ajouter ?" button', async function(assert) {
           // given
           const expectedText = 'Ajouter ?';
@@ -70,7 +70,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         });
       });
 
-      module('when we add a certification issue report', function() {
+      module('when we add a certification issue report', () => {
         test('it should show "Ajouter / modifier" button', async function(assert) {
           // given
           const expectedTextWithIssueReport = 'Ajouter / modifier';
@@ -100,7 +100,7 @@ module('Acceptance | Session Finalization', function(hooks) {
         });
       });
 
-      module('when we delete a certification issue report', function() {
+      module('when we delete a certification issue report', () => {
         test('it should show the remaining count of issue reports', async function(assert) {
           // given
           const BTN_ADD_ISSUE_REPORT_FOR_CERTIFICATION_COURSE_1 = '[data-test-id="finalization-report-certification-issue-reports_1"] .button--showed-as-link';

--- a/certif/tests/acceptance/session-list-test.js
+++ b/certif/tests/acceptance/session-list-test.js
@@ -7,14 +7,14 @@ import moment from 'moment';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session List', function(hooks) {
+module('Acceptance | Session List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let certificationPointOfContact;
 
-  module('When certificationPointOfContact is not authenticated', function() {
+  module('When certificationPointOfContact is not authenticated', () => {
 
     test('it should not be accessible', async function(assert) {
       // when
@@ -26,10 +26,10 @@ module('Acceptance | Session List', function(hooks) {
 
   });
 
-  module('When certificationPointOfContact is authenticated', function(hooks) {
+  module('When certificationPointOfContact is authenticated', (hooks) => {
     let certificationCenterId;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
       certificationCenterId = certificationPointOfContact.currentCertificationCenterId;
 
@@ -52,7 +52,7 @@ module('Acceptance | Session List', function(hooks) {
       assert.dom('.page-title').hasText('Créez votre première session de certification');
     });
 
-    module('when some sessions exist', function() {
+    module('when some sessions exist', () => {
       const nbExtraSessions = 11;
 
       test('it should list the sessions and their attributes with status', async function(assert) {

--- a/certif/tests/acceptance/session-new-test.js
+++ b/certif/tests/acceptance/session-new-test.js
@@ -6,7 +6,7 @@ import { createCertificationPointOfContactWithTermsOfServiceAccepted, authentica
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { setFlatpickrDate } from 'ember-flatpickr/test-support/helpers';
 
-module('Acceptance | Session creation', function(hooks) {
+module('Acceptance | Session creation', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/certif/tests/acceptance/session-update-test.js
+++ b/certif/tests/acceptance/session-update-test.js
@@ -5,7 +5,7 @@ import { createCertificationPointOfContactWithTermsOfServiceAccepted, authentica
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Session Update', function(hooks) {
+module('Acceptance | Session Update', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/certif/tests/acceptance/switch-certification-center-test.js
+++ b/certif/tests/acceptance/switch-certification-center-test.js
@@ -8,14 +8,14 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Switch Certification Center', function(hooks) {
+module('Acceptance | Switch Certification Center', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When connected certificationPointOfContact is linked to only one certification center', function(hooks) {
+  module('When connected certificationPointOfContact is linked to only one certification center', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       const certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();
       await authenticateSession(certificationPointOfContact.id);
     });
@@ -40,13 +40,13 @@ module('Acceptance | Switch Certification Center', function(hooks) {
     });
   });
 
-  module('When connected certificationPointOfContact is linked to more than one certification center', function(hooks) {
+  module('When connected certificationPointOfContact is linked to more than one certification center', (hooks) => {
 
     let currentCertificationCenter;
     let otherCertificationCenter;
     let otherCertificationCenterSession;
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       currentCertificationCenter = server.create('certification-center', { name: 'currentCertificationCenterName', externalId: 'currentCertificationCenterExternalId' });
       currentCertificationCenter.save();
 
@@ -77,7 +77,7 @@ module('Acceptance | Switch Certification Center', function(hooks) {
       assert.dom('.logged-user-menu-item__certification-center-externalId').hasText(`(${otherCertificationCenter.externalId})`);
     });
 
-    module('When certficationPointOfContact click on a certification center', function() {
+    module('When certficationPointOfContact click on a certification center', () => {
 
       test('should change main certification center in summary', async function(assert) {
         // when

--- a/certif/tests/acceptance/terms-of-service-test.js
+++ b/certif/tests/acceptance/terms-of-service-test.js
@@ -10,7 +10,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | terms-of-service', function(hooks) {
+module('Acceptance | terms-of-service', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -25,7 +25,7 @@ module('Acceptance | terms-of-service', function(hooks) {
     assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The certificationPointOfContact is still unauthenticated');
   });
 
-  module('When certificationPointOfContact is authenticated and has not yet accepted terms of service', function(hooks) {
+  module('When certificationPointOfContact is authenticated and has not yet accepted terms of service', (hooks) => {
 
     hooks.beforeEach(async () => {
       certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceNotAccepted();
@@ -71,7 +71,7 @@ module('Acceptance | terms-of-service', function(hooks) {
     });
   });
 
-  module('When certificationPointOfContact has already accepted terms of service', function(hooks) {
+  module('When certificationPointOfContact has already accepted terms of service', (hooks) => {
 
     hooks.beforeEach(async () => {
       certificationPointOfContact = createCertificationPointOfContactWithTermsOfServiceAccepted();

--- a/certif/tests/integration/components/action-button-test.js
+++ b/certif/tests/integration/components/action-button-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | action-btn', function(hooks) {
+module('Integration | Component | action-btn', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders the text passed in when not in a loading state by default', async function(assert) {

--- a/certif/tests/integration/components/add-student-list-test.js
+++ b/certif/tests/integration/components/add-student-list-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | add-student-list', function(hooks) {
+module('Integration | Component | add-student-list', (hooks) => {
   setupRenderingTest(hooks);
 
   let store;
@@ -276,7 +276,7 @@ module('Integration | Component | add-student-list', function(hooks) {
       });
 
       module('when there is already enrolled students (certification candidates), the sticky bar is shown', () => {
-        module('when there is no additional selected student', function(hooks) {
+        module('when there is no additional selected student', (hooks) => {
 
           hooks.beforeEach(async function() {
             // given
@@ -318,7 +318,7 @@ module('Integration | Component | add-student-list', function(hooks) {
           });
         });
 
-        module('when there is additional selected student', function(hooks) {
+        module('when there is additional selected student', (hooks) => {
 
           hooks.beforeEach(async function() {
             // given

--- a/certif/tests/integration/components/certif-checkbox-test.js
+++ b/certif/tests/integration/components/certif-checkbox-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | certif-checkbox', function(hooks) {
+module('Integration | Component | certif-checkbox', (hooks) => {
   setupRenderingTest(hooks);
 
   [

--- a/certif/tests/integration/components/certification-candidate-in-staging-item-test.js
+++ b/certif/tests/integration/components/certification-candidate-in-staging-item-test.js
@@ -14,7 +14,7 @@ async function renderComponent() {
                 @updateCandidateData={{this.updateDataStub}} />`);
 }
 
-module('Integration | Component | certification-candidate-in-staging-item', function(hooks) {
+module('Integration | Component | certification-candidate-in-staging-item', (hooks) => {
   setupRenderingTest(hooks);
 
   let saveStub;
@@ -75,7 +75,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
     assert.equal(cancelStub.calledWith(candidateInStaging), true);
   });
 
-  module('when filling the line with sufficient correct data', function(hooks) {
+  module('when filling the line with sufficient correct data', (hooks) => {
     hooks.beforeEach(async () => {
       candidateInStaging.set('firstName', 'Salut');
       candidateInStaging.set('lastName', 'Salut');
@@ -104,7 +104,7 @@ module('Integration | Component | certification-candidate-in-staging-item', func
 
   });
 
-  module('when filling the line with incorrect ', function(hooks) {
+  module('when filling the line with incorrect ', (hooks) => {
     hooks.beforeEach(async () => {
       candidateInStaging.set('firstName', 'Salut');
       candidateInStaging.set('lastName', 'Salut');

--- a/certif/tests/integration/components/enrolled-candidates-test.js
+++ b/certif/tests/integration/components/enrolled-candidates-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | enrolled-candidates', function(hooks) {
+module('Integration | Component | enrolled-candidates', (hooks) => {
   setupRenderingTest(hooks);
 
   const CERTIFICATION_CANDIDATES_TABLE_SELECTOR = 'certification-candidates-table tbody';

--- a/certif/tests/integration/components/import-candidates-test.js
+++ b/certif/tests/integration/components/import-candidates-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | import-candidates', function(hooks) {
+module('Integration | Component | import-candidates', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders texts about Feuille émargement', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/add-issue-report-modal-test.js
+++ b/certif/tests/integration/components/issue-report-modal/add-issue-report-modal-test.js
@@ -10,7 +10,7 @@ import {
   categoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | add-issue-report-modal', function(hooks) {
+module('Integration | Component | add-issue-report-modal', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it show candidate informations in title', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/candidate-information-change-certification-issue-report-fields-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { certificationIssueReportSubcategories } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | candidate-information-change-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | candidate-information-change-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-candidate-information-change';

--- a/certif/tests/integration/components/issue-report-modal/connection-or-end-screen-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/connection-or-end-screen-certification-issue-report-fields-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import { certificationIssueReportCategories, categoryToLabel } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | connection-or-end-screen-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | connection-or-end-screen-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-connection-or-end-screen';

--- a/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/fraud-certification-issue-report-fields-test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-module('Integration | Component | issue-report-modal/fraud-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | issue-report-modal/fraud-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-fraud';

--- a/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/in-challenge-certification-issue-report-fields-test.js
@@ -12,7 +12,7 @@ import {
 } from 'pix-certif/models/certification-issue-report';
 import { RadioButtonCategoryWithSubcategoryWithDescriptionAndQuestionNumber } from 'pix-certif/components/issue-report-modal/add-issue-report-modal';
 
-module('Integration | Component | in-challenge-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | in-challenge-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should call toggle function on click radio button', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/issue-report-modal-test.js
+++ b/certif/tests/integration/components/issue-report-modal/issue-report-modal-test.js
@@ -5,7 +5,7 @@ import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | issue-report-modal', function(hooks) {
+module('Integration | Component | issue-report-modal', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it show candidate informations in title', async function(assert) {

--- a/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/late-or-leaving-certification-issue-report-fields-test.js
@@ -6,7 +6,7 @@ import { certificationIssueReportSubcategories } from 'pix-certif/models/certifi
 
 import sinon from 'sinon';
 
-module('Integration | Component | late-or-leaving-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | late-or-leaving-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-late-or-leaving';

--- a/certif/tests/integration/components/issue-report-modal/other-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/other-certification-issue-report-fields-test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-module('Integration | Component | other-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | other-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-other';

--- a/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
+++ b/certif/tests/integration/components/issue-report-modal/technical-problem-certification-issue-report-fields-test.js
@@ -4,7 +4,7 @@ import { render, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
 
-module('Integration | Component | issue-report-modal/technical-problem-certification-issue-report-fields', function(hooks) {
+module('Integration | Component | issue-report-modal/technical-problem-certification-issue-report-fields', (hooks) => {
   setupRenderingTest(hooks);
 
   const INPUT_RADIO_SELECTOR = '#input-radio-for-category-technical-problem';

--- a/certif/tests/integration/components/issue-reports-modal-test.js
+++ b/certif/tests/integration/components/issue-reports-modal-test.js
@@ -11,7 +11,7 @@ import {
   subcategoryToLabel,
 } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | issue-reports-modal', function(hooks) {
+module('Integration | Component | issue-reports-modal', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it show candidate informations in title', async function(assert) {

--- a/certif/tests/integration/components/login-form-test.js
+++ b/certif/tests/integration/components/login-form-test.js
@@ -12,7 +12,7 @@ const errorMessages = {
   NOT_LINKED_CERTIFICATION_MSG: 'L\'accès à Pix Certif est limité aux centres de certification Pix. Contactez le référent de votre centre de certification si vous pensez avoir besoin d\'y accéder.',
 };
 
-module('Integration | Component | login-form', function(hooks) {
+module('Integration | Component | login-form', (hooks) => {
   setupRenderingTest(hooks);
 
   let sessionStub;
@@ -156,9 +156,9 @@ module('Integration | Component | login-form', function(hooks) {
     assert.dom('#login-form-error-message').hasText(ENV.APP.API_ERROR_MESSAGES.INTERNAL_SERVER_ERROR.MESSAGE);
   });
 
-  module('when password is hidden', function(hooks) {
+  module('when password is hidden', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       // given
       await render(hbs`{{login-form}});`);
     });

--- a/certif/tests/integration/components/pagination-control-test.js
+++ b/certif/tests/integration/components/pagination-control-test.js
@@ -14,7 +14,7 @@ function getMetaForPage(pageNumber) {
   };
 }
 
-module('Integration | Component | pagination-control', function(hooks) {
+module('Integration | Component | pagination-control', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should disable previous button when user is on first page', async function(assert) {

--- a/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
+++ b/certif/tests/integration/components/session-finalization-examiner-global-comment-step-test.js
@@ -5,7 +5,7 @@ import { render, fillIn, click } from '@ember/test-helpers';
 import Object from '@ember/object';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | session-finalization-examiner-global-comment-step', function(hooks) {
+module('Integration | Component | session-finalization-examiner-global-comment-step', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders the radio buttons', async function(assert) {

--- a/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
+++ b/certif/tests/integration/components/session-finalization-formbuilder-link-step-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 import config from 'pix-certif/config/environment';
 
-module('Integration | Component | session-finalization-formbuilder-link-step', function(hooks) {
+module('Integration | Component | session-finalization-formbuilder-link-step', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {

--- a/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
+++ b/certif/tests/integration/components/session-finalization-reports-informations-step-test.js
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { run } from '@ember/runloop';
 import { certificationIssueReportCategories } from 'pix-certif/models/certification-issue-report';
 
-module('Integration | Component | session-finalization-reports-informations-step', function(hooks) {
+module('Integration | Component | session-finalization-reports-informations-step', (hooks) => {
   setupRenderingTest(hooks);
   let reportA;
   let reportB;

--- a/certif/tests/integration/components/session-finalization-step-container-test.js
+++ b/certif/tests/integration/components/session-finalization-step-container-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | session-finalization-step-container', function(hooks) {
+module('Integration | Component | session-finalization-step-container', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {

--- a/certif/tests/integration/components/user-logged-menu-test.js
+++ b/certif/tests/integration/components/user-logged-menu-test.js
@@ -7,7 +7,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Integration | Component | user-logged-menu', function(hooks) {
+module('Integration | Component | user-logged-menu', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -50,7 +50,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     assert.contains(`${certificationPointOfContact.firstName} ${certificationPointOfContact.lastName}`);
   });
 
-  module('when certification center doesn\'t have an externalId', function() {
+  module('when certification center doesn\'t have an externalId', () => {
 
     test('should display the user certification center name only', async function(assert) {
       // given
@@ -64,7 +64,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     });
   });
 
-  module('when certification center does have an externalId', function() {
+  module('when certification center does have an externalId', () => {
 
     test('should display the user certification center name and certification center externalId', function(assert) {
       // then
@@ -72,7 +72,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     });
   });
 
-  module('when menu is close', function() {
+  module('when menu is close', () => {
 
     test('should display the chevron-down icon', function(assert) {
       // then
@@ -90,7 +90,7 @@ module('Integration | Component | user-logged-menu', function(hooks) {
     });
   });
 
-  module('when menu is open', function() {
+  module('when menu is open', () => {
 
     test('should display the chevron-up icon', async function(assert) {
       // when

--- a/certif/tests/integration/helpers/format-percentage-test.js
+++ b/certif/tests/integration/helpers/format-percentage-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Helper | format-percentage', function(hooks) {
+module('Integration | Helper | format-percentage', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders correct value', async function(assert) {

--- a/certif/tests/unit/adapters/application-test.js
+++ b/certif/tests/unit/adapters/application-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+module('Unit | Adapters | ApplicationAdapter', (hooks) => {
   setupTest(hooks);
 
   test('should specify /api as the root url', function(assert) {
@@ -13,7 +13,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
-  module('get headers()', function() {
+  module('get headers()', () => {
 
     test('should add header with authentication token when the session is authenticated', function(assert) {
       // Given
@@ -39,7 +39,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     });
   });
 
-  module('ajax()', function() {
+  module('ajax()', () => {
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');

--- a/certif/tests/unit/adapters/certification-candidate-test.js
+++ b/certif/tests/unit/adapters/certification-candidate-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapters | certification-candidate', function(hooks) {
+module('Unit | Adapters | certification-candidate', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -15,7 +15,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
 
     test('should build url from sessionId', async function(assert) {
       // when
@@ -28,7 +28,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
     });
   });
 
-  module('#urlForCreateRecord', function() {
+  module('#urlForCreateRecord', () => {
 
     test('should build create url from certification-candidate id', async function(assert) {
       // when
@@ -50,7 +50,7 @@ module('Unit | Adapters | certification-candidate', function(hooks) {
 
   });
 
-  module('#urlForDeleteRecord', function() {
+  module('#urlForDeleteRecord', () => {
 
     test('should build delete url from certification-candidate id', async function(assert) {
       // when

--- a/certif/tests/unit/adapters/certification-issue-report-test.js
+++ b/certif/tests/unit/adapters/certification-issue-report-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 import sinon from 'sinon';
 
-module('Unit | Adapter | certification issue report', function(hooks) {
+module('Unit | Adapter | certification issue report', (hooks) => {
   setupTest(hooks);
 
   test('it exists', async function(assert) {

--- a/certif/tests/unit/adapters/certification-point-of-contact-test.js
+++ b/certif/tests/unit/adapters/certification-point-of-contact-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapters | certification-point-of-contact', function(hooks) {
+module('Unit | Adapters | certification-point-of-contact', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -13,7 +13,7 @@ module('Unit | Adapters | certification-point-of-contact', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
 
     test('it should build specific url when adding option for acceptPixCertifTermsOfService', async function(assert) {
       // when

--- a/certif/tests/unit/adapters/division-test.js
+++ b/certif/tests/unit/adapters/division-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapters | division', function(hooks) {
+module('Unit | Adapters | division', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -14,7 +14,7 @@ module('Unit | Adapters | division', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
 
     test('should build url from certificationCenterId', async function(assert) {
       // when

--- a/certif/tests/unit/adapters/session-test.js
+++ b/certif/tests/unit/adapters/session-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | session', function(hooks) {
+module('Unit | Adapter | session', (hooks) => {
   setupTest(hooks);
 
   let adapter;

--- a/certif/tests/unit/adapters/student-test.js
+++ b/certif/tests/unit/adapters/student-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapter | student', function(hooks) {
+module('Unit | Adapter | student', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -13,7 +13,7 @@ module('Unit | Adapter | student', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#urlForFindAll', function() {
+  module('#urlForFindAll', () => {
 
     test('should build query url from student id', async function(assert) {
       // given

--- a/certif/tests/unit/components/add-student-list-test.js
+++ b/certif/tests/unit/components/add-student-list-test.js
@@ -5,7 +5,7 @@ import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import sinon from 'sinon';
 import times from 'lodash/times';
 
-module('Unit | Component | add-student-list', function(hooks) {
+module('Unit | Component | add-student-list', (hooks) => {
   setupTest(hooks);
 
   let component;
@@ -16,7 +16,7 @@ module('Unit | Component | add-student-list', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('#computed hasCheckedSomething', function() {
+  module('#computed hasCheckedSomething', () => {
 
     test('it should be false if has no checked student', function(assert) {
       // given
@@ -53,7 +53,7 @@ module('Unit | Component | add-student-list', function(hooks) {
     });
   });
 
-  module('#computed hasCheckedEverything', function() {
+  module('#computed hasCheckedEverything', () => {
 
     test('it should be false if they are not all checked', function(assert) {
       // given
@@ -90,7 +90,7 @@ module('Unit | Component | add-student-list', function(hooks) {
     });
   });
 
-  module('#action toggleItem', function() {
+  module('#action toggleItem', () => {
 
     test('it should toggle the isSelected attribute of the student', function(assert) {
       // given
@@ -105,7 +105,7 @@ module('Unit | Component | add-student-list', function(hooks) {
     });
   });
 
-  module('#action enrollStudents', function() {
+  module('#action enrollStudents', () => {
     test('it should save only selected students via the session', async function(assert) {
       // given
       const sessionId = 1;

--- a/certif/tests/unit/components/app-modal-test.js
+++ b/certif/tests/unit/components/app-modal-test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { keyUp } from 'ember-keyboard';
 
-module('Unit | Component | app-modal', function(hooks) {
+module('Unit | Component | app-modal', (hooks) => {
 
   setupTest(hooks);
 
@@ -14,7 +14,7 @@ module('Unit | Component | app-modal', function(hooks) {
     modal = this.owner.lookup('component:app-modal');
   });
 
-  module('#init', function() {
+  module('#init', () => {
     test('should set the overlay as translucent', function(assert) {
       // then
       assert.equal(modal.get('translucentOverlay'), true);
@@ -26,7 +26,7 @@ module('Unit | Component | app-modal', function(hooks) {
     });
   });
 
-  module('#closeOnEsc', function() {
+  module('#closeOnEsc', () => {
     test('should use the "close" action', function(assert) {
       // Given
       const sendActionStub = sinon.stub();

--- a/certif/tests/unit/components/enrolled-candidates-test.js
+++ b/certif/tests/unit/components/enrolled-candidates-test.js
@@ -3,16 +3,16 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 
-module('Unit | Component | enrolled-candidates', function(hooks) {
+module('Unit | Component | enrolled-candidates', (hooks) => {
   setupTest(hooks);
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:enrolled-candidates');
   });
 
-  module('#saveCertificationCandidate', async function() {
+  module('#saveCertificationCandidate', async () => {
 
     test('should save certification candidate on saveCertificationCandidate action with appropriate adapter options', async function(assert) {
       // given
@@ -71,7 +71,7 @@ module('Unit | Component | enrolled-candidates', function(hooks) {
     });
   });
 
-  module('#deleteCertificationCandidate', async function() {
+  module('#deleteCertificationCandidate', async () => {
 
     test('should delete the candidate action with appropriate adapter options', async function(assert) {
       // given

--- a/certif/tests/unit/components/login-form-test.js
+++ b/certif/tests/unit/components/login-form-test.js
@@ -15,7 +15,7 @@ module('Unit | Component | login-form', (hooks) => {
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     const sessionStub = Service.create({
       authenticate: authenticateStub,
     });

--- a/certif/tests/unit/controllers/authenticated-test.js
+++ b/certif/tests/unit/controllers/authenticated-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated', function(hooks) {
+module('Unit | Controller | authenticated', (hooks) => {
   setupTest(hooks);
 
-  module('#get documentationLink', function() {
+  module('#get documentationLink', () => {
     test('should return a different link whether the center is SCO managing students or not', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated');

--- a/certif/tests/unit/controllers/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/details', function(hooks) {
+module('Unit | Controller | authenticated/sessions/details', (hooks) => {
   setupTest(hooks);
 
-  module('#certificationCandidatesCount', function() {
+  module('#certificationCandidatesCount', () => {
     test('should return a string that matches the candidate count if more than 0 candidate', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/details');
@@ -30,7 +30,7 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
     });
   });
 
-  module('#hasOneOrMoreCandidates', function() {
+  module('#hasOneOrMoreCandidates', () => {
     test('should return true if session has at least 1 candidate', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/details');
@@ -56,11 +56,11 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
     });
   });
 
-  module('#shouldDisplayDownloadButton', function() {
+  module('#shouldDisplayDownloadButton', () => {
 
-    module('when there is at least one enrolled candidate', function() {
+    module('when there is at least one enrolled candidate', () => {
 
-      module('when it should display the CertifPrescriptionScoFeature', function() {
+      module('when it should display the CertifPrescriptionScoFeature', () => {
 
         test('should return true ', function(assert) {
           // given
@@ -95,9 +95,9 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
     });
   });
 
-  module('#shouldDisplayResultRecipientInfoMessage', function() {
+  module('#shouldDisplayResultRecipientInfoMessage', () => {
 
-    module('when the current user certification center does manage students', function() {
+    module('when the current user certification center does manage students', () => {
       test('should also return false', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
@@ -113,7 +113,7 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
       });
     });
 
-    module('when current user is if of type Sco and does not managing students', function() {
+    module('when current user is if of type Sco and does not managing students', () => {
       test('should return true', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/details');
@@ -130,7 +130,7 @@ module('Unit | Controller | authenticated/sessions/details', function(hooks) {
     });
   });
 
-  module('when there is no enrolled candidate', function() {
+  module('when there is no enrolled candidate', () => {
     test('Should return false.', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/details');

--- a/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/details/certification-candidates-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/details/certification-candidates', function(hooks) {
+module('Unit | Controller | authenticated/sessions/details/certification-candidates', (hooks) => {
   setupTest(hooks);
 
-  module('#computed hasOneOrMoreCandidates()', function() {
+  module('#computed hasOneOrMoreCandidates()', () => {
     test('It should return true when has one or more candidates', function(assert) {
       // given
       const controller = this.owner.lookup('controller:authenticated/sessions/details/certification-candidates');

--- a/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/finalize-test.js
@@ -4,10 +4,10 @@ import ArrayProxy from '@ember/array/proxy';
 
 const FINALIZE_PATH = 'authenticated/sessions/finalize';
 
-module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
+module('Unit | Controller | ' + FINALIZE_PATH, (hooks) => {
   setupTest(hooks);
 
-  module('#computed uncheckedHasSeenEndTestScreenCount', function() {
+  module('#computed uncheckedHasSeenEndTestScreenCount', () => {
 
     test('it should count no unchecked box if no report', function(assert) {
       // given
@@ -65,7 +65,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#computed hasUncheckedHasSeenEndTestScreen', function() {
+  module('#computed hasUncheckedHasSeenEndTestScreen', () => {
 
     test('it should be false if no unchecked certification reports', function(assert) {
 
@@ -106,7 +106,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#action updateExaminerGlobalComment', function() {
+  module('#action updateExaminerGlobalComment', () => {
 
     test('it should left session examiner global comment untouched if input value exceeds max size', function(assert) {
       // given
@@ -154,7 +154,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#action updateCertificationIssueReport', function() {
+  module('#action updateCertificationIssueReport', () => {
 
     test('it should left issue report description untouched if input value exceeds max size', function(assert) {
       // given
@@ -202,7 +202,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#action toggleCertificationReportHasSeenEndTestScreen', function() {
+  module('#action toggleCertificationReportHasSeenEndTestScreen', () => {
 
     test('it should toggle the hasSeenEndTestScreen attribute of the certif parameter', function(assert) {
       // given
@@ -218,7 +218,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#action toggleAllCertificationReportsHasSeenEndTestScreen', function() {
+  module('#action toggleAllCertificationReportsHasSeenEndTestScreen', () => {
 
     [
       { hasSeenEndTestScreen1: true, hasSeenEndTestScreen2: true, expectedState: false },
@@ -249,7 +249,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     );
   });
 
-  module('#action openModal', function() {
+  module('#action openModal', () => {
 
     test('it should set flag showConfirmModal to true', function(assert) {
       // given
@@ -263,7 +263,7 @@ module('Unit | Controller | ' + FINALIZE_PATH, function(hooks) {
     });
   });
 
-  module('#action close', function() {
+  module('#action close', () => {
 
     test('it should set flag showConfirmModal to false', function(assert) {
       // given

--- a/certif/tests/unit/controllers/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/list-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
 
-module('Unit | Controller | authenticated/sessions/list', function(hooks) {
+module('Unit | Controller | authenticated/sessions/list', (hooks) => {
   setupTest(hooks);
 
-  module('#computed hasSession', function() {
+  module('#computed hasSession', () => {
 
     test('it should know when there is no sessions', function(assert) {
       // given
@@ -39,9 +39,9 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
     });
   });
 
-  module('#shouldDisplayResultRecipientInfoMessage', function() {
+  module('#shouldDisplayResultRecipientInfoMessage', () => {
 
-    module('when the current user certification center does manage students', function() {
+    module('when the current user certification center does manage students', () => {
       test('should also return false', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/list');
@@ -57,7 +57,7 @@ module('Unit | Controller | authenticated/sessions/list', function(hooks) {
       });
     });
 
-    module('when current user is not sco managing students', function() {
+    module('when current user is not sco managing students', () => {
       test('should return true', function(assert) {
         // given
         const controller = this.owner.lookup('controller:authenticated/sessions/list');

--- a/certif/tests/unit/controllers/authenticated/sessions/new-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/new-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/new', function(hooks) {
+module('Unit | Controller | authenticated/sessions/new', (hooks) => {
   setupTest(hooks);
 
-  module('#action createSession', function(hooks) {
+  module('#action createSession', (hooks) => {
     let controller;
     let event;
     const sessionId = 'sessionId';
@@ -44,7 +44,7 @@ module('Unit | Controller | authenticated/sessions/new', function(hooks) {
     });
   });
 
-  module('#action cancel', function(hooks) {
+  module('#action cancel', (hooks) => {
     let controller;
     const sessionId = 'sessionId';
     const session = { id: sessionId };
@@ -64,7 +64,7 @@ module('Unit | Controller | authenticated/sessions/new', function(hooks) {
     });
   });
 
-  module('#action onDatePicked', function(hooks) {
+  module('#action onDatePicked', (hooks) => {
     let controller;
     const session = { date: '' };
 
@@ -83,7 +83,7 @@ module('Unit | Controller | authenticated/sessions/new', function(hooks) {
     });
   });
 
-  module('#action onTimePicked', function(hooks) {
+  module('#action onTimePicked', (hooks) => {
     let controller;
     const session = { time: '' };
 

--- a/certif/tests/unit/controllers/authenticated/sessions/update-test.js
+++ b/certif/tests/unit/controllers/authenticated/sessions/update-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import sinon from 'sinon';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/sessions/update', function(hooks) {
+module('Unit | Controller | authenticated/sessions/update', (hooks) => {
   setupTest(hooks);
 
-  module('#action updateSession', function(hooks) {
+  module('#action updateSession', (hooks) => {
     let controller;
     let event;
     const sessionId = 'sessionId';
@@ -44,7 +44,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     });
   });
 
-  module('#action cancel', function(hooks) {
+  module('#action cancel', (hooks) => {
     let controller;
     const sessionId = 'sessionId';
     const session = { id: sessionId };
@@ -64,7 +64,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     });
   });
 
-  module('#action onDatePicked', function(hooks) {
+  module('#action onDatePicked', (hooks) => {
     let controller;
     const session = { date: '' };
 
@@ -83,7 +83,7 @@ module('Unit | Controller | authenticated/sessions/update', function(hooks) {
     });
   });
 
-  module('#action onTimePicked', function(hooks) {
+  module('#action onTimePicked', (hooks) => {
     let controller;
     const session = { time: '' };
 

--- a/certif/tests/unit/controllers/terms-of-service-test.js
+++ b/certif/tests/unit/controllers/terms-of-service-test.js
@@ -2,11 +2,11 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | terms-of-service', function(hooks) {
+module('Unit | Controller | terms-of-service', (hooks) => {
   setupTest(hooks);
   let controller;
 
-  module('#action submit', function(hooks) {
+  module('#action submit', (hooks) => {
 
     hooks.beforeEach(function() {
       controller = this.owner.lookup('controller:terms-of-service');

--- a/certif/tests/unit/models/certification-issue-report-test.js
+++ b/certif/tests/unit/models/certification-issue-report-test.js
@@ -12,7 +12,7 @@ import {
   subcategoryToCode,
 } from 'pix-certif/models/certification-issue-report';
 
-module('Unit | Model | certification issue report', function(hooks) {
+module('Unit | Model | certification issue report', (hooks) => {
   setupTest(hooks);
 
   test('it should return the right label for the category', function(assert) {

--- a/certif/tests/unit/models/certification-report-test.js
+++ b/certif/tests/unit/models/certification-report-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import { A } from '@ember/array';
 
-module('Unit | Model | certification report', function(hooks) {
+module('Unit | Model | certification report', (hooks) => {
   setupTest(hooks);
 
   test('it should return the right data in the finalized session model', function(assert) {
@@ -26,7 +26,7 @@ module('Unit | Model | certification report', function(hooks) {
     assert.equal(model.firstIssueReportDescription, '');
   });
 
-  module('#firstIssueReportDescription', function() {
+  module('#firstIssueReportDescription', () => {
     test('it should the first description of certification issue report', function(assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/certif/tests/unit/models/session-test.js
+++ b/certif/tests/unit/models/session-test.js
@@ -4,10 +4,10 @@ import { run } from '@ember/runloop';
 import config from '../../../config/environment';
 import { CREATED, FINALIZED } from 'pix-certif/models/session';
 
-module('Unit | Model | session', function(hooks) {
+module('Unit | Model | session', (hooks) => {
   setupTest(hooks);
 
-  module('#displayStatus', function() {
+  module('#displayStatus', () => {
 
     test('it should return the correct displayName', function(assert) {
       // given
@@ -27,7 +27,7 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#urlToUpload', function() {
+  module('#urlToUpload', () => {
     test('it should return the correct urlToUpload', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -38,7 +38,7 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#urlToDownloadAttendanceSheet', function() {
+  module('#urlToDownloadAttendanceSheet', () => {
     test('it should return the correct urlToDownloadAttendanceSheet', function(assert) {
       // given
       const store = this.owner.lookup('service:store');
@@ -50,7 +50,7 @@ module('Unit | Model | session', function(hooks) {
     });
   });
 
-  module('#urlToDownloadSessionIssueReportSheet', function() {
+  module('#urlToDownloadSessionIssueReportSheet', () => {
     test('it should return the correct urlToDownloadSessionIssueReportSheet', function(assert) {
       // given
       const store = this.owner.lookup('service:store');

--- a/certif/tests/unit/models/student-test.js
+++ b/certif/tests/unit/models/student-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import pick from 'lodash/pick';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | student', function(hooks) {
+module('Unit | Model | student', (hooks) => {
   setupTest(hooks);
 
   test('it creates a StudentModel', function(assert) {

--- a/certif/tests/unit/routes/application-test.js
+++ b/certif/tests/unit/routes/application-test.js
@@ -13,7 +13,7 @@ function createLoadServiceStub() {
   });
 }
 
-module('Unit | Route | application', function(hooks) {
+module('Unit | Route | application', (hooks) => {
   setupTest(hooks);
 
   test('it should load the current user', function(assert) {

--- a/certif/tests/unit/routes/authenticated/index-test.js
+++ b/certif/tests/unit/routes/authenticated/index-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions', function(hooks) {
+module('Unit | Route | authenticated/sessions', (hooks) => {
   setupTest(hooks);
 
   test('it should redirects to authenticated.sessions.list', async function(assert) {

--- a/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/add-student-test.js
@@ -4,11 +4,11 @@ import sinon from 'sinon';
 
 import EmberObject from '@ember/object';
 
-module('Unit | Route | authenticated/sessions/add-student', function(hooks) {
+module('Unit | Route | authenticated/sessions/add-student', (hooks) => {
   setupTest(hooks);
   let route;
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const session_id = 1;
     const session = { id: session_id };
     const certificationCenterId = Symbol('certificationCenterId');

--- a/certif/tests/unit/routes/authenticated/sessions/details-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/details', function(hooks) {
+module('Unit | Route | authenticated/sessions/details', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,12 +10,12 @@ module('Unit | Route | authenticated/sessions/details', function(hooks) {
     route = this.owner.lookup('route:authenticated/sessions/details');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const session_id = 1;
     const returnedSession = Symbol('session');
     const returnedCertifCandidates = [Symbol('certification-candidate')];
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.findRecord = sinon.stub().resolves(returnedSession);
       route.store.query = sinon.stub().withArgs('certification-candidate', { sessionId: session_id }).resolves(returnedCertifCandidates);
     });

--- a/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/details/certification-candidate-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/details/certification-candidates', function(hooks) {
+module('Unit | Route | authenticated/sessions/details/certification-candidates', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,10 +10,10 @@ module('Unit | Route | authenticated/sessions/details/certification-candidates',
     route = this.owner.lookup('route:authenticated/sessions/details/certification-candidates');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const expectedModel = Symbol('model');
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.modelFor = sinon.stub().returns(expectedModel);
     });
 

--- a/certif/tests/unit/routes/authenticated/sessions/finalize-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/finalize-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/finalize', function(hooks) {
+module('Unit | Route | authenticated/sessions/finalize', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/sessions/finalize', function(hooks) {
     route = this.owner.lookup('route:authenticated/sessions/finalize');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const session_id = 1;
     const returnedSession = Symbol('session');
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.findRecord = sinon.stub().resolves(returnedSession);
     });
 
@@ -29,18 +29,18 @@ module('Unit | Route | authenticated/sessions/finalize', function(hooks) {
     });
   });
 
-  module('#afterModel', function(hooks) {
+  module('#afterModel', (hooks) => {
     const model = { session: {} };
     let transition;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       transition = { abort: sinon.stub() };
       route.notifications.error = sinon.stub();
     });
 
-    module('when model is already finalized', function(hooks) {
+    module('when model is already finalized', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         model.isFinalized = true;
       });
 
@@ -63,9 +63,9 @@ module('Unit | Route | authenticated/sessions/finalize', function(hooks) {
       });
     });
 
-    module('when model is not finalized', function(hooks) {
+    module('when model is not finalized', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         model.isFinalized = false;
       });
 

--- a/certif/tests/unit/routes/authenticated/sessions/list-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/list-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/list', function(hooks) {
+module('Unit | Route | authenticated/sessions/list', (hooks) => {
   setupTest(hooks);
 
-  module('#model', function() {
+  module('#model', () => {
 
     test('it should return certification center sessions', async function(assert) {
       // given

--- a/certif/tests/unit/routes/authenticated/sessions/new-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/new-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/new', function(hooks) {
+module('Unit | Route | authenticated/sessions/new', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,11 +10,11 @@ module('Unit | Route | authenticated/sessions/new', function(hooks) {
     route = this.owner.lookup('route:authenticated/sessions/new');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const createdSession = Symbol('newSession');
     const certificationCenterId = 123;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.createRecord = sinon.stub().resolves(createdSession);
       route.currentUser = { certificationPointOfContact: { currentCertificationCenterId: certificationCenterId } };
     });
@@ -29,13 +29,13 @@ module('Unit | Route | authenticated/sessions/new', function(hooks) {
     });
   });
 
-  module('#deactivate', function(hooks) {
+  module('#deactivate', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.controller = { model: { deleteRecord: sinon.stub().returns() } };
     });
 
-    module('when model has dirty attributes', function() {
+    module('when model has dirty attributes', () => {
 
       test('it should call rollback on controller model', function(assert) {
         // given
@@ -50,7 +50,7 @@ module('Unit | Route | authenticated/sessions/new', function(hooks) {
       });
     });
 
-    module('when model has clean attributes', function() {
+    module('when model has clean attributes', () => {
 
       test('it should not call rollback on controller model', function(assert) {
         // given

--- a/certif/tests/unit/routes/authenticated/sessions/update-test.js
+++ b/certif/tests/unit/routes/authenticated/sessions/update-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/sessions/update', function(hooks) {
+module('Unit | Route | authenticated/sessions/update', (hooks) => {
   setupTest(hooks);
   let route;
 
@@ -10,10 +10,10 @@ module('Unit | Route | authenticated/sessions/update', function(hooks) {
     route = this.owner.lookup('route:authenticated/sessions/update');
   });
 
-  module('#model', function(hooks) {
+  module('#model', (hooks) => {
     const session_id = 1;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.store.findRecord = sinon.stub().withArgs('session', session_id).resolves({});
     });
 
@@ -27,9 +27,9 @@ module('Unit | Route | authenticated/sessions/update', function(hooks) {
     });
   });
 
-  module('#deactivate', function(hooks) {
+  module('#deactivate', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       route.controller = { model: { rollbackAttributes: sinon.stub().returns() } };
     });
 

--- a/certif/tests/unit/routes/login-test.js
+++ b/certif/tests/unit/routes/login-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | login', function(hooks) {
+module('Unit | Route | login', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/certif/tests/unit/routes/logout-test.js
+++ b/certif/tests/unit/routes/logout-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | logout', function(hooks) {
+module('Unit | Route | logout', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/certif/tests/unit/routes/not-found-test.js
+++ b/certif/tests/unit/routes/not-found-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | not-found', function(hooks) {
+module('Unit | Route | not-found', (hooks) => {
   setupTest(hooks);
 
   test('should redirect to application route', function(assert) {

--- a/certif/tests/unit/routes/terms-of-service-test.js
+++ b/certif/tests/unit/routes/terms-of-service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | terms-of-service', function(hooks) {
+module('Unit | Route | terms-of-service', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/certif/tests/unit/services/current-user-test.js
+++ b/certif/tests/unit/services/current-user-test.js
@@ -4,11 +4,11 @@ import { reject, resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Unit | Service | current-user', function(hooks) {
+module('Unit | Service | current-user', (hooks) => {
 
   setupTest(hooks);
 
-  module('user is authenticated', function() {
+  module('user is authenticated', () => {
 
     test('should load the current certification point of contact', async function(assert) {
       // Given
@@ -35,7 +35,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user is not authenticated', function() {
+  module('user is not authenticated', () => {
 
     test('should do nothing', async function(assert) {
       // Given
@@ -53,7 +53,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user token is expired', function() {
+  module('user token is expired', () => {
 
     test('should redirect to login', async function(assert) {
       // Given

--- a/certif/tests/unit/services/featureToggles-test.js
+++ b/certif/tests/unit/services/featureToggles-test.js
@@ -4,11 +4,11 @@ import { resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Unit | Service | feature toggles', function(hooks) {
+module('Unit | Service | feature toggles', (hooks) => {
 
   setupTest(hooks);
 
-  module('feature toggles are loaded', function() {
+  module('feature toggles are loaded', () => {
 
     test('should load the feature toggles', async function(assert) {
       // Given

--- a/mon-pix/app/components/challenge-item-qcu.js
+++ b/mon-pix/app/components/challenge-item-qcu.js
@@ -12,7 +12,7 @@ export default class ChallengeItemQcu extends ChallengeItemGeneric {
   _getAnswerValue() {
     const checkedInputValues = [];
     const radioInputElements = document.querySelectorAll('input[type="radio"]:checked');
-    Array.prototype.forEach.call(radioInputElements, function(element) {
+    Array.prototype.forEach.call(radioInputElements, (element) => {
       checkedInputValues.push(element.getAttribute('data-value'));
     });
     return checkedInputValues.join('');

--- a/mon-pix/app/components/feedback-panel.js
+++ b/mon-pix/app/components/feedback-panel.js
@@ -153,7 +153,7 @@ export default class FeedbackPanel extends Component {
   }
 
   _scrollIntoFeedbackPanel() {
-    later(function() {
+    later(() => {
       const feedbackPanelElements = document.getElementsByClassName('feedback-panel__view');
       if (feedbackPanelElements && feedbackPanelElements[0]) {
         feedbackPanelElements[0].scrollIntoView();

--- a/mon-pix/tests/integration/components/comparison-window-test.js
+++ b/mon-pix/tests/integration/components/comparison-window-test.js
@@ -91,7 +91,7 @@ describe('Integration | Component | comparison-window', function() {
       { status: 'partially' },
       { status: 'timedout' },
       { status: 'default' },
-    ].forEach(function(data) {
+    ].forEach((data) => {
 
       it(`should display the good icon in title when answer's result is "${data.status}"`, async function() {
         // given

--- a/mon-pix/tests/integration/components/form-textfield-date-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-date-test.js
@@ -59,7 +59,7 @@ describe('Integration | Component | form textfield date', function() {
       { expectedRendering: 'div', item: MESSAGE, expectedLength: 3 },
       { expectedRendering: 'input', item: INPUT, expectedLength: 3 },
 
-    ].forEach(function({ expectedRendering, item, expectedLength }) {
+    ].forEach(({ expectedRendering, item, expectedLength }) => {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
         expect(findAll(item)).to.have.length(expectedLength);
@@ -73,7 +73,7 @@ describe('Integration | Component | form textfield date', function() {
       { item: `${MESSAGE}#monthValidationMessage`, expectedRendering: 'div.message', expectedText: 'month message' },
       { item: `${MESSAGE}#yearValidationMessage`, expectedRendering: 'div.message', expectedText: 'year message' },
 
-    ].forEach(function({ item, expectedRendering, expectedText }) {
+    ].forEach(({ item, expectedRendering, expectedText }) => {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
         expect(find(item).textContent).to.contains(expectedText);
@@ -90,7 +90,7 @@ describe('Integration | Component | form textfield date', function() {
       const inputValueToValidate = { day: null, month: null, year: null };
       const expectedInputValue = { day: '10', month: '12', year: '2010' };
 
-      this.set('validate', function(attribute, value) {
+      this.set('validate', (attribute, value) => {
         isActionValidateHandled[attribute] = true;
         inputValueToValidate[attribute] = value;
       });

--- a/mon-pix/tests/integration/components/form-textfield-test.js
+++ b/mon-pix/tests/integration/components/form-textfield-test.js
@@ -44,7 +44,7 @@ describe('Integration | Component | form textfield', function() {
       { expectedRendering: 'div', item: MESSAGE, expectedLength: 1 },
       { expectedRendering: 'input', item: INPUT, expectedLength: 1 },
 
-    ].forEach(function({ expectedRendering, item, expectedLength }) {
+    ].forEach(({ expectedRendering, item, expectedLength }) => {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
         expect(findAll(item)).to.have.length(expectedLength);
@@ -56,7 +56,7 @@ describe('Integration | Component | form textfield', function() {
       { item: LABEL, expectedRendering: 'label', expectedText: LABEL_TEXT },
       { item: MESSAGE, expectedRendering: 'div.message', expectedText: MESSAGE_TEXT },
 
-    ].forEach(function({ item, expectedRendering, expectedText }) {
+    ].forEach(({ item, expectedRendering, expectedText }) => {
       it(`Should render a ${expectedRendering}`, function() {
         // Then
         expect(find(item).textContent.toUpperCase()).to.contains(expectedText);
@@ -73,7 +73,7 @@ describe('Integration | Component | form textfield', function() {
       let inputValueToValidate;
       const expectedInputValue = 'firstname';
 
-      this.set('validate', function(arg) {
+      this.set('validate', (arg) => {
         isActionValidateHandled = true;
         inputValueToValidate = arg;
       });

--- a/mon-pix/tests/integration/components/qcm-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcm-solution-panel-test.js
@@ -192,7 +192,7 @@ describe('Integration | Component | qcm-solution-panel.js', function() {
 
         // Then
         const size = findAll('.comparison-window .qcm-proposal-label__checkbox-picture').length;
-        times(size, function(index) {
+        times(size, (index) => {
           expect(find('.comparison-window .qcm-proposal-label__checkbox-picture:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
         });
       });

--- a/mon-pix/tests/integration/components/qcu-solution-panel-test.js
+++ b/mon-pix/tests/integration/components/qcu-solution-panel-test.js
@@ -75,7 +75,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`);
 
       // Then
-      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
+      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, (index) => {
         expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
       });
     });
@@ -260,7 +260,7 @@ describe('Integration | Component | qcu-solution-panel.js', function() {
       await render(hbs`<QcuSolutionPanel @answer={{this.answer}} @challenge={{this.challenge}} @solution={{this.solution}} @solutionToDisplay={{this.solutionToDisplay}}/>`);
 
       // Then
-      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, function(index) {
+      times(findAll('.comparison-window .qcu-solution-panel__radio-button').length, (index) => {
         expect(find('.comparison-window .qcu-solution-panel__radio-button:eq(' + index + ')').getAttribute('disabled')).to.equal('disabled');
       });
     });

--- a/mon-pix/tests/integration/components/result-item-campaign-test.js
+++ b/mon-pix/tests/integration/components/result-item-campaign-test.js
@@ -86,7 +86,7 @@ describe('Integration | Component | result-item', function() {
       { status: 'aband', color: 'grey' },
       { status: 'partially', color: 'orange' },
       { status: 'timedout', color: 'red' },
-    ].forEach(function(data) {
+    ].forEach((data) => {
 
       it(`should display a relevant result icon when the result of the answer is "${data.status}"`, async function() {
         // given

--- a/mon-pix/tests/integration/components/routes/register-form-test.js
+++ b/mon-pix/tests/integration/components/routes/register-form-test.js
@@ -152,7 +152,7 @@ describe('Integration | Component | routes/register-form', function() {
 
     [{ stringFilledIn: '' },
       { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -170,7 +170,7 @@ describe('Integration | Component | routes/register-form', function() {
 
     [{ stringFilledIn: '' },
       { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -189,7 +189,7 @@ describe('Integration | Component | routes/register-form', function() {
     [{ stringFilledIn: '' },
       { stringFilledIn: 'a' },
       { stringFilledIn: '32' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on dayOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -208,7 +208,7 @@ describe('Integration | Component | routes/register-form', function() {
     [{ stringFilledIn: '' },
       { stringFilledIn: 'a' },
       { stringFilledIn: '13' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on monthOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -227,7 +227,7 @@ describe('Integration | Component | routes/register-form', function() {
     [{ stringFilledIn: '' },
       { stringFilledIn: 'a' },
       { stringFilledIn: '10000' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on yearOfBirth field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -246,7 +246,7 @@ describe('Integration | Component | routes/register-form', function() {
     [{ stringFilledIn: ' ' },
       { stringFilledIn: 'a' },
       { stringFilledIn: 'shi.fu' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given
@@ -297,7 +297,7 @@ describe('Integration | Component | routes/register-form', function() {
       { stringFilledIn: 'password' },
       { stringFilledIn: 'password1' },
       { stringFilledIn: 'Password' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
 
       it(`should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function() {
         // given

--- a/mon-pix/tests/integration/components/signin-form-test.js
+++ b/mon-pix/tests/integration/components/signin-form-test.js
@@ -164,7 +164,7 @@ describe('Integration | Component | signin form', function() {
       const expectedEmail = 'email@example.fr';
       const expectedPassword = 'azerty';
 
-      this.set('onSubmitAction', function(email, password) {
+      this.set('onSubmitAction', (email, password) => {
         // then
         actualEmail = email;
         actualPassword = password;

--- a/mon-pix/tests/integration/components/signup-form-test.js
+++ b/mon-pix/tests/integration/components/signup-form-test.js
@@ -49,7 +49,7 @@ describe('Integration | Component | SignupForm', function() {
     [
       { locale: 'fr', expectedFormTitle: 'Inscrivez-vous' },
       { locale: 'en', expectedFormTitle: 'Sign up' },
-    ].forEach(function(testCase) {
+    ].forEach((testCase) => {
       it(`${testCase.locale}`, async function() {
         const expectedTitle = testCase.expectedFormTitle;
         this.set('user', userEmpty);
@@ -90,7 +90,7 @@ describe('Integration | Component | SignupForm', function() {
       { expectedRendering: 'cgu checkbox', input: CHECKBOX_CGU_INPUT, expected: 1 },
       { expectedRendering: 'cgu label', input: CHECKBOX_CGU_LABEL, expected: 1 },
       { expectedRendering: 'submit button', input: SUBMIT_BUTTON_CONTAINER, expected: 1 },
-    ].forEach(function({ expectedRendering, input, expected }) {
+    ].forEach(({ expectedRendering, input, expected }) => {
       it(`should render ${expectedRendering}`, function() {
         expect(findAll(input)).to.have.length(expected);
       });

--- a/mon-pix/tests/unit/components/result-item-test.js
+++ b/mon-pix/tests/unit/components/result-item-test.js
@@ -35,7 +35,7 @@ describe('Unit | Component | result-item-component', function() {
       answerWithEmptyResult,
       answerWithUndefinedResult,
       answerWithNullResult,
-    ].forEach(function(answer) {
+    ].forEach((answer) => {
       it(`should returns undefined when answer provided is: ${answer.name}`, function() {
         // when
         component = createGlimmerComponent('component:result-item', { answer });
@@ -119,7 +119,7 @@ describe('Unit | Component | result-item-component', function() {
       { challengeType: 'QROCM-dep', expected: true },
       { challengeType: 'QCU', expected: true },
       { challengeType: 'OtherType', expected: false },
-    ].forEach(function(data) {
+    ].forEach((data) => {
 
       it(`should return ${data.expected} when challenge type is ${data.challengeType}`, function() {
         // given

--- a/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/restricted/join-sco-test.js
@@ -46,7 +46,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         '0',
         '444',
         'ee',
-      ].forEach(function(wrongDayOfBirth) {
+      ].forEach((wrongDayOfBirth) => {
         it(`should display an error when dayOfBirth is ${wrongDayOfBirth}`, async function() {
           // when
           await component.actions.triggerInputDayValidation.call(component, 'dayOfBirth', wrongDayOfBirth);
@@ -63,7 +63,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         '1',
         '01',
         '31',
-      ].forEach(function(validDayOfBirth) {
+      ].forEach((validDayOfBirth) => {
         it(`should not display an error when dayOfBirth is ${validDayOfBirth}`, async function() {
           // when
           await component.actions.triggerInputDayValidation.call(component, 'dayOfBirth', validDayOfBirth);
@@ -86,7 +86,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         '0',
         '444',
         'ee',
-      ].forEach(function(wrongMonthOfBirth) {
+      ].forEach((wrongMonthOfBirth) => {
         it(`should display an error when monthOfBirth is ${wrongMonthOfBirth}`, async function() {
           // when
           await component.actions.triggerInputMonthValidation.call(component, 'monthOfBirth', wrongMonthOfBirth);
@@ -103,7 +103,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         '1',
         '01',
         '12',
-      ].forEach(function(validMonthOfBirth) {
+      ].forEach((validMonthOfBirth) => {
         it(`should not display an error when monthOfBirth is ${validMonthOfBirth}`, async function() {
           // when
           await component.actions.triggerInputMonthValidation.call(component, 'monthOfBirth', validMonthOfBirth);
@@ -130,7 +130,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
         '0011',
         '0111',
         '10000',
-      ].forEach(function(wrongYearOfBirth) {
+      ].forEach((wrongYearOfBirth) => {
         it(`should display an error when yearOfBirth is ${wrongYearOfBirth}`, async function() {
           // when
           await component.actions.triggerInputYearValidation.call(component, 'yearOfBirth', wrongYearOfBirth);
@@ -146,7 +146,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       [
         '1000',
         '9999',
-      ].forEach(function(validYearOfBirth) {
+      ].forEach((validYearOfBirth) => {
         it(`should not display an error when yearOfBirth is ${validYearOfBirth}`, async function() {
           // when
           await component.actions.triggerInputYearValidation.call(component, 'yearOfBirth', validYearOfBirth);
@@ -165,7 +165,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       [
         '',
         ' ',
-      ].forEach(function(wrongString) {
+      ].forEach((wrongString) => {
         it(`should display an error when firstName is "${wrongString}"`, async function() {
           // when
           await component.actions.triggerInputStringValidation.call(component, 'firstName', wrongString);
@@ -189,7 +189,7 @@ describe('Unit | Component | routes/campaigns/restricted/join-sco', function() {
       [
         'Robert',
         'Smith',
-      ].forEach(function(validString) {
+      ].forEach((validString) => {
         it(`should not display an error when firstName is ${validString}`, async function() {
           // when
           await component.actions.triggerInputStringValidation.call(component, 'firstName', validString);

--- a/mon-pix/tests/unit/routes/assessments/challenge-test.js
+++ b/mon-pix/tests/unit/routes/assessments/challenge-test.js
@@ -246,10 +246,10 @@ describe('Unit | Route | Assessments | Challenge', function() {
 
         // when / then
         return route.actions.saveAnswerAndNavigate.call(route, challengeOne, assessment, answerValue, answerTimeout)
-          .then(function() {
+          .then(() => {
             throw new Error('was supposed to fail');
           })
-          .catch(function() {
+          .catch(() => {
             sinon.assert.called(route.actions.error);
             sinon.assert.called(answerToChallengeOne.rollbackAttributes);
           });

--- a/mon-pix/tests/unit/services/url-test.js
+++ b/mon-pix/tests/unit/services/url-test.js
@@ -81,7 +81,7 @@ describe('Unit | Service | locale', function() {
         { language: 'fr', currentDomainExtension: 'org', expectedHomeUrl: 'https://pix.org' },
         { language: 'en', currentDomainExtension: 'fr', expectedHomeUrl: 'https://pix.fr/en-gb' },
         { language: 'en', currentDomainExtension: 'org', expectedHomeUrl: 'https://pix.org/en-gb' },
-      ].forEach(function(testCase) {
+      ].forEach((testCase) => {
         it(`should get "${testCase.expectedHomeUrl}" when current domain="${testCase.currentDomainExtension}" and lang="${testCase.language}"`, function() {
           // given
           const service = this.owner.lookup('service:url');

--- a/mon-pix/tests/unit/utils/email-validator-test.js
+++ b/mon-pix/tests/unit/utils/email-validator-test.js
@@ -14,7 +14,7 @@ describe('Unit | Utility | email validator', function() {
       'INVALID_EMAIL@pix.',
       '@pix.fr',
       '@pix',
-    ].forEach(function(badEmail) {
+    ].forEach((badEmail) => {
       it(`should return false when email is invalid: ${badEmail}`, function() {
         expect(isEmailValid(badEmail)).to.be.false;
       });
@@ -32,7 +32,7 @@ describe('Unit | Utility | email validator', function() {
       'user+beta@pix.fr',
       'user+beta@pix.gouv.fr',
       'user+beta@pix.beta.gouv.fr',
-    ].forEach(function(validEmail) {
+    ].forEach((validEmail) => {
       it(`should return true if provided email is valid: ${validEmail}`, function() {
         expect(isEmailValid(validEmail)).to.be.true;
       });

--- a/mon-pix/tests/unit/utils/labeled-checkboxes-test.js
+++ b/mon-pix/tests/unit/utils/labeled-checkboxes-test.js
@@ -57,7 +57,7 @@ describe('Unit | Utility | labeled checkboxes', function() {
       answers: [false, true],
       output: [],
     }]
-      .forEach(function(testCase) {
+      .forEach((testCase) => {
         it('Should reply to proposals'
           + JSON.stringify(testCase.proposals)
           + ' and answers '

--- a/mon-pix/tests/unit/utils/password-validator-test.js
+++ b/mon-pix/tests/unit/utils/password-validator-test.js
@@ -42,7 +42,7 @@ describe('Unit | Utility | password validator', function() {
       '+!@)-=`"#&1',
       '+!@)-=`"#&1A',
       '+!@)-=`"#&1a',
-    ].forEach(function(badPassword) {
+    ].forEach((badPassword) => {
       it(`should return false when password is invalid: ${badPassword}`, function() {
         expect(isPasswordvalid(badPassword)).to.be.false;
       });
@@ -65,7 +65,7 @@ describe('Unit | Utility | password validator', function() {
       '1234Password avec espace',
       '1A      a1',
       'Aà1      ',
-    ].forEach(function(validPassword) {
+    ].forEach((validPassword) => {
       it(`should return true if provided password is valid: ${validPassword}`, function() {
         expect(isPasswordvalid(validPassword)).to.be.true;
       });

--- a/orga/tests/acceptance/authentication-test.js
+++ b/orga/tests/acceptance/authentication-test.js
@@ -18,12 +18,12 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | authentication', function(hooks) {
+module('Acceptance | authentication', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When user is not logged in', function() {
+  module('When user is not logged in', () => {
 
     test('it should redirect user to login page', async function(assert) {
       // when
@@ -35,7 +35,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When prescriber is already logged in', function(hooks) {
+  module('When prescriber is already logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -59,7 +59,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When prescriber is logging in but has not accepted terms of service yet', function(hooks) {
+  module('When prescriber is logging in but has not accepted terms of service yet', (hooks) => {
 
     let user;
 
@@ -101,7 +101,7 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When user is logging in and has accepted terms of service', function(hooks) {
+  module('When user is logging in and has accepted terms of service', (hooks) => {
     let user;
 
     hooks.beforeEach(() => {
@@ -143,9 +143,9 @@ module('Acceptance | authentication', function(hooks) {
     });
   });
 
-  module('When prescriber is already authenticated', function() {
+  module('When prescriber is already authenticated', () => {
 
-    module('When the organization has not credits and prescriber is ADMIN', function(hooks) {
+    module('When the organization has not credits and prescriber is ADMIN', (hooks) => {
       hooks.beforeEach(async () => {
         const user = createPrescriberForOrganization({ firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' }, { name: 'BRO & Evil Associates' }, 'ADMIN');
 
@@ -166,7 +166,7 @@ module('Acceptance | authentication', function(hooks) {
 
     });
 
-    module('When prescriber has already accepted terms of service', function(hooks) {
+    module('When prescriber has already accepted terms of service', (hooks) => {
 
       hooks.beforeEach(async () => {
         const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -206,7 +206,7 @@ module('Acceptance | authentication', function(hooks) {
       });
     });
 
-    module('When prescriber is admin', function(hooks) {
+    module('When prescriber is admin', (hooks) => {
 
       hooks.beforeEach(async () => {
         const user = createUserMembershipWithRole('ADMIN');
@@ -244,7 +244,7 @@ module('Acceptance | authentication', function(hooks) {
         assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
       });
 
-      module('When the organization has credits and prescriber is ADMIN', function(hooks) {
+      module('When the organization has credits and prescriber is ADMIN', (hooks) => {
         hooks.beforeEach(async () => {
           const user = createPrescriberForOrganization({ firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' }, { name: 'BRO & Evil Associates', credit: 10000 }, 'ADMIN');
 
@@ -265,7 +265,7 @@ module('Acceptance | authentication', function(hooks) {
 
       });
 
-      module('When prescriber belongs to an organization that is managing students', function(hooks) {
+      module('When prescriber belongs to an organization that is managing students', (hooks) => {
 
         hooks.beforeEach(async () => {
           const user = createUserManagingStudents('ADMIN');
@@ -305,7 +305,7 @@ module('Acceptance | authentication', function(hooks) {
           assert.dom('.sidebar-menu a:first-child').hasNoClass('active');
         });
 
-        module('when feature toggle for exporting certification results is enabled', function() {
+        module('when feature toggle for exporting certification results is enabled', () => {
 
           test('should redirect to certifications page', async function(assert) {
             // given
@@ -322,7 +322,7 @@ module('Acceptance | authentication', function(hooks) {
           });
         });
 
-        module('when feature toggle for exporting certification results is not enabled', function() {
+        module('when feature toggle for exporting certification results is not enabled', () => {
 
           test('should not show Certifications menu', async function(assert) {
             // given
@@ -346,7 +346,7 @@ module('Acceptance | authentication', function(hooks) {
       });
     });
 
-    module('When user is member', function(hooks) {
+    module('When user is member', (hooks) => {
 
       hooks.beforeEach(async () => {
         const user = createUserMembershipWithRole('MEMBER');
@@ -370,7 +370,7 @@ module('Acceptance | authentication', function(hooks) {
         assert.dom('.sidebar-menu a:first-child ').hasClass('active');
       });
 
-      module('When the organization has credits and prescriber is MEMBER', function(hooks) {
+      module('When the organization has credits and prescriber is MEMBER', (hooks) => {
         hooks.beforeEach(async () => {
           const user = createPrescriberForOrganization({ firstName: 'Harry', lastName: 'Cover', email: 'harry@cover.com' }, { name: 'BRO & Evil Associates', credit: 10000 }, 'MEMBER');
 
@@ -391,7 +391,7 @@ module('Acceptance | authentication', function(hooks) {
 
       });
 
-      module('When user belongs to an organization that is managing students', function(hooks) {
+      module('When user belongs to an organization that is managing students', (hooks) => {
 
         hooks.beforeEach(async () => {
           const user = createUserManagingStudents('MEMBER');

--- a/orga/tests/acceptance/campaign-analysis-test.js
+++ b/orga/tests/acceptance/campaign-analysis-test.js
@@ -9,7 +9,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Analysis', function(hooks) {
+module('Acceptance | Campaign Analysis', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/campaign-collective-result-test.js
+++ b/orga/tests/acceptance/campaign-collective-result-test.js
@@ -9,7 +9,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Collective Result', function(hooks) {
+module('Acceptance | Campaign Collective Result', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/campaign-creation-test.js
+++ b/orga/tests/acceptance/campaign-creation-test.js
@@ -12,7 +12,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Creation', function(hooks) {
+module('Acceptance | Campaign Creation', (hooks) => {
 
   let availableTargetProfiles;
 
@@ -33,7 +33,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
 
   module('when the prescriber is authenticated', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       createPrescriberByUser(user);
 
@@ -91,7 +91,7 @@ module('Acceptance | Campaign Creation', function(hooks) {
 
   module('when prescriber is authenticated and can collect profiles', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       const user = createUserThatCanCollectProfiles();
       createPrescriberByUser(user);
 

--- a/orga/tests/acceptance/campaign-details-test.js
+++ b/orga/tests/acceptance/campaign-details-test.js
@@ -10,12 +10,12 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Details', function(hooks) {
+module('Acceptance | Campaign Details', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When prescriber is not logged in', function() {
+  module('When prescriber is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // given
@@ -29,7 +29,7 @@ module('Acceptance | Campaign Details', function(hooks) {
     });
   });
 
-  module('When prescriber is logged in', function(hooks) {
+  module('When prescriber is logged in', (hooks) => {
 
     hooks.beforeEach(async () => {
       const user = createUserWithMembershipAndTermsOfServiceAccepted();

--- a/orga/tests/acceptance/campaign-list-test.js
+++ b/orga/tests/acceptance/campaign-list-test.js
@@ -11,12 +11,12 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign List', function(hooks) {
+module('Acceptance | Campaign List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When prescriber is not logged in', function() {
+  module('When prescriber is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated prescriber', async function(assert) {
       // when
@@ -27,7 +27,7 @@ module('Acceptance | Campaign List', function(hooks) {
     });
   });
 
-  module('When prescriber is logged in', function(hooks) {
+  module('When prescriber is logged in', (hooks) => {
 
     let user;
 
@@ -82,7 +82,7 @@ module('Acceptance | Campaign List', function(hooks) {
       assert.equal(currentURL(), '/campagnes/1');
     });
 
-    module('When using creator filter', function(hooks) {
+    module('When using creator filter', (hooks) => {
       let creator;
 
       hooks.beforeEach(async () => {

--- a/orga/tests/acceptance/campaign-participants-individual-analysis-test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-analysis-test.js
@@ -9,7 +9,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Participants Individual Analysis', function(hooks) {
+module('Acceptance | Campaign Participants Individual Analysis', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/campaign-participants-individual-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-individual-results-test.js
@@ -9,7 +9,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Participants Individual Results', function(hooks) {
+module('Acceptance | Campaign Participants Individual Results', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/campaign-participants-results-test.js
+++ b/orga/tests/acceptance/campaign-participants-results-test.js
@@ -10,7 +10,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Participants Results', function(hooks) {
+module('Acceptance | Campaign Participants Results', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -32,7 +32,7 @@ module('Acceptance | Campaign Participants Results', function(hooks) {
     });
   });
 
-  module('When prescriber arrives on participants page', function() {
+  module('When prescriber arrives on participants page', () => {
 
     test('it could click on user to go to details', async function(assert) {
       // when

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -11,7 +11,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Participants', function(hooks) {
+module('Acceptance | Campaign Participants', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -40,7 +40,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
     });
   });
 
-  module('When prescriber arrives on participants page', function() {
+  module('When prescriber arrives on participants page', () => {
 
     test('it should display participant list with default settings for pagination', async function(assert) {
       // when
@@ -78,7 +78,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
     });
   });
 
-  module('When prescriber is already on participants page and changes pagination', function() {
+  module('When prescriber is already on participants page and changes pagination', () => {
 
     test('it should display participant list with updated page size', async function(assert) {
       // given

--- a/orga/tests/acceptance/campaign-profiles-test.js
+++ b/orga/tests/acceptance/campaign-profiles-test.js
@@ -8,7 +8,7 @@ import { createUserWithMembershipAndTermsOfServiceAccepted, createPrescriberByUs
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Profiles', function(hooks) {
+module('Acceptance | Campaign Profiles', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -31,7 +31,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
     server.createList('campaign-profiles-collection-participation-summary', rowCount);
   });
 
-  module('When user arrives on profiles page', function() {
+  module('When user arrives on profiles page', () => {
 
     test('it should display profile list with default settings for pagination', async function(assert) {
       // when
@@ -58,7 +58,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
     });
   });
 
-  module('When user is already on profiles page and changes pagination', function() {
+  module('When user is already on profiles page and changes pagination', () => {
 
     test('it should display profile list with updated page size', async function(assert) {
       // given

--- a/orga/tests/acceptance/campaign-update-test.js
+++ b/orga/tests/acceptance/campaign-update-test.js
@@ -11,7 +11,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Update', function(hooks) {
+module('Acceptance | Campaign Update', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/certifications-test.js
+++ b/orga/tests/acceptance/certifications-test.js
@@ -5,7 +5,7 @@ import { authenticateSession } from 'ember-simple-auth/test-support';
 import { createUserManagingStudents, createPrescriberByUser } from '../helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Certifications page', function(hooks) {
+module('Acceptance | Certifications page', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -22,12 +22,12 @@ module('Acceptance | Certifications page', function(hooks) {
     });
   });
 
-  module('When feature toggle for exporting certification results is enabled', function() {
+  module('When feature toggle for exporting certification results is enabled', () => {
     hooks.beforeEach(async () => {
       server.create('feature-toggle', { id: 0, isCertificationResultsInOrgaEnabled: true });
     });
 
-    module('When user arrives on certifications page', function() {
+    module('When user arrives on certifications page', () => {
 
       test('should show Certifications page', async function(assert) {
         // given / when

--- a/orga/tests/acceptance/dissociate-student-test.js
+++ b/orga/tests/acceptance/dissociate-student-test.js
@@ -25,18 +25,18 @@ async function createAuthenticatedSession() {
 }
 
 const DASH_CHARACTER = '\u2013';
-module('Acceptance | Student List', function(hooks) {
+module('Acceptance | Student List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let user;
   let organizationId;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     user = await createAuthenticatedSession();
   });
 
-  module('when the student is dissociated from the user', function() {
+  module('when the student is dissociated from the user', () => {
 
     test('it does not display the action button', async function(assert) {
       organizationId = user.memberships.models.firstObject.organizationId;

--- a/orga/tests/acceptance/information-banner-test.js
+++ b/orga/tests/acceptance/information-banner-test.js
@@ -5,12 +5,12 @@ import { setupApplicationTest } from 'ember-qunit';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Information Banner', function(hooks) {
+module('Acceptance | Information Banner', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('ImportStudents banner', function() {
+  module('ImportStudents banner', () => {
 
     test('should redirect to /eleves when clicking on banner button', async function(assert) {
       // given

--- a/orga/tests/acceptance/join-request-test.js
+++ b/orga/tests/acceptance/join-request-test.js
@@ -7,16 +7,16 @@ import Response from 'ember-cli-mirage/response';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | join-request', function(hooks) {
+module('Acceptance | join-request', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     await visit('/demande-administration-sco');
   });
 
-  module('When user submits the join request form', function() {
+  module('When user submits the join request form', () => {
 
     test('it should fail if the uai does not belong to any organization', async function(assert) {
       // given

--- a/orga/tests/acceptance/join-test.js
+++ b/orga/tests/acceptance/join-test.js
@@ -14,13 +14,13 @@ import {
 } from '../helpers/test-init';
 import setupIntl from '../helpers/setup-intl';
 
-module('Acceptance | join', function(hooks) {
+module('Acceptance | join', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
   setupIntl(hooks);
 
-  module('When prescriber tries to go on join page', function() {
+  module('When prescriber tries to go on join page', () => {
 
     test('it should remain on join page when organization-invitation exists', async function(assert) {
       // given
@@ -67,9 +67,9 @@ module('Acceptance | join', function(hooks) {
     });
   });
 
-  module('Login', function() {
+  module('Login', () => {
 
-    module('When prescriber is logging in but has not accepted terms of service yet', function(hooks) {
+    module('When prescriber is logging in but has not accepted terms of service yet', (hooks) => {
 
       let user;
       let organizationInvitationId;
@@ -123,7 +123,7 @@ module('Acceptance | join', function(hooks) {
       });
     });
 
-    module('When prescriber is logging in and has accepted terms of service', function(hooks) {
+    module('When prescriber is logging in and has accepted terms of service', (hooks) => {
       let user;
       let organizationInvitationId;
       let code;
@@ -177,7 +177,7 @@ module('Acceptance | join', function(hooks) {
       });
     });
 
-    module('When prescriber is logging in but his credentials are invalid', function(hooks) {
+    module('When prescriber is logging in but his credentials are invalid', (hooks) => {
 
       let user;
       let organizationInvitationId;
@@ -215,7 +215,7 @@ module('Acceptance | join', function(hooks) {
       });
     });
 
-    module('When prescriber has already accepted organization-invitation or prescriber is already a member of the organization', function(hooks) {
+    module('When prescriber has already accepted organization-invitation or prescriber is already a member of the organization', (hooks) => {
 
       let user;
       let organizationInvitationId;
@@ -256,11 +256,11 @@ module('Acceptance | join', function(hooks) {
     });
   });
 
-  module('Register', function() {
+  module('Register', () => {
 
-    module('When prescriber is registering', function() {
+    module('When prescriber is registering', () => {
 
-      module('When a pending organization-invitation already exists', function(hooks) {
+      module('When a pending organization-invitation already exists', (hooks) => {
 
         let organizationId;
 
@@ -293,7 +293,7 @@ module('Acceptance | join', function(hooks) {
         });
       });
 
-      module('When prescriber already exist', function(hooks) {
+      module('When prescriber already exist', (hooks) => {
 
         let organizationId;
 

--- a/orga/tests/acceptance/profile-test.js
+++ b/orga/tests/acceptance/profile-test.js
@@ -10,7 +10,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Campaign Profile', function(hooks) {
+module('Acceptance | Campaign Profile', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/orga/tests/acceptance/remove-membership-test.js
+++ b/orga/tests/acceptance/remove-membership-test.js
@@ -24,13 +24,13 @@ async function createAuthenticatedSession() {
   return user;
 }
 
-module('Acceptance | Remove membership', function(hooks) {
+module('Acceptance | Remove membership', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
   let user;
 
-  hooks.beforeEach(async function() {
+  hooks.beforeEach(async () => {
     const adminUser = await createAuthenticatedSession();
     const organizationId = adminUser.memberships.models.firstObject.organizationId;
 

--- a/orga/tests/acceptance/sco-student-list-test.js
+++ b/orga/tests/acceptance/sco-student-list-test.js
@@ -13,14 +13,14 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Sco Student List', function(hooks) {
+module('Acceptance | Sco Student List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let organizationId;
 
-  module('When prescriber is not logged in', function() {
+  module('When prescriber is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated prescriber', async function(assert) {
       // when
@@ -31,7 +31,7 @@ module('Acceptance | Sco Student List', function(hooks) {
     });
   });
 
-  module('When prescriber is logged in', function(hooks) {
+  module('When prescriber is logged in', (hooks) => {
 
     let user;
 
@@ -40,9 +40,9 @@ module('Acceptance | Sco Student List', function(hooks) {
       notificationMessagesService.clearAll();
     });
 
-    module('When organization is not managing students or is not SCO', function(hooks) {
+    module('When organization is not managing students or is not SCO', (hooks) => {
 
-      hooks.beforeEach(async function() {
+      hooks.beforeEach(async () => {
         user = createUserWithMembershipAndTermsOfServiceAccepted();
         createPrescriberByUser(user);
 
@@ -63,9 +63,9 @@ module('Acceptance | Sco Student List', function(hooks) {
       });
     });
 
-    module('When prescriber is looking for students', function(hooks) {
+    module('When prescriber is looking for students', (hooks) => {
 
-      hooks.beforeEach(async function() {
+      hooks.beforeEach(async () => {
         user = createUserManagingStudents();
         createPrescriberByUser(user);
 
@@ -124,9 +124,9 @@ module('Acceptance | Sco Student List', function(hooks) {
       });
     });
 
-    module('When organization is managing students', function(hooks) {
+    module('When organization is managing students', (hooks) => {
 
-      hooks.beforeEach(async function() {
+      hooks.beforeEach(async () => {
         user = createUserManagingStudents();
         createPrescriberByUser(user);
 
@@ -150,12 +150,12 @@ module('Acceptance | Sco Student List', function(hooks) {
         assert.equal(currentURL(), '/eleves');
       });
 
-      module('when student authenticated by username and email', async function(hooks) {
+      module('when student authenticated by username and email', async (hooks) => {
 
         const username = 'firstname.lastname0112';
         const email = 'firstname.lastname0112@example.net';
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           server.create('student', {
             organizationId,
             firstName: 'FirstName',
@@ -205,9 +205,9 @@ module('Acceptance | Sco Student List', function(hooks) {
         });
       });
 
-      module('when student authenticated by GAR', async function(hooks) {
+      module('when student authenticated by GAR', async (hooks) => {
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           server.create('student', {
             organizationId,
             isAuthenticatedFromGar: true,
@@ -245,9 +245,9 @@ module('Acceptance | Sco Student List', function(hooks) {
         });
       });
 
-      module('when student authenticated by GAR and username', async function(hooks) {
+      module('when student authenticated by GAR and username', async (hooks) => {
 
-        hooks.beforeEach(function() {
+        hooks.beforeEach(() => {
           server.create('student', {
             organizationId,
             isAuthenticatedFromGar: true,
@@ -297,9 +297,9 @@ module('Acceptance | Sco Student List', function(hooks) {
       });
     });
 
-    module('When admin uploads a file', function(hooks) {
+    module('When admin uploads a file', (hooks) => {
 
-      hooks.beforeEach(async function() {
+      hooks.beforeEach(async () => {
         user = createUserManagingStudents('ADMIN');
         createPrescriberByUser(user);
 

--- a/orga/tests/acceptance/sup-student-list-test.js
+++ b/orga/tests/acceptance/sup-student-list-test.js
@@ -11,7 +11,7 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Sup Student List', function(hooks) {
+module('Acceptance | Sup Student List', (hooks) => {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -22,8 +22,8 @@ module('Acceptance | Sup Student List', function(hooks) {
     notificationMessagesService.clearAll();
   });
 
-  module('When admin', function(hooks) {
-    hooks.beforeEach(async function() {
+  module('When admin', (hooks) => {
+    hooks.beforeEach(async () => {
       user = createUserManagingStudents('ADMIN', 'SUP');
       createPrescriberByUser(user);
 
@@ -35,7 +35,7 @@ module('Acceptance | Sup Student List', function(hooks) {
       });
     });
 
-    module('And uploads a file', function() {
+    module('And uploads a file', () => {
       test('it should display success message and reload students', async function(assert) {
         // given
         await visit('/etudiants');
@@ -68,7 +68,7 @@ module('Acceptance | Sup Student List', function(hooks) {
       });
     });
 
-    module('And edit the student number', function(hooks) {
+    module('And edit the student number', (hooks) => {
       hooks.beforeEach(() => {
         const { organizationId } = user.memberships.models.firstObject;
         server.create('student', {

--- a/orga/tests/acceptance/switch-organization-test.js
+++ b/orga/tests/acceptance/switch-organization-test.js
@@ -11,14 +11,14 @@ import {
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Switch Organization', function(hooks) {
+module('Acceptance | Switch Organization', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  module('When connected prescriber is linked to only one organization', function(hooks) {
+  module('When connected prescriber is linked to only one organization', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       const user = createUserWithMembershipAndTermsOfServiceAccepted();
       createPrescriberByUser(user);
 
@@ -50,9 +50,9 @@ module('Acceptance | Switch Organization', function(hooks) {
     });
   });
 
-  module('When connected prescriber is linked to multiples organizations', function(hooks) {
+  module('When connected prescriber is linked to multiples organizations', (hooks) => {
 
-    hooks.beforeEach(async function() {
+    hooks.beforeEach(async () => {
       const user = createUserWithMultipleMemberships();
       createPrescriberByUser(user);
 
@@ -76,7 +76,7 @@ module('Acceptance | Switch Organization', function(hooks) {
       assert.dom('.logged-user-menu-item__organization-externalId').hasText('(HEAVEN)');
     });
 
-    module('When prescriber click on an organization', function() {
+    module('When prescriber click on an organization', () => {
 
       test('should change main organization in summary', async function(assert) {
         // when
@@ -99,7 +99,7 @@ module('Acceptance | Switch Organization', function(hooks) {
         assert.dom('.logged-user-menu-item__organization-externalId').hasText('(EXTBRO)');
       });
 
-      module('When prescriber is on campaign page with pagination', function() {
+      module('When prescriber is on campaign page with pagination', () => {
 
         test('it should reset the queryParams when redirecting', async function(assert) {
           // given
@@ -114,7 +114,7 @@ module('Acceptance | Switch Organization', function(hooks) {
         });
       });
 
-      module('When user switch from a not managing student organization to a managing student organization', function() {
+      module('When user switch from a not managing student organization to a managing student organization', () => {
 
         test('it should display student menu item', async function(assert) {
           // when

--- a/orga/tests/acceptance/team-creation-test.js
+++ b/orga/tests/acceptance/team-creation-test.js
@@ -13,7 +13,7 @@ import setupIntl from '../helpers/setup-intl';
 
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
-module('Acceptance | Team Creation', function(hooks) {
+module('Acceptance | Team Creation', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -29,7 +29,7 @@ module('Acceptance | Team Creation', function(hooks) {
     assert.equal(currentURL(), '/connexion');
   });
 
-  module('When prescriber is logged in', function(hooks) {
+  module('When prescriber is logged in', (hooks) => {
 
     let organizationId;
     let user;
@@ -39,7 +39,7 @@ module('Acceptance | Team Creation', function(hooks) {
       notificationMessagesService.clearAll();
     });
 
-    module('When prescriber is a member', function(hooks) {
+    module('When prescriber is a member', (hooks) => {
 
       hooks.beforeEach(async () => {
         user = createUserMembershipWithRole('MEMBER');
@@ -62,7 +62,7 @@ module('Acceptance | Team Creation', function(hooks) {
       });
     });
 
-    module('When prescriber is an admin', function(hooks) {
+    module('When prescriber is an admin', (hooks) => {
 
       let inputLabel;
       let cancelButton;

--- a/orga/tests/acceptance/team-list-test.js
+++ b/orga/tests/acceptance/team-list-test.js
@@ -12,14 +12,14 @@ import {
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import times from 'lodash/times';
 
-module('Acceptance | Team List', function(hooks) {
+module('Acceptance | Team List', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   let user;
 
-  module('When prescriber is not logged in', function() {
+  module('When prescriber is not logged in', () => {
 
     test('it should not be accessible by an unauthenticated user', async function(assert) {
       // when
@@ -30,9 +30,9 @@ module('Acceptance | Team List', function(hooks) {
     });
   });
 
-  module('When prescriber is logged in', function() {
+  module('When prescriber is logged in', () => {
 
-    module('When prescriber is a member', function(hooks) {
+    module('When prescriber is a member', (hooks) => {
 
       hooks.beforeEach(async () => {
         user = createUserMembershipWithRole('MEMBER');
@@ -55,7 +55,7 @@ module('Acceptance | Team List', function(hooks) {
       });
     });
 
-    module('When prescriber is an admin', function(hooks) {
+    module('When prescriber is an admin', (hooks) => {
 
       hooks.beforeEach(async () => {
         user = createUserMembershipWithRole('ADMIN');
@@ -87,7 +87,7 @@ module('Acceptance | Team List', function(hooks) {
     });
   });
 
-  module('When the prescriber comes back to this route', function(hooks) {
+  module('When the prescriber comes back to this route', (hooks) => {
 
     hooks.beforeEach(async () => {
       user = createUserMembershipWithRole('ADMIN');

--- a/orga/tests/acceptance/terms-of-service-test.js
+++ b/orga/tests/acceptance/terms-of-service-test.js
@@ -10,7 +10,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 import { createPrescriberWithPixOrgaTermsOfService } from '../helpers/test-init';
 
-module('Acceptance | terms-of-service', function(hooks) {
+module('Acceptance | terms-of-service', (hooks) => {
 
   setupApplicationTest(hooks);
   setupMirage(hooks);
@@ -26,7 +26,7 @@ module('Acceptance | terms-of-service', function(hooks) {
     assert.notOk(currentSession(this.application).get('isAuthenticated'), 'The user is still unauthenticated');
   });
 
-  module('When prescriber has not accepted terms of service yet', function(hooks) {
+  module('When prescriber has not accepted terms of service yet', (hooks) => {
 
     hooks.beforeEach(async () => {
       prescriber = createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServiceAccepted: false });
@@ -62,7 +62,7 @@ module('Acceptance | terms-of-service', function(hooks) {
     });
   });
 
-  module('When prescriber has already accepted terms of service', function(hooks) {
+  module('When prescriber has already accepted terms of service', (hooks) => {
 
     hooks.beforeEach(async () => {
       prescriber = createPrescriberWithPixOrgaTermsOfService({ pixOrgaTermsOfServiceAccepted: true });

--- a/orga/tests/integration/components/chevron_test.js
+++ b/orga/tests/integration/components/chevron_test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | chevron', function(hooks) {
+module('Integration | Component | chevron', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/orga/tests/integration/components/circle-chart-test.js
+++ b/orga/tests/integration/components/circle-chart-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | circle-chart', function(hooks) {
+module('Integration | Component | circle-chart', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', () => {
 
     test('should render component', async function(assert) {
       // when

--- a/orga/tests/integration/components/current-organization-test.js
+++ b/orga/tests/integration/components/current-organization-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | current-organization', function(hooks) {
+module('Integration | Component | current-organization', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it displays the name of the given organization', async function(assert) {

--- a/orga/tests/integration/components/dissociate-user-modal-test.js
+++ b/orga/tests/integration/components/dissociate-user-modal-test.js
@@ -5,7 +5,7 @@ import { render } from '@ember/test-helpers';
 import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | dissociate-user-modal', function(hooks) {
+module('Integration | Component | dissociate-user-modal', (hooks) => {
 
   setupRenderingTest(hooks);
 
@@ -17,7 +17,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     return render(hbs`<DissociateUserModal @refreshModel={{refreshModel}} @display={{display}} @close={{close}} @student={{student}}/>`);
   });
 
-  module('when the user is authenticated with an email', function() {
+  module('when the user is authenticated with an email', () => {
 
     test('it displays a message for user authentified by email', async function(assert) {
       this.set('student', { hasEmail: true, email: 'rocky.balboa@example.net', firstName: 'Rocky', lastName: 'Balboa' });
@@ -26,7 +26,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     });
   });
 
-  module('when the user is authenticated with an username', function() {
+  module('when the user is authenticated with an username', () => {
 
     test('it displays a message for user authentified by username', async function(assert) {
       this.set('student', { hasUsername: true, username: 'appolo.creed', firstName: 'Appolo', lastName: 'Creed' });
@@ -35,7 +35,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     });
   });
 
-  module('when the user is authenticated with GAR', function() {
+  module('when the user is authenticated with GAR', () => {
 
     test('it displays a message for user authentified with GAR', async function(assert) {
       this.set('student', { hasEmail: false, hasUsername: false, firstName: 'Ivan', lastName: 'Drago' });
@@ -44,7 +44,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
     });
   });
 
-  module('dissociate button', function() {
+  module('dissociate button', () => {
     let studentAdapter;
     let notifications;
 
@@ -57,7 +57,7 @@ module('Integration | Component | dissociate-user-modal', function(hooks) {
       sinon.stub(notifications, 'sendError');
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       studentAdapter.dissociateUser.restore();
     });
 

--- a/orga/tests/integration/components/dropdown/icon-trigger-test.js
+++ b/orga/tests/integration/components/dropdown/icon-trigger-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | Dropdown | icon-trigger', function(hooks) {
+module('Integration | Component | Dropdown | icon-trigger', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 

--- a/orga/tests/integration/components/edit-student-number-modal-test.js
+++ b/orga/tests/integration/components/edit-student-number-modal-test.js
@@ -7,7 +7,7 @@ import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-lab
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | edit-student-number-modal', function(hooks) {
+module('Integration | Component | edit-student-number-modal', (hooks) => {
   setupIntlRenderingTest(hooks);
   let closeStub;
   let notificationsStub;
@@ -36,15 +36,15 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
     return render(hbs`<EditStudentNumberModal @display={{display}} @closeModal={{close}} @student={{this.student}} @onSaveStudentNumber={{onSaveStudentNumber}}/>`);
   });
 
-  module('when the edit student number modal is open', function() {
+  module('when the edit student number modal is open', () => {
 
-    module('when there is student number', function() {
+    module('when there is student number', () => {
       test('should render component with student number text', async function(assert) {
         assert.contains(`Numéro étudiant actuel de ${this.student.firstName} ${this.student.lastName} est : ${this.student.studentNumber}`);
       });
     });
 
-    module('when there is no student number yet', function() {
+    module('when there is no student number yet', () => {
       test('should not render component with student number text', async function(assert) {
         this.student.set('studentNumber', null);
         render(hbs`<EditStudentNumberModal @display={{display}} @closeModal={{close}} @student={{this.student}} @onSaveStudentNumber={{onSaveStudentNumber}}/>`);
@@ -61,7 +61,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       assert.contains('Mettre à jour');
     });
 
-    module('When a student number is entered', function() {
+    module('When a student number is entered', () => {
 
       test('should have the update button enable', async function(assert) {
         // when
@@ -73,7 +73,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when a student number is not entered yet', function() {
+    module('when a student number is not entered yet', () => {
 
       test('should have the update button disable', async function(assert) {
         // when
@@ -86,7 +86,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the update button is clicked and a good student number is entered', function() {
+    module('when the update button is clicked and a good student number is entered', () => {
       test('it display success notification', async function(assert) {
         // given
         onSaveStudentNumberStub.withArgs(123456).resolves();
@@ -102,7 +102,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the update button is clicked and a wrong student number is entered', function() {
+    module('when the update button is clicked and a wrong student number is entered', () => {
       test('it display error message', async function(assert) {
         // when
         await fillInByLabel('Nouveau numéro étudiant', ' ');
@@ -113,7 +113,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the update button is clicked with the student number and this student number already exist', function() {
+    module('when the update button is clicked with the student number and this student number already exist', () => {
       test('it display an error under student number input', async function(assert) {
         // given
         const error = {
@@ -133,7 +133,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the update button is clicked with the student number and this student number already exist', function() {
+    module('when the update button is clicked with the student number and this student number already exist', () => {
       test('it remove errors when submitting is a success', async function(assert) {
         // given
         const error = {
@@ -155,7 +155,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the close button is clicked', function() {
+    module('when the close button is clicked', () => {
       test('it remove errors and student number value', async function(assert) {
         // given
         const error = {
@@ -176,7 +176,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
       });
     });
 
-    module('when the cancel button is clicked', function() {
+    module('when the cancel button is clicked', () => {
       test('it remove errors and student number value too', async function(assert) {
         // given
         const error = {
@@ -198,7 +198,7 @@ module('Integration | Component | edit-student-number-modal', function(hooks) {
     });
   });
 
-  module('when the edit student number modal is not open', function() {
+  module('when the edit student number modal is not open', () => {
     test('should not render component', async function(assert) {
       // given
       this.set('display', false);

--- a/orga/tests/integration/components/information-banner-test.js
+++ b/orga/tests/integration/components/information-banner-test.js
@@ -4,12 +4,12 @@ import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
-module('Integration | Component | information-banner', function(hooks) {
+module('Integration | Component | information-banner', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   module('Import Banner', () => {
-    module('when prescriber’s organization is of type SCO that manages students', function() {
-      module('when prescriber has not imported student yet', function() {
+    module('when prescriber’s organization is of type SCO that manages students', () => {
+      module('when prescriber has not imported student yet', () => {
         class CurrentUserStub extends Service {
           prescriber = { areNewYearSchoolingRegistrationsImported: false }
           isSCOManagingStudents = true;
@@ -29,7 +29,7 @@ module('Integration | Component | information-banner', function(hooks) {
         });
       });
 
-      module('when prescriber has already imported students', function() {
+      module('when prescriber has already imported students', () => {
         test('should not render the banner', async function(assert) {
           // given
           class CurrentUserStub extends Service {
@@ -47,7 +47,7 @@ module('Integration | Component | information-banner', function(hooks) {
       });
     });
 
-    module('when prescriber’s organization is not of type SCO that manages students', function() {
+    module('when prescriber’s organization is not of type SCO that manages students', () => {
 
       test('should not render the banner regardless of whether students have been imported or not', async function(assert) {
         // given
@@ -68,7 +68,7 @@ module('Integration | Component | information-banner', function(hooks) {
   });
 
   module('Campaign Banner', () => {
-    module('when prescriber’s organization is of type SCO that manages students', function() {
+    module('when prescriber’s organization is of type SCO that manages students', () => {
       test('should render the campaign banner for non agriculture', async function(assert) {
         // given
         class CurrentUserStub extends Service {
@@ -102,7 +102,7 @@ module('Integration | Component | information-banner', function(hooks) {
       });
     });
 
-    module('when prescriber’s organization is not of type SCO that manages students', function() {
+    module('when prescriber’s organization is not of type SCO that manages students', () => {
       test('should not display the campaign banner', async function(assert) {
         // given
         class CurrentUserStub extends Service {

--- a/orga/tests/integration/components/manage-authentication-method-modal-test.js
+++ b/orga/tests/integration/components/manage-authentication-method-modal-test.js
@@ -9,11 +9,11 @@ import EmberObject from '@ember/object';
 import { triggerCopySuccess } from 'ember-cli-clipboard/test-support';
 import faker from 'faker';
 
-module('Integration | Component | manage-authentication-method-modal', function(hooks) {
+module('Integration | Component | manage-authentication-method-modal', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 
-  module('When Student is not connected with GAR method', function(hooks) {
+  module('When Student is not connected with GAR method', (hooks) => {
 
     const username = 'john.doe0112';
     const email = 'john.doe0112@example.net';
@@ -46,7 +46,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
       this.display = true;
     });
 
-    module('When Student is connected with username method', function() {
+    module('When Student is connected with username method', () => {
 
       test('should render component with username field', async function(assert) {
         // when
@@ -78,7 +78,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
       });
     });
 
-    module('When Student is connected with email and username method', function() {
+    module('When Student is connected with email and username method', () => {
 
       test('should render component with email field', async function(assert) {
         // when
@@ -109,7 +109,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
       });
     });
 
-    module('When Student is connected with email only', function() {
+    module('When Student is connected with email only', () => {
 
       test('should render add username authentication method', async function(assert) {
         // when
@@ -122,7 +122,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
       });
     });
 
-    module('When password is generated', function() {
+    module('When password is generated', () => {
 
       let generatedPassword;
 
@@ -194,7 +194,7 @@ module('Integration | Component | manage-authentication-method-modal', function(
     });
   });
 
-  module('When Student is connected with GAR method', function() {
+  module('When Student is connected with GAR method', () => {
 
     hooks.beforeEach(function() {
       this.studentGAR = EmberObject.create({

--- a/orga/tests/integration/components/modal/dialog-test.js
+++ b/orga/tests/integration/components/modal/dialog-test.js
@@ -5,10 +5,10 @@ import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | modal', function(hooks) {
+module('Integration | Component | modal', (hooks) => {
   setupIntlRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', () => {
     let close;
 
     hooks.beforeEach(function() {

--- a/orga/tests/integration/components/organization-credit-info-test.js
+++ b/orga/tests/integration/components/organization-credit-info-test.js
@@ -11,7 +11,7 @@ class CurrentUserStub extends Service {
   };
 }
 
-module('Integration | Component | organization-credit-info', function(hooks) {
+module('Integration | Component | organization-credit-info', (hooks) => {
   setupIntlRenderingTest(hooks);
   let currentUserStub;
 

--- a/orga/tests/integration/components/pagination-control-test.js
+++ b/orga/tests/integration/components/pagination-control-test.js
@@ -17,7 +17,7 @@ function getMetaForPage({ pageNumber, rowCount = 50 }) {
   };
 }
 
-module('Integration | Component | pagination-control', function(hooks) {
+module('Integration | Component | pagination-control', (hooks) => {
   setupIntlRenderingTest(hooks);
   let replaceWithStub;
 
@@ -120,7 +120,7 @@ module('Integration | Component | pagination-control', function(hooks) {
     assert.ok(replaceWithStub.calledWith({ queryParams: { pageSize: '10', pageNumber: 1 } }));
   });
 
-  module('When no results', function() {
+  module('When no results', () => {
     test('it should disable previous button and next button', async function(assert) {
       // given
       this.set('meta', getMetaForPage({ pageNumber: 1, rowCount: 0 }));

--- a/orga/tests/integration/components/pix-loader-test.js
+++ b/orga/tests/integration/components/pix-loader-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | pix-loader', function(hooks) {
+module('Integration | Component | pix-loader', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', () => {
 
     test('should render component', async function(assert) {
       // when

--- a/orga/tests/integration/components/previous-page-button_test.js
+++ b/orga/tests/integration/components/previous-page-button_test.js
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import Service from '@ember/service';
 import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 
-module('Integration | Component | previous-page-button', function(hooks) {
+module('Integration | Component | previous-page-button', (hooks) => {
   setupRenderingTest(hooks);
   let transitionToStub;
 
@@ -35,7 +35,7 @@ module('Integration | Component | previous-page-button', function(hooks) {
     assert.contains('Coucou');
   });
 
-  module('when clicked on', function() {
+  module('when clicked on', () => {
     test('it should transition to specified route with provided routeId param if any', async function(assert) {
       // given
       this.route = 'someRoute';

--- a/orga/tests/integration/components/progress-bar-test.js
+++ b/orga/tests/integration/components/progress-bar-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | progress-bar', function(hooks) {
+module('Integration | Component | progress-bar', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', () => {
     test('should render the component with the given value', async function(assert) {
       // given
       this.set('value', 80);

--- a/orga/tests/integration/components/progression-gauge-test.js
+++ b/orga/tests/integration/components/progression-gauge-test.js
@@ -3,10 +3,10 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | progression-gauge', function(hooks) {
+module('Integration | Component | progression-gauge', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('Component rendering', function() {
+  module('Component rendering', () => {
 
     test('should render component', async function(assert) {
       // when

--- a/orga/tests/integration/components/recommendation-indicator-test.js
+++ b/orga/tests/integration/components/recommendation-indicator-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | recommendation-indicator', function(hooks) {
+module('Integration | Component | recommendation-indicator', (hooks) => {
   setupRenderingTest(hooks);
 
   test('should display recommendation indicator with a level of 4 for value 0', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tab-test.js
@@ -3,7 +3,7 @@ import { click, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/campaign/analysis/tab', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/analysis/tab', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -35,8 +35,8 @@ module('Integration | Component | routes/authenticated/campaign/analysis/tab', f
     this.set('campaignTubeRecommendations', [campaignTubeRecommendation_1, campaignTubeRecommendation_2]);
   });
 
-  module('when analysis is displayed', async function(hooks) {
-    hooks.beforeEach(async function() {
+  module('when analysis is displayed', async (hooks) => {
+    hooks.beforeEach(async () => {
       await render(hbs`<Routes::Authenticated::Campaign::Analysis::Tab
         @campaignTubeRecommendations={{campaignTubeRecommendations}}
         @displayAnalysis={{true}}

--- a/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/analysis/tube-recommendation-row-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/analysis/tube-recommendation-row', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/analysis/tube-recommendation-row', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/details-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/assessment/details', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/assessment/details', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -80,8 +80,8 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
     assert.dom(`a[href="/campagnes/${campaign.id}/evaluations/${campaignAssessmentParticipation.id}/analyse"]`).hasText('Analyse');
   });
 
-  module('is shared', function() {
-    module('when participant has shared results', function() {
+  module('is shared', () => {
+    module('when participant has shared results', () => {
       test('it displays the sharing date', async function(assert) {
         const campaignAssessmentParticipation = {
           isShared: true,
@@ -100,7 +100,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
       });
     });
 
-    module('when participant has not shared results', function() {
+    module('when participant has not shared results', () => {
       test('it does not displays the sharing date', async function(assert) {
         const campaignAssessmentParticipation = {
           isShared: false,
@@ -118,8 +118,8 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
     });
   });
 
-  module('identifiant', function() {
-    module('when the external id is present', function() {
+  module('identifiant', () => {
+    module('when the external id is present', () => {
       test('it displays the external id', async function(assert) {
         const campaignAssessmentParticipation = {
           participantExternalId: 'i12345',
@@ -137,7 +137,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         assert.contains('i12345');
       });
     });
-    module('when the external id is not present', function() {
+    module('when the external id is not present', () => {
       test('it does not display the external id', async function(assert) {
         const campaignAssessmentParticipation = {
           participantExternalId: null,
@@ -156,8 +156,8 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
     });
   });
 
-  module('results information', function() {
-    module('when the participation is shared', function() {
+  module('results information', () => {
+    module('when the participation is shared', () => {
       test('it should not display campaign progression', async function(assert) {
         const campaignAssessmentParticipation = {
           progression: 100,
@@ -192,7 +192,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         assert.dom('[aria-label="Résultat"]').containsText('45 / 50 ACQUIS');
       });
 
-      module('when the campaign has stages', function() {
+      module('when the campaign has stages', () => {
         test('it displays stages acquired', async function(assert) {
           const campaign = {
             hasStages: true,
@@ -212,7 +212,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         });
       });
 
-      module('when the campaign has no stages', function() {
+      module('when the campaign has no stages', () => {
         test('it displays campaign participation mastery percentage', async function(assert) {
           const campaignAssessmentParticipation = {
             masteryPercentage: 65,
@@ -230,7 +230,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         });
       });
 
-      module('when the campaign has badges', function() {
+      module('when the campaign has badges', () => {
         test('it displays badges acquired', async function(assert) {
           const campaign = { hasBadges: true };
           const campaignAssessmentParticipation = { isShared: true, badges: [{ id: 1, title: 'Les bases' }] };
@@ -244,7 +244,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         });
       });
 
-      module('when the campaign has not badges', function() {
+      module('when the campaign has not badges', () => {
         test('it does not display badges acquired', async function(assert) {
           const campaign = { hasBadges: false };
           const campaignAssessmentParticipation = { isShared: true, badges: [{ id: 1, title: 'Les bases' }] };
@@ -258,7 +258,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
         });
       });
 
-      module('when the campaign has badges but the participant has not acquired one', function() {
+      module('when the campaign has badges but the participant has not acquired one', () => {
         test('it does not display badges', async function(assert) {
           const campaign = { hasBadges: true };
           const campaignAssessmentParticipation = { isShared: true, badges: [] };
@@ -273,7 +273,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/detai
       });
     });
 
-    module('when the participation is not shared', function() {
+    module('when the participation is not shared', () => {
       test('it does not display results', async function(assert) {
         const campaignAssessmentParticipation = {
           isShared: false,

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/list-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/assessment/list', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/assessment/list', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -14,7 +14,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     store = this.owner.lookup('service:store');
   });
 
-  module('when a participant has shared his results', function() {
+  module('when a participant has shared his results', () => {
     test('it should display the participant\'s results', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -71,7 +71,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when a participant has not shared his results yet', function() {
+  module('when a participant has not shared his results yet', () => {
     test('it should display that participant\'s results are pending', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -127,7 +127,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when a participant has not finished the assessment', function() {
+  module('when a participant has not finished the assessment', () => {
     test('it should display that participant\'s results are still ongoing', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -161,7 +161,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when the campaign asked for an external id', function() {
+  module('when the campaign asked for an external id', () => {
     test('it should display participant\'s results with external id', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -186,7 +186,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when nobody started the campaign yet', function() {
+  module('when nobody started the campaign yet', () => {
     test('it should display "waiting for participants"', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -209,7 +209,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when the campaign doesn‘t have badges', function() {
+  module('when the campaign doesn‘t have badges', () => {
     test('it should not display badge column', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -231,7 +231,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when the campaign has badges', function() {
+  module('when the campaign has badges', () => {
     test('it should display badge column', async function(assert) {
       // given
       const badge = store.createRecord('badge');
@@ -278,7 +278,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when the campaign has stages', function() {
+  module('when the campaign has stages', () => {
     test('it should display stars instead of mastery percentage in result column', async function(assert) {
       // given
       const stage = store.createRecord('stage', { threshold: 50 });
@@ -302,7 +302,7 @@ module('Integration | Component | routes/authenticated/campaign/assessment/list'
     });
   });
 
-  module('when user works for a SCO organization which manages students', function() {
+  module('when user works for a SCO organization which manages students', () => {
     class CurrentUserStub extends Service {
       prescriber = { areNewYearSchoolingRegistrationsImported: false }
       isSCOManagingStudents = true;

--- a/orga/tests/integration/components/routes/authenticated/campaign/assessment/results-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/assessment/results-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/assessment/results', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/assessment/results', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;

--- a/orga/tests/integration/components/routes/authenticated/campaign/collective-results/success-indicator-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/collective-results/success-indicator-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaigns/details/collective-results/success-indicator', function(hooks) {
+module('Integration | Component | routes/authenticated/campaigns/details/collective-results/success-indicator', (hooks) => {
   setupRenderingTest(hooks);
 
   test('should display value', async function(assert) {

--- a/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/collective-results/tab-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/collective-results/tab', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/collective-results/tab', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;

--- a/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/details/tab-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 
-module('Integration | Component | routes/authenticated/campaign/details/tab', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/details/tab', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -17,8 +17,8 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     this.owner.register('service:url', UrlStub);
   });
 
-  module('on TargetProfile display', function() {
-    module('when type is ASSESSMENT', function() {
+  module('on TargetProfile display', () => {
+    module('when type is ASSESSMENT', () => {
       test('it should display target profile related to campaign', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -36,7 +36,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       });
     });
 
-    module('when type is PROFILES_COLLECTION', function() {
+    module('when type is PROFILES_COLLECTION', () => {
       test('it should not display target profile', async function(assert) {
         const campaign = store.createRecord('campaign', {
           type: 'PROFILES_COLLECTION',
@@ -53,8 +53,8 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     });
   });
 
-  module('on idPixLabel display', function() {
-    module('when idPixLabel is set', function() {
+  module('on idPixLabel display', () => {
+    module('when idPixLabel is set', () => {
       test('it should display the idPixLabel', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -71,7 +71,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       });
     });
 
-    module('when idPixLabel is not set', function() {
+    module('when idPixLabel is not set', () => {
       test('it should not display the idPixLabel', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -89,7 +89,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     });
   });
 
-  module('on campaign url display', function() {
+  module('on campaign url display', () => {
     test('it should display the campaign url', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', { code: '1234' });
@@ -104,8 +104,8 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     });
   });
 
-  module('on campaign title display', function() {
-    module('when type is ASSESSMENT', function() {
+  module('on campaign title display', () => {
+    module('when type is ASSESSMENT', () => {
       test('it should display the campaign title', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -123,7 +123,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       });
     });
 
-    module('when type is PROFILES_COLLECTION', function() {
+    module('when type is PROFILES_COLLECTION', () => {
       test('it should not display the campaign title', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -141,7 +141,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     });
   });
 
-  module('on Archived action display', function() {
+  module('on Archived action display', () => {
     test('it should display the button archived', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', { isArchived: false });
@@ -156,8 +156,8 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
     });
   });
 
-  module('on Modify action display', function() {
-    module('when the campaign is not archived', function() {
+  module('on Modify action display', () => {
+    module('when the campaign is not archived', () => {
       test('it should display the button modify', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', { isArchived: false });
@@ -172,7 +172,7 @@ module('Integration | Component | routes/authenticated/campaign/details/tab', fu
       });
     });
 
-    module('when the campaign is archived', function() {
+    module('when the campaign is archived', () => {
       test('it should not display the button modify', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', { isArchived: true });

--- a/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/list-test.js
@@ -3,7 +3,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/campaign/list', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/list', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -11,7 +11,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
     this.set('triggerFilteringSpy', () => {});
   });
 
-  module('When there are no campaigns to display', function() {
+  module('When there are no campaigns to display', () => {
     test('it should display an empty list message', async function(assert) {
       // given
       const campaigns = [];
@@ -29,7 +29,7 @@ module('Integration | Component | routes/authenticated/campaign/list', function(
     });
   });
 
-  module('When there are campaigns to display', function() {
+  module('When there are campaigns to display', () => {
     test('it should display a list of campaigns', async function(assert) {
       // given
       const campaigns = [

--- a/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
@@ -7,7 +7,7 @@ import EmberObject from '@ember/object';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/campaign/new', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/new', (hooks) => {
   setupIntlRenderingTest(hooks);
   let receivedCampaign;
 
@@ -37,7 +37,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     assert.dom('textarea').hasAttribute('maxLength', '350');
   });
 
-  module('when user cannot create campaign of type PROFILES_COLLECTION', function() {
+  module('when user cannot create campaign of type PROFILES_COLLECTION', () => {
 
     test('it should display fields for campaign title and target profile by default', async function(assert) {
       // given
@@ -64,7 +64,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user choose to create a campaign of type ASSESSMENT', function() {
+  module('when user choose to create a campaign of type ASSESSMENT', () => {
 
     test('it should display fields for campaign title and target profile', async function(assert) {
       // given
@@ -104,7 +104,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user‘s organization is SCO and is managing student and user is creating an assessment campaign', function() {
+  module('when user‘s organization is SCO and is managing student and user is creating an assessment campaign', () => {
 
     test('it should display comment for target profile selection', async function(assert) {
       // given
@@ -123,7 +123,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user‘s organization is not (SCO and managing student) user is creating an assessment campaign', function() {
+  module('when user‘s organization is not (SCO and managing student) user is creating an assessment campaign', () => {
 
     test('it should not display comment for target profile selection', async function(assert) {
       // given
@@ -142,7 +142,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user has not chosen yet to ask or not an external user ID', function() {
+  module('when user has not chosen yet to ask or not an external user ID', () => {
     test('it should not display gdpr footnote', async function(assert) {
       //given
       this.campaign = EmberObject.create({});
@@ -155,7 +155,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user choose not to ask an external user ID', function() {
+  module('when user choose not to ask an external user ID', () => {
     test('it should not display gdpr footnote either', async function(assert) {
       //given
       this.campaign = EmberObject.create({});
@@ -169,7 +169,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     });
   });
 
-  module('when user choose to ask an external user ID', function() {
+  module('when user choose to ask an external user ID', () => {
     test('it should display gdpr footnote', async function(assert) {
       //given
       this.campaign = EmberObject.create({});
@@ -196,7 +196,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     assert.deepEqual(receivedCampaign.name, 'Ma campagne');
   });
 
-  module('when there are errors', function() {
+  module('when there are errors', () => {
     test('it should display errors messages when the name, the campaign purpose and the external user id fields are empty ', async function(assert) {
       // given
       class CurrentUserStub extends Service {

--- a/orga/tests/integration/components/routes/authenticated/campaign/participation-filters-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/participation-filters-test.js
@@ -6,7 +6,7 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 
-module('Integration | Component | routes/authenticated/campaign/participation-filters', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/participation-filters', (hooks) => {
   setupIntlRenderingTest(hooks);
   let store;
 
@@ -14,7 +14,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
     store = this.owner.lookup('service:store');
   });
 
-  module('when campaign does not need filters', function() {
+  module('when campaign does not need filters', () => {
     test('it should not display anything', async function(assert) {
       const campaign = store.createRecord('campaign', { id: 1 });
       this.set('campaign', campaign);
@@ -27,7 +27,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
     });
   });
 
-  module('when user works for a SCO organization which manages students', function() {
+  module('when user works for a SCO organization which manages students', () => {
     class CurrentUserStub extends Service {
       prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = true;
@@ -82,7 +82,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
     });
   });
 
-  module('when user does not work for a SCO organization which manages students', function() {
+  module('when user does not work for a SCO organization which manages students', () => {
     class CurrentUserStub extends Service {
       prescriber = { areNewYearSchoolingRegistrationsImported: false };
       isSCOManagingStudents = false;
@@ -113,7 +113,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       assert.notContains('d2');
     });
 
-    module('when campaign has badges and has type ASSESSMENT', function() {
+    module('when campaign has badges and has type ASSESSMENT', () => {
       test('it displays the badge filter', async function(assert) {
         // given
         const badge = store.createRecord('badge', { title: 'Les bases' });
@@ -153,7 +153,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('when the campaign has no badge', function() {
+    module('when the campaign has no badge', () => {
       test('should not displays the badge filter', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -171,7 +171,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('when the campaign has badge but is not assessment type', function() {
+    module('when the campaign has badge but is not assessment type', () => {
       test('it should not displays the badge filter', async function(assert) {
         // given
         const badge = store.createRecord('badge', { id: 'badge1', title: 'Les bases' });
@@ -190,7 +190,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('when campaign has no stages', function() {
+    module('when campaign has no stages', () => {
       test('should not displays the stage filter', async function(assert) {
         // given
         const campaign = store.createRecord('campaign', {
@@ -208,7 +208,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('when the campaign has stage but is not assessment type', function() {
+    module('when the campaign has stage but is not assessment type', () => {
       test('it should not displays the stage filter', async function(assert) {
         // given
         const stage = store.createRecord('stage', { id: 'stage1' });
@@ -227,7 +227,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('when campaign has stages and has type ASSESSMENT', function() {
+    module('when campaign has stages and has type ASSESSMENT', () => {
       test('it displays the stage filter', async function(assert) {
         // given
         const stage = store.createRecord('stage', { id: 'stage1', threshold: 40 });
@@ -266,7 +266,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
       });
     });
 
-    module('display number of filtered participants as Pix filter banner details', function() {
+    module('display number of filtered participants as Pix filter banner details', () => {
       test('it should display one filtered participant', async function(assert) {
         // given
         const badge = store.createRecord('badge');
@@ -312,7 +312,7 @@ module('Integration | Component | routes/authenticated/campaign/participation-fi
         assert.contains('2 participants');
       });
 
-      module('when there is a reset Filter button', function() {
+      module('when there is a reset Filter button', () => {
         test('it triggers the reset filters button when user has clicked', async function(assert) {
           //given
           const badge = store.createRecord('badge');

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/details-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/profile/details', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/profile/details', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   test('it displays user information', async function(assert) {
@@ -37,8 +37,8 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
     assert.contains('01 janv. 2020');
   });
 
-  module('is shared', function() {
-    module('when participant has shared results', function() {
+  module('is shared', () => {
+    module('when participant has shared results', () => {
       test('it displays the sharing date', async function(assert) {
         const campaignProfile = {
           isShared: true,
@@ -56,7 +56,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
         assert.contains('02 janv. 2020');
       });
     });
-    module('when participant has not shared results', function() {
+    module('when participant has not shared results', () => {
       test('it does not displays the sharing date', async function(assert) {
         const campaignProfile = {
           isShared: false,
@@ -74,8 +74,8 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
     });
   });
 
-  module('identifiant', function() {
-    module('when the external id is present', function() {
+  module('identifiant', () => {
+    module('when the external id is present', () => {
       test('it displays the external id', async function(assert) {
         const campaignProfile = {
           externalId: 'i12345',
@@ -91,7 +91,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
         assert.contains('i12345');
       });
     });
-    module('when the external id is not present', function() {
+    module('when the external id is not present', () => {
       test('it does not display the external id', async function(assert) {
         const campaignProfile = {
           externalId: null,
@@ -109,8 +109,8 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
     });
   });
 
-  module('certification info', function() {
-    module('when the  profile is shared', function() {
+  module('certification info', () => {
+    module('when the  profile is shared', () => {
       test('it displays the pix score', async function(assert) {
         const campaignProfile = {
           pixScore: '124',
@@ -158,8 +158,8 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
         assert.contains('2');
       });
 
-      module('certifiable badge', function() {
-        module('when the profile is certifiable', function() {
+      module('certifiable badge', () => {
+        module('when the profile is certifiable', () => {
           test('it displays certifiable', async function(assert) {
             const campaignProfile = {
               isCertifiable: true,
@@ -177,7 +177,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
           });
         });
 
-        module('when the profile is not certifiable', function() {
+        module('when the profile is not certifiable', () => {
           test('it does not display certifiable', async function(assert) {
             const campaignProfile = {
               isCertifiable: false,
@@ -197,7 +197,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/details'
       });
     });
 
-    module('when the  profile is not shared', function() {
+    module('when the  profile is not shared', () => {
       test('it does not display the pix score', async function(assert) {
         const campaignProfile = {
           isShared: false,

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/list-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
-module('Integration | Component | routes/authenticated/campaign/profile/list', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/profile/list', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   const goToProfilePage = () => {};
@@ -15,7 +15,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
     store = this.owner.lookup('service:store');
   });
 
-  module('when there are profiles', function() {
+  module('when there are profiles', () => {
     test('it should display the profile list', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -129,7 +129,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
     });
   });
 
-  module('when there is no profile', function() {
+  module('when there is no profile', () => {
     test('it should the empty state', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -154,7 +154,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/list', f
     });
   });
 
-  module('when user works for a SCO organization which manages students', function() {
+  module('when user works for a SCO organization which manages students', () => {
     class CurrentUserStub extends Service {
       prescriber = { areNewYearSchoolingRegistrationsImported: false }
       isSCOManagingStudents = true;

--- a/orga/tests/integration/components/routes/authenticated/campaign/profile/table-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/profile/table-test.js
@@ -3,10 +3,10 @@ import setupIntlRenderingTest from '../../../../../../helpers/setup-intl-renderi
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/campaign/profile/table', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/profile/table', (hooks) => {
   setupIntlRenderingTest(hooks);
 
-  module('when profile is not shared', function() {
+  module('when profile is not shared', () => {
     test('it displays empty table message', async function(assert) {
       this.isShared = false;
       this.competences = [];
@@ -17,7 +17,7 @@ module('Integration | Component | routes/authenticated/campaign/profile/table', 
     });
   });
 
-  module('when profile is shared', function() {
+  module('when profile is shared', () => {
     test('it displays area color as border', async function(assert) {
       this.competences = [{ name: 'name1', areaColor: 'jaffa' }];
       this.isShared = true;

--- a/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/report-test.js
@@ -10,7 +10,7 @@ class CurrentUserStub extends Service {
   }
 }
 
-module('Integration | Component | routes/authenticated/campaign/report', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/report', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let store;
@@ -49,7 +49,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     assert.contains('1234PixTest');
   });
 
-  module('When there is some results', function() {
+  module('When there is some results', () => {
     test('it should display campaign participants number', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -80,7 +80,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     });
   });
 
-  module('When there is no results', function() {
+  module('When there is no results', () => {
     test('it should display "-" when no one participated', async function(assert) {
       // given
       const campaign = store.createRecord('campaign', {
@@ -112,7 +112,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
     });
   });
 
-  module('Navigation', function() {
+  module('Navigation', () => {
 
     hooks.beforeEach(function() {
       this.owner.setupRouter();
@@ -130,7 +130,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       assert.dom('nav a[href="/campagnes/12"]').hasText('Détails');
     });
 
-    module('When campaign type is ASSESSMENT', function(hooks) {
+    module('When campaign type is ASSESSMENT', (hooks) => {
       hooks.beforeEach(async function() {
         const campaign = store.createRecord('campaign', {
           id: 13,
@@ -156,7 +156,7 @@ module('Integration | Component | routes/authenticated/campaign/report', functio
       });
     });
 
-    module('When campaign type is PROFILES_COLLECTION', function(hooks) {
+    module('When campaign type is PROFILES_COLLECTION', (hooks) => {
       hooks.beforeEach(async function() {
         // given
         const campaign = store.createRecord('campaign', {

--- a/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/update-test.js
@@ -6,7 +6,7 @@ import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/cli
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
-module('Integration | Component | routes/authenticated/campaign/update', function(hooks) {
+module('Integration | Component | routes/authenticated/campaign/update', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 
@@ -37,7 +37,7 @@ module('Integration | Component | routes/authenticated/campaign/update', functio
     assert.deepEqual(this.campaign.title, 'New title');
   });
 
-  module('When campaign type is ASSESSMENT', function() {
+  module('When campaign type is ASSESSMENT', () => {
     test('it should display campaign title input', async function(assert) {
       this.campaign = EmberObject.create({ isTypeAssessment: true });
 
@@ -48,7 +48,7 @@ module('Integration | Component | routes/authenticated/campaign/update', functio
     });
   });
 
-  module('When campaign type is not ASSESSMENT', function() {
+  module('When campaign type is not ASSESSMENT', () => {
     test('it should not display campaign title input', async function(assert) {
       this.campaign = EmberObject.create({ isTypeAssessment: false });
 

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -7,7 +7,7 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/sco-students | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/sco-students | list-items', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 
@@ -67,7 +67,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     assert.contains('01/02/2010');
   });
 
-  module('when user is filtering some users', function() {
+  module('when user is filtering some users', () => {
 
     test('it should trigger filtering with lastname', async function(assert) {
       // given
@@ -125,7 +125,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
-  module('when user is not reconciled', function({ beforeEach }) {
+  module('when user is not reconciled', ({ beforeEach }) => {
 
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
@@ -150,7 +150,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
-  module('when user is reconciled', function({ beforeEach }) {
+  module('when user is reconciled', ({ beforeEach }) => {
 
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
@@ -177,7 +177,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
     });
   });
 
-  module('when user authentification method is username', function({ beforeEach }) {
+  module('when user authentification method is username', ({ beforeEach }) => {
 
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
@@ -203,7 +203,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
   });
 
-  module('when user authentification method is email', function({ beforeEach }) {
+  module('when user authentification method is email', ({ beforeEach }) => {
 
     beforeEach(function() {
       const store = this.owner.lookup('service:store');
@@ -229,7 +229,7 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
 
   });
 
-  module('when user authentification method is samlId', function({ beforeEach }) {
+  module('when user authentification method is samlId', ({ beforeEach }) => {
 
     beforeEach(function() {
       const store = this.owner.lookup('service:store');

--- a/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sup-students/list-items-test.js
@@ -6,7 +6,7 @@ import Service from '@ember/service';
 import sinon from 'sinon';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/authenticated/sup-students | list-items', function(hooks) {
+module('Integration | Component | routes/authenticated/sup-students | list-items', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   hooks.beforeEach(function() {
@@ -21,7 +21,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
     assert.contains('Étudiants');
   });
 
-  module('when user is admin', function(hooks) {
+  module('when user is admin', (hooks) => {
     hooks.beforeEach(function() {
       class CurrentUserStub extends Service {
         organization = Object.create({ id: 1 });
@@ -50,7 +50,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
     });
   });
 
-  module('when user is only member', function(hooks) {
+  module('when user is only member', (hooks) => {
     hooks.beforeEach(function() {
       class CurrentUserStub extends Service {
         isAdminInOrganization = false;
@@ -120,7 +120,7 @@ module('Integration | Component | routes/authenticated/sup-students | list-items
     assert.contains('01/02/2010');
   });
 
-  module('when user is filtering some users', function() {
+  module('when user is filtering some users', () => {
     test('it should trigger filtering with lastname', async function(assert) {
       const triggerFiltering = sinon.spy();
       this.set('triggerFiltering', triggerFiltering);

--- a/orga/tests/integration/components/routes/authenticated/team/invitations-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/invitations-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 import moment from 'moment';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/team | invitations', function(hooks) {
+module('Integration | Component | routes/authenticated/team | invitations', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 

--- a/orga/tests/integration/components/routes/authenticated/team/items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/items-test.js
@@ -5,13 +5,13 @@ import hbs from 'htmlbars-inline-precompile';
 import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/click-by-label';
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/team | list-items | items', function(hooks) {
+module('Integration | Component | routes/authenticated/team | list-items | items', (hooks) => {
 
   setupIntlRenderingTest(hooks);
   let adminMembership;
   let memberMembership;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     adminMembership = {
       id: 1,
       displayRole: 'Administrateur',
@@ -51,7 +51,7 @@ module('Integration | Component | routes/authenticated/team | list-items | items
     assert.dom('button[aria-label="Afficher les actions"]').exists;
   });
 
-  module('When edit organization role button is clicked', function() {
+  module('When edit organization role button is clicked', () => {
 
     test('it should show update and save button, and show the drop down to select role to update', async function(assert) {
       // given

--- a/orga/tests/integration/components/routes/authenticated/team/members-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/members-test.js
@@ -4,7 +4,7 @@ import hbs from 'htmlbars-inline-precompile';
 
 import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/authenticated/team | members', function(hooks) {
+module('Integration | Component | routes/authenticated/team | members', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 

--- a/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
+++ b/orga/tests/integration/components/routes/authenticated/team/new-item-test.js
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 import fillInByLabel from '../../../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import setupIntl from '../../../../../helpers/setup-intl';
 
-module('Integration | Component | routes/authenticated/team/new-item', function(hooks) {
+module('Integration | Component | routes/authenticated/team/new-item', (hooks) => {
 
   setupRenderingTest(hooks);
   setupIntl(hooks);

--- a/orga/tests/integration/components/routes/join-request-form-test.js
+++ b/orga/tests/integration/components/routes/join-request-form-test.js
@@ -4,17 +4,17 @@ import { render, triggerEvent } from '@ember/test-helpers';
 import fillInByLabel from '../../../helpers/extended-ember-test-helpers/fill-in-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/join-request-form', function(hooks) {
+module('Integration | Component | routes/join-request-form', (hooks) => {
   setupRenderingTest(hooks);
 
-  module('when are not fill correctly', function() {
+  module('when are not fill correctly', () => {
 
     const EMPTY_FIRSTNAME_ERROR_MESSAGE = 'Votre prénom n’est pas renseigné.';
     const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
 
     [{ stringFilledIn: '' },
       { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
       test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
         // given
         await render(hbs`<Routes::JoinRequestForm />`);
@@ -30,7 +30,7 @@ module('Integration | Component | routes/join-request-form', function(hooks) {
 
     [{ stringFilledIn: '' },
       { stringFilledIn: ' ' },
-    ].forEach(function({ stringFilledIn }) {
+    ].forEach(({ stringFilledIn }) => {
       test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
         // given
         await render(hbs`<Routes::JoinRequestForm />`);

--- a/orga/tests/integration/components/routes/login-form-test.js
+++ b/orga/tests/integration/components/routes/login-form-test.js
@@ -12,7 +12,7 @@ import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-
 
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Integration | Component | routes/login-form', function(hooks) {
+module('Integration | Component | routes/login-form', (hooks) => {
 
   setupIntlRenderingTest(hooks);
 
@@ -50,9 +50,9 @@ module('Integration | Component | routes/login-form', function(hooks) {
     assert.dom('#login-form-error-message').doesNotExist();
   });
 
-  module('When there is no invitation', function(hooks) {
+  module('When there is no invitation', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       SessionStub.prototype.authenticate = function(authenticator, email, password, scope) {
         this.authenticator = authenticator;
         this.email = email;
@@ -81,9 +81,9 @@ module('Integration | Component | routes/login-form', function(hooks) {
     });
   });
 
-  module('When there is an invitation', function(hooks) {
+  module('When there is an invitation', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       StoreStub.prototype.createRecord = () => {
         return EmberObject.create({
           save() {
@@ -165,7 +165,7 @@ module('Integration | Component | routes/login-form', function(hooks) {
     assert.dom('login-form__information').doesNotExist();
   });
 
-  module('when password is hidden', function(hooks) {
+  module('when password is hidden', (hooks) => {
 
     let showButtonText;
 

--- a/orga/tests/integration/components/routes/login-or-register-test.js
+++ b/orga/tests/integration/components/routes/login-or-register-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import clickByLabel from '../../../helpers/extended-ember-test-helpers/click-by-label';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | routes/login-or-register', function(hooks) {
+module('Integration | Component | routes/login-or-register', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {

--- a/orga/tests/integration/components/routes/register-form-test.js
+++ b/orga/tests/integration/components/routes/register-form-test.js
@@ -14,7 +14,7 @@ const EMPTY_LASTNAME_ERROR_MESSAGE = 'Votre nom n’est pas renseigné.';
 const EMPTY_EMAIL_ERROR_MESSAGE = 'Votre email n’est pas valide.';
 const INCORRECT_PASSWORD_FORMAT_ERROR_MESSAGE = 'Votre mot de passe doit contenir 8 caractères au minimum et comporter au moins une majuscule, une minuscule et un chiffre.';
 
-module('Integration | Component | routes/register-form', function(hooks) {
+module('Integration | Component | routes/register-form', (hooks) => {
   setupRenderingTest(hooks);
 
   class SessionStub extends Service {}
@@ -34,7 +34,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
     assert.dom('.register-form').exists();
   });
 
-  module('successful cases', function() {
+  module('successful cases', () => {
 
     hooks.beforeEach(function() {
       this.owner.unregister('service:store');
@@ -80,13 +80,13 @@ module('Integration | Component | routes/register-form', function(hooks) {
     });
   });
 
-  module('errors management', function() {
+  module('errors management', () => {
 
     module('error display', () => {
 
       [{ stringFilledIn: '' },
         { stringFilledIn: ' ' },
-      ].forEach(function({ stringFilledIn }) {
+      ].forEach(({ stringFilledIn }) => {
         test(`it should display an error message on firstName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
           // given
           await render(hbs`<Routes::RegisterForm/>`);
@@ -103,7 +103,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
 
       [{ stringFilledIn: '' },
         { stringFilledIn: ' ' },
-      ].forEach(function({ stringFilledIn }) {
+      ].forEach(({ stringFilledIn }) => {
         test(`it should display an error message on lastName field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
           // given
           await render(hbs`<Routes::RegisterForm/>`);
@@ -121,7 +121,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
       [{ stringFilledIn: ' ' },
         { stringFilledIn: 'a' },
         { stringFilledIn: 'shi.fu' },
-      ].forEach(function({ stringFilledIn }) {
+      ].forEach(({ stringFilledIn }) => {
 
         test(`it should display an error message on email field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
           // given
@@ -141,7 +141,7 @@ module('Integration | Component | routes/register-form', function(hooks) {
         { stringFilledIn: 'password' },
         { stringFilledIn: 'password1' },
         { stringFilledIn: 'Password' },
-      ].forEach(function({ stringFilledIn }) {
+      ].forEach(({ stringFilledIn }) => {
 
         test(`it should display an error message on password field, when '${stringFilledIn}' is typed and focused out`, async function(assert) {
           // given

--- a/orga/tests/integration/components/search-input-test.js
+++ b/orga/tests/integration/components/search-input-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | search-input', function(hooks) {
+module('Integration | Component | search-input', (hooks) => {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function() {

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -4,7 +4,7 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 
-module('Integration | Component | sidebar-menu', function(hooks) {
+module('Integration | Component | sidebar-menu', (hooks) => {
   setupRenderingTest(hooks);
 
   test('it should display documentation for a pro organization', async function(assert) {

--- a/orga/tests/integration/components/stage-stars-test.js
+++ b/orga/tests/integration/components/stage-stars-test.js
@@ -3,7 +3,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-module('Integration | Component | stage-stars', function(hooks) {
+module('Integration | Component | stage-stars', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   test('should render stars for given stages', async function(assert) {

--- a/orga/tests/integration/components/tables/header-sort-test.js
+++ b/orga/tests/integration/components/tables/header-sort-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | Tables | header-sort', function(hooks) {
+module('Integration | Component | Tables | header-sort', (hooks) => {
   setupRenderingTest(hooks);
 
   let onSortStub;
@@ -22,7 +22,7 @@ module('Integration | Component | Tables | header-sort', function(hooks) {
     assert.contains('Header');
   });
 
-  module('When header sort is enabled', function() {
+  module('When header sort is enabled', () => {
     test('should display arrow', async function(assert) {
       // when
       await render(hbs`<Table::HeaderSort @isDisabled={{false}}>Header</Table::HeaderSort>`);
@@ -42,7 +42,7 @@ module('Integration | Component | Tables | header-sort', function(hooks) {
     });
   });
 
-  module('When header sort is disabled', function() {
+  module('When header sort is disabled', () => {
     test('should not display arrow', async function(assert) {
       // when
       await render(hbs`<Table::HeaderSort @isDisabled={{true}}>Header</Table::HeaderSort>`);

--- a/orga/tests/integration/components/user-logged-menu-test.js
+++ b/orga/tests/integration/components/user-logged-menu-test.js
@@ -6,7 +6,7 @@ import Object from '@ember/object';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 
-module('Integration | Component | user-logged-menu', function(hooks) {
+module('Integration | Component | user-logged-menu', (hooks) => {
   setupIntlRenderingTest(hooks);
 
   let prescriber, organization, organization2, organization3;

--- a/orga/tests/unit/adapters/application-test.js
+++ b/orga/tests/unit/adapters/application-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | ApplicationAdapter', function(hooks) {
+module('Unit | Adapters | ApplicationAdapter', (hooks) => {
   setupTest(hooks);
 
   test('should specify /api as the root url', function(assert) {
@@ -13,7 +13,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     assert.equal(applicationAdapter.namespace, 'api');
   });
 
-  module('get headers()', function() {
+  module('get headers()', () => {
 
     test('should add header with authentication token when the session is authenticated', function(assert) {
       // Given
@@ -74,7 +74,7 @@ module('Unit | Adapters | ApplicationAdapter', function(hooks) {
     });
   });
 
-  module('ajax()', function() {
+  module('ajax()', () => {
     test('should queue ajax calls', function(assert) {
       // Given
       const applicationAdapter = this.owner.lookup('adapter:application');

--- a/orga/tests/unit/adapters/campaign-profile-test.js
+++ b/orga/tests/unit/adapters/campaign-profile-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapters | campaign-profile', function(hooks) {
+module('Unit | Adapters | campaign-profile', (hooks) => {
   setupTest(hooks);
 
   let adapter;

--- a/orga/tests/unit/adapters/campaign-test.js
+++ b/orga/tests/unit/adapters/campaign-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import ENV from 'pix-orga/config/environment';
 
-module('Unit | Adapter | campaign', function(hooks) {
+module('Unit | Adapter | campaign', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -17,7 +17,7 @@ module('Unit | Adapter | campaign', function(hooks) {
     adapter.set('ajax', ajaxStub);
   });
 
-  module('archive', function() {
+  module('archive', () => {
     test('it should send a PUT request with a proper url', async function(assert) {
       // when
       await adapter.archive(model);
@@ -26,7 +26,7 @@ module('Unit | Adapter | campaign', function(hooks) {
     });
   });
 
-  module('unarchive', function() {
+  module('unarchive', () => {
     test('it should send a DELETE request with a proper url', async function(assert) {
       // when
       await adapter.unarchive(model);

--- a/orga/tests/unit/adapters/division-test.js
+++ b/orga/tests/unit/adapters/division-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapters | division', function(hooks) {
+module('Unit | Adapters | division', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -14,7 +14,7 @@ module('Unit | Adapters | division', function(hooks) {
     adapter.ajax = ajaxStub;
   });
 
-  module('#urlForQuery', function() {
+  module('#urlForQuery', () => {
 
     test('should build url from organizationId', async function(assert) {
       // when

--- a/orga/tests/unit/adapters/membership-test.js
+++ b/orga/tests/unit/adapters/membership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Adapter | membership', function(hooks) {
+module('Unit | Adapter | membership', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -12,7 +12,7 @@ module('Unit | Adapter | membership', function(hooks) {
     sinon.stub(adapter, 'ajax').resolves();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(() => {
     adapter.ajax.restore();
   });
 
@@ -27,9 +27,9 @@ module('Unit | Adapter | membership', function(hooks) {
     });
   });
 
-  module('#updateRecord', function() {
+  module('#updateRecord', () => {
 
-    module('when disabled adapter option is provided', function() {
+    module('when disabled adapter option is provided', () => {
 
       test('it should trigger a POST request to /memberships/{id}/disable', async function(assert) {
         // when

--- a/orga/tests/unit/adapters/organization-invitation-response-test.js
+++ b/orga/tests/unit/adapters/organization-invitation-response-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Adapters | organization-invitation-response', function(hooks) {
+module('Unit | Adapters | organization-invitation-response', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -10,7 +10,7 @@ module('Unit | Adapters | organization-invitation-response', function(hooks) {
     adapter = this.owner.lookup('adapter:organization-invitation-response');
   });
 
-  module('#urlForCreateRecord', function() {
+  module('#urlForCreateRecord', () => {
 
     test('should build update url from organization-invitation-response id', async function(assert) {
       // given

--- a/orga/tests/unit/adapters/prescriber-test.js
+++ b/orga/tests/unit/adapters/prescriber-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 
-module('Unit | Adapters | prescriber', function(hooks) {
+module('Unit | Adapters | prescriber', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -13,7 +13,7 @@ module('Unit | Adapters | prescriber', function(hooks) {
     adapter.set('ajax', ajaxStub);
   });
 
-  module('#urlForQueryRecord', function() {
+  module('#urlForQueryRecord', () => {
 
     test('should add /prescription inside prescriber query record', function(assert) {
       // when
@@ -24,7 +24,7 @@ module('Unit | Adapters | prescriber', function(hooks) {
     });
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
 
     test('it should redirect to pix-orga-terms-of-service-acceptance', async function(assert) {
       // when

--- a/orga/tests/unit/adapters/student-test.js
+++ b/orga/tests/unit/adapters/student-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import ENV from 'pix-orga/config/environment';
 
-module('Unit | Adapters | student', function(hooks) {
+module('Unit | Adapters | student', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -25,7 +25,7 @@ module('Unit | Adapters | student', function(hooks) {
     });
   });
 
-  module('#dissociateUser', function() {
+  module('#dissociateUser', () => {
 
     test('it performs the request to dissociate user from student', async function(assert) {
       // given
@@ -47,7 +47,7 @@ module('Unit | Adapters | student', function(hooks) {
     });
   });
 
-  module('#updateRecord', function() {
+  module('#updateRecord', () => {
     test('it performs the request to update the student number', async function(assert) {
       // given
       const studentId = 10;

--- a/orga/tests/unit/adapters/user-orga-setting-test.js
+++ b/orga/tests/unit/adapters/user-orga-setting-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import { resolve } from 'rsvp';
 import sinon from 'sinon';
 
-module('Unit | Adapters | user-orga-setting', function(hooks) {
+module('Unit | Adapters | user-orga-setting', (hooks) => {
   setupTest(hooks);
 
   let adapter;
@@ -15,7 +15,7 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
     adapter.set('ajax', ajaxStub);
   });
 
-  module('#urlForUpdateRecord', function() {
+  module('#urlForUpdateRecord', () => {
 
     test('it should build update url from user id', async function(assert) {
       // when
@@ -27,14 +27,14 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
     });
   });
 
-  module('#updateRecord', function() {
-    module('when userId adapterOption passed', function(hooks) {
+  module('#updateRecord', () => {
+    module('when userId adapterOption passed', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         sinon.stub(adapter, 'ajax');
       });
 
-      hooks.afterEach(function() {
+      hooks.afterEach(() => {
         adapter.ajax.restore();
       });
 
@@ -58,7 +58,7 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
     });
   });
 
-  module('#urlForCreateRecord', function() {
+  module('#urlForCreateRecord', () => {
 
     test('it should build create url from user id', async function(assert) {
       // when
@@ -70,14 +70,14 @@ module('Unit | Adapters | user-orga-setting', function(hooks) {
     });
   });
 
-  module('#createRecord', function() {
-    module('when userId adapterOption passed', function(hooks) {
+  module('#createRecord', () => {
+    module('when userId adapterOption passed', (hooks) => {
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         sinon.stub(adapter, 'ajax');
       });
 
-      hooks.afterEach(function() {
+      hooks.afterEach(() => {
         adapter.ajax.restore();
       });
 

--- a/orga/tests/unit/components/routes/login-form-test.js
+++ b/orga/tests/unit/components/routes/login-form-test.js
@@ -10,7 +10,7 @@ module('Unit | Component | Routes | login-form', (hooks) => {
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:routes/login-form');
   });
 

--- a/orga/tests/unit/components/user-logged-menu-test.js
+++ b/orga/tests/unit/components/user-logged-menu-test.js
@@ -8,7 +8,7 @@ module('Unit | Component | user-logged-menu', (hooks) => {
 
   let component;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(() => {
     component = createGlimmerComponent('component:user-logged-menu');
   });
 

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/assessments-test.js
@@ -1,15 +1,15 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/campaigns/campaign/assessments', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/campaign/assessments', (hooks) => {
   setupTest(hooks);
   let controller;
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/campaigns/campaign/assessments');
   });
 
-  module('triggerFiltering', function() {
-    module('division filter', function() {
+  module('triggerFiltering', () => {
+    module('division filter', () => {
       test('update the division filter', function(assert) {
         // given
         controller.triggerFiltering({ divisions: ['6eme'] });
@@ -27,7 +27,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessments', funct
       });
     });
 
-    module('badge filter', function() {
+    module('badge filter', () => {
       test('update the badge filter', function(assert) {
         // given
         controller.triggerFiltering({ badges: ['badge1'] });
@@ -45,7 +45,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessments', funct
       });
     });
 
-    module('stage filter', function() {
+    module('stage filter', () => {
       test('update the stage filter', function(assert) {
         // given
         controller.triggerFiltering({ stages: ['stage1'] });
@@ -64,7 +64,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/assessments', funct
     });
   });
 
-  module('resetFiltering', function() {
+  module('resetFiltering', () => {
     test('reset the filters', function(assert) {
       //given
       controller.set('pageNumber', 1);

--- a/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/campaign/profiles-test.js
@@ -2,14 +2,14 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/campaigns/campaign/profiles', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/campaign/profiles', (hooks) => {
   setupTest(hooks);
   let controller;
   hooks.beforeEach(function() {
     controller = this.owner.lookup('controller:authenticated/campaigns/campaign/profiles');
   });
 
-  module('triggerFiltering', function() {
+  module('triggerFiltering', () => {
     test('update the divisions', function(assert) {
       const fetchCampaign = sinon.stub();
       controller.set('fetchCampaign', fetchCampaign);
@@ -23,7 +23,7 @@ module('Unit | Controller | authenticated/campaigns/campaign/profiles', function
     });
   });
 
-  module('resetFiltering', function() {
+  module('resetFiltering', () => {
     test('reset the divisions', function(assert) {
       //given
       controller.set('pageNumber', 1);

--- a/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/list-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import ArrayProxy from '@ember/array/proxy';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/list', (hooks) => {
   setupTest(hooks);
   let controller;
 
@@ -11,7 +11,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
     controller = this.owner.lookup('controller:authenticated/campaigns/list');
   });
 
-  module('#get displayNoCampaignPanel', function() {
+  module('#get displayNoCampaignPanel', () => {
 
     test('it should know when it should display "No campaign panel"', function(assert) {
       // given
@@ -43,7 +43,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       assert.equal(displayNoCampaignPanel, false);
     });
 
-    module('when there is a filter on campaigns name that does not match any campaign', function() {
+    module('when there is a filter on campaigns name that does not match any campaign', () => {
       // given
       const filterName = 'Dog';
       const campaign1 = { name: 'Cat', createdAt: new Date('2018-08-07') };
@@ -65,9 +65,9 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
     });
   });
 
-  module('#get isArchived', function() {
+  module('#get isArchived', () => {
 
-    module('when status is archived', function() {
+    module('when status is archived', () => {
 
       test('it should returns true', function(assert) {
         // given
@@ -81,7 +81,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
       });
     });
 
-    module('when status is not archived', function() {
+    module('when status is not archived', () => {
 
       test('it should returns false', function(assert) {
         // given
@@ -96,7 +96,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
     });
   });
 
-  module('#action updateCampaignStatus', function() {
+  module('#action updateCampaignStatus', () => {
 
     test('it should update controller status field', function(assert) {
       // given
@@ -110,7 +110,7 @@ module('Unit | Controller | authenticated/campaigns/list', function(hooks) {
     });
   });
 
-  module('#action goToCampaignPage', function() {
+  module('#action goToCampaignPage', () => {
 
     test('it should call transitionToRoute with appropriate arguments', function(assert) {
       // given

--- a/orga/tests/unit/controllers/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/campaigns/new', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/new', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/controllers/authenticated/campaigns/update-test.js
+++ b/orga/tests/unit/controllers/authenticated/campaigns/update-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | authenticated/campaigns/update', function(hooks) {
+module('Unit | Controller | authenticated/campaigns/update', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/controllers/authenticated/certifications-test.js
+++ b/orga/tests/unit/controllers/authenticated/certifications-test.js
@@ -3,10 +3,10 @@ import sinon from 'sinon';
 import Service from '@ember/service';
 import setupIntlRenderingTest from '../../../helpers/setup-intl-rendering';
 
-module('Unit | Controller | authenticated/certifications', function(hooks) {
+module('Unit | Controller | authenticated/certifications', (hooks) => {
   setupIntlRenderingTest(hooks);
 
-  module('#onSelectDivision', function() {
+  module('#onSelectDivision', () => {
 
     test('should change the value of the selected division', async function(assert) {
       // given
@@ -32,7 +32,7 @@ module('Unit | Controller | authenticated/certifications', function(hooks) {
     });
   });
 
-  module('#downloadSessionResultFile', function() {
+  module('#downloadSessionResultFile', () => {
 
     test('should call the file-saver service with the right parameters', async function(assert) {
       // given

--- a/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sup-students/list-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import ENV from 'pix-orga/config/environment';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
+module('Unit | Controller | authenticated/sup-students/list', (hooks) => {
   setupTest(hooks);
   const currentUser = { organization: { id: 1 }, prescriber: { lang: 'fr' } };
   const session = { data: { authenticated: { access_token: 12345 } } };
@@ -16,7 +16,7 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
     controller.currentUser = currentUser;
   });
 
-  module('#importStudents', function() {
+  module('#importStudents', () => {
     test('it sends the chosen file to the API', async function(assert) {
       const importStudentsURL = `${ENV.APP.API_HOST}/api/organizations/${currentUser.organization.id}/schooling-registrations/import-csv`;
       const headers = { Authorization: `Bearer ${12345}`, 'Accept-Language': controller.currentUser.prescriber.lang };
@@ -29,10 +29,10 @@ module('Unit | Controller | authenticated/sup-students/list', function(hooks) {
       assert.ok(file.uploadBinary.calledWith(importStudentsURL, { headers }));
     });
 
-    module('manage CSV import errors', function(hooks) {
+    module('manage CSV import errors', (hooks) => {
       let file;
 
-      hooks.beforeEach(function() {
+      hooks.beforeEach(() => {
         controller.session = session;
         controller.currentUser = currentUser;
         file = { uploadBinary: sinon.stub() };

--- a/orga/tests/unit/controllers/authenticated/team/list/members-test.js
+++ b/orga/tests/unit/controllers/authenticated/team/list/members-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Controller | authenticated/team/list/members', function(hooks) {
+module('Unit | Controller | authenticated/team/list/members', (hooks) => {
   setupTest(hooks);
   const currentUser = { organization: { id: 1 } };
   let controller;

--- a/orga/tests/unit/controllers/terms-of-service-test.js
+++ b/orga/tests/unit/controllers/terms-of-service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Controller | terms-of-service', function(hooks) {
+module('Unit | Controller | terms-of-service', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/helpers/display-campaign-errors-test.js
+++ b/orga/tests/unit/helpers/display-campaign-errors-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | display-campaign-errors', function(hooks) {
+module('Unit | Helper | display-campaign-errors', (hooks) => {
   setupTest(hooks);
   let helper;
   hooks.beforeEach(function() {
@@ -9,14 +9,14 @@ module('Unit | Helper | display-campaign-errors', function(hooks) {
     helper = this.owner.factoryFor('helper:display-campaign-errors').create();
   });
 
-  module('when there is an error', function() {
+  module('when there is an error', () => {
     test('it returns the intlKey corresponding to the name error message', function(assert) {
       const nameErrors = [{ attribute: 'name', message: 'CAMPAIGN_NAME_IS_REQUIRED' }];
       assert.equal(helper.compute([nameErrors]), 'Veuillez donner un nom à votre campagne.');
     });
   });
 
-  module('when there is no error', function() {
+  module('when there is no error', () => {
     test('it returns the intlKey corresponding to the type error message', function(assert) {
       const noError = [];
       assert.equal(helper.compute([noError]), null);

--- a/orga/tests/unit/helpers/join-test.js
+++ b/orga/tests/unit/helpers/join-test.js
@@ -2,7 +2,7 @@ import { join } from 'pix-orga/helpers/join';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | join', function(hooks) {
+module('Unit | Helper | join', (hooks) => {
   setupTest(hooks);
 
   module('join', () => {

--- a/orga/tests/unit/helpers/multiply-test.js
+++ b/orga/tests/unit/helpers/multiply-test.js
@@ -2,7 +2,7 @@ import { multiply } from 'pix-orga/helpers/multiply';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | multiply', function(hooks) {
+module('Unit | Helper | multiply', (hooks) => {
   setupTest(hooks);
 
   module('multiply', () => {

--- a/orga/tests/unit/helpers/percentage-test.js
+++ b/orga/tests/unit/helpers/percentage-test.js
@@ -2,7 +2,7 @@ import { percentage } from 'pix-orga/helpers/percentage';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | percentage', function(hooks) {
+module('Unit | Helper | percentage', (hooks) => {
   setupTest(hooks);
 
   module('percentage', () => {

--- a/orga/tests/unit/helpers/sum-test.js
+++ b/orga/tests/unit/helpers/sum-test.js
@@ -2,7 +2,7 @@ import { sum } from 'pix-orga/helpers/sum';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Helper | sum', function(hooks) {
+module('Unit | Helper | sum', (hooks) => {
   setupTest(hooks);
 
   module('sum', () => {

--- a/orga/tests/unit/models/campaign-assessment-participation-competence-result-test.js
+++ b/orga/tests/unit/models/campaign-assessment-participation-competence-result-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | CampaignAssessmentParticipationCompetenceResult', function(hooks) {
+module('Unit | Model | CampaignAssessmentParticipationCompetenceResult', (hooks) => {
   setupTest(hooks);
 
-  module('totalSkillsCountPercentage', function() {
+  module('totalSkillsCountPercentage', () => {
 
     test('should retrieve 100 since the competence is the highest number of total skills count', function(assert) {
       const store = this.owner.lookup('service:store');
@@ -47,7 +47,7 @@ module('Unit | Model | CampaignAssessmentParticipationCompetenceResult', functio
     });
   });
 
-  module('validatedSkillsCountPercentage', function() {
+  module('validatedSkillsCountPercentage', () => {
 
     test('should retrieve 100 since the user has validated all the competence', function(assert) {
       const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/models/campaign-assessment-participation-result-test.js
+++ b/orga/tests/unit/models/campaign-assessment-participation-result-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | campaignAssessmentParticipationResult', function(hooks) {
+module('Unit | Model | campaignAssessmentParticipationResult', (hooks) => {
   setupTest(hooks);
 
-  module('maxTotalSkillsCount', function() {
+  module('maxTotalSkillsCount', () => {
 
     test('should calculate max total skills', function(assert) {
       const store = this.owner.lookup('service:store');
@@ -29,7 +29,7 @@ module('Unit | Model | campaignAssessmentParticipationResult', function(hooks) {
     });
   });
 
-  module('sortedCompetenceResults', function() {
+  module('sortedCompetenceResults', () => {
 
     test('should sort competence results', function(assert) {
       const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/models/campaign-collective-results-test.js
+++ b/orga/tests/unit/models/campaign-collective-results-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | campaign-collective-results', function(hooks) {
+module('Unit | Model | campaign-collective-results', (hooks) => {
   setupTest(hooks);
 
-  module('averageValidatedSkillsSum', function() {
+  module('averageValidatedSkillsSum', () => {
 
     test('it should return the sum of competences average validated skills', function(assert) {
       //given
@@ -35,7 +35,7 @@ module('Unit | Model | campaign-collective-results', function(hooks) {
     });
   });
 
-  module('averageResult', function() {
+  module('averageResult', () => {
 
     test('it should return average result', function(assert) {
       //given
@@ -68,7 +68,7 @@ module('Unit | Model | campaign-collective-results', function(hooks) {
     });
   });
 
-  module('totalSkills', function() {
+  module('totalSkills', () => {
 
     test('it should return total skills', function(assert) {
       //given
@@ -102,7 +102,7 @@ module('Unit | Model | campaign-collective-results', function(hooks) {
 
   });
 
-  module('maxTotalSkillsCountInCompetences', function() {
+  module('maxTotalSkillsCountInCompetences', () => {
     test('it should return the highest value among the total skills counts', function(assert) {
       //given
       const store = this.owner.lookup('service:store');

--- a/orga/tests/unit/models/campaign-participation-test.js
+++ b/orga/tests/unit/models/campaign-participation-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | campaign-participation', function(hooks) {
+module('Unit | Model | campaign-participation', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/models/campaign-profile-test.js
+++ b/orga/tests/unit/models/campaign-profile-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | campaign-profile', function(hooks) {
+module('Unit | Model | campaign-profile', (hooks) => {
   setupTest(hooks);
 
   test('it should return the campaign-profile sorted competences', function(assert) {

--- a/orga/tests/unit/models/campaign-test.js
+++ b/orga/tests/unit/models/campaign-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | campaign', function(hooks) {
+module('Unit | Model | campaign', (hooks) => {
   setupTest(hooks);
 
   test('it should return the right data in the campaign model', function(assert) {
@@ -14,7 +14,7 @@ module('Unit | Model | campaign', function(hooks) {
     assert.equal(model.code, 'ABC123');
   });
 
-  module('#urlToResult', function() {
+  module('#urlToResult', () => {
     test('it should construct the url to result of the campaign with type assessment', function(assert) {
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('campaign', {
@@ -40,7 +40,7 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('#readableType', function(hooks) {
+  module('#readableType', (hooks) => {
     let store;
 
     hooks.beforeEach(function() {
@@ -64,7 +64,7 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('#hasStages', function() {
+  module('#hasStages', () => {
     test('returns true while campaign contains stages', function(assert) {
       const store = this.owner.lookup('service:store');
       const stage = store.createRecord('stage', { threshold: 45 });
@@ -85,7 +85,7 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('#hasBadges', function() {
+  module('#hasBadges', () => {
     test('returns true while campaign contains badges', function(assert) {
       const store = this.owner.lookup('service:store');
       const badge = store.createRecord('badge', { threshold: 45 });
@@ -106,7 +106,7 @@ module('Unit | Model | campaign', function(hooks) {
     });
   });
 
-  module('#creatorFullName', function() {
+  module('#creatorFullName', () => {
     test('it should return the fullname, combination of last and first name', function(assert) {
       const store = this.owner.lookup('service:store');
       const model = store.createRecord('campaign', { creatorFirstName: 'Jean-Baptiste', creatorLastName: 'Poquelin' });

--- a/orga/tests/unit/models/membership-test.js
+++ b/orga/tests/unit/models/membership-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | membership', function(hooks) {
+module('Unit | Model | membership', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/models/organization-invitation-response-test.js
+++ b/orga/tests/unit/models/organization-invitation-response-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | organization-invitation-response', function(hooks) {
+module('Unit | Model | organization-invitation-response', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/models/organization-invitation-test.js
+++ b/orga/tests/unit/models/organization-invitation-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | organization-invitation', function(hooks) {
+module('Unit | Model | organization-invitation', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/models/organization-test.js
+++ b/orga/tests/unit/models/organization-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | organization', function(hooks) {
+module('Unit | Model | organization', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/models/student-test.js
+++ b/orga/tests/unit/models/student-test.js
@@ -1,12 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Model | student', function(hooks) {
+module('Unit | Model | student', (hooks) => {
 
   setupTest(hooks);
-  module('#authenticationMethods', function() {
+  module('#authenticationMethods', () => {
 
-    module('when not reconciled', function() {
+    module('when not reconciled', () => {
       test('it should return empty message', function(assert) {
         // given
         const store = this.owner.lookup('service:store');
@@ -18,9 +18,9 @@ module('Unit | Model | student', function(hooks) {
       });
     });
 
-    module('when reconciled', function() {
+    module('when reconciled', () => {
 
-      module('single authentication method', function() {
+      module('single authentication method', () => {
         test('it should return Identifiant message key when identified by username', function(assert) {
           // given
           const store = this.owner.lookup('service:store');
@@ -65,7 +65,7 @@ module('Unit | Model | student', function(hooks) {
         });
       });
 
-      module('multiple authentication method', function() {
+      module('multiple authentication method', () => {
 
         test('it should return 2 message keys, excluding GAR', function(assert) {
           // given
@@ -91,7 +91,7 @@ module('Unit | Model | student', function(hooks) {
     });
   });
 
-  module('#isStudentAssociated', function(hooks) {
+  module('#isStudentAssociated', (hooks) => {
     let store;
     hooks.beforeEach(function() {
       store = this.owner.lookup('service:store');
@@ -122,7 +122,7 @@ module('Unit | Model | student', function(hooks) {
     });
   });
 
-  module('#displayAddUsernameAuthentication', function(hooks) {
+  module('#displayAddUsernameAuthentication', (hooks) => {
     let store;
     hooks.beforeEach(function() {
       store = this.owner.lookup('service:store');

--- a/orga/tests/unit/models/target-profile-test.js
+++ b/orga/tests/unit/models/target-profile-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | target profile', function(hooks) {
+module('Unit | Model | target profile', (hooks) => {
   setupTest(hooks);
 
   // Replace this with your real tests.

--- a/orga/tests/unit/models/user-test.js
+++ b/orga/tests/unit/models/user-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 
-module('Unit | Model | user', function(hooks) {
+module('Unit | Model | user', (hooks) => {
 
   setupTest(hooks);
 

--- a/orga/tests/unit/routes/application-test.js
+++ b/orga/tests/unit/routes/application-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import Service from '@ember/service';
 import sinon from 'sinon';
 
-module('Unit | Route | application', function(hooks) {
+module('Unit | Route | application', (hooks) => {
   setupTest(hooks);
 
   let saveStub;
@@ -14,9 +14,9 @@ module('Unit | Route | application', function(hooks) {
     store = this.owner.lookup('service:store');
   });
 
-  module('sessionAuthenticated', function(hooks) {
+  module('sessionAuthenticated', (hooks) => {
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       saveStub = sinon.stub().resolves();
       prescriber = store.createRecord('prescriber', { id: 1, lang: 'en' });
       prescriber.save = saveStub;
@@ -77,7 +77,7 @@ module('Unit | Route | application', function(hooks) {
     });
   });
 
-  module('beforeModel', function(hooks) {
+  module('beforeModel', (hooks) => {
 
     hooks.beforeEach(function() {
       saveStub = sinon.stub().resolves();

--- a/orga/tests/unit/routes/authenticated-test.js
+++ b/orga/tests/unit/routes/authenticated-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated', function(hooks) {
+module('Unit | Route | authenticated', (hooks) => {
 
   setupTest(hooks);
 

--- a/orga/tests/unit/routes/authenticated/campaigns-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/campaigns', function(hooks) {
+module('Unit | Route | authenticated/campaigns', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign-test.js
@@ -3,7 +3,7 @@ import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import Service from '@ember/service';
 
-module('Unit | Route | authenticated/campaigns/campaign', function(hooks) {
+module('Unit | Route | authenticated/campaigns/campaign', (hooks) => {
   setupTest(hooks);
 
   let route, params;

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/assessments-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/assessments-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/campaigns/campaign/assessments', function(hooks) {
+module('Unit | Route | authenticated/campaigns/campaign/assessments', (hooks) => {
   setupTest(hooks);
 
   let route;
@@ -11,11 +11,11 @@ module('Unit | Route | authenticated/campaigns/campaign/assessments', function(h
     route = this.owner.lookup('route:authenticated/campaigns/campaign/assessments');
   });
 
-  module('fetchSummaries', function(hooks) {
+  module('fetchSummaries', (hooks) => {
     let store;
     let storeStub;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       storeStub = {
         query: sinon.stub(),
       };
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/campaigns/campaign/assessments', function(h
       route.store = storeStub;
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       route.store = store;
     });
 

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/collective-results-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/collective-results-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/campaigns/campaign/campaign-collective-results', function(hooks) {
+module('Unit | Route | authenticated/campaigns/campaign/campaign-collective-results', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/campaign/profiles-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hooks) {
+module('Unit | Route | authenticated/campaigns/campaign/profiles', (hooks) => {
   setupTest(hooks);
 
   let route;
@@ -11,11 +11,11 @@ module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hook
     route = this.owner.lookup('route:authenticated/campaigns/campaign/profiles');
   });
 
-  module('fetchProfileSummaries', function(hooks) {
+  module('fetchProfileSummaries', (hooks) => {
     let store;
     let storeStub;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       storeStub = {
         query: sinon.stub(),
       };
@@ -23,7 +23,7 @@ module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hook
       route.store = storeStub;
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       route.store = store;
     });
 
@@ -59,11 +59,11 @@ module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hook
     });
   });
 
-  module('loading', function(hooks) {
+  module('loading', (hooks) => {
     let store;
     let storeStub;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(() => {
       storeStub = {
         query: sinon.stub(),
       };
@@ -71,25 +71,25 @@ module('Unit | Route | authenticated/campaigns/campaign/profiles', function(hook
       route.store = storeStub;
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(() => {
       route.store = store;
     });
 
-    module('when the transition comes from "authenticated.campaigns.campaign.profiles"', function() {
+    module('when the transition comes from "authenticated.campaigns.campaign.profiles"', () => {
       test('if returns false', function(assert) {
         const transition = { from: { name: 'authenticated.campaigns.campaign.profiles' } };
         assert.equal(route.loading(transition), false);
       });
     });
 
-    module('when the transition comes from somewhere else', function() {
+    module('when the transition comes from somewhere else', () => {
       test('if returns undefined', function(assert) {
         const transition = { from: { name: 'authenticated.campaigns.campaign' } };
         assert.equal(route.loading(transition), undefined);
       });
     });
 
-    module('when the transition has no from attribute', function() {
+    module('when the transition has no from attribute', () => {
       test('if keeps loading page', function(assert) {
         const transition = {};
         assert.equal(route.loading(transition), undefined);

--- a/orga/tests/unit/routes/authenticated/campaigns/list-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/campaigns/list', function(hooks) {
+module('Unit | Route | authenticated/campaigns/list', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/new-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/campaigns/new', function(hooks) {
+module('Unit | Route | authenticated/campaigns/new', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/campaigns/update-test.js
+++ b/orga/tests/unit/routes/authenticated/campaigns/update-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/campaigns/update', function(hooks) {
+module('Unit | Route | authenticated/campaigns/update', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/certifications-test.js
+++ b/orga/tests/unit/routes/authenticated/certifications-test.js
@@ -5,10 +5,10 @@ import EmberObject from '@ember/object';
 
 import sinon from 'sinon';
 
-module('Unit | Route | authenticated/certifications', function(hooks) {
+module('Unit | Route | authenticated/certifications', (hooks) => {
   setupTest(hooks);
 
-  module('beforeModel', function() {
+  module('beforeModel', () => {
     test('should redirect to application when featureToggles.isCertificationResultsInOrgaEnabled is false', function(assert) {
       // given
       class CurrentUserStub extends Service {
@@ -135,7 +135,7 @@ module('Unit | Route | authenticated/certifications', function(hooks) {
     });
   });
 
-  module('#model', function() {
+  module('#model', () => {
 
     test('it should return a list of options based on organization divisions', async function(assert) {
       // given

--- a/orga/tests/unit/routes/authenticated/team-test.js
+++ b/orga/tests/unit/routes/authenticated/team-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/team', function(hooks) {
+module('Unit | Route | authenticated/team', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/team/list-test.js
+++ b/orga/tests/unit/routes/authenticated/team/list-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/team/list', function(hooks) {
+module('Unit | Route | authenticated/team/list', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/authenticated/team/new-test.js
+++ b/orga/tests/unit/routes/authenticated/team/new-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | authenticated/team/new', function(hooks) {
+module('Unit | Route | authenticated/team/new', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/join-request-test.js
+++ b/orga/tests/unit/routes/join-request-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | join-request', function(hooks) {
+module('Unit | Route | join-request', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/join-test.js
+++ b/orga/tests/unit/routes/join-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | join', function(hooks) {
+module('Unit | Route | join', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/join-when-authenticated-test.js
+++ b/orga/tests/unit/routes/join-when-authenticated-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | join-when-authenticated', function(hooks) {
+module('Unit | Route | join-when-authenticated', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/login-test.js
+++ b/orga/tests/unit/routes/login-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | login', function(hooks) {
+module('Unit | Route | login', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/logout-test.js
+++ b/orga/tests/unit/routes/logout-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | logout', function(hooks) {
+module('Unit | Route | logout', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/routes/not-found-test.js
+++ b/orga/tests/unit/routes/not-found-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | not-found', function(hooks) {
+module('Unit | Route | not-found', (hooks) => {
   setupTest(hooks);
 
   test('should redirect to application route', function(assert) {

--- a/orga/tests/unit/routes/terms-of-service-test.js
+++ b/orga/tests/unit/routes/terms-of-service-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
-module('Unit | Route | terms-of-service', function(hooks) {
+module('Unit | Route | terms-of-service', (hooks) => {
   setupTest(hooks);
 
   test('it exists', function(assert) {

--- a/orga/tests/unit/services/current-user-test.js
+++ b/orga/tests/unit/services/current-user-test.js
@@ -4,11 +4,11 @@ import { reject, resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Unit | Service | current-user', function(hooks) {
+module('Unit | Service | current-user', (hooks) => {
 
   setupTest(hooks);
 
-  module('user is authenticated', function(hooks) {
+  module('user is authenticated', (hooks) => {
 
     let currentUserService;
     let connectedUser;
@@ -69,7 +69,7 @@ module('Unit | Service | current-user', function(hooks) {
       assert.equal(currentUserService.organization, organization);
     });
 
-    module('When member is not ADMIN', function() {
+    module('When member is not ADMIN', () => {
 
       test('should set isAdminInOrganization to false', async function(assert) {
         // given
@@ -86,7 +86,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('When member is ADMIN', function() {
+    module('When member is ADMIN', () => {
 
       test('should set isAdminInOrganization to true', async function(assert) {
         // given
@@ -103,7 +103,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('When member is part of SCO organization which is managing students', function() {
+    module('When member is part of SCO organization which is managing students', () => {
       test('should set isSCOManagingStudents to true', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: true, isSco: true });
@@ -133,7 +133,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('When member is part of SUP organization which is managing students', function() {
+    module('When member is part of SUP organization which is managing students', () => {
       test('should set isSCOManagingStudents to false', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'SUP', isManagingStudents: true, isSco: false, isSup: true });
@@ -163,7 +163,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('When member is part of PRO organization which is managing students', function() {
+    module('When member is part of PRO organization which is managing students', () => {
       test('should set isSCOManagingStudents to false with PRO organization', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'PRO', isManagingStudents: true, isPro: true, isSco: false });
@@ -193,7 +193,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('When organization does not manage students', function() {
+    module('When organization does not manage students', () => {
       test('should set isSCOManagingStudents to false when organization is SCO', async function(assert) {
         // given
         const organization = Object.create({ id: 9, type: 'SCO', isManagingStudents: false, isSco: true });
@@ -223,7 +223,7 @@ module('Unit | Service | current-user', function(hooks) {
       });
     });
 
-    module('when user has userOrgaSettings', function() {
+    module('when user has userOrgaSettings', () => {
       test('should prefer organization from userOrgaSettings rather than first membership', async function(assert) {
         // given
         const organization1 = Object.create({ id: 9 });
@@ -243,7 +243,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user is not authenticated', function() {
+  module('user is not authenticated', () => {
 
     test('should do nothing', async function(assert) {
       // given
@@ -261,7 +261,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user is not a prescriber anymore', function() {
+  module('user is not a prescriber anymore', () => {
 
     test('should redirect to login because not a prescriber', async function(assert) {
       // given
@@ -286,7 +286,7 @@ module('Unit | Service | current-user', function(hooks) {
     });
   });
 
-  module('user token is expired', function() {
+  module('user token is expired', () => {
 
     test('should redirect to login', async function(assert) {
       // given

--- a/orga/tests/unit/services/error-messages-test.js
+++ b/orga/tests/unit/services/error-messages-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import setupIntl from '../../helpers/setup-intl';
 
-module('Unit | Service | Error messages', function(hooks) {
+module('Unit | Service | Error messages', (hooks) => {
   setupTest(hooks);
   setupIntl(hooks);
 

--- a/orga/tests/unit/services/feature-toggle-test.js
+++ b/orga/tests/unit/services/feature-toggle-test.js
@@ -4,11 +4,11 @@ import { resolve } from 'rsvp';
 import Object from '@ember/object';
 import Service from '@ember/service';
 
-module('Unit | Service | feature toggles', function(hooks) {
+module('Unit | Service | feature toggles', (hooks) => {
 
   setupTest(hooks);
 
-  module('feature toggles are loaded', function() {
+  module('feature toggles are loaded', () => {
 
     test('should load the feature toggles', async function(assert) {
       // Given

--- a/orga/tests/unit/services/file-saver-test.js
+++ b/orga/tests/unit/services/file-saver-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | file-saver', function(hooks) {
+module('Unit | Service | file-saver', (hooks) => {
   setupTest(hooks);
   let fileSaver;
 
@@ -10,7 +10,7 @@ module('Unit | Service | file-saver', function(hooks) {
     fileSaver = this.owner.lookup('service:file-saver');
   });
 
-  module('#save', function() {
+  module('#save', () => {
     const id = 123456;
     const url = `/attestation/${id}`;
     const token = 'mytoken';
@@ -29,7 +29,7 @@ module('Unit | Service | file-saver', function(hooks) {
       downloadFileForModernBrowsersStub = sinon.stub().returns();
     });
 
-    module('when response has a status 200', function() {
+    module('when response has a status 200', () => {
       test('should use fileName and fileContent from response', async function(assert) {
         // given
         const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };
@@ -53,7 +53,7 @@ module('Unit | Service | file-saver', function(hooks) {
       });
     });
 
-    module('when response has not a status 200', function() {
+    module('when response has not a status 200', () => {
       test('should throw', async function(assert) {
         // given
         const headers = { get: sinon.stub().withArgs('Content-Disposition').returns(`attachment; filename=${responseFileName}`) };

--- a/orga/tests/unit/services/url-test.js
+++ b/orga/tests/unit/services/url-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
-module('Unit | Service | url', function(hooks) {
+module('Unit | Service | url', (hooks) => {
   setupTest(hooks);
 
-  module('#campaignsRootUrl', function() {
+  module('#campaignsRootUrl', () => {
 
     test('should get default campaigns root url when is defined', function(assert) {
       // given

--- a/orga/tests/unit/utils/email-validator-test.js
+++ b/orga/tests/unit/utils/email-validator-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import isEmailValid from 'pix-orga/utils/email-validator';
 
-module('Unit | Utils | email validator', function(hooks) {
+module('Unit | Utils | email validator', (hooks) => {
   setupTest(hooks);
 
-  module('Invalid emails', function() {
+  module('Invalid emails', () => {
     [
       '',
       ' ',
@@ -16,14 +16,14 @@ module('Unit | Utils | email validator', function(hooks) {
       'INVALID_EMAIL@pix.',
       '@pix.fr',
       '@pix',
-    ].forEach(function(badEmail) {
+    ].forEach((badEmail) => {
       test(`should return false when email is invalid: ${badEmail}`, function(assert) {
         assert.equal(isEmailValid(badEmail), false);
       });
     });
   });
 
-  module('Valid emails', function() {
+  module('Valid emails', () => {
     [
       'user@pix.fr',
       'user@pix.fr ',
@@ -34,7 +34,7 @@ module('Unit | Utils | email validator', function(hooks) {
       'user+beta@pix.fr',
       'user+beta@pix.gouv.fr',
       'user+beta@pix.beta.gouv.fr',
-    ].forEach(function(validEmail) {
+    ].forEach((validEmail) => {
       test(`should return true if provided email is valid: ${validEmail}`, function(assert) {
         assert.equal(isEmailValid(validEmail), true);
       });

--- a/orga/tests/unit/utils/input-validator-test.js
+++ b/orga/tests/unit/utils/input-validator-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import InputValidator from 'pix-orga/utils/input-validator';
 
-module('Unit | Utils | input validator', function(hooks) {
+module('Unit | Utils | input validator', (hooks) => {
   setupTest(hooks);
 
   test('should have error when validation fails', function(assert) {

--- a/orga/tests/unit/utils/password-validator-test.js
+++ b/orga/tests/unit/utils/password-validator-test.js
@@ -2,10 +2,10 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import isPasswordValid from 'pix-orga/utils/password-validator';
 
-module('Unit | Utils | password validator', function(hooks) {
+module('Unit | Utils | password validator', (hooks) => {
   setupTest(hooks);
 
-  module('Validation rules', function() {
+  module('Validation rules', () => {
 
     test('should contain at least 8 characters:', function(assert) {
       assert.equal(isPasswordValid('Ab123456'), true);
@@ -29,7 +29,7 @@ module('Unit | Utils | password validator', function(hooks) {
 
   });
 
-  module('Invalid password', function() {
+  module('Invalid password', () => {
     [
       '',
       ' ',
@@ -43,14 +43,14 @@ module('Unit | Utils | password validator', function(hooks) {
       '+!@)-=`"#&1',
       '+!@)-=`"#&1A',
       '+!@)-=`"#&1a',
-    ].forEach(function(badPassword) {
+    ].forEach((badPassword) => {
       test(`should return false when password is invalid: ${badPassword}`, function(assert) {
         assert.equal(isPasswordValid(badPassword), false);
       });
     });
   });
 
-  module('Valid password', function() {
+  module('Valid password', () => {
     [
       'PIXBETa1',
       'PIXBETa12',
@@ -66,7 +66,7 @@ module('Unit | Utils | password validator', function(hooks) {
       '1234Password avec espace',
       '1A      a1',
       'Aà1      ',
-    ].forEach(function(validPassword) {
+    ].forEach((validPassword) => {
       test(`should return true if provided password is valid: ${validPassword}`, function(assert) {
         assert.equal(isPasswordValid(validPassword), true);
       });


### PR DESCRIPTION
## :unicorn: Problème
Le choix d'implémentation des fonctions (nommées ou anonymes) est laissé au développeur:
- function `const foo = function (bar){`
- arrow-function `const foo = (bar)=>{`

Dans la plupart des cas, les fonctionnalités sont identiques.

> An arrow function expression is a compact alternative to a traditional function expression, but is limited and can't be used in all situations.

[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)

Mais cela amène de l'hétérogénéité dans le code, alors que les arrow-function sont plus concises.

## :robot: Solution
Imposer l'usage des arrow-function : 
- dans le code existant, remplacer toutes les occurences de fonction par des arrow là où c'est possible (option `--fix`)
- ajouter la règle eslint [mocha/prefer-arrow-callback](https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/prefer-arrow-callback.md) 

Si les arguments ne vous semblent pas convaincants ou méritent d'être explicités, je peux créer une ADR.

## :rainbow: Remarques
Les fonctions anonymes utilisées par Mocha traitées [dans cette PR.](https://github.com/1024pix/pix/pull/2764)

La règle utilisée provient du plugin ESLint `mocha`, mais n'affecte pas les fonctions du  code de test.
La raison est la suivante: il existe une règle native Eslint [prefer-arrow-callback](https://eslint.org/docs/rules/prefer-arrow-callback) mais celle-ci cause des régressions dans Mocha. La règle du plugin ESLint `mocha` résoud ce problème.

## :100: Pour tester
Remplacer une arrow-function par une function, vérifier qu'une erreur de lint `prefer-arrow-callback`  apparaît
Rajouter un `this.setTimeout(500);` dans le corps de la fonction et vérifier que l'erreur de lint disparaît.
