### PR TITLE
[FEATURE] Changer le titre de la page quand l'épreuve timée est terminée (PIX-2283).

### DIFF
--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -49,7 +49,7 @@ export default class ChallengeItemGeneric extends Component {
   @action
   setChallengeAsTimedOut() {
     this.hasChallengeTimedOut = true;
-    this.args.timedoutChallenge();
+    this.args.timeoutChallenge();
   }
 
   @action
@@ -68,7 +68,10 @@ export default class ChallengeItemGeneric extends Component {
       this.isValidateButtonEnabled = false;
 
       return this.args.answerValidated(this.args.challenge, this.args.assessment, this._getAnswerValue(), this._getTimeout())
-        .finally(() => this.isValidateButtonEnabled = true);
+        .finally(() => {
+          this.isValidateButtonEnabled = true;
+          this.args.finishChallenge();
+        });
     }
   }
 
@@ -84,7 +87,10 @@ export default class ChallengeItemGeneric extends Component {
       this.isSkipButtonEnabled = false;
 
       return this.args.answerValidated(this.args.challenge, this.args.assessment, '#ABAND#', this._getTimeout())
-        .finally(() => this.isSkipButtonEnabled = true);
+        .finally(() => {
+          this.isSkipButtonEnabled = true;
+          this.args.finishChallenge();
+        });
     }
   }
 

--- a/mon-pix/app/components/challenge-item-generic.js
+++ b/mon-pix/app/components/challenge-item-generic.js
@@ -49,6 +49,7 @@ export default class ChallengeItemGeneric extends Component {
   @action
   setChallengeAsTimedOut() {
     this.hasChallengeTimedOut = true;
+    this.args.timedoutChallenge();
   }
 
   @action

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
+import { action } from '@ember/object';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled'];
@@ -10,6 +11,7 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
+  @tracked challengeTitle = 'pages.challenge.title';
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -19,7 +21,12 @@ export default class ChallengeController extends Controller {
     const stepNumber = progressInAssessment.getCurrentStepNumber(this.model.assessment, get(this.model, 'answer.id'));
     const totalChallengeNumber = progressInAssessment.getMaxStepsNumber(this.model.assessment);
 
-    return this.intl.t('pages.challenge.title', { stepNumber, totalChallengeNumber });
+    return this.intl.t(this.challengeTitle, { stepNumber, totalChallengeNumber });
+  }
+
+  @action
+  timedoutChallenge() {
+    this.challengeTitle = 'pages.challenge.timed-out-title';
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/controllers/assessments/challenge.js
+++ b/mon-pix/app/controllers/assessments/challenge.js
@@ -4,6 +4,8 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import progressInAssessment from 'mon-pix/utils/progress-in-assessment';
 import { action } from '@ember/object';
+const defaultPageTitle = 'pages.challenge.title';
+const timedOutPageTitle = 'pages.challenge.timed-out-title';
 
 export default class ChallengeController extends Controller {
   queryParams = ['newLevel', 'competenceLeveled'];
@@ -11,7 +13,7 @@ export default class ChallengeController extends Controller {
   @service currentUser;
   @tracked newLevel = null;
   @tracked competenceLeveled = null;
-  @tracked challengeTitle = 'pages.challenge.title';
+  @tracked challengeTitle = defaultPageTitle;
 
   get showLevelup() {
     return this.model.assessment.showLevelup && this.newLevel;
@@ -25,8 +27,13 @@ export default class ChallengeController extends Controller {
   }
 
   @action
-  timedoutChallenge() {
-    this.challengeTitle = 'pages.challenge.timed-out-title';
+  timeoutChallenge() {
+    this.challengeTitle = timedOutPageTitle;
+  }
+
+  @action
+  finishChallenge() {
+    this.challengeTitle = defaultPageTitle;
   }
 
   get displayHomeLink() {

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -17,6 +17,7 @@
                 challenge=@model.challenge
                 answer=@model.answer
                 assessment=@model.assessment
+                timedoutChallenge=this.timedoutChallenge
                 answerValidated=(route-action "saveAnswerAndNavigate")
                 resumeAssessment=(route-action "resumeAssessment")
     }}

--- a/mon-pix/app/templates/assessments/challenge.hbs
+++ b/mon-pix/app/templates/assessments/challenge.hbs
@@ -17,7 +17,8 @@
                 challenge=@model.challenge
                 answer=@model.answer
                 assessment=@model.assessment
-                timedoutChallenge=this.timedoutChallenge
+                timeoutChallenge=this.timeoutChallenge
+                finishChallenge=this.finishChallenge
                 answerValidated=(route-action "saveAnswerAndNavigate")
                 resumeAssessment=(route-action "resumeAssessment")
     }}

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -249,6 +249,7 @@
         },
         "challenge": {
             "title": "Question {stepNumber} of {totalChallengeNumber}",
+            "timed-out-title": "Timed out - Question {stepNumber} of {totalChallengeNumber}",
             "actions": {
                 "continue": "Continue",
                 "validate": "Validate",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -249,6 +249,7 @@
         },
         "challenge": {
             "title": "Épreuve {stepNumber} sur {totalChallengeNumber}",
+            "timed-out-title": "Temps écoulé - Épreuve {stepNumber} sur {totalChallengeNumber}",
             "actions": {
                 "continue": "Poursuivre",
                 "validate": "Je valide",


### PR DESCRIPTION
## :unicorn: Problème
Lorsque l'épreuve timée est terminée, l'utilisateur qui est possiblement sur un autre onglet n'est pas au courant.
Pour le tenir au courant du changement et pour indiquer le changement de situation coté a11y, le titre doit changer.

## :robot: Solution
Changer la clé de traduction pour le titre quand l'épreuve timée tombe en timed out.
La rechanger quand l'épreuve est passé (pour ne pas garder le titre modifié entre les différentes épreuves)

## :rainbow: Remarques
- Fonctionnellement OK, preneuse de retour sur l'implémentation (pas easy sur cette partie un peu endêttée)
- A voir pour des tests e2e possiblement

## :100: Pour tester
Répondre à des questions sur les compétences, et quand on tombe sur une épreuve timée, voir 