### PR TITLE
[FEATURE] Supprimer une méthode de connexion d'un utilisateur dans Pix Admin (PIX-2103).

### DIFF
--- a/admin/app/adapters/user.js
+++ b/admin/app/adapters/user.js
@@ -25,6 +25,25 @@ export default class UserAdapter extends ApplicationAdapter {
       return this.ajax(url, 'POST');
     }
 
+    if (snapshot.adapterOptions && snapshot.adapterOptions.dissociate) {
+      const url = this.urlForUpdateRecord(snapshot.id) + '/dissociate';
+      return this.ajax(url, 'PATCH');
+    }
+
+    if (snapshot.adapterOptions && snapshot.adapterOptions.removeAuthenticationMethod) {
+      const payload = {
+        data: {
+          data: {
+            attributes: {
+              type: snapshot.adapterOptions.type,
+            },
+          },
+        },
+      };
+      const url = this.urlForUpdateRecord(snapshot.id) + '/remove-authentication';
+      return this.ajax(url, 'POST', payload);
+    }
+
     return super.updateRecord(...arguments);
   }
 

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -124,7 +124,9 @@
 </section>
 
 <section class="page-section mb_10 user-authentication-method">
-  <h2 class="page-section__title user-authentication-method__title">Méthodes de connexion</h2>
+  <header class="page-section__header">
+  <h2 class="page-section__title">Méthodes de connexion</h2>
+  </header>
   <div class="user-authentication-method__item" data-test-email>
     <span>Adresse e-mail</span>
     {{#if @user.hasEmailAuthenticationMethod}}

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -102,17 +102,17 @@
       <div class="col-md-4">
         {{#if this.canAdministratorModifyUserDetails}}
           <button
-            type="button"
-            class="btn btn-outline-default"
-            aria-label="Modifier"
+                  type="button"
+                  class="btn btn-outline-default"
+                  aria-label="Modifier"
             {{on "click" this.changeEditionMode}}
           >
             Modifier
           </button>
           <button
-            type="button"
-            class="btn btn-danger"
-            aria-label="Anonymiser"
+                  type="button"
+                  class="btn btn-danger"
+                  aria-label="Anonymiser"
             {{on "click" this.toggleDisplayAnonymizeModal}}
           >
             Anonymiser cet utilisateur
@@ -125,38 +125,82 @@
 
 <section class="page-section mb_10 user-authentication-method">
   <header class="page-section__header">
-  <h2 class="page-section__title">Méthodes de connexion</h2>
+    <h2 class="page-section__title">Méthodes de connexion</h2>
   </header>
   <div class="user-authentication-method__item" data-test-email>
-    <span>Adresse e-mail</span>
+    <div class="user-authentication-method-item__label">
+      <span>Adresse e-mail</span>
+      {{#if @user.hasEmailAuthenticationMethod}}
+        <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+      {{else}}
+        <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      {{/if}}
+    </div>
     {{#if @user.hasEmailAuthenticationMethod}}
-      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
-    {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <PixButton
+              class="user-authentication-method__remove-button"
+              @type="button"
+              @triggerAction={{fn this.toggleDisplayRemoveAuthenticationMethodModal 'EMAIL'}}
+              data-test-remove-email>
+        SUPPRIMER
+      </PixButton>
     {{/if}}
   </div>
   <div class="user-authentication-method__item" data-test-username>
-    <span>Identifiant</span>
+    <div class="user-authentication-method-item__label">
+      <span>Identifiant</span>
+      {{#if @user.hasUsernameAuthenticationMethod}}
+        <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+      {{else}}
+        <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      {{/if}}
+    </div>
     {{#if @user.hasUsernameAuthenticationMethod}}
-      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
-    {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <PixButton
+              class="user-authentication-method__remove-button"
+              @type="button"
+              @triggerAction={{fn this.toggleDisplayRemoveAuthenticationMethodModal 'USERNAME'}}
+              data-test-remove-username>
+        SUPPRIMER
+      </PixButton>
     {{/if}}
   </div>
   <div class="user-authentication-method__item" data-test-pole-emploi>
-    <span>Pôle Emploi</span>
+    <div class="user-authentication-method-item__label">
+      <span>Pôle Emploi</span>
+      {{#if @user.hasPoleEmploiAuthenticationMethod}}
+        <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+      {{else}}
+        <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      {{/if}}
+    </div>
     {{#if @user.hasPoleEmploiAuthenticationMethod}}
-      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
-    {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <PixButton
+              class="user-authentication-method__remove-button"
+              @type="button"
+              @triggerAction={{fn this.toggleDisplayRemoveAuthenticationMethodModal 'POLE_EMPLOI'}}
+              data-test-remove-pole-emploi>
+        SUPPRIMER
+      </PixButton>
     {{/if}}
   </div>
   <div class="user-authentication-method__item" data-test-mediacentre>
-    <span>Médiacentre</span>
+    <div class="user-authentication-method-item__label">
+      <span>Médiacentre</span>
+      {{#if @user.hasGARAuthenticationMethod}}
+        <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
+      {{else}}
+        <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      {{/if}}
+    </div>
     {{#if @user.hasGARAuthenticationMethod}}
-      <FaIcon @icon="check-circle" class="user-authentication-method-item__check" />
-    {{else}}
-      <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
+      <PixButton
+              class="user-authentication-method__remove-button"
+              @type="button"
+              @triggerAction={{fn this.toggleDisplayRemoveAuthenticationMethodModal 'GAR'}}
+              data-test-remove-mediacentre>
+        SUPPRIMER
+      </PixButton>
     {{/if}}
   </div>
 </section>
@@ -228,3 +272,10 @@
               @confirm={{this.dissociate}}
               @cancel={{this.toggleDisplayDissociateModal}}
               @show={{this.displayDissociateModal}} />
+
+<ConfirmPopup @message="Suppression de la méthode de connexion suivante : {{this.translatedType}}"
+              @title="Confirmer la suppression"
+              @submitTitle="Oui, je supprime"
+              @confirm={{this.removeAuthenticationMethod}}
+              @cancel={{this.toggleDisplayRemoveAuthenticationMethodModal}}
+              @show={{this.displayRemoveAuthenticationMethodModal}} />

--- a/admin/app/components/user-detail-personal-information.hbs
+++ b/admin/app/components/user-detail-personal-information.hbs
@@ -136,7 +136,7 @@
         <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
       {{/if}}
     </div>
-    {{#if @user.hasEmailAuthenticationMethod}}
+    {{#if (and @user.hasEmailAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
       <PixButton
               class="user-authentication-method__remove-button"
               @type="button"
@@ -155,7 +155,7 @@
         <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
       {{/if}}
     </div>
-    {{#if @user.hasUsernameAuthenticationMethod}}
+    {{#if (and @user.hasUsernameAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
       <PixButton
               class="user-authentication-method__remove-button"
               @type="button"
@@ -174,7 +174,7 @@
         <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
       {{/if}}
     </div>
-    {{#if @user.hasPoleEmploiAuthenticationMethod}}
+    {{#if (and @user.hasPoleEmploiAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
       <PixButton
               class="user-authentication-method__remove-button"
               @type="button"
@@ -193,7 +193,7 @@
         <FaIcon @icon="times-circle" class="user-authentication-method-item__uncheck" />
       {{/if}}
     </div>
-    {{#if @user.hasGARAuthenticationMethod}}
+    {{#if (and @user.hasGARAuthenticationMethod (not @user.hasOnlyOneAuthenticationMethod))}}
       <PixButton
               class="user-authentication-method__remove-button"
               @type="button"

--- a/admin/app/controllers/authenticated/users/get.js
+++ b/admin/app/controllers/authenticated/users/get.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+
+export default class GetController extends Controller {
+
+  @action
+  async removeAuthenticationMethod(type) {
+    await this.model.save({ adapterOptions: { removeAuthenticationMethod: true, type } });
+    this.send('refreshModel');
+  }
+}

--- a/admin/app/models/user.js
+++ b/admin/app/models/user.js
@@ -38,4 +38,13 @@ export default class User extends Model {
   get hasGARAuthenticationMethod() {
     return this.authenticationMethods.any((authenticationMethod) => authenticationMethod.identityProvider === 'GAR');
   }
+
+  get hasOnlyOneAuthenticationMethod() {
+    return [
+      this.hasEmailAuthenticationMethod,
+      this.hasUsernameAuthenticationMethod,
+      this.hasGARAuthenticationMethod,
+      this.hasPoleEmploiAuthenticationMethod,
+    ].filter((hasAuthenticationMethod) => hasAuthenticationMethod).length === 1;
+  }
 }

--- a/admin/app/routes/authenticated/users/get.js
+++ b/admin/app/routes/authenticated/users/get.js
@@ -1,8 +1,14 @@
 import Route from '@ember/routing/route';
+import { action } from '@ember/object';
 
 export default class AuthenticatedUsersGetRoute extends Route {
 
   model(params) {
-    return this.store.findRecord('user', params.user_id, { include: 'schoolingRegistrations' });
+    return this.store.findRecord('user', params.user_id, { include: 'schoolingRegistrations,authenticationMethods' });
+  }
+
+  @action
+  refreshModel() {
+    this.refresh();
   }
 }

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -18,17 +18,12 @@
 
 .user-authentication-method {
 
-  &__title {
-    font-size: 18px;
-    padding: 4px 0 12px 0;
-  }
-
   &__item {
     display: flex;
     align-items: center;
     justify-content: space-between;
     width: 150px;
-    margin: 5px 0;
+    margin: 8px 0;
     color: $grey-40;
   }
 

--- a/admin/app/styles/components/user-detail-personal-information-section.scss
+++ b/admin/app/styles/components/user-detail-personal-information-section.scss
@@ -21,13 +21,26 @@
   &__item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    width: 150px;
     margin: 8px 0;
     color: $grey-40;
   }
 
+  &__remove-button {
+    background-color: transparent;
+    color: red;
+    font-size: 0.75rem;
+    border: none;
+    padding: 0 0 0 10px;
+  }
+
   .user-authentication-method-item {
+
+    &__label {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 175px;
+    }
 
     &__check {
       color: $success;

--- a/admin/app/styles/misc/global.scss
+++ b/admin/app/styles/misc/global.scss
@@ -5,7 +5,7 @@ html, body {
 }
 
 html {
-  font-family: 'Open Sans', Arial, sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
   color: $grey-90;
 }
 
@@ -14,7 +14,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: 'Raleway', Arial, sans-serif;
+  font-family: 'Roboto', Arial, sans-serif;
 }
 
 figure.work-in-progress {

--- a/admin/app/styles/misc/page.scss
+++ b/admin/app/styles/misc/page.scss
@@ -34,18 +34,16 @@
     .page-section {
       background: $white;
       border-radius: 5px;
-      padding: 20px;
+      padding: 32px;
 
       .page-section__header {
         display: flex;
-        justify-content: space-between;
         align-items: center;
         margin-bottom: 20px;
 
         .page-section__title {
-          font-size: 1.4rem;
-          display: inline-block;
-          margin-bottom: 0;
+          font-size: 1.2rem;
+          font-weight: 600;
         }
       }
     }

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -7,5 +7,5 @@
 </header>
 
 <main class="page-body">
-  <UserDetailPersonalInformation @user={{@model}}/>
+  <UserDetailPersonalInformation @user={{@model}} @removeAuthenticationMethod={{this.removeAuthenticationMethod}}/>
 </main>

--- a/admin/app/templates/authenticated/users/get.hbs
+++ b/admin/app/templates/authenticated/users/get.hbs
@@ -6,6 +6,6 @@
   </div>
 </header>
 
-<main class="page-body" id="organizations-get-page">
+<main class="page-body">
   <UserDetailPersonalInformation @user={{@model}}/>
 </main>

--- a/admin/config/environment.js
+++ b/admin/config/environment.js
@@ -57,8 +57,7 @@ module.exports = function(environment) {
     },
 
     googleFonts: [
-      'Raleway',
-      'Open+Sans',
+      'Roboto:300,400,500,600',
     ],
 
     // Set or update content security policies

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -177,6 +177,22 @@ export default function() {
     return user.update(expectedUpdatedUser);
   });
 
+  this.post('/admin/users/:id/remove-authentication', (schema, request) => {
+    const userId = request.params.id;
+    const params = JSON.parse(request.requestBody);
+    const type = params.data.attributes.type;
+
+    if (type === 'EMAIL') {
+      const authenticationMethod = schema.authenticationMethods.findBy({ identityProvider: 'PIX' });
+      authenticationMethod.destroy();
+
+      const user = schema.users.findBy({ id: userId });
+      user.update({ email: null });
+    }
+
+    return new Response(204);
+  });
+
   this.get('feature-toggles', (schema) => {
     return schema.featureToggles.findOrCreateBy({ id: 0 });
   });

--- a/admin/tests/acceptance/user-details-personal-information-test.js
+++ b/admin/tests/acceptance/user-details-personal-information-test.js
@@ -15,6 +15,8 @@ module('Acceptance | User details personal information', function(hooks) {
 
   hooks.beforeEach(async function() {
     const schoolingRegistration = this.server.create('schooling-registration', { firstName: 'John' });
+    const pixAuthenticationMethod = this.server.create('authentication-method', { identityProvider: 'PIX' });
+    const garAuthenticationMethod = this.server.create('authentication-method', { identityProvider: 'GAR' });
     user = this.server.create('user', {
       'first-name': 'john',
       'last-name': 'harry',
@@ -22,6 +24,7 @@ module('Acceptance | User details personal information', function(hooks) {
       'is-authenticated-from-gar': false,
     });
     user.schoolingRegistrations = [schoolingRegistration];
+    user.authenticationMethods = [pixAuthenticationMethod, garAuthenticationMethod];
     user.save();
     await createAuthenticateSession({ userId: user.id });
   });
@@ -93,6 +96,22 @@ module('Acceptance | User details personal information', function(hooks) {
       // then
       assert.equal(currentURL(), `/users/${user.id}`);
       assert.notContains(organizationName);
+    });
+  });
+
+  module('when administrator click on remove authentication method button', function() {
+
+    test('should not display remove link and display unchecked icon', async function(assert) {
+      // given
+      await visit(`/users/${user.id}`);
+
+      // when
+      await click('button[data-test-remove-email]');
+      await click('.modal-dialog .btn-primary');
+
+      // then
+      assert.dom('div[data-test-email] > div > svg').hasClass('user-authentication-method-item__uncheck');
+      assert.dom('div[data-test-email] > div > button[data-test-remove-email]').notExists;
     });
   });
 

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { click, render } from '@ember/test-helpers';
+import { click, find, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
 import Service from '@ember/service';
@@ -218,6 +218,20 @@ module('Integration | Component | user-detail-personal-information', function(ho
 
           // then
           assert.dom('div[data-test-mediacentre] > div > svg').hasClass('user-authentication-method-item__check');
+        });
+
+        module('When user has only one authentication method', function() {
+
+          test('it should not display a remove authentication method link', async function(assert) {
+            // given
+            this.set('user', { hasOnlyOneAuthenticationMethod: true });
+
+            // when
+            await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+            // then
+            assert.notOk(find('.user-authentication-method__remove-button'));
+          });
         });
       });
     });

--- a/admin/tests/integration/components/user-detail-personal-information-test.js
+++ b/admin/tests/integration/components/user-detail-personal-information-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberObject from '@ember/object';
+import Service from '@ember/service';
 import sinon from 'sinon';
 
 import clickByLabel from '../../helpers/extended-ember-test-helpers/click-by-label';
@@ -183,7 +184,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
           await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
 
           // then
-          assert.dom('div[data-test-email] > svg').hasClass('user-authentication-method-item__check');
+          assert.dom('div[data-test-email] > div > svg').hasClass('user-authentication-method-item__check');
         });
 
         test('should display user’s username authentication method', async function(assert) {
@@ -194,7 +195,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
           await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
 
           // then
-          assert.dom('div[data-test-username] > svg').hasClass('user-authentication-method-item__check');
+          assert.dom('div[data-test-username] > div > svg').hasClass('user-authentication-method-item__check');
         });
 
         test('should display user’s Pole Emploi authentication method', async function(assert) {
@@ -205,7 +206,7 @@ module('Integration | Component | user-detail-personal-information', function(ho
           await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
 
           // then
-          assert.dom('div[data-test-pole-emploi] > svg').hasClass('user-authentication-method-item__check');
+          assert.dom('div[data-test-pole-emploi] > div > svg').hasClass('user-authentication-method-item__check');
         });
 
         test('should display user’s GAR authentication method', async function(assert) {
@@ -216,10 +217,9 @@ module('Integration | Component | user-detail-personal-information', function(ho
           await render(hbs `<UserDetailPersonalInformation @user={{this.user}}/>`);
 
           // then
-          assert.dom('div[data-test-mediacentre] > svg').hasClass('user-authentication-method-item__check');
+          assert.dom('div[data-test-mediacentre] > div > svg').hasClass('user-authentication-method-item__check');
         });
       });
-
     });
   });
 
@@ -398,4 +398,106 @@ module('Integration | Component | user-detail-personal-information', function(ho
     });
   });
 
+  module('when the administrator click on remove authentication method button', function() {
+
+    test('should display remove authentication methode confirm modal', async function(assert) {
+      // given
+      const user = EmberObject.create({
+        lastName: 'Harry',
+        firstName: 'John',
+        email: 'john.harry@gmail.com',
+        username: 'john.harry.1010',
+        hasEmailAuthenticationMethod: true,
+      });
+
+      this.set('user', user);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+
+      // when
+      await click('button[data-test-remove-email]');
+
+      // then
+      assert.contains('Confirmer la suppression');
+    });
+
+    // eslint-disable-next-line mocha/no-identical-title
+    test('should close the modal on click on cancel button', async function(assert) {
+      // given
+      const user = EmberObject.create({
+        lastName: 'Harry',
+        firstName: 'John',
+        email: 'john.harry@gmail.com',
+        username: 'john.harry.1010',
+        hasEmailAuthenticationMethod: true,
+      });
+
+      this.set('user', user);
+      await render(hbs`<UserDetailPersonalInformation @user={{this.user}}/>`);
+      await click('button[data-test-remove-email]');
+
+      // when
+      await click('.modal-dialog .btn-secondary');
+
+      // then
+      assert.dom('.modal-dialog').doesNotExist();
+    });
+
+    module('when the administrator confirm the removal', function() {
+
+      test('should call removeAuthenticationMethod parameter', async function(assert) {
+        // given
+        const user = EmberObject.create({
+          lastName: 'Harry',
+          firstName: 'John',
+          email: 'john.harry@gmail.com',
+          username: 'john.harry.1010',
+          hasEmailAuthenticationMethod: true,
+        });
+        this.set('user', user);
+        const removeAuthenticationMethodStub = sinon.stub();
+        this.set('removeAuthenticationMethod', removeAuthenticationMethodStub);
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}} @removeAuthenticationMethod={{this.removeAuthenticationMethod}}/>`);
+        await click('button[data-test-remove-email]');
+
+        // when
+        await click('.modal-dialog .btn-primary');
+
+        // then
+        assert.ok(removeAuthenticationMethodStub.called);
+        assert.dom('.modal-dialog').doesNotExist();
+      });
+
+      test('should display an error message when the administrator try to remove the last authentication method', async function(assert) {
+        // given
+        const user = EmberObject.create({
+          lastName: 'Harry',
+          firstName: 'John',
+          email: 'john.harry@gmail.com',
+          hasEmailAuthenticationMethod: true,
+        });
+        this.set('user', user);
+        const removeAuthenticationMethodStub = sinon.stub();
+        this.set('removeAuthenticationMethod', removeAuthenticationMethodStub);
+
+        const notificationErrorStub = sinon.stub();
+        class NotificationsStub extends Service {
+          error = notificationErrorStub;
+        }
+        this.owner.register('service:notifications', NotificationsStub);
+
+        removeAuthenticationMethodStub.rejects({ errors: [{ status: '403' }] });
+
+        await render(hbs`<UserDetailPersonalInformation @user={{this.user}} @removeAuthenticationMethod={{this.removeAuthenticationMethod}}/>`);
+        await click('button[data-test-remove-email]');
+
+        // when
+        await click('.modal-dialog .btn-primary');
+
+        // then
+        sinon.assert.calledWith(notificationErrorStub, 'Vous ne pouvez pas supprimer la dernière méthode de connexion de cet utilisateur');
+        assert.dom('.modal-dialog').doesNotExist();
+      });
+    });
+  });
 });

--- a/admin/tests/unit/adapters/user-test.js
+++ b/admin/tests/unit/adapters/user-test.js
@@ -45,7 +45,6 @@ module('Unit | Adapter | user', function(hooks) {
 
       test('should send a POST request to user anonymize endpoint', async function(assert) {
         // given
-        adapter.ajax.resolves();
         const expectedUrl = 'http://localhost:3000/api/admin/users/123/anonymize';
         const adapterOptions = { anonymizeUser: true };
 
@@ -61,6 +60,55 @@ module('Unit | Adapter | user', function(hooks) {
         assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
       });
     });
-  });
 
+    module('when dissociate adapterOptions is passed', function() {
+
+      test('should send a PATCH request to user dissociate endpoint', async function(assert) {
+        // given
+        const expectedUrl = 'http://localhost:3000/api/admin/users/123/dissociate';
+        const adapterOptions = { dissociate: true };
+
+        // when
+        await adapter.updateRecord(
+          null,
+          { modelName: 'user' },
+          { id: 123, adapterOptions },
+        );
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'PATCH');
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+
+    module('when remove authentication adapterOptions is passed', function() {
+
+      test('should send a POST request to user remove authentication endpoint', async function(assert) {
+        // given
+        const expectedUrl = 'http://localhost:3000/api/admin/users/123/remove-authentication';
+        const type = 'EMAIL';
+        const adapterOptions = { removeAuthenticationMethod: true, type };
+        const expectedPayload = {
+          data: {
+            data: {
+              attributes: {
+                type,
+              },
+            },
+          },
+        };
+
+        // when
+        await adapter.updateRecord(
+          null,
+          { modelName: 'user' },
+          { id: 123, adapterOptions },
+        );
+
+        // then
+        sinon.assert.calledWith(adapter.ajax, expectedUrl, 'POST', expectedPayload);
+        assert.ok(adapter); /* required because QUnit wants at least one expect (and does not accept Sinon's one) */
+      });
+    });
+  });
 });

--- a/admin/tests/unit/models/user-test.js
+++ b/admin/tests/unit/models/user-test.js
@@ -77,4 +77,27 @@ module('Unit | Model | user', function(hooks) {
       assert.equal(user.hasGARAuthenticationMethod, true);
     });
   });
+
+  module('hasOnlyOneAuthenticationMethod', function() {
+
+    test('it should return true when user has only one authentication method', function(assert) {
+      // given
+      const authenticationMethod = store.createRecord('authentication-method', { identityProvider: 'GAR' });
+      const user = store.createRecord('user', { authenticationMethods: [authenticationMethod] });
+
+      // then
+      assert.equal(user.hasOnlyOneAuthenticationMethod, true);
+    });
+
+    test('it should return false when user has more than one authentication method', function(assert) {
+      // given
+      const garAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'GAR' });
+      const poleEmploiAuthenticationMethod = store.createRecord('authentication-method', { identityProvider: 'POLE_EMPLOI' });
+      const user = store.createRecord('user', { authenticationMethods: [garAuthenticationMethod, poleEmploiAuthenticationMethod] });
+
+      // then
+      assert.equal(user.hasOnlyOneAuthenticationMethod, false);
+    });
+
+  });
 });

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -103,6 +103,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.UserNotAuthorizedToGenerateUsernamePasswordError) {
     return new HttpErrors.ForbiddenError(error.message);
   }
+  if (error instanceof DomainErrors.UserNotAuthorizedToRemoveAuthenticationMethod) {
+    return new HttpErrors.ForbiddenError(error.message);
+  }
   if (error instanceof DomainErrors.CertificationCandidateAlreadyLinkedToUserError) {
     return new HttpErrors.ForbiddenError('Le candidat de certification est déjà lié à un utilisateur.');
   }

--- a/api/lib/application/users/index.js
+++ b/api/lib/application/users/index.js
@@ -111,6 +111,36 @@ exports.register = async function(server) {
       },
     },
     {
+      method: 'POST',
+      path: '/api/admin/users/{id}/remove-authentication',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.userId,
+          }),
+          payload: Joi.object({
+            data: {
+              attributes: {
+                type: Joi.string().valid('GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI').required(),
+              },
+            },
+          }),
+          options: {
+            allowUnknown: true,
+          },
+        },
+        handler: userController.removeAuthenticationMethod,
+        notes: [
+          '- Permet à un administrateur de supprimer une méthode de connexion',
+        ],
+        tags: ['api', 'administration', 'user'],
+      },
+    },
+    {
       method: 'GET',
       path: '/api/users/{id}/memberships',
       config: {

--- a/api/lib/application/users/user-controller.js
+++ b/api/lib/application/users/user-controller.js
@@ -234,4 +234,11 @@ module.exports = {
     return userDetailsForAdminSerializer.serialize(userDetailsForAdmin);
   },
 
+  async removeAuthenticationMethod(request, h) {
+    const userId = parseInt(request.params.id);
+    const type = request.payload.data.attributes.type;
+    await usecases.removeAuthenticationMethod({ userId, type });
+    return h.response().code(204);
+  },
+
 };

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -681,6 +681,12 @@ class UserNotAuthorizedToUpdatePasswordError extends DomainError {
   }
 }
 
+class UserNotAuthorizedToRemoveAuthenticationMethod extends DomainError {
+  constructor(message = 'L\'utilisateur n\'est pas autorisé à supprimer cette méthode de connexion.') {
+    super(message);
+  }
+}
+
 class SchoolingRegistrationNotFound extends NotFoundError {
   constructor(message = 'Aucune inscription d‘élève n‘a été trouvée.') {
     super(message);
@@ -842,6 +848,7 @@ module.exports = {
   UserNotAuthorizedToGenerateUsernamePasswordError,
   UserNotAuthorizedToGetCampaignResultsError,
   UserNotAuthorizedToGetCertificationCoursesError,
+  UserNotAuthorizedToRemoveAuthenticationMethod,
   UserNotAuthorizedToUpdateCampaignError,
   UserNotAuthorizedToUpdatePasswordError,
   UserNotAuthorizedToUpdateResourceError,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -247,6 +247,7 @@ module.exports = injectDependencies({
   reconcileUserToOrganization: require('./reconcile-user-to-organization'),
   rememberUserHasSeenAssessmentInstructions: require('./remember-user-has-seen-assessment-instructions'),
   rememberUserHasSeenNewDashboardInfo: require('./remember-user-has-seen-new-dashboard-info'),
+  removeAuthenticationMethod: require('./remove-authentication-method'),
   resetScorecard: require('./reset-scorecard'),
   retrieveLastOrCreateCertificationCourse: require('./retrieve-last-or-create-certification-course'),
   saveCertificationCenter: require('./save-certification-center'),

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -10,19 +10,19 @@ module.exports = async function removeAuthenticationMethod({
   const user = await userRepository.get(userId);
 
   if (type === 'EMAIL') {
-    await userRepository.updateEmail(userId, null);
 
     if (!user.username) {
       await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.PIX, authenticationMethodRepository);
     }
+    await userRepository.updateEmail({ id: userId, email: null });
   }
 
   if (type === 'USERNAME') {
-    await userRepository.updateUsername({ id: userId, username: null });
 
     if (!user.email) {
       await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.PIX, authenticationMethodRepository);
     }
+    await userRepository.updateUsername({ id: userId, username: null });
   }
 
   if (type === 'GAR') {

--- a/api/lib/domain/usecases/remove-authentication-method.js
+++ b/api/lib/domain/usecases/remove-authentication-method.js
@@ -1,0 +1,45 @@
+const AuthenticationMethod = require('../models/AuthenticationMethod');
+const { UserNotAuthorizedToRemoveAuthenticationMethod } = require('../errors');
+
+module.exports = async function removeAuthenticationMethod({
+  userId,
+  type,
+  userRepository,
+  authenticationMethodRepository,
+}) {
+  const user = await userRepository.get(userId);
+
+  if (type === 'EMAIL') {
+    await userRepository.updateEmail(userId, null);
+
+    if (!user.username) {
+      await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.PIX, authenticationMethodRepository);
+    }
+  }
+
+  if (type === 'USERNAME') {
+    await userRepository.updateUsername({ id: userId, username: null });
+
+    if (!user.email) {
+      await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.PIX, authenticationMethodRepository);
+    }
+  }
+
+  if (type === 'GAR') {
+    await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.GAR, authenticationMethodRepository);
+  }
+
+  if (type === 'POLE_EMPLOI') {
+    await _removeAuthenticationMethod(userId, AuthenticationMethod.identityProviders.POLE_EMPLOI, authenticationMethodRepository);
+  }
+};
+
+async function _removeAuthenticationMethod(userId, identityProvider, authenticationMethodRepository) {
+  const authenticationMethods = await authenticationMethodRepository.findByUserId({ userId });
+
+  if (authenticationMethods.length === 1) {
+    throw new UserNotAuthorizedToRemoveAuthenticationMethod();
+  }
+
+  await authenticationMethodRepository.removeByUserIdAndIdentityProvider({ userId, identityProvider });
+}

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -231,4 +231,7 @@ module.exports = {
       });
   },
 
+  async removeByUserIdAndIdentityProvider({ userId, identityProvider }) {
+    return BookshelfAuthenticationMethod.where({ userId, identityProvider }).destroy({ require: true });
+  },
 };

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -234,4 +234,12 @@ module.exports = {
   async removeByUserIdAndIdentityProvider({ userId, identityProvider }) {
     return BookshelfAuthenticationMethod.where({ userId, identityProvider }).destroy({ require: true });
   },
+
+  async findByUserId({ userId }) {
+    const bookshelfAuthenticationMethods = await BookshelfAuthenticationMethod
+      .where({ userId })
+      .fetchAll();
+
+    return bookshelfAuthenticationMethods.map((bookshelfAuthenticationMethod) => _toDomainEntity(bookshelfAuthenticationMethod));
+  },
 };

--- a/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
+++ b/api/tests/acceptance/application/users/users-controller-remove-authentication-method_test.js
@@ -1,0 +1,64 @@
+const { databaseBuilder, expect, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster, knex } = require('../../../test-helper');
+const createServer = require('../../../../server');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+
+describe('Acceptance | Controller | users-controller-remove-authentication-method', () => {
+
+  let server;
+  let user;
+  let options;
+
+  beforeEach(async () => {
+    server = await createServer();
+    user = databaseBuilder.factory.buildUser({ username: 'jhn.doe0101', email: null });
+    databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+    databaseBuilder.factory.buildAuthenticationMethod({
+      userId: user.id,
+      identityProvider: AuthenticationMethod.identityProviders.GAR,
+    });
+
+    const pixMaster = await insertUserWithRolePixMaster();
+    options = {
+      method: 'POST',
+      url: `/api/admin/users/${user.id}/remove-authentication`,
+      payload: {
+        data: {
+          attributes: {
+            type: 'USERNAME',
+          },
+        },
+      },
+      headers: { authorization: generateValidRequestAuthorizationHeader(pixMaster.id) },
+    };
+    return databaseBuilder.commit();
+  });
+
+  describe('POST /admin/users/:id/remove-authentication', () => {
+
+    it('should return 204', async () => {
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(204);
+    });
+
+    it('should set the username to null', async () => {
+      // when
+      await server.inject(options);
+
+      // then
+      const updatedUser = await knex('users').where({ id: user.id }).first();
+      expect(updatedUser.username).to.be.null;
+    });
+
+    it('should remove PIX authenticationMethod', async () => {
+      // when
+      await server.inject(options);
+
+      // then
+      const pixAuthenticationMethod = await knex('authentication-methods').where({ userId: user.id, identityProvider: AuthenticationMethod.identityProviders.PIX }).first();
+      expect(pixAuthenticationMethod).to.be.undefined;
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -586,4 +586,36 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       expect(result).to.be.undefined;
     });
   });
+
+  describe('#findByUserId', () => {
+
+    it('should return the user\'s authentication methods', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      databaseBuilder.factory.buildAuthenticationMethod({
+        identityProvider: AuthenticationMethod.identityProviders.GAR,
+        externalIdentifier: 'externalIdentifier',
+        userId });
+      databaseBuilder.factory.buildAuthenticationMethod.buildWithHashedPassword({ userId });
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.findByUserId({ userId });
+
+      // then
+      expect(result.length).to.equal(2);
+    });
+
+    it('should return an empty array if user has no authentication methods', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      await databaseBuilder.commit();
+
+      // when
+      const result = await authenticationMethodRepository.findByUserId({ userId });
+
+      // then
+      expect(result.length).to.equal(0);
+    });
+  });
 });

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -564,4 +564,26 @@ describe('Integration | Repository | AuthenticationMethod', () => {
     });
   });
 
+  describe('#removeByUserIdAndIdentityProvider', () => {
+
+    it('should remove the authentication method by userId and identityProvider', async () => {
+      // given
+      const userId = databaseBuilder.factory.buildUser().id;
+      const identityProvider = AuthenticationMethod.identityProviders.GAR;
+
+      databaseBuilder.factory.buildAuthenticationMethod({
+        identityProvider,
+        externalIdentifier: 'externalIdentifier',
+        userId,
+      });
+      await databaseBuilder.commit();
+
+      // when
+      await authenticationMethodRepository.removeByUserIdAndIdentityProvider({ userId, identityProvider });
+
+      // then
+      const result = await knex('authentication-methods').where({ userId, identityProvider }).first();
+      expect(result).to.be.undefined;
+    });
+  });
 });

--- a/api/tests/unit/application/users/index_test.js
+++ b/api/tests/unit/application/users/index_test.js
@@ -425,4 +425,69 @@ describe('Unit | Router | user-router', () => {
     });
   });
 
+  describe('POST /api/admin/users/{id}/remove-authentication', () => {
+
+    beforeEach(() => {
+      sinon.stub(userController, 'removeAuthenticationMethod').returns('ok');
+      sinon.stub(securityPreHandlers, 'checkUserHasRolePixMaster').callsFake((request, h) => h.response(true));
+      httpTestServer = startServer();
+    });
+
+    ['GAR', 'EMAIL', 'USERNAME', 'POLE_EMPLOI']
+      .forEach((type) => {
+        it(`should return 200 when type is ${type}`, async () => {
+          // given
+          const url = '/api/admin/users/1/remove-authentication';
+          const payload = {
+            data: {
+              attributes: {
+                type,
+              },
+            },
+          };
+
+          // when
+          const result = await httpTestServer.request('POST', url, payload);
+
+          // then
+          expect(result.statusCode).to.equal(200);
+        });
+      });
+
+    it('should return 400 when id is not a number', async () => {
+      // given
+      const url = '/api/admin/users/wrongId/remove-authentication';
+      const payload = {
+        data: {
+          attributes: {
+            type: 'EMAIL',
+          },
+        },
+      };
+
+      // when
+      const result = await httpTestServer.request('POST', url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+
+    it('should return 400 when type is not GAR or EMAIL or USERNAME or POLE_EMPLOI', async () => {
+      // given
+      const url = '/api/admin/users/1/remove-authentication';
+      const payload = {
+        data: {
+          attributes: {
+            type: 'INVALID',
+          },
+        },
+      };
+
+      // when
+      const result = await httpTestServer.request('POST', url, payload);
+
+      // then
+      expect(result.statusCode).to.equal(400);
+    });
+  });
 });

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -1,0 +1,220 @@
+const { expect, sinon, domainBuilder, catchErr } = require('../../../test-helper');
+const removeAuthenticationMethod = require('../../../../lib/domain/usecases/remove-authentication-method');
+const { UserNotAuthorizedToRemoveAuthenticationMethod } = require('../../../../lib/domain/errors');
+const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
+
+describe('Unit | UseCase | remove-authentication-method', () => {
+
+  let userRepository;
+  let authenticationMethodRepository;
+
+  beforeEach(() => {
+    userRepository = {
+      get: sinon.stub(),
+      updateEmail: sinon.stub(),
+      updateUsername: sinon.stub(),
+    };
+    authenticationMethodRepository = {
+      findByUserId: sinon.stub(),
+      removeByUserIdAndIdentityProvider: sinon.stub(),
+    };
+  });
+
+  function buildPIXAndGARAndPoleEmploiAuthenticationMethod(userId) {
+    return [
+      domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId }),
+      domainBuilder.buildAuthenticationMethod({
+        userId,
+        identityProvider: AuthenticationMethod.identityProviders.GAR,
+      }),
+      domainBuilder.buildAuthenticationMethod.buildPoleEmploiAuthenticationMethod({ userId }),
+    ];
+  }
+
+  context('When type is EMAIL', () => {
+
+    const type = 'EMAIL';
+
+    it('should set the email to null', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(userRepository.updateEmail).to.have.been.calledWith(user.id, null);
+    });
+
+    context('When user does not have a username', () => {
+
+      it('should remove PIX authentication method', async () => {
+        // given
+        const user = domainBuilder.buildUser({ username: null });
+        userRepository.get.resolves(user);
+        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.PIX,
+        });
+      });
+    });
+
+    context('When user has a username', () => {
+
+      it('should not remove PIX authentication method', async () => {
+        // given
+        const user = domainBuilder.buildUser({ username: 'john.doe0101' });
+        userRepository.get.resolves(user);
+        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
+      });
+    });
+  });
+
+  context('When type is USERNAME', () => {
+
+    const type = 'USERNAME';
+
+    it('should set the username to null', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(userRepository.updateUsername).to.have.been.calledWith({ id: user.id, username: null });
+    });
+
+    context('When user does not have an email', () => {
+
+      it('should remove PIX authentication method', async () => {
+        // given
+        const user = domainBuilder.buildUser({ email: null });
+        userRepository.get.resolves(user);
+        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+          userId: user.id,
+          identityProvider: AuthenticationMethod.identityProviders.PIX,
+        });
+      });
+    });
+
+    context('When user has an email', () => {
+
+      it('should not remove PIX authentication method', async () => {
+        // given
+        const user = domainBuilder.buildUser({ email: 'john.doe@example.net' });
+        userRepository.get.resolves(user);
+        const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+        authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+        // when
+        await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+        // then
+        expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
+      });
+    });
+  });
+
+  context('When type is GAR', () => {
+
+    const type = 'GAR';
+
+    it('should remove GAR authentication method', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        userId: user.id,
+        identityProvider: AuthenticationMethod.identityProviders.GAR,
+      });
+    });
+  });
+
+  context('When type is POLE_EMPLOI', () => {
+
+    const type = 'POLE_EMPLOI';
+
+    it('should remove POLE_EMPLOI authentication method', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethods = buildPIXAndGARAndPoleEmploiAuthenticationMethod(user.id);
+      authenticationMethodRepository.findByUserId.resolves(authenticationMethods);
+
+      // when
+      await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.have.been.calledWith({
+        userId: user.id,
+        identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI,
+      });
+    });
+  });
+
+  context('When there is only one remaining authentication method', () => {
+
+    it('should throw a UserNotAuthorizedToRemoveAuthenticationMethod', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+      authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
+
+      // when
+      const error = await catchErr(removeAuthenticationMethod)({ userId: user.id, type: 'EMAIL', userRepository, authenticationMethodRepository });
+
+      // then
+      expect(error).to.be.an.instanceOf(UserNotAuthorizedToRemoveAuthenticationMethod);
+    });
+
+    it('should not remove the authentication method', async () => {
+      // given
+      const user = domainBuilder.buildUser();
+      userRepository.get.resolves(user);
+      const authenticationMethod = domainBuilder.buildAuthenticationMethod.buildWithHashedPassword({ userId: user.id });
+      authenticationMethodRepository.findByUserId.resolves([authenticationMethod]);
+
+      // when
+      await catchErr(removeAuthenticationMethod)({ userId: user.id, type: 'EMAIL', userRepository, authenticationMethodRepository });
+
+      // then
+      expect(authenticationMethodRepository.removeByUserIdAndIdentityProvider).to.not.have.been.called;
+    });
+  });
+});

--- a/api/tests/unit/domain/usecases/remove-authentication-method_test.js
+++ b/api/tests/unit/domain/usecases/remove-authentication-method_test.js
@@ -46,7 +46,7 @@ describe('Unit | UseCase | remove-authentication-method', () => {
       await removeAuthenticationMethod({ userId: user.id, type, userRepository, authenticationMethodRepository });
 
       // then
-      expect(userRepository.updateEmail).to.have.been.calledWith(user.id, null);
+      expect(userRepository.updateEmail).to.have.been.calledWith({ id: user.id, email: null });
     });
 
     context('When user does not have a username', () => {


### PR DESCRIPTION
## :unicorn: Problème
Après avoir listé les différentes méthodes de connexion ( pr [2425](https://github.com/1024pix/pix/pull/2788) ), nous souhaitons pouvoir supprimer ces dernières.

## :robot: Solution
Pouvoir supprimer chaque méthode de connexion par un bouton "supprimer". 
Le bouton apparaît uniquement si l'utilisateur à la méthode de connexion.
<img width="302" alt="Capture d’écran 2021-04-02 à 16 43 36" src="https://user-images.githubusercontent.com/58915422/113425740-b2f8d800-93d2-11eb-8c5e-c8be80b0e254.png">


## :rainbow: Remarques
- Si une seule méthode existante, le bouton supprimer ne s'affiche pas.

## :100: Pour tester
Chercher l'utilisateur `"Blue Ivy"` :

- Supprimer la première méthode et constater le changement sur le détail de l'utilisateur ( champ supprimé ) et l’icône dans les méthodes de connexion.
