### PR TITLE
[FEATURE] Monter la limite du numéro d'épreuve de 48 à 64 lors de la finalisation de session pour inclure les épreuves Pix+ Droit (PIX-2368)

### DIFF
--- a/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
+++ b/certif/app/components/issue-report-modal/in-challenge-certification-issue-report-fields.hbs
@@ -17,7 +17,7 @@
         @id="input-for-category-in-challenge-question-number"
         @name="question-number"
         @type="number"
-        @max="48"
+        @max="64"
         @required="true"
         @value={{@inChallengeCategory.questionNumber}}
         placeholder="7"


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la mise en oeuvre de la certification Pix+ Droit, le test de certification sera mis à jour pour les publics passant cette certification avec 4 épreuves par domaine du référentiel Pix+ Droit posées en plus des 3 épreuves par compétence du référentiel Pix (4 domaines). Les utilisateurs Pix certif de centres proposant cette certification doivent pouvoir remonter un signalement sur les épreuves Pix+ droit.
Aujourd’hui, sur la page de finalisation d’une session de certification dans Pix Certif, pour les signalement de type “Problème sur une épreuve”, le numéro d'épreuve est plafonné à 48 et le message d’erreur suivant est affiché : 
![image_48](https://user-images.githubusercontent.com/48727874/113388125-ecf3bb00-938d-11eb-824e-32ec53e122a2.png)


## :robot: Solution
Monter la limite à 64 au niveau de l'input.

## :rainbow: Remarques

## :100: Pour tester
Essayer de finaliser la session 4 du compte certifsco@example.net (ne pas la finaliser pour de bon comme ça tout le monde peut tester ;) ).
Essayer d'ajouter un signalement sur une épreuve, et éprouver le champ
