### PR TITLE
[FEATURE] Changement de la pagination à 25 par défaut au lieu de 10 dans la liste des participants sur Pix Orga (PIX-2428).

### DIFF
--- a/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/assessments.js
@@ -6,7 +6,7 @@ export default class AssessmentsController extends Controller {
   queryParams = ['pageNumber', 'pageSize', 'divisions', 'badges', 'stages'];
 
   @tracked pageNumber = 1;
-  @tracked pageSize = 10;
+  @tracked pageSize = 25;
   @tracked divisions = [];
   @tracked badges = [];
   @tracked stages = [];

--- a/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/controllers/authenticated/campaigns/campaign/profiles.js
@@ -5,7 +5,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ProfilesController extends Controller {
   queryParams = ['pageNumber', 'pageSize', 'divisions'];
   @tracked pageNumber = 1;
-  @tracked pageSize = 10;
+  @tracked pageSize = 25;
   @tracked divisions = [];
 
   @action

--- a/orga/app/routes/authenticated/campaigns/campaign/assessments.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/assessments.js
@@ -54,7 +54,7 @@ export default class AssessmentsRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 10;
+      controller.pageSize = 25;
       controller.divisions = [];
       controller.badges = [];
       controller.stages = [];

--- a/orga/app/routes/authenticated/campaigns/campaign/profiles.js
+++ b/orga/app/routes/authenticated/campaigns/campaign/profiles.js
@@ -46,9 +46,8 @@ export default class ProfilesRoute extends Route {
   resetController(controller, isExiting) {
     if (isExiting) {
       controller.pageNumber = 1;
-      controller.pageSize = 10;
+      controller.pageSize = 25;
       controller.divisions = [];
     }
   }
 }
-

--- a/orga/tests/acceptance/campaign-participants-test.js
+++ b/orga/tests/acceptance/campaign-participants-test.js
@@ -16,8 +16,8 @@ module('Acceptance | Campaign Participants', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  const pageSize = 10;
-  const rowCount = 50;
+  const pageSize = 25;
+  const rowCount = 100;
 
   hooks.beforeEach(async () => {
     const user = createUserWithMembershipAndTermsOfServiceAccepted();
@@ -28,9 +28,9 @@ module('Acceptance | Campaign Participants', function(hooks) {
     server.create('campaign-assessment-participation-summary', { id: 1, lastName: 'AAAAAAAA_IAM_FIRST' });
     server.createList('campaign-assessment-participation', rowCount, { campaignId: 1 });
     server.createList('campaign-assessment-participation-result', rowCount, { campaignId: 1 });
-    server.createList('campaign-assessment-participation-summary', 20, 'completed');
-    server.createList('campaign-assessment-participation-summary', 10, 'ongoing');
-    server.createList('campaign-assessment-participation-summary', 19, 'shared');
+    server.createList('campaign-assessment-participation-summary', 50, 'completed');
+    server.createList('campaign-assessment-participation-summary', 20, 'ongoing');
+    server.createList('campaign-assessment-participation-summary', 29, 'shared');
 
     await authenticateSession({
       user_id: user.id,
@@ -48,13 +48,13 @@ module('Acceptance | Campaign Participants', function(hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: pageSize });
-      assert.contains('Page 1 / 5');
+      assert.contains('Page 1 / 4');
       assert.dom('.page-size option:checked').hasText(pageSize.toString());
     });
 
     test('it should display participant list with settings in url for pagination', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 50;
       const changedPageNumber = 2;
 
       // when
@@ -82,7 +82,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
 
     test('it should display participant list with updated page size', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 50;
 
       // when
       await visit('/campagnes/1/evaluations');
@@ -96,7 +96,7 @@ module('Acceptance | Campaign Participants', function(hooks) {
 
     test('it should change participant list page when user clicks on next page', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 10;
 
       await visit('/campagnes/1/evaluations');
       await fillInByLabel('Sélectionner une pagination', changedPageSize);
@@ -106,13 +106,13 @@ module('Acceptance | Campaign Participants', function(hooks) {
       await clickByLabel('Aller à la page suivante');
 
       // then
-      assert.contains('Page 2 / 2');
+      assert.contains('Page 2 / 10');
       assert.dom('table tbody').doesNotContainText(someElementFromPage1);
     });
 
     test('it should go back to first page when user changes page size', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 50;
       const startPage = 3;
 
       // when

--- a/orga/tests/acceptance/campaign-profiles-test.js
+++ b/orga/tests/acceptance/campaign-profiles-test.js
@@ -15,8 +15,8 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
   let user;
 
-  const pageSize = 10;
-  const rowCount = 50;
+  const pageSize = 25;
+  const rowCount = 100;
   hooks.beforeEach(async () => {
     user = createUserWithMembershipAndTermsOfServiceAccepted();
     createPrescriberByUser(user);
@@ -39,13 +39,13 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
       // then
       assert.dom('table tbody tr').exists({ count: pageSize });
-      assert.contains('Page 1 / 5');
+      assert.contains('Page 1 / 4');
       assert.dom('.page-size option:checked').hasText(pageSize.toString());
     });
 
     test('it should display profile list with settings in url for pagination', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 50;
       const changedPageNumber = 2;
 
       // when
@@ -62,7 +62,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
     test('it should display profile list with updated page size', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 50;
 
       // when
       await visit('/campagnes/1/profils');
@@ -76,7 +76,7 @@ module('Acceptance | Campaign Profiles', function(hooks) {
 
     test('it should change profile list page when user clicks on next page', async function(assert) {
       // given
-      const changedPageSize = 25;
+      const changedPageSize = 10;
 
       await visit('/campagnes/1/profils');
       await fillInByLabel('Sélectionner une pagination', changedPageSize);
@@ -86,14 +86,14 @@ module('Acceptance | Campaign Profiles', function(hooks) {
       await clickByLabel('Aller à la page suivante');
 
       // then
-      assert.contains('Page 2 / 2');
+      assert.contains('Page 2 / 10');
       assert.dom('table tbody').doesNotContainText(someElementFromPage1);
     });
 
     test('it should go back to first page when user changes page size', async function(assert) {
       // given
-      const changedPageSize = 25;
-      const startPage = 3;
+      const changedPageSize = 50;
+      const startPage = 2;
 
       // when
       await visit(`/campagnes/1/profils?pageNumber=${startPage}`);
@@ -106,4 +106,3 @@ module('Acceptance | Campaign Profiles', function(hooks) {
     });
   });
 });
-


### PR DESCRIPTION
## :unicorn: Problème
Les Orgas SUP et  SCO souhaiteraient d'avoir la pagination à 25 au lieu de 10 dans la lists des participants car leur classe se compose de 20 à 30 personnes, la pagination actuelle est limitée à 10.

## :robot: Solution
passer la pagination à 25 par défaut au lieu de 10 pour la liste des participants des campagnes d'évaluation  et de collect de profile.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur PixOrga avec un compte Sco ou Pro, puis cliquez sur menu Campaigns, sélectionnez une campaign, puis sélectionnez le tab participants.
vous pourrez voir que le numéro de la pagination à la fin de la page et le QueryParameter pageSize dans l'url sont 25.