### PR TITLE
[BUGFIX] Affichage de la bonne identité dans le détail d'un participant à une campagne de collecte de profils (PIX-2427).

### DIFF
--- a/api/lib/infrastructure/repositories/campaign-profile-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-profile-repository.js
@@ -31,10 +31,10 @@ async function _fetchCampaignProfileAttributesFromCampaignParticipation(campaign
         'campaign-participations.participantExternalId',
       ])
         .from('campaign-participations')
-        .join('users', 'campaign-participations.userId', 'users.id')
-        .leftJoin('schooling-registrations', 'campaign-participations.userId', 'schooling-registrations.userId')
-        .leftJoin('campaigns', function() {
-          this.on({ 'campaign-participations.campaignId': 'campaigns.id' })
+        .leftJoin('users', 'campaign-participations.userId', 'users.id')
+        .innerJoin('campaigns', 'campaign-participations.campaignId', 'campaigns.id')
+        .leftJoin('schooling-registrations', function() {
+          this.on({ 'campaign-participations.userId': 'schooling-registrations.userId' })
             .andOn({ 'campaigns.organizationId': 'schooling-registrations.organizationId' });
         })
         .where({

--- a/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/campaign-profile-repository_test.js
@@ -90,12 +90,26 @@ describe('Integration | Repository | CampaignProfileRepository', function() {
       });
 
       it('return the first name and last name of the schooling registration', async () => {
-        const campaignId = databaseBuilder.factory.buildCampaign().id;
         const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
         const campaignParticipationId = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration({ firstName: 'Greg', lastName: 'Duboire', organizationId }, { campaignId }).id;
         await databaseBuilder.commit();
 
         const campaignProfile = await CampaignProfileRepository.findProfile({ campaignId, campaignParticipationId, locale });
+
+        expect(campaignProfile.firstName).to.equal('Greg');
+        expect(campaignProfile.lastName).to.equal('Duboire');
+      });
+
+      it('return the first name and last name of the current schooling registration', async () => {
+        const oldOrganizationId = databaseBuilder.factory.buildOrganization().id;
+        const organizationId = databaseBuilder.factory.buildOrganization().id;
+        const campaignId = databaseBuilder.factory.buildCampaign({ organizationId }).id;
+        const campaignParticipationCreated = databaseBuilder.factory.buildCampaignParticipationWithSchoolingRegistration({ firstName: 'Greg', lastName: 'Duboire', organizationId }, { campaignId });
+        databaseBuilder.factory.buildSchoolingRegistration({ firstName: 'Gregoire', lastName: 'Dub', organizationId: oldOrganizationId, userId: campaignParticipationCreated.userId });
+        await databaseBuilder.commit();
+
+        const campaignProfile = await CampaignProfileRepository.findProfile({ campaignId, campaignParticipationId: campaignParticipationCreated.id, locale });
 
         expect(campaignProfile.firstName).to.equal('Greg');
         expect(campaignProfile.lastName).to.equal('Duboire');


### PR DESCRIPTION
## :unicorn: Problème
Dans le détail d'un participant à une campagne de collecte de profils, lorsqu'un utilisateur est lié à plusieurs établissements, alors on ne prenait pas forcément en compte uniquement celui qui était en train de visionner son espace Orga, ce qui fait que parfois, le nom et prénom pouvaient varier, suivant ce qui été renseigné dans un établissement antérieur.

## :robot: Solution
Corriger ce problème.

## :rainbow: Remarques
Rien à signaler.

## :100: Pour tester
TODO
