### PR TITLE
[FEATURE] Afficher la liste des épreuves posées en certif sur l'onglet "Neutralisation" (PIX-2358)

### DIFF
--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -23,16 +23,18 @@ export default class CertificationDetails extends Model {
       answer.order = count;
       count++;
     });
-    let competences = competenceData.reduce((accumulator, value) => {
-      accumulator[value.index] = value;
+
+    let competences = competenceData.reduce((accumulator, competence) => {
+      accumulator[competence.index] = competence;
       return accumulator;
     }, {});
-    competences = answers.reduce((accumulator, value) => {
-      if (accumulator[value.competence]) {
-        if (!accumulator[value.competence].answers) {
-          accumulator[value.competence].answers = [];
+
+    competences = answers.reduce((accumulator, answer) => {
+      if (accumulator[answer.competence]) {
+        if (!accumulator[answer.competence].answers) {
+          accumulator[answer.competence].answers = [];
         }
-        accumulator[value.competence].answers.push(value);
+        accumulator[answer.competence].answers.push(answer);
       }
       return accumulator;
     }, competences);

--- a/admin/app/models/certification-details.js
+++ b/admin/app/models/certification-details.js
@@ -14,22 +14,24 @@ export default class CertificationDetails extends Model {
   @attr() completedAt;
   @attr() listChallengesAndAnswers;
 
-  @computed('competencesWithMark', 'listChallengesAndAnswers')
-  get competences() {
-    const competenceData = this.competencesWithMark;
-    const answers = this.listChallengesAndAnswers;
+  @computed('listChallengesAndAnswers')
+  get answers() {
     let count = 1;
-    answers.forEach((answer) => {
+    return this.listChallengesAndAnswers.map((answer) => {
       answer.order = count;
       count++;
+      return answer;
     });
+  }
 
-    let competences = competenceData.reduce((accumulator, competence) => {
+  @computed('answers', 'competencesWithMark')
+  get competences() {
+    let competences = this.competencesWithMark.reduce((accumulator, competence) => {
       accumulator[competence.index] = competence;
       return accumulator;
     }, {});
 
-    competences = answers.reduce((accumulator, answer) => {
+    competences = this.answers.reduce((accumulator, answer) => {
       if (accumulator[answer.competence]) {
         if (!accumulator[answer.competence].answers) {
           accumulator[answer.competence].answers = [];

--- a/admin/app/routes/authenticated/certifications/certification/neutralization.js
+++ b/admin/app/routes/authenticated/certifications/certification/neutralization.js
@@ -1,4 +1,8 @@
 import Route from '@ember/routing/route';
 
 export default class CertificationNeutralizationRoute extends Route {
+  async model() {
+    const { certification_id } = this.paramsFor('authenticated.certifications.certification');
+    return this.store.findRecord('certification-details', certification_id);
+  }
 }

--- a/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
+++ b/admin/app/templates/authenticated/certifications/certification/neutralization.hbs
@@ -1,0 +1,32 @@
+{{#if this.model.answers}}
+  <table class="table-admin table-admin__auto-width">
+    <thead>
+      <tr>
+        <th>
+          Numéro de question
+        </th>
+        <th>
+          RecId de l'épreuve
+        </th>
+        <th>
+          Action
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {{#each this.model.answers as |answer| }}
+        <tr>
+          <td>
+            {{answer.order}}
+          </td>
+          <td>
+            {{answer.challengeId}}
+          </td>
+          <td></td>
+        </tr>
+      {{/each}}
+    </tbody>
+  </table>
+{{else}}
+  <p>Aucune épreuve posée.</p>
+{{/if}}

--- a/admin/mirage/config.js
+++ b/admin/mirage/config.js
@@ -113,6 +113,11 @@ export default function() {
     return schema.certifiedProfiles.find(id);
   });
 
+  this.get('/admin/certifications/:id/details', (schema, request) => {
+    const id = request.params.id;
+    return schema.certificationDetails.find(id);
+  });
+
   this.get('/admin/sessions/:id/generate-results-download-link', { sessionResultsLink: 'http://link-to-results.fr' });
 
   this.post('/organizations/:id/invitations', (schema, request) => {

--- a/admin/tests/acceptance/authenticated/certifications/certification/neutralization-test.js
+++ b/admin/tests/acceptance/authenticated/certifications/certification/neutralization-test.js
@@ -1,0 +1,141 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+import { createAuthenticateSession } from 'pix-admin/tests/helpers/test-init';
+
+module('Acceptance | Route | routes/authenticated/certifications/certification | neutralization', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    const user = server.create('user');
+    await createAuthenticateSession({ userId: user.id });
+  });
+
+  module('when there is no challenge for this certification', function() {
+
+    test('it renders "Aucune épreuve posée"', async function(assert) {
+      // given
+      this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
+      const certificationId = this.server.create('certification').id;
+      this.server.create('certification-detail', {
+        id: certificationId,
+        competencesWithMark: [],
+        status: 'started',
+        listChallengesAndAnswers: [],
+      });
+
+      // when
+      await visit(`/certifications/${certificationId}/neutralization`);
+
+      // then
+      assert.contains('Aucune épreuve posée.');
+    });
+  });
+
+  module('when there are challenges for this certification', function() {
+
+    test('it renders a challenge list', async function(assert) {
+      // given
+      const listChallengesAndAnswers = [{
+        result: 'ok',
+        value: 'Dummy value',
+        challengeId: 'recCGEqqWBQnzD3NZ',
+        competence: '1.1',
+        skill: '',
+      },
+      {
+        result: 'ok',
+        value: 'Dummy value',
+        challengeId: 'recABCEdeef1234',
+        competence: '1.2',
+        skill: '',
+      }];
+
+      const competencesWithMark = [
+        {
+          'area_code': '1',
+          'index': '1.1',
+        },
+        {
+          'area_code': '1',
+          'index': '1.2',
+        },
+      ];
+
+      this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
+      const certificationId = this.server.create('certification').id;
+      this.server.create('certification-detail', {
+        id: certificationId,
+        competencesWithMark,
+        status: 'started',
+        listChallengesAndAnswers,
+      });
+
+      // when
+      await visit(`/certifications/${certificationId}/neutralization`);
+
+      // then
+      assert.contains('recCGEqqWBQnzD3NZ');
+      assert.contains('recABCEdeef1234');
+    });
+
+    test('it sort challenges by order property', async function(assert) {
+      // given
+      const listChallengesAndAnswers = [{
+        result: 'ok',
+        value: 'Dummy value',
+        challengeId: 'recCGEqqWBQnzD3NZ',
+        competence: '1.1',
+        skill: '',
+      },
+      {
+        result: 'ok',
+        value: 'Dummy value',
+        challengeId: 'recABCEdeef1234',
+        competence: '1.2',
+        skill: '',
+      },
+      {
+        result: 'ok',
+        value: 'Dummy value',
+        challengeId: 'recZXYW4321',
+        competence: '1.1',
+        skill: '',
+      }];
+
+      const competencesWithMark = [
+        {
+          'area_code': '1',
+          'index': '1.1',
+        },
+        {
+          'area_code': '1',
+          'index': '1.2',
+        },
+      ];
+
+      this.server.create('feature-toggle', { isNeutralizationAutoEnabled: true });
+      const certificationId = this.server.create('certification').id;
+      this.server.create('certification-detail', {
+        id: certificationId,
+        competencesWithMark,
+        status: 'started',
+        listChallengesAndAnswers,
+      });
+
+      // when
+      await visit(`/certifications/${certificationId}/neutralization`);
+
+      // then
+      const firstRowContent = document.querySelector('tr:nth-child(1) td:nth-child(2)').innerText;
+      const secondRowContent = document.querySelector('tr:nth-child(2) td:nth-child(2)').innerText;
+      const thirdRowContent = document.querySelector('tr:nth-child(3) td:nth-child(2)').innerText;
+      assert.equal(firstRowContent, 'recCGEqqWBQnzD3NZ');
+      assert.equal(secondRowContent, 'recABCEdeef1234');
+      assert.equal(thirdRowContent, 'recZXYW4321');
+    });
+  });
+});

--- a/admin/tests/unit/models/certification-details-test.js
+++ b/admin/tests/unit/models/certification-details-test.js
@@ -5,10 +5,27 @@ import { run } from '@ember/runloop';
 module('Unit | Model | certification details', function(hooks) {
   setupTest(hooks);
 
-  // Replace this with your real tests.
-  test('it exists', function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = run(() => store.createRecord('certification-details', {}));
-    assert.ok(model);
+  module('#get answers', function() {
+    test('it returns answers with order property', function(assert) {
+      // given
+      const store = this.owner.lookup('service:store');
+      const listChallengesAndAnswers = [
+        { id: 'answerId1' },
+        { id: 'answerId2' },
+        { id: 'answerId3' },
+      ];
+
+      // when
+      const certification = run(() => store.createRecord('certification-details', {
+        listChallengesAndAnswers,
+      }));
+
+      // then
+      assert.deepEqual(certification.answers, [
+        { id: 'answerId1', order: 1 },
+        { id: 'answerId2', order: 2 },
+        { id: 'answerId3', order: 3 },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de l'épix Neutralisation auto des épreuves certif, nous allons permettre au pôle certification de neutraliser plus simplement une ou plusieurs épreuves d’une certification. Pour cela, il faut que le pôle certif ait accès pour chaque certif à la liste des épreuves posées pour un test de certification.

## :robot: Solution
Dans Pix Admin > page de détails d’une certification > onglet “Neutralisation”, ajouter un tableau avec pour chaque épreuve 
une ligne et trois colonnes : 
- une colonne **Numéro de la question**
- une colonne **RecId de l'épreuve**
- une colonne **Actions** qui accueillera le bouton neutraliser

Pour une certification pour laquelle aucune épreuve n’est disponible (certification au statut “Démarrée” sans aucune épreuve) : afficher “Aucune épreuve posée”

## :rainbow: Remarques
*RAS*

## :100: Pour tester
- Se connecter à Pix Admin
- Se rendre dans une session de certification (par ex. la 6)
- Ouvrir une certification et se rendre dans l'onglet **Neutralisation (en chantier)**
- Constater qu'apparaît un tableau avec la liste des questions et le recId de l'épreuve
