### PR TITLE
[FEATURE] Permettre de dissocier un utilisateur d'une seule inscription scolaire dans Pix Admin (PIX-2356).

### DIFF
--- a/admin/app/adapters/schooling-registration.js
+++ b/admin/app/adapters/schooling-registration.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default class SchoolingRegistrationAdapter extends ApplicationAdapter {
+
+  urlForDeleteRecord(id) {
+    return `${this.host}/${this.namespace}/schooling-registration-user-associations/${id}`;
+  }
+}

--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -25,11 +25,7 @@ export default class UserAdapter extends ApplicationAdapter {
       return this.ajax(url, 'POST');
     }
 
-    if (snapshot.adapterOptions && snapshot.adapterOptions.dissociate) {
-      const url = this.urlForUpdateRecord(snapshot.id) + '/dissociate';
-      return this.ajax(url, 'PATCH');
-    }
-
     return super.updateRecord(...arguments);
   }
+
 }

--- a/admin/app/components/confirm-popup.hbs
+++ b/admin/app/components/confirm-popup.hbs
@@ -8,6 +8,7 @@
   @position="center"
   @onSubmit={{@confirm}}
   @onHide={{@cancel}}
+  @submitButtonType={{if @submitButtonType @submitButtonType "primary"}}
 >
   <p>{{@message}}</p>
   <p class="confirm-popup__errors">{{@error}}</p>

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -119,7 +119,7 @@
             type="button"
             class="btn btn-danger"
             aria-label="Anonymiser"
-            {{on "click" this.toggleDisplayConfirm}}
+            {{on "click" this.toggleDisplayAnonymizeModal}}
           >
             Anonymiser cet utilisateur
           </button>
@@ -133,24 +133,6 @@
   <header class="page-section__header">
     <h2 class="page-section__title">Informations élèves SCO</h2>
   </header>
