### PR TITLE
[FEATURE] A11Y- Ajout d'un aria-label hidden pour ne pas tenter de lire le svg du cercle (PIX-1883).

### DIFF
--- a/mon-pix/app/templates/components/circle-chart.hbs
+++ b/mon-pix/app/templates/components/circle-chart.hbs
@@ -1,5 +1,5 @@
 <div class="circle-chart" ...attributes>
-  <svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " @chartClass}}>
+  <svg viewBox="1.2 1.2 33.6 33.6" class={{concat "circle-chart__content " @chartClass}} aria-hidden="true">
     <path class={{concat "circle " @thicknessClass}}
           d="M18 2 a 16 16 0 0 1 0 32 a 16 16 0 0 1 0 -32">
     </path>


### PR DESCRIPTION
## :unicorn: Problème
Dans les résultats de campagne, le cercle de résultat global contient du svg qui ne pouvait être lu via voice-over.

## :robot: Solution
Ajout d'un aria-hidden à true pour éviter ça.

## :rainbow: Remarques

## :100: Pour tester
Finir la campagne et voir que le aria-hidden est bien présent.