### PR TITLE
[FEATURE] Création de liens d'évitements (PIX-1862).

### DIFF
--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -1,4 +1,4 @@
-<section class="page-container dashboard-content">
+<main id="main" class="page-container dashboard-content">
   <h1 class="sr-only">{{t 'pages.dashboard.title'}}</h1>
 
   {{#if this.hasNewInformationToShow}}
@@ -118,4 +118,4 @@
     <!-- Div ajoutée afin de créer le layout Grid CSS -->
   </section>
 
-</section>
+</main>

--- a/mon-pix/app/components/skiplink.hbs
+++ b/mon-pix/app/components/skiplink.hbs
@@ -1,0 +1,1 @@
+<a class="skip-link" href={{@href}}>{{@label}}</a>

--- a/mon-pix/app/styles/app.scss
+++ b/mon-pix/app/styles/app.scss
@@ -102,6 +102,7 @@ of an adaptative/mobile-first approach — refactoring is welcome here */
 @import 'components/user-logged-menu';
 @import 'components/communication-banner';
 @import 'components/pix-toggle';
+@import 'components/skip-link';
 
 /* pages */
 @import 'pages/assessment-challenge';

--- a/mon-pix/app/styles/components/_skip-link.scss
+++ b/mon-pix/app/styles/components/_skip-link.scss
@@ -1,0 +1,15 @@
+.skip-link {
+  position: absolute;
+  padding: 0.5em;
+  margin: 8px;
+  color: $white;
+  background-color: $blue;
+  transform: translateY(calc(-100% - 8px));
+  transition: transform 0.3s;
+  z-index: 1;
+
+  &:focus,
+  &:active {
+    transform: translateY(0);
+  }
+}

--- a/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
+++ b/mon-pix/app/templates/campaigns/assessment/tutorial.hbs
@@ -2,7 +2,7 @@
 {{page-title 'Didacticiel'}}
 
 <div class="campaign-tutorial">
-  <main class="rounded-panel rounded-panel--strong campaign-tutorial__container">
+  <main id="main" class="rounded-panel rounded-panel--strong campaign-tutorial__container">
 
     <h1 class="sr-only">{{t 'pages.tutorial.title'}}</h1>
 

--- a/mon-pix/app/templates/certifications/start.hbs
+++ b/mon-pix/app/templates/certifications/start.hbs
@@ -4,7 +4,7 @@
   <burger.outlet>
 
     <NavbarHeader @burger={{burger}} />
-    <PixBackgroundHeader>
+    <PixBackgroundHeader id="main">
 
       {{#if model.isCertifiable}}
         <PixBlock @shadow="heavy" class="certification-start-page__block">

--- a/mon-pix/app/templates/competences/details.hbs
+++ b/mon-pix/app/templates/competences/details.hbs
@@ -1,14 +1,16 @@
 {{page-title @model.name}}
+
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
+
     <NavbarHeader @burger={{burger}} />
-    <div class="background-banner-wrapper competence-details">
+    <main id="main" class="background-banner-wrapper competence-details">
       <div class="background-banner"></div>
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
         <ScorecardDetails @scorecard={{@model}} />
       </div>
-    </div>
+    </main>
 
     <Footer />
 

--- a/mon-pix/app/templates/competences/results.hbs
+++ b/mon-pix/app/templates/competences/results.hbs
@@ -5,7 +5,7 @@
 
     <NavbarHeader @burger={{burger}} />
 
-    <div class="background-banner-wrapper">
+    <main id="main" class="background-banner-wrapper">
       <div class="background-banner"></div>
 
       <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
@@ -50,7 +50,7 @@
           <ScorecardDetails @scorecard={{@model.scorecard}} />
         {{/if}}
       </div>
-    </div>
+    </main>
 
     <Footer />
 

--- a/mon-pix/app/templates/components/certification-joiner.hbs
+++ b/mon-pix/app/templates/components/certification-joiner.hbs
@@ -8,7 +8,6 @@
         <div class="certification-joiner__row">
           <label class="certification-joiner__label" for="certificationJoinerSessionId">{{t "pages.certification-joiner.form.fields.session-number"}}</label>
           <Input
-            {{autofocus}}
             id="certificationJoinerSessionId"
             class={{if this.sessionIdIsNotANumberError "certification-joiner__input--invalid"}}
             pattern={{this.SESSION_ID_VALIDATION_PATTERN}}

--- a/mon-pix/app/templates/components/certification-starter.hbs
+++ b/mon-pix/app/templates/components/certification-starter.hbs
@@ -7,7 +7,7 @@
     </p>
     <form autocomplete="off">
         <div class="certification-course-page__session-code-input">
-          <Input {{autofocus}} required={{true}} @id="certificationStarterSessionCode" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
+          <Input required={{true}} @id="certificationStarterSessionCode" @type="text" @value={{this.inputAccessCode}} @maxlength="6" @spellcheck={{false}} />
           {{#if this.errorMessage}}
               <div class="certification-course-page__errors">{{this.errorMessage}}</div>
           {{/if}}

--- a/mon-pix/app/templates/components/footer.hbs
+++ b/mon-pix/app/templates/components/footer.hbs
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer id="footer" class="footer">
   <div class="footer__container">
     <div class="footer-container__logos">
       <PixLogo/>

--- a/mon-pix/app/templates/components/navbar-header.hbs
+++ b/mon-pix/app/templates/components/navbar-header.hbs
@@ -1,3 +1,6 @@
+<Skiplink @href="#main" @label={{t 'common.skip-links.skip-to-content'}} />
+<Skiplink @href="#footer" @label={{t 'common.skip-links.skip-to-footer'}} />
+
 <nav class="navbar-header">
   {{#if (media 'isDesktop')}}
     <NavbarDesktopHeader @shouldShowTheMarianneLogo={{this.isFrenchDomainExtension}}/>

--- a/mon-pix/app/templates/components/profile-content.hbs
+++ b/mon-pix/app/templates/components/profile-content.hbs
@@ -1,4 +1,4 @@
-<div class="background-banner-wrapper">
+<main id="main" class="background-banner-wrapper">
   <div class="background-banner"></div>
 
   <div class="rounded-panel rounded-panel--strong rounded-panel--over-background-banner profile__panel">
@@ -27,4 +27,4 @@
       </p>
    {{/if}}
   </div>
-</div>
+</main>

--- a/mon-pix/app/templates/fill-in-campaign-code.hbs
+++ b/mon-pix/app/templates/fill-in-campaign-code.hbs
@@ -8,6 +8,7 @@
       <div class="background-banner"></div>
 
       <main
+        id="main"
         class="fill-in-campaign-code__container rounded-panel rounded-panel--strong rounded-panel--over-background-banner">
         <h1 class="fill-in-campaign-code__title rounded-panel-title">
           {{this.firstTitle}}

--- a/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
+++ b/mon-pix/app/templates/fill-in-certificate-verification-code.hbs
@@ -4,7 +4,7 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
-    <PixBackgroundHeader>
+    <PixBackgroundHeader id="main">
       <PixBlock class="fill-in-certificate-verification-code">
         <form class="fill-in-certificate-verification-code__form" autocomplete="off">
 

--- a/mon-pix/app/templates/user-account.hbs
+++ b/mon-pix/app/templates/user-account.hbs
@@ -5,7 +5,7 @@
 
     <NavbarHeader @burger={{burger}} @campaignParticipations={{@model.campaignParticipations}}/>
 
-    <main>
+    <main id="main">
       <div class="background-banner">
         <div class="user-account__banner">
           <h1 class="user-account-banner__title">{{t 'pages.user-account.title'}}</h1>

--- a/mon-pix/app/templates/user-certifications/index.hbs
+++ b/mon-pix/app/templates/user-certifications/index.hbs
@@ -1,5 +1,5 @@
-<div class="page-container user-certifications-page__container">
+<main id="main" class="page-container user-certifications-page__container">
     <h1 class="user-certifications-page__title">{{t "pages.certifications-list.title"}}</h1>
 
     <UserCertificationsPanel @certifications={{@model}} />
-</div>
+</main>

--- a/mon-pix/app/templates/user-tests.hbs
+++ b/mon-pix/app/templates/user-tests.hbs
@@ -2,17 +2,18 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
-    <PixBackgroundHeader>
-      <div class="user-tests-banner">
-        <img src="{{this.rootURL}}/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" aria-hidden="true"/>
-        <h3 class="user-tests-banner__title">{{t 'pages.user-tests.title'}}</h3>
-      </div>
-    </PixBackgroundHeader>
+    <main id="main">
+      <PixBackgroundHeader>
+        <div class="user-tests-banner">
+          <img src="{{this.rootURL}}/images/background/user-test-banner.svg" class="user-tests-banner__icon" role="none" alt="" />
+          <h3 class="user-tests-banner__title">{{t 'pages.user-tests.title'}}</h3>
+        </div>
+      </PixBackgroundHeader>
 
-    <section class="user-tests-main">
-      <CampaignParticipationOverview::Grid @model={{this.model}}/>
-    </section>
-
-    <Footer />
+      <section class="user-tests-main">
+        <CampaignParticipationOverview::Grid @model={{this.model}}/>
+      </section>
+    </main>
+    <Footer/>
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/app/templates/user-tutorials.hbs
+++ b/mon-pix/app/templates/user-tutorials.hbs
@@ -3,41 +3,45 @@
 <BurgerMenu @animation="push" @translucentOverlay={{true}} as |burger|>
   <burger.outlet>
     <NavbarHeader @burger={{burger}} />
-    <header role="banner" class="background-banner">
-      <div class="user-tutorials-banner">
-        <img src="{{rootURL}}/images/background/tutorials-banner.svg" class="user-tutorials-banner__icon" role="none" alt=""/>
-        <h3 class="user-tutorials-banner__title">{{t 'pages.user-tutorials.title'}}</h3>
-        <p class="user-tutorials-banner__description">
-          {{t 'pages.user-tutorials.description'}}
-        </p>
-      </div>
-    </header>
-    {{#if this.model}}
-      <article aria-label={{t 'pages.user-tutorials.label'}} class="user-tutorials-content">
-        <h3 class="user-tutorials-content__title">{{t 'pages.user-tutorials.list.title'}}</h3>
-        <div>
-          {{#each this.model as |userTutorial|}}
-            <TutorialItem @tutorial={{userTutorial.tutorial}} />
-          {{/each}}
-        </div>
-      </article>
-    {{else}}
-      <article aria-label={{t 'pages.user-tutorials.label'}} class="rounded-panel user-tutorials-no-tutorial">
-        <div class="user-tutorials-no-tutorial__illustration">
-          <img src="{{rootURL}}/{{t 'pages.user-tutorials.empty-list-info.image-link'}}"
-               role="none"
+    <main id="main">
+      <header role="banner" class="background-banner">
+        <div class="user-tutorials-banner">
+          <img src="{{rootURL}}/images/background/tutorials-banner.svg" class="user-tutorials-banner__icon" role="none"
                alt=""/>
-        </div>
-        <div class="user-tutorials-no-tutorial__instructions">
-          <h4 class="user-tutorials-no-tutorial-instructions__title">{{t 'pages.user-tutorials.empty-list-info.title'}}</h4>
-          <p class="user-tutorials-no-tutorial-instructions__description">
-            {{t 'pages.user-tutorials.empty-list-info.description.part1'}}
-            <FaIcon @prefix="far" @icon='bookmark'></FaIcon>
-            {{t 'pages.user-tutorials.empty-list-info.description.part2'}}
+          <h3 class="user-tutorials-banner__title">{{t 'pages.user-tutorials.title'}}</h3>
+          <p class="user-tutorials-banner__description">
+            {{t 'pages.user-tutorials.description'}}
           </p>
         </div>
-      </article>
-    {{/if}}
-    <Footer />
+      </header>
+      {{#if this.model}}
+        <article aria-label={{t 'pages.user-tutorials.label'}} class="user-tutorials-content">
+          <h3 class="user-tutorials-content__title">{{t 'pages.user-tutorials.list.title'}}</h3>
+          <div>
+            {{#each this.model as |userTutorial|}}
+              <TutorialItem @tutorial={{userTutorial.tutorial}} />
+            {{/each}}
+          </div>
+        </article>
+      {{else}}
+        <article aria-label={{t 'pages.user-tutorials.label'}} class="rounded-panel user-tutorials-no-tutorial">
+          <div class="user-tutorials-no-tutorial__illustration">
+            <img src="{{rootURL}}/{{t 'pages.user-tutorials.empty-list-info.image-link'}}"
+                 role="none"
+                 alt=""/>
+          </div>
+          <div class="user-tutorials-no-tutorial__instructions">
+            <h4 class="user-tutorials-no-tutorial-instructions__title">{{t
+                    'pages.user-tutorials.empty-list-info.title'}}</h4>
+            <p class="user-tutorials-no-tutorial-instructions__description">
+              {{t 'pages.user-tutorials.empty-list-info.description.part1'}}
+              <FaIcon @prefix="far" @icon='bookmark'></FaIcon>
+              {{t 'pages.user-tutorials.empty-list-info.description.part2'}}
+            </p>
+          </div>
+        </article>
+      {{/if}}
+    </main>
+    <Footer/>
   </burger.outlet>
 </BurgerMenu>

--- a/mon-pix/tests/integration/components/navbar-header-test.js
+++ b/mon-pix/tests/integration/components/navbar-header-test.js
@@ -8,6 +8,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { setBreakpoint } from 'ember-responsive/test-support';
+import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | navbar-header', function() {
 
@@ -22,6 +23,11 @@ describe('Integration | Component | navbar-header', function() {
     it('should be rendered in desktop mode', function() {
       // then
       expect(find('.navbar-desktop-header__container')).to.exist;
+    });
+
+    it('should render skip links', async function() {
+      expect(contains(this.intl.t('common.skip-links.skip-to-content'))).to.exist;
+      expect(contains(this.intl.t('common.skip-links.skip-to-footer'))).to.exist;
     });
   });
 
@@ -53,6 +59,13 @@ describe('Integration | Component | navbar-header', function() {
       // then
       expect(find('.navbar-mobile-header__container')).to.exist;
       expect(find('.navbar-mobile-header__burger-icon')).to.not.exist;
+    });
+
+    it('should render skip links', async function() {
+      await render(hbs`<NavbarHeader/>`);
+
+      expect(contains(this.intl.t('common.skip-links.skip-to-content'))).to.exist;
+      expect(contains(this.intl.t('common.skip-links.skip-to-footer'))).to.exist;
     });
   });
 });

--- a/mon-pix/tests/integration/components/skiplink-test.js
+++ b/mon-pix/tests/integration/components/skiplink-test.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { contains } from '../../helpers/contains';
+import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
+
+describe('Integration | Component | Skip Link', function() {
+  setupIntlRenderingTest();
+
+  it('displays supplied label and links to the correct anchor', async function() {
+    await render(hbs`<Skiplink @href="#anchor-link" @label="go-to-link" />`);
+
+    expect(contains('go-to-link')).to.exist;
+
+    const skipLink = this.element.getElementsByClassName('skip-link')[0];
+    expect(skipLink.href).to.contain('#anchor-link');
+  });
+});
+

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -48,7 +48,11 @@
             "test": "Your test is loading"
         },
         "or": "or",
-        "pix": "pix"
+        "pix": "pix",
+        "skip-links": {
+            "skip-to-content": "Skip to main content",
+            "skip-to-footer": "Skip to footer"
+        }
     },
     "pages": {
         "assessment-banner": {

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -48,7 +48,11 @@
             "test": "Votre test est en cours de chargement"
         },
         "or": "ou",
-        "pix": "pix"
+        "pix": "pix",
+        "skip-links": {
+            "skip-to-content": "Aller au contenu",
+            "skip-to-footer": "Aller au bas de page"
+        }
     },
     "pages": {
         "assessment-banner": {


### PR DESCRIPTION
## :unicorn: Problème
Les utilisateurs qui naviguent à l'aide d'un assistant vocal sont obligés de traverser tout le menu et un certain nombre de liens avant de pouvoir accéder au contenu et footer de la page.

## :robot: Solution
Prévoir la possiblité d'accéder directement au contenu en une étape, à l'aide de [liens d'évitement](https://css-tricks.com/how-to-create-a-skip-to-content-link/).

## :rainbow: Remarques
- Si la navigation [ne fonctionne pas sur Firefox (MacOS)](https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Preference_reference/accessibility.tabfocus), il faut activer une option : Taper `about:config` en URL, chercher `accessibility.tabfocus` et lui donner la valeur `7`.
- Le mettre sur mobile ?
- Le design est une proposition
- Il a fallu supprimer l'autofocus sur certains formulaires qui capturent directement l'attention de l'utilisateur (assez peu pratique pour les personnes qui utilisent des assistants)

Exemples 

https://www.oui.sncf/

![image](https://user-images.githubusercontent.com/5982021/114062518-e7b7d400-9897-11eb-828c-748d0f193bd3.png)

https://www.impots.gouv.fr/portail/

![image](https://user-images.githubusercontent.com/5982021/114063733-344fdf00-9899-11eb-9db2-dbd9fa7e7331.png)

https://wwws.airfrance.fr/ : 
 
![image](https://user-images.githubusercontent.com/5982021/114064850-5138e200-989a-11eb-9729-800f95f19c13.png)


## :100: Pour tester
- Rejoindre une page qui contient le menu. 
- Lorsque j'appuie sur tab, je vois : 

![image](https://user-images.githubusercontent.com/5982021/114061410-b5f23d80-9896-11eb-9805-99068036db23.png)
- J'appuie sur `entrée`, je suis téléporté vers le contenu principal de la page 🚀
