### PR TITLE
[FEATURE] Affichage de l'information certifiable sur les badges dans l'admin

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -1,25 +1,25 @@
 <header class="page-header">
   <div class="page-title">
-    <p>Résultat Thématique<span class="wire">&nbsp;>&nbsp;</span>{{@model.id}}</p>
+    <p>Résultat Thématique<span class="wire">&nbsp;>&nbsp;</span>{{@badge.id}}</p>
   </div>
 </header>
 
 <main class="page-body">
   <section class="page-section mb_10">
     <div class="page-section__header">
-      <h1 class="page-section__title">{{@model.name}}</h1>
+      <h1 class="page-section__title">{{@badge.name}}</h1>
     </div>
     <div class="page-section__details badge-data">
       <div class="badge-data__image">
-        <img src={{@model.imageUrl}} alt="" role="presentation" width="90px"/><br>
+        <img src={{@badge.imageUrl}} alt="" role="presentation" width="90px"/><br>
       </div>
       <div class="page-section__details">
-        ID : {{@model.id}}<br>
-        Titre : {{@model.title}}<br>
-        Key : {{@model.key}}<br>
-        Message : {{@model.message}}<br>
-        Message alternatif : {{@model.altMessage}}<br>
-        <PixTag @color={{this.isCertifiableColor}}>{{this.isCertifiableText}}</PixTag><br>
+        ID : {{@badge.id}}<br>
+        Titre : {{@badge.title}}<br>
+        Clé : {{@badge.key}}<br>
+        Message : {{@badge.message}}<br>
+        Message alternatif : {{@badge.altMessage}}<br>
+        <PixTag @color={{this.isCertifiableColor}} class="badge-data__tags">{{this.isCertifiableText}}</PixTag><br>
       </div>
     </div>
   </section>

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -15,10 +15,11 @@
       </div>
       <div class="page-section__details">
         ID : {{@model.id}}<br>
-        Title : {{@model.title}}<br>
+        Titre : {{@model.title}}<br>
         Key : {{@model.key}}<br>
         Message : {{@model.message}}<br>
         Message alternatif : {{@model.altMessage}}<br>
+        <PixTag @color={{this.isCertifiableColor}}>{{this.isCertifiableText}}</PixTag><br>
       </div>
     </div>
   </section>

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -1,0 +1,13 @@
+import Component from '@glimmer/component';
+
+export default class Badge extends Component {
+
+  get isCertifiableColor() {
+    return this.args.model.isCertifiable ? 'green' : 'yellow';
+  }
+
+  get isCertifiableText() {
+    return this.args.model.isCertifiable ? 'Certifiable' : 'Non certifiable';
+  }
+
+}

--- a/admin/app/components/badges/badge.js
+++ b/admin/app/components/badges/badge.js
@@ -3,11 +3,11 @@ import Component from '@glimmer/component';
 export default class Badge extends Component {
 
   get isCertifiableColor() {
-    return this.args.model.isCertifiable ? 'green' : 'yellow';
+    return this.args.badge.isCertifiable ? 'green' : 'yellow';
   }
 
   get isCertifiableText() {
-    return this.args.model.isCertifiable ? 'Certifiable' : 'Non certifiable';
+    return this.args.badge.isCertifiable ? 'Certifiable' : 'Non certifiable';
   }
 
 }

--- a/admin/app/models/badge.js
+++ b/admin/app/models/badge.js
@@ -8,4 +8,5 @@ export default class Badge extends Model {
   @attr() message;
   @attr() imageUrl;
   @attr() altMessage;
+  @attr() isCertifiable;
 }

--- a/admin/app/styles/components/badges/badge.scss
+++ b/admin/app/styles/components/badges/badge.scss
@@ -4,4 +4,8 @@
   &__image {
     margin-right: 20px;
   }
+
+  &__tags {
+    margin: 8px 0;
+  }
 }

--- a/admin/app/templates/authenticated/badges/badge.hbs
+++ b/admin/app/templates/authenticated/badges/badge.hbs
@@ -1,1 +1,1 @@
-<Badges::Badge @model={{@model}} />
+<Badges::Badge @badge={{@model}} />

--- a/admin/tests/integration/components/badges/badge-test.js
+++ b/admin/tests/integration/components/badges/badge-test.js
@@ -24,7 +24,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
 
   test('should render all details about the badge', async function(assert) {
     //when
-    await render(hbs`<Badges::Badge @model={{this.badge}} />`);
+    await render(hbs`<Badges::Badge @badge={{this.badge}} />`);
 
     //then
     assert.dom('.page-section__details').exists();
@@ -34,7 +34,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
     assert.ok(detailsContent.match(badge.message), 'message');
     assert.ok(detailsContent.match(badge.id), 'id');
     assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
-    assert.ok(detailsContent.match(badge.altMessage), 'Certifiable');
+    assert.ok(detailsContent.match('Certifiable'), 'Certifiable');
     assert.dom('.page-section__details img').exists();
     assert.dom('.page-section__details img').hasAttribute('src', 'data:,');
   });

