### PR TITLE
[FEATURE] Afficher les méthodes de connexion d'un utilisateur sur Pix Admin (PIX-2425).

### DIFF
--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -123,6 +123,42 @@
   {{/if}}
 </section>
 
+<section class="page-section mb_10 user-authentication-method">
+  <h2 class="page-section__title user-authentication-method__title">Méthodes de connexion</h2>
+  <div class="user-authentication-method__item" data-test-email>
+    <span>Adresse e-mail</span>
+    {{#if @user.hasEmailAuthenticationMethod}}
+      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+    {{else}}
+      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+    {{/if}}
+  </div>
+  <div class="user-authentication-method__item" data-test-username>
+    <span>Identifiant</span>
+    {{#if @user.hasUsernameAuthenticationMethod}}
+      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+    {{else}}
+      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+    {{/if}}
+  </div>
+  <div class="user-authentication-method__item" data-test-pole-emploi>
+    <span>Pôle Emploi</span>
+    {{#if @user.hasPoleEmploiAuthenticationMethod}}
+      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+    {{else}}
+      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+    {{/if}}
+  </div>
+  <div class="user-authentication-method__item" data-test-mediacentre>
+    <span>Médiacentre</span>
+    {{#if @user.hasGARAuthenticationMethod}}
+      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+    {{else}}
+      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+    {{/if}}
+  </div>
+</section>
+
 <section class="page-section mb_10">
   <header class="page-section__header">
     <h2 class="page-section__title">Informations élèves SCO</h2>

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -76,12 +76,6 @@
               <span class="attibute__label">Identifiant : </span>
               <span class="attribute__value user__username">{{@user.username}}</span>
             </div>
-            <div class="attribute authenticated-from-gar">
-              <span class="attibute__label">Connecté via le GAR : </span>
-              <span class="attribute__value user__is-authenticated-from-gar">
-                {{if @user.isAuthenticatedFromGAR 'OUI''NON'}}
-              </span>
-            </div>
             <br>
             <div class="attribute cgu">
               <span class="attibute__label">CGU Pix App validé : </span>

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -81,7 +81,7 @@ export default class UserDetailPersonalInformationComponent extends Component {
   }
 
   get canAdministratorModifyUserDetails() {
-    return !((this.args.user.username !== null) || this.args.user.isAuthenticatedFromGAR);
+    return !(this.args.user.username !== null);
   }
 
   get externalURL() {

--- a/admin/app/models/authentication-method.js
+++ b/admin/app/models/authentication-method.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class AuthenticationMethod extends Model {
+
+  @attr() identityProvider;
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -16,9 +16,26 @@ export default class User extends Model {
   @hasMany('membership') memberships;
   @hasMany('certification-center-membership') certificationCenterMemberships;
   @hasMany('schooling-registration') schoolingRegistrations;
+  @hasMany('authentication-method') authenticationMethods;
 
   @computed('firstName', 'lastName')
   get fullName() {
     return `${this.firstName} ${this.lastName}`;
+  }
+
+  get hasEmailAuthenticationMethod() {
+    return this.email && this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'PIX');
+  }
+
+  get hasUsernameAuthenticationMethod() {
+    return this.username && this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'PIX');
+  }
+
+  get hasPoleEmploiAuthenticationMethod() {
+    return this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'POLE_EMPLOI');
+  }
+
+  get hasGARAuthenticationMethod() {
+    return this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'GAR');
   }
 }

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -12,7 +12,6 @@ export default class User extends Model {
   @attr('boolean') cgu;
   @attr('boolean') pixOrgaTermsOfServiceAccepted;
   @attr('boolean') pixCertifTermsOfServiceAccepted;
-  @attr('boolean') isAuthenticatedFromGAR;
 
   @hasMany('membership') memberships;
   @hasMany('certification-center-membership') certificationCenterMemberships;

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -15,3 +15,32 @@
 .schooling-registrations-table {
   margin-top: 20px;
 }
+
+.user-authentication-method {
+
+  &__title {
+    font-size: 18px;
+    padding: 4px 0 12px 0;
+  }
+
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 150px;
+    margin: 5px 0;
+    color: $grey-40;
+  }
+
+  .user-authentication-method-item {
+
+    &__check {
+      color: $success;
+    }
+
+    &__uncheck {
+      color: $grey-30;
+    }
+
+  }
+}

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -14,100 +14,39 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
   module('When the administrator click on user details', async function() {
 
-    module('update button', async function() {
-
-      test('should display the update button when user is connected by email only', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: 'john.harry@example.net',
-          username: null,
-          isAuthenticatedFromGAR: false,
-        });
+    module('update button', async function() {test('should display the update button when user is connected by email only', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: null,
+      });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('button[aria-label="Modifier"]').exists();
       });
 
-      test('should not display the update button when user is connected from GAR only', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: null,
-          username: null,
-          isAuthenticatedFromGAR: true,
-        });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('button[aria-label="Modifier"]').doesNotExist();
-      });
-
       test('should not display the update button when user is connected with username only', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: null,
-          username: 'john.harry2018',
-          isAuthenticatedFromGAR: false,
-        });
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: null,
+        username: 'john.harry2018',
+      });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      test('should not display the update button when user is connected with username and email', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: 'john.harry@example.net',
-          username: 'john.harry2018',
-          isAuthenticatedFromGAR: false,
-        });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('button[aria-label="Modifier"]').doesNotExist();
+    test('should not display the update button when user is connected with username and email', async function(assert) {
+      this.set('user', {
+        firstName: 'John',
+        lastName: 'Harry',
+        email: 'john.harry@example.net',
+        username: 'john.harry2018',
       });
-
-      test('should not display the update button when user is connected with email and GAR', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: 'john.harry@example.net',
-          username: null,
-          isAuthenticatedFromGAR: true,
-        });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('button[aria-label="Modifier"]').doesNotExist();
-      });
-
-      test('should not display the update button when user is connected with username and GAR', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: null,
-          username: 'john.harry2018',
-          isAuthenticatedFromGAR: true,
-        });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('button[aria-label="Modifier"]').doesNotExist();
-      });
-
-      test('should not display the update button when user is connected with username, email and GAR', async function(assert) {
-        this.set('user', {
-          firstName: 'John',
-          lastName: 'Harry',
-          email: 'john.harry@example.net',
-          username: 'john.harry2018',
-          isAuthenticatedFromGAR: true,
-        });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -258,7 +197,6 @@ module('Integration | Component | user-detail-personal-information', function(ho
         firstName: 'John',
         email: 'john.harry@gmail.com',
         username: null,
-        isAuthenticatedFromGAR: false,
       });
     });
 
