### PR TITLE
[FEATURE][i18n] Ajout de l'internationalisation dans le modèle d'import SCO AGRI CFA (PIX-2310).

### DIFF
--- a/api/lib/application/organizations/organization-controller.js
+++ b/api/lib/application/organizations/organization-controller.js
@@ -132,7 +132,7 @@ module.exports = {
     const organizationId = parseInt(request.params.id);
     const { format } = request.query;
 
-    await usecases.importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload: request.payload, format });
+    await usecases.importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload: request.payload, format, i18n: request.i18n });
     return h.response(null).code(204);
   },
 
@@ -168,6 +168,6 @@ module.exports = {
 
     return h.response(template)
       .header('Content-Type', 'text/csv;charset=utf-8')
-      .header('Content-Disposition', `attachment; filename=${request.i18n.__('higher-schooling-registration-csv.template-name')}.csv`);
+      .header('Content-Disposition', `attachment; filename=${request.i18n.__('csv-template.template-name')}.csv`);
   },
 };

--- a/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
+++ b/api/lib/domain/usecases/get-schooling-registrations-csv-template.js
@@ -1,7 +1,7 @@
 const csvSerializer = require('../../infrastructure/serializers/csv/csv-serializer');
 const { UserNotAuthorizedToAccessEntityError } = require('../errors');
 const HigherSchoolingRegistrationColumns = require('../../infrastructure/serializers/csv/higher-schooling-registration-columns');
