### PR TITLE
[BUGFIX] Empecher l'embed de dépasser de l'iframe

### DIFF
--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -61,6 +61,7 @@
 }
 
 .embed__simulator {
+  -webkit-overflow-scrolling: touch;
   height: calc(100% + 5px);
   overflow: auto;
 

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -61,7 +61,7 @@
 }
 
 .embed__simulator {
-  height: 100%;
+  height: calc(100% + 5px);
   overflow: auto;
 
   &.blurred {
@@ -73,7 +73,7 @@
   position: relative;
   border: none;
   width: 100%;
-  height: 100%;
+  height: calc(100% - 5px);
 }
 
 .embed__reboot {

--- a/mon-pix/app/styles/components/_challenge-embed-simulator.scss
+++ b/mon-pix/app/styles/components/_challenge-embed-simulator.scss
@@ -62,6 +62,7 @@
 
 .embed__simulator {
   height: 100%;
+  overflow: auto;
 
   &.blurred {
     filter: blur(5px);


### PR DESCRIPTION
## :unicorn: Problème
Sur IOS < 13, les embed dépasse du cadre de l'iframe.
Le champ de réponse est alors caché et il n'est plus possible de répondre ni de passer l'épreuve.

## :robot: Solution
- mettre `overflow: auto` sur le parent de l'iframe

## :rainbow: Remarques
Utilisation de `-webkit-overflow-scrolling: touch` 
https://developer.mozilla.org/fr/docs/Web/CSS/-webkit-overflow-scrolling

## :100: Pour tester
Sur device IOS < 13
Est-ce que le contenu de l'iframe s'affiche correctement sur l'épreuve:
https://app-pr2769.review.pix.fr/challenges/recYCcrYL8X2O35n9/preview
