### PR TITLE
[TECH] Prévenir les injections SQL dans l'API.

### DIFF
--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -10,8 +10,6 @@ rules:
   no-sync: error
   no-restricted-syntax:
      -  error
-     -  selector: "CallExpression[callee.object.name='knex'][callee.property.name='raw'][arguments.0.type='TemplateLiteral']"
-        message: "do not use template strings with knex.raw to avoid SQL injection"
      # These 2 selectors are duplicated from ../eslintrc.yaml as they are overridden by default
      # TODO: find a way to keep without redefining them
      -  selector: "NewExpression[callee.name=Date][arguments.length=1][arguments.0.type=Literal]:not([arguments.0.value=/^[12][0-9]{3}-(0[0-9]|1[0-2])-([0-2][0-9]|3[01])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z)?$/])"

--- a/api/.eslintrc.yaml
+++ b/api/.eslintrc.yaml
@@ -3,6 +3,9 @@ extends: '../.eslintrc.yaml'
 globals:
   include: true
 
+plugins:
+  - knex
+
 rules:
   no-sync: error
   no-restricted-syntax:
@@ -15,3 +18,4 @@ rules:
         message: "Use only ISO8601 UTC syntax ('2019-03-12T01:02:03Z') in Date constructor"
      -  selector: "CallExpression[callee.object.object.name='faker'][callee.object.property.name='internet'][callee.property.name='email']"
         message: "Use only faker.internet.exampleEmail()"
+  knex/avoid-injections: error

--- a/api/db/database-builder/database-builder.js
+++ b/api/db/database-builder/database-builder.js
@@ -62,41 +62,42 @@ module.exports = class DatabaseBuilder {
       'pix_roles',
     );
     const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
