### PR TITLE
[DOCS] Proposition de bonnes pratiques autour du testing de textes traduits sur les applications front Ember (PIX-2418)

### DIFF
--- a/docs/Ember.md
+++ b/docs/Ember.md
@@ -1,4 +1,8 @@
-## Utilisation de transitionTo
+# Ember
+
+## Général
+
+### Utilisation de transitionTo
 
 Éviter les `transistionTo` dans le hook `model()`. Privilégier leur utilisation dans l’`afterModel()`, une fois que le modèle est chargé.
 
@@ -28,6 +32,36 @@ export default Route.extend({
       return this.transitionTo('board');
     }
   }
+});
+```
+
+## Tests
+
+### Tester le texte traduit par EmberIntl
+
+Afin d'être complètement agnostique de la locale de l'environnement de test, on privilégiera le fait de tester les textes traduits en passant
+par le `helper` `t` fourni par `ember-intl/test-support`. Ainsi, on s'affranchira de la contrainte de langue et on se concentrera plutôt
+sur la clé de traduction attendue sur un test donné ([procédé documenté dans la doc EmberIntl](https://ember-intl.github.io/ember-intl/versions/master/docs/guide/testing#t-key-options-)).
+
+Pour tester les textes traduits dans les templates :
+```js
+import { module, test } from 'qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl, t } from 'ember-intl/test-support';
+
+module('Integration | Component | hello', function(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+  
+  test('it should display a welcome message', async function (assert) {
+    // when
+    await render(hbs`<Hello/>`);
+
+    // then
+    assert.dom().hasText(t('pages.hello.welcome-message'));
+  });
 });
 ```
 

--- a/docs/Ember.md
+++ b/docs/Ember.md
@@ -88,4 +88,28 @@ module('Unit | Service | Error messages', function(hooks) {
 });
 ```
 
+Enfin, si vraiment on souhaite tester une traduction spécifique, il faut alors spécifier la locale lors du setup de test :
+```js
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupIntl, t } from 'ember-intl/test-support';
+
+module('Unit | Service | Error messages', function(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks, 'fr-fr');
+
+  test('should return the message when error code is found', function(assert) {
+    // given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    
+    // when
+    const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
+    
+    // then
+    assert.equal(message, 'Le nom de la campagne est obligatoire');
+  });
+});
+```
+*Note: La pratique n'est pas recommandée sauf exception*
+
 

