### PR TITLE
[FEATURE] Restreindre l'accès d'un utilisateur anonyme lors d'une campagne à accès simplifiée (Pix-2363).

### DIFF
--- a/mon-pix/app/routes/application.js
+++ b/mon-pix/app/routes/application.js
@@ -38,9 +38,22 @@ export default Route.extend(ApplicationRouteMixin, {
     }
   },
 
+  async _checkAnonymousAccess(transition) {
+
+    const allowedRoutesForAnonymousAccess = ['fill-in-campaign-code', 'campaigns.assessment.tutorial', 'campaigns.start-or-resume', 'campaigns.campaign-landing-page', 'assessments.challenge', 'campaigns.assessment.skill-review', 'assessments.checkpoint'];
+    const isUserAnonymous = get(this.session, 'data.authenticated.authenticator') === 'authenticator:anonymous';
+    const isRouteAccessNotAllowedForAnonymousUser = !allowedRoutesForAnonymousAccess.includes(get(transition, 'to.name'));
+
+    if (isUserAnonymous && isRouteAccessNotAllowedForAnonymousUser) {
+      await this._logoutUser();
+      this.replaceWith('/campagnes');
+    }
+  },
+
   async beforeModel(transition) {
     this.headData.description = this.intl.t('application.description');
     await this._checkForURLAuthentication(transition);
+    await this._checkAnonymousAccess(transition);
 
     await this.featureToggles.load().catch();
 

--- a/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
+++ b/mon-pix/tests/acceptance/logout-anonymous-user-when-access-to-not-allowed-pages_test.js
@@ -1,0 +1,78 @@
+import { currentURL } from '@ember/test-helpers';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import { currentSession } from 'ember-simple-auth/test-support';
+import visit from '../helpers/visit';
+import { setupApplicationTest } from 'ember-mocha';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+const EXPECTED_ROUTE_CAMPAIGN = '/campagnes';
+const SIMPLIFIED_CODE_CAMPAIGN = 'SIMPLIFIE';
+const ID_ASSESSMENT = '10000029';
+const CODE_CHALLENGE = 'rec1lRuv6iIYn5Ek2';
+
+describe('Acceptance | Campaigns | Simplified access | Anonymous user access to not allowed pages', function() {
+
+  setupApplicationTest();
+  setupMirage();
+  let campaign;
+
+  context('When user logged as anonymous, and the access to campaign is simplified', () => {
+
+    beforeEach(async () => {
+      campaign = server.create('campaign', { isSimplifiedAccess: true, idPixLabel: 'Les anonymes' });
+      await currentSession().authenticate('authenticator:anonymous', { campaignCode: campaign.code });
+    });
+
+    describe('When access to not allowed profil page', function() {
+
+      it('should logout anonymous user and redirect to campaign page', async function() {
+
+        // when
+        await visit('/competences');
+
+        // then
+        expect(currentURL()).to.equal(EXPECTED_ROUTE_CAMPAIGN);
+        expect(currentSession(this.application).get('isAuthenticated')).to.be.false;
+      });
+    });
+
+    describe('When access to allowed pages #', function() {
+
+      // to reduce acceptance time test, we test multiple routes in the same test
+      it('should access to the page', async function() {
+
+        // when
+        const CAMPAIGN_RESULT_ROUTE = `/campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/resultats/${ID_ASSESSMENT}`;
+        await visit(CAMPAIGN_RESULT_ROUTE);
+        // then
+        expect(currentURL()).to.equal(CAMPAIGN_RESULT_ROUTE);
+        expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
+
+        // when
+        const CHALLENGE_ROUTE = `/assessments/${ID_ASSESSMENT}/challenges/${CODE_CHALLENGE}`;
+        await visit(`${CHALLENGE_ROUTE}`);
+        // then
+        expect(currentURL()).to.equal(CHALLENGE_ROUTE);
+        expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
+
+        // when
+        const CAMPAIGN_DIDACTICIEL_ROUTE = `campagnes/${SIMPLIFIED_CODE_CAMPAIGN}/evaluation/didacticiel`;
+        await visit(CAMPAIGN_DIDACTICIEL_ROUTE);
+        // then
+        expect(currentURL()).to.equal(CAMPAIGN_DIDACTICIEL_ROUTE);
+        expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
+
+        // when
+        const CAMPAIGN_ROUTE = `campagnes/${SIMPLIFIED_CODE_CAMPAIGN}`;
+        await visit(CAMPAIGN_ROUTE);
+        // then
+        expect(currentURL()).to.equal(CAMPAIGN_ROUTE);
+        expect(currentSession(this.application).get('isAuthenticated')).to.be.true;
+
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## :unicorn: Problème
Quand un utilisateur anonyme quitte un parcours sans le finir ou ferme son onglet ou son navigateur, un utilisateur suivant qui saisit n'importe quelle page de Pix app (accueil / tuto / etc....) se retrouve sur la page sans menu et donc sans possibilité de se déconnecter. 

## :robot: Solution
Bloquer l'accès à Pix app dès lors qu'un utilisateur anonyme à une session ouverte. Déconnecter l'utilisateur et le rediriger vers la page de saisie de code de campagne.

## :rainbow: Remarques
Lors du hook before model de la route, on vérifie que la transition d'un utilisateur anonyme figure parmi une whitelist de pages autorisés pour ce parcours.
 
## :100: Pour tester
1- Accéder à la page [/campagnes](https://app-pr2806.review.pix.fr/campagnes) avec le code SIMPLIFIE
2- Quitter le parcours et allez vers les pages de profil, certificats ...
3- Vérifier qu'on ait bien déconnecté et qu'on est redirigé vers la page de campagne.

Faire un test de non régression de tout le parcours simplifie d'un utilisateur anonyme. En faisant des refresh de pages pour vérifier qu'on ait toujours connecté.
