### PR TITLE
[TECH] Supprimer l'utlisation du repository campaign participation result dans le calcul des badges acquis (PIX-2395).

### DIFF
--- a/api/lib/domain/models/BadgeResults.js
+++ b/api/lib/domain/models/BadgeResults.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+
+class BadgeResults {
+  constructor(badges, skills, knowledgeElements) {
+    this.masteryPercentage = _computeMasteryPercentage(skills, knowledgeElements);
+
+    this.campaignParticipationBadges = badges.map(({ id, badgePartnerCompetences }) => {
+      return {
+        id,
+        partnerCompetenceResults: _buildPartnerCompetenceResults(badgePartnerCompetences, knowledgeElements),
+      };
+    });
+  }
+
+  static build(badges, skills, knowledgeElements) {
+    return new BadgeResults(badges, skills, knowledgeElements);
+  }
+}
+
+function _computeMasteryPercentage(skills, knowledgeElement) {
+  const validatedSkillsCount = _.filter(knowledgeElement, 'isValidated').length;
+
+  return Math.round(validatedSkillsCount * 100 / skills.length);
+}
+
+function _buildPartnerCompetenceResults(partnerCompetences, knowledgeElements) {
+  return partnerCompetences.map((partnerCompetence) => {
+    const competenceKnowledgeElements = _findKnowledgeElementsFrom(partnerCompetence, knowledgeElements);
+    return {
+      id: partnerCompetence.id,
+      masteryPercentage: _computeMasteryPercentage(partnerCompetence.skillIds, competenceKnowledgeElements),
+    };
+  });
+}
+function _findKnowledgeElementsFrom(partnerCompetence, knowledgeElements) {
+  return knowledgeElements.filter(({ skillId }) => partnerCompetence.skillIds.includes(skillId));
+}
+
+module.exports = BadgeResults;

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -376,13 +376,13 @@ async function _createAndCompleteCampaignParticipation({ user, campaign, badge, 
     campaignParticipationId: campaignParticipation.id,
   });
   const anyDateBeforeCampaignParticipation = new Date(campaignParticipation.sharedAt.getTime() - 60 * 1000);
-
+  const skillId = `recSkill0_${campaign.id}`;
   databaseBuilder.factory.buildTargetProfileSkill({
     targetProfileId: campaign.targetProfileId,
-    skillId: 'recSkill0_0',
+    skillId,
   });
   databaseBuilder.factory.buildKnowledgeElement({
-    skillId: 'recSkill0_0',
+    skillId,
     assessmentId: campaignAssessment.id,
     userId: user.id,
     competenceId: 'recCompetence0',

--- a/api/tests/unit/domain/models/BadgeResults_test.js
+++ b/api/tests/unit/domain/models/BadgeResults_test.js
@@ -1,0 +1,44 @@
+const { domainBuilder, expect } = require('../../../test-helper');
+const BadgeResults = require('../../../../lib/domain/models/BadgeResults');
+const KnowledgeElement = require('../../../../lib/domain/models/KnowledgeElement');
+
+describe('Unit | Domain | Models | BadgeResults', () => {
+  context('masteryPercentage', () => {
+    it('computes the global mastery percentage', async () => {
+      const skills = ['skill1', 'skill2', 'skill3'];
+      const knowledgeElements = [domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED })];
+      const badgeResults = new BadgeResults([], skills, knowledgeElements);
+
+      expect(badgeResults.masteryPercentage).to.deep.equal(33);
+    });
+
+  });
+  context('when there are partner competences', () => {
+    it('computes the mastery percentage for every partner competences', async () => {
+      const skills = ['skill1', 'skill2', 'skill3', 'skill4'];
+      const competence1 = { id: 'C1', skillIds: ['skill1', 'skill2'] };
+      const competence2 = { id: 'C2', skillIds: ['skill3'] };
+      const competence3 = { id: 'C3', skillIds: ['skill4'] };
+      const badge1 = {
+        id: 1,
+        badgePartnerCompetences: [competence1, competence2],
+      };
+      const badge2 = {
+        id: 2,
+        badgePartnerCompetences: [competence3],
+      };
+      const knowledgeElements = [
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill1', status: KnowledgeElement.StatusType.VALIDATED }),
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill2', status: KnowledgeElement.StatusType.INVALIDATED }),
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill3', status: KnowledgeElement.StatusType.VALIDATED }),
+        domainBuilder.buildKnowledgeElement({ skillId: 'skill4', status: KnowledgeElement.StatusType.INVALIDATED }),
+      ];
+      const badgeResults = new BadgeResults([badge1, badge2], skills, knowledgeElements);
+
+      expect(badgeResults.campaignParticipationBadges).to.deep.equal([
+        { id: 1, partnerCompetenceResults: [{ id: 'C1', masteryPercentage: 50 }, { id: 'C2', masteryPercentage: 100 }] },
+        { id: 2, partnerCompetenceResults: [{ id: 'C3', masteryPercentage: 0 }] },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Le campaign-participation-repository a une interface qui prend en paramètre la listes des badges acquis.
L'utilisation de se repository couple le calcul des résultat d'une campagne et le calcul des badges acquis et propose une interface peu pratique.

## :robot: Solution
Supprimer l'utilisation du repository

## :rainbow: Remarques
RAS

## :100: Pour tester
Test de non régression sur l'acquisition des badges
