### PR TITLE
[FEATURE] Ajouter un lien vers la FAQ "Comment se certifier" sur le bandeau "Bravo vous êtes certifiable" (PIX-2400)

### DIFF
--- a/mon-pix/app/styles/components/_congratulations-certification-banner.scss
+++ b/mon-pix/app/styles/components/_congratulations-certification-banner.scss
@@ -7,7 +7,7 @@
   box-sizing: border-box;
   height: 194px;
   display: flex;
-  flex-flow: row nowrap;
+  flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
 }
@@ -30,13 +30,29 @@
   }
 }
 
-.congratulations-banner__message {
+@mixin textBannerStyle {
   color: $grey-10;
   font-weight: $font-normal;
   font-family: $font-open-sans;
-  font-size: 1.5rem;
   line-height: 2rem;
   text-align: center;
+}
+
+.congratulations-banner__message {
+  @include textBannerStyle();
+
+  font-size: 1.5rem;
+  margin-bottom: 5px;
+}
+
+.congratulations-banner__link {
+  @include textBannerStyle();
+
+  font-size: 0.875rem;
+
+  &__icon {
+    margin: auto 5px;
+  }
 }
 
 @include device-is('mobile') {

--- a/mon-pix/app/templates/components/congratulations-certification-banner.hbs
+++ b/mon-pix/app/templates/components/congratulations-certification-banner.hbs
@@ -1,6 +1,18 @@
-<div class="congratulations-banner" >
-  <button aria-label={{t 'common.actions.close'}} class="icon-button congratulations-banner__icon" {{on 'click' @closeBanner}} type="button">
-    <FaIcon @icon="times"></FaIcon>
+<div class="congratulations-banner">
+  <button aria-label={{t 'common.actions.close' }} class="icon-button congratulations-banner__icon" {{on 'click'
+    @closeBanner}} type="button">
+    <FaIcon @icon="times"/>
   </button>
-  <p class="congratulations-banner__message">{{t "pages.certification-joiner.congratulation-banner.message" fullName=@fullName htmlSafe=true}}</p>
+  <p class="congratulations-banner__message">
+    {{t "pages.certification-joiner.congratulation-banner.message"
+    fullName=@fullName htmlSafe=true}}
+  </p>
+  <a href={{t "pages.certification-joiner.congratulation-banner.link.url" }}
+    class="congratulations-banner__link"
+    target="_blank"
+    rel="noopener noreferrer">
+    <FaIcon @icon="arrow-right" class="congratulations-banner__link__icon" />
+    {{t "pages.certification-joiner.congratulation-banner.link.text" }}
+    <FaIcon @icon="external-link-alt" class="congratulations-banner__link__icon" />
+  </a>
 </div>

--- a/mon-pix/config/icons.js
+++ b/mon-pix/config/icons.js
@@ -14,6 +14,7 @@ module.exports = function() {
       'copy',
       'exclamation-circle',
       'exclamation-triangle',
+      'external-link-alt',
       'eye',
       'eye-slash',
       'hourglass-end',

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -161,7 +161,11 @@
         "certification-joiner": {
             "title": "Join a certification session",
             "congratulation-banner": {
-                "message": "Well done, {fullName},'<br>'your profile can now be certified."
+                "message": "Well done, {fullName},'<br>'your profile can now be certified.",
+                "link": {
+                    "text": "How do I certify my digital skills?",
+                    "url": "https://support.pix.fr/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+                }
             },
             "first-title": "Join a session",
             "form": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -161,7 +161,11 @@
         "certification-joiner": {
             "title": "Rejoindre une session de certification",
             "congratulation-banner": {
-                "message": "Bravo {fullName},'<br>'votre profil est certifiable."
+                "message": "Bravo {fullName},'<br>'votre profil est certifiable.",
+                "link": {
+                    "text": "Comment se certifier ?",
+                    "url": "https://support.pix.fr/fr/support/solutions/articles/15000039372-la-certification-pix-c-est-quoi-"
+                }
             },
             "first-title": "Rejoindre une session",
             "form": {


### PR DESCRIPTION
## :coffee: Contexte 
Lorsqu’un utilisateur ayant un profil certifiable clique sur l’onglet “Certifications” sur app.pix.fr, il voit un bandeau lui indiquant “Bravo, votre profil est certifiable”.

## :unicorn: Problème
Certains utilisateurs, à la vue de ce bandeau et de la page “Rejoindre une session”, pensent qu’il est juste nécessaire d’avoir un numéro de session à disposition (sans inscription préalable dans un centre de certification agréé), ou encore qu’ils sont certifiés d’office, et contactent le support soit pour demander où trouver le numéro de session, ou pour savoir où récupérer leur certificat Pix.

## :robot: Solution
Sur le bandeau, ajouter un lien vers la FAQ avec les explications sur comment se certifier (se rapprocher d’un centre agréé etc) : 

## :rainbow: Remarques
La traduction anglaise est supprimée dans un second commit car la page FAQ en version anglaise n'existe pas.

## :100: Pour tester
Se rendre sur Pix App avec un profil certifiable.
Cliquer sur Certifications.
Constater la présence du bandeau et du lien dans le bandeau.
