### PR TITLE
[BUGFIX] Garder la langue quand je suis connecté en simplifié/anonyme.

### DIFF
--- a/api/lib/application/authentication/authentication-controller.js
+++ b/api/lib/application/authentication/authentication-controller.js
@@ -66,8 +66,8 @@ module.exports = {
 
   async authenticateAnonymousUser(request, h) {
 
-    const { 'campaign_code': campaignCode } = request.payload;
-    const accessToken = await usecases.authenticateAnonymousUser({ campaignCode });
+    const { 'campaign_code': campaignCode, lang } = request.payload;
+    const accessToken = await usecases.authenticateAnonymousUser({ campaignCode, lang });
 
     const response = {
       token_type: 'bearer',

--- a/api/lib/application/authentication/index.js
+++ b/api/lib/application/authentication/index.js
@@ -76,6 +76,7 @@ exports.register = async (server) => {
         validate: {
           payload: Joi.object().required().keys({
             campaign_code: Joi.string().required(),
+            lang: Joi.string().required(),
           }),
         },
         handler: AuthenticationController.authenticateAnonymousUser,

--- a/api/lib/domain/usecases/authenticate-anonymous-user.js
+++ b/api/lib/domain/usecases/authenticate-anonymous-user.js
@@ -3,6 +3,7 @@ const { UserCantBeCreatedError } = require('../errors');
 
 module.exports = async function authenticateAnonymousUser({
   campaignCode,
+  lang = 'fr',
   campaignToJoinRepository,
   userRepository,
   tokenService,
@@ -20,6 +21,7 @@ module.exports = async function authenticateAnonymousUser({
       cgu: false,
       mustValidateTermsOfService: false,
       isAnonymous: true,
+      lang,
     }),
   });
 

--- a/api/tests/acceptance/application/authentication-controller_test.js
+++ b/api/tests/acceptance/application/authentication-controller_test.js
@@ -492,6 +492,7 @@ describe('Acceptance | Controller | authentication-controller', () => {
     context('When is not simplified Access Campaign', () => {
 
       const campaignCode = 'RANDOM123';
+      const lang = 'en';
 
       beforeEach(async () => {
         const targetProfile = databaseBuilder.factory.buildTargetProfile({ isSimplifiedAccess: false });
@@ -505,6 +506,7 @@ describe('Acceptance | Controller | authentication-controller', () => {
           },
           payload: querystring.stringify({
             campaign_code: campaignCode,
+            lang,
           }),
         };
 
@@ -527,6 +529,7 @@ describe('Acceptance | Controller | authentication-controller', () => {
       const firstName = '';
       const lastName = '';
       const isAnonymous = true;
+      const lang = 'en';
 
       beforeEach(async () => {
 
@@ -541,6 +544,7 @@ describe('Acceptance | Controller | authentication-controller', () => {
           },
           payload: querystring.stringify({
             campaign_code: simplifiedAccessCampaignCode,
+            lang,
           }),
         };
 

--- a/api/tests/integration/application/authentication/index_test.js
+++ b/api/tests/integration/application/authentication/index_test.js
@@ -382,6 +382,7 @@ describe('Integration | Application | Route | AuthenticationRouter', () => {
     beforeEach(() => {
       payload = querystring.stringify({
         campaign_code: code,
+        lang: 'fr',
       });
     });
 

--- a/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
+++ b/api/tests/unit/domain/usecases/authenticate-anonymous-user_test.js
@@ -6,12 +6,14 @@ const authenticateAnonymousUser = require('../../../../lib/domain/usecases/authe
 
 describe('Unit | UseCase | authenticate-anonymous-user', () => {
   let campaignCode;
+  let lang;
   let campaignToJoinRepository;
   let userRepository;
   let tokenService;
 
   beforeEach(() => {
     campaignCode = 'SIMPLIFIE';
+    lang = 'en';
     campaignToJoinRepository = {
       getByCode: sinon.stub(),
     };
@@ -34,11 +36,12 @@ describe('Unit | UseCase | authenticate-anonymous-user', () => {
       cgu: false,
       mustValidateTermsOfService: false,
       isAnonymous: true,
+      lang: lang,
     });
     userRepository.create.resolves({ id: 1 });
 
     // when
-    await authenticateAnonymousUser({ campaignCode, campaignToJoinRepository, userRepository, tokenService });
+    await authenticateAnonymousUser({ campaignCode, lang, campaignToJoinRepository, userRepository, tokenService });
 
     // then
     expect(campaignToJoinRepository.getByCode).to.have.been.calledWith(campaignCode);

--- a/mon-pix/app/authenticators/anonymous.js
+++ b/mon-pix/app/authenticators/anonymous.js
@@ -4,13 +4,15 @@ import fetch from 'fetch';
 import RSVP from 'rsvp';
 import { decodeToken } from 'mon-pix/helpers/jwt';
 import { isEmpty } from '@ember/utils';
+import { inject as service } from '@ember/service';
 
 export default BaseAuthenticator.extend({
+  intl: service(),
 
   serverTokenEndpoint: `${ENV.APP.API_HOST}/api/token/anonymous`,
 
   async authenticate({ campaignCode }) {
-    const bodyObject = { campaign_code: campaignCode };
+    const bodyObject = { campaign_code: campaignCode, lang: this.intl.t('current-lang') };
 
     const body = Object.keys(bodyObject)
       .map((k) => `${k}=${encodeURIComponent(bodyObject[k])}`)


### PR DESCRIPTION
## :unicorn: Problème
Dans les campagnes simplifiés, la langue n'est pas gardé lors de la connexion

## :robot: Solution
Passer la langue lors de la création du compte

## :rainbow: Remarques

## :100: Pour tester
Lancer les campagnes SIMPLIFIE en anglais ou en fr, et voir que la langue reste la même
https://app-pr2763.review.pix.org/campagnes/SIMPLIFIE?lang=en
https://app-pr2763.review.pix.org/campagnes/SIMPLIFIE