-const SchoolingRegistrationParser = require('../../infrastructure/serializers/csv/schooling-registration-parser');
+const SchoolingRegistrationColumns = require('../../infrastructure/serializers/csv/schooling-registration-columns');
 
 module.exports = async function getSchoolingRegistrationsCsvTemplate({
   userId,
@@ -22,12 +22,11 @@ module.exports = async function getSchoolingRegistrationsCsvTemplate({
     header = _getCsvColumns(new HigherSchoolingRegistrationColumns(i18n).columns);
 
   } else if (isSco && isAgriculture) {
-    header = _getCsvColumns(SchoolingRegistrationParser.COLUMNS);
+    header = _getCsvColumns(new SchoolingRegistrationColumns(i18n).columns);
   } else {
     throw new UserNotAuthorizedToAccessEntityError('User organization is not allowed to download csv template.');
   }
 
-  //Create HEADER of CSV
   return _createHeaderOfCSV(header);
 };
 

--- a/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
+++ b/api/lib/domain/usecases/import-schooling-registrations-from-siecle.js
@@ -11,7 +11,7 @@ const ERRORS = {
   INVALID_FILE_EXTENSION: 'INVALID_FILE_EXTENSION',
 };
 
-module.exports = async function importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, schoolingRegistrationsXmlService, schoolingRegistrationRepository, organizationRepository }) {
+module.exports = async function importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, schoolingRegistrationsXmlService, schoolingRegistrationRepository, organizationRepository, i18n }) {
   let schoolingRegistrationData = [];
 
   const organization = await organizationRepository.get(organizationId);
@@ -22,7 +22,7 @@ module.exports = async function importSchoolingRegistrationsFromSIECLEFormat({ o
   } else if (format === 'csv') {
     const buffer = await fs.readFile(path);
 
-    const csvSiecleParser = SchoolingRegistrationParser.buildParser(buffer, organizationId, organization.isAgriculture);
+    const csvSiecleParser = SchoolingRegistrationParser.buildParser(buffer, organizationId, i18n, organization.isAgriculture);
     schoolingRegistrationData = csvSiecleParser.parse().registrations;
   } else {
     throw new FileValidationError('INVALID_FILE_EXTENSION', { fileExtension: format });

--- a/api/lib/infrastructure/serializers/csv/higher-schooling-registration-columns.js
+++ b/api/lib/infrastructure/serializers/csv/higher-schooling-registration-columns.js
@@ -8,19 +8,19 @@ class HigherSchoolingRegistrationColumns {
 
   setColumns() {
     return [
-      new CsvColumn({ name: 'firstName', label: this.translate('higher-schooling-registration-csv.firstname'), isRequired: true, checkEncoding: true }),
-      new CsvColumn({ name: 'middleName', label: this.translate('higher-schooling-registration-csv.middle-name') }),
-      new CsvColumn({ name: 'thirdName', label: this.translate('higher-schooling-registration-csv.third-name') }),
-      new CsvColumn({ name: 'lastName', label: this.translate('higher-schooling-registration-csv.lastname'), isRequired: true }),
-      new CsvColumn({ name: 'preferredLastName', label: this.translate('higher-schooling-registration-csv.preferred-lastname') }),
-      new CsvColumn({ name: 'birthdate', label: this.translate('higher-schooling-registration-csv.birthdate'), isRequired: true, isDate: true }),
-      new CsvColumn({ name: 'email', label: this.translate('higher-schooling-registration-csv.email') }),
-      new CsvColumn({ name: 'studentNumber', label: this.translate('higher-schooling-registration-csv.student-number'), isRequired: true, checkEncoding: true }),
-      new CsvColumn({ name: 'department', label: this.translate('higher-schooling-registration-csv.department') }),
-      new CsvColumn({ name: 'educationalTeam', label: this.translate('higher-schooling-registration-csv.educational-team') }),
-      new CsvColumn({ name: 'group', label: this.translate('higher-schooling-registration-csv.group') }),
-      new CsvColumn({ name: 'diploma', label: this.translate('higher-schooling-registration-csv.diploma') }),
-      new CsvColumn({ name: 'studyScheme', label: this.translate('higher-schooling-registration-csv.study-scheme') }),
+      new CsvColumn({ name: 'firstName', label: this.translate('csv-template.higher-schooling-registrations.first-name'), isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'middleName', label: this.translate('csv-template.higher-schooling-registrations.middle-name') }),
+      new CsvColumn({ name: 'thirdName', label: this.translate('csv-template.higher-schooling-registrations.third-name') }),
+      new CsvColumn({ name: 'lastName', label: this.translate('csv-template.higher-schooling-registrations.last-name'), isRequired: true }),
+      new CsvColumn({ name: 'preferredLastName', label: this.translate('csv-template.higher-schooling-registrations.preferred-lastname') }),
+      new CsvColumn({ name: 'birthdate', label: this.translate('csv-template.higher-schooling-registrations.birthdate'), isRequired: true, isDate: true }),
+      new CsvColumn({ name: 'email', label: this.translate('csv-template.higher-schooling-registrations.email') }),
+      new CsvColumn({ name: 'studentNumber', label: this.translate('csv-template.higher-schooling-registrations.student-number'), isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'department', label: this.translate('csv-template.higher-schooling-registrations.department') }),
+      new CsvColumn({ name: 'educationalTeam', label: this.translate('csv-template.higher-schooling-registrations.educational-team') }),
+      new CsvColumn({ name: 'group', label: this.translate('csv-template.higher-schooling-registrations.group') }),
+      new CsvColumn({ name: 'diploma', label: this.translate('csv-template.higher-schooling-registrations.diploma') }),
+      new CsvColumn({ name: 'studyScheme', label: this.translate('csv-template.higher-schooling-registrations.study-scheme') }),
     ];
   }
 }

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-columns.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-columns.js
@@ -1,0 +1,29 @@
+const { CsvColumn } = require('./csv-registration-parser');
+
+class SchoolingRegistrationColumns {
+  constructor(i18n) {
+    this.translate = i18n.__;
+    this.columns = this.setColumns();
+  }
+
+  setColumns() {
+    return [
+      new CsvColumn({ name: 'nationalIdentifier', label: this.translate('csv-template.schooling-registrations.national-identifier'), isRequired: true }),
+      new CsvColumn({ name: 'firstName', label: this.translate('csv-template.schooling-registrations.first-name'), isRequired: true, checkEncoding: true }),
+      new CsvColumn({ name: 'middleName', label: this.translate('csv-template.schooling-registrations.middle-name') }),
+      new CsvColumn({ name: 'thirdName', label: this.translate('csv-template.schooling-registrations.third-name') }),
+      new CsvColumn({ name: 'lastName', label: this.translate('csv-template.schooling-registrations.last-name'), isRequired: true }),
+      new CsvColumn({ name: 'preferredLastName', label: this.translate('csv-template.schooling-registrations.preferred-last-name') }),
+      new CsvColumn({ name: 'birthdate', label: this.translate('csv-template.schooling-registrations.birthdate'), isRequired: true, isDate: true }),
+      new CsvColumn({ name: 'birthCityCode', label: this.translate('csv-template.schooling-registrations.birth-city-code') }),
+      new CsvColumn({ name: 'birthCity', label: this.translate('csv-template.schooling-registrations.birth-city') }),
+      new CsvColumn({ name: 'birthProvinceCode', label: this.translate('csv-template.schooling-registrations.birth-province-code'), isRequired: true }),
+      new CsvColumn({ name: 'birthCountryCode', label: this.translate('csv-template.schooling-registrations.birth-country-code'), isRequired: true }),
+      new CsvColumn({ name: 'status', label: this.translate('csv-template.schooling-registrations.status'), isRequired: true }),
+      new CsvColumn({ name: 'MEFCode', label: this.translate('csv-template.schooling-registrations.mef-code'), isRequired: true }),
+      new CsvColumn({ name: 'division', label: this.translate('csv-template.schooling-registrations.division'), isRequired: true }),
+    ];
+  }
+}
+
+module.exports = SchoolingRegistrationColumns;

--- a/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
+++ b/api/lib/infrastructure/serializers/csv/schooling-registration-parser.js
@@ -2,27 +2,11 @@ const SchoolingRegistration = require('../../../domain/models/SchoolingRegistrat
 const { checkValidation } = require('../../../domain/validators/schooling-registration-validator');
 const { checkValidationUnicity } = require('../../../domain/validators/schooling-registration-set-validator');
 
-const { CsvRegistrationParser, CsvColumn } = require('./csv-registration-parser');
+const { CsvRegistrationParser } = require('./csv-registration-parser');
 const { CsvImportError } = require('../../../../lib/domain/errors');
+const SchoolingRegistrationColumns = require('./schooling-registration-columns');
 
 const STATUS = SchoolingRegistration.STATUS;
-
-const COLUMNS = [
-  new CsvColumn({ name: 'nationalIdentifier', label: 'Identifiant unique*', isRequired: true }),
-  new CsvColumn({ name: 'firstName', label: 'Premier prénom*', isRequired: true, checkEncoding: true }),
-  new CsvColumn({ name: 'middleName', label: 'Deuxième prénom' }),
-  new CsvColumn({ name: 'thirdName', label: 'Troisième prénom' }),
-  new CsvColumn({ name: 'lastName', label: 'Nom de famille*', isRequired: true }),
-  new CsvColumn({ name: 'preferredLastName', label: 'Nom d\'usage' }),
-  new CsvColumn({ name: 'birthdate', label: 'Date de naissance (jj/mm/aaaa)*', isRequired: true, isDate: true }),
-  new CsvColumn({ name: 'birthCityCode', label: 'Code commune naissance**' }),
-  new CsvColumn({ name: 'birthCity', label: 'Libellé commune naissance**' }),
-  new CsvColumn({ name: 'birthProvinceCode', label: 'Code département naissance*', isRequired: true }),
-  new CsvColumn({ name: 'birthCountryCode', label: 'Code pays naissance*', isRequired: true }),
-  new CsvColumn({ name: 'status', label: 'Statut*', isRequired: true }),
-  new CsvColumn({ name: 'MEFCode', label: 'Code MEF*', isRequired: true }),
-  new CsvColumn({ name: 'division', label: 'Division*', isRequired: true }),
-];
 
 const ERRORS = {
   INA_FORMAT: 'INA_FORMAT',
@@ -66,10 +50,12 @@ class SchoolingRegistrationSet {
 
 class SchoolingRegistrationParser extends CsvRegistrationParser {
 
-  constructor(input, organizationId, hasApprentice = false) {
+  constructor(input, organizationId, i18n, hasApprentice = false) {
     const registrationSet = new SchoolingRegistrationSet(hasApprentice);
 
-    super(input, organizationId, COLUMNS, registrationSet);
+    const columns = new SchoolingRegistrationColumns(i18n).columns;
+
+    super(input, organizationId, columns, registrationSet);
   }
 
   _handleError(err, index) {
@@ -97,7 +83,4 @@ class SchoolingRegistrationParser extends CsvRegistrationParser {
   }
 }
 
-SchoolingRegistrationParser.COLUMNS = COLUMNS;
-
 module.exports = SchoolingRegistrationParser;
-

--- a/api/scripts/prod/import-apprentices.js
+++ b/api/scripts/prod/import-apprentices.js
@@ -5,13 +5,17 @@ const { CsvColumn } = require('../../lib/infrastructure/serializers/csv/csv-regi
 
 const SchoolingRegistrationParser = require('../../lib/infrastructure/serializers/csv/schooling-registration-parser');
 const fs = require('fs');
+
 const { knex } = require('../../db/knex-database-connection');
 
 const column = new CsvColumn({ name: 'uai', label: 'UAI*', isRequired: true });
 
+const { getI18n } = require('../../tests/tooling/i18n/i18n');
+const i18n = getI18n();
+
 class CsvApprenticesParser extends SchoolingRegistrationParser {
-  constructor(input, oranizationByUAI) {
-    super(input, null, true);
+  constructor(input, oranizationByUAI, i18n) {
+    super(input, null, i18n, true);
     this.organizationByUai = oranizationByUAI;
     this._columns.push(column);
   }
@@ -53,7 +57,7 @@ async function importApprentices(filePath, fileSystem) {
   const input = fileSystem.readFileSync(filePath);
   const organizationByUai = await findOrganizationByUai();
 
-  const csvApprenticesParser = new CsvApprenticesParser(input, organizationByUai);
+  const csvApprenticesParser = new CsvApprenticesParser(input, organizationByUai, i18n);
   const schoolingRegistrationSet = csvApprenticesParser.parse();
   await knex.batchInsert('schooling-registrations', schoolingRegistrationSet.registrations);
 }

--- a/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/organizations/organization-controller-import-schooling-registrations_test.js
@@ -9,9 +9,11 @@ const createServer = require('../../../../server');
 require('events').EventEmitter.defaultMaxListeners = 60;
 
 const Membership = require('../../../../lib/domain/models/Membership');
-const { COLUMNS } = require('../../../../lib/infrastructure/serializers/csv/schooling-registration-parser');
+const SchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/schooling-registration-columns');
+const { getI18n } = require('../../../tooling/i18n/i18n');
+const i18n = getI18n();
 
-const schoolingRegistrationCsvColumns = COLUMNS.map((column) => column.label).join(';');
+const schoolingRegistrationCsvColumns = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
 
 describe('Acceptance | Application | organization-controller-import-schooling-registrations', () => {
 

--- a/api/tests/integration/scripts/prod/import-apprentices_test.js
+++ b/api/tests/integration/scripts/prod/import-apprentices_test.js
@@ -4,9 +4,13 @@ const importApprentices = require('../../../../scripts/prod/import-apprentices')
 const iconv = require('iconv-lite');
 const { CsvImportError, OrganizationNotFoundError } = require('../../../../lib/domain/errors');
 
-const { COLUMNS } = require('../../../../lib/infrastructure/serializers/csv/schooling-registration-parser');
+const SchoolingRegistrationColumns = require('../../../../lib/infrastructure/serializers/csv/schooling-registration-columns');
 
-const schoolingRegistrationCsvColumns = [...COLUMNS, { label: 'UAI*' }].map((column) => column.label).join(';');
+const { getI18n } = require('../../../tooling/i18n/i18n');
+const i18n = getI18n();
+
+const columns = new SchoolingRegistrationColumns(i18n).columns;
+const schoolingRegistrationCsvColumns = [...columns, { label: 'UAI*' }].map((column) => column.label).join(';');
 
 describe('Integration | Scripts | import-apprentices', () => {
   const fileSystem = {
@@ -126,7 +130,8 @@ describe('Integration | Scripts | import-apprentices', () => {
       });
     });
     context('when the header is not correctly formed', () => {
-      const requiredColumns = [...COLUMNS, { label: 'UAI*' }].map((column) => column.label);
+      const columns = new SchoolingRegistrationColumns(i18n).columns;
+      const requiredColumns = [...columns, { label: 'UAI*' }].map((column) => column.label);
 
       requiredColumns.forEach((missingColumn) => {
         it('throws a CsvImportError', async () => {

--- a/api/tests/unit/application/organizations/organization-controller_test.js
+++ b/api/tests/unit/application/organizations/organization-controller_test.js
@@ -555,6 +555,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
         params: { id: organizationId.toString() },
         query: { format },
         payload: { path: 'path-to-file' },
+        i18n,
       };
 
       sinon.stub(usecases, 'importSchoolingRegistrationsFromSIECLEFormat');
@@ -568,7 +569,7 @@ describe('Unit | Application | Organizations | organization-controller', () => {
       await organizationController.importSchoolingRegistrationsFromSIECLE(request, hFake);
 
       // then
-      expect(usecases.importSchoolingRegistrationsFromSIECLEFormat).to.have.been.calledWith({ organizationId, payload, format });
+      expect(usecases.importSchoolingRegistrationsFromSIECLEFormat).to.have.been.calledWith({ organizationId, payload, format, i18n });
     });
   });
 

--- a/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
+++ b/api/tests/unit/domain/usecases/get-schooling-registrations-csv-template_test.js
@@ -19,7 +19,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
 
       // when
-      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository, i18n });
+      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, i18n, membershipRepository });
 
       // then
       const csvExpected = '\uFEFF"Premier prénom";' +
@@ -74,7 +74,7 @@ describe('Unit | UseCase | get-schooling-registrations-csv-template', () => {
       sinon.stub(membershipRepository, 'findByUserIdAndOrganizationId').resolves([membership]);
 
       // when
-      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository });
+      const result = await getSchoolingRegistrationsCsvTemplate({ userId, organizationId, membershipRepository, i18n });
 
       // then
       const csvExpected = '\uFEFF"Identifiant unique*";' +

--- a/api/tests/unit/domain/usecases/import-schooling-registrations-from-siecle_test.js
+++ b/api/tests/unit/domain/usecases/import-schooling-registrations-from-siecle_test.js
@@ -7,6 +7,9 @@ const SchoolingRegistrationParser = require('../../../../lib/infrastructure/seri
 
 const fs = require('fs').promises;
 
+const { getI18n } = require('../../../tooling/i18n/i18n');
+const i18n = getI18n();
+
 describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
 
   const organizationUAI = '123ABC';
@@ -49,7 +52,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
       it('should save these informations for SCO', async () => {
         const organization = { isAgriculture: false, externalId: organizationUAI };
         organizationRepositoryStub.get.withArgs(organizationId).resolves(organization);
-        SchoolingRegistrationParser.buildParser.withArgs(buffer, organizationId, organization.isAgriculture).returns(parser);
+        SchoolingRegistrationParser.buildParser.withArgs(buffer, organizationId, i18n, organization.isAgriculture).returns(parser);
 
         const schoolingRegistration1 = new SchoolingRegistration({
           id: undefined,
@@ -86,7 +89,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
 
         parser.parse.returns({ registrations: [schoolingRegistration1, schoolingRegistration2] });
 
-        await importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, organizationRepository: organizationRepositoryStub, schoolingRegistrationsXmlService: schoolingRegistrationsXmlServiceStub, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
+        await importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, organizationRepository: organizationRepositoryStub, schoolingRegistrationsXmlService: schoolingRegistrationsXmlServiceStub, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub, i18n });
 
         expect(schoolingRegistrationRepositoryStub.addOrUpdateOrganizationSchoolingRegistrations).to.have.been.called;
       });
@@ -94,7 +97,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
       it('should save these informations for SCO Agri', async () => {
         const organization = { isAgriculture: true, externalId: organizationUAI };
         organizationRepositoryStub.get.withArgs(organizationId).resolves(organization);
-        SchoolingRegistrationParser.buildParser.withArgs(buffer, organizationId, organization.isAgriculture).returns(parser);
+        SchoolingRegistrationParser.buildParser.withArgs(buffer, organizationId, i18n, organization.isAgriculture).returns(parser);
 
         // given
         const schoolingRegistration1 = new SchoolingRegistration({
@@ -133,7 +136,7 @@ describe('Unit | UseCase | import-schooling-registrations-from-siecle', () => {
         parser.parse.returns({ registrations: [schoolingRegistration1, schoolingRegistration2] });
 
         // when
-        await importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, organizationRepository: organizationRepositoryStub, schoolingRegistrationsXmlService: schoolingRegistrationsXmlServiceStub, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub });
+        await importSchoolingRegistrationsFromSIECLEFormat({ organizationId, payload, format, organizationRepository: organizationRepositoryStub, schoolingRegistrationsXmlService: schoolingRegistrationsXmlServiceStub, schoolingRegistrationRepository: schoolingRegistrationRepositoryStub, i18n });
 
         expect(schoolingRegistrationRepositoryStub.addOrUpdateOrganizationAgriSchoolingRegistrations).to.have.been.calledWith([schoolingRegistration1, schoolingRegistration2], organizationId);
       });

--- a/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
+++ b/api/tests/unit/infrastructure/serializers/csv/schooling-registration-parser_test.js
@@ -2,8 +2,11 @@ const iconv = require('iconv-lite');
 const { expect, catchErr } = require('../../../../test-helper');
 const SchoolingRegistrationParser = require('../../../../../lib/infrastructure/serializers/csv/schooling-registration-parser');
 const { CsvImportError } = require('../../../../../lib/domain/errors');
+const SchoolingRegistrationColumns = require('../../../../../lib/infrastructure/serializers/csv/schooling-registration-columns');
+const { getI18n } = require('../../../../tooling/i18n/i18n');
+const i18n = getI18n();
 
-const schoolingRegistrationCsvColumns = SchoolingRegistrationParser.COLUMNS.map((column) => column.label).join(';');
+const schoolingRegistrationCsvColumns = new SchoolingRegistrationColumns(i18n).columns.map((column) => column.label).join(';');
 
 describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
   context('when the header is not correctly formed', () => {
@@ -16,7 +19,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           let input = schoolingRegistrationCsvColumns.replace(`${field}`, '');
           input = input.replace(';;', ';');
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+          const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
           const error = await catchErr(parser.parse, parser)();
 
@@ -29,7 +32,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
       it('should throw an CsvImportError', async () => {
         const input = schoolingRegistrationCsvColumns.replace('Premier prénom*;', '');
         const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+        const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
         const error = await catchErr(parser.parse, parser)();
 
@@ -43,7 +46,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
       it('returns no registrations', () => {
         const input = schoolingRegistrationCsvColumns;
         const encodedInput = iconv.encode(input, 'utf8');
-        const parser = new SchoolingRegistrationParser(encodedInput, 123);
+        const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
 
         const { registrations } = parser.parse();
 
@@ -59,7 +62,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           456F;O-Ren;;;Ishii;Cottonmouth;01/01/1980;;Shangai;99;99132;ST;MEF1;Division 2;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, 456);
+          const parser = new SchoolingRegistrationParser(encodedInput, 456, i18n);
 
           const { registrations } = parser.parse();
           expect(registrations).to.have.lengthOf(2);
@@ -72,7 +75,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           `;
           const organizationId = 789;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, organizationId);
+          const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n);
 
           const { registrations } = parser.parse();
           expect(registrations[0]).to.includes({
@@ -118,7 +121,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;aaaaa;97422;;200;99100;AP;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+          const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
 
           const error = await catchErr(parser.parse, parser)();
 
@@ -134,7 +137,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;97422;;200;${wrongData};ST;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+          const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
 
           const error = await catchErr(parser.parse, parser)();
 
@@ -150,7 +153,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
           123F;Beatrix;The;Bride;Kiddo;Black Mamba;01/01/1980;${wrongData};;974;99100;ST;MEF1;Division 1;
           `;
           const encodedInput = iconv.encode(input, 'utf8');
-          const parser = new SchoolingRegistrationParser(encodedInput, 123);
+          const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
 
           const error = await catchErr(parser.parse, parser)();
 
@@ -167,7 +170,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
             `;
             const organizationId = 789;
             const encodedInput = iconv.encode(input, 'utf8');
-            const parser = new SchoolingRegistrationParser(encodedInput, organizationId, true);
+            const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n, true);
 
             const { registrations } = parser.parse();
             expect(registrations[0]).to.includes({
@@ -187,7 +190,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
               `;
 
               const encodedInput = iconv.encode(input, 'utf8');
-              const parser = new SchoolingRegistrationParser(encodedInput, 123);
+              const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n);
 
               const error = await catchErr(parser.parse, parser)();
 
@@ -207,7 +210,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
               `;
               const organizationId = 789;
               const encodedInput = iconv.encode(input, 'utf8');
-              const parser = new SchoolingRegistrationParser(encodedInput, organizationId, isAgriculture);
+              const parser = new SchoolingRegistrationParser(encodedInput, organizationId, i18n, isAgriculture);
 
               const { registrations } = parser.parse();
 
@@ -231,7 +234,7 @@ describe('Unit | Infrastructure | SchoolingRegistrationParser', () => {
               `;
 
               const encodedInput = iconv.encode(input, 'utf8');
-              const parser = new SchoolingRegistrationParser(encodedInput, 123, isAgriculture);
+              const parser = new SchoolingRegistrationParser(encodedInput, 123, i18n, isAgriculture);
 
               const error = await catchErr(parser.parse, parser)();
 

--- a/api/translations/en.json
+++ b/api/translations/en.json
@@ -79,22 +79,6 @@
     "ACCEPT_CGU": "Please agree to the terms and conditions of use.",
     "FILL_USERNAME_OR_EMAIL": "Please enter an email address and/or a username."
   },
-  "higher-schooling-registration-csv": {
-    "birthdate": "Date of birth (DD/MM/YYYY)",
-    "department": "Department",
-    "diploma": "Degree",
-    "educational-team": "Teaching staff",
-    "email": "Email address",
-    "firstname": "First Name",
-    "group": "Group",
-    "lastname": "Last name",
-    "middle-name": "Middle name #1",
-    "preferred-lastname": "Preferred name",
-    "student-number": "Student number",
-    "study-scheme": "Status",
-    "template-name": "import-template",
-    "third-name": "Middle name #2"
-  },
   "organization-invitation-email": {
     "params": {
       "acceptInvitation": "Accept the invitation",
@@ -137,5 +121,39 @@
       "weCannotSendYourPassword": "Hello, for security reasons, we cannot send your password by email."
     },
     "subject": "Pix password reset request"
+  },
+  "csv-template": {
+    "higher-schooling-registrations": {
+      "birthdate": "Date of birth (DD/MM/YYYY)",
+      "department": "Department",
+      "diploma": "Degree",
+      "educational-team": "Teaching staff",
+      "email": "Email address",
+      "first-name": "First Name",
+      "group": "Group",
+      "last-name": "Last name",
+      "middle-name": "Middle name #1",
+      "preferred-lastname": "Preferred name",
+      "student-number": "Student number",
+      "study-scheme": "Status",
+      "third-name": "Middle name #2"
+    },
+    "schooling-registrations": {
+      "birthdate": "Date of birth (DD/MM/YYYY)*",
+      "birth-city": "Place of birth**",
+      "birth-city-code": "City of birth code**",
+      "birth-province-code": "Province of birth code*",
+      "birth-country-code": "Country code*",
+      "division": "Class*",
+      "first-name": "First name*",
+      "last-name": "Last name*",
+      "middle-name": "Middle name #1",
+      "mef-code": "MEF code*",
+      "national-identifier": "Unique identifier*",
+      "preferred-last-name": "Preferred name",
+      "status": "Status*",
+      "third-name": "Middle name #2"
+    },
+    "template-name": "import-template"
   }
 }

--- a/api/translations/fr.json
+++ b/api/translations/fr.json
@@ -1,28 +1,4 @@
 {
-  "campaign": {
-    "common": {
-      "no": "Non",
-      "not-available": "NA",
-      "yes": "Oui"
-    },
-    "profiles-collection": {
-      "campaign-id": "ID Campagne",
-      "campaign-name": "Nom de la campagne",
-      "certifiable-skills": "Nombre de compétences certifiables",
-      "file-name": "Resultats-{{name}}-{{id}}-{{date}}.csv",
-      "is-certifiable": "Certifiable (O/N)",
-      "is-sent": "Envoi (O/N)",
-      "organization-name": "Nom de l'organisation",
-      "participant-division": "Classe",
-      "participant-firstname": "Prénom du Participant",
-      "participant-lastname": "Nom du Participant",
-      "participant-student-number": "Numéro Étudiant",
-      "pix-score": "Nombre de pix total",
-      "sent-on": "Date de l'envoi",
-      "skill-level": "Niveau pour la compétence {{name}}",
-      "skill-ranking": "Nombre de pix pour la compétence {{name}}"
-    }
-  },
   "campaign-export": {
     "assessment": {
       "competence-area": {
@@ -103,22 +79,6 @@
     "ACCEPT_CGU": "Vous devez accepter les conditions d’utilisation de Pix pour créer un compte.",
     "FILL_USERNAME_OR_EMAIL": "Vous devez renseigner une adresse e-mail et/ou un identifiant."
   },
-  "higher-schooling-registration-csv": {
-    "birthdate": "Date de naissance (jj/mm/aaaa)",
-    "department": "Composante",
-    "diploma": "Diplôme",
-    "educational-team": "Équipe pédagogique",
-    "email": "Email",
-    "firstname": "Premier prénom",
-    "group": "Groupe",
-    "lastname": "Nom de famille",
-    "middle-name": "Deuxième prénom",
-    "preferred-lastname": "Nom d'usage",
-    "student-number": "Numéro étudiant",
-    "study-scheme": "Régime",
-    "template-name": "modele-import",
-    "third-name": "Troisième prénom"
-  },
   "organization-invitation-email": {
     "params": {
       "acceptInvitation": "Accepter l’invitation",
@@ -161,5 +121,39 @@
       "weCannotSendYourPassword": "Bonjour, pour des raisons de sécurité, nous ne vous envoyons pas votre mot de passe par e-mail."
     },
     "subject": "Demande de réinitialisation de mot de passe Pix"
+  },
+  "csv-template": {
+    "higher-schooling-registrations": {
+      "birthdate": "Date de naissance (jj/mm/aaaa)",
+      "department": "Composante",
+      "diploma": "Diplôme",
+      "educational-team": "Équipe pédagogique",
+      "email": "Email",
+      "first-name": "Premier prénom",
+      "group": "Groupe",
+      "last-name": "Nom de famille",
+      "middle-name": "Deuxième prénom",
+      "preferred-lastname": "Nom d'usage",
+      "student-number": "Numéro étudiant",
+      "study-scheme": "Régime",
+      "third-name": "Troisième prénom"
+    },
+    "schooling-registrations": {
+      "birthdate": "Date de naissance (jj/mm/aaaa)*",
+      "birth-city": "Libellé commune naissance**",
+      "birth-city-code": "Code commune naissance**",
+      "birth-province-code": "Code département naissance*",
+      "birth-country-code": "Code pays naissance*",
+      "division": "Division*",
+      "first-name": "Premier prénom*",
+      "last-name": "Nom de famille*",
+      "middle-name": "Deuxième prénom",
+      "mef-code": "Code MEF*",
+      "national-identifier": "Identifiant unique*",
+      "preferred-last-name": "Nom d'usage",
+      "status": "Statut*",
+      "third-name": "Troisième prénom"
+    },
+    "template-name": "modele-import"
   }
 }

--- a/orga/app/components/routes/authenticated/sco-students/list-items.js
+++ b/orga/app/components/routes/authenticated/sco-students/list-items.js
@@ -35,7 +35,7 @@ export default class ListItems extends Component {
   }
 
   get urlToDownloadCsvTemplate() {
-    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}`;
+    return `${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/csv-template?accessToken=${this.session.data.authenticated.access_token}&lang=${this.currentUser.prescriber.lang}`;
   }
 
   @action

--- a/orga/app/controllers/authenticated/sco-students/list.js
+++ b/orga/app/controllers/authenticated/sco-students/list.js
@@ -56,6 +56,7 @@ export default class ListController extends Controller {
       await file.uploadBinary(`${ENV.APP.API_HOST}/api/organizations/${this.currentUser.organization.id}/schooling-registrations/import-siecle?format=${format}`, {
         headers: {
           Authorization: `Bearer ${access_token}`,
+          'Accept-Language': this.currentUser.prescriber.lang,
         },
       });
       this.refresh();

--- a/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
+++ b/orga/tests/integration/components/routes/authenticated/sco-students/list-items-test.js
@@ -343,6 +343,9 @@ module('Integration | Component | routes/authenticated/sco-students | list-items
             isAgriculture = true;
             isCFA = true;
             organization = {};
+            prescriber = {
+              lang: 'fr',
+            };
           }
 
           this.set('importStudentsSpy', () => {});

--- a/orga/tests/unit/controllers/authenticated/sco-students/list-test.js
+++ b/orga/tests/unit/controllers/authenticated/sco-students/list-test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 module('Unit | Controller | authenticated/sco-students/list', function(hooks) {
   setupTest(hooks);
-  const currentUser = { organization: { id: 1 } };
+  const currentUser = { organization: { id: 1 }, prescriber: { lang: 'fr' } };
   const session = { data: { authenticated: { access_token: 12345 } } };
   let controller;
 
@@ -21,7 +21,7 @@ module('Unit | Controller | authenticated/sco-students/list', function(hooks) {
 
       test('it sends the chosen csv file to the API', async function(assert) {
         const importStudentsURL = `${ENV.APP.API_HOST}/api/organizations/${currentUser.organization.id}/schooling-registrations/import-siecle?format=csv`;
-        const headers = { Authorization: `Bearer ${12345}` };
+        const headers = { Authorization: `Bearer ${12345}`, 'Accept-Language': currentUser.prescriber.lang };
         const file = { uploadBinary: sinon.spy() };
 
         currentUser.isAgriculture = true;
@@ -36,7 +36,7 @@ module('Unit | Controller | authenticated/sco-students/list', function(hooks) {
 
       test('it sends the chosen xml file to the API', async function(assert) {
         const importStudentsURL = `${ENV.APP.API_HOST}/api/organizations/${currentUser.organization.id}/schooling-registrations/import-siecle?format=xml`;
-        const headers = { Authorization: `Bearer ${12345}` };
+        const headers = { Authorization: `Bearer ${12345}`, 'Accept-Language': currentUser.prescriber.lang };
         const file = { uploadBinary: sinon.spy() };
 
         currentUser.isAgriculture = false;


### PR DESCRIPTION
## :unicorn: Problème
le ficher csv d'import modèle pour l'import des étudiants sur Pix Orga n'est pas internationalisé

## :robot: Solution
Traduire les columns du fichier csv import modèle en fonction de current language envoyée dans le request.

Un module i18n est ajouté dans le request url , puis passé vers où retrouvent les colonnes de csv à traduire.
il n'était pas possible de fair passer le module i18n du controller jusqu'au fichier où se trouvaient les colonnes du modèle d'import, donc un nouveau fichier appelé schooling-registration-columns.js a été créé pour faire le lien.


## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Allez sur pixOrga avec un compte SCO , menu étudiante , cliquez sur télécharger le modèle . En fonction du paramètre lang de l'url. les colonnes du fichier téléchargé s'afficheront dans la langue sélectionnée.
