### PR TITLE
[FEATURE] Ajout d'une page de détails des résultats thématique dans l'admin (PIX-2446)

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -1,0 +1,25 @@
+<header class="page-header">
+  <div class="page-title">
+    <p>Résultat Thématique<span class="wire">&nbsp;>&nbsp;</span>{{@model.id}}</p>
+  </div>
+</header>
+
+<main class="page-body">
+  <section class="page-section mb_10">
+    <div class="page-section__header">
+      <h1 class="page-section__title">{{@model.name}}</h1>
+    </div>
+    <div class="page-section__details badge-data">
+      <div class="badge-data__image">
+        <img src={{@model.imageUrl}} alt="" role="presentation" width="90px"/><br>
+      </div>
+      <div class="page-section__details">
+        ID : {{@model.id}}<br>
+        Title : {{@model.title}}<br>
+        Key : {{@model.key}}<br>
+        Message : {{@model.message}}<br>
+        Message alternatif : {{@model.altMessage}}<br>
+      </div>
+    </div>
+  </section>
+</main>

--- a/admin/app/components/target-profiles/badges.hbs
+++ b/admin/app/components/target-profiles/badges.hbs
@@ -9,6 +9,7 @@
             <th class="badges-table__key">Key</th>
             <th class="badges-table__name">Nom</th>
             <th>Message</th>
+            <th class="badges-table__actions">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -19,6 +20,7 @@
               <td>{{badge.key}}</td>
               <td>{{badge.title}}</td>
               <td>{{badge.message}}</td>
+              <td><LinkTo @route="authenticated.badges.badge" @model={{badge}} class="btn btn-outline-default btn-thin">Voir détail</LinkTo></td>
             </tr>
           {{/each}}
         </tbody>

--- a/admin/app/router.js
+++ b/admin/app/router.js
@@ -82,6 +82,10 @@ Router.map(function() {
       this.route('stage', { path: '/:stage_id' });
     });
 
+    this.route('badges', function() {
+      this.route('badge', { path: '/:badge_id' });
+    });
+
     this.route('tools');
   });
 });

--- a/admin/app/routes/authenticated/badges/badge.js
+++ b/admin/app/routes/authenticated/badges/badge.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default class BadgeRoute extends Route {
+
+  model(params) {
+    return this.store.findRecord('badge', params.badge_id);
+  }
+}

--- a/admin/app/styles/app.scss
+++ b/admin/app/styles/app.scss
@@ -51,3 +51,4 @@
 @import 'components/target-profiles/details';
 @import 'components/target-profiles/insight';
 @import 'components/target-profiles/stages';
+@import 'components/badges/badge';

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -1,0 +1,7 @@
+.badge-data {
+  display: flex;
+
+  &__image {
+    margin-right: 20px;
+  }
+}

--- a/admin/app/styles/components/target-profiles/badges.scss
+++ b/admin/app/styles/components/target-profiles/badges.scss
@@ -18,4 +18,8 @@
       width: 90px;
     }
   }
+
+  &__actions {
+    width: 140px;
+  }
 }

--- a/admin/app/templates/authenticated/badges.hbs
+++ b/admin/app/templates/authenticated/badges.hbs
@@ -1,0 +1,3 @@
+<div class="page">
+  {{outlet}}
+</div>

