### PR TITLE
[CLEANUP] Refacto du proposal as block pour mieux afficher les blocs avec du markdown (PIX-2438).

### DIFF
--- a/mon-pix/app/components/qroc-proposal.js
+++ b/mon-pix/app/components/qroc-proposal.js
@@ -2,12 +2,15 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
+import { inject as service } from '@ember/service';
 
 export default class QrocProposal extends Component {
+  @service intl;
 
   get _blocks() {
     return proposalsAsBlocks(this.args.proposals).map((block) => {
       block.randomName = generateRandomString(block.input);
+      block.ariaLabel = block.autoAriaLabel ? this.intl.t('pages.challenge.answer-input.numbered-label', { number: block.ariaLabel }) : block.ariaLabel;
       return block;
     });
   }

--- a/mon-pix/app/components/qrocm-proposal.js
+++ b/mon-pix/app/components/qrocm-proposal.js
@@ -2,14 +2,17 @@ import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import generateRandomString from 'mon-pix/utils/generate-random-string';
 import proposalsAsBlocks from 'mon-pix/utils/proposals-as-blocks';
+import { inject as service } from '@ember/service';
 
 export default class QrocmProposal extends Component {
+  @service intl;
 
   get proposalBlocks() {
     return proposalsAsBlocks(this.args.proposals)
       .map((block) => {
         block.showText = block.text && !block.ariaLabel && !block.input;
         block.randomName = generateRandomString(block.input);
+        block.ariaLabel = block.autoAriaLabel ? this.intl.t('pages.challenge.answer-input.numbered-label', { number: block.ariaLabel }) : block.ariaLabel;
         return block;
       });
   }

--- a/mon-pix/app/styles/components/_qrocm-proposals.scss
+++ b/mon-pix/app/styles/components/_qrocm-proposals.scss
@@ -1,6 +1,6 @@
 .qrocm-proposal {
 
   &__label {
-    display: contents;
+    display: inline;
   }
 }

--- a/mon-pix/app/styles/components/_qrocm-proposals.scss
+++ b/mon-pix/app/styles/components/_qrocm-proposals.scss
@@ -1,6 +1,6 @@
 .qrocm-proposal {
 
   &__label {
-    display: inline-block;
+    display: contents;
   }
 }

--- a/mon-pix/app/styles/components/_qrocm-solution-panel.scss
+++ b/mon-pix/app/styles/components/_qrocm-solution-panel.scss
@@ -59,6 +59,6 @@
 .correction-qrocm-text {
 
   &__label {
-    display: inline-block;
+    display: block;
   }
 }

--- a/mon-pix/app/templates/components/qrocm-proposal.hbs
+++ b/mon-pix/app/templates/components/qrocm-proposal.hbs
@@ -53,12 +53,6 @@
                aria-label={{block.ariaLabel}}
                onkeydown={{action 'onInputChange'}} />
       {{/if}}
-
     {{/if}}
-
-    {{#if block.breakline}}
-      <br>
-    {{/if}}
-
   {{/each}}
 </div>

--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -1,12 +1,12 @@
 import isEmpty from 'lodash/isEmpty';
 
-const MINIMUM_SIZE_FOR_LABEL = 5;
+const MINIMUM_SIZE_FOR_LABEL = 6;
 function stringHasPlaceholder(input) {
-  return 1 <= input.indexOf('#');
+  return 1 < input.indexOf('#');
 }
 
 function stringHasAriaLabel(input) {
-  return 1 <= input.indexOf('§');
+  return 1 < input.indexOf('§');
 }
 
 function _isInput(block) {
@@ -32,17 +32,15 @@ function buildLineFrom(textBlock, challengeResponseTemplate) {
 class TextBlock {
 
   constructor({ text }) {
-    if (text) {
-      if (text.substring(0, 1) === '\n') {
-        text = '<br/>' + text;
-      }
-      if (text.substring(text.length - 1, text.length) === '\n') {
-        text = text + '<br/>';
-      }
-      this._text = text;
-    } else {
-      this._text = text ? text.replace('\n', '<br/>') : text;
+
+    const firstCharacter = text.substring(0, 1);
+    const secondCharacter = text.substring(1, 2);
+    const isListItem = firstCharacter === '-'
+      || Number.isInteger(Number(firstCharacter)) && secondCharacter === '.';
+    if (isListItem) {
+      text = '\n' + text;
     }
+    this._text = text ? text.replace(/\n/g, '<br/>') : text;
     this._input = null;
     this._placeholder = null;
     this._ariaLabel = null;
@@ -67,10 +65,7 @@ class TextBlock {
 
   get() {
     return {
-      input: this._input,
       text: this._text,
-      placeholder: this._placeholder,
-      ariaLabel: this._ariaLabel,
       type: this._type,
     };
   }
@@ -147,32 +142,32 @@ class ChallengeResponseTemplate {
 
   constructor() {
     this._template = [];
-    this._detailledTemplate = [];
+    this._detailedTemplate = [];
     this._inputCount = 0;
   }
 
   add(block) {
-    this._detailledTemplate.push(block);
+    this._detailedTemplate.push(block);
   }
 
   constructFinalTemplate() {
-    for (let index = 0; index < this._detailledTemplate.length; index++) {
-      if (this._detailledTemplate[index].type) {
-        this._template.push(this._detailledTemplate[index].get());
+    for (let index = 0; index < this._detailedTemplate.length; index++) {
+      if (this._detailedTemplate[index].type) {
+        this._template.push(this._detailedTemplate[index].get());
       }
     }
   }
 
-  mixteTextAndInputBlock() {
-    for (let index = 1; index < this._detailledTemplate.length; index++) {
-      if (this._detailledTemplate[index].type == 'input'
-        && this._detailledTemplate[index].autoAriaLabel
-        && this._detailledTemplate[index - 1].type == 'text'
-        && this._detailledTemplate[index - 1].text.length > MINIMUM_SIZE_FOR_LABEL) {
-        this._detailledTemplate[index].setText(this._detailledTemplate[index - 1].text);
-        this._detailledTemplate[index].removeAriaLabel();
-        this._detailledTemplate[index].setAutoAriaLabel(false);
-        this._detailledTemplate[index - 1].removeType();
+  updateBlockDetails() {
+    for (let index = 1; index < this._detailedTemplate.length; index++) {
+      if (this._detailedTemplate[index].type === 'input'
+        && this._detailedTemplate[index].autoAriaLabel
+        && this._detailedTemplate[index - 1].type === 'text'
+        && this._detailedTemplate[index - 1].text.length > MINIMUM_SIZE_FOR_LABEL) {
+        this._detailedTemplate[index].setText(this._detailedTemplate[index - 1].text);
+        this._detailedTemplate[index].removeAriaLabel();
+        this._detailedTemplate[index].setAutoAriaLabel(false);
+        this._detailedTemplate[index - 1].removeType();
       }
     }
   }
@@ -202,7 +197,7 @@ export default function proposalsAsBlocks(proposals) {
     buildLineFrom(block, challengeResponseTemplate);
   });
 
-  challengeResponseTemplate.mixteTextAndInputBlock();
+  challengeResponseTemplate.updateBlockDetails();
   challengeResponseTemplate.constructFinalTemplate();
   return challengeResponseTemplate.get();
 }

--- a/mon-pix/app/utils/proposals-as-blocks.js
+++ b/mon-pix/app/utils/proposals-as-blocks.js
@@ -83,7 +83,7 @@ class InputBlock {
     this._input = inputText;
     this._placeholder = null;
     this._text = null;
-    this._ariaLabel = 'Réponse ' + inputIndex;
+    this._ariaLabel = inputIndex.toString();
     this._autoAriaLabel = true;
     this._type = 'input';
   }
@@ -127,6 +127,10 @@ class InputBlock {
     this._text = text;
   }
 
+  setAutoAriaLabel(boolean) {
+    this._autoAriaLabel = boolean;
+  }
+
   get() {
     return {
       input: this._input,
@@ -134,6 +138,7 @@ class InputBlock {
       placeholder: this._placeholder,
       ariaLabel: this._ariaLabel,
       type: this._type,
+      autoAriaLabel: this._autoAriaLabel,
     };
   }
 }
@@ -166,6 +171,7 @@ class ChallengeResponseTemplate {
         && this._detailledTemplate[index - 1].text.length > MINIMUM_SIZE_FOR_LABEL) {
         this._detailledTemplate[index].setText(this._detailledTemplate[index - 1].text);
         this._detailledTemplate[index].removeAriaLabel();
+        this._detailledTemplate[index].setAutoAriaLabel(false);
         this._detailledTemplate[index - 1].removeType();
       }
     }

--- a/mon-pix/tests/acceptance/challenge-qrocm-test.js
+++ b/mon-pix/tests/acceptance/challenge-qrocm-test.js
@@ -30,7 +30,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
       expect(findAll('.challenge-response__proposal')[0].disabled).to.be.false;
       expect(findAll('.challenge-response__proposal')[1].disabled).to.be.false;
       expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
-      expect(find('div[data-test="qrocm-label-2"]').innerHTML).to.contains('Station <em>2</em> :');
+      expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
 
       expect(find('.alert')).to.not.exist;
     });
@@ -88,7 +88,7 @@ describe('Acceptance | Displaying a QROCM challenge', () => {
     it('should set the input text with previous answers and propose to continue', async () => {
       // then
       expect(find('div[data-test="qrocm-label-0"]').innerHTML).to.contains('Station <strong>1</strong> :');
-      expect(find('div[data-test="qrocm-label-2"]').innerHTML).to.contains('Station <em>2</em> :');
+      expect(find('div[data-test="qrocm-label-1"]').innerHTML).to.contains('Station <em>2</em> :');
       expect(findAll('.challenge-response__proposal')[0].value).to.equal('Republique');
       expect(findAll('.challenge-response__proposal')[1].value).to.equal('Chatelet');
 

--- a/mon-pix/tests/acceptance/user-dashboard-test.js
+++ b/mon-pix/tests/acceptance/user-dashboard-test.js
@@ -293,7 +293,6 @@ describe('Acceptance | User dashboard page', function() {
       it('should not render any new-information banner', async function() {
         // given
         user = server.create('user', 'withEmail', 'hasSeenNewDashboardInfo');
-        console.log(user);
 
         // when
         await authenticateByEmail(user);

--- a/mon-pix/tests/integration/components/qrocm-proposal-test.js
+++ b/mon-pix/tests/integration/components/qrocm-proposal-test.js
@@ -92,10 +92,6 @@ describe('Integration | Component | QROCm proposal', function() {
     [
       { proposals: '${input}', expectedAriaLabel: ['Réponse 1'] },
       { proposals: '${rep1}, ${rep2} ${rep3}', expectedAriaLabel: ['Réponse 1', 'Réponse 2', 'Réponse 3'] },
-      { proposals: 'Réponses :↵${rep1}\n${rep2}', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
-      { proposals: 'Vidéo : ${video#.ex1} ${video2#.ex2}\nImage : ${image} ${image2}', expectedAriaLabel: ['Réponse 1', 'Réponse 2', 'Réponse 3', 'Réponse 4'] },
-      { proposals: 'Le protocole ${https} assure que la communication entre l\'ordinateur d\'Adèle et le serveur de la banque est ${sécurisée}.', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
-      { proposals: '- ${NumA} Il classe les pages trouvées pour les présenter\n- ${NumB} Il sélectionne  les pages correspondant aux mots', expectedAriaLabel: ['Réponse 1', 'Réponse 2'] },
     ].forEach((data) => {
       describe(`Component aria-label accessibility when proposal is ${data.proposals}`, function() {
 
@@ -118,7 +114,7 @@ describe('Integration | Component | QROCm proposal', function() {
           // then
           expect(allInputElements.length).to.be.equal(data.expectedAriaLabel.length);
           allInputElements.forEach((element, index) => {
-            expect(element.getAttribute('aria-label')).to.equal(data.expectedAriaLabel[index]);
+            expect(element.getAttribute('aria-label')).to.contains(data.expectedAriaLabel[index]);
           });
         });
 

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
@@ -21,20 +21,22 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
 
       const expectedBlocksData = [{
         input: 'smiley1',
-        text: 'content :',
+        text: 'content : ',
         ariaLabel: null,
+        autoAriaLabel: false,
         inputClass: '',
         answer: ':)',
-        placeholder: undefined,
-      }, {
-        breakline: true,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'smiley2',
-        text: 'triste :',
+        text: '<br/>\n\ntriste : ',
         ariaLabel: null,
+        autoAriaLabel: false,
         inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //when

--- a/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-dep-solution-panel-test.js
@@ -30,7 +30,7 @@ describe('Unit | Component | qrocm-dep-solution-panel', function() {
         type: 'input',
       }, {
         input: 'smiley2',
-        text: '<br/>\n\ntriste : ',
+        text: '<br/><br/>triste : ',
         ariaLabel: null,
         autoAriaLabel: false,
         inputClass: 'correction-qroc-box-answer--aband',

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -38,6 +38,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         solution: ':-)',
         emptyOrWrongAnswer: false,
         placeholder: null,
+        autoAriaLabel: false,
         type: 'input',
       }, {
         input: 'smiley2',
@@ -48,6 +49,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: ':(',
         solution: ':-(',
         emptyOrWrongAnswer: false,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -77,6 +79,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }, {
@@ -88,6 +91,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -118,6 +122,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }, {
@@ -129,6 +134,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -162,6 +168,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }, {
@@ -173,6 +180,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '2',
         solution: '3',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -203,6 +211,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }, {
@@ -214,6 +223,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '3',
         solution: '6',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -244,6 +254,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }, {
@@ -255,6 +266,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: 'Pas de réponse',
         solution: '1',
         emptyOrWrongAnswer: true,
+        autoAriaLabel: false,
         placeholder: null,
         type: 'input',
       }];
@@ -290,6 +302,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         answer: '2',
         solution: '2',
         emptyOrWrongAnswer: false,
+        autoAriaLabel: false,
         placeholder: null,
       }];
 

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -30,27 +30,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const expectedBlocksData = [{
         input: 'smiley1',
-        text: 'content :',
+        text: 'content : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--correct',
         answer: ':)',
         solution: ':-)',
         emptyOrWrongAnswer: false,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'smiley2',
-        text: 'triste :',
+        text: '<br/>\n\ntriste : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--correct',
         answer: ':(',
         solution: ':-(',
         emptyOrWrongAnswer: false,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -71,27 +70,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
       solution = 'num1: \n - 2\n\nnum2:\n - 1';
       const result = [{
         input: 'num1',
-        text: 'Clé USB :',
+        text: 'Clé USB : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'num2',
-        text: 'Carte mémoire (SD) :',
+        text: '<br/>\n\nCarte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -113,27 +111,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'num1',
-        text: 'Clé USB :',
+        text: 'Clé USB : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'num2',
-        text: 'Carte mémoire (SD) :',
+        text: '<br/>\n\nCarte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -158,27 +155,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'num1',
-        text: '- alain@pix.fr :',
+        text: '- alain@pix.fr : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '1',
         solution: '2',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'num2',
-        text: '- leonie@pix.fr :',
+        text: '<br/>\n\n- leonie@pix.fr : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '3',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -200,27 +196,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'Num1',
-        text: '- Combien le dossier "projet PIX" contient-il de dossiers ?',
+        text: '- Combien le dossier "projet PIX" contient-il de dossiers ? ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '2',
         solution: '1',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'Num2',
-        text: '- Combien le dossier "images" contient-il de fichiers ?',
+        text: '<br/>\n\n- Combien le dossier "images" contient-il de fichiers ? ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
         answer: '3',
         solution: '6',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -242,27 +237,26 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'num1',
-        text: 'Clé USB :',
+        text: 'Clé USB : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '2',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
-      }, {
-        breakline: true,
-        showText: undefined,
+        placeholder: null,
+        type: 'input',
       }, {
         input: 'num2',
-        text: 'Carte mémoire (SD) :',
+        text: '<br/>\n\nCarte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--aband',
         answer: 'Pas de réponse',
         solution: '1',
         emptyOrWrongAnswer: true,
-        placeholder: undefined,
+        placeholder: null,
+        type: 'input',
       }];
 
       //When
@@ -288,14 +282,15 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'num1',
-        text: 'Clé USB :',
+        text: 'Clé USB : ',
         ariaLabel: null,
+        type: 'input',
         showText: false,
         inputClass: 'correction-qroc-box-answer--correct',
         answer: '2',
         solution: '2',
         emptyOrWrongAnswer: false,
-        placeholder: undefined,
+        placeholder: null,
       }];
 
       //When

--- a/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
+++ b/mon-pix/tests/unit/components/qrocm-ind-solution-panel-test.js
@@ -42,7 +42,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'smiley2',
-        text: '<br/>\n\ntriste : ',
+        text: '<br/><br/>triste : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--correct',
@@ -84,7 +84,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'num2',
-        text: '<br/>\n\nCarte mémoire (SD) : ',
+        text: '<br/><br/>Carte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -127,7 +127,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'num2',
-        text: '<br/>\n\nCarte mémoire (SD) : ',
+        text: '<br/><br/>Carte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -161,7 +161,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'num1',
-        text: '- alain@pix.fr : ',
+        text: '<br/>- alain@pix.fr : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -173,7 +173,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'num2',
-        text: '<br/>\n\n- leonie@pix.fr : ',
+        text: '<br/><br/>- leonie@pix.fr : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -204,7 +204,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
 
       const result = [{
         input: 'Num1',
-        text: '- Combien le dossier "projet PIX" contient-il de dossiers ? ',
+        text: '<br/>- Combien le dossier "projet PIX" contient-il de dossiers ? ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -216,7 +216,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'Num2',
-        text: '<br/>\n\n- Combien le dossier "images" contient-il de fichiers ? ',
+        text: '<br/><br/>- Combien le dossier "images" contient-il de fichiers ? ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--wrong',
@@ -259,7 +259,7 @@ describe('Unit | Component | qrocm-ind-solution-panel', function() {
         type: 'input',
       }, {
         input: 'num2',
-        text: '<br/>\n\nCarte mémoire (SD) : ',
+        text: '<br/><br/>Carte mémoire (SD) : ',
         ariaLabel: null,
         showText: false,
         inputClass: 'correction-qroc-box-answer--aband',

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -24,49 +24,49 @@ describe('Unit | Utility | proposals as blocks', function() {
     {
       data: '${qroc}',
       expected: [
-        { input: 'qroc', text: null, placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
+        { input: 'qroc', text: null, placeholder: null, ariaLabel: '1', type: 'input', autoAriaLabel: true },
       ],
     },
     {
       data: '${annee#19XX}',
       expected: [
-        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Réponse 1', type: 'input' },
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: '1', type: 'input', autoAriaLabel: true },
       ],
     },
     {
       data: '${annee#19XX§Année de construction}',
       expected: [
-        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input' },
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input', autoAriaLabel: false },
       ],
     },
     {
       data: 'Et ta réponse est : ${annee#19XX§Année de construction}',
       expected: [
         { text: 'Et ta réponse est : ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
-        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input' },
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input', autoAriaLabel: false },
       ],
     },
     {
       data: 'Test: ${test#1 ou 2}',
       expected: [
-        { text: 'Test: ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input' },
+        { text: 'Test: ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input', autoAriaLabel: false },
       ],
     },
     {
       data: 'Test: ${test} (kilometres)',
       expected: [
-        { text: 'Test: ', input: 'test', placeholder: null, ariaLabel: null, type: 'input' },
+        { text: 'Test: ', input: 'test', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
         { text: ' (kilometres)', input: null, placeholder: null, ariaLabel: null, type: 'text' },
       ],
     },
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [
-        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: '1', type: 'input', autoAriaLabel: true },
         { input: null, text: ', ', placeholder: null, ariaLabel: null, type: 'text' },
-        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 2', type: 'input' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: '2', type: 'input', autoAriaLabel: true },
         { input: null, text: ' ', placeholder: null, ariaLabel: null, type: 'text' },
-        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 3', type: 'input' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: '3', type: 'input', autoAriaLabel: true },
       ],
     },
     {
@@ -85,13 +85,13 @@ describe('Unit | Utility | proposals as blocks', function() {
       data: '- ${plop}',
       expected: [
         { text: '- ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
-        { text: null, input: 'plop', placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
+        { text: null, input: 'plop', placeholder: null, ariaLabel: '1', type: 'input', autoAriaLabel: true },
       ],
     },
     {
       data: '- line ${plop}',
       expected: [
-        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null, type: 'input' },
+        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
       ],
     },
   ];

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -12,70 +12,73 @@ describe('Unit | Utility | proposals as blocks', function() {
     {
       data: 'Text',
       expected: [
-        { text: 'Text', input: undefined, placeholder: undefined, ariaLabel: null },
+        { text: 'Text', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+      ],
+    },
+    {
+      data: '\nTexte avec des \n retours à la ligne \n',
+      expected: [
+        { text: '<br/>\nTexte avec des \n retours à la ligne \n<br/>', input: null, placeholder: null, ariaLabel: null, type: 'text' },
       ],
     },
     {
       data: '${qroc}',
       expected: [
-        { input: 'qroc', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' },
+        { input: 'qroc', text: null, placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
       ],
     },
     {
-      data: 'Test: ${test}',
+      data: '${annee#19XX}',
       expected: [
-        { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null },
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Réponse 1', type: 'input' },
+      ],
+    },
+    {
+      data: 'Test: ${test#1 ou 2}',
+      expected: [
+        { text: 'Test: ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input' },
       ],
     },
     {
       data: 'Test: ${test} (kilometres)',
       expected: [
-        { text: 'Test:', input: 'test', placeholder: undefined, ariaLabel: null },
-        { text: '(kilometres)', input: undefined, placeholder: undefined, ariaLabel: null },
+        { text: 'Test: ', input: 'test', placeholder: null, ariaLabel: null, type: 'input' },
+        { text: ' (kilometres)', input: null, placeholder: null, ariaLabel: null, type: 'text' },
       ],
     },
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [
-        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 1' },
-        { input: undefined, text: ',', placeholder: undefined, ariaLabel: null },
-        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 2' },
-        { input: 'plop', text: undefined, placeholder: undefined, ariaLabel: 'Réponse 3' },
-      ],
-    },
-    {
-      data: '${plop#var}',
-      expected: [
-        { input: 'plop', placeholder: 'var', text: undefined, ariaLabel: 'Réponse 1' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
+        { input: null, text: ', ', placeholder: null, ariaLabel: null, type: 'text' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 2', type: 'input' },
+        { input: null, text: ' ', placeholder: null, ariaLabel: null, type: 'text' },
+        { input: 'plop', text: null, placeholder: null, ariaLabel: 'Réponse 3', type: 'input' },
       ],
     },
     {
       data: 'line1\nline2',
       expected: [
-        { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
-        { breakline: true },
-        { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null },
+        { text: 'line1\nline2', input: null, placeholder: null, ariaLabel: null, type: 'text' },
       ],
     },
     {
       data: 'line1\r\nline2',
       expected: [
-        { text: 'line1', input: undefined, placeholder: undefined, ariaLabel: null },
-        { breakline: true },
-        { text: 'line2', input: undefined, placeholder: undefined, ariaLabel: null },
+        { text: 'line1\r\nline2', input: null, placeholder: null, ariaLabel: null, type: 'text' },
       ],
     },
     {
       data: '- ${plop}',
       expected: [
-        { text: '-', input: undefined, placeholder: undefined, ariaLabel: null },
-        { text: undefined, input: 'plop', placeholder: undefined, ariaLabel: 'Réponse 1' },
+        { text: '- ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: null, input: 'plop', placeholder: null, ariaLabel: 'Réponse 1', type: 'input' },
       ],
     },
     {
       data: '- line ${plop}',
       expected: [
-        { text: '- line', input: 'plop', placeholder: undefined, ariaLabel: null },
+        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null , type: 'input'},
       ],
     },
   ];

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -12,13 +12,13 @@ describe('Unit | Utility | proposals as blocks', function() {
     {
       data: 'Text',
       expected: [
-        { text: 'Text', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: 'Text', type: 'text' },
       ],
     },
     {
       data: '\nTexte avec des \n retours à la ligne \n',
       expected: [
-        { text: '<br/>\nTexte avec des \n retours à la ligne \n<br/>', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: '<br/>Texte avec des <br/> retours à la ligne <br/>', type: 'text' },
       ],
     },
     {
@@ -42,56 +42,63 @@ describe('Unit | Utility | proposals as blocks', function() {
     {
       data: 'Et ta réponse est : ${annee#19XX§Année de construction}',
       expected: [
-        { text: 'Et ta réponse est : ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: 'Et ta réponse est : ', type: 'text' },
         { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input', autoAriaLabel: false },
       ],
     },
     {
-      data: 'Test: ${test#1 ou 2}',
+      data: 'Réponse : ${test#1 ou 2}',
       expected: [
-        { text: 'Test: ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input', autoAriaLabel: false },
+        { text: 'Réponse : ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input', autoAriaLabel: false },
       ],
     },
     {
-      data: 'Test: ${test} (kilometres)',
+      data: 'Réponse : ${test} (kilometres)',
       expected: [
-        { text: 'Test: ', input: 'test', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
-        { text: ' (kilometres)', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: 'Réponse : ', input: 'test', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
+        { text: ' (kilometres)', type: 'text' },
       ],
     },
     {
       data: '${plop}, ${plop} ${plop}',
       expected: [
         { input: 'plop', text: null, placeholder: null, ariaLabel: '1', type: 'input', autoAriaLabel: true },
-        { input: null, text: ', ', placeholder: null, ariaLabel: null, type: 'text' },
+        { text: ', ', type: 'text' },
         { input: 'plop', text: null, placeholder: null, ariaLabel: '2', type: 'input', autoAriaLabel: true },
-        { input: null, text: ' ', placeholder: null, ariaLabel: null, type: 'text' },
+        { text: ' ', type: 'text' },
         { input: 'plop', text: null, placeholder: null, ariaLabel: '3', type: 'input', autoAriaLabel: true },
       ],
     },
     {
       data: 'line1\nline2',
       expected: [
-        { text: 'line1\nline2', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: 'line1<br/>line2', type: 'text' },
       ],
     },
     {
-      data: 'line1\r\nline2',
+      data: 'line1\r<br/>line2',
       expected: [
-        { text: 'line1\r\nline2', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: 'line1\r<br/>line2', type: 'text' },
       ],
     },
     {
-      data: '- ${plop}',
+      data: '-${plop}',
       expected: [
-        { text: '- ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { text: '<br/>-', type: 'text' },
         { text: null, input: 'plop', placeholder: null, ariaLabel: '1', type: 'input', autoAriaLabel: true },
       ],
     },
     {
+      data: '1.${plop}',
+      expected: [
+        { text: '<br/>1.', input: 'plop', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
+      ],
+    },
+
+    {
       data: '- line ${plop}',
       expected: [
-        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
+        { text: '<br/>- line ', input: 'plop', placeholder: null, ariaLabel: null, type: 'input', autoAriaLabel: false },
       ],
     },
   ];

--- a/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
+++ b/mon-pix/tests/unit/utils/proposals-as-blocks-test.js
@@ -34,6 +34,19 @@ describe('Unit | Utility | proposals as blocks', function() {
       ],
     },
     {
+      data: '${annee#19XX§Année de construction}',
+      expected: [
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input' },
+      ],
+    },
+    {
+      data: 'Et ta réponse est : ${annee#19XX§Année de construction}',
+      expected: [
+        { text: 'Et ta réponse est : ', input: null, placeholder: null, ariaLabel: null, type: 'text' },
+        { input: 'annee', text: null, placeholder: '19XX', ariaLabel: 'Année de construction', type: 'input' },
+      ],
+    },
+    {
       data: 'Test: ${test#1 ou 2}',
       expected: [
         { text: 'Test: ', input: 'test', placeholder: '1 ou 2', ariaLabel: null, type: 'input' },
@@ -78,7 +91,7 @@ describe('Unit | Utility | proposals as blocks', function() {
     {
       data: '- line ${plop}',
       expected: [
-        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null , type: 'input'},
+        { text: '- line ', input: 'plop', placeholder: null, ariaLabel: null, type: 'input' },
       ],
     },
   ];

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -266,6 +266,9 @@
                 "skip": "Skip"
             },
             "already-answered": "You have already answered this question",
+            "answer-input": {
+                "numbered-label": "Answer {number}"
+            },
             "certification": {
                 "title": "Certification {certificationNumber}",
                 "banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -266,6 +266,9 @@
                 "skip": "Je passe"
             },
             "already-answered": "Vous avez déjà répondu à cette question",
+            "answer-input": {
+                "numbered-label": "Réponse {number}"
+            },
             "certification": {
                 "title": "Certification {certificationNumber}",
                 "banner": {


### PR DESCRIPTION
## :unicorn: Problème
Certaines épreuves avec du markdown s'affiche mal car le proposalAsBlock découpe tout ligne par ligne, et chaque ligne se retrouve dans une div. Ce qui empêche les listes par exemple, ou le code multiligne, qui se retrouve sur plusieurs lignes.

## :robot: Solution
Changement du fonctionnement du proposalAsBlock : un block est soit un ensemble de ligne de texte, soit un input

## :rainbow: Remarques
Une modification avait été apporté pour ajouter un aria-label ou un label aux champs inputs.
Le précédent fonctionnement est actuellement modifié et prend le texte précédent comme label, ou simplement "Réponse 1".
Propositon de modification des champs QROC pour pouvoir préciser le label que l'on souhaite, via `§`.

TODO : 
- Avoir une trad pour le label de base "Réponse 1"

## :100: Pour tester
Exemple d'épreuve : recu3kReqB0Zva48R