+    // eslint-disable-next-line knex/avoid-injections
     return this.knex.raw(`TRUNCATE ${tables}`);
   }
 
   async _initTablesOrderedByDependencyWithDirtinessMap() {
     // See this link : https://stackoverflow.com/questions/51279588/sort-tables-in-order-of-dependency-postgres
-    const results = await this.knex.raw('with recursive fk_tree as ( ' +
-      'select t.oid as reloid, ' +
-      't.relname as table_name, ' +
-      's.nspname as schema_name, ' +
-      'null::name as referenced_table_name, ' +
-      'null::name as referenced_schema_name, ' +
-      '1 as level ' +
-      'from pg_class t ' +
-      'join pg_namespace s on s.oid = t.relnamespace ' +
-      'where relkind = \'r\' ' +
-      'and not exists (select * ' +
-      'from pg_constraint ' +
-      'where contype = \'f\' ' +
-      'and conrelid = t.oid) ' +
-      'and s.nspname = \'public\' ' +
-      'union all ' +
-      'select ref.oid, ' +
-      'ref.relname, ' +
-      'rs.nspname, ' +
-      'p.table_name, ' +
-      'p.schema_name, ' +
-      'p.level + 1 ' +
-      'from pg_class ref ' +
-      'join pg_namespace rs on rs.oid = ref.relnamespace ' +
-      'join pg_constraint c on c.contype = \'f\' and c.conrelid = ref.oid ' +
-      'join fk_tree p on p.reloid = c.confrelid ), all_tables as ( ' +
-      'select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as ' +
-      'last_table_row from fk_tree ) ' +
-      'select table_name ' +
-      'from all_tables at where last_table_row = 1 order by level DESC;');
+    const results = await this.knex.raw(`with recursive fk_tree as (
+      select t.oid as reloid,
+      t.relname as table_name,
+      s.nspname as schema_name,
+      null::name as referenced_table_name,
+      null::name as referenced_schema_name,
+      1 as level
+      from pg_class t
+      join pg_namespace s on s.oid = t.relnamespace
+      where relkind = 'r'
+      and not exists (select *
+      from pg_constraint
+      where contype = 'f'
+      and conrelid = t.oid)
+      and s.nspname = 'public'
+      union all
+      select ref.oid,
+      ref.relname,
+      rs.nspname,
+      p.table_name,
+      p.schema_name,
+      p.level + 1
+      from pg_class ref
+      join pg_namespace rs on rs.oid = ref.relnamespace
+      join pg_constraint c on c.contype = 'f' and c.conrelid = ref.oid
+      join fk_tree p on p.reloid = c.confrelid ), all_tables as (
+      select schema_name, table_name, level, row_number() over (partition by schema_name, table_name order by level desc) as
+      last_table_row from fk_tree )
+      select table_name
+      from all_tables at where last_table_row = 1 order by level DESC;`);
 
     this.tablesOrderedByDependencyWithDirtinessMap = _.map(results.rows, ({ table_name }) => {
       return {

--- a/api/db/knex-database-connection.js
+++ b/api/db/knex-database-connection.js
@@ -30,6 +30,7 @@ const knex = require('knex')(knexConfig);
 async function disconnect() {
   return knex.destroy();
 }
+
 const _databaseName = knex.client.database();
 
 const _dbSpecificQueries = {
@@ -39,9 +40,10 @@ const _dbSpecificQueries = {
 
 async function listAllTableNames() {
   const bindings = [_databaseName];
-  const query = _dbSpecificQueries.listTablesQuery;
 
-  const resultSet = await knex.raw(query, bindings);
+  const resultSet = await knex.raw(
+    'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema() AND table_catalog = ?',
+    bindings);
 
   const rows = resultSet.rows;
   return _.map(rows, 'table_name');
@@ -58,7 +60,7 @@ async function emptyAllTables() {
   const tables = _.map(tablesToDelete, (tableToDelete) => `"${tableToDelete}"`).join();
 
   const query = _dbSpecificQueries.emptyTableQuery;
-  // eslint-disable-next-line no-restricted-syntax
+  // eslint-disable-next-line knex/avoid-injections,no-restricted-syntax
   return knex.raw(`${query}${tables}`);
 }
 

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -23,6 +23,7 @@ function _toDomainEntity(bookshelfAuthenticationMethod) {
     updatedAt: attributes.updatedAt,
   });
 }
+
 function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationComplement) {
   if (identityProvider === AuthenticationMethod.identityProviders.PIX) {
     return new AuthenticationMethod.PixAuthenticationComplement(bookshelfAuthenticationComplement);
@@ -34,6 +35,7 @@ function _toAuthenticationComplement(identityProvider, bookshelfAuthenticationCo
 
   return undefined;
 }
+
 module.exports = {
 
   async create({
@@ -59,7 +61,8 @@ module.exports = {
       })
       .save(
         {
-          authenticationComplement: Bookshelf.knex.raw(`jsonb_set("authenticationComplement", '{password}', '"${hashedPassword}"')`),
+          // eslint-disable-next-line quotes
+          authenticationComplement: Bookshelf.knex.raw(`jsonb_set("authenticationComplement", '{password}', ?)`, `"${hashedPassword}"`),
         },
         { patch: true, method: 'update' },
       )
@@ -215,7 +218,7 @@ module.exports = {
       })
       .save(
         {
-          authenticationComplement: Bookshelf.knex.raw(`jsonb_set("authenticationComplement", '{shouldChangePassword}', '${shouldChangePassword}')`),
+          authenticationComplement: Bookshelf.knex.raw('jsonb_set("authenticationComplement", \'{shouldChangePassword}\', ?)', shouldChangePassword),
         },
         { patch: true, method: 'update' },
       )

--- a/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-overview-repository.js
@@ -41,7 +41,7 @@ function _findByUserId({ userId }) {
         organizationName: 'organizations.name',
         assessmentState: 'assessments.state',
         assessmentCreatedAt: 'assessments.createdAt',
-        participationState: knex.raw(_computeCampaignParticipationState()),
+        participationState: _computeCampaignParticipationState(),
       })
         .from('campaign-participations')
         .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
@@ -58,13 +58,14 @@ function _findByUserId({ userId }) {
 }
 
 function _computeCampaignParticipationState() {
-  return `
+  // eslint-disable-next-line no-restricted-syntax
+  return knex.raw(`
   CASE
     WHEN campaigns."archivedAt" IS NOT NULL THEN 'ARCHIVED'
-    WHEN assessments.state = '${Assessment.states.STARTED}' THEN 'ONGOING'
+    WHEN assessments.state = ? THEN 'ONGOING'
     WHEN "isShared" IS true THEN 'ENDED'
     ELSE 'TO_SHARE'
-  END`;
+  END`, Assessment.states.STARTED) ;
 }
 
 function _filterMostRecentAssessments(queryBuilder) {

--- a/api/lib/infrastructure/repositories/campaign-to-join-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-to-join-repository.js
@@ -41,9 +41,10 @@ module.exports = {
         'targetProfileImageUrl': 'target-profiles.imageUrl',
         'targetProfileIsSimplifiedAccess': 'target-profiles.isSimplifiedAccess',
       })
-      .select(knex.raw('EXISTS(SELECT true FROM "organization-tags" ' +
-        'JOIN tags ON "organization-tags"."tagId" = "tags".id ' +
-        'WHERE "tags"."name" = \'POLE EMPLOI\' AND "organization-tags"."organizationId" = "organizations".id) as "organizationIsPoleEmploi"'))
+      // eslint-disable-next-line no-restricted-syntax
+      .select(knex.raw(`EXISTS(SELECT true FROM "organization-tags"
+        JOIN tags ON "organization-tags"."tagId" = "tags".id
+        WHERE "tags"."name" = 'POLE EMPLOI' AND "organization-tags"."organizationId" = "organizations".id) as "organizationIsPoleEmploi"`))
       .join('organizations', 'organizations.id', 'campaigns.organizationId')
       .leftJoin('target-profiles', 'target-profiles.id', 'campaigns.targetProfileId')
       .leftJoin('organization-tags', 'organization-tags.organizationId', 'organizations.id')

--- a/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
+++ b/api/lib/infrastructure/repositories/certification-point-of-contact-repository.js
@@ -11,13 +11,14 @@ module.exports = {
         lastName: 'users.lastName',
         email: 'users.email',
         pixCertifTermsOfServiceAccepted: 'users.pixCertifTermsOfServiceAccepted',
-        certificationCenters: knex.raw('JSON_AGG(JSON_BUILD_OBJECT(' +
-          '\'id\', "certification-centers"."id",' +
-          '\'name\', "certification-centers"."name",' +
-          '\'type\', "certification-centers"."type",' +
-          '\'externalId\', "certification-centers"."externalId",' +
-          '\'isRelatedOrganizationManagingStudents\', "organizations"."isManagingStudents"' +
-        ') ORDER BY "certification-center-memberships"."createdAt" DESC)'),
+        // eslint-disable-next-line no-restricted-syntax
+        certificationCenters: knex.raw(`JSON_AGG(JSON_BUILD_OBJECT(
+          'id', "certification-centers"."id",
+          'name', "certification-centers"."name",
+          'type', "certification-centers"."type",
+          'externalId', "certification-centers"."externalId",
+          'isRelatedOrganizationManagingStudents', "organizations"."isManagingStudents"
+        ) ORDER BY "certification-center-memberships"."createdAt" DESC)`),
       })
       .from('users')
       .join('certification-center-memberships', 'certification-center-memberships.userId', 'users.id')

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2636,6 +2636,12 @@
         }
       }
     },
+    "eslint-plugin-knex": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-knex/-/eslint-plugin-knex-0.1.5.tgz",
+      "integrity": "sha512-LQLmJ9khA0VBAipwfLZziiDPEPk9lbn/1nz2nXeQdKQHpcmy4edn+j/GNVDIWXOqNIZ7eLXoMNZ7JjtbH5u19w==",
+      "dev": true
+    },
     "eslint-plugin-mocha": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-8.1.0.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -84,6 +84,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-sorted": "^0.2.0",
     "eslint": "^7.22.0",
