### PR TITLE
[INFRA] Uniformise un champs de message d'erreur dans un log

### DIFF
--- a/api/lib/application/sessions/session-controller.js
+++ b/api/lib/application/sessions/session-controller.js
@@ -285,7 +285,6 @@ function _logSessionBatchPublicationErrors(result) {
     logger.warn({
       batchId: result.batchId,
       sessionId,
-      message: sessionAndError[sessionId].message,
-    });
+    }, sessionAndError[sessionId].message);
   }
 }

--- a/api/tests/unit/application/session/session-controller_test.js
+++ b/api/tests/unit/application/session/session-controller_test.js
@@ -808,14 +808,12 @@ describe('Unit | Controller | sessionController', () => {
       expect(logger.warn).to.have.been.calledWithExactly({
         batchId: 'batchId',
         sessionId: 'sessionId1',
-        message: 'an error',
-      });
+      }, 'an error');
 
       expect(logger.warn).to.have.been.calledWithExactly({
         batchId: 'batchId',
         sessionId: 'sessionId2',
-        message: 'another error',
-      });
+      }, 'another error');
     });
 
     it('returns the serialized batch id', async () => {


### PR DESCRIPTION
## :unicorn: Problème

Dans le log d'erreur lors de la publication de sessions en masse, le message d'erreur est stocké dans un champs json inhabituel et non indexé dans Datadog, le champs `"message"`. Habituellement, ces messages sont stockés dans le champs `"msg"` qui est indexé.

## :robot: Solution

Passer le message d'erreur à faire apparaître dans le champs `"msg"` correctement à `logger.warn()`, voir ci-dessous pour les options.

## :rainbow: Remarques

TIL ce qui suit.

Dans le reste du code, le champs `"msg"` n'est pas explicite, c'est le champs rempli automatiquement par le logger quand on lui passe un texte :

```
> logger.warn("un texte")
{"name":"pix-api","hostname":"pc","pid":56712,"level":40,"msg":"un texte","time":"2021-04-01T13:41:30.067Z","v":0}
```

Quand on log un objet en premier argument, les champs de l'objet sont mergés avec les champs du log :

```
> logger.warn({"un champ": "d'un objet"})
{"name":"pix-api","hostname":"pc","pid":56712,"level":40,"un champ":"d'un objet","msg":"","time":"2021-04-01T13:42:47.461Z","v":0}
```

Quand on passe un champs `"msg"` dans le premier objet, ce champs est écrasé :

```
> logger.warn({"un champ": "d'un objet", msg: "un texte"})
{"name":"pix-api","hostname":"pc","pid":59171,"level":40,"un champ":"d'un objet","msg":"","time":"2021-04-01T13:52:50.775Z","v":0}
```

Quand on log un objet suivi d'un texte, l'objet est mergé avec les champs du log et le texte arrive dans le champs `"msg"` :

```
> logger.warn({"un champ": "d'un objet"}, "un texte")
{"name":"pix-api","hostname":"pc","pid":56712,"level":40,"un champ":"d'un objet","msg":"un texte","time":"2021-04-01T13:46:43.260Z","v":0}
```

Quand on log un texte suivi d'un objet, l'objet est dumpé en json à la suite du texte dans le champs `"msg"` :
```
> logger.warn("un texte", {"un champ": "d'un objet"})
{"name":"pix-api","hostname":"pc","pid":56712,"level":40,"msg":"un texte { 'un champ': \"d'un objet\" }","time":"2021-04-01T13:42:21.446Z","v":0}
```

## :100: Pour tester

Afficher un log d'erreur de publication groupée de sessions.
