### PR TITLE
[BUGFIX] Le mésusage de la DomainTransaction provoque des deadlocks dans le flux de complétion d'asssessment (PIX-2457)

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -9,7 +9,6 @@ const challengeSerializer = require('../../infrastructure/serializers/jsonapi/ch
 const competenceEvaluationSerializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer');
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
-const DomainTransaction = require('../../infrastructure/DomainTransaction');
 
 module.exports = {
 
@@ -76,10 +75,8 @@ module.exports = {
   async completeAssessment(request) {
     const assessmentId = parseInt(request.params.id);
 
-    await DomainTransaction.execute(async (domainTransaction) => {
-      const event = await usecases.completeAssessment({ domainTransaction, assessmentId });
-      await events.eventDispatcher.dispatch(event, domainTransaction);
-    });
+    const event = await usecases.completeAssessment({ assessmentId });
+    await events.eventDispatcher.dispatch(event);
 
     return null;
   },

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -5,7 +5,6 @@ const { checkEventType } = require('./check-event-type');
 const eventType = AssessmentCompleted;
 
 const handleBadgeAcquisition = async function({
-  domainTransaction,
   event,
   badgeCriteriaService,
   badgeAcquisitionRepository,
@@ -28,7 +27,7 @@ const handleBadgeAcquisition = async function({
     });
 
     if (!_.isEmpty(badgesAcquisitionToCreate)) {
-      await badgeAcquisitionRepository.create(badgesAcquisitionToCreate, domainTransaction);
+      await badgeAcquisitionRepository.create(badgesAcquisitionToCreate);
     }
   }
 };

--- a/api/lib/domain/events/handle-partner-certification.js
+++ b/api/lib/domain/events/handle-partner-certification.js
@@ -5,7 +5,6 @@ const eventType = CertificationScoringCompleted;
 
 async function handlePartnerCertifications({
   event,
-  domainTransaction,
   partnerCertificationRepository,
 }) {
   checkEventType(event, eventType);
@@ -13,11 +12,10 @@ async function handlePartnerCertifications({
     certificationCourseId: event.certificationCourseId,
     userId: event.userId,
     reproducibilityRate: event.reproducibilityRate,
-    domainTransaction,
   });
 
   if (partnerCertification.isEligible()) {
-    await partnerCertificationRepository.save({ partnerCertification, domainTransaction });
+    await partnerCertificationRepository.save({ partnerCertification });
   }
 }
 

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -7,7 +7,6 @@ const {
 module.exports = async function completeAssessment({
   assessmentId,
   assessmentRepository,
-  domainTransaction,
 }) {
   const assessment = await assessmentRepository.get(assessmentId);
 
@@ -15,7 +14,7 @@ module.exports = async function completeAssessment({
     throw new AlreadyRatedAssessmentError();
   }
 
-  await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
+  await assessmentRepository.completeByAssessmentId(assessmentId);
 
   return new AssessmentCompleted({
     assessmentId: assessment.id,

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -3,6 +3,7 @@ const BookshelfAssessmentResult = require('../data/assessment-result');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const { knex } = require('../bookshelf');
 const { MissingAssessmentId, AssessmentResultNotCreatedError } = require('../../domain/errors');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
   async save({
@@ -15,7 +16,7 @@ module.exports = {
     id,
     juryId,
     assessmentId,
-  }, domainTransaction = {}) {
+  }, domainTransaction = DomainTransaction.emptyTransaction()) {
     if (_.isNil(assessmentId)) {
       throw new MissingAssessmentId();
     }

--- a/api/lib/infrastructure/repositories/badge-acquisition-repository.js
+++ b/api/lib/infrastructure/repositories/badge-acquisition-repository.js
@@ -6,9 +6,9 @@ const DomainTransaction = require('../DomainTransaction');
 module.exports = {
 
   async create(badgeAcquisitionsToCreate = [], domainTransaction = DomainTransaction.emptyTransaction()) {
-    const results = await Bookshelf.knex('badge-acquisitions')
-      .insert(badgeAcquisitionsToCreate, 'id')
-      .transacting(domainTransaction.knexTransaction);
+    const knexConn = domainTransaction.knexTransaction || Bookshelf.knex;
+    const results = await knexConn('badge-acquisitions')
+      .insert(badgeAcquisitionsToCreate, 'id');
     return results;
   },
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -28,7 +28,7 @@ module.exports = {
     return savedCertificationCourse;
   },
 
-  async changeCompletionDate(certificationCourseId, completedAt = null, domainTransaction = {}) {
+  async changeCompletionDate(certificationCourseId, completedAt = null, domainTransaction = DomainTransaction.emptyTransaction()) {
     const certificationCourseBookshelf = new CertificationCourseBookshelf({ id: certificationCourseId, completedAt });
     const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting: domainTransaction.knexTransaction });
     return _toDomain(savedCertificationCourse);

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -1,13 +1,14 @@
 const BookshelfCompetenceMark = require('../data/competence-mark');
 const CompetenceMark = require('../../domain/models/CompetenceMark');
 const { knex } = require('../bookshelf');
+const DomainTransaction = require('../DomainTransaction');
 
 function _toDomain(competenceMark) {
   return new CompetenceMark(competenceMark);
 }
 
 module.exports = {
-  async save(competenceMark, domainTransaction = {}) {
+  async save(competenceMark, domainTransaction = DomainTransaction.emptyTransaction()) {
     await competenceMark.validate();
     const savedCompetenceMark = await new BookshelfCompetenceMark(competenceMark)
       .save(null, { transacting: domainTransaction.knexTransaction });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -3,7 +3,6 @@ const assessmentController = require('../../../../lib/application/assessments/as
 const usecases = require('../../../../lib/domain/usecases');
 const events = require('../../../../lib/domain/events');
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
-const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
 describe('Unit | Controller | assessment-controller', function() {
@@ -140,36 +139,27 @@ describe('Unit | Controller | assessment-controller', function() {
   describe('#completeAssessment', () => {
     const assessmentId = 2;
     const assessmentCompletedEvent = new AssessmentCompleted();
-    const domainTransaction = Symbol('domain transaction');
-    let transactionToBeExecuted;
 
     beforeEach(() => {
       sinon.stub(usecases, 'completeAssessment');
       usecases.completeAssessment.resolves(assessmentCompletedEvent);
-
       sinon.stub(events.eventDispatcher, 'dispatch');
-      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
-        transactionToBeExecuted = lambda;
-      });
     });
 
     it('should call the completeAssessment use case', async () => {
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
-      await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ domainTransaction, assessmentId });
+      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ assessmentId });
     });
 
     it('should dispatch the assessment completed event', async () => {
-
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
-      await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent, domainTransaction);
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent);
     });
   });
 

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -6,8 +6,6 @@ const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCom
 describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
   describe('#handleBadgeAcquisition', () => {
-    const domainTransaction = Symbol('a DomainTransaction');
-
     const badgeRepository = {
       findByCampaignParticipationId: _.noop,
     };
@@ -33,7 +31,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
       const event = 'not an event of the correct type';
       // when / then
       const error = await catchErr(handleBadgeAcquisition)(
-        { event, ...dependencies, domainTransaction },
+        { event, ...dependencies },
       );
 
       // then
@@ -77,14 +75,14 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
             badgeId,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
-          }], domainTransaction);
+          }]);
         });
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
@@ -140,14 +138,14 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(false);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
             badgeId: badge1.id,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
-          }], domainTransaction);
+          }]);
         });
 
         it('should create two badges when both badges requirements are fulfilled', async () => {
@@ -160,13 +158,13 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([
             { badgeId: badge1.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
             { badgeId: badge2.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
-          ], domainTransaction);
+          ]);
         });
       });
 
