### PR TITLE
[FEATURE]  Automatisation ajustement jury (PIX-2113)

### DIFF
--- a/api/db/database-builder/factory/build-certification-challenge.js
+++ b/api/db/database-builder/factory/build-certification-challenge.js
@@ -11,6 +11,7 @@ module.exports = function buildCertificationChallenge({
   courseId,
   createdAt = new Date('2020-01-01'),
   updatedAt = new Date('2020-01-02'),
+  isNeutralized = false,
 } = {}) {
 
   courseId = _.isUndefined(courseId) ? buildCertificationCourse().id : courseId;
@@ -24,6 +25,7 @@ module.exports = function buildCertificationChallenge({
     courseId,
     createdAt,
     updatedAt,
+    isNeutralized,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-challenges',

--- a/api/db/migrations/20210316221427_add-column-isNeutralized-in-certification-challenges.js
+++ b/api/db/migrations/20210316221427_add-column-isNeutralized-in-certification-challenges.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'certification-challenges';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean('isNeutralized').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('isNeutralized');
+  });
+};

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -42,9 +42,11 @@ module.exports = {
   async neutralizeChallenge(request, h) {
     const challengeRecId = request.payload.data.attributes.challengeRecId;
     const certificationCourseId = request.payload.data.attributes.certificationCourseId;
+    const juryId = request.auth.credentials.userId;
     const event = await usecases.neutralizeChallenge({
       challengeRecId,
       certificationCourseId,
+      juryId,
     });
     await events.eventDispatcher.dispatch(event);
     return h.response().code(204);

--- a/api/lib/application/assessment-results/assessment-result-controller.js
+++ b/api/lib/application/assessment-results/assessment-result-controller.js
@@ -1,6 +1,8 @@
 const AssessmentResult = require('../../domain/models/AssessmentResult');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
 const assessmentResultService = require('../../domain/services/assessment-result-service');
+const usecases = require('../../domain/usecases');
+const events = require('../../domain/events');
 
 // TODO: Should be removed and replaced by a real serializer
 function _deserializeResultsAdd(json) {
@@ -35,5 +37,16 @@ module.exports = {
     // FIXME (re)calculate partner certifications which may be invalidated/validated
     await assessmentResultService.save({ ...assessmentResult, juryId }, competenceMarks);
     return null;
+  },
+
+  async neutralizeChallenge(request, h) {
+    const challengeRecId = request.payload.data.attributes.challengeRecId;
+    const certificationCourseId = request.payload.data.attributes.certificationCourseId;
+    const event = await usecases.neutralizeChallenge({
+      challengeRecId,
+      certificationCourseId,
+    });
+    await events.eventDispatcher.dispatch(event);
+    return h.response().code(204);
   },
 };

--- a/api/lib/application/assessment-results/index.js
+++ b/api/lib/application/assessment-results/index.js
@@ -1,5 +1,7 @@
 const AssessmentResultController = require('./assessment-result-controller');
 const securityPreHandlers = require('../security-pre-handlers');
+const identifiersType = require('../../domain/types/identifiers-type');
+const Joi = require('joi');
 
 exports.register = async function(server) {
   server.route([
@@ -12,6 +14,28 @@ exports.register = async function(server) {
           assign: 'hasRolePixMaster',
         }],
         handler: AssessmentResultController.save,
+        tags: ['api'],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/api/admin/assessment-results/neutralize-challenge',
+      config: {
+        validate: {
+          payload: Joi.object({
+            data: {
+              attributes: {
+                certificationCourseId: identifiersType.certificationCourseId,
+                challengeRecId: Joi.string().required(),
+              },
+            },
+          }),
+        },
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        handler: AssessmentResultController.neutralizeChallenge,
         tags: ['api'],
       },
     },

--- a/api/lib/application/error-manager.js
+++ b/api/lib/application/error-manager.js
@@ -76,6 +76,9 @@ function _mapToHttpError(error) {
   if (error instanceof DomainErrors.ChallengeAlreadyAnsweredError) {
     return new HttpErrors.ConflictError('This challenge has already been answered.');
   }
+  if (error instanceof DomainErrors.ChallengeToBeNeutralizedNotFoundError) {
+    return new HttpErrors.NotFoundError(error.message);
+  }
   if (error instanceof DomainErrors.NotFoundError) {
     return new HttpErrors.NotFoundError(error.message);
   }

--- a/api/lib/domain/errors.js
+++ b/api/lib/domain/errors.js
@@ -399,6 +399,12 @@ class ChallengeAlreadyAnsweredError extends DomainError {
   }
 }
 
+class ChallengeToBeNeutralizedNotFoundError extends DomainError {
+  constructor() {
+    super('La question à neutraliser n\'a pas été posée lors du test de certification');
+  }
+}
+
 class CsvParsingError extends DomainError {
   constructor(message = 'Les données n\'ont pas pu être parsées.') {
     super(message);
@@ -790,6 +796,7 @@ module.exports = {
   CertificationCourseNotPublishableError,
   CertificationCourseUpdateError,
   ChallengeAlreadyAnsweredError,
+  ChallengeToBeNeutralizedNotFoundError,
   CompetenceResetError,
   CsvImportError,
   CsvParsingError,

--- a/api/lib/domain/events/ChallengeNeutralized.js
+++ b/api/lib/domain/events/ChallengeNeutralized.js
@@ -1,6 +1,7 @@
 class ChallengeNeutralized {
-  constructor({ certificationCourseId }) {
+  constructor({ certificationCourseId, juryId }) {
     this.certificationCourseId = certificationCourseId;
+    this.juryId = juryId;
   }
 }
 

--- a/api/lib/domain/events/ChallengeNeutralized.js
+++ b/api/lib/domain/events/ChallengeNeutralized.js
@@ -1,0 +1,7 @@
+class ChallengeNeutralized {
+  constructor({ certificationCourseId }) {
+    this.certificationCourseId = certificationCourseId;
+  }
+}
+
+module.exports = ChallengeNeutralized;

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -10,7 +10,6 @@ const { checkEventType } = require('./check-event-type');
 const eventType = ChallengeNeutralized;
 
 async function handleCertificationRescoring({
-  domainTransaction,
   event,
   assessmentResultRepository,
   certificationAssessmentRepository,
@@ -22,7 +21,6 @@ async function handleCertificationRescoring({
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(event.certificationCourseId);
   await _calculateCertificationScore({
     certificationAssessment,
-    domainTransaction,
     assessmentResultRepository,
     competenceMarkRepository,
     scoringCertificationService,
@@ -33,7 +31,6 @@ async function handleCertificationRescoring({
 
 async function _calculateCertificationScore({
   certificationAssessment,
-  domainTransaction,
   assessmentResultRepository,
   competenceMarkRepository,
   scoringCertificationService,
@@ -44,7 +41,6 @@ async function _calculateCertificationScore({
     await _saveResult({
       certificationAssessmentScore,
       certificationAssessment,
-      domainTransaction,
       assessmentResultRepository,
       competenceMarkRepository,
       juryId,
@@ -65,7 +61,6 @@ async function _calculateCertificationScore({
 async function _saveResult({
   certificationAssessment,
   certificationAssessmentScore,
-  domainTransaction,
   assessmentResultRepository,
   competenceMarkRepository,
   juryId,
@@ -74,19 +69,18 @@ async function _saveResult({
     certificationAssessment,
     certificationAssessmentScore,
     assessmentResultRepository,
-    domainTransaction,
     juryId,
   });
 
   await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
     const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
-    return competenceMarkRepository.save(competenceMarkDomain, domainTransaction);
+    return competenceMarkRepository.save(competenceMarkDomain);
   });
 }
 
-function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, domainTransaction, juryId }) {
+function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, juryId }) {
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id, juryId);
-  return assessmentResultRepository.save(assessmentResult, domainTransaction);
+  return assessmentResultRepository.save(assessmentResult);
 }
 
 async function _saveResultAfterCertificationComputeError({

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -1,0 +1,101 @@
+const AssessmentResult = require('../models/AssessmentResult');
+const CertificationScoringCompleted = require('./CertificationScoringCompleted.js');
+const CompetenceMark = require('../models/CompetenceMark');
+const bluebird = require('bluebird');
+const {
+  CertificationComputeError,
+} = require('../errors');
+const ChallengeNeutralized = require('./ChallengeNeutralized');
+const { checkEventType } = require('./check-event-type');
+
+const eventType = ChallengeNeutralized;
+
+async function handleCertificationRescoring({
+  domainTransaction,
+  event,
+  assessmentResultRepository,
+  certificationAssessmentRepository,
+  competenceMarkRepository,
+  scoringCertificationService,
+}) {
+  checkEventType(event, eventType);
+
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(event.certificationCourseId);
+  await _calculateCertificationScore({
+    certificationAssessment,
+    domainTransaction,
+    assessmentResultRepository,
+    competenceMarkRepository,
+    scoringCertificationService,
+  });
+  return null;
+}
+
+async function _calculateCertificationScore({
+  certificationAssessment,
+  domainTransaction,
+  assessmentResultRepository,
+  competenceMarkRepository,
+  scoringCertificationService,
+}) {
+  try {
+    const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore(certificationAssessment);
+    await _saveResult({
+      certificationAssessmentScore,
+      certificationAssessment,
+      domainTransaction,
+      assessmentResultRepository,
+      competenceMarkRepository,
+    });
+  } catch (error) {
+    if (!(error instanceof CertificationComputeError)) {
+      throw error;
+    }
+    await _saveResultAfterCertificationComputeError({
+      certificationAssessment,
+      assessmentResultRepository,
+      certificationComputeError: error,
+    });
+  }
+}
+
+async function _saveResult({
+  certificationAssessment,
+  certificationAssessmentScore,
+  domainTransaction,
+  assessmentResultRepository,
+  competenceMarkRepository,
+}) {
+  const assessmentResult = await _createAssessmentResult({
+    certificationAssessment,
+    certificationAssessmentScore,
+    assessmentResultRepository,
+    domainTransaction,
+  });
+
+  await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
+    const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
+    return competenceMarkRepository.save(competenceMarkDomain, domainTransaction);
+  });
+}
+
+function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, domainTransaction }) {
+  const assessmentResult = AssessmentResult.buildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id);
+  // TODO : juryId
+  // TODO : emitter => Est-ce le même que "Jury Pix" ? ou un autre type "Rescoring" ?
+  return assessmentResultRepository.save(assessmentResult, domainTransaction);
+}
+
+async function _saveResultAfterCertificationComputeError({
+  certificationAssessment,
+  assessmentResultRepository,
+  certificationComputeError,
+}) {
+  const assessmentResult = AssessmentResult.buildAlgoErrorResult(certificationComputeError, certificationAssessment.id);
+  // TODO : juryID
+  // TODO : emitter => Est-ce le même que "Jury Pix" ? ou un autre type "Rescoring" ?
+  await assessmentResultRepository.save(assessmentResult);
+}
+
+handleCertificationRescoring.eventType = eventType;
+module.exports = handleCertificationRescoring;

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -8,6 +8,7 @@ const ChallengeNeutralized = require('./ChallengeNeutralized');
 const { checkEventType } = require('./check-event-type');
 
 const eventType = ChallengeNeutralized;
+const EMITTER = 'PIX-ALGO-NEUTRALIZATION'; // to be refined according to rescoring reason
 
 async function handleCertificationRescoring({
   event,
@@ -83,7 +84,8 @@ function _createAssessmentResult({ certificationAssessment, certificationAssessm
     pixScore: certificationAssessmentScore.nbPix,
     status: certificationAssessmentScore.status,
     assessmentId: certificationAssessment.id,
-    juryId
+    emitter: EMITTER,
+    juryId,
   });
   return assessmentResultRepository.save(assessmentResult);
 }
@@ -97,7 +99,8 @@ async function _saveResultAfterCertificationComputeError({
   const assessmentResult = AssessmentResult.buildAlgoErrorResult({
     error: certificationComputeError,
     assessmentId: certificationAssessment.id,
-    juryId
+    juryId,
+    emitter: EMITTER,
   });
   await assessmentResultRepository.save(assessmentResult);
 }

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -73,7 +73,7 @@ async function _saveResult({
   });
 
   await bluebird.mapSeries(certificationAssessmentScore.competenceMarks, (competenceMark) => {
-    const competenceMarkDomain = new CompetenceMark({ ...competenceMark, ...{ assessmentResultId: assessmentResult.id } });
+    const competenceMarkDomain = new CompetenceMark({ ...competenceMark, assessmentResultId: assessmentResult.id });
     return competenceMarkRepository.save(competenceMarkDomain);
   });
 }

--- a/api/lib/domain/events/handle-certification-rescoring.js
+++ b/api/lib/domain/events/handle-certification-rescoring.js
@@ -79,7 +79,12 @@ async function _saveResult({
 }
 
 function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository, juryId }) {
-  const assessmentResult = AssessmentResult.buildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id, juryId);
+  const assessmentResult = AssessmentResult.buildStandardAssessmentResult({
+    pixScore: certificationAssessmentScore.nbPix,
+    status: certificationAssessmentScore.status,
+    assessmentId: certificationAssessment.id,
+    juryId
+  });
   return assessmentResultRepository.save(assessmentResult);
 }
 
@@ -89,7 +94,11 @@ async function _saveResultAfterCertificationComputeError({
   certificationComputeError,
   juryId,
 }) {
-  const assessmentResult = AssessmentResult.buildAlgoErrorResult(certificationComputeError, certificationAssessment.id, juryId);
+  const assessmentResult = AssessmentResult.buildAlgoErrorResult({
+    error: certificationComputeError,
+    assessmentId: certificationAssessment.id,
+    juryId
+  });
   await assessmentResultRepository.save(assessmentResult);
 }
 

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -93,7 +93,11 @@ async function _saveResult({
 }
 
 function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository }) {
-  const assessmentResult = AssessmentResult.buildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id);
+  const assessmentResult = AssessmentResult.buildStandardAssessmentResult({
+    pixScore: certificationAssessmentScore.nbPix,
+    status: certificationAssessmentScore.status,
+    assessmentId: certificationAssessment.id
+  });
   return assessmentResultRepository.save(assessmentResult);
 }
 
@@ -103,7 +107,10 @@ async function _saveResultAfterCertificationComputeError({
   certificationCourseRepository,
   certificationComputeError,
 }) {
-  const assessmentResult = AssessmentResult.buildAlgoErrorResult(certificationComputeError, certificationAssessment.id);
+  const assessmentResult = AssessmentResult.buildAlgoErrorResult({
+    error: certificationComputeError,
+    assessmentId: certificationAssessment.id,
+  });
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(certificationAssessment.certificationCourseId, new Date());
 }

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -9,6 +9,7 @@ const AssessmentCompleted = require('./AssessmentCompleted');
 const { checkEventType } = require('./check-event-type');
 
 const eventType = AssessmentCompleted;
+const EMITTER = 'PIX-ALGO';
 
 async function handleCertificationScoring({
   event,
@@ -96,7 +97,8 @@ function _createAssessmentResult({ certificationAssessment, certificationAssessm
   const assessmentResult = AssessmentResult.buildStandardAssessmentResult({
     pixScore: certificationAssessmentScore.nbPix,
     status: certificationAssessmentScore.status,
-    assessmentId: certificationAssessment.id
+    assessmentId: certificationAssessment.id,
+    emitter: EMITTER,
   });
   return assessmentResultRepository.save(assessmentResult);
 }
@@ -110,6 +112,7 @@ async function _saveResultAfterCertificationComputeError({
   const assessmentResult = AssessmentResult.buildAlgoErrorResult({
     error: certificationComputeError,
     assessmentId: certificationAssessment.id,
+    emitter: EMITTER,
   });
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(certificationAssessment.certificationCourseId, new Date());

--- a/api/lib/domain/events/index.js
+++ b/api/lib/domain/events/index.js
@@ -37,6 +37,7 @@ dependencies.partnerCertificationRepository = partnerCertificationRepository;
 const handlersToBeInjected = {
   handleBadgeAcquisition: require('./handle-badge-acquisition'),
   handleCertificationScoring: require('./handle-certification-scoring'),
+  handleCertificationRescoring: require('./handle-certification-rescoring'),
   handlePartnerCertifications: require('./handle-partner-certification'),
   handlePoleEmploiParticipationFinished: require('./handle-pole-emploi-participation-finished'),
   handlePoleEmploiParticipationShared: require('./handle-pole-emploi-participation-shared'),

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -34,23 +34,25 @@ class AssessmentResult {
     this.juryId = juryId;
   }
 
-  static buildAlgoErrorResult(error, assessmentId) {
+  static buildAlgoErrorResult(error, assessmentId, juryId) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: error.message,
       pixScore: 0,
       status: 'error',
       assessmentId,
+      juryId,
     });
   }
 
-  static buildStandardAssessmentResult(pixScore, status, assessmentId) {
+  static buildStandardAssessmentResult(pixScore, status, assessmentId, juryId) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: 'Computed',
       pixScore: pixScore,
       status,
       assessmentId,
+      juryId,
     });
   }
 

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -34,9 +34,9 @@ class AssessmentResult {
     this.juryId = juryId;
   }
 
-  static buildAlgoErrorResult({ error, assessmentId, juryId }) {
+  static buildAlgoErrorResult({ error, assessmentId, juryId, emitter }) {
     return new AssessmentResult({
-      emitter: 'PIX-ALGO',
+      emitter,
       commentForJury: error.message,
       pixScore: 0,
       status: 'error',
@@ -45,9 +45,9 @@ class AssessmentResult {
     });
   }
 
-  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId  }) {
+  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId, emitter }) {
     return new AssessmentResult({
-      emitter: 'PIX-ALGO',
+      emitter,
       commentForJury: 'Computed',
       pixScore: pixScore,
       status,

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -34,7 +34,7 @@ class AssessmentResult {
     this.juryId = juryId;
   }
 
-  static buildAlgoErrorResult(error, assessmentId, juryId) {
+  static buildAlgoErrorResult({ error, assessmentId, juryId }) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: error.message,
@@ -45,7 +45,7 @@ class AssessmentResult {
     });
   }
 
-  static buildStandardAssessmentResult(pixScore, status, assessmentId, juryId) {
+  static buildStandardAssessmentResult({ pixScore, status, assessmentId, juryId  }) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: 'Computed',

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -45,6 +45,12 @@ class CertificationAssessment {
     return _.find(this.certificationChallenges, { challengeId }) || null;
   }
 
+  neutralizeChallengeByRecId(recId) {
+    const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId : recId});
+    if (challengeToBeNeutralized) { // TODO : throw if not found ?
+      challengeToBeNeutralized.neutralize();
+    }
+  }
 }
 
 CertificationAssessment.states = states;

--- a/api/lib/domain/models/CertificationAssessment.js
+++ b/api/lib/domain/models/CertificationAssessment.js
@@ -3,6 +3,7 @@ const Joi = require('joi')
 const { validateEntity } = require('../validators/entity-validator');
 const { states } = require('./Assessment');
 const _ = require('lodash');
+const { ChallengeToBeNeutralizedNotFoundError } = require('../errors');
 
 const certificationAssessmentSchema = Joi.object({
   id: Joi.number().integer().required(),
@@ -17,6 +18,7 @@ const certificationAssessmentSchema = Joi.object({
 });
 
 class CertificationAssessment {
+
   constructor({
     id,
     userId,
@@ -46,9 +48,11 @@ class CertificationAssessment {
   }
 
   neutralizeChallengeByRecId(recId) {
-    const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId : recId});
-    if (challengeToBeNeutralized) { // TODO : throw if not found ?
+    const challengeToBeNeutralized = _.find(this.certificationChallenges, { challengeId: recId });
+    if (challengeToBeNeutralized) {
       challengeToBeNeutralized.neutralize();
+    } else {
+      throw new ChallengeToBeNeutralizedNotFoundError();
     }
   }
 }

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -33,6 +33,10 @@ class CertificationChallenge {
       isNeutralized: false,
     });
   }
+
+  neutralize() {
+    this.isNeutralized = true;
+  }
 }
 
 module.exports = CertificationChallenge;

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -6,6 +6,7 @@ class CertificationChallenge {
     challengeId,
     courseId,
     competenceId,
+    isNeutralized,
   } = {}) {
     this.id = id;
     this.associatedSkillName = associatedSkillName;
@@ -13,6 +14,24 @@ class CertificationChallenge {
     this.challengeId = challengeId;
     this.competenceId = competenceId;
     this.courseId = courseId;
+    this.isNeutralized = isNeutralized;
+  }
+
+  static new({
+    associatedSkillName,
+    associatedSkillId,
+    challengeId,
+    competenceId,
+  }) {
+    return new CertificationChallenge({
+      id: undefined,
+      courseId: undefined,
+      associatedSkillName,
+      associatedSkillId,
+      challengeId,
+      competenceId,
+      isNeutralized: false,
+    });
   }
 }
 

--- a/api/lib/domain/models/CertificationChallenge.js
+++ b/api/lib/domain/models/CertificationChallenge.js
@@ -17,7 +17,7 @@ class CertificationChallenge {
     this.isNeutralized = isNeutralized;
   }
 
-  static new({
+  static create({
     associatedSkillName,
     associatedSkillId,
     challengeId,

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -10,14 +10,14 @@ class CertificationContract {
     }
   }
 
-  static assertThatCompetenceHasEnoughChallenge(challengesForCompetence, competenceIndex) {
-    if (challengesForCompetence.length < 1) {
+  static assertThatCompetenceHasAtLeastOneChallenge(challengesForCompetence, competenceIndex) {
+    if (challengesForCompetence.length === 0) {
       throw new CertificationComputeError('Pas assez de challenges posés pour la compétence ' + competenceIndex);
     }
   }
 
-  static assertThatCompetenceHasEnoughAnswers(answerForCompetence, competenceIndex) {
-    if (answerForCompetence.length < 1) {
+  static assertThatCompetenceHasAtLeastOneAnswer(answerForCompetence, competenceIndex) {
+    if (answerForCompetence.length === 0) {
       throw new CertificationComputeError('Pas assez de réponses pour la compétence ' + competenceIndex);
     }
   }

--- a/api/lib/domain/models/CertificationContract.js
+++ b/api/lib/domain/models/CertificationContract.js
@@ -11,13 +11,13 @@ class CertificationContract {
   }
 
   static assertThatCompetenceHasEnoughChallenge(challengesForCompetence, competenceIndex) {
-    if (challengesForCompetence.length < 2) {
+    if (challengesForCompetence.length < 1) {
       throw new CertificationComputeError('Pas assez de challenges posés pour la compétence ' + competenceIndex);
     }
   }
 
   static assertThatCompetenceHasEnoughAnswers(answerForCompetence, competenceIndex) {
-    if (answerForCompetence.length < 2) {
+    if (answerForCompetence.length < 1) {
       throw new CertificationComputeError('Pas assez de réponses pour la compétence ' + competenceIndex);
     }
   }

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -1,5 +1,4 @@
 const {
-  MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED,
   UNCERTIFIED_LEVEL,
 } = require('../constants');
 
@@ -31,20 +30,16 @@ class CertifiedLevel {
     estimatedLevel,
     reproducibilityRate,
   }) {
-    if (numberOfCorrectAnswers < 2) {
-      if (numberOfNeutralizedAnswers === 1) {
-        if (reproducibilityRate >= MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED) {
-          return this.validate(estimatedLevel);
-        } else if (reproducibilityRate >= 70) {
-          return this.downgrade(estimatedLevel);
-        }
-      }
-      return this.uncertify();
+    const rule = _rules.find((rule) => rule.isAppliable({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers,
+      numberOfNeutralizedAnswers,
+    }));
+    if (!rule) {
+      return CertifiedLevel.uncertify(); // TODO : throw ?
+    } else {
+      return rule.apply({ reproducibilityRate, estimatedLevel });
     }
-    if (reproducibilityRate < MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED && numberOfCorrectAnswers === 2) {
-      return this.downgrade(estimatedLevel);
-    }
-    return this.validate(estimatedLevel);
   }
 
   static _for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
@@ -139,7 +134,126 @@ class Rule {
     }
   }
 }
-
+class Rule1 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 3,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.validate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.validate,
+    });
+  }
+}
+class Rule2 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 2,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.downgrade,
+      actionWhenReproducibilityBelow70: CertifiedLevel.downgrade,
+    });
+  }
+}
+class Rule3 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 2,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.validate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.validate,
+    });
+  }
+}
+class Rule4 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 1,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule5 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 1,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.downgrade,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule6 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 1,
+      numberOfNeutralizedAnswers: 2,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.validate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.downgrade,
+    });
+  }
+}
+class Rule7 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule8 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule9 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 2,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule10 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 3,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 3,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
 class Rule11 extends Rule {
   constructor() {
     super({
@@ -250,6 +364,16 @@ class Rule19 extends Rule {
 }
 
 const _rules = [
+  new Rule1(),
+  new Rule2(),
+  new Rule3(),
+  new Rule4(),
+  new Rule5(),
+  new Rule6(),
+  new Rule7(),
+  new Rule8(),
+  new Rule9(),
+  new Rule10(),
   new Rule11(),
   new Rule12(),
   new Rule13(),

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -27,7 +27,7 @@ class CertifiedLevel {
     }
   }
 
-  static uncertify() {
+  static invalidate() {
     return new CertifiedLevel({ value: UNCERTIFIED_LEVEL, status: statuses.UNCERTIFIED });
   }
 
@@ -141,9 +141,9 @@ class Rule4 extends Rule {
       numberOfChallengesAnswered: 3,
       numberOfCorrectAnswers: 1,
       numberOfNeutralizedAnswers: 0,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -156,7 +156,7 @@ class Rule5 extends Rule {
       numberOfNeutralizedAnswers: 1,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
       actionWhenReproducibilityBetween70And80: CertifiedLevel.downgrade,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -180,9 +180,9 @@ class Rule7 extends Rule {
       numberOfChallengesAnswered: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -193,9 +193,9 @@ class Rule8 extends Rule {
       numberOfChallengesAnswered: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -206,9 +206,9 @@ class Rule9 extends Rule {
       numberOfChallengesAnswered: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 2,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -219,9 +219,9 @@ class Rule10 extends Rule {
       numberOfChallengesAnswered: 3,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 3,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -247,7 +247,7 @@ class Rule12 extends Rule {
       numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
       actionWhenReproducibilityBetween70And80: CertifiedLevel.downgrade,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -271,9 +271,9 @@ class Rule14 extends Rule {
       numberOfChallengesAnswered: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -284,9 +284,9 @@ class Rule15 extends Rule {
       numberOfChallengesAnswered: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -297,9 +297,9 @@ class Rule16 extends Rule {
       numberOfChallengesAnswered: 2,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 2,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -323,9 +323,9 @@ class Rule18 extends Rule {
       numberOfChallengesAnswered: 1,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 1,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }
@@ -336,9 +336,9 @@ class Rule19 extends Rule {
       numberOfChallengesAnswered: 1,
       numberOfCorrectAnswers: 0,
       numberOfNeutralizedAnswers: 0,
-      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
-      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.invalidate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.invalidate,
     });
   }
 }

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -11,25 +11,34 @@ class CertifiedLevel {
 
   static from({
     numberOfChallengesAnswered,
+    numberOfNeutralizedAnswers,
     numberOfCorrectAnswers,
     estimatedLevel,
     reproducibilityRate,
   }) {
     if (numberOfChallengesAnswered === 3) {
-      return CertifiedLevel._for3Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+      return CertifiedLevel._for3Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
     } else if (numberOfChallengesAnswered === 2) {
-      return CertifiedLevel._for2Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+      return CertifiedLevel._for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
     } else {
-      return CertifiedLevel._for1Challenge({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+      return CertifiedLevel._for1Challenge({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
     }
   }
 
   static _for3Challenges({
     numberOfCorrectAnswers,
+    numberOfNeutralizedAnswers,
     estimatedLevel,
     reproducibilityRate,
   }) {
     if (numberOfCorrectAnswers < 2) {
+      if (numberOfNeutralizedAnswers === 1) {
+        if (reproducibilityRate >= MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED) {
+          return this.validate(estimatedLevel);
+        } else if (reproducibilityRate >= 70) {
+          return this.downgrade(estimatedLevel);
+        }
+      }
       return this.uncertify();
     }
     if (reproducibilityRate < MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED && numberOfCorrectAnswers === 2) {
@@ -38,7 +47,7 @@ class CertifiedLevel {
     return this.validate(estimatedLevel);
   }
 
-  static _for2Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate }) {
+  static _for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
     if (numberOfCorrectAnswers === 2) {
       return this.validate(estimatedLevel);
     } else if (numberOfCorrectAnswers === 1) {
@@ -53,7 +62,7 @@ class CertifiedLevel {
     return this.uncertify();
   }
 
-  static _for1Challenge({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate }) {
+  static _for1Challenge({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
     if (numberOfCorrectAnswers === 1) {
       if (reproducibilityRate >= 70) {
         return this.validate(estimatedLevel);

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -21,7 +21,7 @@ class CertifiedLevel {
       numberOfNeutralizedAnswers,
     });
     if (!rule) {
-      return CertifiedLevel.uncertify(); // TODO : should not be possible, throw instead ?
+      throw new Error('Règle de calcul de niveau certifié manquante.');
     } else {
       return rule.apply({ reproducibilityRate, estimatedLevel });
     }
@@ -270,7 +270,7 @@ class Rule14 extends Rule {
     super({
       numberOfChallengesAnswered: 2,
       numberOfCorrectAnswers: 0,
-      numberOfNeutralizedAnswers: 1,
+      numberOfNeutralizedAnswers: 0,
       actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
       actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
       actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -75,7 +75,7 @@ class Rule {
     this.actionWhenReproducibilityBelow70 = actionWhenReproducibilityBelow70;
   }
 
-  isAppliable({
+  isApplicable({
     numberOfChallengesAnswered,
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
@@ -370,7 +370,7 @@ const _rules = {
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
   }) {
-    return this.rules.find((rule) => rule.isAppliable({
+    return this.rules.find((rule) => rule.isApplicable({
       numberOfChallengesAnswered,
       numberOfCorrectAnswers,
       numberOfNeutralizedAnswers,

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -10,6 +10,21 @@ class CertifiedLevel {
   }
 
   static from({
+    numberOfChallengesAnswered,
+    numberOfCorrectAnswers,
+    estimatedLevel,
+    reproducibilityRate,
+  }) {
+    if (numberOfChallengesAnswered === 3) {
+      return CertifiedLevel._for3Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+    } else if (numberOfChallengesAnswered === 2) {
+      return CertifiedLevel._for2Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+    } else {
+      return CertifiedLevel._for1Challenge({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate });
+    }
+  }
+
+  static _for3Challenges({
     numberOfCorrectAnswers,
     estimatedLevel,
     reproducibilityRate,
@@ -21,6 +36,32 @@ class CertifiedLevel {
       return this.downgrade(estimatedLevel);
     }
     return this.validate(estimatedLevel);
+  }
+
+  static _for2Challenges({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate }) {
+    if (numberOfCorrectAnswers === 2) {
+      return this.validate(estimatedLevel);
+    } else if (numberOfCorrectAnswers === 1) {
+      if (reproducibilityRate >= MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED) {
+        return this.validate(estimatedLevel);
+      } else if (reproducibilityRate >= 70) {
+        return this.downgrade(estimatedLevel);
+      } else {
+        return this.uncertify();
+      }
+    }
+    return this.uncertify();
+  }
+
+  static _for1Challenge({ numberOfCorrectAnswers, estimatedLevel, reproducibilityRate }) {
+    if (numberOfCorrectAnswers === 1) {
+      if (reproducibilityRate >= 70) {
+        return this.validate(estimatedLevel);
+      } else {
+        return this.downgrade(estimatedLevel);
+      }
+    }
+    return this.uncertify();
   }
 
   static uncertify() {

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -48,18 +48,16 @@ class CertifiedLevel {
   }
 
   static _for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
-    if (numberOfCorrectAnswers === 2) {
-      return this.validate(estimatedLevel);
-    } else if (numberOfCorrectAnswers === 1) {
-      if (reproducibilityRate >= MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED) {
-        return this.validate(estimatedLevel);
-      } else if (reproducibilityRate >= 70) {
-        return this.downgrade(estimatedLevel);
-      } else {
-        return this.uncertify();
-      }
+    const rule = _rules.find((rule) => rule.isAppliable({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers,
+      numberOfNeutralizedAnswers,
+    }));
+    if (!rule) {
+      return CertifiedLevel.uncertify(); // TODO : throw ?
+    } else {
+      return rule.apply({ reproducibilityRate, estimatedLevel });
     }
-    return this.uncertify();
   }
 
   static _for1Challenge({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
@@ -142,6 +140,78 @@ class Rule {
   }
 }
 
+class Rule11 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 2,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.validate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.validate,
+    });
+  }
+}
+class Rule12 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 1,
+      numberOfNeutralizedAnswers: 0,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.downgrade,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule13 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 1,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.validate,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.validate,
+      actionWhenReproducibilityBelow70: CertifiedLevel.downgrade,
+    });
+  }
+}
+class Rule14 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule15 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 1,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
+class Rule16 extends Rule {
+  constructor() {
+    super({
+      numberOfChallengesAnswered: 2,
+      numberOfCorrectAnswers: 0,
+      numberOfNeutralizedAnswers: 2,
+      actionWhenReproducibilityRateEqualOrAbove80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBetween70And80: CertifiedLevel.uncertify,
+      actionWhenReproducibilityBelow70: CertifiedLevel.uncertify,
+    });
+  }
+}
 class Rule17 extends Rule {
   constructor() {
     super({
@@ -180,6 +250,12 @@ class Rule19 extends Rule {
 }
 
 const _rules = [
+  new Rule11(),
+  new Rule12(),
+  new Rule13(),
+  new Rule14(),
+  new Rule15(),
+  new Rule16(),
   new Rule17(),
   new Rule18(),
   new Rule19(),

--- a/api/lib/domain/models/CertifiedLevel.js
+++ b/api/lib/domain/models/CertifiedLevel.js
@@ -15,54 +15,13 @@ class CertifiedLevel {
     estimatedLevel,
     reproducibilityRate,
   }) {
-    if (numberOfChallengesAnswered === 3) {
-      return CertifiedLevel._for3Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
-    } else if (numberOfChallengesAnswered === 2) {
-      return CertifiedLevel._for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
-    } else {
-      return CertifiedLevel._for1Challenge({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate });
-    }
-  }
-
-  static _for3Challenges({
-    numberOfCorrectAnswers,
-    numberOfNeutralizedAnswers,
-    estimatedLevel,
-    reproducibilityRate,
-  }) {
-    const rule = _rules.find((rule) => rule.isAppliable({
-      numberOfChallengesAnswered: 3,
+    const rule = _rules.findRuleFor({
+      numberOfChallengesAnswered,
       numberOfCorrectAnswers,
       numberOfNeutralizedAnswers,
-    }));
+    });
     if (!rule) {
-      return CertifiedLevel.uncertify(); // TODO : throw ?
-    } else {
-      return rule.apply({ reproducibilityRate, estimatedLevel });
-    }
-  }
-
-  static _for2Challenges({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
-    const rule = _rules.find((rule) => rule.isAppliable({
-      numberOfChallengesAnswered: 2,
-      numberOfCorrectAnswers,
-      numberOfNeutralizedAnswers,
-    }));
-    if (!rule) {
-      return CertifiedLevel.uncertify(); // TODO : throw ?
-    } else {
-      return rule.apply({ reproducibilityRate, estimatedLevel });
-    }
-  }
-
-  static _for1Challenge({ numberOfCorrectAnswers, numberOfNeutralizedAnswers, estimatedLevel, reproducibilityRate }) {
-    const rule = _rules.find((rule) => rule.isAppliable({
-      numberOfChallengesAnswered: 1,
-      numberOfCorrectAnswers,
-      numberOfNeutralizedAnswers,
-    }));
-    if (!rule) {
-      return CertifiedLevel.uncertify(); // TODO : throw ?
+      return CertifiedLevel.uncertify(); // TODO : should not be possible, throw instead ?
     } else {
       return rule.apply({ reproducibilityRate, estimatedLevel });
     }
@@ -115,15 +74,17 @@ class Rule {
     this.actionWhenReproducibilityBetween70And80 = actionWhenReproducibilityBetween70And80;
     this.actionWhenReproducibilityBelow70 = actionWhenReproducibilityBelow70;
   }
+
   isAppliable({
     numberOfChallengesAnswered,
     numberOfCorrectAnswers,
     numberOfNeutralizedAnswers,
   }) {
     return (numberOfChallengesAnswered === this.numberOfChallengesAnswered
-    && numberOfCorrectAnswers === this.numberOfCorrectAnswers
-    && numberOfNeutralizedAnswers === this.numberOfNeutralizedAnswers);
+      && numberOfCorrectAnswers === this.numberOfCorrectAnswers
+      && numberOfNeutralizedAnswers === this.numberOfNeutralizedAnswers);
   }
+
   apply({ reproducibilityRate, estimatedLevel }) {
     if (reproducibilityRate >= 80) {
       return this.actionWhenReproducibilityRateEqualOrAbove80(estimatedLevel);
@@ -134,6 +95,7 @@ class Rule {
     }
   }
 }
+
 class Rule1 extends Rule {
   constructor() {
     super({
@@ -146,6 +108,7 @@ class Rule1 extends Rule {
     });
   }
 }
+
 class Rule2 extends Rule {
   constructor() {
     super({
@@ -158,6 +121,7 @@ class Rule2 extends Rule {
     });
   }
 }
+
 class Rule3 extends Rule {
   constructor() {
     super({
@@ -170,6 +134,7 @@ class Rule3 extends Rule {
     });
   }
 }
+
 class Rule4 extends Rule {
   constructor() {
     super({
@@ -182,6 +147,7 @@ class Rule4 extends Rule {
     });
   }
 }
+
 class Rule5 extends Rule {
   constructor() {
     super({
@@ -194,6 +160,7 @@ class Rule5 extends Rule {
     });
   }
 }
+
 class Rule6 extends Rule {
   constructor() {
     super({
@@ -206,6 +173,7 @@ class Rule6 extends Rule {
     });
   }
 }
+
 class Rule7 extends Rule {
   constructor() {
     super({
@@ -218,6 +186,7 @@ class Rule7 extends Rule {
     });
   }
 }
+
 class Rule8 extends Rule {
   constructor() {
     super({
@@ -230,6 +199,7 @@ class Rule8 extends Rule {
     });
   }
 }
+
 class Rule9 extends Rule {
   constructor() {
     super({
@@ -242,6 +212,7 @@ class Rule9 extends Rule {
     });
   }
 }
+
 class Rule10 extends Rule {
   constructor() {
     super({
@@ -254,6 +225,7 @@ class Rule10 extends Rule {
     });
   }
 }
+
 class Rule11 extends Rule {
   constructor() {
     super({
@@ -266,6 +238,7 @@ class Rule11 extends Rule {
     });
   }
 }
+
 class Rule12 extends Rule {
   constructor() {
     super({
@@ -278,6 +251,7 @@ class Rule12 extends Rule {
     });
   }
 }
+
 class Rule13 extends Rule {
   constructor() {
     super({
@@ -290,6 +264,7 @@ class Rule13 extends Rule {
     });
   }
 }
+
 class Rule14 extends Rule {
   constructor() {
     super({
@@ -302,6 +277,7 @@ class Rule14 extends Rule {
     });
   }
 }
+
 class Rule15 extends Rule {
   constructor() {
     super({
@@ -314,6 +290,7 @@ class Rule15 extends Rule {
     });
   }
 }
+
 class Rule16 extends Rule {
   constructor() {
     super({
@@ -326,6 +303,7 @@ class Rule16 extends Rule {
     });
   }
 }
+
 class Rule17 extends Rule {
   constructor() {
     super({
@@ -338,6 +316,7 @@ class Rule17 extends Rule {
     });
   }
 }
+
 class Rule18 extends Rule {
   constructor() {
     super({
@@ -350,6 +329,7 @@ class Rule18 extends Rule {
     });
   }
 }
+
 class Rule19 extends Rule {
   constructor() {
     super({
@@ -363,24 +343,37 @@ class Rule19 extends Rule {
   }
 }
 
-const _rules = [
-  new Rule1(),
-  new Rule2(),
-  new Rule3(),
-  new Rule4(),
-  new Rule5(),
-  new Rule6(),
-  new Rule7(),
-  new Rule8(),
-  new Rule9(),
-  new Rule10(),
-  new Rule11(),
-  new Rule12(),
-  new Rule13(),
-  new Rule14(),
-  new Rule15(),
-  new Rule16(),
-  new Rule17(),
-  new Rule18(),
-  new Rule19(),
-];
+const _rules = {
+  rules: [
+    new Rule1(),
+    new Rule2(),
+    new Rule3(),
+    new Rule4(),
+    new Rule5(),
+    new Rule6(),
+    new Rule7(),
+    new Rule8(),
+    new Rule9(),
+    new Rule10(),
+    new Rule11(),
+    new Rule12(),
+    new Rule13(),
+    new Rule14(),
+    new Rule15(),
+    new Rule16(),
+    new Rule17(),
+    new Rule18(),
+    new Rule19(),
+  ],
+  findRuleFor({
+    numberOfChallengesAnswered,
+    numberOfCorrectAnswers,
+    numberOfNeutralizedAnswers,
+  }) {
+    return this.rules.find((rule) => rule.isAppliable({
+      numberOfChallengesAnswered,
+      numberOfCorrectAnswers,
+      numberOfNeutralizedAnswers,
+    }));
+  },
+};

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -42,7 +42,17 @@ module.exports = class CompetenceAnswerCollection {
   }
 
   numberOfNeutralizedChallenges() {
-    return this.answers.filter((answer) => answer.challenge.isNeutralized).length;
+    return _(this.answers).map((answer) => {
+      if (answer.challenge.isNeutralized) {
+        if (this.answers.length < 3 && answer.isQROCMdep()) {
+          return 2;
+        } else {
+          return 1;
+        }
+      } else {
+        return 0;
+      }
+    }).sum();
   }
 };
 

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -40,6 +40,10 @@ module.exports = class CompetenceAnswerCollection {
     }).sum();
     return numberOfChallenges;
   }
+
+  numberOfNeutralizedChallenges() {
+    return 0;
+  }
 };
 
 class AnswerForScoring {

--- a/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
+++ b/api/lib/domain/models/CompetenceAnswerCollectionForScoring.js
@@ -42,7 +42,7 @@ module.exports = class CompetenceAnswerCollection {
   }
 
   numberOfNeutralizedChallenges() {
-    return 0;
+    return this.answers.filter((answer) => answer.challenge.isNeutralized).length;
   }
 };
 

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -108,7 +108,7 @@ function _pickCertificationChallengeForSkill({ skill, competenceId, allChallenge
 
   if (alreadySelectedChallengeIds.includes(challenge.id)) return;
 
-  return CertificationChallenge.new({
+  return CertificationChallenge.create({
     challengeId: challenge.id,
     competenceId,
     associatedSkillName: skill.name,

--- a/api/lib/domain/services/certification-challenges-service.js
+++ b/api/lib/domain/services/certification-challenges-service.js
@@ -108,7 +108,7 @@ function _pickCertificationChallengeForSkill({ skill, competenceId, allChallenge
 
   if (alreadySelectedChallengeIds.includes(challenge.id)) return;
 
-  return new CertificationChallenge({
+  return CertificationChallenge.new({
     challengeId: challenge.id,
     competenceId,
     associatedSkillName: skill.name,

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -69,7 +69,7 @@ function _getCompetenceWithFailedLevel(listCompetences) {
       id: competence.id,
       positionedLevel: competence.estimatedLevel,
       positionedScore: competence.pixScore,
-      obtainedLevel: CertifiedLevel.uncertify().value,
+      obtainedLevel: CertifiedLevel.invalidate().value,
       obtainedScore: 0,
     };
   });

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -32,8 +32,8 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
     const answersForCompetence = _selectAnswersMatchingCertificationChallenges(answers, challengesForCompetence);
 
     if (!continueOnError) {
-      CertificationContract.assertThatCompetenceHasEnoughChallenge(challengesForCompetence, competence.index);
-      CertificationContract.assertThatCompetenceHasEnoughAnswers(answersForCompetence, competence.index);
+      CertificationContract.assertThatCompetenceHasAtLeastOneChallenge(challengesForCompetence, competence.index);
+      CertificationContract.assertThatCompetenceHasAtLeastOneAnswer(answersForCompetence, competence.index);
       CertificationContract.assertThatEveryAnswerHasMatchingChallenge(answersForCompetence, challengesForCompetence);
     }
 

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -42,6 +42,7 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
     const certifiedLevel = CertifiedLevel.from({
       numberOfChallengesAnswered: competenceAnswerCollection.numberOfChallengesAnswered(),
       numberOfCorrectAnswers: competenceAnswerCollection.numberOfCorrectAnswers(),
+      numberOfNeutralizedAnswers: competenceAnswerCollection.numberOfNeutralizedChallenges(),
       estimatedLevel: competence.estimatedLevel,
       reproducibilityRate,
     });

--- a/api/lib/domain/services/certification-result-service.js
+++ b/api/lib/domain/services/certification-result-service.js
@@ -40,6 +40,7 @@ function _getCompetencesWithCertifiedLevelAndScore(answers, listCompetences, rep
     const competenceAnswerCollection = CompetenceAnswerCollectionForScoring.from({ answersForCompetence, challengesForCompetence });
 
     const certifiedLevel = CertifiedLevel.from({
+      numberOfChallengesAnswered: competenceAnswerCollection.numberOfChallengesAnswered(),
       numberOfCorrectAnswers: competenceAnswerCollection.numberOfCorrectAnswers(),
       estimatedLevel: competence.estimatedLevel,
       reproducibilityRate,

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -266,6 +266,7 @@ module.exports = injectDependencies({
   updateOrganizationInformation: require('./update-organization-information'),
   publishSession: require('./publish-session'),
   unpublishSession: require('./unpublish-session'),
+  neutralizeChallenge: require('./neutralize-challenge'),
   publishSessionsInBatch: require('./publish-sessions-in-batch'),
   updateSchoolingRegistrationDependentUserPassword: require('./update-schooling-registration-dependent-user-password'),
   updateSession: require('./update-session'),

--- a/api/lib/domain/usecases/neutralize-challenge.js
+++ b/api/lib/domain/usecases/neutralize-challenge.js
@@ -4,9 +4,10 @@ module.exports = async function neutralizeChallenge({
   certificationAssessmentRepository,
   certificationCourseId,
   challengeRecId,
+  juryId,
 }) {
   const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
   certificationAssessment.neutralizeChallengeByRecId(challengeRecId);
   await certificationAssessmentRepository.save(certificationAssessment);
-  return new ChallengeNeutralized({ certificationCourseId });
+  return new ChallengeNeutralized({ certificationCourseId, juryId });
 };

--- a/api/lib/domain/usecases/neutralize-challenge.js
+++ b/api/lib/domain/usecases/neutralize-challenge.js
@@ -1,0 +1,12 @@
+const ChallengeNeutralized = require('../events/ChallengeNeutralized');
+
+module.exports = async function neutralizeChallenge({
+  certificationAssessmentRepository,
+  certificationCourseId,
+  challengeRecId,
+}) {
+  const certificationAssessment = await certificationAssessmentRepository.getByCertificationCourseId(certificationCourseId);
+  certificationAssessment.neutralizeChallengeByRecId(challengeRecId);
+  await certificationAssessmentRepository.save(certificationAssessment);
+  return new ChallengeNeutralized({ certificationCourseId });
+};

--- a/api/lib/infrastructure/repositories/certification-assessment-repository.js
+++ b/api/lib/infrastructure/repositories/certification-assessment-repository.js
@@ -84,4 +84,12 @@ module.exports = {
     });
   },
 
+  async save(certificationAssessment) {
+    for (const challenge of certificationAssessment.certificationChallenges) {
+      await knex('certification-challenges')
+        .where({ id: challenge.id })
+        .update(_.pick(challenge, ['isNeutralized']));
+    }
+  },
+
 };

--- a/api/scripts/generate-certification-results.js
+++ b/api/scripts/generate-certification-results.js
@@ -1,0 +1,53 @@
+const { knex } = require('../db/knex-database-connection');
+const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
+const bluebird = require('bluebird');
+const scoringCertificationService = require('../lib/domain/services/scoring/scoring-certification-service');
+const certificationAssessmentRepository = require('../lib/infrastructure/repositories/certification-assessment-repository');
+
+async function _retrieveLastScoredAssessmentIds() {
+  const result = await knex.raw(`
+    SELECT ass.id FROM "certification-courses" AS cc
+    JOIN "assessments" AS ass ON ass."certificationCourseId" = cc."id"
+    JOIN "assessment-results" AS assr ON assr."assessmentId" = ass."id"
+    WHERE cc."completedAt" IS NOT NULL
+    ORDER BY cc."updatedAt" DESC LIMIT ??;
+  `, ASSESSMENT_COUNT);
+  return result.rows.map((row) => row.id);
+}
+
+async function _computeScore(assessmentIds) {
+  const scores = await bluebird.map(assessmentIds, async (assessmentId) => {
+    try {
+      const certificationAssessment = await certificationAssessmentRepository.get(assessmentId);
+      const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore(certificationAssessment);
+      return certificationAssessmentScore;
+    } catch (err) {
+      const message = `Erreur de génération pour l'assessment : ${assessmentId}`;
+      console.error(message);
+      return { message };
+    }
+  }, { concurrency: ~~process.env.CONCURRENCY || 10 });
+  return scores;
+}
+
+async function main() {
+  try {
+    console.error(`Récupération de ${ASSESSMENT_COUNT} assessments...`);
+    const assessmentIds = await _retrieveLastScoredAssessmentIds();
+    const scores = await _computeScore(assessmentIds);
+    scores.forEach((score) => console.log(score));
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/api/scripts/generate-last-assessments-score.js
+++ b/api/scripts/generate-last-assessments-score.js
@@ -1,0 +1,68 @@
+const { knex } = require('../db/knex-database-connection');
+const _ = require('lodash');
+const ASSESSMENT_COUNT = parseInt(process.env.ASSESSMENT_COUNT) || 100;
+const ASSESSMENT_ID = parseInt(process.env.ASSESSMENT_ID) || null;
+const bluebird = require('bluebird');
+const scoringCertificationService = require('../lib/domain/services/scoring/scoring-certification-service');
+const certificationAssessmentRepository = require('../lib/infrastructure/repositories/certification-assessment-repository');
+async function _retrieveLastScoredAssessmentIds() {
+  const result = await knex.raw(`
+    SELECT ass.id FROM "certification-courses" AS cc
+    JOIN "assessments" AS ass ON ass."certificationCourseId" = cc."id"
+    JOIN "assessment-results" AS assr ON assr."assessmentId" = ass."id"
+    WHERE cc."completedAt" IS NOT NULL
+    ORDER BY cc."updatedAt" DESC LIMIT ??;
+  `, ASSESSMENT_COUNT);
+
+  const lastScoredAssessmentIds = _(result.rows).map((row) => row.id).sortBy().value();
+
+  console.log({ lastScoredAssessmentIds });
+
+  return lastScoredAssessmentIds;
+}
+
+async function _computeScore(assessmentIds) {
+  const scores = await bluebird.map(assessmentIds, async (assessmentId) => {
+    try {
+      const certificationAssessment = await certificationAssessmentRepository.get(assessmentId);
+      const certificationAssessmentScore = await scoringCertificationService.calculateCertificationAssessmentScore(certificationAssessment);
+      certificationAssessmentScore.assessmentId = assessmentId;
+
+      certificationAssessmentScore.competenceMarks.forEach((competenceMark) => {
+        competenceMark.assessmentId = assessmentId;
+      });
+
+      return certificationAssessmentScore;
+    } catch (err) {
+      const message = `Erreur de génération pour l'assessment : ${assessmentId}`;
+      console.error(message);
+      return { message };
+    }
+  }, { concurrency: ~~process.env.CONCURRENCY || 10 });
+  return scores;
+}
+async function main() {
+  try {
+    let assessmentIds = [];
+    if (ASSESSMENT_ID) {
+      assessmentIds = [ASSESSMENT_ID];
+    } else {
+      console.error(`Récupération de ${ASSESSMENT_COUNT} assessments...`);
+      assessmentIds = await _retrieveLastScoredAssessmentIds();
+    }
+    const scores = await _computeScore(assessmentIds);
+    scores.forEach((score) => console.log(score));
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+if (require.main === module) {
+  main().then(
+    () => process.exit(0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/api/tests/integration/application/error-manager_test.js
+++ b/api/tests/integration/application/error-manager_test.js
@@ -154,6 +154,14 @@ describe('Integration | API | Controller Error', () => {
       expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
       expect(responseDetail(response)).to.equal('Aucun résultat de certification pour cette classe.');
     });
+
+    it('responds Not Found when a ChallengeToBeNeutralizedNotFoundError error occurs', async () => {
+      routeHandler.throws(new DomainErrors.ChallengeToBeNeutralizedNotFoundError());
+      const response = await server.inject(options);
+
+      expect(response.statusCode).to.equal(NOT_FOUND_ERROR);
+      expect(responseDetail(response)).to.equal('La question à neutraliser n\'a pas été posée lors du test de certification');
+    });
   });
 
   context('409 Conflict', () => {

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -33,7 +33,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
         }).id;
         dbf.buildAnswer({ assessmentId: certificationAssessmentId });
         dbf.buildAnswer({ assessmentId: certificationAssessmentId });
-        dbf.buildCertificationChallenge({ courseId: expectedCertificationCourseId });
+        dbf.buildCertificationChallenge({ courseId: expectedCertificationCourseId, isNeutralized: true });
         dbf.buildCertificationChallenge({ courseId: expectedCertificationCourseId });
 
         return databaseBuilder.commit();
@@ -53,6 +53,7 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
         expect(certificationAssessment.certificationAnswersByDate).to.have.length(2);
         expect(certificationAssessment.certificationChallenges).to.have.length(2);
+        expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
       });
     });
 

--- a/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-challenge.js
@@ -8,6 +8,7 @@ module.exports = function buildCertificationChallenge({
   courseId = 456,
   associatedSkillId = buildSkill().id,
   associatedSkillName = buildSkill().name,
+  isNeutralized = false,
 } = {}) {
 
   return new CertificationChallenge({
@@ -17,5 +18,6 @@ module.exports = function buildCertificationChallenge({
     courseId,
     associatedSkillId,
     associatedSkillName,
+    isNeutralized,
   });
 };

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -114,11 +114,13 @@ describe('Unit | Controller | assessment-results', () => {
             },
           },
         },
+        auth: { credentials: { userId: 7 } },
       };
-      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1 });
+      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
       sinon.stub(usecases, 'neutralizeChallenge').withArgs({
         certificationCourseId: 1,
         challengeRecId: 'rec43mpMIR5dUzdjh',
+        juryId: 7,
       }).resolves(eventToBeDispatched);
       sinon.stub(events, 'eventDispatcher').value({
         dispatch: sinon.stub(),

--- a/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
+++ b/api/tests/unit/application/assessment-results/assessment-result-controller_test.js
@@ -5,6 +5,9 @@ const assessmentResultService = require('../../../../lib/domain/services/assessm
 
 const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
+const usecases = require('../../../../lib/domain/usecases');
+const events = require('../../../../lib/domain/events');
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
 
 describe('Unit | Controller | assessment-results', () => {
 
@@ -96,6 +99,37 @@ describe('Unit | Controller | assessment-results', () => {
       // then
       expect(response).to.be.null;
       expect(assessmentResultService.save).to.have.been.calledWithMatch(expectedAssessmentResult, [competenceMark1, competenceMark2, competenceMark3]);
+    });
+  });
+
+  describe('#neutralizeChallenge', () => {
+    it('neutralizes the challenge and dispatches the event', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+      };
+      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1 });
+      sinon.stub(usecases, 'neutralizeChallenge').withArgs({
+        certificationCourseId: 1,
+        challengeRecId: 'rec43mpMIR5dUzdjh',
+      }).resolves(eventToBeDispatched);
+      sinon.stub(events, 'eventDispatcher').value({
+        dispatch: sinon.stub(),
+      });
+
+      // when
+      const response = await assessmentResultController.neutralizeChallenge(request, hFake);
+
+      // then
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
+      expect(response.statusCode).to.equal(204);
     });
   });
 });

--- a/api/tests/unit/application/assessment-results/index_test.js
+++ b/api/tests/unit/application/assessment-results/index_test.js
@@ -1,0 +1,135 @@
+const { sinon, expect, hFake } = require('../../../test-helper');
+
+const assessmentResultController = require('../../../../lib/application/assessment-results/assessment-result-controller');
+const assessmentResultService = require('../../../../lib/domain/services/assessment-result-service');
+
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
+const usecases = require('../../../../lib/domain/usecases');
+const events = require('../../../../lib/domain/events');
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+
+describe('Unit | Controller | assessment-results', () => {
+
+  describe('#save', () => {
+
+    const request = {
+      payload: {
+        data: {
+          attributes: {
+            'assessment-id': 2,
+            'certification-id': 1,
+            level: 3,
+            'pix-score': 27,
+            status: 'validated',
+            emitter: 'Jury',
+            'comment-for-jury': 'Envie de faire un nettoyage de printemps dans les notes',
+            'comment-for-candidate': 'Tada',
+            'comment-for-organization': 'Je suis sûr que vous etes ok avec nous',
+            'competences-with-mark': [
+              {
+                level: 2,
+                score: 18,
+                'area_code': 2,
+                'competence_code': 2.1,
+              }, {
+                level: 3,
+                score: 27,
+                'area_code': 3,
+                'competence_code': 3.2,
+              }, {
+                level: 1,
+                score: 9,
+                'area_code': 1,
+                'competence_code': 1.3,
+              },
+            ],
+          },
+          type: 'assessment-results',
+        },
+      },
+      auth: {
+        credentials: {
+          userId: 1,
+        },
+      },
+    };
+
+    beforeEach(() => {
+
+      sinon.stub(assessmentResultService, 'save').resolves();
+    });
+
+    it('should return a Assessment Result and an Array of Competence Marks', async () => {
+      // given
+      const expectedAssessmentResult = new AssessmentResult({
+        assessmentId: 2,
+        level: 3,
+        pixScore: 27,
+        status: 'validated',
+        emitter: 'Jury',
+        commentForJury: 'Envie de faire un nettoyage de printemps dans les notes',
+        commentForCandidate: 'Tada',
+        commentForOrganization: 'Je suis sûr que vous etes ok avec nous',
+        juryId: 1,
+      });
+
+      const competenceMark1 = new CompetenceMark({
+        level: 2,
+        score: 18,
+        area_code: 2,
+        competence_code: 2.1,
+      });
+      const competenceMark2 = new CompetenceMark({
+        level: 3,
+        score: 27,
+        area_code: 3,
+        competence_code: 3.2,
+      });
+      const competenceMark3 = new CompetenceMark({
+        level: 1,
+        score: 9,
+        area_code: 1,
+        competence_code: 1.3,
+      });
+
+      // when
+      const response = await assessmentResultController.save(request, hFake);
+
+      // then
+      expect(response).to.be.null;
+      expect(assessmentResultService.save).to.have.been.calledWithMatch(expectedAssessmentResult, [competenceMark1, competenceMark2, competenceMark3]);
+    });
+  });
+
+  describe('#neutralizeChallenge', () => {
+    it('neutralizes the challenge and dispatches the event', async () => {
+      // given
+      const request = {
+        payload: {
+          data: {
+            attributes: {
+              certificationCourseId: 1,
+              challengeRecId: 'rec43mpMIR5dUzdjh',
+            },
+          },
+        },
+      };
+      const eventToBeDispatched = new ChallengeNeutralized({ certificationCourseId: 1 });
+      sinon.stub(usecases, 'neutralizeChallenge').withArgs({
+        certificationCourseId: 1,
+        challengeRecId: 'rec43mpMIR5dUzdjh',
+      }).resolves(eventToBeDispatched);
+      sinon.stub(events, 'eventDispatcher').value({
+        dispatch: sinon.stub(),
+      });
+
+      // when
+      const response = await assessmentResultController.neutralizeChallenge(request, hFake);
+
+      // then
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWithExactly(eventToBeDispatched);
+      expect(response.statusCode).to.equal(204);
+    });
+  });
+});

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -1,0 +1,146 @@
+const _ = require('lodash');
+const { expect, sinon, domainBuilder } = require('../../../test-helper');
+const { handleCertificationRescoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
+const AssessmentResult = require('../../../../lib/domain/models/AssessmentResult');
+const { CertificationComputeError } = require('../../../../lib/domain/errors');
+
+describe('Unit | Domain | Events | handle-certification-rescoring', () => {
+
+  it('computes and persists the assessment result and competence marks when computation succeeds', async () => {
+    // given
+    const assessmentResultRepository = { save: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+    const competenceMarkRepository = { save: sinon.stub() };
+    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+
+    const event = new ChallengeNeutralized({ certificationCourseId: 1 });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: 1,
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs(1).resolves(certificationAssessment);
+
+    const competenceMarkData2 = domainBuilder.buildCompetenceMark();
+    const competenceMarkData1 = domainBuilder.buildCompetenceMark();
+    const nbPix = Symbol('nbPix');
+    const status = Symbol('status');
+    const certificationAssessmentScore = {
+      nbPix,
+      status,
+      competenceMarks: [competenceMarkData1, competenceMarkData2],
+      percentageCorrectAnswers: 80,
+    };
+    scoringCertificationService.calculateCertificationAssessmentScore.withArgs(certificationAssessment)
+      .resolves(certificationAssessmentScore);
+
+    const assessmentResultToBeSaved = new AssessmentResult({
+      id: undefined,
+      commentForJury: 'Computed',
+      emitter: 'PIX-ALGO',
+      pixScore: nbPix,
+      status: status,
+      assessmentId: 123,
+    });
+    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+    assessmentResultRepository.save
+      .withArgs(assessmentResultToBeSaved)
+      .resolves(savedAssessmentResult);
+
+    const domainTransaction = Symbol('domain transaction');
+
+    const dependendencies = {
+      assessmentResultRepository,
+      certificationAssessmentRepository,
+      competenceMarkRepository,
+      scoringCertificationService,
+    };
+
+    // when
+    await handleCertificationRescoring(
+      {
+        ...dependendencies,
+        event,
+        domainTransaction,
+      });
+
+    // then
+    expect(assessmentResultRepository.save).to.have.been.calledWith(assessmentResultToBeSaved);
+    competenceMarkData1.assessmentResultId = savedAssessmentResult.id;
+    competenceMarkData2.assessmentResultId = savedAssessmentResult.id;
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData1, domainTransaction);
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData2, domainTransaction);
+  });
+
+  it('computes and persists the assessment result in error when computation fails', async () => {
+    // given
+    const assessmentResultRepository = { save: sinon.stub() };
+    const certificationAssessmentRepository = { getByCertificationCourseId: sinon.stub() };
+    const competenceMarkRepository = { save: sinon.stub() };
+    const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
+
+    const event = new ChallengeNeutralized({ certificationCourseId: 1 });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: 1,
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId.withArgs(1).resolves(certificationAssessment);
+
+    scoringCertificationService.calculateCertificationAssessmentScore.withArgs(certificationAssessment)
+      .rejects(new CertificationComputeError('Oopsie'));
+
+    const assessmentResultToBeSaved = new AssessmentResult({
+      id: undefined,
+      emitter: 'PIX-ALGO',
+      commentForJury: 'Oopsie',
+      pixScore: 0,
+      status: 'error',
+      assessmentId: 123,
+    });
+    const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
+    assessmentResultRepository.save
+      .withArgs(assessmentResultToBeSaved)
+      .resolves(savedAssessmentResult);
+
+    const domainTransaction = Symbol('domain transaction');
+
+    const dependendencies = {
+      assessmentResultRepository,
+      certificationAssessmentRepository,
+      competenceMarkRepository,
+      scoringCertificationService,
+    };
+
+    // when
+    await handleCertificationRescoring(
+      {
+        ...dependendencies,
+        event,
+        domainTransaction,
+      });
+
+    // then
+    expect(assessmentResultRepository.save).to.have.been.calledWith(assessmentResultToBeSaved);
+  });
+});

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -47,7 +47,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
     const assessmentResultToBeSaved = new AssessmentResult({
       id: undefined,
       commentForJury: 'Computed',
-      emitter: 'PIX-ALGO',
+      emitter: 'PIX-ALGO-NEUTRALIZATION',
       pixScore: nbPix,
       status: status,
       assessmentId: 123,
@@ -109,7 +109,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
 
     const assessmentResultToBeSaved = new AssessmentResult({
       id: undefined,
-      emitter: 'PIX-ALGO',
+      emitter: 'PIX-ALGO-NEUTRALIZATION',
       commentForJury: 'Oopsie',
       pixScore: 0,
       status: 'error',

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -58,8 +58,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       .withArgs(assessmentResultToBeSaved)
       .resolves(savedAssessmentResult);
 
-    const domainTransaction = Symbol('domain transaction');
-
     const dependendencies = {
       assessmentResultRepository,
       certificationAssessmentRepository,
@@ -72,15 +70,14 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       {
         ...dependendencies,
         event,
-        domainTransaction,
       });
 
     // then
     expect(assessmentResultRepository.save).to.have.been.calledWith(assessmentResultToBeSaved);
     competenceMarkData1.assessmentResultId = savedAssessmentResult.id;
     competenceMarkData2.assessmentResultId = savedAssessmentResult.id;
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData1, domainTransaction);
-    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData2, domainTransaction);
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData1);
+    expect(competenceMarkRepository.save).to.have.been.calledWithExactly(competenceMarkData2);
   });
 
   it('computes and persists the assessment result in error when computation fails', async () => {
@@ -124,8 +121,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       .withArgs(assessmentResultToBeSaved)
       .resolves(savedAssessmentResult);
 
-    const domainTransaction = Symbol('domain transaction');
-
     const dependendencies = {
       assessmentResultRepository,
       certificationAssessmentRepository,
@@ -138,7 +133,6 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       {
         ...dependendencies,
         event,
-        domainTransaction,
       });
 
     // then

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -15,7 +15,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1 });
+    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -52,6 +52,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       pixScore: nbPix,
       status: status,
       assessmentId: 123,
+      juryId: 7,
     });
     const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
     assessmentResultRepository.save
@@ -90,7 +91,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
     const competenceMarkRepository = { save: sinon.stub() };
     const scoringCertificationService = { calculateCertificationAssessmentScore: sinon.stub() };
 
-    const event = new ChallengeNeutralized({ certificationCourseId: 1 });
+    const event = new ChallengeNeutralized({ certificationCourseId: 1, juryId: 7 });
     const certificationAssessment = new CertificationAssessment({
       id: 123,
       userId: 123,
@@ -117,6 +118,7 @@ describe('Unit | Domain | Events | handle-certification-rescoring', () => {
       pixScore: 0,
       status: 'error',
       assessmentId: 123,
+      juryId: 7,
     });
     const savedAssessmentResult = new AssessmentResult({ ...assessmentResultToBeSaved, id: 4 });
     assessmentResultRepository.save

--- a/api/tests/unit/domain/events/handle-certification-rescoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-rescoring_test.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { expect, sinon, domainBuilder } = require('../../../test-helper');
 const { handleCertificationRescoring } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -117,9 +117,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         });
 
         // then
-        expect(AssessmentResult.buildAlgoErrorResult).to.have.been.calledWithExactly(
-          { error: computeError, assessmentId: certificationAssessment.id }
-        );
+        expect(AssessmentResult.buildAlgoErrorResult).to.have.been.calledWithExactly({
+          error: computeError,
+          assessmentId: certificationAssessment.id,
+          emitter: 'PIX-ALGO',
+        });
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
           errorAssessmentResult,
         );
@@ -163,6 +165,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           pixScore: certificationAssessmentScore.nbPix,
           status: certificationAssessmentScore.status,
           assessmentId: certificationAssessment.id,
+          emitter: 'PIX-ALGO',
         });
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
         expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -118,7 +118,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
         // then
         expect(AssessmentResult.buildAlgoErrorResult).to.have.been.calledWithExactly(
-          computeError, certificationAssessment.id,
+          { error: computeError, assessmentId: certificationAssessment.id }
         );
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
           errorAssessmentResult,
@@ -159,11 +159,11 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         });
 
         // then
-        expect(AssessmentResult.buildStandardAssessmentResult).to.have.been.calledWithExactly(
-          certificationAssessmentScore.nbPix,
-          certificationAssessmentScore.status,
-          certificationAssessment.id,
-        );
+        expect(AssessmentResult.buildStandardAssessmentResult).to.have.been.calledWithExactly({
+          pixScore: certificationAssessmentScore.nbPix,
+          status: certificationAssessmentScore.status,
+          assessmentId: certificationAssessment.id,
+        });
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
         expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
           certificationAssessment.certificationCourseId, now,

--- a/api/tests/unit/domain/models/CertificationAssessment_test.js
+++ b/api/tests/unit/domain/models/CertificationAssessment_test.js
@@ -128,6 +128,39 @@ describe('Unit | Domain | Models | CertificationAssessment', () => {
 
       // then
       expect(certificationChallenge).to.be.null;
+
+    });
+  });
+
+  describe('#neutralizeChallengeByRecId', () => {
+
+    it('neutralizes the challenge when the challenge was asked', () => {
+      // given
+      const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+
+      const certificationAssessment = new CertificationAssessment({
+        id: 123,
+        userId: 123,
+        certificationCourseId: 123,
+        createdAt: new Date('2020-01-01'),
+        completedAt: new Date('2020-01-01'),
+        state: CertificationAssessment.states.STARTED,
+        isV2Certification: true,
+        certificationChallenges: [
+          challengeToBeNeutralized,
+          domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+          domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        ],
+        certificationAnswersByDate: ['answer'],
+      });
+
+      // when
+      certificationAssessment.neutralizeChallengeByRecId(challengeToBeNeutralized.challengeId);
+
+      // then
+      expect(certificationAssessment.certificationChallenges[0].isNeutralized).to.be.true;
+      expect(certificationAssessment.certificationChallenges[1].isNeutralized).to.be.false;
+      expect(certificationAssessment.certificationChallenges[2].isNeutralized).to.be.false;
     });
   });
 });

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -11,7 +11,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
   context('when 3 challenges were answered', () => {
 
     // TODO : Check for missing rules
-    context('when 3 answers are correct', () => {
+    context('rule n°1: 3 answers are correct', () => {
 
       it('certifies the estimated level', () => {
         // when
@@ -29,7 +29,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('when only 2 answers are correct', () => {
+    context('rule n°2 : only 2 answers are correct', () => {
 
       it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
@@ -59,7 +59,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('when less than 2 answers are correct', () => {
+    context('rules n°4 and n°7: less than 2 answers are correct', () => {
 
       it('does not certify a level', () => {
         // when
@@ -79,26 +79,27 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when only 2 challenges were asked', () => {
 
-    context('when 2 answers are correct', () => {
+    context('rule n°11: 2 answers are correct', () => {
 
-      it('downgrades and certifies the level below the estimated level', () => {
+      it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
           reproducibilityRate: 0, // unimportant
         });
 
         // then
-        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.value).to.equal(3);
         expect(certifiedLevel.isUncertified()).to.be.false;
-        expect(certifiedLevel.isDowngraded()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
       });
     });
 
-    context('when only 1 answer is correct and the other one is KO', () => {
+    context('rule n°12: only 1 answer is correct and the other one is KO', () => {
 
-      it('does not certify any level', () => {
+      it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 2,
@@ -108,7 +109,37 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         });
 
         // then
-        expect(certifiedLevel.value).to.equal(-1);
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+
+      it(`certifies a level below the estimated level when reproducibility rate >= 70% and < ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 70,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.true;
+      });
+
+      it('does not certify a level when reproducibility rate < 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 69,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
         expect(certifiedLevel.isUncertified()).to.be.true;
         expect(certifiedLevel.isDowngraded()).to.be.false;
       });
@@ -117,19 +148,56 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when only 1 challenge was asked', () => {
 
-    it('does not certify any level', () => {
-      // when
-      const certifiedLevel = CertifiedLevel.from({
-        numberOfChallengesAnswered: 1,
-        numberOfCorrectAnswers: 1,
-        estimatedLevel: 3,
-        reproducibilityRate: 70,
+    context('rule n°17: and the answer is correct', () => {
+
+      it('certifies the estimated level when reproducibility rate >= 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 1,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 70,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
       });
 
-      // then
-      expect(certifiedLevel.value).to.equal(-1);
-      expect(certifiedLevel.isUncertified()).to.be.true;
-      expect(certifiedLevel.isDowngraded()).to.be.false;
+      it('certifies a level below the estimated level when reproducibility rate < 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 1,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 69,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.true;
+      });
+    });
+
+    context('and the answer is incorrect', () => {
+
+      it('does not certify any level', () => {
+        // TODO : differentiate between uncertified and not-certifiable
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 1,
+          numberOfCorrectAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 69, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
     });
   });
 });

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -501,4 +501,17 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
   });
+
+  context('when no rule is applicable', () => {
+    it('throws', () => {
+      // when
+      expect(() => CertifiedLevel.from({
+        numberOfChallengesAnswered: 1000,
+        numberOfNeutralizedAnswers: 1000,
+        numberOfCorrectAnswers: 1000,
+        estimatedLevel: 0, // unimportant
+        reproducibilityRate: 0, // unimportant
+      })).to.throw();
+    });
+  });
 });

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -202,6 +202,99 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         expect(certifiedLevel.isDowngraded()).to.be.false;
       });
     });
+
+    context('rule n°13: 1 OK, 1 NEUTRALIZED', () => {
+
+      it('certifies the estimated level when reproducibility rate >= 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 1,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 70,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+
+      it('certifies a level below the estimated level when reproducibility rate < 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 1,
+          numberOfCorrectAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 69,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.true;
+      });
+    });
+
+    context('rule n°14: 2 KO', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 0,
+          numberOfCorrectAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°15: 1 KO, 1 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 1,
+          numberOfCorrectAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°16: 2 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 2,
+          numberOfCorrectAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
   });
 
   context('when only 1 challenge was asked', () => {

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -11,13 +11,14 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
   context('when 3 challenges were answered', () => {
 
     // TODO : Check for missing rules
-    context('rule n°1: 3 answers are correct', () => {
+    context('rule n°1: 3 OK', () => {
 
       it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 3,
           numberOfCorrectAnswers: 3,
+          numberOfNeutralizedAnswers: 0,
           estimatedLevel: 3,
           reproducibilityRate: 0, // unimportant
         });
@@ -29,12 +30,13 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('rule n°2 : only 2 answers are correct', () => {
+    context('rule n°2 : 2 OK, 1 KO', () => {
 
       it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 3,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
           reproducibilityRate: MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED,
@@ -48,6 +50,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 3,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
           reproducibilityRate: MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED - 1,
@@ -59,15 +62,66 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('rules n°4 and n°7: less than 2 answers are correct', () => {
+    context('rules n°4 : 1 OK, 2 KO', () => {
 
       it('does not certify a level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 3,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+      });
+    });
+
+    context('rules n°5: 1 OK, 1 KO, 1 NEUTRALIZED', () => {
+
+      it(`certifies the estimated level is reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}`, () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 1,
+          numberOfNeutralizedAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+
+      it(`certifies a level below the estimated on if reproducibility rate >= 70% and < ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}`, () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 1,
+          numberOfNeutralizedAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 70,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.true;
+      });
+
+      it('does not certify a level if reproducibility level < 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 1,
+          numberOfNeutralizedAnswers: 1,
+          estimatedLevel: 3,
+          reproducibilityRate: 69,
         });
 
         // then
@@ -79,12 +133,13 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when only 2 challenges were asked', () => {
 
-    context('rule n°11: 2 answers are correct', () => {
+    context('rule n°11: 2 OK', () => {
 
       it('certifies the estimated level', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 2,
           estimatedLevel: 3,
           reproducibilityRate: 0, // unimportant
@@ -97,12 +152,13 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('rule n°12: only 1 answer is correct and the other one is KO', () => {
+    context('rule n°12: 1 OK, 1 KO', () => {
 
       it(`certifies the estimated level when reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}%`, () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED,
@@ -118,6 +174,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: 70,
@@ -133,6 +190,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 2,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: 69,
@@ -148,12 +206,13 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when only 1 challenge was asked', () => {
 
-    context('rule n°17: and the answer is correct', () => {
+    context('rule n°17: 1 OK', () => {
 
       it('certifies the estimated level when reproducibility rate >= 70%', () => {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 1,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: 70,
@@ -169,6 +228,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 1,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 1,
           estimatedLevel: 3,
           reproducibilityRate: 69,
@@ -181,13 +241,13 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('and the answer is incorrect', () => {
+    context('rule n°18: 1 KO', () => {
 
       it('does not certify any level', () => {
-        // TODO : differentiate between uncertified and not-certifiable
         // when
         const certifiedLevel = CertifiedLevel.from({
           numberOfChallengesAnswered: 1,
+          numberOfNeutralizedAnswers: 0,
           numberOfCorrectAnswers: 0,
           estimatedLevel: 3, // unimportant
           reproducibilityRate: 69, // unimportant

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -10,7 +10,6 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
 
   context('when 3 challenges were answered', () => {
 
-    // TODO : Check for missing rules
     context('rule n°1: 3 OK', () => {
 
       it('certifies the estimated level', () => {
@@ -62,7 +61,26 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('rules n°4 : 1 OK, 2 KO', () => {
+    context('rules n°3 : 2 OK, 1 NEUTRALIZED', () => {
+
+      it('certifies the estimated level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfNeutralizedAnswers: 1,
+          numberOfCorrectAnswers: 2,
+          estimatedLevel: 3,
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°4 : 1 OK, 2 KO', () => {
 
       it('does not certify a level', () => {
         // when
@@ -80,7 +98,7 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
       });
     });
 
-    context('rules n°5: 1 OK, 1 KO, 1 NEUTRALIZED', () => {
+    context('rule n°5: 1 OK, 1 KO, 1 NEUTRALIZED', () => {
 
       it(`certifies the estimated level is reproducibility rate >= ${MINIMUM_REPRODUCIBILITY_RATE_TO_BE_TRUSTED}`, () => {
         // when
@@ -127,6 +145,117 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         // then
         expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
         expect(certifiedLevel.isUncertified()).to.be.true;
+      });
+    });
+
+    context('rule n°6: 1 OK, 2 NEUTRALIZED', () => {
+
+      it('certifies the estimated level if reproducibility rate is >= 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 1,
+          numberOfNeutralizedAnswers: 2,
+          estimatedLevel: 3,
+          reproducibilityRate: 70,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(3);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+
+      it('certifies a level below the estimated on if reproducibility rate < 70%', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 1,
+          numberOfNeutralizedAnswers: 2,
+          estimatedLevel: 3,
+          reproducibilityRate: 69,
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(2);
+        expect(certifiedLevel.isUncertified()).to.be.false;
+        expect(certifiedLevel.isDowngraded()).to.be.true;
+      });
+    });
+
+    context('rule n°7: 3 KO', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 0,
+          numberOfNeutralizedAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°8: 2 KO, 1 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 0,
+          numberOfNeutralizedAnswers: 1,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°9: 1 KO, 2 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 0,
+          numberOfNeutralizedAnswers: 2,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
+
+    context('rule n°10: 3 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 3,
+          numberOfCorrectAnswers: 0,
+          numberOfNeutralizedAnswers: 3,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 100, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
       });
     });
   });

--- a/api/tests/unit/domain/models/CertifiedLevel_test.js
+++ b/api/tests/unit/domain/models/CertifiedLevel_test.js
@@ -259,5 +259,24 @@ describe('Unit | Domain | Models | CertifiedLevel', function() {
         expect(certifiedLevel.isDowngraded()).to.be.false;
       });
     });
+
+    context('rule n°19: 1 NEUTRALIZED', () => {
+
+      it('does not certify any level', () => {
+        // when
+        const certifiedLevel = CertifiedLevel.from({
+          numberOfChallengesAnswered: 1,
+          numberOfNeutralizedAnswers: 1,
+          numberOfCorrectAnswers: 0,
+          estimatedLevel: 3, // unimportant
+          reproducibilityRate: 69, // unimportant
+        });
+
+        // then
+        expect(certifiedLevel.value).to.equal(UNCERTIFIED_LEVEL);
+        expect(certifiedLevel.isUncertified()).to.be.true;
+        expect(certifiedLevel.isDowngraded()).to.be.false;
+      });
+    });
   });
 });

--- a/api/tests/unit/domain/models/CertifiedScore_test.js
+++ b/api/tests/unit/domain/models/CertifiedScore_test.js
@@ -32,7 +32,7 @@ describe('Unit | Domain | Models | CertifiedScore', function() {
   it('is equal to 0 if the estimated level is uncertified', () => {
     // when
     const certifiedScore = CertifiedScore.from({
-      certifiedLevel: CertifiedLevel.uncertify(),
+      certifiedLevel: CertifiedLevel.invalidate(),
       estimatedScore: 10,
     });
 

--- a/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
@@ -180,6 +180,44 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       // then
       expect(numberOfNeutralizeChallenges).to.equal(3);
     });
+    it('counts a neutralized QROCMDep challenge as two neutralized challenges when less than 3 challenges', () => {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'rec1234', type: 'QCM', isNeutralized: true });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'rec456', type: 'QROCM-dep', isNeutralized: true });
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: [answer1, answer2],
+        challengesForCompetence: [challenge1, challenge2],
+      });
+
+      // when
+      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+
+      // then
+      expect(numberOfNeutralizeChallenges).to.equal(3);
+    });
+
+    it('counts a neutralized QROCMDep challenge as a single neutralized challenge when 3 challenges', () => {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'rec1234', type: 'QCM', isNeutralized: true });
+      const challenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'rec456', type: 'QROCM-dep', isNeutralized: true });
+      const challenge3 = _buildDecoratedCertificationChallenge({ challengeId: 'rec789', type: 'QCM', isNeutralized: true });
+
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
+      const answer3 = domainBuilder.buildAnswer({ challengeId: challenge3.challengeId });
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: [answer1, answer2, answer3],
+        challengesForCompetence: [challenge1, challenge2, challenge3],
+      });
+
+      // when
+      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+
+      // then
+      expect(numberOfNeutralizeChallenges).to.equal(3);
+    });
   });
 });
 

--- a/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
@@ -147,6 +147,21 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       expect(numberOfChallengesAnswered).to.equal(3);
     });
   });
+  context('#numberOfNeutralizedChallenges', () => {
+    it('equals 0 when no answers', () => {
+      // given
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: [],
+        challengesForCompetence: [],
+      });
+
+      // when
+      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+
+      // then
+      expect(numberOfNeutralizeChallenges).to.equal(0);
+    });
+  });
 });
 
 function _buildDecoratedCertificationChallenge({ challengeId, type }) {

--- a/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
@@ -3,7 +3,7 @@ const CompetenceAnswerCollectionForScoring = require('../../../../lib/domain/mod
 const AnswerStatus = require('../../../../lib/domain/models/AnswerStatus');
 
 describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', function() {
-  context('#numberOfAnsweredChallenges', () => {
+  context('#numberOfChallengesAnswered', () => {
     it('equals 0 when no answers', () => {
       // given
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
@@ -38,7 +38,7 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       expect(numberOfChallengesAnswered).to.equal(3);
     });
 
-    it('counts QROCMDeps as double ', () => {
+    it('counts QROCMDeps as double if only two answers or less', () => {
       // given
       const challenge1 = _buildDecoratedCertificationChallenge({ challengeId: 'chal1', type: 'QCM' });
       const qROCMDepChallenge2 = _buildDecoratedCertificationChallenge({ challengeId: 'chal2', type: 'QROCM-dep' });
@@ -47,6 +47,26 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
         answersForCompetence: [answer1, qROCMDepAnswer2 ],
         challengesForCompetence: [challenge1, qROCMDepChallenge2 ],
+      });
+
+      // when
+      const numberOfChallengesAnswered = answerCollection.numberOfChallengesAnswered();
+
+      // then
+      expect(numberOfChallengesAnswered).to.equal(3);
+    });
+
+    it('counts QROCMDeps as single if more than two answers', () => {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ type: 'QCM' });
+      const challenge2 = _buildDecoratedCertificationChallenge({ type: 'QCM' });
+      const qROCMDepChallenge3 = _buildDecoratedCertificationChallenge({ type: 'QROCM-dep' });
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
+      const qROCMDepAnswer3 = domainBuilder.buildAnswer({ challengeId: qROCMDepChallenge3.challengeId });
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: [answer1, answer2, qROCMDepAnswer3 ],
+        challengesForCompetence: [challenge1, challenge2, qROCMDepChallenge3 ],
       });
 
       // when

--- a/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
+++ b/api/tests/unit/domain/models/CompetenceAnswerCollectionForScoring_test.js
@@ -148,7 +148,7 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
     });
   });
   context('#numberOfNeutralizedChallenges', () => {
-    it('equals 0 when no answers', () => {
+    it('equals 0 when there are no answers', () => {
       // given
       const answerCollection = CompetenceAnswerCollectionForScoring.from({
         answersForCompetence: [],
@@ -161,11 +161,30 @@ describe('Unit | Domain | Models | CompetenceAnswerCollectionForScoring', functi
       // then
       expect(numberOfNeutralizeChallenges).to.equal(0);
     });
+    it('equals the number of challenges when there are all neutralized and none of them are QROCMDep', () => {
+      // given
+      const challenge1 = _buildDecoratedCertificationChallenge({ type: 'QCM', isNeutralized: true });
+      const challenge2 = _buildDecoratedCertificationChallenge({ type: 'QCM', isNeutralized: true });
+      const challenge3 = _buildDecoratedCertificationChallenge({ type: 'QCM', isNeutralized: true });
+      const answer1 = domainBuilder.buildAnswer({ challengeId: challenge1.challengeId });
+      const answer2 = domainBuilder.buildAnswer({ challengeId: challenge2.challengeId });
+      const answer3 = domainBuilder.buildAnswer({ challengeId: challenge3.challengeId });
+      const answerCollection = CompetenceAnswerCollectionForScoring.from({
+        answersForCompetence: [answer1, answer2, answer3],
+        challengesForCompetence: [challenge1, challenge2, challenge3],
+      });
+
+      // when
+      const numberOfNeutralizeChallenges = answerCollection.numberOfNeutralizedChallenges();
+
+      // then
+      expect(numberOfNeutralizeChallenges).to.equal(3);
+    });
   });
 });
 
-function _buildDecoratedCertificationChallenge({ challengeId, type }) {
-  const challenge = domainBuilder.buildCertificationChallenge({ challengeId });
+function _buildDecoratedCertificationChallenge({ challengeId, type, isNeutralized }) {
+  const challenge = domainBuilder.buildCertificationChallenge({ challengeId, isNeutralized });
   challenge.type = type; // TODO : CertificationChallenge are decorated with type in certification-result-service, find a better way.
   return challenge;
 }

--- a/api/tests/unit/domain/services/certification-challenges-service_test.js
+++ b/api/tests/unit/domain/services/certification-challenges-service_test.js
@@ -50,6 +50,7 @@ describe('Unit | Service | Certification Challenge Service', () => {
       associatedSkillName: skill.name,
       associatedSkillId: skill.id,
       competenceId: skill.competenceId,
+      isNeutralized: false,
     });
   }
 

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -44,6 +44,7 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       ...dependencies,
       certificationCourseId,
       challengeRecId: challengeToBeNeutralized.challengeId,
+      juryId: 7,
     });
 
     // then
@@ -91,10 +92,11 @@ describe('Unit | UseCase | neutralize-challenge', () => {
       ...dependencies,
       certificationCourseId,
       challengeRecId: challengeToBeNeutralized.challengeId,
+      juryId: 7,
     });
 
     // then
     expect(event).to.be.an.instanceof(ChallengeNeutralized);
-    expect(event).to.deep.equal({ certificationCourseId });
+    expect(event).to.deep.equal({ certificationCourseId, juryId: 7 });
   });
 });

--- a/api/tests/unit/domain/usecases/neutralize-challenge_test.js
+++ b/api/tests/unit/domain/usecases/neutralize-challenge_test.js
@@ -1,0 +1,100 @@
+const {
+  sinon,
+  expect,
+  domainBuilder,
+} = require('../../../test-helper');
+const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
+const neutralizeChallenge = require('../../../../lib/domain/usecases/neutralize-challenge');
+const ChallengeNeutralized = require('../../../../lib/domain/events/ChallengeNeutralized');
+
+describe('Unit | UseCase | neutralize-challenge', () => {
+  it('neutralizes a challenge by its recId', async () => {
+    // given
+    const certificationCourseId = 1;
+    const certificationAssessmentRepository = {
+      getByCertificationCourseId: sinon.stub(),
+      save: sinon.spy(), // FIXME : do it without a spy ?
+    };
+    const dependencies = {
+      certificationAssessmentRepository,
+    };
+
+    const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: 1,
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        challengeToBeNeutralized,
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId
+      .withArgs(certificationCourseId)
+      .resolves(certificationAssessment);
+
+    // when
+    await neutralizeChallenge({
+      ...dependencies,
+      certificationCourseId,
+      challengeRecId: challengeToBeNeutralized.challengeId,
+    });
+
+    // then
+    expect(
+      certificationAssessmentRepository.save
+        .getCall(0)
+        .args[0]
+        .certificationChallenges[0].isNeutralized,
+    ).to.be.true;
+  });
+
+  it('return a ChallengeNeutralized event', async () => {
+    // given
+    const certificationCourseId = 1;
+    const certificationAssessmentRepository = {
+      getByCertificationCourseId: sinon.stub(),
+      save: sinon.stub(),
+    };
+    const dependencies = {
+      certificationAssessmentRepository,
+    };
+
+    const challengeToBeNeutralized = domainBuilder.buildCertificationChallenge({ isNeutralized: false });
+    const certificationAssessment = new CertificationAssessment({
+      id: 123,
+      userId: 123,
+      certificationCourseId: 1,
+      createdAt: new Date('2020-01-01'),
+      completedAt: new Date('2020-01-01'),
+      state: CertificationAssessment.states.STARTED,
+      isV2Certification: true,
+      certificationChallenges: [
+        challengeToBeNeutralized,
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+        domainBuilder.buildCertificationChallenge({ isNeutralized: false }),
+      ],
+      certificationAnswersByDate: ['answer'],
+    });
+    certificationAssessmentRepository.getByCertificationCourseId
+      .withArgs(certificationCourseId)
+      .resolves(certificationAssessment);
+
+    // when
+    const event = await neutralizeChallenge({
+      ...dependencies,
+      certificationCourseId,
+      challengeRecId: challengeToBeNeutralized.challengeId,
+    });
+
+    // then
+    expect(event).to.be.an.instanceof(ChallengeNeutralized);
+    expect(event).to.deep.equal({ certificationCourseId });
+  });
+});


### PR DESCRIPTION
## :unicorn: Problème
Les règles 12, 13, 17 étaient appliquées manuellement par le pôle Certif

## :robot: Solution
Les implémenter automatiquement

## :100: Pour tester
- Faire un tunnel ssh vers la réplication
- se mettre sur `dev`
- Lancer la commande ```ASSESSMENT_COUNT=1000 node generate-last-assessments-score.js > fichier1.txt```
- se mettre sur la branche `pix-2113-certification-rescoring-part2`
- Lancer la commande ```ASSESSMENT_COUNT=1000 node generate-last-assessments-score.js > fichier2.txt```
- Comparer les deux fichiers ```git diff --no-index fichier1.txt fichier2.txt```
- Vérifier que les différences correspondent à l'application automatique des règles 12, 13, et 17