### PR TITLE
[FEATURE] Changement de wording dans la page de l'envoi des résultats d'une campagne archivée sur Mon-Pix (2429).

### DIFF
--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -892,7 +892,7 @@
                 "try-again": "Try again"
             },
             "already-shared": "Thank you, your results have been submitted!",
-            "archived": "This personalised test has been archived by the organiser.'<br>' It is no longer to possible to submit results, but they have been taken into account for your personalised test.",
+            "archived": "This personalised test has been archived by the organiser.'<br>' It is no longer possible to submit results.",
             "badges-title": "Your thematic results",
             "details": {
                 "header-skill": "Skills tested",

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -892,7 +892,7 @@
                 "try-again": "Je retente"
             },
             "already-shared": "Merci, vos résultats ont bien été envoyés !",
-            "archived": "Ce parcours a été archivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible mais ils sont bien pris en compte dans votre parcours.",
+            "archived": "Ce parcours a été archivé par l'organisateur.'<br>' L'envoi des résultats n'est plus possible.",
             "badges-title": "Vos résultats thématiques",
             "details": {
                 "header-skill": "Compétences testées",


### PR DESCRIPTION
## :unicorn: Problème
le wording à été changé pour cette page
 
## :robot: Solution
Remplacer l'ancien texte par le nouveau

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
se connectez à Pix App
- Commencez  une campagne 
- Répondez à quelques questions puis quittez la campagne sans envoyer ses résultats 
- Allez sur Pix Orga et archivée la campagne 
- Se reconnecter à nouveau sur Pix app et revenir à la même campagne pour envoyer ses résultats 
- Un message apparaîtra avec le nouvel  texte :  Ce parcours a été archivé par l'organisateur. L'envoi des résultats n'est plus possible.