--- a/admin/tests/integration/components/badges/badge-test.js
+++ b/admin/tests/integration/components/badges/badge-test.js
@@ -16,6 +16,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
       imageUrl: 'data:,',
       key: 'ma clef',
       altMessage: 'mon message alternatif',
+      isCertifiable: true,
     };
 
     this.set('badge', badge);
@@ -33,6 +34,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
     assert.ok(detailsContent.match(badge.message), 'message');
     assert.ok(detailsContent.match(badge.id), 'id');
     assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
+    assert.ok(detailsContent.match(badge.altMessage), 'Certifiable');
     assert.dom('.page-section__details img').exists();
     assert.dom('.page-section__details img').hasAttribute('src', 'data:,');
   });

--- a/admin/tests/unit/components/badges/badge-test.js
+++ b/admin/tests/unit/components/badges/badge-test.js
@@ -10,7 +10,7 @@ module('Unit |  Component | Badges | badge', function(hooks) {
     test('returns color and text when is certifiable', function(assert) {
       const component = createComponent('component:badges/badge');
       component.args = {
-        model: { isCertifiable: true },
+        badge: { isCertifiable: true },
       };
 
       assert.equal(component.isCertifiableColor, 'green');
@@ -20,7 +20,7 @@ module('Unit |  Component | Badges | badge', function(hooks) {
     test('returns color and text when is not certifiable', function(assert) {
       const component = createComponent('component:badges/badge');
       component.args = {
-        model: { isCertifiable: false },
+        badge: { isCertifiable: false },
       };
 
       assert.equal(component.isCertifiableColor, 'yellow');

--- a/admin/tests/unit/components/badges/badge-test.js
+++ b/admin/tests/unit/components/badges/badge-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import createComponent from '../../../helpers/create-glimmer-component';
+
+module('Unit |  Component | Badges | badge', function(hooks) {
+  setupTest(hooks);
+
+  module('isCertifiable', function() {
+    test('returns color and text when is certifiable', function(assert) {
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        model: { isCertifiable: true },
+      };
+
+      assert.equal(component.isCertifiableColor, 'green');
+      assert.equal(component.isCertifiableText, 'Certifiable');
+    });
+
+    test('returns color and text when is not certifiable', function(assert) {
+      const component = createComponent('component:badges/badge');
+      component.args = {
+        model: { isCertifiable: false },
+      };
+
+      assert.equal(component.isCertifiableColor, 'yellow');
+      assert.equal(component.isCertifiableText, 'Non certifiable');
+    });
+  });
+});

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -4,7 +4,7 @@ module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title'],
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable'],
     }).serialize(badge);
   },
 };

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -40,6 +40,7 @@ describe('Acceptance | API | Badges', () => {
           id: badge.id.toString(),
           attributes: {
             'alt-message': 'Message alternatif',
+            'is-certifiable': false,
             'image-url': 'url_image',
             message: 'Bravo',
             title: 'titre du badge',

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -296,6 +296,7 @@ describe('Acceptance | Controller | target-profile-controller', () => {
         id: badge.id.toString(),
         attributes: {
           'alt-message': badge.altMessage,
+          'is-certifiable': false,
           'image-url': badge.imageUrl,
           'key': badge.key,
           'message': badge.message,

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -15,6 +15,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
         key: 'BANANA',
         title: 'Banana',
         targetProfileId: '1',
+        isCertifiable: false,
       });
 
       const expectedSerializedBadge = {
@@ -22,6 +23,7 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
           attributes: {
             'alt-message': 'You won a banana badge',
             'image-url': '/img/banana.svg',
+            'is-certifiable': false,
             message: 'Congrats, you won a banana badge',
             title: 'Banana',
             key: 'BANANA',


### PR DESCRIPTION
## :unicorn: Problème
Le nouveau champ `isCertifiable` des badges n'est pas affiché.

## :robot: Solution
On affiche le champ dans l'admin.
![Screenshot 2021-04-08 at 11-26-55 Pix Admin](https://user-images.githubusercontent.com/86659/114002955-a9052800-985d-11eb-9564-e6d751cda1a9.png)
- vert quand certifiable
- jaune quand non certifiable


## :rainbow: Remarques


## :100: Pour tester
1. Aller sur un badge
2. Voir l'information certifiable sur la page
