### PR TITLE
[FEATURE] Autoriser l'affichage du MarkDown sur le message de description en fin de parcours (PIX-2331).

### DIFF
--- a/api/db/seeds/data/campaigns-builder.js
+++ b/api/db/seeds/data/campaigns-builder.js
@@ -150,6 +150,15 @@ function _buildCampaignForPro(databaseBuilder) {
     creatorId: 2,
     targetProfileId: TARGET_PROFILE_PIC_DIAG_INITIAL_ID,
     idPixLabel: null,
+    customResultPageButtonUrl: 'https://pix.fr/',
+    customResultPageButtonText: 'Voir Pix ! Avec du markdown ',
+    customResultPageText: `---
+__Plus d'infos :)__
+
+- __[Pix](https://pix.fr)__ - Allez sur mon pix !
+- __[Google](https://google.fr/)__ - Faites des recherches sur google.
+
+---`,
   });
 
   databaseBuilder.factory.buildCampaign({

--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.hbs
@@ -88,7 +88,7 @@
         <p class="skill-review-organization-message__organization-name">{{this.organizationName}}</p>
         {{#if this.showOrganizationMessage}}
           <div class="skill-review-organization-message__text">
-            <p>{{this.organizationMessage}}</p>
+            <MarkdownToHtml @markdown={{this.organizationMessage}}/>
           </div>
         {{/if}}
         {{#if this.showOrganizationButton}}

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -1,4 +1,3 @@
-import { describe, beforeEach } from 'mocha';
 import { expect } from 'chai';
 import { contains } from '../../../../../helpers/contains';
 import { click, find, render } from '@ember/test-helpers';
@@ -407,7 +406,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
 
       it('should not display the block for the message', function() {
-        // debugger
+
         // Then
         expect(contains('J\'envoie mes résultats')).to.exist;
         expect(contains('Message de votre organisation')).to.not.exist;


### PR DESCRIPTION
## :unicorn: Problème
Le MarkDown n'était pas supporté

## :robot: Solution
Supporter le Markdown

## :rainbow: Remarques
> _RAS_

## :100: Pour tester
Se connecter avec `jaune.attend@example.net`, lien mes parcours. Reprendre le parcours en cours . Et vérifier qu'à la fin le markdown s'affiche correctement.