@@ -268,7 +206,6 @@ module('Integration | Component | user-detail-personal-information', function(ho
         lastName: 'Harry',
         email: 'john.harry@example.net',
         username: null,
-        isAuthenticatedFromGAR: false,
       });
 
       await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -315,7 +252,6 @@ module('Integration | Component | user-detail-personal-information', function(ho
         firstName: 'John',
         email: 'john.harry@gmail.com',
         username: null,
-        isAuthenticatedFromGAR: false,
       });
     });
 

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,10 +1,9 @@
 import { module, test } from 'qunit';
-import sinon from 'sinon';
-
 import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+import sinon from 'sinon';
 
 import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 
@@ -14,13 +13,15 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
   module('When the administrator click on user details', async function() {
 
-    module('update button', async function() {test('should display the update button when user is connected by email only', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: null,
-      });
+    module('update button', async function() {
+
+      test('should display the update button when user is connected by email only', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: null,
+        });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -28,25 +29,25 @@ module('Integration | Component | user-detail-personal-information', function(ho
       });
 
       test('should not display the update button when user is connected with username only', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: null,
-        username: 'john.harry2018',
-      });
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: null,
+          username: 'john.harry2018',
+        });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-    test('should not display the update button when user is connected with username and email', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: 'john.harry2018',
-      });
+      test('should not display the update button when user is connected with username and email', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: 'john.harry2018',
+        });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
@@ -86,22 +87,6 @@ module('Integration | Component | user-detail-personal-information', function(ho
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('.user__username').hasText(this.user.username);
-      });
-
-      test('should display that user is authenticated from GAR', async function(assert) {
-        this.set('user', { isAuthenticatedFromGAR: true });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('.user__is-authenticated-from-gar').hasText('OUI');
-      });
-
-      test('should display that user is not authenticated from GAR', async function(assert) {
-        this.set('user', { isAuthenticatedFromGAR: false });
-
-        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        assert.dom('.user__is-authenticated-from-gar').hasText('NON');
       });
     });
 