--- a/admin/app/templates/authenticated/badges/badge.hbs
+++ b/admin/app/templates/authenticated/badges/badge.hbs
@@ -1,0 +1,1 @@
+<Badges::Badge @model={{@model}} />

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -11,6 +11,7 @@ import {
 
 import { Response } from 'ember-cli-mirage';
 import { createMembership } from './handlers/memberships';
+import { getBadge } from './handlers/badges';
 import { createStage } from './handlers/stages';
 import { findPaginatedAndFilteredSessions } from './handlers/find-paginated-and-filtered-sessions';
 import { findPaginatedOrganizationMemberships } from './handlers/organizations';
@@ -93,6 +94,7 @@ export default function() {
   this.get('/organizations/:id/memberships', findPaginatedOrganizationMemberships);
   this.get('/organizations/:id/target-profiles', getOrganizationTargetProfiles);
   this.post('/organizations/:id/target-profiles', attachTargetProfiles);
+  this.get('/admin/badges/:id', getBadge);
   this.post('/admin/target-profiles');
   this.get('/admin/target-profiles');
   this.get('/admin/target-profiles/:id');

--- a/admin/mirage/handlers/badges.js
+++ b/admin/mirage/handlers/badges.js
@@ -1,0 +1,6 @@
+function getBadge(schema, request) {
+  const id = request.params.id;
+  return schema.badges.find(id);
+}
+
+export { getBadge };

--- a/admin/tests/acceptance/authenticated/badges/badges-test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges-test.js
@@ -1,0 +1,28 @@
+import { find, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
+import { module, test } from 'qunit';
+import { createAuthenticateSession } from '../../../helpers/test-init';
+
+module('Acceptance | authenticated/badges/badge', function(hooks) {
+
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let currentUser;
+  let badge;
+
+  hooks.beforeEach(async function() {
+    currentUser = server.create('user');
+    await createAuthenticateSession({ userId: currentUser.id });
+
+    badge = this.server.create('badge', { id: 1, title: 'My badge' });
+  });
+
+  test('should display the badge', async function(assert) {
+    await visit(`/badges/${badge.id}`);
+
+    const badgeElement = find('.page-section__details');
+    assert.ok(badgeElement.textContent.match(badge.title));
+  });
+});

--- a/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
+++ b/admin/tests/acceptance/authenticated/target-profiles/insight-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, findAll, visit } from '@ember/test-helpers';
+import { click, currentURL, fillIn, findAll, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { module, test } from 'qunit';
@@ -17,8 +17,8 @@ module('Acceptance | authenticated/targets-profile/target-profile/insight', func
     await createAuthenticateSession({ userId: currentUser.id });
 
     targetProfile = this.server.create('target-profile', { name: 'Profil cible du ghetto' });
-    this.server.create('badge', { title: 'My badge' });
-    this.server.create('badge', { title: 'My badge 2' });
+    this.server.create('badge', { id: 100, title: 'My badge' });
+    this.server.create('badge', { id: 101, title: 'My badge 2' });
 
     this.server.create('stage', { title: 'My stage' });
   });
@@ -28,6 +28,14 @@ module('Acceptance | authenticated/targets-profile/target-profile/insight', func
 
     assert.contains('My badge');
     assert.contains('My stage');
+  });
+
+  test('should be able to see the details of a badge', async function(assert) {
+    await visit(`/target-profiles/${targetProfile.id}/insight`);
+
+    await click('.insight__section:nth-child(1) a');
+
+    assert.equal(currentURL(), '/badges/100');
   });
 
   test('should be able to add a new stage', async function(assert) {

--- a/admin/tests/integration/components/badges/badge-test.js
+++ b/admin/tests/integration/components/badges/badge-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | Badges::Badge', function(hooks) {
+  let badge;
+
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    badge = {
+      id: 42,
+      title: 'mon titre',
+      message: 'mon message',
+      imageUrl: 'data:,',
+      key: 'ma clef',
+      altMessage: 'mon message alternatif',
+    };
+
+    this.set('badge', badge);
+  });
+
+  test('should render all details about the badge', async function(assert) {
+    //when
+    await render(hbs`<Badges::Badge @model={{this.badge}} />`);
+
+    //then
+    assert.dom('.page-section__details').exists();
+    const detailsContent = find('.page-section__details').textContent;
+    assert.ok(detailsContent.match(badge.title), 'title');
+    assert.ok(detailsContent.match(badge.key), 'key');
+    assert.ok(detailsContent.match(badge.message), 'message');
+    assert.ok(detailsContent.match(badge.id), 'id');
+    assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
+    assert.dom('.page-section__details img').exists();
+    assert.dom('.page-section__details img').hasAttribute('src', 'data:,');
+  });
+});