-  {{#if @user.schoolingRegistrations}}
-  <div class="schooling-registrations-buttons">
-    {{#if this.isLoading}}
-      <button type="button" disabled class="btn btn-danger">
-        <span class="loader-in-button">&nbsp;</span>
-      </button>
-    {{else}}
-      <button
-              type="button"
-              class="btn btn-danger"
-              data-test-dissociate
-        {{on "click" this.dissociate}}
-      >
-        Dissocier
-      </button>
-    {{/if}}
-  </div>
-  {{/if}}
 
   <div class="schooling-registrations-table content-text content-text--small">
     <table class="table-admin">
@@ -165,6 +147,7 @@
         <th class="table__column--wide">Nom de l'orga</th>
         <th>Date d'import</th>
         <th>Dernière MAJ</th>
+        <th>Actions</th>
       </tr>
       </thead>
       <tbody>
@@ -179,10 +162,20 @@
           <td title="{{schoolingRegistration.organizationName}}">{{schoolingRegistration.organizationName}}</td>
           <td>{{format-date schoolingRegistration.createdAt}}</td>
           <td>{{format-date schoolingRegistration.updatedAt}}</td>
+          <td>
+            <PixButton
+                    @triggerAction={{fn this.toggleDisplayDissociateModal schoolingRegistration}}
+                    @border="squircle-small"
+                    class="btn btn-danger"
+                    data-test-dissociate-schooling-registration="{{schoolingRegistration.id}}"
+            >
+              Dissocier
+            </PixButton>
+          </td>
         </tr>
       {{else}}
         <tr>
-          <td colspan="9" class="table-admin-empty">Aucun résultat</td>
+          <td colspan="10" class="table-admin-empty">Aucun résultat</td>
         </tr>
       {{/each}}
       </tbody>
@@ -192,5 +185,14 @@
 
 <ConfirmPopup @message="Êtes-vous sûr de vouloir anonymiser cet utilisateur ? Ceci n’est pas réversible."
               @confirm={{this.anonymizeUser}}
-              @cancel={{this.toggleDisplayConfirm}}
-              @show={{this.displayConfirm}} />
+              @cancel={{this.toggleDisplayAnonymizeModal}}
+              @submitButtonType="danger"
+              @show={{this.displayAnonymizeModal}} />
+
+<ConfirmPopup @message="Êtes-vous sûr de vouloir dissocier cet élève ?"
+              @title="Confirmer la dissociation"
+              @submitTitle="Oui, je dissocie"
+              @submitButtonType="danger"
+              @confirm={{this.dissociate}}
+              @cancel={{this.toggleDisplayDissociateModal}}
+              @show={{this.displayDissociateModal}} />

--- a/admin/app/components/user-detail-personal-information.js
+++ b/admin/app/components/user-detail-personal-information.js
@@ -67,10 +67,13 @@ class Form extends Object.extend(Validations) {
 export default class UserDetailPersonalInformationComponent extends Component {
 
   @tracked isEditionMode = false;
-  @tracked displayConfirm = false;
+  @tracked displayAnonymizeModal = false;
+  @tracked displayDissociateModal = false;
   @tracked isLoading = false;
 
   @service notifications;
+
+  schoolingRegistrationToDissociate = null;
 
   constructor() {
     super(...arguments);
@@ -94,18 +97,21 @@ export default class UserDetailPersonalInformationComponent extends Component {
   }
 
   @action
-  toggleDisplayConfirm(event) {
-    if (event) {
-      event.preventDefault();
-    }
-    this.displayConfirm = !this.displayConfirm;
+  toggleDisplayAnonymizeModal() {
+    this.displayAnonymizeModal = !this.displayAnonymizeModal;
+  }
+
+  @action
+  toggleDisplayDissociateModal(schoolingRegistration) {
+    this.schoolingRegistrationToDissociate = schoolingRegistration;
+    this.displayDissociateModal = !this.displayDissociateModal;
   }
 
   @action
   async anonymizeUser() {
     await this.args.user.save({ adapterOptions: { anonymizeUser: true } });
     await this.args.user.reload();
-    this.toggleDisplayConfirm();
+    this.toggleDisplayAnonymizeModal();
   }
 
   @action
@@ -138,17 +144,16 @@ export default class UserDetailPersonalInformationComponent extends Component {
   }
 
   @action
-  async dissociate(event) {
-    event.preventDefault();
-
+  async dissociate() {
     this.isLoading = true;
     try {
-      await this.args.user.save({ adapterOptions: { dissociate: true } });
+      await this.schoolingRegistrationToDissociate.destroyRecord();
       this.notifications.success(DISSOCIATE_SUCCESS_NOTIFICATION_MESSAGE);
     } catch (response) {
       const errorMessage = 'Une erreur est survenue !';
       this.notifications.error(errorMessage);
     } finally {
+      this.displayDissociateModal = false;
       this.isLoading = false;
     }
   }

--- a/admin/app/models/schooling-registration.js
+++ b/admin/app/models/schooling-registration.js
@@ -1,4 +1,4 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class SchoolingRegistration extends Model {
 
@@ -11,4 +11,6 @@ export default class SchoolingRegistration extends Model {
   @attr() organizationName;
   @attr() createdAt;
   @attr() updatedAt;
+
+  @belongsTo('user') user;
 }

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -179,14 +179,10 @@ export default function() {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });
 
-  this.patch('/admin/users/:id/dissociate', (schema, request) => {
-    const userId = request.params.id;
-    const expectedUpdatedUser = {
-      schoolingRegistrations: [],
-    };
-
-    const user = schema.users.findBy({ id: userId });
-    return user.update(expectedUpdatedUser);
+  this.delete('/schooling-registration-user-associations/:id', (schema, request) => {
+    const schoolingRegistrationId = request.params.id;
+    schema.db.schoolingRegistrations.remove(schoolingRegistrationId);
+    return new Response(204);
   });
 
 }

--- a/admin/tests/acceptance/user-details-personal-information-test.js
+++ b/admin/tests/acceptance/user-details-personal-information-test.js
@@ -4,6 +4,8 @@ import { setupApplicationTest } from 'ember-qunit';
 import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
+import clickByLabel from '../helpers/extended-ember-test-helpers/click-by-label';
+
 module('Acceptance | User details personal information', function(hooks) {
 
   setupApplicationTest(hooks);
@@ -61,7 +63,7 @@ module('Acceptance | User details personal information', function(hooks) {
       await click('button[aria-label="Anonymiser"]');
 
       // when
-      await click('.modal-dialog .btn-primary');
+      await clickByLabel('Confirmer');
 
       // then
       assert.contains(`prenom_${user.id}`);
@@ -72,15 +74,25 @@ module('Acceptance | User details personal information', function(hooks) {
 
   module('when administrator click on dissociate button', function() {
 
-    test('should not display dissociate button after', async function(assert) {
+    test('should not display registration any more', async function(assert) {
       // given
+      const organizationName = 'Organisation_to_dissociate_of';
+      const schoolingRegistrationToDissociate = this.server.create('schooling-registration', {
+        id: 10,
+        organizationName,
+      });
+      user.schoolingRegistrations.models.push(schoolingRegistrationToDissociate);
+      user.save();
+
       await visit(`/users/${user.id}`);
+      await click('button[data-test-dissociate-schooling-registration="10"]');
 
       // when
-      await click('button[data-test-dissociate]');
+      await clickByLabel('Oui, je dissocie');
 
       // then
-      assert.dom('button[data-test-dissociate]').doesNotExist();
+      assert.equal(currentURL(), `/users/${user.id}`);
+      assert.notContains(organizationName);
     });
   });
 

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -10,248 +10,266 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
   module('When the administrator click on user details', async function() {
 
-    test('should display the update button when user is connected by email only', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: null,
-        isAuthenticatedFromGAR: false,
+    module('update button', async function() {
+
+      test('should display the update button when user is connected by email only', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: null,
+          isAuthenticatedFromGAR: false,
+        });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('button[aria-label="Modifier"]').exists();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected from GAR only', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: null,
+          username: null,
+          isAuthenticatedFromGAR: true,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').exists();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected from GAR only', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: null,
-        username: null,
-        isAuthenticatedFromGAR: true,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected with username only', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: null,
+          username: 'john.harry2018',
+          isAuthenticatedFromGAR: false,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected with username only', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: null,
-        username: 'john.harry2018',
-        isAuthenticatedFromGAR: false,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected with username and email', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: 'john.harry2018',
+          isAuthenticatedFromGAR: false,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected with username and email', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: 'john.harry2018',
-        isAuthenticatedFromGAR: false,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected with email and GAR', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: null,
+          isAuthenticatedFromGAR: true,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected with email and GAR', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: null,
-        isAuthenticatedFromGAR: true,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected with username and GAR', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: null,
+          username: 'john.harry2018',
+          isAuthenticatedFromGAR: true,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected with username and GAR', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: null,
-        username: 'john.harry2018',
-        isAuthenticatedFromGAR: true,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should not display the update button when user is connected with username, email and GAR', async function(assert) {
+        this.set('user', {
+          firstName: 'John',
+          lastName: 'Harry',
+          email: 'john.harry@example.net',
+          username: 'john.harry2018',
+          isAuthenticatedFromGAR: true,
+        });
 
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should not display the update button when user is connected with username, email and GAR', async function(assert) {
-      this.set('user', {
-        firstName: 'John',
-        lastName: 'Harry',
-        email: 'john.harry@example.net',
-        username: 'john.harry2018',
-        isAuthenticatedFromGAR: true,
+        assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('button[aria-label="Modifier"]').doesNotExist();
     });
 
-    test('should display user’s first name', async function(assert) {
-      this.set('user', { firstName: 'John' });
+    module('user authentication', async function() {
 
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      test('should display user’s first name', async function (assert) {
+        this.set('user', { firstName: 'John' });
 
-      assert.dom('.user__first-name').hasText(this.user.firstName);
-    });
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-    test('should display user’s last name', async function(assert) {
-      this.set('user', { lastName: 'Snow' });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__last-name').hasText(this.user.lastName);
-    });
-
-    test('should display user’s email', async function(assert) {
-      this.set('user', { email: 'john.snow@winterfell.got' });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__email').hasText(this.user.email);
-    });
-
-    test('should display user’s username', async function(assert) {
-      this.set('user', { username: 'kingofthenorth' });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__username').hasText(this.user.username);
-    });
-
-    test('should display "OUI" when user accepted Pix App terms of service', async function(assert) {
-      this.set('user', { cgu: true });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__cgu').hasText('OUI');
-    });
-
-    test('should display "NON" when user not accepted Pix App terms of service', async function(assert) {
-      this.set('user', { cgu: false });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__cgu').hasText('NON');
-    });
-
-    test('should display "OUI" when user accepted Pix Orga terms of service', async function(assert) {
-      this.set('user', { pixOrgaTermsOfServiceAccepted: true });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
-    });
-
-    test('should display "NON" when user not accepted Pix Orga terms of service', async function(assert) {
-      this.set('user', { pixOrgaTermsOfServiceAccepted: false });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
-    });
-
-    test('should display "OUI" when user accepted Pix Certif terms of service', async function(assert) {
-      this.set('user', { pixCertifTermsOfServiceAccepted: true });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
-    });
-
-    test('should display "NON" when user not accepted Pix Certif terms of service', async function(assert) {
-      this.set('user', { pixCertifTermsOfServiceAccepted: false });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
-    });
-
-    test('should display that user is authenticated from GAR', async function(assert) {
-      this.set('user', { isAuthenticatedFromGAR: true });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__is-authenticated-from-gar').hasText('OUI');
-    });
-
-    test('should display that user is not authenticated from GAR', async function(assert) {
-      this.set('user', { isAuthenticatedFromGAR: false });
-
-      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-      assert.dom('.user__is-authenticated-from-gar').hasText('NON');
-    });
-
-    module('When user has no schoolingRegistrations', function() {
-
-      test('should not display dissociate button', async function(assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [] });
-
-        // when
-        await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-        // then
-        assert.dom('button[data-test-dissociate]').doesNotExist();
+        assert.dom('.user__first-name').hasText(this.user.firstName);
       });
 
-      test('should display no result in schooling registrations table', async function(assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [] });
+      test('should display user’s last name', async function (assert) {
+        this.set('user', { lastName: 'Snow' });
 
-        // when
-        await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-        // then
-        assert.contains('Aucun résultat');
+        assert.dom('.user__last-name').hasText(this.user.lastName);
       });
+
+      test('should display user’s email', async function (assert) {
+        this.set('user', { email: 'john.snow@winterfell.got' });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__email').hasText(this.user.email);
+      });
+
+      test('should display user’s username', async function (assert) {
+        this.set('user', { username: 'kingofthenorth' });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__username').hasText(this.user.username);
+      });
+
+
+      test('should display that user is authenticated from GAR', async function(assert) {
+        this.set('user', { isAuthenticatedFromGAR: true });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__is-authenticated-from-gar').hasText('OUI');
+      });
+
+      test('should display that user is not authenticated from GAR', async function(assert) {
+        this.set('user', { isAuthenticatedFromGAR: false });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__is-authenticated-from-gar').hasText('NON');
+      });
+
     });
 
-    module('When user has schoolingRegistrations', function() {
+    module('terms of service', async function() {
 
-      test('should display dissociate button', async function(assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [{ id: 1 }] });
-        const expectedText = 'Dissocier';
+      test('should display "OUI" when user accepted Pix App terms of service', async function (assert) {
+        this.set('user', { cgu: true });
 
-        // when
-        await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-        // then
-        const foundButton = find('button[data-test-dissociate]');
-        assert.dom(foundButton).hasText(expectedText);
+        assert.dom('.user__cgu').hasText('OUI');
       });
 
-      test('should display schooling registrations in table', async function(assert) {
-        // given
-        this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
+      test('should display "NON" when user not accepted Pix App terms of service', async function (assert) {
+        this.set('user', { cgu: false });
 
-        // when
-        await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
-        assert.dom('tr[aria-label="Inscription"]').exists({ count: 2 });
+        assert.dom('.user__cgu').hasText('NON');
+      });
+
+      test('should display "OUI" when user accepted Pix Orga terms of service', async function (assert) {
+        this.set('user', { pixOrgaTermsOfServiceAccepted: true });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
+      });
+
+      test('should display "NON" when user not accepted Pix Orga terms of service', async function (assert) {
+        this.set('user', { pixOrgaTermsOfServiceAccepted: false });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
+      });
+
+      test('should display "OUI" when user accepted Pix Certif terms of service', async function (assert) {
+        this.set('user', { pixCertifTermsOfServiceAccepted: true });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
+      });
+
+      test('should display "NON" when user not accepted Pix Certif terms of service', async function (assert) {
+        this.set('user', { pixCertifTermsOfServiceAccepted: false });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+        assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
+      });
+
+    });
+
+    module('schooling registrations', async function() {
+
+      module('When user has no schoolingRegistrations', function () {
+
+        test('should not display dissociate button', async function (assert) {
+          // given
+          this.set('user', { schoolingRegistrations: [] });
+
+          // when
+          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.dom('button[data-test-dissociate]').doesNotExist();
+        });
+
+        test('should display no result in schooling registrations table', async function (assert) {
+          // given
+          this.set('user', { schoolingRegistrations: [] });
+
+          // when
+          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          assert.contains('Aucun résultat');
+        });
+      });
+
+      module('When user has schoolingRegistrations', function () {
+
+        test('should display dissociate button', async function (assert) {
+          // given
+          this.set('user', { schoolingRegistrations: [{ id: 1 }] });
+          const expectedText = 'Dissocier';
+
+          // when
+          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          // then
+          const foundButton = find('button[data-test-dissociate]');
+          assert.dom(foundButton).hasText(expectedText);
+        });
+
+
+
+        test('should display schooling registrations in table', async function (assert) {
+          // given
+          this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
+
+          // when
+          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+          assert.dom('tr[aria-label="Inscription"]').exists({ count: 2 });
+        });
       });
     });
   });

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,8 +1,12 @@
 import { module, test } from 'qunit';
+import sinon from 'sinon';
+
 import { setupRenderingTest } from 'ember-qunit';
-import { click, find, render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+
+import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
 
 module('Integration | Component | user-detail-personal-information', function(hooks) {
 
@@ -109,12 +113,11 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
         assert.dom('button[aria-label="Modifier"]').doesNotExist();
       });
-
     });
 
     module('user authentication', async function() {
 
-      test('should display user’s first name', async function (assert) {
+      test('should display user’s first name', async function(assert) {
         this.set('user', { firstName: 'John' });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -122,7 +125,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__first-name').hasText(this.user.firstName);
       });
 
-      test('should display user’s last name', async function (assert) {
+      test('should display user’s last name', async function(assert) {
         this.set('user', { lastName: 'Snow' });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -130,7 +133,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__last-name').hasText(this.user.lastName);
       });
 
-      test('should display user’s email', async function (assert) {
+      test('should display user’s email', async function(assert) {
         this.set('user', { email: 'john.snow@winterfell.got' });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -138,14 +141,13 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__email').hasText(this.user.email);
       });
 
-      test('should display user’s username', async function (assert) {
+      test('should display user’s username', async function(assert) {
         this.set('user', { username: 'kingofthenorth' });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('.user__username').hasText(this.user.username);
       });
-
 
       test('should display that user is authenticated from GAR', async function(assert) {
         this.set('user', { isAuthenticatedFromGAR: true });
@@ -162,12 +164,11 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
         assert.dom('.user__is-authenticated-from-gar').hasText('NON');
       });
-
     });
 
     module('terms of service', async function() {
 
-      test('should display "OUI" when user accepted Pix App terms of service', async function (assert) {
+      test('should display "OUI" when user accepted Pix App terms of service', async function(assert) {
         this.set('user', { cgu: true });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -175,7 +176,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__cgu').hasText('OUI');
       });
 
-      test('should display "NON" when user not accepted Pix App terms of service', async function (assert) {
+      test('should display "NON" when user not accepted Pix App terms of service', async function(assert) {
         this.set('user', { cgu: false });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -183,7 +184,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__cgu').hasText('NON');
       });
 
-      test('should display "OUI" when user accepted Pix Orga terms of service', async function (assert) {
+      test('should display "OUI" when user accepted Pix Orga terms of service', async function(assert) {
         this.set('user', { pixOrgaTermsOfServiceAccepted: true });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -191,7 +192,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('OUI');
       });
 
-      test('should display "NON" when user not accepted Pix Orga terms of service', async function (assert) {
+      test('should display "NON" when user not accepted Pix Orga terms of service', async function(assert) {
         this.set('user', { pixOrgaTermsOfServiceAccepted: false });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -199,7 +200,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__pix-orga-terms-of-service-accepted').hasText('NON');
       });
 
-      test('should display "OUI" when user accepted Pix Certif terms of service', async function (assert) {
+      test('should display "OUI" when user accepted Pix Certif terms of service', async function(assert) {
         this.set('user', { pixCertifTermsOfServiceAccepted: true });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
@@ -207,32 +208,20 @@ module('Integration | Component | user-detail-personal-information', function(ho
         assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('OUI');
       });
 
-      test('should display "NON" when user not accepted Pix Certif terms of service', async function (assert) {
+      test('should display "NON" when user not accepted Pix Certif terms of service', async function(assert) {
         this.set('user', { pixCertifTermsOfServiceAccepted: false });
 
         await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
 
         assert.dom('.user__pix-certif-terms-of-service-accepted').hasText('NON');
       });
-
     });
 
     module('schooling registrations', async function() {
 
-      module('When user has no schoolingRegistrations', function () {
+      module('When user has no schoolingRegistrations', function() {
 
-        test('should not display dissociate button', async function (assert) {
-          // given
-          this.set('user', { schoolingRegistrations: [] });
-
-          // when
-          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-          // then
-          assert.dom('button[data-test-dissociate]').doesNotExist();
-        });
-
-        test('should display no result in schooling registrations table', async function (assert) {
+        test('should display no result in schooling registrations table', async function(assert) {
           // given
           this.set('user', { schoolingRegistrations: [] });
 
@@ -244,24 +233,9 @@ module('Integration | Component | user-detail-personal-information', function(ho
         });
       });
 
-      module('When user has schoolingRegistrations', function () {
+      module('When user has schoolingRegistrations', function() {
 
-        test('should display dissociate button', async function (assert) {
-          // given
-          this.set('user', { schoolingRegistrations: [{ id: 1 }] });
-          const expectedText = 'Dissocier';
-
-          // when
-          await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
-
-          // then
-          const foundButton = find('button[data-test-dissociate]');
-          assert.dom(foundButton).hasText(expectedText);
-        });
-
-
-
-        test('should display schooling registrations in table', async function (assert) {
+        test('should display schooling registrations in table', async function(assert) {
           // given
           this.set('user', { schoolingRegistrations: [{ id: 1 }, { id: 2 }] });
 
@@ -363,6 +337,92 @@ module('Integration | Component | user-detail-personal-information', function(ho
       await click('.modal-dialog .btn-secondary');
 
       assert.dom('.modal-dialog').doesNotExist();
+    });
+  });
+
+  module('when the administrator click on dissociate button', async function() {
+
+    test('should display dissociate confirm modal', async function(assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const schoolingRegistration = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        schoolingRegistrations: [schoolingRegistration],
+      });
+      this.set('user', user);
+
+      await render(hbs `<UserDetailPersonalInformation @user={{this.user}} />`);
+
+      // when
+      await click('button[data-test-dissociate-schooling-registration]');
+
+      // then
+      assert.contains('Confirmer la dissociation');
+    });
+
+    test('should close the modal on click on cancel button', async function(assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const schoolingRegistration = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        schoolingRegistrations: [schoolingRegistration],
+      });
+      this.set('user', user);
+
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      await click('button[data-test-dissociate-schooling-registration]');
+
+      // when
+      await clickByLabel('Annuler');
+
+      assert.notContains('Confirmer la dissociation');
+      assert.notOk(destroyRecordStub.called);
+    });
+
+    test('should call destroyRecord on click on confirm button', async function(assert) {
+      // given
+      const destroyRecordStub = sinon.stub();
+      const schoolingRegistration = EmberObject.create({
+        id: 1,
+        firstName: 'John',
+        lastName: 'Harry',
+        destroyRecord: destroyRecordStub,
+      });
+      const user = EmberObject.create({
+        firstName: 'John',
+        lastName: 'Harry',
+        username: 'user.name0112',
+        isAuthenticatedFromGAR: false,
+        schoolingRegistrations: [schoolingRegistration],
+      });
+      this.set('user', user);
+
+      await render(hbs `<UserDetailPersonalInformation @user={{this.user}} />`);
+      await click('button[data-test-dissociate-schooling-registration]');
+
+      // when
+      await clickByLabel('Oui, je dissocie');
+
+      // then
+      assert.ok(destroyRecordStub.called);
     });
   });
 

--- a/admin/tests/unit/adapters/schooling-registration-test.js
+++ b/admin/tests/unit/adapters/schooling-registration-test.js
@@ -1,0 +1,31 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import ENV from 'pix-admin/config/environment';
+
+module('Unit | Adapter | schooling-registration', function(hooks) {
+
+  setupTest(hooks);
+
+  let adapter;
+
+  hooks.beforeEach(function() {
+    adapter = this.owner.lookup('adapter:schooling-registration');
+  });
+
+  module('#urlForDeleteRecord', function() {
+
+    test('it performs the request to dissociate user from student', async function(assert) {
+      // given
+      const schoolingRegistration = { id: 12345 };
+      const expectedUrl = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations/${schoolingRegistration.id}`;
+
+      // when
+      const url = adapter.urlForDeleteRecord(schoolingRegistration.id);
+
+      // then
+      assert.equal(url, expectedUrl);
+    });
+  });
+
+});

--- a/admin/tests/unit/adapters/user-test.js
+++ b/admin/tests/unit/adapters/user-test.js
@@ -10,9 +10,15 @@ module('Unit | Adapter | user', function(hooks) {
 
   hooks.beforeEach(function() {
     adapter = this.owner.lookup('adapter:user');
+    sinon.stub(adapter, 'ajax');
+  });
+
+  hooks.afterEach(function() {
+    adapter.ajax.restore();
   });
 
   module('#urlForFindRecord', function() {
+
     test('should add /admin inside the default find record url', function(assert) {
       // when
       const url = adapter.urlForFindRecord(123, 'users');
@@ -23,6 +29,7 @@ module('Unit | Adapter | user', function(hooks) {
   });
 
   module('#urlForUpdateRecord', function() {
+
     test('should add /admin inside the default update record url', function(assert) {
       // when
       const url = adapter.urlForUpdateRecord(123);
@@ -32,20 +39,13 @@ module('Unit | Adapter | user', function(hooks) {
     });
   });
 
-  module('#updateRecord', function(hooks) {
-
-    hooks.beforeEach(function() {
-      sinon.stub(adapter, 'ajax').resolves();
-    });
-
-    hooks.afterEach(function() {
-      adapter.ajax.restore();
-    });
+  module('#updateRecord', function() {
 
     module('when anonymizeUser adapterOptions is passed', function() {
 
       test('should send a POST request to user anonymize endpoint', async function(assert) {
         // given
+        adapter.ajax.resolves();
         const expectedUrl = 'http://localhost:3000/api/admin/users/123/anonymize';
         const adapterOptions = { anonymizeUser: true };
 
@@ -58,26 +58,6 @@ module('Unit | Adapter | user', function(hooks) {
 
         // then
         sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST');
-        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
-      });
-    });
-
-    module('when dissociate adapterOptions is passed', function() {
-
-      test('should send a PATCH request to user dissociate endpoint', async function(assert) {
-        // given
-        const expectedUrl = 'http://localhost:3000/api/admin/users/123/dissociate';
-        const adapterOptions = { dissociate: true };
-
-        // when
-        await adapter.updateRecord(
-          null,
-          { modelName: 'user' },
-          { id: 123, adapterOptions },
-        );
-
-        // then
-        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH');
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });

--- a/admin/tests/unit/components/user-detail-personal-information-test.js
+++ b/admin/tests/unit/components/user-detail-personal-information-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import createGlimmerComponent from '../../helpers/create-glimmer-component';
 import ENV from 'pix-admin/config/environment';
+import sinon from 'sinon';
 
 module('Unit | Component | user-detail-personal-information', function(hooks) {
 
@@ -11,11 +12,19 @@ module('Unit | Component | user-detail-personal-information', function(hooks) {
 
   hooks.beforeEach(function() {
     component = createGlimmerComponent('component:user-detail-personal-information');
+    component.notifications = {
+      success: sinon.stub(),
+      error: sinon.stub(),
+    };
   });
 
   test('it should generate dashboard URL based on environment and object', async function(assert) {
     // given
-    const args = { user: { id: 1 } };
+    const args = {
+      user: {
+        id: 1,
+      },
+    };
     const baseUrl = 'https://metabase.pix.fr/dashboard/132?id=';
     const expectedUrl = baseUrl + args.user.id;
 
@@ -27,6 +36,41 @@ module('Unit | Component | user-detail-personal-information', function(hooks) {
 
     // then
     assert.equal(actualUrl, expectedUrl);
+  });
+
+  module('#dissociate', function(hooks) {
+
+    let schoolingRegistration;
+
+    hooks.beforeEach(function() {
+      schoolingRegistration = {
+        id: 1,
+        destroyRecord: sinon.stub(),
+      };
+    });
+
+    test('it should call destroy on model schooling-registration', async function(assert) {
+      // given
+      component.toggleDisplayDissociateModal(schoolingRegistration);
+
+      // when
+      await component.dissociate(schoolingRegistration);
+
+      // then
+      assert.ok(schoolingRegistration.destroyRecord.called);
+      assert.ok(component.notifications.success.called);
+    });
+
+    test('it should notify an error if destroyRecord fail', async function(assert) {
+      // given
+      schoolingRegistration.destroyRecord.rejects();
+
+      // when
+      await component.dissociate(schoolingRegistration);
+
+      // then
+      assert.ok(component.notifications.error.called);
+    });
   });
 
 });

--- a/api/lib/application/schooling-registration-user-associations/index.js
+++ b/api/lib/application/schooling-registration-user-associations/index.js
@@ -186,16 +186,12 @@ exports.register = async function(server) {
 
     {
       method: 'DELETE',
-      path: '/api/schooling-registration-user-associations',
+      path: '/api/schooling-registration-user-associations/{id}',
       config: {
         handler: schoolingRegistrationUserAssociationController.dissociate,
         validate: {
-          payload: Joi.object({
-            data: {
-              attributes: {
-                'schooling-registration-id': identifiersType.schoolingRegistrationId,
-              },
-            },
+          params: Joi.object({
+            id: identifiersType.schoolingRegistrationId,
           }),
         },
         notes: [

--- a/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
+++ b/api/lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller.js
@@ -89,9 +89,9 @@ module.exports = {
   },
 
   async dissociate(request, h) {
-    const payload = request.payload.data.attributes;
     const { userId } = request.auth.credentials;
-    await usecases.dissociateUserFromSchoolingRegistration({ userId, schoolingRegistrationId: payload['schooling-registration-id'] });
+    const schoolingRegistrationId = request.params.id;
+    await usecases.dissociateUserFromSchoolingRegistration({ userId, schoolingRegistrationId });
     return h.response().code(204);
   },
 

--- a/api/lib/domain/usecases/dissociate-user-from-schooling-registration.js
+++ b/api/lib/domain/usecases/dissociate-user-from-schooling-registration.js
@@ -1,20 +1,31 @@
+const some = require('lodash/some');
 const { ForbiddenAccess } = require('../errors');
-const _ = require('lodash');
 
 module.exports = async function dissociateUserFromSchoolingRegistrationData({
-  schoolingRegistrationRepository,
-  membershipRepository,
-  userId,
   schoolingRegistrationId,
+  userId,
+  membershipRepository,
+  schoolingRegistrationRepository,
   userRepository,
 }) {
-  await _checkUserCanDissociateUserFromSchoolingRegistration(userId, schoolingRegistrationId, schoolingRegistrationRepository, membershipRepository, userRepository);
+  await _checkUserCanDissociateUserFromSchoolingRegistration({
+    schoolingRegistrationId,
+    userId,
+    membershipRepository,
+    schoolingRegistrationRepository,
+    userRepository,
+  });
 
   await schoolingRegistrationRepository.dissociateUserFromSchoolingRegistration(schoolingRegistrationId);
 };
 
-async function _checkUserCanDissociateUserFromSchoolingRegistration(userId, schoolingRegistrationId, schoolingRegistrationRepository, membershipRepository, userRepository) {
-
+async function _checkUserCanDissociateUserFromSchoolingRegistration({
+  schoolingRegistrationId,
+  userId,
+  membershipRepository,
+  schoolingRegistrationRepository,
+  userRepository,
+}) {
   const userIsPixMaster = await userRepository.isPixMaster(userId);
 
   const schoolingRegistration = await schoolingRegistrationRepository.get(schoolingRegistrationId);
@@ -24,9 +35,7 @@ async function _checkUserCanDissociateUserFromSchoolingRegistration(userId, scho
     includeOrganization: true,
   });
 
-  if (!userIsPixMaster && !_.some(memberships, 'isAdmin')) {
+  if (!userIsPixMaster && !some(memberships, 'isAdmin')) {
     throw new ForbiddenAccess();
   }
-
 }
-

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -1,6 +1,7 @@
 const {
   databaseBuilder,
   expect,
+  insertUserWithRolePixMaster,
   generateValidRequestAuthorizationHeader,
   generateIdTokenForExternalUser,
   knex,
@@ -1244,37 +1245,74 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
   describe('DELETE /api/schooling-registration-user-associations', () => {
 
-    it('should return an 204 status after having successfully dissociated user from schoolingRegistration', async () => {
-      const organization = databaseBuilder.factory.buildOrganization();
-      const user = databaseBuilder.factory.buildUser();
-      databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id, organizationRole: Membership.roles.ADMIN });
-      const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id });
+    context('When user is admin of the organization', () => {
 
-      const authorizationToken = generateValidRequestAuthorizationHeader(user.id);
+      it('should return an 204 status after having successfully dissociated user from schoolingRegistration', async () => {
+        const organization = databaseBuilder.factory.buildOrganization();
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id, organizationRole: Membership.roles.ADMIN });
+        const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id });
 
-      await databaseBuilder.commit();
+        const authorizationToken = generateValidRequestAuthorizationHeader(user.id);
 
-      const options = {
-        method: 'DELETE',
-        url: '/api/schooling-registration-user-associations/',
-        headers: {
-          authorization: authorizationToken,
-        },
-        payload: {
-          data: {
-            attributes: {
-              'schooling-registration-id': schoolingRegistration.id,
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'DELETE',
+          url: '/api/schooling-registration-user-associations/',
+          headers: {
+            authorization: authorizationToken,
+          },
+          payload: {
+            data: {
+              attributes: {
+                'schooling-registration-id': schoolingRegistration.id,
+              },
             },
           },
-        },
-      };
+        };
 
-      const response = await server.inject(options);
+        const response = await server.inject(options);
 
-      expect(response.statusCode).to.equal(204);
+        expect(response.statusCode).to.equal(204);
+      });
+
     });
 
-    it('should return an 403 status when user is not admin of the organization', async () => {
+    context('When user has the role pixMaster', () => {
+
+      it('should return an 204 status after having successfully dissociated user from schoolingRegistration', async () => {
+        const organization = databaseBuilder.factory.buildOrganization();
+        const pixMaster = await insertUserWithRolePixMaster();
+        const user = databaseBuilder.factory.buildUser();
+        databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id, organizationRole: Membership.roles.ADMIN });
+        const schoolingRegistration = databaseBuilder.factory.buildSchoolingRegistration({ organizationId: organization.id });
+
+        await databaseBuilder.commit();
+
+        const options = {
+          method: 'DELETE',
+          url: '/api/schooling-registration-user-associations/',
+          headers: {
+            authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
+          },
+          payload: {
+            data: {
+              attributes: {
+                'schooling-registration-id': schoolingRegistration.id,
+              },
+            },
+          },
+        };
+
+        const response = await server.inject(options);
+
+        expect(response.statusCode).to.equal(204);
+      });
+
+    });
+
+    it('should return an 403 status when user is neither admin of the organization nor has role pix master', async () => {
       const organization = databaseBuilder.factory.buildOrganization();
       const user = databaseBuilder.factory.buildUser();
       databaseBuilder.factory.buildMembership({ organizationId: organization.id, userId: user.id, organizationRole: Membership.roles.MEMBER });

--- a/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
+++ b/api/tests/acceptance/application/schooling-registration-user-association-controller_test.js
@@ -1259,16 +1259,9 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         const options = {
           method: 'DELETE',
-          url: '/api/schooling-registration-user-associations/',
+          url: `/api/schooling-registration-user-associations/${schoolingRegistration.id}`,
           headers: {
             authorization: authorizationToken,
-          },
-          payload: {
-            data: {
-              attributes: {
-                'schooling-registration-id': schoolingRegistration.id,
-              },
-            },
           },
         };
 
@@ -1292,16 +1285,9 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
         const options = {
           method: 'DELETE',
-          url: '/api/schooling-registration-user-associations/',
+          url: `/api/schooling-registration-user-associations/${schoolingRegistration.id}`,
           headers: {
             authorization: generateValidRequestAuthorizationHeader(pixMaster.id),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'schooling-registration-id': schoolingRegistration.id,
-              },
-            },
           },
         };
 
@@ -1324,16 +1310,9 @@ describe('Acceptance | Controller | Schooling-registration-user-associations', (
 
       const options = {
         method: 'DELETE',
-        url: '/api/schooling-registration-user-associations/',
+        url: `/api/schooling-registration-user-associations/${schoolingRegistration.id}`,
         headers: {
           authorization: authorizationToken,
-        },
-        payload: {
-          data: {
-            attributes: {
-              'schooling-registration-id': schoolingRegistration.id,
-            },
-          },
         },
       };
 

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -1,56 +1,66 @@
-const { expect, sinon, generateValidRequestAuthorizationHeader } = require('../../../test-helper');
-const Hapi = require('@hapi/hapi');
-const schoolingRegistrationUserAssociationController = require('../../../../lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller');
-const preHandler = require('../../../../lib/application/security-pre-handlers');
+const {
+  expect,
+  generateValidRequestAuthorizationHeader,
+  HttpTestServer,
+  sinon,
+} = require('../../../test-helper');
 
-const route = require('../../../../lib/application/schooling-registration-user-associations');
+const preHandler = require('../../../../lib/application/security-pre-handlers');
+const schoolingRegistrationUserAssociationController = require('../../../../lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller');
+
+const moduleUnderTest = require('../../../../lib/application/schooling-registration-user-associations');
 
 describe('Unit | Application | Router | campaign-router ', function() {
 
-  let server;
-  const userId = 2;
   const organizationId = 2;
   const studentId = '1234';
+  const userId = 2;
+
+  let httpTestServer;
 
   beforeEach(() => {
-    sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
     sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+    sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
 
-    server = Hapi.server();
-
-    return server.register(route);
+    httpTestServer = new HttpTestServer(moduleUnderTest);
   });
 
   describe('PATCH /api/organizations/id/schooling-registration-user-associations/studentId', () => {
 
+    const method = 'PATCH';
+    const headers = {
+      authorization: generateValidRequestAuthorizationHeader(userId),
+    };
+
+    let payload;
+    let url;
+
+    beforeEach(() => {
+      payload = {
+        data: {
+          attributes: {
+            'student-number': '1234',
+          },
+        },
+      };
+    });
+
+    afterEach(() => {
+      preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
+    });
+
     context('when the user is authenticated', () => {
+
       beforeEach(() => {
         preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response(true));
       });
 
-      afterEach(() => {
-        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
-      });
-
       it('should exist', async () => {
         // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'student-number': '1234',
-              },
-            },
-          },
-        };
+        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
 
         // when
-        const response = await server.inject(options);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(200);
@@ -58,123 +68,65 @@ describe('Unit | Application | Router | campaign-router ', function() {
 
       it('should return a 422 status error when student-number parameter is not a string', async () => {
         // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'student-number': 1234,
-              },
-            },
-          },
-        };
+        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
+        payload.data.attributes['student-number'] = 1234;
 
         // when
-        const response = await server.inject(options);
-
-        const payload = JSON.parse(response.payload);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
+        const responsePayload = JSON.parse(response.payload);
         expect(response.statusCode).to.equal(422);
-        expect(payload.errors[0].title).to.equal('Unprocessable entity');
-        expect(payload.errors[0].detail).to.equal('Un des champs saisis n’est pas valide.');
+        expect(responsePayload.errors[0].title).to.equal('Unprocessable entity');
+        expect(responsePayload.errors[0].detail).to.equal('Un des champs saisis n’est pas valide.');
       });
 
       it('should return a 404 status error when organizationId parameter is not a number', async () => {
         // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/organizations/FAKE_ORGANIZATION_ID/schooling-registration-user-associations/${studentId}`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'student-number': '1234',
-              },
-            },
-          },
-        };
+        url = `/api/organizations/FAKE_ORGANIZATION_ID/schooling-registration-user-associations/${studentId}`;
 
         // when
-        const response = await server.inject(options);
-
-        const payload = JSON.parse(response.payload);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
+        const responsePayload = JSON.parse(response.payload);
         expect(response.statusCode).to.equal(404);
-        expect(payload.errors[0].title).to.equal('Not Found');
-        expect(payload.errors[0].detail).to.equal('Ressource non trouvée');
+        expect(responsePayload.errors[0].title).to.equal('Not Found');
+        expect(responsePayload.errors[0].detail).to.equal('Ressource non trouvée');
       });
 
       it('should return a 404 status error when studentId parameter is not a number', async () => {
         // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/FAKE_STUDENT_ID`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'student-number': '1234',
-              },
-            },
-          },
-        };
+        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/FAKE_STUDENT_ID`;
 
         // when
-        const response = await server.inject(options);
-
-        const payload = JSON.parse(response.payload);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
+        const responsePayload = JSON.parse(response.payload);
         expect(response.statusCode).to.equal(404);
-        expect(payload.errors[0].title).to.equal('Not Found');
-        expect(payload.errors[0].detail).to.equal('Ressource non trouvée');
+        expect(responsePayload.errors[0].title).to.equal('Not Found');
+        expect(responsePayload.errors[0].detail).to.equal('Ressource non trouvée');
       });
-
     });
 
     context('when the user is not authenticated', () => {
+
       beforeEach(() => {
         preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.callsFake((request, h) => h.response().code(403).takeover());
       });
 
-      afterEach(() => {
-        preHandler.checkUserIsAdminInSUPOrganizationManagingStudents.restore();
-      });
-
       it('should return an error when the user is not authenticated', async () => {
         // given
-        const options = {
-          method: 'PATCH',
-          url: `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`,
-          headers: {
-            authorization: generateValidRequestAuthorizationHeader(userId),
-          },
-          payload: {
-            data: {
-              attributes: {
-                'student-number': '1234',
-              },
-            },
-          },
-        };
+        url = `/api/organizations/${organizationId}/schooling-registration-user-associations/${studentId}`;
 
         // when
-        const response = await server.inject(options);
+        const response = await httpTestServer.request(method, url, payload, null, headers);
 
         // then
         expect(response.statusCode).to.equal(403);
       });
     });
-
   });
+
 });

--- a/api/tests/unit/application/schooling-registration-user-associations/index_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/index_test.js
@@ -10,7 +10,7 @@ const schoolingRegistrationUserAssociationController = require('../../../../lib/
 
 const moduleUnderTest = require('../../../../lib/application/schooling-registration-user-associations');
 
-describe('Unit | Application | Router | campaign-router ', function() {
+describe('Unit | Application | Router | schooling-registration-user-associations-router', function() {
 
   const organizationId = 2;
   const studentId = '1234';
@@ -20,6 +20,8 @@ describe('Unit | Application | Router | campaign-router ', function() {
 
   beforeEach(() => {
     sinon.stub(preHandler, 'checkUserIsAdminInSUPOrganizationManagingStudents');
+
+    sinon.stub(schoolingRegistrationUserAssociationController, 'dissociate').returns('ok');
     sinon.stub(schoolingRegistrationUserAssociationController, 'updateStudentNumber').returns('ok');
 
     httpTestServer = new HttpTestServer(moduleUnderTest);
@@ -126,6 +128,39 @@ describe('Unit | Application | Router | campaign-router ', function() {
         // then
         expect(response.statusCode).to.equal(403);
       });
+    });
+  });
+
+  describe('DELETE /api/schooling-registration-user-associations/{id}', () => {
+
+    const method = 'DELETE';
+    const headers = {
+      authorization: generateValidRequestAuthorizationHeader(userId),
+    };
+    const payload = null;
+
+    let url;
+
+    it('should return a HTTP status code 200', async () => {
+      // given
+      url = '/api/schooling-registration-user-associations/1';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+    });
+
+    it('should return a HTTP status code 400 if id parameter is not a number', async () => {
+      // given
+      url = '/api/schooling-registration-user-associations/ABC';
+
+      // when
+      const response = await httpTestServer.request(method, url, payload, null, headers);
+
+      // then
+      expect(response.statusCode).to.equal(400);
     });
   });
 

--- a/api/tests/unit/application/schooling-registration-user-associations/schooling-registration-user-associations-controller_test.js
+++ b/api/tests/unit/application/schooling-registration-user-associations/schooling-registration-user-associations-controller_test.js
@@ -1,0 +1,34 @@
+const { expect, hFake, sinon } = require('../../../test-helper');
+
+const usecases = require('../../../../lib/domain/usecases');
+
+const schoolingRegistrationUserAssociationController = require('../../../../lib/application/schooling-registration-user-associations/schooling-registration-user-association-controller');
+
+describe('Unit | Application | Controller | schooling-registration-user-associations', () => {
+
+  describe('#dissociate', () => {
+
+    beforeEach(() => {
+      sinon.stub(usecases, 'dissociateUserFromSchoolingRegistration');
+    });
+
+    it('should call the usecase', async () => {
+      // given
+      const userId = 1;
+      const schoolingRegistrationId = 1;
+      const request = {
+        auth: { credentials: { userId } },
+        params: { id: schoolingRegistrationId },
+      };
+      usecases.dissociateUserFromSchoolingRegistration.resolves();
+
+      // when
+      await schoolingRegistrationUserAssociationController.dissociate(request, hFake);
+
+      // then
+      expect(usecases.dissociateUserFromSchoolingRegistration)
+        .to.have.been.calledWith({ schoolingRegistrationId, userId });
+    });
+  });
+
+});

--- a/api/tests/unit/domain/usecases/dissociate-user-from-schooling-registration_test.js
+++ b/api/tests/unit/domain/usecases/dissociate-user-from-schooling-registration_test.js
@@ -6,22 +6,34 @@ describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
 
   let schoolingRegistrationRepositoryStub;
   let membershipRepositoryStub;
+  let userRepositoryStub;
   let schoolingRegistration;
   const organizationId = 1;
   const schoolingRegistrationId = 2;
 
-  context('when the user is an admin of the organization which manage the student', () => {
+  context('when the authenticated user has role pix master', () => {
     const userId = 12;
 
     beforeEach(() => {
 
-      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({
+        organization: { id: organizationId },
+        id: schoolingRegistrationId,
+      });
 
       schoolingRegistrationRepositoryStub = {
         dissociateUserFromSchoolingRegistration: sinon.stub(),
         get: sinon.stub().resolves(schoolingRegistration),
       };
-      membershipRepositoryStub = { findByUserIdAndOrganizationId: sinon.stub().withArgs({ userId, organizationId: 9, includeOrganization: true }).resolves([{ isAdmin: true }]) };
+
+      userRepositoryStub = {
+        isPixMaster: sinon.stub().resolves(true),
+      };
+
+      membershipRepositoryStub = {
+        findByUserIdAndOrganizationId: sinon.stub().resolves([]),
+      };
+
     });
 
     it('should dissociate user from the schooling registration', async () => {
@@ -31,6 +43,7 @@ describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
         schoolingRegistrationId,
         membershipRepository: membershipRepositoryStub,
         schoolingRegistrationRepository: schoolingRegistrationRepositoryStub,
+        userRepository: userRepositoryStub,
       });
 
       // then
@@ -40,18 +53,67 @@ describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
     });
   });
 
-  context('when the user is not a member of the organization which manages the student', () => {
+  context('when the authenticated user is an admin of the organization which manage the student', () => {
     const userId = 12;
 
     beforeEach(() => {
 
-      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({
+        organization: { id: organizationId },
+        id: schoolingRegistrationId,
+      });
+
+      schoolingRegistrationRepositoryStub = {
+        dissociateUserFromSchoolingRegistration: sinon.stub(),
+        get: sinon.stub().resolves(schoolingRegistration),
+      };
+      membershipRepositoryStub = {
+        findByUserIdAndOrganizationId: sinon.stub().withArgs({
+          userId,
+          organizationId: 9,
+          includeOrganization: true,
+        }).resolves([{ isAdmin: true }]),
+      };
+      userRepositoryStub = {
+        isPixMaster: sinon.stub().resolves(false),
+      };
+    });
+
+    it('should dissociate user from the schooling registration', async () => {
+
+      await usecases.dissociateUserFromSchoolingRegistration({
+        userId,
+        schoolingRegistrationId,
+        membershipRepository: membershipRepositoryStub,
+        schoolingRegistrationRepository: schoolingRegistrationRepositoryStub,
+        userRepository: userRepositoryStub,
+      });
+
+      // then
+      expect(schoolingRegistrationRepositoryStub.get).to.be.have.been.calledWith(schoolingRegistrationId);
+      expect(schoolingRegistrationRepositoryStub.dissociateUserFromSchoolingRegistration).to.be.have.been.calledWith(schoolingRegistrationId);
+      expect(membershipRepositoryStub.findByUserIdAndOrganizationId).to.be.have.been.called;
+    });
+  });
+
+  context('when the authenticated user is neither a member of the organization which manages the student nor has role pix master', () => {
+    const userId = 12;
+
+    beforeEach(() => {
+
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({
+        organization: { id: organizationId },
+        id: schoolingRegistrationId,
+      });
 
       schoolingRegistrationRepositoryStub = {
         dissociateUserFromSchoolingRegistration: sinon.stub(),
         get: sinon.stub().resolves(schoolingRegistration),
       };
       membershipRepositoryStub = { findByUserIdAndOrganizationId: sinon.stub().resolves([]) };
+      userRepositoryStub = {
+        isPixMaster: sinon.stub().resolves(false),
+      };
     });
 
     it('throws a ForbiddenAccess error', async () => {
@@ -61,23 +123,30 @@ describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
         schoolingRegistrationId,
         membershipRepository: membershipRepositoryStub,
         schoolingRegistrationRepository: schoolingRegistrationRepositoryStub,
+        userRepository: userRepositoryStub,
       });
 
       expect(error).to.be.instanceof(ForbiddenAccess);
     });
   });
 
-  context('when the user is not a admin of the organization which manages the student', () => {
+  context('when the authenticated user is neither a admin of the organization which manages the student nor has role pix master', () => {
     const userId = 1;
 
     beforeEach(() => {
-      schoolingRegistration = domainBuilder.buildSchoolingRegistration({ organization: { id: organizationId }, id: schoolingRegistrationId });
+      schoolingRegistration = domainBuilder.buildSchoolingRegistration({
+        organization: { id: organizationId },
+        id: schoolingRegistrationId,
+      });
 
       schoolingRegistrationRepositoryStub = {
         dissociateUserFromSchoolingRegistration: sinon.stub(),
         get: sinon.stub().resolves(schoolingRegistration),
       };
       membershipRepositoryStub = { findByUserIdAndOrganizationId: sinon.stub().resolves([{ idAdmin: false }]) };
+      userRepositoryStub = {
+        isPixMaster: sinon.stub().resolves(false),
+      };
     });
 
     it('throws a ForbiddenAccess error', async () => {
@@ -87,6 +156,7 @@ describe('Unit | UseCase | dissociate-user-from-schooling-registration', () => {
         schoolingRegistrationId,
         membershipRepository: membershipRepositoryStub,
         schoolingRegistrationRepository: schoolingRegistrationRepositoryStub,
+        userRepository: userRepositoryStub,
       });
 
       expect(error).to.be.instanceof(ForbiddenAccess);

--- a/orga/app/adapters/student.js
+++ b/orga/app/adapters/student.js
@@ -8,17 +8,9 @@ export default class StudentAdapter extends ApplicationAdapter {
     return `${this.host}/${this.namespace}/organizations/${organizationId}/students`;
   }
 
-  dissociateUser(model) {
-    const data = {
-      data: {
-        attributes: {
-          'schooling-registration-id': model.id,
-        },
-      },
-    };
-
-    const url = `${this.host}/${this.namespace}/schooling-registration-user-associations`;
-    return this.ajax(url, 'DELETE', { data });
+  dissociateUser(student) {
+    const url = `${this.host}/${this.namespace}/schooling-registration-user-associations/${student.id}`;
+    return this.ajax(url, 'DELETE');
   }
 
   updateRecord(store, type, snapshot) {

--- a/orga/mirage/config.js
+++ b/orga/mirage/config.js
@@ -294,11 +294,12 @@ export default function() {
     return schema.campaignAssessmentParticipationResults.findBy({ ...request.params });
   });
 
-  this.delete('/schooling-registration-user-associations', (schema, request) => {
-    const requestBody = JSON.parse(request.requestBody);
+  this.delete('/schooling-registration-user-associations/:id', (schema, request) => {
+    const studentId = request.params.id;
 
-    const student = schema.students.find(requestBody.data.attributes['schooling-registration-id']);
-    return student.update({ email: null });
+    const student = schema.students.find(studentId);
+    return student.update({ email: null, username: null, isAuthenticatedFromGAR: false });
+
   });
 
   this.get('feature-toggles', (schema) => {

--- a/orga/tests/acceptance/dissociate-student-test.js
+++ b/orga/tests/acceptance/dissociate-student-test.js
@@ -46,7 +46,9 @@ module('Acceptance | Student List', function(hooks) {
         id: 1,
         firstName: 'Ellen Louise',
         lastName: 'Ripley',
-        email: 'ellen@ripley.com',
+        email: 'ellen@example.net',
+        username: 'ellen.ripley1234',
+        isAuthenticatedFromGAR: true,
       });
       // when
       await visit('/eleves');

--- a/orga/tests/unit/adapters/student-test.js
+++ b/orga/tests/unit/adapters/student-test.js
@@ -29,21 +29,14 @@ module('Unit | Adapters | student', function(hooks) {
 
     test('it performs the request to dissociate user from student', async function(assert) {
       // given
-      const model = { id: 12345 };
-      const data = {
-        data: {
-          attributes: {
-            'schooling-registration-id': model.id,
-          },
-        },
-      };
-      const url = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations`;
+      const student = { id: 12345 };
+      const url = `${ENV.APP.API_HOST}/api/schooling-registration-user-associations/${student.id}`;
 
       // when
-      await adapter.dissociateUser(model);
+      await adapter.dissociateUser(student);
 
       // then
-      assert.ok(ajaxStub.calledWith(url, 'DELETE', { data }));
+      assert.ok(ajaxStub.calledWith(url, 'DELETE'));
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Lorsqu'une personne souhaite être dissociée, elle contacte le support.
Si elle est associé plusieurs fois, le support ne peut pas traiter la demande qui doit être traitée par le PO en SQL.

Ce traitement manuel :
- a peu de valeur ajoutée s'il arrive fréquemment
- est sujet aux erreurs

## :robot: Solution
Permettre la dissociation individuelle depuis Pix Admin pour que le support soit autonome.

## :rainbow: Remarques
La fonctionnalité de dissociation globale, devenue obsolète, a été supprimée
Le changement de couleur du bouton au survol n'a pas été implémenté (attente PIX-UI)

## :100: Pour tester
Se connecter à [Pix Admin](https://admin-pr2792.review.pix.fr/login) ( pixmaster@example.net / pix123)
Aller dans la [gestion des utilisateurs](https://admin-pr2792.review.pix.fr/users/list)
Rechercher la personne avec plusieurs ?, ex `Blue Ivy Carter`
Tester la dissociation (confirmer et annuler)

Utilisateur avec plusieurs ?
```
SELECT
    u.id, u.email,
    COUNT(1)
FROM users u INNER JOIN "schooling-registrations" sr ON sr."userId" = u.id
WHERE 1=1
GROUP BY
    u.id, U.email
HAVING
    COUNT (1) > 1;
```