@@ -184,6 +169,57 @@ module('Integration | Component | user-detail-personal-information', function(ho
           assert.dom('tr[aria-label="Inscription"]').exists({ count: 2 });
         });
       });
+    });
+
+    module('authentication methods', function() {
+
+      module('When user has authentication methods', function() {
+
+        test('should display user’s email authentication method', async function(assert) {
+          // given
+          this.set('user', { hasEmailAuthenticationMethod: true });
+
+          // when
+          await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.dom('div[data-test-email] > svg').hasClass('user-authentication-method-item__check');
+        });
+
+        test('should display user’s username authentication method', async function(assert) {
+          // given
+          this.set('user', { hasUsernameAuthenticationMethod: true });
+
+          // when
+          await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.dom('div[data-test-username] > svg').hasClass('user-authentication-method-item__check');
+        });
+
+        test('should display user’s Pole Emploi authentication method', async function(assert) {
+          // given
+          this.set('user', { hasPoleEmploiAuthenticationMethod: true });
+
+          // when
+          await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.dom('div[data-test-pole-emploi] > svg').hasClass('user-authentication-method-item__check');
+        });
+
+        test('should display user’s GAR authentication method', async function(assert) {
+          // given
+          this.set('user', { hasGARAuthenticationMethod: true });
+
+          // when
+          await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.dom('div[data-test-mediacentre] > svg').hasClass('user-authentication-method-item__check');
+        });
+      });
+
     });
   });
 

--- a/admin/tests/unit/models/user-test.js
+++ b/admin/tests/unit/models/user-test.js
@@ -26,4 +26,55 @@ module('Unit | Model | user', function(hooks) {
       assert.equal(fullName, 'Jean-Baptiste Poquelin');
     });
   });
+
+  module('#hasEmailAuthenticationMethod', function() {
+
+    test('it should return true when email is defined and user has PIX authentication method', function(assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'PIX' });
+      const user = store.createRecord('user', { email: 'john.doe@example.net', authenticationMethods: [authenticationMethod] });
+
+      // then
+      assert.equal(user.hasEmailAuthenticationMethod, true);
+    });
+  });
+
+  module('#hasUsernameAuthenticationMethod', function() {
+
+    test('it should return true when username is defined and user has PIX authentication method', function(assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'PIX' });
+      const user = store.createRecord('user', {
+        username: 'john.doe0101',
+        authenticationMethods: [authenticationMethod],
+      });
+
+      // then
+      assert.equal(user.hasUsernameAuthenticationMethod, true);
+    });
+  });
+
+  module('#hasPoleEmploiAuthenticationMethod', function() {
+
+    test('it should return true when user has Pole Emploi authentication method', function(assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'POLE_EMPLOI' });
+      const user = store.createRecord('user', { authenticationMethods: [authenticationMethod] });
+
+      // then
+      assert.equal(user.hasPoleEmploiAuthenticationMethod, true);
+    });
+  });
+
+  module('#hasGARAuthenticationMethod', function() {
+
+    test('it should return true when user has GAR authentication method', function(assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'GAR' });
+      const user = store.createRecord('user', { authenticationMethods: [authenticationMethod] });
+
+      // then
+      assert.equal(user.hasGARAuthenticationMethod, true);
+    });
+  });
 });

