### PR TITLE
[BUGFIX] Ajout de tag autorisé dans le markdown to html.

### DIFF
--- a/mon-pix/app/components/markdown-to-html-unsafe.js
+++ b/mon-pix/app/components/markdown-to-html-unsafe.js
@@ -1,23 +1,9 @@
 import Component from '@glimmer/component';
 import showdown from 'showdown';
-import xss from 'xss';
 import { htmlSafe } from '@ember/string';
 import ENV from 'mon-pix/config/environment';
 
-function modifyWhiteList() {
-  return {
-    ...xss.whiteList,
-    style: [],
-    span: ['style'],
-    th: ['style'],
-    td: ['style'],
-    tr: ['style'],
-    table: ['style'],
-    a: ['href', 'rel', 'target', 'title'],
-  };
-}
-
-export default class MarkdownToHtml extends Component {
+export default class MarkdownToHtmlUnsafe extends Component {
   get options() {
     return {
       ...ENV.showdown,
@@ -28,9 +14,6 @@ export default class MarkdownToHtml extends Component {
   get html() {
     const converter = new showdown.Converter(this.options);
     const unsafeHtml = converter.makeHtml(this.args.markdown);
-    const html = xss(unsafeHtml, {
-      whiteList: modifyWhiteList(),
-    });
-    return htmlSafe(html);
+    return htmlSafe(unsafeHtml);
   }
 }

--- a/mon-pix/app/templates/components/challenge-statement.hbs
+++ b/mon-pix/app/templates/components/challenge-statement.hbs
@@ -2,7 +2,7 @@
   <h2 class="sr-only">{{t 'pages.challenge.parts.instruction'}}</h2>
   {{#if this.challengeInstruction}}
     <div class="challenge-statement__instruction-section">
-      <MarkdownToHtml @class="challenge-statement__instruction" @markdown={{this.challengeInstruction}} />
+      <MarkdownToHtmlUnsafe @class="challenge-statement__instruction" @markdown={{this.challengeInstruction}} />
     </div>
   {{/if}}
 

--- a/mon-pix/app/templates/components/markdown-to-html-unsafe.hbs
+++ b/mon-pix/app/templates/components/markdown-to-html-unsafe.hbs
@@ -1,0 +1,3 @@
+<div class={{@class}} ...attributes>
+  {{this.html}}
+</div>

--- a/mon-pix/tests/unit/components/markdown-to-html-unsafe-test.js
+++ b/mon-pix/tests/unit/components/markdown-to-html-unsafe-test.js
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+import createGlimmerComponent from 'mon-pix/tests/helpers/create-glimmer-component';
+
+describe('Unit | Component | markdown-to-html-unsafe', function() {
+
+  let component;
+  setupTest();
+
+  describe('When markdown are passed in parameters', function() {
+    [
+      { markdown: '# Title 1', expectedValue: '<h1 id="title1">Title 1</h1>' },
+      { markdown: '![Pix Logo](http://example.net/pix_logo.png)', expectedValue: '<p><img src="http://example.net/pix_logo.png" alt="Pix Logo" /></p>' },
+    ].forEach(({ markdown, expectedValue }) => {
+      it(`${markdown} should return ${expectedValue}`, function() {
+        // when
+        component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown });
+
+        // then
+        expect(component.html.string).to.equal(expectedValue);
+      });
+    });
+  });
+
+  describe('When unsafe html are passed in parameters', function() {
+    [
+      { markdown: '<script src=http://xss.rocks/xss.js></script>', expectedValue: '<script src=http://xss.rocks/xss.js></script>' },
+      { markdown: '<img src=/ onerror="alert(String.fromCharCode(88,83,83))"></img>', expectedValue: '<p><img src=/ onerror="alert(String.fromCharCode(88,83,83))"></img></p>' },
+    ].forEach(({ markdown, expectedValue }) => {
+      it(`${markdown} should not be transform and return ${expectedValue}`, function() {
+        // when
+        component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown });
+
+        // then
+        expect(component.html.string).to.equal(expectedValue);
+      });
+    });
+  });
+
+  it('should keep rel attribute in tag a when they are present', () => {
+    // given
+    const html = '<a href="/test" rel="noopener noreferrer" target="_blank">Lien vers un site</a>';
+
+    // when
+    component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown: html });
+
+    // then
+    const expectedHtml = `<p>${html}</p>`;
+    expect(component.html.string).to.equal(expectedHtml);
+  });
+
+  describe('when extensions are passed in arguments', () => {
+    it('should use this', () => {
+      // given
+      const markdown = '# Title 1\nCeci est un paragraphe.\n![img](/images.png)';
+      const extensions = 'remove-paragraph-tags';
+
+      // when
+      component = createGlimmerComponent('component:markdown-to-html-unsafe', { markdown, extensions });
+
+      // then
+      const expectedHtml = '<h1 id="title1">Title 1</h1>\nCeci est un paragraphe.\n<img src="/images.png" alt="img" />';
+      expect(component.html.string).to.equal(expectedHtml);
+    });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Certaines épreuves utilisent des tags html, qui ne sont pas autorisés.

## :robot: Solution
Ajouter un nouveau component de markdownToHtml uniquement pour les épreuves Pix

## :rainbow: Remarques
Un nettoyage doit être prévu pour les épreuves pix.

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
