### PR TITLE
[APP] Afficher le message d'une organisation à la fin d'un parcours (PIX-2328)

### DIFF
--- a/api/db/database-builder/factory/build-campaign.js
+++ b/api/db/database-builder/factory/build-campaign.js
@@ -21,6 +21,10 @@ module.exports = function buildCampaign({
   organizationId,
   creatorId,
   targetProfileId,
+  customResultPageText,
+  customResultPageButtonText,
+  customResultPageButtonUrl,
+
 } = {}) {
 
   if (type === Campaign.types.ASSESSMENT) {
@@ -46,6 +50,9 @@ module.exports = function buildCampaign({
     organizationId,
     creatorId,
     targetProfileId,
+    customResultPageText,
+    customResultPageButtonText,
+    customResultPageButtonUrl,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'campaigns',

--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -134,6 +134,7 @@ function _buildCampaignForPro(databaseBuilder) {
     idPixLabel: 'identifiant entreprise',
     title: null,
     customLandingPageText: null,
+    customResultPageText: 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
   });
 
   databaseBuilder.factory.buildCampaign({

--- a/api/lib/domain/read-models/CampaignToJoin.js
+++ b/api/lib/domain/read-models/CampaignToJoin.js
@@ -21,6 +21,9 @@ class CampaignToJoin {
     targetProfileName,
     targetProfileImageUrl,
     targetProfileIsSimplifiedAccess,
+    customResultPageText,
+    customResultPageButtonText,
+    customResultPageButtonUrl,
   } = {}) {
     this.id = id;
     this.code = code;
@@ -41,6 +44,9 @@ class CampaignToJoin {
     this.organizationIsPoleEmploi = organizationIsPoleEmploi;
     this.targetProfileName = targetProfileName;
     this.targetProfileImageUrl = targetProfileImageUrl;
+    this.customResultPageText = customResultPageText;
+    this.customResultPageButtonText = customResultPageButtonText;
+    this.customResultPageButtonUrl = customResultPageButtonUrl;
   }
 
   get isAssessment() {

--- a/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/campaign-to-join-serializer.js
@@ -7,7 +7,7 @@ module.exports = {
       attributes: ['code', 'title', 'type', 'idPixLabel', 'customLandingPageText',
         'externalIdHelpImageUrl', 'alternativeTextToExternalIdHelpImage', 'isArchived', 'isForAbsoluteNovice',
         'isRestricted', 'isSimplifiedAccess', 'organizationName', 'organizationType', 'organizationLogoUrl',
-        'organizationIsPoleEmploi', 'targetProfileName', 'targetProfileImageUrl'],
+        'organizationIsPoleEmploi', 'targetProfileName', 'targetProfileImageUrl', 'customResultPageText', 'customResultPageButtonText', 'customResultPageButtonUrl'],
     }).serialize(campaignsToJoin);
   },
 };

--- a/api/tests/unit/application/campaign/campaign-controller_test.js
+++ b/api/tests/unit/application/campaign/campaign-controller_test.js
@@ -224,6 +224,9 @@ describe('Unit | Application | Controller | Campaign', () => {
           'organization-logo-url': campaignToJoin.organizationLogoUrl,
           'target-profile-name': campaignToJoin.targetProfileName,
           'target-profile-image-url': campaignToJoin.targetProfileImageUrl,
+          'custom-result-page-text': campaignToJoin.customResultPageText,
+          'custom-result-page-button-text': campaignToJoin.customResultPageButtonText,
+          'custom-result-page-button-url': campaignToJoin.customResultPageButtonUrl,
         },
       });
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/campaign-to-join-serializer_test.js
@@ -35,6 +35,9 @@ describe('Unit | Serializer | JSONAPI | campaign-to-join-serializer', () => {
             'organization-logo-url': campaignToJoin.organizationLogoUrl,
             'target-profile-name': campaignToJoin.targetProfileName,
             'target-profile-image-url': campaignToJoin.targetProfileImageUrl,
+            'custom-result-page-text': campaignToJoin.customResultPageText,
+            'custom-result-page-button-text': campaignToJoin.customResultPageButtonText,
+            'custom-result-page-button-url': campaignToJoin.customResultPageButtonUrl,
           },
         },
       });

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -84,7 +84,7 @@
         </div>
       {{/if}}
       <div class="skill-review-organization-message__content">