+    "eslint-plugin-knex": "^0.1.5",
     "eslint-plugin-mocha": "^8.1.0",
     "mocha": "^8.3.2",
     "mocha-junit-reporter": "^2.0.0",

--- a/api/scripts/data-generation/generate-certifications-for-organization.js
+++ b/api/scripts/data-generation/generate-certifications-for-organization.js
@@ -275,13 +275,13 @@ async function _createCertificationResultsWithMarks({ assessmentIds, status, pix
     SELECT DISTINCT "assessmentResultId",
            SUM("score") OVER (PARTITION BY "assessmentResultId") AS final_score
     FROM "competence-marks"
-    WHERE "assessmentResultId" = ANY(ARRAY[${assessmentResultIds.join(',')}])
+    WHERE "assessmentResultId" = ANY(ARRAY[?])
   )
   UPDATE "assessment-results"
   SET "pixScore" = "sum_score"."final_score"
   FROM sum_score
   WHERE "assessment-results".id = sum_score."assessmentResultId"
-  `);
+  `, assessmentResultIds.join(','));
 }
 
 async function _createCompetenceMarksForCompetence({ competence, assessmentResultIds, transaction }) {

--- a/api/scripts/generate-certification-test-statistics.js
+++ b/api/scripts/generate-certification-test-statistics.js
@@ -25,8 +25,8 @@ async function _retrieveUserIds() {
     FROM "users"
     JOIN "certification-courses" ON "certification-courses"."userId" = "users"."id"
     ORDER BY "users"."id" DESC
-    LIMIT ${USER_COUNT};
-  `);
+    LIMIT ?;
+  `, USER_COUNT);
   return _.map(result.rows, 'id');
 }
 

