### PR TITLE
[FEATURE] Afficher le bouton personnalisé dans la page de fin de parcours (Pix-2327)

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -135,6 +135,8 @@ function _buildCampaignForPro(databaseBuilder) {
     title: null,
     customLandingPageText: null,
     customResultPageText: 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.',
+    customResultPageButtonUrl: 'https://pix.fr/',
+    customResultPageButtonText: 'Voir Pix !',
   });
 
   databaseBuilder.factory.buildCampaign({

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -65,7 +65,8 @@
               </a>
             {{else}}
               <CampaignShareButton
-                      @isShared={{@model.campaignParticipation.isShared}}
+                      @isShared={{this.isShared}}
+                      @displayPixLink={{this.displayPixLink}}
                       @shareCampaignParticipation={{this.shareCampaignParticipation}}
               />
             {{/if}}
@@ -75,8 +76,7 @@
     </div>
   </PixBlock>
 {{/if}}
-
-{{#if this.showOrganizationMessage}}
+{{#if this.displayOrganizationCustomMessage}}
   <PixBlock class="skill-review__organization-message">
       {{#if this.organizationLogoUrl}}
         <div class="skill-review-organization-message__logo">
@@ -86,9 +86,14 @@
       <div class="skill-review-organization-message__content">
         <p class="skill-review-organization-message__title">{{t 'pages.skill-review.organization-message'}}</p>
         <p class="skill-review-organization-message__organization-name">{{this.organizationName}}</p>
-        <div class="skill-review-organization-message__text">
-          <p>{{this.organizationMessageText}}</p>
-        </div>
+        {{#if this.showOrganizationMessage}}
+          <div class="skill-review-organization-message__text">
+            <p>{{this.organizationMessage}}</p>
+          </div>
+        {{/if}}
+        {{#if this.showOrganizationButton}}
+          <a class="skill-review-organization-message__link" target="_blank" rel="noopener noreferrer" href={{this.customButtonUrl}}>{{this.customButtonText}}<FaIcon @icon='external-link-alt' aria-hidden="true"></FaIcon></a>
+        {{/if}}
       </div>
   </PixBlock>
 {{/if}}

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -49,11 +49,23 @@ export default class SkillReview extends Component {
     return this.args.model.campaignParticipation.campaignParticipationResult.get('stageCount');
   }
 
-  get showOrganizationMessage() {
-    return Boolean(this.args.model.campaignParticipation.campaign.get('customResultPageText'));
+  get isShared() {
+    return this.args.model.campaignParticipation.get('isShared');
   }
 
-  get organizationMessageText() {
+  get displayPixLink() {
+    return !this.showOrganizationButton;
+  }
+
+  get displayOrganizationCustomMessage() {
+    return Boolean((this.showOrganizationMessage || this.showOrganizationButton) && this.isShared);
+  }
+
+  get showOrganizationMessage() {
+    return Boolean(this.organizationMessage);
+  }
+
+  get organizationMessage() {
     return this.args.model.campaignParticipation.campaign.get('customResultPageText');
   }
 
@@ -63,6 +75,18 @@ export default class SkillReview extends Component {
 
   get organizationName() {
     return this.args.model.campaignParticipation.campaign.get('organizationName');
+  }
+
+  get showOrganizationButton() {
+    return Boolean(this.customButtonText && this.customButtonUrl);
+  }
+
+  get customButtonUrl() {
+    return this.args.model.campaignParticipation.campaign.get('customResultPageButtonUrl');
+  }
+
+  get customButtonText() {
+    return this.args.model.campaignParticipation.campaign.get('customResultPageButtonText');
   }
 
   @action

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -67,12 +67,13 @@
   }
 
   &__begin-improvement {
-    border-top: 1px dashed $grey-22;
+    border-bottom: 1px dashed $grey-22;
     padding: 30px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: 30px;
   }
 
   &__explain-text {
@@ -197,6 +198,22 @@
 
     p {
       margin: 0;
+    }
+  }
+
+  &__link {
+    background-color: $blue;
+    border-radius: 4px;
+    color: $white;
+    padding: 8px 12px;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 0.875rem;
+    margin-top: 4px;
+    cursor: pointer;
+
+    svg {
+      margin-left: 8px;
     }
   }
 }

--- a/mon-pix/app/templates/components/campaign-share-button.hbs
+++ b/mon-pix/app/templates/components/campaign-share-button.hbs
@@ -1,22 +1,23 @@
 {{#if @isShared}}
-  <div class="skill-review-share__thanks">
-    {{t 'pages.skill-review.already-shared'}}
-  </div>
-  <LinkTo @route="index" class="skill-review-share__back-to-home link">
-    <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
-    {{t 'pages.skill-review.actions.continue'}}
-  </LinkTo>
+  {{#if @displayPixLink}}
+    <div class="skill-review-share__thanks">
+      {{t 'pages.skill-review.already-shared'}}
+    </div>
+    <LinkTo @route="index" class="skill-review-share__back-to-home link">
+      <FaIcon @icon='arrow-right' aria-hidden="true"></FaIcon>
+      {{t 'pages.skill-review.actions.continue'}}
+    </LinkTo>
+  {{/if}}
 {{else}}
+  <PixButton
+          class="button button--green button--round skill-review-share__button"
+          aria-hidden="true"
+          @triggerAction={{@shareCampaignParticipation}}
+          @loading-color="white">
+    {{t 'pages.skill-review.actions.send'}}
+  </PixButton>
 
-      <PixButton
-              class="button button--green button--round skill-review-share__button"
-              aria-hidden="true"
-              @triggerAction={{@shareCampaignParticipation}}
-              @loading-color="white">
-        {{t 'pages.skill-review.actions.send'}}
-      </PixButton>
-
-      <p class="skill-review-share__legal">
-      {{t 'pages.skill-review.send-results'}}
-    </p>
+  <p class="skill-review-share__legal">
+  {{t 'pages.skill-review.send-results'}}
+</p>
 {{/if}}

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -36,9 +36,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         const campaign = {
           campaignParticipation: {
             id: 8654,
-            isShared: false,
             save: sinon.stub().rejects(),
             set: sinon.stub().resolves(),
+            get: sinon.stub(),
             rollbackAttributes: sinon.stub(),
             campaignParticipationResult: {
               masteryPercentage: 90,
@@ -50,7 +50,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             },
           },
         };
-
+        campaign.campaignParticipation.get.withArgs('isShared').returns(false);
         this.set('campaign', campaign);
         this.set('assessmentId', 'BADGES123');
         this.set('acquiredBadges', null);
@@ -71,9 +71,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         const campaign = {
           campaignParticipation: {
             id: 8654,
-            isShared: false,
             save: sinon.stub().rejects(),
             set: sinon.stub().resolves(),
+            get: sinon.stub(),
             rollbackAttributes: sinon.stub(),
             campaignParticipationResult: {
               masteryPercentage: 90,
@@ -88,6 +88,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             },
           },
         };
+        campaign.campaignParticipation.get.withArgs('isShared').returns(false);
 
         this.set('campaign', campaign);
         this.set('assessmentId', 'BADGES123');
@@ -115,9 +116,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       const campaignParticipation = {
         campaignParticipation: {
           id: 8654,
-          isShared: false,
           save: sinon.stub().rejects(),
           set: sinon.stub().resolves(),
+          get: sinon.stub(),
           rollbackAttributes: sinon.stub(),
           campaign: {
             isForAbsoluteNovice: true,
@@ -133,6 +134,8 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           },
         },
       };
+
+      campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(false);
 
       this.set('campaignParticipation', campaignParticipation);
       this.set('assessmentId', 'BADGES123');
@@ -161,60 +164,104 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   });
 
   describe('The block of the organisation message', function() {
-    context('when the organization has a message', function() {
-      context('when the organization has a logo', function() {
-        beforeEach(async function() {
-          // Given
-          const campaignParticipation = {
-            campaignParticipation: {
-              campaignParticipationResult: {
-                get: sinon.stub().returns([]),
-              },
-              campaign: {
-                customResultPageText: 'Bravo !',
-                organizationLogoUrl: 'www.logo-example.com',
-                organizationName: 'Dragon & Co',
+    context('When the camapaign is shared', function() {
+      context('when the organization has a message', function() {
+        context('when the organization has a logo', function() {
+          beforeEach(async function() {
+            // Given
+            const campaignParticipation = {
+              campaignParticipation: {
                 get: sinon.stub(),
+                campaignParticipationResult: {
+                  get: sinon.stub().returns([]),
+                },
+                campaign: {
+                  customResultPageText: 'Bravo !',
+                  organizationLogoUrl: 'www.logo-example.com',
+                  organizationName: 'Dragon & Co',
+                  get: sinon.stub(),
+                },
               },
-            },
-          };
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-          this.set('campaignParticipation', campaignParticipation);
-          // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-              @model={{campaignParticipation}}/>`);
-        });
-        it('should display the block for the message', function() {
-          // Then
-          expect(contains('Message de votre organisation')).to.exist;
-          expect(contains('Dragon & Co')).to.exist;
+            };
+            campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            this.set('campaignParticipation', campaignParticipation);
+            // When
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+                @model={{campaignParticipation}}/>`);
+          });
+          it('should display the block for the message', function() {
+            // Then
+            expect(contains('Message de votre organisation')).to.exist;
+            expect(contains('Dragon & Co')).to.exist;
+          });
+
+          it('should show the logo of the organization ', function() {
+            // Then
+            expect(find('[src="www.logo-example.com"]')).to.exist;
+          });
         });
 
-        it('should show the logo of the organization ', function() {
-          // Then
-          expect(find('[src="www.logo-example.com"]')).to.exist;
+        context('when the organization has no logo', function() {
+          beforeEach(async function() {
+            // Given
+            const campaignParticipation = {
+              campaignParticipation: {
+                get: sinon.stub(),
+                campaignParticipationResult: {
+                  get: sinon.stub().returns([]),
+                },
+                campaign: {
+                  customResultPageText: 'Bravo !',
+                  organizationLogoUrl: null,
+                  organizationName: 'Dragon & Co',
+                  get: sinon.stub(),
+                },
+              },
+            };
+            campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            this.set('campaignParticipation', campaignParticipation);
+            // When
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+                @model={{campaignParticipation}}/>`);
+          });
+
+          it('should display the block for the message', function() {
+            // Then
+            expect(contains('Dragon & Co')).to.exist;
+            expect(contains('Message de votre organisation')).to.exist;
+          });
+
+          it('should not display the logo of the organization ', function() {
+            // Then
+            expect(find('[src="www.logo-example.com"]')).to.not.exist;
+          });
         });
       });
-
-      context('when the organization has no logo', function() {
+      context('when the organization has no message', function() {
         beforeEach(async function() {
           // Given
           const campaignParticipation = {
             campaignParticipation: {
+              get: sinon.stub(),
               campaignParticipationResult: {
                 get: sinon.stub().returns([]),
               },
               campaign: {
-                customResultPageText: 'Bravo !',
+                customResultPageText: null,
                 organizationLogoUrl: null,
                 organizationName: 'Dragon & Co',
                 get: sinon.stub(),
               },
             },
           };
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
           campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
           campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
           this.set('campaignParticipation', campaignParticipation);
@@ -223,37 +270,135 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               @model={{campaignParticipation}}/>`);
         });
 
-        it('should display the block for the message', function() {
+        it('should not display the block for the message', function() {
           // Then
-          expect(contains('Dragon & Co')).to.exist;
-          expect(contains('Message de votre organisation')).to.exist;
+          expect(contains('Message de votre organisation')).to.not.exist;
+        });
+      });
+
+      context('when the organization has a customResultPageButtonUrl and a customResultPageButtonText', function() {
+        beforeEach(async function() {
+          // Given
+          const campaignParticipation = {
+            campaignParticipation: {
+              get: sinon.stub(),
+              campaignParticipationResult: {
+                get: sinon.stub().returns([]),
+              },
+              campaign: {
+                organizationName: 'Dragon & Co',
+                customResultPageButtonUrl: 'www.my-url.net',
+                customResultPageButtonText: 'Next step',
+                get: sinon.stub(),
+              },
+            },
+          };
+          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('campaignParticipation', campaignParticipation);
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{campaignParticipation}}/>`);
         });
 
-        it('should not display the div for the logo of the organization ', function() {
+        it('should display the button', function() {
           // Then
-          expect(find('[src="www.logo-example.com"]')).to.not.exist;
+          expect(find('[href="www.my-url.net"]')).to.exist;
+          expect(find('[target="_blank"]')).to.exist;
+          expect(contains('Next step')).to.exist;
+        });
+      });
+
+      context('when the organization only has a customResultPageButtonUrl', function() {
+        beforeEach(async function() {
+          // Given
+          const campaignParticipation = {
+            campaignParticipation: {
+              get: sinon.stub(),
+              campaignParticipationResult: {
+                get: sinon.stub().returns([]),
+              },
+              campaign: {
+                organizationName: 'Dragon & Co',
+                customResultPageButtonUrl: 'www.my-url.net',
+                customResultPageButtonText: null,
+                get: sinon.stub(),
+              },
+            },
+          };
+          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('campaignParticipation', campaignParticipation);
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{campaignParticipation}}/>`);
+        });
+
+        it('should not display the button', function() {
+          // Then
+          expect(find('[href="www.my-url.net"]')).to.not.exist;
+          expect(contains('Next step')).to.not.exist;
+        });
+      });
+
+      context('when the organization has neither a message nor a button', function() {
+        beforeEach(async function() {
+          // Given
+          const campaignParticipation = {
+            campaignParticipation: {
+              get: sinon.stub(),
+              campaignParticipationResult: {
+                get: sinon.stub().returns([]),
+              },
+              campaign: {
+                customResultPageText: null,
+                organizationLogoUrl: null,
+                customResultPageButtonUrl: null,
+                customResultPageButtonText: null,
+                organizationName: 'Dragon & Co',
+                get: sinon.stub(),
+              },
+            },
+          };
+          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
+          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('campaignParticipation', campaignParticipation);
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{campaignParticipation}}/>`);
+        });
+
+        it('should not display the block for the message', function() {
+          // Then
+          expect(contains('Message de votre organisation')).to.not.exist;
         });
       });
     });
-
-    context('when the organization has no message', function() {
+    context('when the campaign is not shared and the organization has a message or a button', function() {
       beforeEach(async function() {
         // Given
         const campaignParticipation = {
           campaignParticipation: {
+            get: sinon.stub(),
             campaignParticipationResult: {
               get: sinon.stub().returns([]),
             },
             campaign: {
-              customResultPageText: null,
-              organizationLogoUrl: null,
+              customResultPageText: 'Bravo !',
               organizationName: 'Dragon & Co',
               get: sinon.stub(),
             },
           },
         };
-        campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
-        campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+        campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(false);
+        campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
         campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
         this.set('campaignParticipation', campaignParticipation);
         // When
@@ -262,7 +407,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
 
       it('should not display the block for the message', function() {
+        // debugger
         // Then
+        expect(contains('J\'envoie mes résultats')).to.exist;
         expect(contains('Message de votre organisation')).to.not.exist;
       });
     });

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -191,14 +191,14 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     });
   });
 
-  describe('#organizationMessageText', function() {
+  describe('#organizationMessage', function() {
 
     it('should return the text of the message organization', function() {
       // given
       component.args.model.campaignParticipation.campaign.customResultPageText = 'Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.';
 
       // when
-      const result = component.organizationMessageText;
+      const result = component.organizationMessage;
 
       // then
       expect(result).to.equal('Afin de vous faire progresser, nous vous proposons des documents pour aller plus loin dans les compétences que vous venez de tester.');
@@ -230,6 +230,123 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
 
       // then
       expect(name).to.equal('Amazing Orga');
+    });
+  });
+
+  describe('#showOrganizationButton', function() {
+
+    it('should return true when the organization has a customResultPageButtonText and a customResultPageButtonUrl', async function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Go to the next step';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+
+      // when
+      const result = await component.showOrganizationButton;
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return false when the organization has no a customResultPageButtonText ', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = null;
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+
+      // when
+      const result = component.showOrganizationButton;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return false when the organization has noa customResultPageButtonUrl', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Next step';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = null;
+
+      // when
+      const result = component.showOrganizationButton;
+
+      // then
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('#customButtonUrl', function() {
+
+    it('should return the url of the custom button', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+
+      // when
+      const url = component.customButtonUrl;
+
+      // then
+      expect(url).to.equal('www.my-url.net');
+    });
+  });
+
+  describe('#customButtonText', function() {
+
+    it('should return the text of the custom button', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Next step';
+
+      // when
+      const url = component.customButtonText;
+
+      // then
+      expect(url).to.equal('Next step');
+    });
+  });
+
+  describe('#isShared', function() {
+
+    it('should return the value of isShared', function() {
+      // given
+      component.args.model.campaignParticipation.isShared = true;
+
+      // when
+      const result = component.isShared;
+
+      // then
+      expect(result).to.be.true;
+    });
+  });
+
+  describe('#displayPixLink', function() {
+
+    it('should return false when there are customResultPageButtonText and customResultPageButtonUrl', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Next step';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      // when
+      const result = component.displayPixLink;
+
+      // then
+      expect(result).to.be.false;
+    });
+
+    it('should return true when customResultPageButtonText or customResultPageButtonUrl is empty', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = null;
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      // when
+      const result = component.displayPixLink;
+
+      // then
+      expect(result).to.be.true;
+    });
+
+    it('should return true when customResultPageButtonText and customResultPageButtonUrl are empty', function() {
+      // given
+      component.args.model.campaignParticipation.campaign.customResultPageButtonText = null;
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = null;
+      // when
+      const result = component.displayPixLink;
+
+      // then
+      expect(result).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## :unicorn: Problème
Sur la page de fin de parcours, afficher le bouton qui, au clic, ouvre un nouvelle fenêtre avec comme url celle donnée par l'organisation.

## :robot: Solution

## :rainbow: Remarques


## :100: Pour tester
Aller sur Pix-App avec le compte de jaune.attend@example.net et allers dans "Mes Parcours" et aller voir le détail du parcours terminer avec des paliers.