--- a/api/db/seeds/data/users-builder.js
+++ b/api/db/seeds/data/users-builder.js
@@ -56,6 +56,18 @@ function usersBuilder({ databaseBuilder }) {
     userId: userWithSamlId.id,
   });
 
+  const userFromPoleEmploi = databaseBuilder.factory.buildUser.withRawPassword({
+    firstName: 'Paul',
+    lastName: 'Amplois',
+    email: null,
+    rawPassword: 'Password123',
+    cgu: false,
+  });
+
+  databaseBuilder.factory.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({
+    userId: userFromPoleEmploi.id,
+  });
+
   const userWithLastTermsOfServiceValidated = {
     firstName: 'lasttermsofservice',
     lastName: 'validated',

--- a/api/lib/domain/models/UserDetailsForAdmin.js
+++ b/api/lib/domain/models/UserDetailsForAdmin.js
@@ -9,8 +9,8 @@ class UserDetailsForAdmin {
     email,
     pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted,
-    isAuthenticatedFromGAR,
     schoolingRegistrations,
+    authenticationMethods,
   } = {}) {
     this.id = id;
     this.cgu = cgu;
@@ -18,10 +18,10 @@ class UserDetailsForAdmin {
     this.lastName = lastName;
     this.username = username;
     this.email = email;
-    this.isAuthenticatedFromGAR = isAuthenticatedFromGAR;
     this.pixOrgaTermsOfServiceAccepted = pixOrgaTermsOfServiceAccepted;
     this.pixCertifTermsOfServiceAccepted = pixCertifTermsOfServiceAccepted;
     this.schoolingRegistrations = schoolingRegistrations;
+    this.authenticationMethods = authenticationMethods;
   }
 }
 

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -391,14 +391,9 @@ function _toUserDetailsForAdminDomain(bookshelfUser) {
     cgu: rawUserDetailsForAdmin.cgu,
     pixOrgaTermsOfServiceAccepted: rawUserDetailsForAdmin.pixOrgaTermsOfServiceAccepted,
     pixCertifTermsOfServiceAccepted: rawUserDetailsForAdmin.pixCertifTermsOfServiceAccepted,
-    isAuthenticatedFromGAR: _isUserAuthenticatedFromGAR(bookshelfUser),
     schoolingRegistrations: _toSchoolingRegistrationsForAdmin(rawUserDetailsForAdmin.schoolingRegistrations),
+    authenticationMethods: rawUserDetailsForAdmin.authenticationMethods,
   });
-}
-
-function _isUserAuthenticatedFromGAR(bookshelfUser) {
-  const authenticationMethods = bookshelfUser.related('authenticationMethods').toJSON();
-  return authenticationMethods.some((authenticationMethod) => authenticationMethod.identityProvider === AuthenticationMethod.identityProviders.GAR);
 }
 
 function _toSchoolingRegistrationsForAdmin(schoolingRegistrations) {

--- a/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/user-details-for-admin-serializer.js
@@ -8,13 +8,18 @@ module.exports = {
       attributes: [
         'firstName', 'lastName', 'email', 'username', 'cgu',
         'pixOrgaTermsOfServiceAccepted', 'pixCertifTermsOfServiceAccepted',
-        'isAuthenticatedFromGAR', 'schoolingRegistrations',
+        'schoolingRegistrations', 'authenticationMethods',
       ],
       schoolingRegistrations: {
         ref: 'id',
         includes: true,
         attributes: ['firstName', 'lastName', 'birthdate', 'division', 'organizationId', 'organizationExternalId',
           'organizationName', 'createdAt', 'updatedAt'],
+      },
+      authenticationMethods: {
+        ref: 'id',
+        includes: true,
+        attributes: ['identityProvider'],
       },
     }).serialize(usersDetailsForAdmin);
   },

