### PR TITLE
[FEATURE] Amélioration de l'a11y sur la page de présentation de campagne (PIX-1879).

### DIFF
--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -130,6 +130,7 @@
   }
 
   .article-list {
+    display: block;
     color: $grey-100;
     font-size: 0.875rem;
     line-height: 22px;

--- a/mon-pix/app/styles/pages/_campaign-landing-page.scss
+++ b/mon-pix/app/styles/pages/_campaign-landing-page.scss
@@ -120,6 +120,15 @@
     font-size: 1.375rem;
     font-weight: $font-light;
     text-align: center;
+
+    &::after {
+      content: "";
+      position: relative;
+      height: 15px;
+      width: 100px;
+      border-bottom: 2px solid $blue;
+      margin: 35px auto;
+    }
   }
 
   .article-title {
@@ -146,14 +155,6 @@
   .complement {
     width: 80%;
   }
-}
-
-.campaign-landing-page__details__line {
-  box-sizing: border-box;
-  width: 100px;
-  border: 1px solid $blue;
-  border-radius: 5px;
-  margin: 35px auto;
 }
 
 .campaign-landing-page__details__measure__container {

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -39,9 +39,7 @@
               <p class="campaign-landing-page__details__text article-title ">
                 {{t "pages.campaign-landing.assessment.evaluate.title"}}
               </p>
-              <p class="campaign-landing-page__details__text article-list">
-                {{t "pages.campaign-landing.assessment.evaluate.list" htmlSafe=true}}
-              </p>
+              {{t "pages.campaign-landing.assessment.evaluate.list" htmlSafe=true}}
             </div>
           </div>
           <p class="campaign-landing-page__details__text article-text complement">

--- a/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
+++ b/mon-pix/app/templates/campaigns/campaign-landing-page.hbs
@@ -30,7 +30,6 @@
           <h2 class="campaign-landing-page__details__text title">
             {{t "pages.campaign-landing.assessment.details"}}
           </h2>
-          <hr class="campaign-landing-page__details__line">
 
           <div class="campaign-landing-page__details__measure__container">
             <img class="campaign-landing-page__details__article-image measure"

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -81,7 +81,7 @@
                 "evaluate": {
                     "title": "Assess your digital skills with fun tests on different subjects, such as:",
                     "complement": "The Pix public service for the assessment and certification of digital skills enables assessment of your level in 5 major skill areas covering current uses of digital technology.",
-                    "list": "'<ul><li>'finding information on the internet,'</li><li>'producing documents,'</li><li>'communicating and collaborating online,'</li><li>'securing your work environment,'</li><li>'etc.'</li></ul>'",
+                    "list": "'<ul class=\"campaign-landing-page__details__text article-list\"><li>'finding information on the internet,'</li><li>'producing documents,'</li><li>'communicating and collaborating online,'</li><li>'securing your work environment,'</li><li>'etc.'</li></ul>'",
                     "more-info": {
                         "link": "https://pix.org/en-gb/skills-assessed-by-pix",
                         "label": "Find out more."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -81,7 +81,7 @@
                 "evaluate": {
                     "title": "Mesurer vos compétences numériques avec des tests ludiques sur différents thèmes comme :",
                     "complement": "Le service public d’évaluation et de certification des compétences numériques Pix permet d’évaluer son niveau dans 5 grands domaines de compétences, qui couvrent l’ensemble des usages actuels du numérique.",
-                    "list": "'<ul><li>'rechercher de l’information sur internet,'</li><li>'rédiger des documents,'</li><li>'communiquer et collaborer en ligne,'</li><li>'sécuriser son environnement de travail,'</li><li>'etc.'</li></ul>'",
+                    "list": "'<ul class=\"campaign-landing-page__details__text article-list\" data=\"/images/icons/icon-reload.svg\"><li>'rechercher de l’information sur internet,'</li><li>'rédiger des documents,'</li><li>'communiquer et collaborer en ligne,'</li><li>'sécuriser son environnement de travail,'</li><li>'etc.'</li></ul>'",
                     "more-info": {
                         "link": "https://pix.fr/competences",
                         "label": "En savoir plus."


### PR DESCRIPTION
## :unicorn: Problème

La page de présentation de campagne contient des tags HTML qui viennent entacher son accessibilité : 

- tag `<hr>` utilisé à une fin autre qu'une séparation sémantique
- tag `<p>` entourant une liste non ordonnée.

## :robot: Solution

Suppression de ces éléments utilisés à des fins stylistiques et modification du style CSS en conséquence.

## :rainbow: Remarques

Dans le premier commit, il eut également été possible de remplacer le tag `<p>` par une `<div>` afin de ne pas avoir à modifier le style en conséquence.

Le choix a toutefois été fait ici de supprimer purement et simplement ce tag afin de ne pas surcharger le HTML avec des tags inutiles.
Cela nous contraint toutefois à répéter la classe CSS utilisée jusqu'alors dans les traductions, dédoublant ainsi les endroits où modifier le style si celui-ci venait à changer.

Si cela s'avère trop contraignant, il sera alors tout à fait possible d'utiliser la `<div>` en lieu et place du `<p>`et conserver le style dans le template `campaign-landing-page.hbs`.

## :100: Pour tester

Entrer un code de campagne et vérifier :
- l'absence de balise `p` autour de la liste des thèmes pouvant être testés
- le remplacement du tag `<hr>` par une border
