### PR TITLE
[FEATURE] Changer la puce de couleur par une barre de couleur pour les compétences (PIX-2337)

### DIFF
--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -87,28 +87,36 @@
 
 .skill-review-competence {
 
-  &__bullet {
-    font-size: 1.125rem;
-    margin-right: 12px;
+  &__border {
+    padding: 0.5rem 0;
+    margin-right: 1rem;
+    border-style: solid;
+    border-width: 1.5px;
+    border-radius: 1.5px;
 
     &--jaffa {
       color: $information-light;
+      background: $information-light;
     }
 
     &--emerald {
       color: $content-light;
+      background: $content-light;
     }
 
     &--cerulean {
       color: $communication-light;
+      background: $communication-light;
     }
 
     &--wild-strawberry {
       color: $security-light;
+      background: $security-light;
     }
 
     &--butterfly-bush {
       color: $environment-light;
+      background: $environment-light;
     }
   }
 }

--- a/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
+++ b/mon-pix/app/templates/components/campaign-skill-review-competence-result.hbs
@@ -11,7 +11,7 @@
     {{#each @partnerCompetenceResults as |partnerCompetence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <th scope="row">
-          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{partnerCompetence.areaColor}}" aria-hidden="true">&#8226;</span>
+          <span class="skill-review-competence__border skill-review-competence__border--{{partnerCompetence.areaColor}}" aria-hidden="true"></span>
           <span>{{partnerCompetence.name}}</span>
         </th>
         <td>
@@ -26,7 +26,7 @@
     {{#each @competenceResults as |competence|}}
       <tr aria-label="{{t "pages.skill-review.details.result-by-skill"}}">
         <th scope="row">
-          <span class="skill-review-competence__bullet skill-review-competence__bullet--{{competence.areaColor}}" aria-hidden="true">&#8226;</span>
+          <span class="skill-review-competence__border skill-review-competence__border--{{competence.areaColor}}" aria-hidden="true"></span>
           <span>{{competence.name}}</span>
         </th>
         <td>


### PR DESCRIPTION
## :unicorn: Problème
L'affichage des couleurs des compétences sur PixApp et sur PixOrga ne sont pas cohérent

## :robot: Solution
Afficher sur PixApp les couleurs  des compétences sous la forme de barres

## :rainbow: Remarques
RAS

## :100: Pour tester
Afficher les résultats de jaune.attend@pix.fr pour les campagnes :
- AZERTY654
- BADGES123
Les couleurs à gauche des noms des compétences doivent être des barres
