### PR TITLE
[TECH] Empêcher le re-scoring lors de la récupération des détails de certification sur Admin (PIX-2419)

### DIFF
--- a/admin/app/models/feature-toggle.js
+++ b/admin/app/models/feature-toggle.js
@@ -1,0 +1,5 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class FeatureToggle extends Model {
+  @attr('boolean') isNeutralizationAutoEnabled;
+}

--- a/admin/app/routes/application.js
+++ b/admin/app/routes/application.js
@@ -7,10 +7,12 @@ export default class ApplicationRoute extends Route.extend(ApplicationRouteMixin
   @service currentUser;
   @service notifications;
   @service url;
+  @service featureToggles;
 
   routeAfterAuthentication = 'authenticated';
 
-  beforeModel() {
+  async beforeModel() {
+    await this.featureToggles.load();
     return this._loadCurrentUser();
   }
 

--- a/admin/app/routes/authenticated/certifications/certification/details.js
+++ b/admin/app/routes/authenticated/certifications/certification/details.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default class CertificationDetailsRoute extends Route {
   model() {
     const { certification_id } = this.paramsFor('authenticated.certifications.certification');
-    return this.store.findRecord('certificationDetails', certification_id);
+    return this.store.findRecord('certification-details', certification_id);
   }
 
   setupController(controller, model) {

--- a/admin/app/serializers/certification-details.js
+++ b/admin/app/serializers/certification-details.js
@@ -1,9 +1,12 @@
 import JSONAPISerializer from '@ember-data/serializer/json-api';
+import { inject as service } from '@ember/service';
 
 export default class CertificationDetails extends JSONAPISerializer {
 
+  @service featureToggles;
+
   normalizeFindRecordResponse(store, primaryModelClass, payload, id) {
-    if (!payload.data) {
+    if (!this.featureToggles.featureToggles.isNeutralizationAutoEnabled && !payload.data) {
       payload.data = {
         attributes: {
           competencesWithMark: payload.competencesWithMark,
@@ -17,13 +20,16 @@ export default class CertificationDetails extends JSONAPISerializer {
         },
         type: 'certificationDetails',
       };
+      payload.data.id = id;
     }
-    payload.data.id = id;
     return this.normalizeSingleResponse(...arguments);
   }
 
   keyForAttribute(key) {
-    return key;
+    if (!this.featureToggles.featureToggles.isNeutralizationAutoEnabled) {
+      return key;
+    }
+    return super.keyForAttribute(...arguments);
   }
 
   modelNameFromPayloadKey() {

--- a/admin/app/services/feature-toggles.js
+++ b/admin/app/services/feature-toggles.js
@@ -1,0 +1,9 @@
+import Service, { inject as service } from '@ember/service';
+
+export default class FeatureTogglesService extends Service {
+  @service store;
+
+  async load() {
+    this.featureToggles = await this.store.queryRecord('feature-toggle', { id: 0 });
+  }
+}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -175,6 +175,10 @@ export default function() {
     return user.update(expectedUpdatedUser);
   });
 
+  this.get('feature-toggles', (schema) => {
+    return schema.featureToggles.findOrCreateBy({ id: 0 });
+  });
+
   this.patch('/admin/users/:id/dissociate', (schema, request) => {
     const userId = request.params.id;
     const expectedUpdatedUser = {

--- a/admin/mirage/factories/feature-toggle.js
+++ b/admin/mirage/factories/feature-toggle.js
@@ -1,0 +1,6 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  id: 0,
+  isNeutralizationAutoEnabled: false,
+});

--- a/admin/tests/unit/serializers/certification-details-test.js
+++ b/admin/tests/unit/serializers/certification-details-test.js
@@ -1,11 +1,18 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
+import Service from '@ember/service';
 
 module('Unit | Serializer | certification details', function(hooks) {
   setupTest(hooks);
 
   test('it serializes records', function(assert) {
+    class FeatureTogglesMock extends Service {
+      featureToggles = {};
+    }
+
+    this.owner.register('service:feature-toggles', FeatureTogglesMock);
+
     const store = this.owner.lookup('service:store');
     const record = run(() => store.createRecord('certification-details', {}));
 

--- a/admin/tests/unit/services/feature-toggles-test.js
+++ b/admin/tests/unit/services/feature-toggles-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { resolve } from 'rsvp';
+import Object from '@ember/object';
+import Service from '@ember/service';
+
+module('Unit | Service | feature toggles', function(hooks) {
+
+  setupTest(hooks);
+
+  module('feature toggles are loaded', function() {
+
+    test('should load the feature toggles', async function(assert) {
+      // Given
+      const featureToggles = Object.create({
+        isTotoEnabled: false,
+      });
+      const storeStub = Service.create({
+        queryRecord: () => resolve(featureToggles),
+      });
+      const featureToggleService = this.owner.lookup('service:featureToggles');
+      featureToggleService.set('store', storeStub);
+
+      // When
+      await featureToggleService.load();
+
+      // Then
+      assert.equal(featureToggleService.featureToggles.isTotoEnabled, false);
+    });
+  });
+});

--- a/api/lib/application/certification-courses/certification-course-controller.js
+++ b/api/lib/application/certification-courses/certification-course-controller.js
@@ -1,5 +1,6 @@
 const certificationService = require('../../domain/services/certification-service');
 const certificationCourseService = require('../../domain/services/certification-course-service');
+const certificationDetailsSerializer = require('../../infrastructure/serializers/jsonapi/certification-details-serializer');
 const certificationResultSerializer = require('../../infrastructure/serializers/jsonapi/certification-result-serializer');
 const certificationSerializer = require('../../infrastructure/serializers/jsonapi/certification-serializer');
 const certificationCourseSerializer = require('../../infrastructure/serializers/jsonapi/certification-course-serializer');
@@ -13,6 +14,13 @@ module.exports = {
   computeResult(request) {
     const certificationCourseId = request.params.id;
     return certificationService.calculateCertificationResultByCertificationCourseId(certificationCourseId);
+  },
+
+  async getCertificationDetails(request) {
+    const certificationCourseId = request.params.id;
+    const certificationDetails = await usecases.getCertificationDetails({ certificationCourseId });
+
+    return certificationDetailsSerializer.serialize(certificationDetails);
   },
 
   async getResult(request) {

--- a/api/lib/application/certification-courses/index.js
+++ b/api/lib/application/certification-courses/index.js
@@ -4,6 +4,7 @@ const securityPreHandlers = require('../security-pre-handlers');
 const certificationCourseController = require('./certification-course-controller');
 
 const identifiersType = require('../../domain/types/identifiers-type');
+const config = require('../../config');
 
 exports.register = async function(server) {
   server.route([
@@ -20,7 +21,13 @@ exports.register = async function(server) {
             id: identifiersType.certificationCourseId,
           }),
         },
-        handler: certificationCourseController.computeResult,
+        handler: (request) => {
+          if (config.featureToggles.isNeutralizationAutoEnabled) {
+            return certificationCourseController.getCertificationDetails(request);
+          } else {
+            return certificationCourseController.computeResult(request);
+          }
+        },
         tags: ['api'],
         notes: [
           'Cette route est utilisé par Pix Admin',

--- a/api/lib/config.js
+++ b/api/lib/config.js
@@ -125,6 +125,7 @@ module.exports = (function() {
 
     featureToggles: {
       isAprilFoolEnabled: isFeatureEnabled(process.env.FT_IS_APRIL_FOOL_ENABLED),
+      isNeutralizationAutoEnabled: isFeatureEnabled(process.env.FT_IS_NEUTRALIZATION_AUTO_ENABLED),
       isPoleEmploiEnabled: isFeatureEnabled(process.env.IS_POLE_EMPLOI_ENABLED),
       isCertificationResultsInOrgaEnabled: isFeatureEnabled(process.env.FT_IS_CERTIFICATION_RESULTS_IN_ORGA_ENABLED),
     },

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -2,6 +2,7 @@ const Joi = require('joi')
   .extend(require('@joi/date'));
 const { validateEntity } = require('../validators/entity-validator');
 const { states } = require('./Assessment');
+const _ = require('lodash');
 
 const certificationAssessmentSchema = Joi.object({
   id: Joi.number().integer().required(),
@@ -39,6 +40,11 @@ class CertificationAssessment {
 
     validateEntity(certificationAssessmentSchema, this);
   }
+
+  getCertificationChallenge(challengeId) {
+    return _.find(this.certificationChallenges, { challengeId }) || null;
+  }
+
 }
 
 CertificationAssessment.states = states;

--- a/api/lib/domain/models/PlacementProfile.js
+++ b/api/lib/domain/models/PlacementProfile.js
@@ -32,6 +32,10 @@ class PlacementProfile {
   getPixScore() {
     return _.sumBy(this.userCompetences, 'pixScore');
   }
+
+  getUserCompetence(competenceId) {
+    return _.find(this.userCompetences, { id: competenceId }) || null;
+  }
 }
 
 module.exports = PlacementProfile;

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -1,0 +1,27 @@
+class CertificationDetails {
+  constructor({
+    id,
+    userId,
+    createdAt,
+    completedAt,
+    status,
+    totalScore,
+    percentageCorrectAnswers,
+    competencesWithMark,
+    listChallengesAndAnswers,
+  }) {
+    this.id = id;
+    this.userId = userId;
+    this.createdAt = createdAt;
+    this.completedAt = completedAt;
+    this.status = status;
+    this.totalScore = totalScore;
+    this.percentageCorrectAnswers = percentageCorrectAnswers;
+    this.competencesWithMark = competencesWithMark;
+    this.listChallengesAndAnswers = listChallengesAndAnswers;
+  }
+}
+
+module.exports = {
+  CertificationDetails,
+};

--- a/api/lib/domain/read-models/CertificationDetails.js
+++ b/api/lib/domain/read-models/CertificationDetails.js
@@ -1,3 +1,6 @@
+const _ = require('lodash');
+const { ReproducibilityRate } = require('../models/ReproducibilityRate');
+
 class CertificationDetails {
   constructor({
     id,
@@ -20,8 +23,72 @@ class CertificationDetails {
     this.competencesWithMark = competencesWithMark;
     this.listChallengesAndAnswers = listChallengesAndAnswers;
   }
+
+  static from({
+    certificationAssessment,
+    competenceMarks,
+    placementProfile,
+  }) {
+    const reproducibilityRate = ReproducibilityRate.from({ answers: certificationAssessment.certificationAnswersByDate });
+    const competencesWithMark = _buildCompetencesWithMark({ competenceMarks, placementProfile });
+    const listChallengesAndAnswers = _buildListChallengesAndAnswers({ certificationAssessment, competencesWithMark });
+
+    return new CertificationDetails({
+      id: certificationAssessment.certificationCourseId,
+      userId: certificationAssessment.userId,
+      createdAt: certificationAssessment.createdAt,
+      completedAt: certificationAssessment.completedAt,
+      status: certificationAssessment.state,
+      totalScore: _.sumBy(competenceMarks, 'score'),
+      percentageCorrectAnswers: reproducibilityRate.value,
+      competencesWithMark,
+      listChallengesAndAnswers,
+    });
+  }
 }
 
-module.exports = {
-  CertificationDetails,
-};
+function _buildCompetencesWithMark({
+  competenceMarks,
+  placementProfile,
+}) {
+  return _.map(competenceMarks, (competenceMark)=> {
+    const userCompetence = placementProfile.getUserCompetence(competenceMark.competenceId);
+
+    return {
+      areaCode: competenceMark.area_code,
+      id: competenceMark.competenceId,
+      index: competenceMark.competence_code,
+      name: userCompetence.name,
+      obtainedLevel: competenceMark.level,
+      obtainedScore: competenceMark.score,
+      positionedLevel: userCompetence.estimatedLevel,
+      positionedScore: userCompetence.pixScore,
+    };
+  });
+
+}
+
+function _buildListChallengesAndAnswers({
+  certificationAssessment,
+  competencesWithMark,
+}) {
+  return _.map(certificationAssessment.certificationAnswersByDate, (certificationAnswer) => {
+    const challengeForAnswer = certificationAssessment.getCertificationChallenge(certificationAnswer.challengeId);
+    const competenceIndex = _getCompetenceIndexForChallenge(challengeForAnswer, competencesWithMark);
+
+    return {
+      challengeId: challengeForAnswer.challengeId,
+      competence: competenceIndex,
+      result: certificationAnswer.result.status,
+      skill: challengeForAnswer.associatedSkillName,
+      value: certificationAnswer.value,
+    };
+  });
+}
+
+function _getCompetenceIndexForChallenge(certificationChallenge, competencesWithMark) {
+  const competenceWithMark = _.find(competencesWithMark, { id: certificationChallenge.competenceId });
+  return competenceWithMark ? competenceWithMark.index : '';
+}
+
+module.exports = CertificationDetails;

--- a/api/lib/domain/usecases/get-certification-details.js
+++ b/api/lib/domain/usecases/get-certification-details.js
@@ -1,0 +1,24 @@
+const CertificationDetails = require('../read-models/CertificationDetails');
+
+module.exports = async function getCertificationDetails({
+  certificationCourseId,
+  competenceMarkRepository,
+  certificationAssessmentRepository,
+  placementProfileService,
+}) {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
+
+  const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+
+  const placementProfile = await placementProfileService.getPlacementProfile({
+    userId: certificationAssessment.userId,
+    limitDate: certificationAssessment.createdAt,
+    isV2Certification: certificationAssessment.isV2Certification,
+  });
+
+  return CertificationDetails.from({
+    competenceMarks,
+    certificationAssessment,
+    placementProfile,
+  });
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -196,6 +196,7 @@ module.exports = injectDependencies({
   getCertificationCandidate: require('./get-certification-candidate'),
   getCertificationCenter: require('./get-certification-center'),
   getCertificationCourse: require('./get-certification-course'),
+  getCertificationDetails: require('./get-certification-details'),
   getCertificationsResultsForLS: require('./certificate/get-certifications-results-for-ls'),
   getCertificationPointOfContact: require('./get-certification-point-of-contact'),
   getCorrectionForAnswer: require('./get-correction-for-answer'),

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -8,7 +8,8 @@ const { NotFoundError } = require('../../domain/errors');
 
 async function _getCertificationChallenges(certificationCourseId) {
   const certificationChallengeRows = await knex('certification-challenges')
-    .where({ courseId: certificationCourseId });
+    .where({ courseId: certificationCourseId })
+    .orderBy('id', 'asc');
 
   return _.map(certificationChallengeRows, (certificationChallengeRow) => new CertificationChallenge({
     ...certificationChallengeRow,

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -1,8 +1,9 @@
 const BookshelfCompetenceMark = require('../data/competence-mark');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
+const { knex } = require('../bookshelf');
 
-function _toDomain(bookshelfCompetenceMark) {
-  return new CompetenceMark(bookshelfCompetenceMark.attributes);
+function _toDomain(competenceMark) {
+  return new CompetenceMark(competenceMark);
 }
 
 module.exports = {
@@ -17,6 +18,24 @@ module.exports = {
     const competenceMarks = await BookshelfCompetenceMark
       .where({ assessmentResultId })
       .fetchAll();
-    return competenceMarks.models.map(_toDomain);
+    return competenceMarks.models.map((model) =>_toDomain(model.attributes));
+  },
+
+  async findByCertificationCourseId(certificationCourseId) {
+    const competenceMarks = await knex('competence-marks')
+      .select(
+        'competence-marks.id',
+        'area_code',
+        'competence_code',
+        'competence-marks.competenceId',
+        'competence-marks.level',
+        'competence-marks.score',
+        'competence-marks.assessmentResultId',
+      )
+      .join('assessment-results', 'assessmentResultId', 'assessment-results.id')
+      .join('assessments', 'assessmentId', 'assessments.id')
+      .where({ certificationCourseId });
+
+    return competenceMarks.map(_toDomain);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/certification-details-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/certification-details-serializer.js
@@ -1,0 +1,10 @@
+const { Serializer } = require('jsonapi-serializer');
+
+module.exports = {
+  serialize(certificationDetails) {
+    return new Serializer('certification-details', {
+      attributes: ['userId', 'createdAt', 'completedAt', 'status',
+        'totalScore', 'percentageCorrectAnswers', 'competencesWithMark', 'listChallengesAndAnswers'],
+    }).serialize(certificationDetails);
+  },
+};

--- a/api/tests/acceptance/application/certification-course-controller_test.js
+++ b/api/tests/acceptance/application/certification-course-controller_test.js
@@ -1,5 +1,6 @@
 const { expect, databaseBuilder, knex, learningContentBuilder, mockLearningContent, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../test-helper');
 const createServer = require('../../../server');
+const config = require('../../../lib/config');
 
 const { CertificationIssueReportCategories } = require('../../../lib/domain/models/CertificationIssueReportCategory');
 const Assessment = require('../../../lib/domain/models/Assessment');
@@ -12,58 +13,67 @@ describe('Acceptance | API | Certification Course', () => {
     server = await createServer();
   });
 
-  describe('GET /api/admin/certifications/{id}/details', () => {
+  describe('when FT_IS_NEUTRALIZATION_AUTO_ENABLED toggle is enabled ', () => {
 
-    it('Should respond with a status 200', async () => {
+    describe('GET /api/admin/certifications/{id}/details', () => {
 
-      // given
-      await insertUserWithRolePixMaster();
-      const options = {
-        method: 'GET',
-        url: '/api/admin/certifications/1234/details',
-        headers: {
-          authorization: generateValidRequestAuthorizationHeader(),
-        },
-      };
-
-      const learningContent = [{
-        id: '1. Information et données',
-        competences: [{
-          id: 'competence_id',
-          tubes: [{
-            id: 'recTube1',
-            skills: [{
-              challenges: [
-                { id: 'k_challenge_id' },
-              ],
-            }],
-          }],
-        }],
-      }];
-
-      const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
-      mockLearningContent(learningContentObjects);
-
-      databaseBuilder.factory.buildCertificationCourse({ id: 1234, isV2Certification: true });
-      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: 1234, competenceId: 'competence_id' }).id;
-      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
-      databaseBuilder.factory.buildCompetenceMark({ assessmentResultId, competenceId: 'competence_id' });
-
-      databaseBuilder.factory.buildCertificationChallenge({
-        courseId: 1234,
-        competenceId: 'competence_id',
-        challengeId: 'k_challenge_id',
+      afterEach(function() {
+        config.featureToggles.isNeutralizationAutoEnabled = false;
       });
 
-      databaseBuilder.factory.buildAnswer({ challengeId: 'k_challenge_id', assessmentId });
+      it('Should respond with a status 200', async () => {
 
-      await databaseBuilder.commit();
+        config.featureToggles.isNeutralizationAutoEnabled = true;
 
-      // when
-      const result = await server.inject(options);
+        // given
+        await insertUserWithRolePixMaster();
+        const options = {
+          method: 'GET',
+          url: '/api/admin/certifications/1234/details',
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(),
+          },
+        };
 
-      // then
-      expect(result.statusCode).to.equal(200);
+        const learningContent = [{
+          id: '1. Information et données',
+          competences: [{
+            id: 'competence_id',
+            tubes: [{
+              id: 'recTube1',
+              skills: [{
+                challenges: [
+                  { id: 'k_challenge_id' },
+                ],
+              }],
+            }],
+          }],
+        }];
+
+        const learningContentObjects = learningContentBuilder.buildLearningContent(learningContent);
+        mockLearningContent(learningContentObjects);
+
+        databaseBuilder.factory.buildCertificationCourse({ id: 1234, isV2Certification: true });
+        const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId: 1234, competenceId: 'competence_id' }).id;
+        const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
+        databaseBuilder.factory.buildCompetenceMark({ assessmentResultId, competenceId: 'competence_id' });
+
+        databaseBuilder.factory.buildCertificationChallenge({
+          courseId: 1234,
+          competenceId: 'competence_id',
+          challengeId: 'k_challenge_id',
+        });
+
+        databaseBuilder.factory.buildAnswer({ challengeId: 'k_challenge_id', assessmentId });
+
+        await databaseBuilder.commit();
+
+        // when
+        const result = await server.inject(options);
+
+        // then
+        expect(result.statusCode).to.equal(200);
+      });
     });
   });
 

--- a/api/tests/acceptance/application/feature-toggle-controller_tests.js
+++ b/api/tests/acceptance/application/feature-toggle-controller_tests.js
@@ -26,6 +26,7 @@ describe('Acceptance | Controller | feature-toggle-controller', () => {
             'is-april-fool-enabled': false,
             'is-pole-emploi-enabled': false,
             'is-certification-results-in-orga-enabled': false,
+            'is-neutralization-auto-enabled': false,
           },
           type: 'feature-toggles',
         },

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -79,6 +79,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
     context('when the certification assessment exists', () => {
       let firstAnswerInTime;
       let secondAnswerInTime;
+      let firstChallengeId;
+      let secondChallengeId;
 
       beforeEach(() => {
         const dbf = databaseBuilder.factory;
@@ -106,8 +108,8 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
           createdAt: new Date('2020-06-24T00:00:00Z'),
         }).id;
 
-        dbf.buildCertificationChallenge({ courseId: certificationCourseId });
-        dbf.buildCertificationChallenge({ courseId: certificationCourseId });
+        secondChallengeId = dbf.buildCertificationChallenge({ courseId: certificationCourseId, id: 123 }).id;
+        firstChallengeId = dbf.buildCertificationChallenge({ courseId: certificationCourseId, id: 456 }).id;
 
         return databaseBuilder.commit();
       });
@@ -134,6 +136,14 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
         // then
         expect(_.map(certificationAssessment.certificationAnswersByDate, 'id')).to.deep.equal([firstAnswerInTime, secondAnswerInTime]);
+      });
+
+      it('should return the certification challenges ordered by id', async () => {
+        // when
+        const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
+
+        // then
+        expect(_.map(certificationAssessment.certificationChallenges, 'id')).to.deep.equal([secondChallengeId, firstChallengeId]);
       });
     });
 

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -73,17 +73,15 @@ describe('Integration | Repository | CompetenceMark', () => {
       await databaseBuilder.commit();
     });
 
-    it('should return all competence-marks for one assessmentResult', () => {
+    it('should return all competence-marks for one assessmentResult', async () => {
       // when
-      const promise = competenceMarkRepository.findByAssessmentResultId(assessmentResultId);
+      const competenceMarks = await competenceMarkRepository.findByAssessmentResultId(assessmentResultId);
 
       // then
-      return promise.then((competenceMarks) => {
-        const sortedCompetenceMarks = _.sortBy(competenceMarks, [(mark) => { return mark.id; }]);
-        expect(sortedCompetenceMarks[0].id).to.equal(competenceMarkIds[0]);
-        expect(sortedCompetenceMarks[1].id).to.equal(competenceMarkIds[2]);
-        expect(sortedCompetenceMarks.length).to.equal(2);
-      });
+      const sortedCompetenceMarks = _.sortBy(competenceMarks, [(mark) => { return mark.id; }]);
+      expect(sortedCompetenceMarks[0].id).to.equal(competenceMarkIds[0]);
+      expect(sortedCompetenceMarks[1].id).to.equal(competenceMarkIds[2]);
+      expect(sortedCompetenceMarks.length).to.equal(2);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -86,4 +86,34 @@ describe('Integration | Repository | CompetenceMark', () => {
       });
     });
   });
+
+  describe('#findByCertificationCourseId', () => {
+
+    it('should return all competence-marks for one certificationCourseId', async () => {
+
+      // given
+      const certificationCourseId = databaseBuilder.factory.buildCertificationCourse({}).id;
+      const assessmentId = databaseBuilder.factory.buildAssessment({ certificationCourseId }).id;
+      const assessmentResultId = databaseBuilder.factory.buildAssessmentResult({ assessmentId }).id;
+      const anotherAssessmentResultId = databaseBuilder.factory.buildAssessmentResult({}).id;
+      const competenceMarkIds = _.map([
+        { score: 13, level: 2, area_code: '4', competence_code: '4.2', assessmentResultId },
+        { score: 10, level: 1, area_code: '3', competence_code: '3.1', assessmentResultId: anotherAssessmentResultId },
+        { score: 24, level: 3, area_code: '3', competence_code: '3.1', assessmentResultId },
+      ], (mark) => {
+        return databaseBuilder.factory.buildCompetenceMark(mark).id;
+      });
+      await databaseBuilder.commit();
+
+      // when
+      const competenceMarks = await competenceMarkRepository.findByCertificationCourseId(certificationCourseId);
+
+      // then
+      const sortedCompetenceMarks = _.sortBy(competenceMarks, [(mark) => { return mark.id; }]);
+      expect(sortedCompetenceMarks[0]).to.be.instanceOf(CompetenceMark);
+      expect(sortedCompetenceMarks[0].id).to.equal(competenceMarkIds[0]);
+      expect(sortedCompetenceMarks[1].id).to.equal(competenceMarkIds[2]);
+      expect(sortedCompetenceMarks.length).to.equal(2);
+    });
+  });
 });

--- a/api/tests/tooling/domain-builder/factory/build-answer.js
+++ b/api/tests/tooling/domain-builder/factory/build-answer.js
@@ -39,4 +39,70 @@ buildAnswer.uncorrected = function({
   });
 };
 
+buildAnswer.ok = function({
+  id = 123,
+  resultDetails = null,
+  timeout = null,
+  value = '1',
+  assessmentId = 456,
+  challengeId = 'recChallenge123',
+  timeSpent = 20,
+} = {}) {
+
+  return buildAnswer({
+    id,
+    result: AnswerStatus.OK,
+    resultDetails,
+    timeout,
+    value,
+    assessmentId,
+    challengeId,
+    timeSpent,
+  });
+};
+
+buildAnswer.ko = function({
+  id = 123,
+  resultDetails = null,
+  timeout = null,
+  value = '1',
+  assessmentId = 456,
+  challengeId = 'recChallenge123',
+  timeSpent = 20,
+} = {}) {
+
+  return buildAnswer({
+    id,
+    result: AnswerStatus.KO,
+    resultDetails,
+    timeout,
+    value,
+    assessmentId,
+    challengeId,
+    timeSpent,
+  });
+};
+
+buildAnswer.skipped = function({
+  id = 123,
+  resultDetails = null,
+  timeout = null,
+  value = '1',
+  assessmentId = 456,
+  challengeId = 'recChallenge123',
+  timeSpent = 20,
+} = {}) {
+
+  return buildAnswer({
+    id,
+    result: AnswerStatus.SKIPPED,
+    resultDetails,
+    timeout,
+    value,
+    assessmentId,
+    challengeId,
+    timeSpent,
+  });
+};
+
 module.exports = buildAnswer;

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
@@ -1,4 +1,5 @@
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
+const buildCertificationChallenge = require('./build-certification-challenge');
 
 module.exports = function buildCertificationAssessment(
   {
@@ -9,7 +10,7 @@ module.exports = function buildCertificationAssessment(
     completedAt = new Date('2020-01-01'),
     state = CertificationAssessment.states.STARTED,
     isV2Certification = true,
-    certificationChallenges = [],
+    certificationChallenges = [buildCertificationChallenge()],
     certificationAnswersByDate = [],
   } = {}) {
   return new CertificationAssessment({

--- a/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-assessment.js
@@ -1,0 +1,26 @@
+const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
+
+module.exports = function buildCertificationAssessment(
+  {
+    id = 123,
+    userId = 123,
+    certificationCourseId = 123,
+    createdAt = new Date('2020-01-01'),
+    completedAt = new Date('2020-01-01'),
+    state = CertificationAssessment.states.STARTED,
+    isV2Certification = true,
+    certificationChallenges = [],
+    certificationAnswersByDate = [],
+  } = {}) {
+  return new CertificationAssessment({
+    id,
+    userId,
+    certificationCourseId,
+    createdAt,
+    completedAt,
+    state,
+    isV2Certification,
+    certificationChallenges,
+    certificationAnswersByDate,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-certification-details.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-details.js
@@ -1,0 +1,41 @@
+const CertificationDetails = require('../../../../lib/domain/read-models/CertificationDetails');
+const { states } = require('../../../../lib/domain/models/CertificationAssessment');
+
+module.exports = function buildCertificationDetails({
+  id = 123,
+  userId = 456,
+  createdAt = new Date('2020-01-01'),
+  completedAt = new Date('2020-03-03'),
+  status = states.COMPLETED,
+  totalScore = 555,
+  percentageCorrectAnswers = 75,
+  competencesWithMark = [{
+    areaCode: '1',
+    id: 'recComp1',
+    index: '1.1',
+    name: 'manger des fruits',
+    obtainedLevel: 1,
+    obtainedScore: 9,
+    positionedLevel: 2,
+    positionedScore: 17,
+  }],
+  listChallengesAndAnswers = [{
+    challengeId: 'recChal1',
+    competence: '1.1',
+    result: 'ok',
+    skill: 'manger une mangue',
+    value: 'miam',
+  }],
+} = {}) {
+  return new CertificationDetails({
+    id,
+    userId,
+    createdAt,
+    completedAt,
+    status,
+    totalScore,
+    percentageCorrectAnswers,
+    competencesWithMark,
+    listChallengesAndAnswers,
+  });
+};

--- a/api/tests/tooling/domain-builder/factory/build-placement-profile.js
+++ b/api/tests/tooling/domain-builder/factory/build-placement-profile.js
@@ -1,0 +1,39 @@
+const _ = require('lodash');
+const PlacementProfile = require('../../../../lib/domain/models/PlacementProfile');
+const buildUserCompetence = require('./build-user-competence');
+
+const buildPlacementProfile = function buildPlacementProfile({
+  profileDate = new Date('2020-01-01'),
+  userId = 123,
+  userCompetences = [buildUserCompetence()],
+} = {}) {
+  return new PlacementProfile({
+    profileDate,
+    userId,
+    userCompetences,
+  });
+};
+
+buildPlacementProfile.buildForCompetences = function buildForCompetences({
+  profileDate,
+  userId,
+  competencesData, // [{competence, level, score}, ...]
+}) {
+  const userCompetences = _.map(competencesData, (competenceData) => {
+    return buildUserCompetence({
+      id: competenceData.id,
+      index: competenceData.index,
+      name: competenceData.name,
+      pixScore: competenceData.score,
+      estimatedLevel: competenceData.level,
+    });
+  });
+
+  return buildPlacementProfile({
+    profileDate,
+    userId,
+    userCompetences,
+  });
+};
+
+module.exports = buildPlacementProfile;

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -16,6 +16,7 @@ module.exports = {
   buildCampaignParticipationInfo: require('./build-campaign-participation-info'),
   buildCampaignReport: require('./build-campaign-report'),
   buildCampaignToJoin: require('./build-campaign-to-join'),
+  buildCertificationAssessment: require('./build-certification-assessment'),
   buildCertificationCandidate: require('./build-certification-candidate'),
   buildCertificationIssueReport: require('./build-certification-issue-report'),
   buildSCOCertificationCandidate: require('./build-sco-certification-candidate'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -24,6 +24,7 @@ module.exports = {
   buildCertificationCenterMembership: require('./build-certification-center-membership'),
   buildCertificationChallenge: require('./build-certification-challenge'),
   buildCertificationCourse: require('./build-certification-course'),
+  buildCertificationDetails: require('./build-certification-details'),
   buildCertificationPointOfContact: require('./build-certification-point-of-contact'),
   buildCertificationReport: require('./build-certification-report'),
   buildCertifiedArea: require('./build-certified-area'),

--- a/api/tests/tooling/domain-builder/factory/index.js
+++ b/api/tests/tooling/domain-builder/factory/index.js
@@ -50,6 +50,7 @@ module.exports = {
   buildOrganizationInvitation: require('./build-organization-invitation'),
   buildOrganizationTag: require('./build-organization-tag'),
   buildPixRole: require('./build-pix-role'),
+  buildPlacementProfile: require('./build-placement-profile'),
   buildPoleEmploiSending: require('./build-pole-emploi-sending'),
   buildPrescriber: require('./build-prescriber'),
   buildPrivateCertificate: require('./build-private-certificate'),

--- a/api/tests/unit/application/certification-courses/certification-course-controller_test.js
+++ b/api/tests/unit/application/certification-courses/certification-course-controller_test.js
@@ -49,6 +49,91 @@ describe('Unit | Controller | certification-course-controller', () => {
     });
   });
 
+  describe('#getCertificationDetails', () => {
+
+    it('should return a serialized certification details', async () => {
+      // given
+      sinon.stub(usecases, 'getCertificationDetails');
+      const certificationCourseId = 1234;
+      const request = {
+        params: {
+          id: certificationCourseId,
+        },
+      };
+
+      usecases.getCertificationDetails
+        .withArgs({ certificationCourseId })
+        .resolves(domainBuilder.buildCertificationDetails({
+          competencesWithMark: [
+            {
+              areaCode: '1',
+              id: 'recComp1',
+              index: '1.1',
+              name: 'Manger des fruits',
+              obtainedLevel: 1,
+              obtainedScore: 5,
+              positionedLevel: 3,
+              positionedScore: 45,
+            },
+          ],
+          createdAt: '12-02-2000',
+          completedAt: '15-02-2000',
+          id: 456,
+          listChallengesAndAnswers: [
+            {
+              challengeId: 'rec123',
+              competence: '1.1',
+              result: 'ok',
+              skill: 'manger une mangue',
+              value: 'prout',
+            },
+          ],
+          percentageCorrectAnswers: 100,
+          status: 'started',
+          totalScore: 5,
+          userId: 123,
+        }));
+
+      // when
+      const result = await certificationCourseController.getCertificationDetails(request);
+
+      // then
+      expect(result.data).to.deep.equal({
+        'id': '456',
+        'type': 'certification-details',
+        'attributes': {
+          'user-id': 123,
+          'created-at': '12-02-2000',
+          'completed-at': '15-02-2000',
+          'status': 'started',
+          'total-score': 5,
+          'percentage-correct-answers': 100,
+          'competences-with-mark': [
+            {
+              areaCode: '1',
+              'id': 'recComp1',
+              'index': '1.1',
+              'name': 'Manger des fruits',
+              obtainedLevel: 1,
+              obtainedScore: 5,
+              positionedLevel: 3,
+              positionedScore: 45,
+            },
+          ],
+          'list-challenges-and-answers': [
+            {
+              challengeId: 'rec123',
+              'competence': '1.1',
+              'result': 'ok',
+              'skill': 'manger une mangue',
+              'value': 'prout',
+            },
+          ],
+        },
+      });
+    });
+  });
+
   describe('#getResult', () => {
     const certificationCourseId = 1;
     const request = {

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
-const { expect } = require('../../../test-helper');
+const { expect, domainBuilder } = require('../../../test-helper');
 const { ObjectValidationError } = require('../../../../lib/domain/errors');
 
 describe('Unit | Domain | Models | CertificationAssessment', () => {
@@ -93,6 +93,41 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
       // when
       expect(() => new CertificationAssessment({ ...validArguments, certificationAnswersByDate: [] }))
         .not.to.throw(ObjectValidationError);
+    });
+  });
+
+  describe('#getCertificationChallenge', () => {
+
+    it('returns the challenge for the given challengeId', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2],
+      });
+
+      // when
+      const certificationChallenge = certificationAssessment.getCertificationChallenge('rec1234');
+
+      // then
+      expect(certificationChallenge).to.deep.equal(certificationChallenge1);
+    });
+
+    it('returns null if no certification challenge exists for challengeId', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec1234' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2],
+      });
+
+      // when
+      const certificationChallenge = certificationAssessment.getCertificationChallenge('wrongId');
+
+      // then
+      expect(certificationChallenge).to.be.null;
     });
   });
 });

--- a/api/tests/unit/domain/models/PlacementProfile_test.js
+++ b/api/tests/unit/domain/models/PlacementProfile_test.js
@@ -130,4 +130,31 @@ describe('Unit | Domain | Models | PlacementProfile', () => {
     });
   });
 
+  describe('#getUserCompetence', () => {
+
+    it('returns the userCompetence if exists', () => {
+      const userCompetence1 = new UserCompetence({ id: 'rec123' });
+      const userCompetence2 = new UserCompetence({ id: 'rec456' });
+      const placementProfile = new PlacementProfile({
+        userCompetences: [userCompetence1, userCompetence2],
+      });
+
+      const userCompetence = placementProfile.getUserCompetence('rec123');
+
+      expect(userCompetence).to.deep.equal(userCompetence1);
+    });
+
+    it('returns null if doesn\'t exist', () => {
+      const userCompetence1 = new UserCompetence({ id: 'rec123' });
+      const userCompetence2 = new UserCompetence({ id: 'rec456' });
+      const placementProfile = new PlacementProfile({
+        userCompetences: [userCompetence1, userCompetence2],
+      });
+
+      const userCompetence = placementProfile.getUserCompetence('wrongId');
+
+      expect(userCompetence).to.be.null;
+    });
+  });
+
 });

--- a/api/tests/unit/domain/read-models/CertificationDetails_test.js
+++ b/api/tests/unit/domain/read-models/CertificationDetails_test.js
@@ -1,0 +1,205 @@
+const { expect, domainBuilder } = require('../../../test-helper');
+const CertificationDetails = require('../../../../lib/domain/read-models/CertificationDetails');
+const { states } = require('../../../../lib/domain/models/CertificationAssessment');
+
+describe('Unit | Domain | Read-models | CertificationDetails', () => {
+
+  describe('static #from', () => {
+    it('should return a CertificationDetails', () => {
+      // given
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        id: 123,
+        userId: 456,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-03-03'),
+        state: states.COMPLETED,
+        certificationChallenges: [certificationChallenge],
+        certificationAnswersByDate: [answer],
+      });
+      const competenceMarks = [];
+      const placementProfile = null;
+
+      // when
+      const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+      // then
+      expect(certificationDetails.id).to.equal(123);
+      expect(certificationDetails.userId).to.equal(456);
+      expect(certificationDetails.createdAt).to.deep.equal(new Date('2020-01-01'));
+      expect(certificationDetails.completedAt).to.deep.equal(new Date('2020-03-03'));
+      expect(certificationDetails.status).to.equal(states.COMPLETED);
+    });
+
+    it('should return a totalScore which is the sum of competence marks score', () => {
+      // given
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge],
+        certificationAnswersByDate: [answer],
+      });
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5 });
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 8 });
+      const competenceMarks = [competenceMark1, competenceMark2];
+      const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+        competencesData: [
+          { id: 'recComp1' },
+          { id: 'recComp2' },
+        ],
+      });
+
+      // when
+      const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+      // then
+      expect(certificationDetails.totalScore).to.equal(13);
+    });
+
+    it('should return a percentageCorrectAnswers using the reproducibility calculation', () => {
+      // given
+      const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123' });
+      const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456' });
+      const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456' });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge1, certificationChallenge2],
+        certificationAnswersByDate: [answer1, answer2],
+      });
+      const competenceMarks = [];
+      const placementProfile = null;
+
+      // when
+      const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+      // then
+      expect(certificationDetails.percentageCorrectAnswers).to.equal(50);
+    });
+
+    it('should create competencesWithMark', () => {
+      // given
+      const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123' });
+      const answer = domainBuilder.buildAnswer({ challengeId: 'rec123' });
+      const certificationAssessment = domainBuilder.buildCertificationAssessment({
+        certificationChallenges: [certificationChallenge],
+        certificationAnswersByDate: [answer],
+      });
+      const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+      const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 17, level: 2, competence_code: '2.2', area_code: '2' });
+      const competenceMarks = [competenceMark1, competenceMark2];
+      const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+        competencesData: [
+          { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+          { id: 'recComp2', index: '2.2', name: 'Ranger sa chambre', level: 2, score: 18 },
+        ],
+      });
+
+      // when
+      const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+      // then
+      expect(certificationDetails.competencesWithMark).to.deep.include.members([
+        {
+          areaCode: '1',
+          id: 'recComp1',
+          index: '1.1',
+          name: 'Manger des fruits',
+          obtainedLevel: 1,
+          obtainedScore: 5,
+          positionedLevel: 3,
+          positionedScore: 45,
+        },
+        {
+          areaCode: '2',
+          id: 'recComp2',
+          index: '2.2',
+          name: 'Ranger sa chambre',
+          obtainedLevel: 2,
+          obtainedScore: 17,
+          positionedLevel: 2,
+          positionedScore: 18,
+        },
+      ]);
+    });
+
+    context('#listChallengesAndAnswers', () => {
+
+      it('should create listChallengesAndAnswers', () => {
+        // given
+        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+        const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit' });
+        const answer2 = domainBuilder.buildAnswer.ko({ challengeId: 'rec456', value: 'bidule' });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge1, certificationChallenge2],
+          certificationAnswersByDate: [answer1, answer2],
+        });
+        const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+        const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 17, level: 2, competence_code: '2.2', area_code: '2' });
+        const competenceMarks = [competenceMark1, competenceMark2];
+        const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+          competencesData: [
+            { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+            { id: 'recComp2', index: '2.2', name: 'Ranger sa chambre', level: 2, score: 18 },
+          ],
+        });
+
+        // when
+        const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+        // then
+        expect(certificationDetails.listChallengesAndAnswers).to.deep.include.members([
+          {
+            challengeId: 'rec123',
+            competence: '1.1',
+            result: 'ok',
+            skill: 'manger une mangue',
+            value: 'prout',
+          },
+          {
+            challengeId: 'rec456',
+            competence: '2.2',
+            result: 'ko',
+            skill: 'faire son lit',
+            value: 'bidule',
+          },
+        ]);
+      });
+
+      it('should ignore challenges that do not have answer', () => {
+        // given
+        const certificationChallenge1 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+        const answer1 = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
+        const certificationChallenge2 = domainBuilder.buildCertificationChallenge({ challengeId: 'rec456', competenceId: 'recComp2', associatedSkillName: 'faire son lit' });
+        const certificationAssessment = domainBuilder.buildCertificationAssessment({
+          certificationChallenges: [certificationChallenge1, certificationChallenge2],
+          certificationAnswersByDate: [answer1],
+        });
+        const competenceMark1 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+        const competenceMark2 = domainBuilder.buildCompetenceMark({ competenceId: 'recComp2', score: 17, level: 2, competence_code: '2.2', area_code: '2' });
+        const competenceMarks = [competenceMark1, competenceMark2];
+        const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+          competencesData: [
+            { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+            { id: 'recComp2', index: '2.2', name: 'Ranger sa chambre', level: 2, score: 18 },
+          ],
+        });
+
+        // when
+        const certificationDetails = CertificationDetails.from({ certificationAssessment, placementProfile, competenceMarks });
+
+        // then
+        expect(certificationDetails.listChallengesAndAnswers).to.deep.include.members([
+          {
+            challengeId: 'rec123',
+            competence: '1.1',
+            result: 'ok',
+            skill: 'manger une mangue',
+            value: 'prout',
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/get-certification-details_test.js
+++ b/api/tests/unit/domain/usecases/get-certification-details_test.js
@@ -1,0 +1,96 @@
+const { sinon, expect, domainBuilder } = require('../../../test-helper');
+const getCertificationDetails = require('../../../../lib/domain/usecases/get-certification-details');
+const CertificationDetails = require('../../../../lib/domain/read-models/CertificationDetails');
+
+describe('Unit | UseCase | get-certification-details', () => {
+
+  const certificationAssessmentRepository = {
+    getByCertificationCourseId: sinon.stub(),
+  };
+
+  const placementProfileService = {
+    getPlacementProfile: sinon.stub(),
+  };
+
+  const competenceMarkRepository = {
+    findByCertificationCourseId: sinon.stub(),
+  };
+
+  it('should return the certification details', async () => {
+    // given
+    const certificationCourseId = 1234;
+    const certificationChallenge = domainBuilder.buildCertificationChallenge({ challengeId: 'rec123', competenceId: 'recComp1', associatedSkillName: 'manger une mangue' });
+    const answer = domainBuilder.buildAnswer.ok({ challengeId: 'rec123', value: 'prout' });
+
+    const certificationAssessment = domainBuilder.buildCertificationAssessment({
+      certificationCourseId,
+      certificationChallenges: [certificationChallenge],
+      certificationAnswersByDate: [answer],
+    });
+
+    const competenceMark = domainBuilder.buildCompetenceMark({ competenceId: 'recComp1', score: 5, level: 1, competence_code: '1.1', area_code: '1' });
+    const competenceMarks = [competenceMark];
+    const placementProfile = domainBuilder.buildPlacementProfile.buildForCompetences({
+      competencesData: [
+        { id: 'recComp1', index: '1.1', name: 'Manger des fruits', level: 3, score: 45 },
+      ],
+    });
+
+    certificationAssessmentRepository.getByCertificationCourseId
+      .withArgs(certificationCourseId)
+      .resolves(certificationAssessment);
+
+    placementProfileService.getPlacementProfile
+      .withArgs({
+        userId: certificationAssessment.userId,
+        limitDate: certificationAssessment.createdAt,
+        isV2Certification: certificationAssessment.isV2Certification,
+      })
+      .resolves(placementProfile);
+
+    competenceMarkRepository.findByCertificationCourseId
+      .withArgs(certificationCourseId)
+      .resolves(competenceMarks);
+
+    // when
+    const result = await getCertificationDetails({
+      certificationCourseId,
+      placementProfileService,
+      competenceMarkRepository,
+      certificationAssessmentRepository,
+    });
+
+    //then
+    expect(result).to.be.an.instanceof(CertificationDetails);
+    expect(result).to.deep.equal({
+      competencesWithMark: [
+        {
+          areaCode: '1',
+          id: 'recComp1',
+          index: '1.1',
+          name: 'Manger des fruits',
+          obtainedLevel: 1,
+          obtainedScore: 5,
+          positionedLevel: 3,
+          positionedScore: 45,
+        },
+      ],
+      createdAt: certificationAssessment.createdAt,
+      completedAt: certificationAssessment.completedAt,
+      id: certificationAssessment.certificationCourseId,
+      listChallengesAndAnswers: [
+        {
+          challengeId: 'rec123',
+          competence: '1.1',
+          result: 'ok',
+          skill: 'manger une mangue',
+          value: 'prout',
+        },
+      ],
+      percentageCorrectAnswers: 100,
+      status: 'started',
+      totalScore: 5,
+      userId: 123,
+    });
+  });
+});

--- a/api/tests/unit/infrastructure/serializers/jsonapi/certification-details-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/certification-details-serializer_test.js
@@ -1,0 +1,78 @@
+const { expect, domainBuilder } = require('../../../../test-helper');
+const serializer = require('../../../../../lib/infrastructure/serializers/jsonapi/certification-details-serializer');
+const { states } = require('../../../../../lib/domain/models/CertificationAssessment');
+
+describe('Unit | Serializer | JSONAPI | certification-details-serializer', () => {
+
+  describe('#serialize', () => {
+
+    it('should convert a Certification Details model object into JSON API data', () => {
+      // given
+      const certificationDetails = domainBuilder.buildCertificationDetails({
+        id: 123,
+        userId: 456,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-03-03'),
+        status: states.COMPLETED,
+        totalScore: 555,
+        percentageCorrectAnswers: 75,
+        competencesWithMark: [{
+          areaCode: '1',
+          id: 'recComp1',
+          index: '1.1',
+          name: 'manger des fruits',
+          obtainedLevel: 1,
+          obtainedScore: 9,
+          positionedLevel: 2,
+          positionedScore: 17,
+        }],
+        listChallengesAndAnswers: [{
+          challengeId: 'recChal1',
+          competence: '1.1',
+          result: 'ok',
+          skill: 'manger une mangue',
+          value: 'miam',
+        }],
+      });
+
+      const expectedSerializedCertificationDetails = {
+        data: {
+          type: 'certification-details',
+          id: '123',
+          attributes: {
+            'user-id': 456,
+            'created-at': new Date('2020-01-01'),
+            'completed-at': new Date('2020-03-03'),
+            status: states.COMPLETED,
+            'total-score': 555,
+            'percentage-correct-answers': 75,
+            'competences-with-mark': [{
+              areaCode: '1',
+              id: 'recComp1',
+              index: '1.1',
+              name: 'manger des fruits',
+              obtainedLevel: 1,
+              obtainedScore: 9,
+              positionedLevel: 2,
+              positionedScore: 17,
+            }],
+            'list-challenges-and-answers': [{
+              challengeId: 'recChal1',
+              competence: '1.1',
+              result: 'ok',
+              skill: 'manger une mangue',
+              value: 'miam',
+            }],
+          },
+        },
+      };
+
+      // when
+      const serializedCertificationDetails = serializer.serialize(certificationDetails);
+
+      // then
+      expect(serializedCertificationDetails).to.deep.equal(expectedSerializedCertificationDetails);
+    });
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lors de l'affichage du détail d'une certification côté Admin, la route api utilisée pour récupérer les datas à afficher passe par le service de scoring et re déclenche tout le calcul plutôt que d'utiliser les données enregistrées lors du scoring initial.
Ce comportement va poser problème lors de l'implémentation des nouvelles règles de scoring.

## :robot: Solution
Ne pas passer par le service de scoring pour récupérer le détail d'une certification mais aller récupérer les données du scoring initial en base. 

## :rainbow: Remarques
On doit ajouter un feature toggle ici, car on doit toujours passer par l'ancien rescoring tant que la neutralisation auto n'est pas en place.
FT_IS_NEUTRALIZATION_AUTO_ENABLED

## :100: Pour tester
Positionner le FT_IS_NEUTRALIZATION_AUTO_ENABLED a false dans un premier temps.
Se connecter sur pixAdmin, consulter le détails d'une certif.
Passer le toggle à true, et recharger la page, faire une comparaison de non-régression