--- a/api/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation.js
+++ b/api/scripts/prod/compute-validated-skills-count-for-assessment-campaign-participation.js
@@ -31,6 +31,7 @@ async function computeValidatedSkillsCount(concurrency) {
 async function _updateCampaignParticipations(campaign) {
   const validatedSkillsByParticipationId = await _validatedSkillsCountByUser(campaign);
 
+  // eslint-disable-next-line knex/avoid-injections
   await knex.raw(`UPDATE "campaign-participations"
   SET "validatedSkillsCount" = "participationSkillCounts"."validatedSkillsCount"
   FROM (VALUES ${_toSQLValues(validatedSkillsByParticipationId)}) AS "participationSkillCounts"(id, "validatedSkillsCount")


### PR DESCRIPTION
## :unicorn: Problème
Nous sommes par défaut protégés des [injections SQL](https://owasp.org/www-community/attacks/SQL_Injection) lors de l'utilisation nominative du module `knex`, sauf:
- lorsqu'on utilise les méthodes SQL natives (ex: `raw`, `whereRaw`);
- en introduisant les variables dans la requête (ex. avec un template literal);
- sans passer le binding en paramètre.

La règle custom de lint [suivante](https://github.com/1024pix/pix/blob/dev/api/.eslintrc.yaml#L10) nous protège pour la méthode `raw`, mais elle doit être redéfinie pour chaque autre méthode
```
  no-restricted-syntax:
     -  error
     -  selector: "CallExpression[callee.object.name='knex'][callee.property.name='raw'][arguments.0.type='TemplateLiteral']"
        message: "do not use template strings with knex.raw to avoid SQL injection"
```

Il est possible que le code en question ne soit pas vulnérable car aucune valeur n'est saisie par un utilisateur.
Or, il n'est pas évident pour un développeur de savoir si ce cas a été envisagé ou simplement oublié. Le plus simple est de supprimer partout la possibilité d'injection.

## :robot: Solution
Utiliser la règle `avoid-injections` du module eslint [dédié à knex](https://github.com/AntonNiklasson/eslint-plugin-knex/blob/master/rules/avoid-injections.js)

Celle-ci vérifie effectivement si une variable a été introduite, ce qui permet d'utiliser des template literal pour écrire simplement des requêtes sur plusieurs lignes, sans risquer une injection. La règle custom existante ne permet pas l'utilisation de template literal.

## :rainbow: Remarques
Correction du code sensible à l'injection.
Pour les rares cas où cela n'a pas été possible, désactivation de la règle.

Si l'argument suivant est invoqué, les corrections de code seront  reportés via une autre PR. 
> Cela introduit une dépendance de plus pour une règle, nous préférons le gérer par des règles custom

## :100: Pour tester
Introduire une template literal avec une variable et vérifier qu'une alerte de lint est levée.