--- a/docs/Ember.md
+++ b/docs/Ember.md
@@ -65,4 +65,27 @@ module('Integration | Component | hello', function(hooks) {
 });
 ```
 
+De même, pour tout autre texte traduit par un autre biais :
+```js
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { setupIntl, t } from 'ember-intl/test-support';
+
+module('Unit | Service | Error messages', function(hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test('should return the message when error code is found', function(assert) {
+    // given
+    const errorMessages = this.owner.lookup('service:errorMessages');
+    
+    // when
+    const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
+    
+    // then
+    assert.equal(message, t('api-errors-messages.campaign-creation.name-required'));
+  });
+});
+```
+
 

--- a/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
+++ b/orga/tests/integration/components/routes/authenticated/campaign/new-test.js
@@ -5,10 +5,12 @@ import clickByLabel from '../../../../../helpers/extended-ember-test-helpers/cli
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
-import setupIntlRenderingTest from '../../../../../helpers/setup-intl-rendering';
+import { setupRenderingTest } from 'ember-qunit';
+import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Integration | Component | routes/authenticated/campaign/new', function(hooks) {
-  setupIntlRenderingTest(hooks);
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
   let receivedCampaign;
 
   hooks.beforeEach(function() {
@@ -31,7 +33,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
     // then
-    assert.contains('Nom de la campagne');
+    assert.contains(t('pages.campaign-creation.name.label'));
     assert.dom('button[type="submit"]').exists();
     assert.dom('input[type=text]').hasAttribute('maxLength', '255');
     assert.dom('textarea').hasAttribute('maxLength', '350');
@@ -47,8 +49,8 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.contains('Titre du parcours');
-      assert.contains('Que souhaitez-vous tester ?');
+      assert.contains(t('pages.campaign-creation.test-title.label'));
+      assert.contains(t('pages.campaign-creation.target-profiles-list.label'));
     });
 
     test('it should not contain field to select campaign type', async function(assert) {
@@ -59,8 +61,8 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.notContains('Évaluer les participants');
-      assert.notContains('Collecter les profils Pix des participants');
+      assert.notContains(t('pages.campaign-creation.purpose.assessment'));
+      assert.notContains(t('pages.campaign-creation.purpose.profiles-collection'));
     });
   });
 
@@ -76,11 +78,11 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await clickByLabel('Évaluer les participants');
+      await clickByLabel(t('pages.campaign-creation.purpose.assessment'));
 
       // then
-      assert.contains('Titre du parcours');
-      assert.contains('Que souhaitez-vous tester ?');
+      assert.contains(t('pages.campaign-creation.test-title.label'));
+      assert.contains(t('pages.campaign-creation.purpose.label'));
     });
   });
 
@@ -96,11 +98,11 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await clickByLabel('Collecter les profils Pix des participants');
+      await clickByLabel(t('pages.campaign-creation.purpose.profiles-collection'));
 
       // then
-      assert.notContains('Titre du parcours');
-      assert.notContains('Que souhaitez-vous tester ?');
+      assert.notContains(t('pages.campaign-creation.test-title.label'));
+      assert.notContains(t('pages.campaign-creation.target-profiles-list.label'));
     });
   });
 
@@ -119,7 +121,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.dom('a[href="https://cloud.pix.fr/s/3joGMGYWSpmHg5w"]').hasText('la documentation correspondante');
+      assert.contains(t('pages.campaign-creation.target-profile-informations'));
     });
   });
 
@@ -138,7 +140,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.dom('a[href="https://cloud.pix.fr/s/3joGMGYWSpmHg5w"]').doesNotExist();
+      assert.notContains(t('pages.campaign-creation.target-profile-informations'));
     });
   });
 
@@ -151,7 +153,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.notContains('* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.');
+      assert.notContains(t('pages.campaign-creation.legal-warning'));
     });
   });
 
@@ -162,10 +164,10 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await clickByLabel('No');
+      await clickByLabel(t('pages.campaign-creation.no'));
 
       // then
-      assert.notContains('* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.');
+      assert.notContains(t('pages.campaign-creation.legal-warning'));
     });
   });
 
@@ -176,10 +178,10 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await clickByLabel('Oui');
+      await clickByLabel(t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains('* En vertu de la loi Informatique et libertés, et en tant que responsable de traitement, soyez attentifs à ne pas demander de donnée particulièrement identifiante ou signifiante si ce n’est pas absolument indispensable. Le numéro de sécurité sociale (NIR) est à proscrire ainsi que toute donnée sensible.');
+      assert.contains(t('pages.campaign-creation.legal-warning'));
     });
   });
 
@@ -187,10 +189,10 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
     // given
     this.campaign = EmberObject.create({});
     await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-    await fillInByLabel('Nom de la campagne', 'Ma campagne');
+    await fillInByLabel(t('pages.campaign-creation.name.label'), 'Ma campagne');
 
     // when
-    await clickByLabel('Créer la campagne');
+    await clickByLabel(t('pages.campaign-creation.actions.create'));
 
     // then
     assert.deepEqual(receivedCampaign.name, 'Ma campagne');
@@ -225,12 +227,12 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
 
       // when
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
-      await clickByLabel('Oui');
+      await clickByLabel(t('pages.campaign-creation.yes'));
 
       // then
-      assert.contains('Veuillez donner un nom à votre campagne.');
-      assert.contains('Veuillez choisir l’objectif de votre campagne : Évaluation ou Collecte de profils.');
-      assert.contains('Veuillez préciser le libellé du champ qui sera demandé à vos participants au démarrage du parcours.');
+      assert.contains(t('api-errors-messages.campaign-creation.name-required'));
+      assert.contains(t('api-errors-messages.campaign-creation.purpose-required'));
+      assert.contains(t('api-errors-messages.campaign-creation.external-user-id-required'));
     });
 
     test('it should display errors messages when the target profile field is empty', async function(assert) {
@@ -249,7 +251,7 @@ module('Integration | Component | routes/authenticated/campaign/new', function(h
       await render(hbs`<Routes::Authenticated::Campaign::New @campaign={{campaign}} @createCampaign={{createCampaignSpy}} @cancel={{cancelSpy}}/>`);
 
       // then
-      assert.contains('Veuillez sélectionner un profil cible pour votre campagne.');
+      assert.contains(t('api-errors-messages.campaign-creation.target-profile-required'));
     });
   });
 });

--- a/orga/tests/unit/services/error-messages-test.js
+++ b/orga/tests/unit/services/error-messages-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import setupIntl from '../../helpers/setup-intl';
+import { setupIntl, t } from 'ember-intl/test-support';
 
 module('Unit | Service | Error messages', function(hooks) {
   setupTest(hooks);
@@ -30,7 +30,7 @@ module('Unit | Service | Error messages', function(hooks) {
     // When
     const message = errorMessages.getErrorMessage('CAMPAIGN_NAME_IS_REQUIRED');
     // Then
-    assert.equal(message, 'Veuillez donner un nom à votre campagne.');
+    assert.equal(message, t('api-errors-messages.campaign-creation.name-required'));
   });
 
   test('should return the message with parameters', function(assert) {
@@ -39,7 +39,7 @@ module('Unit | Service | Error messages', function(hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_MIN_LENGTH', { line: 1, field: 'Boo', limit: 2 });
     // Then
-    assert.equal(message, 'Ligne 1 : Le champ “Boo” doit être d’au moins 2 caractères.');
+    assert.equal(message, t('api-errors-messages.student-csv-import.field-min-length', { line: 1, field: 'Boo', limit: 2 }));
   });
 
   test('should concatenate "valids" parameters', function(assert) {
@@ -48,6 +48,10 @@ module('Unit | Service | Error messages', function(hooks) {
     // When
     const message = errorMessages.getErrorMessage('FIELD_BAD_VALUES', { line: 1, field: 'Boo', valids: ['A', 'B'] });
     // Then
-    assert.equal(message, 'Ligne 1 : Le champ “Boo” doit être “A ou B”.');
+    assert.equal(message, t('api-errors-messages.student-csv-import.field-bad-values', {
+      line: 1,
+      field: 'Boo',
+      valids: `A${t('api-errors-messages.or-separator')}B`,
+    }));
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
L'on a évoqué, en point tech, la gêne de devoir tester des chaînes en fixant une locale à l'environnement de test. Il est dommage que l'environnement ne soit pas agnostique de ce détail. Plus encore, il paraît plus pertinent de tester que la bonne clé de traduction soit bien à l'endroit attendu.

## :robot: Solution
Chance, EmberIntl a ce qu'il faut pour baser ses tests sur les clés de traduction plutôt que sur la traduction elle-même.
On propose ici d'alimenter le document Ember.md avec les bonnes pratiques, trouver un consensus.
Cette PR propose deux fichiers de tests sur lesquels ont été appliqués les recommandations (deux fichiers PixOrga).
Cette PR ne **_va pas contenir_** la mise en pratique sur toutes les applis du consensus, ce sera un boulot à faire petit à petit, en point tech par exemple (aussi fun que la glimmerisation 😉 )

## :rainbow: Remarques
Peut-être besoin de suggestion pour la mise en forme du .md. J'ai tendance à revenir à la ligne car sur mon IDE j'aime pas aller trop à droite, mais du coup j'ai l'impression que le rendu final est chelou.

On peut lister les avantages / inconvénients lister en commentaire ou dans les réflexions.
Avantages:
- On peut changer les textes sans casser les tests
- On n'a pas l'impression de tester partiellement (si on teste QUE du 'fr' ou bien QUE de 'en')
- Permet de tester précisément que la clé de traduction attendue est bien au bon endroit (les clés de traduction sont uniques, le contenu pas forcément)

Inconvénients:
- Baisse un peu la lisibilité des tests

J'ai décidé de modifier l'ADR relative à la traduction dans la prochaine PR corrective qui rentre un peu plus dans le lard

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