--- a/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
+++ b/api/tests/acceptance/application/users/update-user-details-for-administration_test.js
@@ -1,4 +1,4 @@
-const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
 
 const createServer = require('../../../../server');
 
@@ -113,6 +113,7 @@ describe('Acceptance | Controller | users-controller-update-user-details-for-adm
           },
         },
       };
+      const authenticationMethod = await knex('authentication-methods').where({ userId: user.id }).first();
 
       // when
       const response = await server.inject(options);
@@ -130,16 +131,32 @@ describe('Acceptance | Controller | users-controller-update-user-details-for-adm
               'cgu': user.cgu,
               'pix-certif-terms-of-service-accepted': user.pixCertifTermsOfServiceAccepted,
               'pix-orga-terms-of-service-accepted': user.pixOrgaTermsOfServiceAccepted,
-              'is-authenticated-from-gar': false,
             },
             'relationships': {
               'schooling-registrations': {
                 'data': [],
               },
+              'authentication-methods': {
+                'data': [
+                  {
+                    'id': `${authenticationMethod.id}`,
+                    'type': 'authenticationMethods',
+                  },
+                ],
+              },
             },
             'id': '1234',
             'type': 'users',
           },
+          'included': [
+            {
+              'attributes': {
+                'identity-provider': `${authenticationMethod.identityProvider}`,
+              },
+              'id': `${authenticationMethod.id}`,
+              'type': 'authenticationMethods',
+            },
+          ],
         },
       );
     });

--- a/api/tests/acceptance/application/users/users-controller-dissociate-schooling-registrations_test.js
+++ b/api/tests/acceptance/application/users/users-controller-dissociate-schooling-registrations_test.js
@@ -49,10 +49,12 @@ describe('Acceptance | Controller | users-controller-dissociate-schooling-regist
           'cgu': user.cgu,
           'pix-orga-terms-of-service-accepted': user.pixOrgaTermsOfServiceAccepted,
           'pix-certif-terms-of-service-accepted': user.pixCertifTermsOfServiceAccepted,
-          'is-authenticated-from-gar': false,
         },
         'relationships': {
           'schooling-registrations': {
+            'data': [],
+          },
+          'authentication-methods': {
             'data': [],
           },
         },

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -577,39 +577,6 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
       expect(result).to.be.instanceOf(UserNotFoundError);
     });
 
-    context('when user is authenticated from GAR', () => {
-
-      it('should return the "isAuthenticatedFromGAR" property to true', async () => {
-        // given
-        const userInDB = databaseBuilder.factory.buildUser(userToInsert);
-        await databaseBuilder.commit();
-
-        // when
-        const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
-
-        // then
-        expect(userDetailsForAdmin).to.be.an.instanceOf(UserDetailsForAdmin);
-        expect(userDetailsForAdmin.cgu).to.be.true;
-      });
-    });
-
-    context('when user is not authenticated from GAR', () => {
-
-      it('should return the "isAuthenticatedFromGAR" property to false', async () => {
-        // given
-        const userInDB = databaseBuilder.factory.buildUser({ ...userToInsert });
-        await databaseBuilder.commit();
-
-        // when
-        const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
-
-        // then
-        expect(userDetailsForAdmin).to.be.an.instanceOf(UserDetailsForAdmin);
-        expect(userDetailsForAdmin.isAuthenticatedFromGAR).to.be.false;
-      });
-
-    });
-
     context('when user has schoolingRegistrations from SCO organization', () => {
 
       it('should return the user with his schoolingRegistrations', async () => {
@@ -669,6 +636,23 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
         // then
         expect(userDetailsForAdmin.schoolingRegistrations.length).to.equal(0);
+      });
+    });
+
+    context('when user has authentication methods', () => {
+
+      it('should return the user with his authentication methods', async () => {
+        // given
+        const userInDB = databaseBuilder.factory.buildUser(userToInsert);
+        databaseBuilder.factory.buildAuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.PIX, userId: userInDB.id });
+        databaseBuilder.factory.buildAuthenticationMethod({ identityProvider: AuthenticationMethod.identityProviders.GAR, userId: userInDB.id });
+        await databaseBuilder.commit();
+
+        // when
+        const userDetailsForAdmin = await userRepository.getUserDetailsForAdmin(userInDB.id);
+
+        // then
+        expect(userDetailsForAdmin.authenticationMethods.length).to.equal(2);
       });
     });
   });

