### PR TITLE
[FEAT] Ajout d'avertissements sur la modale de remise à zéro (PIX-2365).

### DIFF
--- a/mon-pix/app/styles/components/_scorecard-details.scss
+++ b/mon-pix/app/styles/components/_scorecard-details.scss
@@ -219,6 +219,14 @@
     font-family: $font-roboto;
     font-weight: $font-light;
     font-size: 1rem;
+
+    p {
+      font-weight: bold;
+    }
+
+    li:first-child {
+      margin-bottom: 12px;
+    }
   }
 }
 

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -141,7 +141,11 @@
           {{/if}}
         </div>
         <div class="scorecard-details-reset-modal__warning">
-          <p>{{t 'pages.competence-details.actions.reset.modal.warning'}}</p>
+          <p>{{t 'pages.competence-details.actions.reset.modal.warning.header'}}</p>
+          <ul>
+            <li>{{t 'pages.competence-details.actions.reset.modal.warning.ongoing-assessment'}}</li>
+            <li>{{t 'pages.competence-details.actions.reset.modal.warning.certification'}}</li>
+          </ul>
         </div>
       </div>
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -501,7 +501,11 @@
                         "important-message": "Your Pix { earnedPix } will be deleted.",
                         "important-message-above-level-one": "Your level { level } and your Pix { earnedPix } will be deleted.",
                         "title": "Skill reset",
-                        "warning": "NB If you have a personalised test in progress, you might be asked some questions again."
+                        "warning": {
+                            "header": "NB: ",
+                            "ongoing-assessment": "If you have a personalised test in progress, you might be asked some questions again.",
+                            "certification": "If you are planning to certify your profile and results, this could affect your certification."
+                        }
                     }
                 },
                 "start": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -501,7 +501,11 @@
                         "important-message": "Vos { earnedPix } Pix vont être supprimés.",
                         "important-message-above-level-one": "Votre niveau { level } et vos { earnedPix } Pix vont être supprimés.",
                         "title": "Remise à zéro de la compétence",
-                        "warning": "Attention : si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées."
+                        "warning": {
+                            "header": "Attention : ",
+                            "ongoing-assessment": "si vous avez un parcours d’évaluation en cours, certaines questions pourront vous être reposées.",
+                            "certification": "si vous souhaitez faire certifier votre profil et vos différents résultats, cela pourrait altérer votre certification."
+                        }
                     }
                 },
                 "start": {


### PR DESCRIPTION
## :unicorn: Problème

Il faut prévenir plus précisément les utilisateurs des différents effets de la remise à zéro d'une compétence.

## :robot: Solution

Ajout d'une liste pour rendre les différents avertissements.

## :rainbow: Remarques

Le wording est en cours de validation.
Sa traduction sera demandée quand celui-ci sera validé.

Il est possible d'ajouter des classes CSS aux éléments de la liste nouvellement créée afin d'éviter le nesting dans le fichier `_scorecard-details.scss` mais je ne pense pas que cela soit nécessaire, à discuter bien entendu.

## :100: Pour tester

Essayer de mettre une compétence à zéro et voir les nouveaux avertissements.
