### PR TITLE
[FEATURE] Ajout de sous-catégories de signalements pour les liens (PIX-1640).

### DIFF
--- a/mon-pix/app/static-data/feedback-panel-issue-labels.js
+++ b/mon-pix/app/static-data/feedback-panel-issue-labels.js
@@ -64,7 +64,12 @@ const questions = {
   ],
   'link': [
     {
-      name: 'link',
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.link-unauthorized.label',
+      type: 'tutorial',
+      content: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.link-unauthorized.solution',
+    },
+    {
+      name: 'pages.challenge.feedback-panel.form.fields.detail-selection.options.link-other',
       type: 'textbox',
     },
   ],

--- a/mon-pix/tests/acceptance/challenge-feedback-test.js
+++ b/mon-pix/tests/acceptance/challenge-feedback-test.js
@@ -54,7 +54,7 @@ describe('Acceptance | Giving feedback about a challenge', function() {
 
       context('and the form is filled but not sent', function() {
         beforeEach(async function() {
-          await fillIn(DROPDOWN, 'link');
+          await fillIn(DROPDOWN, 'accessibility');
           await fillIn(TEXTAREA, 'TEST_CONTENT');
           await blur(TEXTAREA);
         });
@@ -71,7 +71,7 @@ describe('Acceptance | Giving feedback about a challenge', function() {
 
           it('should always reset the feedback form between two consecutive challenges', async function() {
             await click('.feedback-panel__open-button');
-            await fillIn(DROPDOWN, 'link');
+            await fillIn(DROPDOWN, 'accessibility');
             expect(find(TEXTAREA).value).to.equal('');
           });
         });

--- a/mon-pix/tests/integration/components/feedback-panel-test.js
+++ b/mon-pix/tests/integration/components/feedback-panel-test.js
@@ -21,7 +21,7 @@ const DROPDOWN = '.feedback-panel__dropdown';
 const TUTORIAL_AREA = '.feedback-panel__tutorial-content';
 
 const PICK_CATEGORY_WITH_NESTED_LEVEL = 'question';
-const PICK_CATEGORY_WITH_TEXTAREA = 'link';
+const PICK_CATEGORY_WITH_TEXTAREA = 'accessibility';
 const PICK_CATEGORY_WITH_TUTORIAL = 'picture';
 
 function expectFormViewToBeVisible() {

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -325,6 +325,11 @@
                                     "solution": "Your internet connection may not be strong enough.'<br>'Refresh the page by clicking on the refresh button'<object type=\"image/svg+xml\" class=\"tuto-icon\" data=\"/images/icons/icon-reload.svg\"></object>' next to the address bar. Wait a little while, the simulator might display. '<br><br>'If it doesn’t, you can try again later or from another location with a better connection."
                                 },
                                 "embed-other": "There is another problem with the simulator/app",
+                                "link-unauthorized": {
+                                    "label": "The link has been blocked by my organisation/school…",
+                                    "solution": "You may belong to an organisation (schools, universities, companies, administrations, associations, etc.) that protects its users and devices by limiting the Internet pages you can access."
+                                },
+                                "link-other": "The link doesn’t work or has another problem",
                                 "other-challenge-proposal": "I have a (great) idea to suggest for a question",
                                 "other-site-improvement": "I have a suggestion for improving the platform",
                                 "other-difficulty": "I have another problem",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -325,6 +325,11 @@
                                     "solution": "Votre connexion internet est peut-être trop faible.'<br>'Rechargez la page en appuyant sur le bouton actualiser '<object type=\"image/svg+xml\" class=\"tuto-icon\" data=\"/images/icons/icon-reload.svg\"></object>' à côté de la barre d’adresse. Attendez un peu, le simulateur va peut-être s’afficher. '<br><br>'Si ce n’est pas le cas, pouvez-vous retenter à un autre moment ou depuis un autre endroit avec une meilleure connexion ?"
                                 },
                                 "embed-other": "Le simulateur / l’application a un autre problème",
+                                "link-unauthorized": {
+                                    "label": "Le lien est bloqué par mon organisation / établissement...",
+                                    "solution": "Vous appartenez peut-être à une organisation (établissements scolaires, universitaires, entreprises, administrations, association...) qui protège ses utilisateurs et ses équipements en limitant les pages Internet auxquelles vous avez accès.'<br>'"
+                                },
+                                "link-other": "Le lien ne fonctionne pas ou a un autre problème",
                                 "other-challenge-proposal": "J’ai une idée (géniale) d’épreuve à proposer",
                                 "other-site-improvement": "J’ai une suggestion d’amélioration de la plateforme",
                                 "other-difficulty": "J’ai un autre problème",


### PR DESCRIPTION
## :unicorn: Problème

Il n'est pas possible pour les utilisateurs d'effectuer des signalements précis en ce qui concerne les problèmes liés aux liens dans les épreuves.

## :robot: Solution

Ajout de deux nouvelles sous-catégories pour la catégorie "liens"

## :rainbow: Remarques

La catégorie `links` a été remplacée dans les tests par `accessibility` puisque cette dernière ne comporte pas de sous-catégories et correspond au comportement stipulé dans les tests (catégorie sans sous-catégorie)

En attente des traductions.

## :100: Pour tester

- Constater la présence des sous-catégories de signalement pour la catégorie `liens`
- Tester les signalements et constater de leur présence en DB.