-        <p class="skill-review-organization-message__title">Messsage de votre organisation</p>
+        <p class="skill-review-organization-message__title">{{t 'pages.skill-review.organization-message'}}</p>
         <p class="skill-review-organization-message__organization-name">{{this.organizationName}}</p>
         <div class="skill-review-organization-message__text">
           <p>{{this.organizationMessageText}}</p>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -76,7 +76,7 @@
   </PixBlock>
 {{/if}}
 
-{{#if this.showCustomResultPageDescription}}
+{{#if this.showOrganizationMessage}}
   <PixBlock class="skill-review__organization-message">
       {{#if this.organizationLogoUrl}}
         <div class="skill-review-organization-message__logo">
@@ -87,7 +87,7 @@
         <p class="skill-review-organization-message__title">Messsage de votre organisation</p>
         <p class="skill-review-organization-message__organization-name">{{this.organizationName}}</p>
         <div class="skill-review-organization-message__text">
-          <p>{{this.customResultPageDescription}}</p>
+          <p>{{this.organizationMessageText}}</p>
         </div>
       </div>
   </PixBlock>

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -3,11 +3,10 @@
   <AssessmentBanner @title={{@model.assessment.title}} @displayHomeLink={{false}} />
 </div>
 
-<PixBlock @shadow="heavy" class="skill-review__result-container">
-  {{#if @model.campaignParticipation.campaign.isArchived}}
-
+{{#if @model.campaignParticipation.campaign.isArchived}}
+  <PixBlock class="skill-review__result-abstract-container">
     <div class="skill-review__campaign-archived">
-      <img class="skill-review__campaign-archived-image " src="{{this.rootURL}}/images/illustrations/fat-bee.svg" alt="" role="none">
+      <img class="skill-review__campaign-archived-image" src="{{this.rootURL}}/images/illustrations/fat-bee.svg" alt="" role="none">
       <p class="skill-review__campaign-archived-text">
         {{t 'pages.skill-review.archived' htmlSafe=true}}
       </p>
@@ -15,8 +14,9 @@
         {{t 'pages.skill-review.actions.continue'}}
       </LinkTo>
     </div>
-
-  {{else}}
+  </PixBlock>
+{{else}}
+  <PixBlock class="skill-review__result-abstract-container">
     <div class="skill-review__result-and-action">
       <h2 class="sr-only">{{t 'pages.skill-review.abstract-title'}}</h2>
       {{#if this.showStages}}
@@ -40,13 +40,13 @@
             </div>
           </div>
         {{else}}
-          <p class="rounded-panel-title skill-review-result__abstract">
+          <p class="rounded-panel-title skill-review-result-abstract__text">
             {{t 'pages.skill-review.abstract' percentage=@model.campaignParticipation.campaignParticipationResult.masteryPercentage htmlSafe=true}}
           </p>
         {{/if}}
         <h2 class="sr-only">{{t 'pages.skill-review.send-title'}}</h2>
 
-        <div class="skill-review-result__share-container {{if this.showStages "skill-review-result__share-container--left"}}">
+        <div class="skill-review-result-abstract__share-container {{if this.showStages "skill-review-result-abstract__share-container--left"}}">
           {{#if this.displayErrorMessage}}
             <div class="skill-review-share__error-container">
               <div class="skill-review-share-error__message" aria-live="polite">
@@ -73,37 +73,57 @@
         </div>
       </div>
     </div>
+  </PixBlock>
+{{/if}}
 
-    {{#if this.showBadges}}
-      {{#unless this.hideBadgesTitle}}
-        <h2 class="skill-review-result__badge-subtitle">
-          {{t 'pages.skill-review.badges-title'}}
-        </h2>
-      {{/unless}}
-      <div class="badge-acquired-container">
-        {{#each this.acquiredBadges as |badge|}}
-          <BadgeAcquiredCard
-                  @title={{badge.title}}
-                  @message={{badge.message}}
-                  @imageUrl={{badge.imageUrl}}
-                  @altMessage={{badge.altMessage}}
-          />
-        {{/each}}
+{{#if this.showCustomResultPageDescription}}
+  <PixBlock class="skill-review__organization-message">
+      {{#if this.organizationLogoUrl}}
+        <div class="skill-review-organization-message__logo">
+          <img class="logo" src={{this.organizationLogoUrl}} alt="{{this.organizationName}}">
+        </div>
+      {{/if}}
+      <div class="skill-review-organization-message__content">
+        <p class="skill-review-organization-message__title">Messsage de votre organisation</p>
+        <p class="skill-review-organization-message__organization-name">{{this.organizationName}}</p>
+        <div class="skill-review-organization-message__text">
+          <p>{{this.customResultPageDescription}}</p>
+        </div>
       </div>
-    {{/if}}
+  </PixBlock>
+{{/if}}
 
-    {{#if @model.displayImprovementButton}}
-      <SkillReviewTryAgain
-              @campaignParticipation={{@model.campaignParticipation}}
-              @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
-    {{/if}}
+<PixBlock @shadow="heavy" class="skill-review__result-detail-container">
+  {{#if this.showBadges}}
+    {{#unless this.hideBadgesTitle}}
+      <h2 class="skill-review-result-detail__badge-subtitle">
+        {{t 'pages.skill-review.badges-title'}}
+      </h2>
+    {{/unless}}
+    <div class="badge-acquired-container">
+      {{#each this.acquiredBadges as |badge|}}
+        <BadgeAcquiredCard
+                @title={{badge.title}}
+                @message={{badge.message}}
+                @imageUrl={{badge.imageUrl}}
+                @altMessage={{badge.altMessage}}
+        />
+      {{/each}}
+    </div>
   {{/if}}
+
+  {{#if @model.displayImprovementButton}}
+    <SkillReviewTryAgain
+            @campaignParticipation={{@model.campaignParticipation}}
+            @improvementCampaignParticipation={{this.improvementCampaignParticipation}}/>
+  {{/if}}
+
 
   {{#unless @model.campaignParticipation.campaign.isForAbsoluteNovice}}
 
-    <main class="skill-review-result__content">
-    <div class="skill-review-result__table-header">
-      <h2 class="skill-review-result__subtitle">
+  <main class="skill-review-result-detail__content">
+    <div class="skill-review-result-detail__table-header">
+      <h2 class="skill-review-result-detail__subtitle">
         {{t 'pages.skill-review.details.title'}}
       </h2>
       <CircleChart @value={{@model.campaignParticipation.campaignParticipationResult.masteryPercentage}}>
@@ -120,7 +140,7 @@
     />
   </main>
 
-  <div class="skill-review-result__information">
+  <div class="skill-review-result-detail__information">
     <FaIcon @icon='info-circle' class='skill-review-information__info-icon' aria-hidden="true"/>
     <div class="skill-review-information__text">
       {{t 'pages.skill-review.information'}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -53,7 +53,7 @@ export default class SkillReview extends Component {
     return Boolean(this.args.model.campaignParticipation.campaign.get('customResultPageText'));
   }
 
-  get customResultPageDescription() {
+  get organizationMessageText() {
     return this.args.model.campaignParticipation.campaign.get('customResultPageText');
   }
 

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -49,6 +49,22 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipation.campaignParticipationResult.get('stageCount');
   }
 
+  get showOrganizationMessage() {
+    return Boolean(this.args.model.campaignParticipation.campaign.get('customResultPageText'));
+  }
+
+  get customResultPageDescription() {
+    return this.args.model.campaignParticipation.campaign.get('customResultPageText');
+  }
+
+  get organizationLogoUrl() {
+    return this.args.model.campaignParticipation.campaign.get('organizationLogoUrl');
+  }
+
+  get organizationName() {
+    return this.args.model.campaignParticipation.campaign.get('organizationName');
+  }
+
   @action
   shareCampaignParticipation() {
     this.displayErrorMessage = false;

--- a/mon-pix/app/models/campaign.js
+++ b/mon-pix/app/models/campaign.js
@@ -18,6 +18,9 @@ export default class Campaign extends Model {
   @attr('boolean') organizationIsPoleEmploi;
   @attr('string') targetProfileName;
   @attr('string') targetProfileImageUrl;
+  @attr('string') customResultPageText;
+  @attr('string') customResultPageButtonText;
+  @attr('string') customResultPageButtonUrl;
 
   get isAssessment() {
     return this.type === 'ASSESSMENT';

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -22,12 +22,31 @@
     align-items: center;
   }
 
-  &__result-container {
+  &__result-detail-container,
+  &__result-abstract-container,
+  &__organization-message {
     padding: 40px 10px;
-    margin-top: -160px;
+    box-shadow: 0 7px 14px 0 rgba($grey-200, 0.1), 0 3px 6px 0 rgba(black, 0.1);
 
     @include device-is('tablet') {
       padding: 32px 48px;
+    }
+  }
+
+  &__result-abstract-container {
+    margin-top: -160px;
+  }
+
+  &__organization-message {
+    border-radius: 5px;
+    display: flex;
+    padding: 24px;
+    flex-direction: column;
+
+    @include device-is('tablet') {
+      flex-direction: row;
+      border-radius: 32px 0 32px 32px;
+      padding: 32px;
     }
   }
 
@@ -137,9 +156,54 @@
   }
 }
 
-.skill-review-result {
+.skill-review-organization-message {
 
-  &__abstract {
+  &__logo {
+    text-align: center;
+    margin-bottom: 16px;
+
+    img {
+      width: 118px;
+    }
+
+    @include device-is('tablet') {
+      min-width: 118px;
+      margin-right: 32px;
+      margin-bottom: 0;
+    }
+  }
+
+  &__title {
+    color: $grey-60;
+    font-family: $font-open-sans;
+    font-size: 1rem;
+    font-weight: $font-bold;
+    margin: 0;
+  }
+
+  &__organization-name {
+    color: $grey-90;
+    font-size: 1.5rem;
+    font-family: $font-open-sans;
+    font-weight: $font-normal;
+    margin: 8px 0;
+  }
+
+  &__text {
+    color: $grey-90;
+    font-family: $font-roboto;
+    font-size: 1rem;
+    line-height: 1.625rem;
+
+    p {
+      margin: 0;
+    }
+  }
+}
+
+.skill-review-result-abstract {
+
+  &__text {
     text-align: center;
     text-transform: none;
     margin: 16px 0;
@@ -162,6 +226,36 @@
     }
   }
 
+  &__share-container {
+    padding: 16px 40px 32px 40px;
+    text-align: center;
+
+    &--left {
+      text-align: center;
+
+      @include device-is('tablet') {
+        text-align: left;
+      }
+    }
+  }
+}
+
+.badge-acquired-container {
+  border-bottom: 1px dashed $grey-22;
+  padding-bottom: 24px;
+  margin-bottom: 24px;
+}
+
+.skill-review-result-detail {
+
+  &__badge-container {
+    padding: 40px 10px;
+
+    @include device-is('tablet') {
+      padding: 32px 48px;
+    }
+  }
+
   &__badge-subtitle {
     color: $grey-100;
     font-family: $font-open-sans;
@@ -173,11 +267,6 @@
     @include device-is('tablet') {
       text-align: left;
     }
-  }
-
-  &__content {
-    border-top: 1px dashed $grey-22;
-    margin-top: 24px;
   }
 
   &__information {
@@ -192,30 +281,16 @@
     }
   }
 
-  &__share-container {
-    padding: 16px 40px 32px 40px;
-    text-align: center;
-
-    &--left {
-      text-align: center;
-
-      @include device-is('tablet') {
-        text-align: left;
-      }
-    }
-  }
-
   &__table-header {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
     text-align: center;
-    padding: 0;
+    margin-bottom: 32px;
 
     @include device-is('tablet') {
       flex-direction: row;
-      padding: 20px 0;
     }
   }
 
@@ -224,15 +299,15 @@
     font-family: $font-open-sans;
     font-size: 1.5rem;
     font-weight: $font-normal;
-    margin: 28px 0 24px;
+    margin-bottom: 32px;
   }
 }
 
 .skill-review-share {
 
   &__stage-congrats {
-    padding: 20px 40px 0 40px;
     text-align: center;
+    padding: 20px 40px 0 40px;
 
     @include device-is('tablet') {
       text-align: left;

--- a/mon-pix/tests/acceptance/skill-review-page-test.js
+++ b/mon-pix/tests/acceptance/skill-review-page-test.js
@@ -132,7 +132,7 @@ describe('Acceptance | Campaigns | Campaigns Result', function() {
 
         // then
         expect(find('.badge-acquired-card')).to.exist;
-        expect(find('.skill-review-result__badge-subtitle')).to.exist;
+        expect(find('.skill-review-result-detail__badge-subtitle')).to.exist;
       });
 
       it('should not display the Pix emploi badge when badge is not acquired', async function() {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach } from 'mocha';
 import { expect } from 'chai';
-
+import { contains } from '../../../../../helpers/contains';
 import { click, find, render } from '@ember/test-helpers';
 import Service from '@ember/service';
 import hbs from 'htmlbars-inline-precompile';
@@ -83,6 +83,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               stageCount: 2,
               get: sinon.stub().returns([]),
             },
+            campaign: {
+              get: sinon.stub().returns([]),
+            },
           },
         };
 
@@ -118,6 +121,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           rollbackAttributes: sinon.stub(),
           campaign: {
             isForAbsoluteNovice: true,
+            get: sinon.stub().returns([]),
           },
           campaignParticipationResult: {
             masteryPercentage: 90,
@@ -154,5 +158,113 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       expect(find('.skill-review-result__information')).to.not.exist;
     });
 
+  });
+
+  describe('The block of the organisation message', function() {
+    context('when the organization has a message', function() {
+      context('when the organization has a logo', function() {
+        beforeEach(async function() {
+          // Given
+          const campaignParticipation = {
+            campaignParticipation: {
+              campaignParticipationResult: {
+                get: sinon.stub().returns([]),
+              },
+              campaign: {
+                customResultPageText: 'Bravo !',
+                organizationLogoUrl: 'www.logo-example.com',
+                organizationName: 'Dragon & Co',
+                get: sinon.stub(),
+              },
+            },
+          };
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('campaignParticipation', campaignParticipation);
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{campaignParticipation}}/>`);
+        });
+        it('should display the block for the message', function() {
+          // Then
+          expect(contains('Message de votre organisation')).to.exist;
+          expect(contains('Dragon & Co')).to.exist;
+        });
+
+        it('should show the logo of the organization ', function() {
+          // Then
+          expect(find('[src="www.logo-example.com"]')).to.exist;
+        });
+      });
+
+      context('when the organization has no logo', function() {
+        beforeEach(async function() {
+          // Given
+          const campaignParticipation = {
+            campaignParticipation: {
+              campaignParticipationResult: {
+                get: sinon.stub().returns([]),
+              },
+              campaign: {
+                customResultPageText: 'Bravo !',
+                organizationLogoUrl: null,
+                organizationName: 'Dragon & Co',
+                get: sinon.stub(),
+              },
+            },
+          };
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('campaignParticipation', campaignParticipation);
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{campaignParticipation}}/>`);
+        });
+
+        it('should display the block for the message', function() {
+          // Then
+          expect(contains('Dragon & Co')).to.exist;
+          expect(contains('Message de votre organisation')).to.exist;
+        });
+
+        it('should not display the div for the logo of the organization ', function() {
+          // Then
+          expect(find('[src="www.logo-example.com"]')).to.not.exist;
+        });
+      });
+    });
+
+    context('when the organization has no message', function() {
+      beforeEach(async function() {
+        // Given
+        const campaignParticipation = {
+          campaignParticipation: {
+            campaignParticipationResult: {
+              get: sinon.stub().returns([]),
+            },
+            campaign: {
+              customResultPageText: null,
+              organizationLogoUrl: null,
+              organizationName: 'Dragon & Co',
+              get: sinon.stub(),
+            },
+          },
+        };
+        campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
+        campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+        campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+        this.set('campaignParticipation', campaignParticipation);
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+            @model={{campaignParticipation}}/>`);
+      });
+
+      it('should not display the block for the message', function() {
+        // Then
+        expect(contains('Message de votre organisation')).to.not.exist;
+      });
+    });
   });
 });

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -166,4 +166,70 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
 
   });
 
+  describe('#showOrganizationMessage', function() {
+
+    it('should return true when the campaign has a customResultPageText', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageText = 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.';
+
+      // when
+      const result = component.showOrganizationMessage;
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when the campaign has no customResultPageText ', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageText = null;
+
+      // when
+      const result = component.showOrganizationMessage;
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#organizationMessageText', function() {
+
+    it('should return the text of the message organization', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageText = 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.';
+
+      // when
+      const result = component.organizationMessageText;
+
+      // then
+      expect(result).to.equal('Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.');
+    });
+  });
+
+  describe('#organizationLogoUrl', function() {
+
+    it('should return the logo of the organization', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.organizationLogoUrl = 'www.logo-example.net';
+
+      // when
+      const result = component.organizationLogoUrl;
+
+      // then
+      expect(result).to.equal('www.logo-example.net');
+    });
+  });
+
+  describe('#organizationName', function() {
+
+    it('should return the name of the organization', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.organizationName = 'Amazing Orga';
+
+      // when
+      const name = component.organizationName;
+
+      // then
+      expect(name).to.equal('Amazing Orga');
+    });
+  });
 });

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -903,6 +903,7 @@
             },
             "information": "If you have already completed personalised tests on Pix, questions you have previously answered have not been asked again. However, the result shown here is based on all of your answers.",
             "not-finished": "You can’t submit your results yet, we still have a few questions to ask.",
+            "organization-message" : "Message of your organization",
             "send-results": "Don't forget to submit your results.",
             "send-status": {
                 "in-progress": "Results are being shared..."

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -903,6 +903,7 @@
             },
             "information": "Si vous avez déjà effectué des parcours sur Pix, les questions auxquelles vous aviez répondu ne vous ont pas été posées de nouveau. En revanche, le résultat affiché ici tient compte de l’ensemble de vos réponses.",
             "not-finished": "Vous ne pouvez pas encore envoyer vos résultats, nous avons encore quelques questions à vous poser.",
+            "organization-message" : "Message de votre organisation",
             "send-results": "N'oubliez pas d'envoyer vos résultats à l'organisateur du parcours.",
             "send-status": {
                 "in-progress": "Envoi en cours"


### PR DESCRIPTION
## :unicorn: Problème
Pour la personnalisation de fin de parcours, l'organisation peut laisser un message à ses participants quand ils ont fini leur parcours. Objectif est d'afficher ce message.

## :robot: Solution
Afficher ce message personnalisé.

## :rainbow: Remarques

## :100: Pour tester
Aller sur pix-app avec le compte de jaune.attend@example.net, aller à la page de ses parcours, voir le détail du parcours terminé avec des paliers.
