### PR TITLE
[FEATURE] Gérer le focus des PixModal lors de l'entrée et la sortie (PIX-1870).

### DIFF
--- a/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
+++ b/high-level-tests/e2e/cypress/integration/pix-app/page-title.feature
@@ -17,7 +17,7 @@ Fonctionnalité: Titre des pages
     Et je vais sur Pix
     Et je suis connecté à Pix en tant que "Daenerys Targaryen"
     Lorsque je vais sur la compétence "recH9MjIzN54zXlwr"
-    Alors je vois le titre de la page "Compétence | Mathématiques | Pix"
+    Alors je vois le titre de la page "Mathématiques | Compétence | Pix"
 
   Scénario: j'accède à une épreuve
     Étant donné que tous les comptes sont créés

--- a/mon-pix/app/components/pix-modal.js
+++ b/mon-pix/app/components/pix-modal.js
@@ -2,6 +2,7 @@
 /* eslint ember/require-tagless-components: 0 */
 
 import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
+const defaultOrigin = 'body';
 
 export default ModalDialog.extend({
 
@@ -13,6 +14,7 @@ export default ModalDialog.extend({
   wrapperClass: 'centered-scrolling-wrapper',
   overlayClass: 'centered-scrolling-overlay',
   containerClass: 'centered-scrolling-container',
+  originId: defaultOrigin,
 
   didRender() {
     this._super(...arguments);
@@ -24,6 +26,11 @@ export default ModalDialog.extend({
   willDestroyElement() {
     document.querySelector('#modal-overlays').classList.remove('active');
     document.body.classList.remove('centered-modal-showing');
+    if (document.querySelector(this.originId)) {
+      document.querySelector(this.originId).focus();
+    } else {
+      document.querySelector(defaultOrigin).focus();
+    }
     this._super(...arguments);
   },
 

--- a/mon-pix/app/components/pix-modal.js
+++ b/mon-pix/app/components/pix-modal.js
@@ -18,6 +18,7 @@ export default ModalDialog.extend({
     this._super(...arguments);
     document.querySelector('#modal-overlays').classList.add('active');
     document.body.classList.add('centered-modal-showing');
+    document.querySelector('#pix-modal__close-button').focus();
   },
 
   willDestroyElement() {

--- a/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
+++ b/mon-pix/app/components/routes/campaigns/restricted/join-sco-information-modal.hbs
@@ -1,9 +1,9 @@
-<PixModal @containerClass="join-error-modal" @onClickOverlay={{@closeModal}}>
+<PixModal @containerClass="join-error-modal" @onClickOverlay={{@closeModal}} role="dialog">
   <div class="join-error-modal__header">
     <div class="join-error-modal-header__title">
       <h1 class="join-error-modal-header-title__text">{{t 'pages.join.sco.login-information-title'}}</h1>
     </div>
-    <button class="join-error-modal-header__close" type="button" aria-label={{t "common.actions.close"}} {{on 'click' @closeModal}}>
+    <button id="pix-modal__close-button" class="join-error-modal-header__close" type="button" aria-label={{t "common.actions.close"}} {{on 'click' @closeModal}}>
       <img src="/images/icons/icon-croix.svg" alt={{t 'common.actions.close'}} class="join-error-modal-header-close__icon">
     </button>
   </div>

--- a/mon-pix/app/styles/globals/_buttons.scss
+++ b/mon-pix/app/styles/globals/_buttons.scss
@@ -66,12 +66,14 @@
 
   &--grey {
     background: $grey-15;
+    border: 2px solid $grey-40;
     color: $grey-80;
 
     &:hover,
     &:active,
     &:focus {
       background-color: $grey-20;
+      border: 2px solid $grey-80;
     }
   }
 
@@ -87,13 +89,14 @@
   }
 
   &--red {
-    background: $dark-error;
+    background: $red;
     color: $white;
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $dark-error;
+      background-color: $red-hover;
+      border: 2px solid $yellow;
     }
   }
 

--- a/mon-pix/app/templates/competences.hbs
+++ b/mon-pix/app/templates/competences.hbs
@@ -1,4 +1,3 @@
-{{!-- template-lint-disable no-implicit-this  --}}
-{{page-title model.name}}
+{{page-title (t 'pages.competence-details.title')}}
 
 {{outlet}}

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -1,4 +1,4 @@
-{{page-title (t 'pages.competence-details.title')}}
+{{page-title @model.name}}
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -1,6 +1,7 @@
 <PixModal
         @class="comparison-window-modal"
         @onClickOverlay={{@closeComparisonWindow}}
+        @originId="#button-comparision-answer-{{@answer.id}}"
         role="dialog">
 
   <button type="button" id="pix-modal__close-button" class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{on "click" @closeComparisonWindow}}>

--- a/mon-pix/app/templates/components/comparison-window.hbs
+++ b/mon-pix/app/templates/components/comparison-window.hbs
@@ -1,6 +1,9 @@
-<PixModal @class="comparison-window-modal" @onClickOverlay={{@closeComparisonWindow}}>
+<PixModal
+        @class="comparison-window-modal"
+        @onClickOverlay={{@closeComparisonWindow}}
+        role="dialog">
 
-  <button type="button" class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{on "click" @closeComparisonWindow}}>
+  <button type="button" id="pix-modal__close-button" class="pix-modal__close-link" aria-label={{t "common.actions.close"}} {{on "click" @closeComparisonWindow}}>
     <span>{{t "common.actions.close"}}</span>
     <FaIcon @icon="times-circle" class="logged-user-menu__icon" aria-hidden="true"></FaIcon>
   </button>

--- a/mon-pix/app/templates/components/result-item.hbs
+++ b/mon-pix/app/templates/components/result-item.hbs
@@ -11,7 +11,7 @@
 
     <div class="result-item__correction">
       {{#if this.validationImplementedForChallengeType}}
-        <button {{on 'click' (fn @openAnswerDetails @answer)}} class="result-item__correction-button link js-correct-answer" type="button">
+        <button {{on 'click' (fn @openAnswerDetails @answer)}} id="button-comparision-answer-{{@answer.id}}" class="result-item__correction-button link js-correct-answer" type="button">
           {{t 'pages.result-item.actions.see-answers-and-tutorials.label'}}
         </button>
       {{/if}}

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -120,8 +120,12 @@
   {{/if}}
 </div>
 {{#if this.showResetModal}}
-  <PixModal @containerClass="scorecard-details__reset-modal pix-modal-dialog--wide" @onClickOverlay={{this.closeModal}}>
-    <button class="pix-modal__close-link" type="button" aria-label="{{t 'common.actions.close'}}" {{on 'click' this.closeModal}}>
+  <PixModal
+          @containerClass="scorecard-details__reset-modal pix-modal-dialog--wide"
+          @onClickOverlay={{this.closeModal}}
+          @originId="#reset-button"
+          role="dialog">
+    <button id="pix-modal__close-button" class="pix-modal__close-link" type="button" aria-label="{{t 'common.actions.close'}}" {{on 'click' this.closeModal}}>
       <span>{{t 'common.actions.close'}}</span>
       <FaIcon @icon="times-circle" class="logged-user-menu__icon"></FaIcon>
     </button>

--- a/mon-pix/app/templates/components/scorecard-details.hbs
+++ b/mon-pix/app/templates/components/scorecard-details.hbs
@@ -86,7 +86,7 @@
         </LinkTo>
       {{/if}}
       {{#if this.displayResetButton}}
-        <button class="link link--underline scorecard-details__reset-button" {{on 'click' this.openModal}} type="button">
+        <button id="reset-button" class="link link--underline scorecard-details__reset-button" {{on 'click' this.openModal}} type="button">
           {{t 'pages.competence-details.actions.reset.label'}}
           <div class="sr-only">{{t 'pages.competence-details.for-competence' competence=@scorecard.name}}</div>
         </button>


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'on utilise les PixModal (remise à zéro, réponse aux épreuves, rejoindre le sco), le focus n'entre pas dans la modal mais reste derrière.

## :robot: Solution
- Lorsqu'on rend la modale, mettre le focus sur le premier bouton visible, la fermeture de la modale
- Lorsqu'on sort de la modale, remettre le focus sur un id qu'on aura indiqué avant, le lien de la modale.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Commencer une compétence, aller sur la page compétence, se déplacer au clavier pour aller sur "Remettre à zéro" :  voir le focus dans la modal > Sortir en fermant et se retrouver sur "Remettre à zéro"
- Aller jusqu'à un checkpoint, aller sur une réponse avec le clavier, pouvoir se balader dedans. En sortant, pouvoir revenir sur les réponses directement
- Connecté à UserPixAile, lancer la campagne BADGES456, avec George et voir la modal. Pouvoir aller dedans > En cliquant sur la croix pour sortir, revenir au formulaire.