--- a/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
+++ b/api/tests/tooling/domain-builder/factory/build-user-details-for-admin.js
@@ -11,11 +11,12 @@ module.exports = function buildUserDetailsForAdmin({
   pixOrgaTermsOfServiceAccepted = false,
   isAuthenticatedFromGAR = false,
   schoolingRegistrations = [],
+  authenticationMethods = [],
 } = {}) {
 
   return new UserDetailsForAdmin({
     id, firstName, lastName, email, username,
     cgu, pixOrgaTermsOfServiceAccepted, pixCertifTermsOfServiceAccepted,
-    isAuthenticatedFromGAR, schoolingRegistrations,
+    isAuthenticatedFromGAR, schoolingRegistrations, authenticationMethods,
   });
 };

--- a/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/user-details-for-admin-serializer_test.js
@@ -9,6 +9,7 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', () =
       // given
       const modelObject = domainBuilder.buildUserDetailsForAdmin({
         schoolingRegistrations: [domainBuilder.buildSchoolingRegistrationForAdmin()],
+        authenticationMethods: [{ id: 1, identityProvider: 'PIX' }],
       });
 
       // when
@@ -25,13 +26,18 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', () =
             'cgu': modelObject.cgu,
             'pix-orga-terms-of-service-accepted': modelObject.pixOrgaTermsOfServiceAccepted,
             'pix-certif-terms-of-service-accepted': modelObject.pixCertifTermsOfServiceAccepted,
-            'is-authenticated-from-gar': modelObject.isAuthenticatedFromGAR,
           },
           relationships: {
             'schooling-registrations': {
               'data': [{
                 'id': `${modelObject.schoolingRegistrations[0].id}`,
                 'type': 'schoolingRegistrations',
+              }],
+            },
+            'authentication-methods': {
+              'data': [{
+                'id': `${modelObject.authenticationMethods[0].id}`,
+                'type': 'authenticationMethods',
               }],
             },
           },
@@ -52,6 +58,13 @@ describe('Unit | Serializer | JSONAPI | user-details-for-admin-serializer', () =
           },
           'id': `${modelObject.schoolingRegistrations[0].id}`,
           'type': 'schoolingRegistrations',
+        },
+        {
+          attributes: {
+            'identity-provider': modelObject.authenticationMethods[0].identityProvider,
+          },
+          'id': `${modelObject.authenticationMethods[0].id}`,
+          'type': 'authenticationMethods',
         }],
       });
     });


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, les méthodes de connexion d'un utilisateurs ne sont pas listés sur Pix Admin. Nous souhaitons les afficher pour pouvoir implémenter la future fonctionnalité de supprimer une méthode de connexion.

## :robot: Solution
Lister les différentes méthodes de connexion existantes sur Pix et indiquer par une icône ( ✅ ou  ✖️ ) si l'utilisateur dispose ou non de cette méthode de connexion.

## :rainbow: Remarques
Ajout d'un seed `Paul Amplois` pour vérifier la méthode de connexion Pole Emploi.

## :100: Pour tester
Aller sur la page de détail d'un utilisateur et vérifier que l'affichage des icônes est en adéquation avec ses méthodes de connexion.

- Adresse e-mail uniquement : Chercher prénom `"Daenerys"`

- Identifiant uniquement : Chercher prénom `"George"`

- Adresse e-mail & identifiant : Chercher prénom `"Lance"`

- GAR uniquement : Chercher prénom `"Margaery"`

- Pole Emploi uniquement : Chercher prénom `"Paul"`