@@ -182,7 +180,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+          await handleBadgeAcquisition({ event, ...dependencies });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -200,7 +198,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         const event = new AssessmentCompleted({ userId });
 
         // when
-        await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
+        await handleBadgeAcquisition({ event, ...dependencies });
 
         // then
         expect(badgeAcquisitionRepository.create).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -12,7 +12,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
   const assessmentResultRepository = { save: _.noop };
   const certificationCourseRepository = { changeCompletionDate: _.noop, getCreationDate: _.noop };
   const competenceMarkRepository = { save: _.noop };
-  const domainTransaction = {};
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
   let event;
@@ -58,7 +57,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       const event = 'not an event of the correct type';
       // when / then
       const error = await catchErr(handleCertificationScoring)(
-        { event, ...dependencies, domainTransaction },
+        { event, ...dependencies },
       );
 
       // then
@@ -102,7 +101,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         await handleCertificationScoring({
           event,
           ...dependencies,
-          domainTransaction,
         });
 
         // then
@@ -116,7 +114,6 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         await handleCertificationScoring({
           event,
           ...dependencies,
-          domainTransaction,
         });
 
         // then
@@ -127,7 +124,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           errorAssessmentResult,
         );
         expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
-          certificationAssessment.certificationCourseId, now, domainTransaction,
+          certificationAssessment.certificationCourseId, now,
         );
       });
     });
@@ -158,7 +155,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should build and save an assessment result with the expected arguments', async () => {
         // when
         await handleCertificationScoring({
-          event, ...dependencies, domainTransaction,
+          event, ...dependencies,
         });
 
         // then
@@ -167,16 +164,16 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
           certificationAssessmentScore.status,
           certificationAssessment.id,
         );