--- a/admin/tests/integration/components/target-profiles/badges_test.js
+++ b/admin/tests/integration/components/target-profiles/badges_test.js
@@ -31,6 +31,7 @@ module('Integration | Component | TargetProfiles::Badges', function(hooks) {
     assert.contains('Key');
     assert.contains('Nom');
     assert.contains('Message');
+    assert.contains('Actions');
     assert.dom('tbody tr').exists({ count: 1 });
     assert.equal(find('tbody tr td:first-child').textContent, '1');
     assert.dom('tbody tr td:nth-child(2) img').exists();
@@ -39,6 +40,7 @@ module('Integration | Component | TargetProfiles::Badges', function(hooks) {
     assert.equal(find('tbody tr td:nth-child(3)').textContent, 'My key');
     assert.equal(find('tbody tr td:nth-child(4)').textContent, 'My title');
     assert.equal(find('tbody tr td:nth-child(5)').textContent, 'My message');
+    assert.equal(find('tbody tr td:nth-child(6)').textContent, 'Voir détail');
     assert.notContains('Aucun résultat thématique associé');
   });
 

--- a/api/lib/application/badges/badges-controller.js
+++ b/api/lib/application/badges/badges-controller.js
@@ -1,0 +1,10 @@
+const usecases = require('../../domain/usecases');
+const badgeSerializer = require('../../infrastructure/serializers/jsonapi/badge-serializer');
+
+module.exports = {
+  async getBadge(request) {
+    const badgeId = parseInt(request.params.id);
+    const badge = await usecases.getBadge({ badgeId });
+    return badgeSerializer.serialize(badge);
+  },
+};

--- a/api/lib/application/badges/index.js
+++ b/api/lib/application/badges/index.js
@@ -1,0 +1,32 @@
+const securityPreHandlers = require('../security-pre-handlers');
+const badgesController = require('./badges-controller');
+const Joi = require('joi');
+const identifiersType = require('../../domain/types/identifiers-type');
+
+exports.register = async function(server) {
+  server.route([
+    {
+      method: 'GET',
+      path: '/api/admin/badges/{id}',
+      config: {
+        pre: [{
+          method: securityPreHandlers.checkUserHasRolePixMaster,
+          assign: 'hasRolePixMaster',
+        }],
+        validate: {
+          params: Joi.object({
+            id: identifiersType.badgeId,
+          }),
+        },
+        handler: badgesController.getBadge,
+        tags: ['api', 'badges'],
+        notes: [
+          '- **Cette route est restreinte aux utilisateurs authentifiés avec le rôle Pix Master**\n' +
+          '- Elle permet de récupérer un résultat thématique.',
+        ],
+      },
+    },
+  ]);
+};
+
+exports.name = 'badges-api';

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -1,4 +1,5 @@
 const Joi = require('joi');
+const _ = require('lodash');
 
 const postgreSQLSequenceDefaultStart = 1;
 const postgreSQLSequenceEnd = 2 ** 31 - 1;
@@ -9,52 +10,48 @@ const implementationType = {
   alphanumeric: Joi.string().required(),
 };
 
-const answerId = implementationType.positiveInteger32bits;
-const assessmentId = implementationType.positiveInteger32bits;
-const badgeId = implementationType.positiveInteger32bits;
-const campaignId = implementationType.positiveInteger32bits;
-const campaignParticipationId = implementationType.positiveInteger32bits;
-const certificationCandidateId = implementationType.positiveInteger32bits;
-const certificationCenterId = implementationType.positiveInteger32bits;
-const certificationCenterMembershipId = implementationType.positiveInteger32bits;
-const certificationCourseId = implementationType.positiveInteger32bits;
-const certificationIssueReportId = implementationType.positiveInteger32bits;
-const challengeId = implementationType.alphanumeric255;
-const courseId = implementationType.alphanumeric;
-const competenceId = implementationType.alphanumeric255;
-const membershipId = implementationType.positiveInteger32bits;
-const organizationId = implementationType.positiveInteger32bits;
-const organizationInvitationId = implementationType.positiveInteger32bits;
-const schoolingRegistrationId = implementationType.positiveInteger32bits;
-const sessionId = implementationType.positiveInteger32bits;
-const stageId = implementationType.positiveInteger32bits;
-const targetProfileId = implementationType.positiveInteger32bits;
-const tutorialId = implementationType.alphanumeric;
-const userId = implementationType.positiveInteger32bits;
-const userOrgaSettingsId = implementationType.positiveInteger32bits;
+const valuesToExport = {};
 
-module.exports = {
-  answerId,
-  assessmentId,
-  badgeId,
-  campaignId,
-  campaignParticipationId,
-  certificationCandidateId,
-  certificationCenterId,
-  certificationCenterMembershipId,
-  certificationCourseId,
-  certificationIssueReportId,
-  challengeId,
-  competenceId,
-  courseId,
-  membershipId,
-  organizationId,
-  organizationInvitationId,
-  schoolingRegistrationId,
-  sessionId,
-  stageId,
-  targetProfileId,
-  tutorialId,
-  userId,
-  userOrgaSettingsId,
-};
+function _assignValueToExport(array, implementationType) {
+  _.each(array, function(value) {
+    valuesToExport[value] = implementationType;
+  });
+}
+
+const typesPositiveInteger32bits = [
+  'answerId',
+  'assessmentId',
+  'badgeId',
+  'campaignId',
+  'campaignParticipationId',
+  'certificationCandidateId',
+  'certificationCenterId',
+  'certificationCenterMembershipId',
+  'certificationCourseId',
+  'certificationIssueReportId',
+  'membershipId',
+  'organizationId',
+  'organizationInvitationId',
+  'schoolingRegistrationId',
+  'sessionId',
+  'sessionId',
+  'stageId',
+  'targetProfileId',
+  'userId',
+  'userOrgaSettingsId',
+];
+
+const typesAlphanumeric = [
+  'courseId',
+  'tutorialId',
+];
+const typesAlphanumeric255 = [
+  'challengeId',
+  'competenceId',
+];
+
+_assignValueToExport(typesPositiveInteger32bits, implementationType.positiveInteger32bits);
+_assignValueToExport(typesAlphanumeric, implementationType.alphanumeric);
+_assignValueToExport(typesAlphanumeric255, implementationType.alphanumeric255);
+
+module.exports = valuesToExport;

--- a/api/lib/domain/types/identifiers-type.js
+++ b/api/lib/domain/types/identifiers-type.js
@@ -11,6 +11,7 @@ const implementationType = {
 
 const answerId = implementationType.positiveInteger32bits;
 const assessmentId = implementationType.positiveInteger32bits;
+const badgeId = implementationType.positiveInteger32bits;
 const campaignId = implementationType.positiveInteger32bits;
 const campaignParticipationId = implementationType.positiveInteger32bits;
 const certificationCandidateId = implementationType.positiveInteger32bits;
@@ -35,6 +36,7 @@ const userOrgaSettingsId = implementationType.positiveInteger32bits;
 module.exports = {
   answerId,
   assessmentId,
+  badgeId,
   campaignId,
   campaignParticipationId,
   certificationCandidateId,

--- a/api/lib/domain/usecases/get-badge.js
+++ b/api/lib/domain/usecases/get-badge.js
@@ -1,0 +1,6 @@
+module.exports = function getBadge({
+  badgeId,
+  badgeRepository,
+}) {
+  return badgeRepository.get(badgeId);
+};

--- a/api/lib/domain/usecases/index.js
+++ b/api/lib/domain/usecases/index.js
@@ -186,6 +186,7 @@ module.exports = injectDependencies({
   getAnswer: require('./get-answer'),
   getAssessment: require('./get-assessment'),
   getAttendanceSheet: require('./get-attendance-sheet'),
+  getBadge: require('./get-badge'),
   getCampaign: require('./get-campaign'),
   getCampaignByCode: require('./get-campaign-by-code'),
   getCampaignAssessmentParticipation: require('./get-campaign-assessment-participation'),

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -42,4 +42,10 @@ module.exports = {
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },
 
+  async get(id) {
+    const bookshelfBadge = await BookshelfBadge
+      .where('id', id)
+      .fetch();
+    return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
+  },
 };

--- a/api/lib/routes.js
+++ b/api/lib/routes.js
@@ -3,6 +3,7 @@ module.exports = [
   require('./application/assessment-results'),
   require('./application/assessments'),
   require('./application/authentication'),
+  require('./application/badges'),
   require('./application/cache'),
   require('./application/campaign-participation-results'),
   require('./application/campaign-participations'),

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -1,0 +1,59 @@
+const createServer = require('../../../../server');
+const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insertUserWithRolePixMaster } = require('../../../test-helper');
+
+describe('Acceptance | API | Badges', () => {
+
+  let server, options, userId, badge;
+
+  beforeEach(async () => {
+    server = await createServer();
+  });
+
+  describe('GET /api/admin/badges/{id}', () => {
+
+    beforeEach(async () => {
+      userId = (await insertUserWithRolePixMaster()).id;
+
+      badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'Message alternatif',
+        imageUrl: 'url_image',
+        message: 'Bravo',
+        title: 'titre du badge',
+        key: 'clef du badge',
+        isCertifiable: false,
+      });
+
+      await databaseBuilder.commit();
+    });
+
+    it('should return the badge', async () => {
+      // given
+      options = {
+        method: 'GET',
+        url: `/api/admin/badges/${badge.id}`,
+        headers: { authorization: generateValidRequestAuthorizationHeader(userId) },
+      };
+      const expectedBadge = {
+        data: {
+          type: 'badges',
+          id: badge.id.toString(),
+          attributes: {
+            'alt-message': 'Message alternatif',
+            'image-url': 'url_image',
+            message: 'Bravo',
+            title: 'titre du badge',
+            key: 'clef du badge',
+          },
+        },
+      };
+
+      // when
+      const response = await server.inject(options);
+
+      // then
+      expect(response.statusCode).to.equal(200);
+      expect(response.result).to.deep.equal(expectedBadge);
+    });
+  });
+});

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -317,4 +317,25 @@ describe('Integration | Repository | Badge', () => {
       expect(badges.length).to.equal(0);
     });
   });
+
+  describe('#get', () => {
+    let badge;
+
+    beforeEach(async () => {
+      badge = databaseBuilder.factory.buildBadge({
+        id: 1,
+        altMessage: 'You won the Toto badge!',
+        imageUrl: 'data:,',
+        message: 'Congrats, you won the Toto badge!',
+        key: 'TOTO2',
+      });
+      await databaseBuilder.commit();
+    });
+
+    it('should return a badge', async () => {
+      const myBadge = await badgeRepository.get(badge.id);
+
+      expect(myBadge.id).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
## :unicorn: Problème (PIX-2446)
Nous voulons rajouter l'ensemble des détails d'un résultat thématique dans l'admin, mais nous n'avons pas la place pour cela actuellement.

## :robot: Solution
Nous rajoutons une page de détail d'un résultat thématique qui affiche pour le moment les mêmes informations que dans la liste


## :100: Pour tester

1. Se connecter sur pix-admin
2. Aller sur un profil cible avec résultat thématique
3. Dans la liste des résultats thématique, cliquer sur "Détail"
4. Constater la beauté de la page et de l'information affichée

https://user-images.githubusercontent.com/86659/113716051-77b81b00-96ea-11eb-90e1-7fee10af627c.mp4

