### PR TITLE
[FEATURE] renvoyer la derniere certification pour le livret scolaire (pix-2421)

### DIFF
--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -30,8 +30,8 @@ module.exports = {
       .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
       .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
       .modify(_filterMostRecentAssessments)
-      .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
-      .andWhereRaw('"last-assessment-results".id is null')
+      .whereNull('last-assessment-results')
+      .andWhereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
       .orderBy('lastName', 'ASC')
       .orderBy('firstName', 'ASC');
 

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -4,46 +4,69 @@ const { knex } = require('../bookshelf');
 module.exports = {
 
   async getCertificatesByOrganizationUAI(uai) {
-    const result = await knex
-      .distinct('certification-courses.id')
-      .select({
-        firstName: 'schooling-registrations.firstName',
-        middleName: 'schooling-registrations.middleName',
-        thirdName: 'schooling-registrations.thirdName',
-        lastName: 'schooling-registrations.lastName',
-        birthdate: 'schooling-registrations.birthdate',
-        nationalStudentId: 'schooling-registrations.nationalStudentId',
-        date: 'certification-courses.createdAt',
-        verificationCode: 'certification-courses.verificationCode',
-        deliveredAt: 'sessions.publishedAt',
-        certificationCenter: 'sessions.certificationCenter',
-        isPublished: 'certification-courses.isPublished',
-        status: 'assessment-results.status',
-        pixScore: 'assessment-results.pixScore',
-      })
-      .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResultsJson"'))
-      .from('certification-courses')
-      .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
-      .innerJoin('organizations', 'schooling-registrations.organizationId', 'organizations.id')
-      .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
-      .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
-      .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
-      .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
-      .modify(_filterMostRecentAssessments)
-      .whereNull('last-assessment-results')
-      .andWhereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai)
-      .orderBy('lastName', 'ASC')
-      .orderBy('firstName', 'ASC');
+    const withName = 'last-certifications';
+    const result = await knex.with(withName,
+      knex.distinct('certification-courses.id')
+        .select(
+          {
+            firstName: 'schooling-registrations.firstName',
+            middleName: 'schooling-registrations.middleName',
+            thirdName: 'schooling-registrations.thirdName',
+            lastName: 'schooling-registrations.lastName',
+            birthdate: 'schooling-registrations.birthdate',
+            nationalStudentId: 'schooling-registrations.nationalStudentId',
+            date: 'certification-courses.createdAt',
+            verificationCode: 'certification-courses.verificationCode',
+            deliveredAt: 'sessions.publishedAt',
+            certificationCenter: 'sessions.certificationCenter',
+            isPublished: 'certification-courses.isPublished',
+            status: 'assessment-results.status',
+            assessmentResultsCreatedAt: 'assessment-results.createdAt',
+            pixScore: 'assessment-results.pixScore',
+            userId: 'schooling-registrations.userId',
+            assessmentId: 'assessments.id',
+          },
+        )
+        .select(knex.raw('\'[\' || (string_agg(\'{ "level":\' || "competence-marks".level::VARCHAR || \', "competenceId":"\' || "competence-marks"."competence_code" || \'"}\', \',\') over (partition by "assessment-results".id)) || \']\' as "competenceResultsJson"'))
+        .from('certification-courses')
+        .innerJoin('schooling-registrations', 'schooling-registrations.userId', 'certification-courses.userId')
+        .innerJoin('organizations', 'schooling-registrations.organizationId', 'organizations.id')
+        .innerJoin('assessments', 'assessments.certificationCourseId', 'certification-courses.id')
+        .innerJoin('assessment-results', 'assessment-results.assessmentId', 'assessments.id')
+        .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
+        .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
+        .modify(_filterMostRecentCertificationCourse)
+        .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai),
+    )
+      .select(knex.ref('*').withSchema(withName))
+      .from(withName)
+      .modify(_filterMostRecentAssessmentsResults)
+      .orderBy(`${withName}.lastName`, 'ASC')
+      .orderBy(`${withName}.firstName`, 'ASC');
 
     return result.map(Certificate.from);
 
+    function _filterMostRecentAssessmentsResults(queryBuilder) {
+      const lastAssessmentAlias = 'last-assessment';
+      queryBuilder
+        .leftJoin({ [lastAssessmentAlias]: 'assessment-results' }, function() {
+          this.on(`${lastAssessmentAlias}.assessmentId`, `${withName}.assessmentId`)
+            .andOn(`${withName}.assessmentResultsCreatedAt`, '<', knex.ref(`${lastAssessmentAlias}.createdAt`));
+        })
+        .whereNull(lastAssessmentAlias);
+
+    }
+
+    function _filterMostRecentCertificationCourse(queryBuilder) {
+      const lastCertificationAlias = 'last-certification';
+      queryBuilder
+        .leftJoin({ [lastCertificationAlias]: 'certification-courses' }, function() {
+          this.on(`${lastCertificationAlias}.userId`, 'certification-courses.userId')
+            .andOn('certification-courses.createdAt', '<', knex.ref(`${lastCertificationAlias}.createdAt`));
+        })
+        .whereNull(lastCertificationAlias);
+
+    }
+
   },
 };
-
-function _filterMostRecentAssessments(queryBuilder) {
-  queryBuilder
-    .leftJoin({ 'last-assessment-results': 'assessment-results' }, function() {
-      this.on('last-assessment-results.assessmentId', 'assessments.id')
-        .andOn('assessment-results.createdAt', '<', knex.ref('last-assessment-results.createdAt'));
-    });
-}

--- a/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
+++ b/api/tests/acceptance/application/certifications-livret-scolaire/certification-controller_test.js
@@ -6,7 +6,7 @@ const {
 } = require('../../../test-helper');
 const createServer = require('../../../../server');
 const Assessment = require('../../../../lib/domain/models/Assessment');
-const { buildOrganization, buildValidatedPublishedCertificationData, mockLearningContentCompetences } = require('../../../../tests/tooling/domain-builder/factory/build-certifications-results-for-ls');
+const { buildOrganization, buildValidatedPublishedCertificationData, mockLearningContentCompetences, buildUser, buildSchoolingRegistration } = require('../../../../tests/tooling/domain-builder/factory/build-certifications-results-for-ls');
 
 describe('Acceptance | API | Certifications', () => {
 
@@ -200,9 +200,12 @@ describe('Acceptance | API | Certifications', () => {
 
         // given
         server = await createServer();
-        const { schoolingRegistration, session, certificationCourse }
+        const user = buildUser();
+        const schoolingRegistration = buildSchoolingRegistration({ userId: user.id, organizationId });
+        const { session, certificationCourse }
           = buildValidatedPublishedCertificationData({
-            organizationId,
+            user,
+            schoolingRegistration,
             verificationCode,
             type,
             pixScore,


### PR DESCRIPTION
## :unicorn: Problème
Si un utilisateur à passé plusieurs certification, elles sont toutes ressorties par l'endpoint livret scolaire

## :robot: Solution
Ne renvoyer que la dernière certification

## :rainbow: Remarques
Il faudra prochainement mettre à jour pour ne prendre que la dernière dont le statut n'est pas CANCELED

## :100: Pour tester
Prendre un candidat qui a passé plusieurs certifications, recuperer les certification via l'endpoint /api/organizations/:uid/certifications, constater que l'on ne récupere que la derniere