-        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult, domainTransaction);
+        expect(assessmentResultRepository.save).to.have.been.calledWithExactly(assessmentResult);
         expect(certificationCourseRepository.changeCompletionDate).to.have.been.calledWithExactly(
-          certificationAssessment.certificationCourseId, now, domainTransaction,
+          certificationAssessment.certificationCourseId, now,
         );
       });
 
       it('should return a CertificationScoringCompleted', async () => {
         // when
         const certificationScoringCompleted = await handleCertificationScoring({
-          event, ...dependencies, domainTransaction,
+          event, ...dependencies,
         });
 
         // then
@@ -191,7 +188,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       it('should build and save as many competence marks as present in the certificationAssessmentScore', async () => {
         // when
         await handleCertificationScoring({
-          event, ...dependencies, domainTransaction,
+          event, ...dependencies,
         });
 
         // then
@@ -212,7 +209,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
 
       // when
       const certificationScoringCompleted = await handleCertificationScoring({
-        event, ...dependencies, domainTransaction,
+        event, ...dependencies,
       });
 
       expect(certificationScoringCompleted).to.be.null;

--- a/api/tests/unit/domain/events/handle-partner-certification_test.js
+++ b/api/tests/unit/domain/events/handle-partner-certification_test.js
@@ -4,7 +4,6 @@ const partnerCertificationRepository = require('../../../../lib/infrastructure/r
 const { handlePartnerCertifications } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-partner-certification', () => {
-  const domainTransaction = Symbol('domainTransaction');
   const reproducibilityRate = Symbol('reproducibilityRate');
 
   let event;
@@ -18,7 +17,7 @@ describe('Unit | Domain | Events | handle-partner-certification', () => {
     const event = 'not an event of the correct type';
     // when / then
     const error = await catchErr(handlePartnerCertifications)(
-      { event, ...dependencies, domainTransaction },
+      { event, ...dependencies },
     );
 
     // then
@@ -45,7 +44,6 @@ describe('Unit | Domain | Events | handle-partner-certification', () => {
         certificationCourseId,
         userId,
         reproducibilityRate,
-        domainTransaction,
       }).resolves(cleaCertification);
 
     });
@@ -57,13 +55,12 @@ describe('Unit | Domain | Events | handle-partner-certification', () => {
 
         // when
         await handlePartnerCertifications({
-          event, ...dependencies, domainTransaction,
+          event, ...dependencies,
         });
 
         // then
         expect(partnerCertificationRepository.save).to.have.been.calledWithMatch({
           partnerCertification: cleaCertification,
-          domainTransaction,
         });
       });
     });
@@ -74,7 +71,7 @@ describe('Unit | Domain | Events | handle-partner-certification', () => {
 
         // when
         await handlePartnerCertifications({
-          event, ...dependencies, domainTransaction,
+          event, ...dependencies,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -11,7 +11,6 @@ describe('Unit | UseCase | complete-assessment', () => {
     get: _.noop,
     completeByAssessmentId: _.noop,
   };
-  const domainTransaction = Symbol('domainTransaction');
   const assessmentResultRepository = { save: _.noop };
   const certificationCourseRepository = { changeCompletionDate: _.noop };
   const competenceMarkRepository = { save: _.noop };
@@ -46,7 +45,6 @@ describe('Unit | UseCase | complete-assessment', () => {
         certificationCourseRepository,
         competenceMarkRepository,
         scoringCertificationService,
-        domainTransaction,
       });
 
       // then
@@ -78,11 +76,10 @@ describe('Unit | UseCase | complete-assessment', () => {
               certificationCourseRepository,
               competenceMarkRepository,
               scoringCertificationService,
-              domainTransaction,
             });
 
             // then
-            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id, domainTransaction)).to.be.true;
+            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id)).to.be.true;
           });
 
           it('should return a AssessmentCompleted event', async () => {
@@ -94,7 +91,6 @@ describe('Unit | UseCase | complete-assessment', () => {
               certificationCourseRepository,
               competenceMarkRepository,
               scoringCertificationService,
-              domainTransaction,
             });
 
             // then
@@ -119,7 +115,6 @@ describe('Unit | UseCase | complete-assessment', () => {
           certificationCourseRepository,
           competenceMarkRepository,
           scoringCertificationService,
-          domainTransaction,
         });
 
         // then
@@ -141,7 +136,6 @@ describe('Unit | UseCase | complete-assessment', () => {
           certificationCourseRepository,
           competenceMarkRepository,
           scoringCertificationService,
-          domainTransaction,
         });
 
         // then


### PR DESCRIPTION
## :unicorn: Problème
A nouveau, nous avons eu en production un problème de deadlock. Il s'agit du problème lié au mésusage des DomainTransaction à savoir:
- Lorsqu'on exécute du code dans la callback suivante :
```js
DomainTransaction.execute((transaction) => {
// du code...
});
```
on réserve une connexion BDD. Or, il y a plusieurs endroits dans Pix où le code contenu dans cette callback ne se sert pas de cette connexion réservée, et en réclame une autre au pool de connexions. Ce problème de design couplé à un fort trafic (en l'occurrence, la complétion d'assessment est un événement assez commun dans Pix), on peut se trouver en situation de deadlocks rapidement. (voir ici https://1024pix.atlassian.net/wiki/spaces/DEV/pages/2504065029/Bloquage+du+pool+de+connection+sur+les+transactions)

## :robot: Solution
Solution rapide pour débloquer la situation en prod, on décide de retirer carrément l'usage de la domain transaction autour de la complétion d'assessment.

## :rainbow: Remarques
Solution pansement. A court terme il faut :
- Ré englober la complétion d'assessment dans une logique transactionnelle (afin de ne pas faire les écritures partiellement / consistance )
- Faire une passe dans le code pour identifier tous les **mésusages**

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
