### PR TITLE
[FEATURE] Corriger l'affichage mobile de la page "Mon Compte" sur Pix App (PIX-2319).

### DIFF
--- a/mon-pix/app/components/signin-form.js
+++ b/mon-pix/app/components/signin-form.js
@@ -18,12 +18,12 @@ export default class SigninForm extends Component {
   username = '';
   password = '';
 
-  get isPoleEmploiEnabled() {
-    return this.featureToggles.featureToggles.isPoleEmploiEnabled;
-  }
-
   get homeUrl() {
     return this.url.homeUrl;
+  }
+
+  get displayPoleEmploiButton() {
+    return this.url.isFrenchDomainExtension && this.featureToggles.featureToggles.isPoleEmploiEnabled;
   }
 
   @action

--- a/mon-pix/app/styles/components/_user-account-panel.scss
+++ b/mon-pix/app/styles/components/_user-account-panel.scss
@@ -20,10 +20,25 @@
     min-width: 200px;
     display: flex;
     align-items: center;
+    margin: 0;
+
+    @include device-is('mobile') {
+      padding-bottom: 10px;
+    }
   }
 
   &__value {
     color: $grey-50;
+    margin: 0;
+  }
+
+  &__text {
+    display: flex;
+
+    @include device-is('mobile') {
+      flex-direction: column;
+      padding-left: 10px;
+    }
   }
 
   &__button {

--- a/mon-pix/app/styles/components/_user-account-update-email.scss
+++ b/mon-pix/app/styles/components/_user-account-update-email.scss
@@ -4,6 +4,13 @@
   align-items: center;
   padding: 50px 0 60px 0;
 
+  h3 {
+    @include device-is('mobile') {
+      text-align: center;
+      line-height: 2rem;
+    }
+  }
+
   &__informations {
     padding-top: 12px;
     text-align: center;

--- a/mon-pix/app/styles/pages/_sign-form.scss
+++ b/mon-pix/app/styles/pages/_sign-form.scss
@@ -147,11 +147,15 @@
 
   &__bottom-decoration {
     display: flex;
-    width: 609px;
+    width: calc(100% + 90px);
     padding: 12px 0 32px 0;
 
+    @include device-is('mobile') {
+      width: 100%;
+    }
+
     hr {
-      width: 239px;
+      width: 100%;
       height: 1px;
       border: 1px solid $grey-20;
     }
@@ -159,6 +163,11 @@
     span {
       font-size: 16px;
       color: $grey-80;
+      padding: 0 25px;
+
+      @include device-is('mobile') {
+        padding: 0 15px;
+      }
     }
   }
 

--- a/mon-pix/app/templates/components/navbar-burger-menu.hbs
+++ b/mon-pix/app/templates/components/navbar-burger-menu.hbs
@@ -33,6 +33,9 @@
   <LinkTo @route="user-dashboard" class="navbar-burger-menu-navigation__item">
     {{t 'navigation.main.dashboard'}}
   </LinkTo>
+  <LinkTo @route="user-account" class="navbar-burger-menu-navigation__item" >
+    {{t 'navigation.user.account'}}
+  </LinkTo>
   <LinkTo @route="profile" class="navbar-burger-menu-navigation__item">
     {{t 'navigation.main.skills'}}
   </LinkTo>

--- a/mon-pix/app/templates/components/signin-form.hbs
+++ b/mon-pix/app/templates/components/signin-form.hbs
@@ -48,7 +48,7 @@
       </button>
     </div>
 
-    {{#if this.isPoleEmploiEnabled}}
+    {{#if this.displayPoleEmploiButton}}
     <div class="sign-form-body__bottom-decoration">
       <hr>
       <span>{{t 'pages.sign-in.or'}}</span>

--- a/mon-pix/app/templates/components/user-account-panel.hbs
+++ b/mon-pix/app/templates/components/user-account-panel.hbs
@@ -1,17 +1,23 @@
 <PixBlock>
   <div class="user-account-panel__item">
-    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.first-name'}}</span>
-    <span class="user-account-panel-item__value" data-test-firstName>{{@user.firstName}}</span>
+    <div class="user-account-panel-item__text">
+      <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.first-name'}}</p>
+      <p class="user-account-panel-item__value" data-test-firstName>{{@user.firstName}}</p>
+    </div>
   </div>
   <div class="user-account-panel__item">
-    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.last-name'}}</span>
-    <span class="user-account-panel-item__value" data-test-lastName>{{@user.lastName}}</span>
+    <div class="user-account-panel-item__text">
+      <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.last-name'}}</p>
+      <p class="user-account-panel-item__value" data-test-lastName>{{@user.lastName}}</p>
+    </div>
   </div>
 
   {{#if this.displayEmail}}
   <div class="user-account-panel__item">
-    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</span>
-    <span class="user-account-panel-item__value" data-test-email>{{@user.email}}</span>
+    <div class="user-account-panel-item__text">
+      <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.email'}}</p>
+      <p class="user-account-panel-item__value" data-test-email>{{@user.email}}</p>
+    </div>
       <PixButton
               class="user-account-panel-item__button"
               @triggerAction={{@enableEmailEditionMode}}
@@ -23,13 +29,15 @@
 
   {{#if this.displayUsername}}
   <div class="user-account-panel__item">
-    <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</span>
-    <span class="user-account-panel-item__value" data-test-username>{{@user.username}}</span>
+    <div class="user-account-panel-item__text">
+      <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.username'}}</p>
+      <p class="user-account-panel-item__value" data-test-username>{{@user.username}}</p>
+    </div>
   </div>
   {{/if}}
   {{#if this.displayLanguageSwitch}}
-    <div class="user-account-panel__item">
-      <span class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.lang'}}</span>
+    <div class="user-account-panel__item user-account-panel-item__text">
+        <p class="form-textfield__label user-account-panel-item__label">{{t 'pages.user-account.account-panel.lang'}}</p>
         <div class="user-account-panel-item__select">
           <PixSelect
             class="user-account-panel-item__value"

--- a/mon-pix/tests/integration/components/navbar-burger-menu-test.js
+++ b/mon-pix/tests/integration/components/navbar-burger-menu-test.js
@@ -26,12 +26,13 @@ describe('Integration | Component | navbar-burger-menu', function() {
     // then
     expect(find('.navbar-burger-menu__navigation')).to.exist;
 
-    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(5);
-    expect(findAll('.navbar-burger-menu-navigation__item')[0].textContent.trim()).to.equal('Accueil');
-    expect(findAll('.navbar-burger-menu-navigation__item')[1].textContent.trim()).to.equal('Compétences');
-    expect(findAll('.navbar-burger-menu-navigation__item')[2].textContent.trim()).to.equal('Certification');
-    expect(findAll('.navbar-burger-menu-navigation__item')[3].textContent.trim()).to.equal('Mes tutos');
-    expect(findAll('.navbar-burger-menu-navigation__item')[4].textContent.trim()).to.equal('J\'ai un code');
+    expect(findAll('.navbar-burger-menu-navigation__item')).to.have.lengthOf(6);
+    expect(contains('Accueil')).to.exist;
+    expect(contains('Mon compte')).to.exist;
+    expect(contains('Compétences')).to.exist;
+    expect(contains('Certification')).to.exist;
+    expect(contains('Mes tutos')).to.exist;
+    expect(contains('J\'ai un code')).to.exist;
   });
 
   context('when user has participations', function() {

--- a/mon-pix/tests/integration/components/user-account-panel-test.js
+++ b/mon-pix/tests/integration/components/user-account-panel-test.js
@@ -5,6 +5,7 @@ import setupIntlRenderingTest from '../../helpers/setup-intl-rendering';
 import { find, render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import sinon from 'sinon';
+import { contains } from '../../helpers/contains';
 
 describe('Integration | Component | User account panel', () => {
 
@@ -32,11 +33,11 @@ describe('Integration | Component | User account panel', () => {
     await render(hbs`<UserAccountPanel @user={{this.user}} />`);
 
     // then
-    expect(find('span[data-test-firstName]').textContent).to.include(user.firstName);
-    expect(find('span[data-test-lastName]').textContent).to.include(user.lastName);
-    expect(find('span[data-test-email]').textContent).to.include(user.email);
-    expect(find('span[data-test-username]').textContent).to.include(user.username);
-    expect(find('select[data-test-lang] > option[selected]').textContent).to.include('Français');
+    expect(contains(user.firstName)).to.exist;
+    expect(contains(user.lastName)).to.exist;
+    expect(contains(user.email)).to.exist;
+    expect(contains(user.username)).to.exist;
+    expect(contains('Français')).to.exist;
   });
 
   it('should call Enable Email Edition method', async function() {
@@ -92,7 +93,7 @@ describe('Integration | Component | User account panel', () => {
       await render(hbs`<UserAccountPanel @user={{this.user}} />`);
 
       // then
-      expect(find('span[data-test-username]')).to.not.exist;
+      expect(find('p[data-test-username]')).to.not.exist;
     });
   });
 


### PR DESCRIPTION
## :unicorn: Problème
Sur Pix App, le lien vers la page "Mon compte" n'était pas présent dans le burger menu de la version mobile.

Il y a également un problème d'affichage sur cette même page en mobile, la ligne "Adresse e-mail" sort de l'écran.

<img width="202" alt="Capture d’écran 2021-04-09 à 10 47 43" src="https://user-images.githubusercontent.com/58915422/114154751-09a96900-9921-11eb-8d75-87f92891dd0b.png">

## :robot: Solution
Ajouter le lien dans le burger menu et retoucher le design de la version mobile de la page "Mon Compte"

## :rainbow: Remarques
Dans ce ticket, on masque aussi le bouton Pôle Emploi dans la page de connexion lorsque l'on est sur pix.org.
En effet il n'a pas a être visible en .org et surtout la traduction en anglais n'existe pas ce qui donne ça actuellement en production : 

<img width="314" alt="Capture d’écran 2021-04-09 à 10 42 22" src="https://user-images.githubusercontent.com/58915422/114154093-52aced80-9920-11eb-8a05-20dc46364977.png">

Une retouche css à également été fait sur l'affichage des lignes entre le "OU", qui sortent de l'écran en version mobile.

<img width="305" alt="Capture d’écran 2021-04-09 à 10 44 55" src="https://user-images.githubusercontent.com/58915422/114154448-b505ee00-9920-11eb-9f46-4a16bdcb8dc1.png">

Remplacement des balises `<span>` par des `<p>` ("Il (span) doit uniquement être utilisé lorsqu'aucun autre élément sémantique n'est approprié."  https://developer.mozilla.org/fr/docs/Web/HTML/Element/span)


## :100: Pour tester
- Sur la page de connexion, vérifier que le bouton PE s'affiche bien dans le domaine fr et qu'il soit masqué en org.
- En version mobile : verifier que les lignes restent dans le bloc blanc ( l'app [https://responsively.app/](https://responsively.app/) bien pratique pour voir différents devices 😉  )

Toujours en mobile: 
- Vérifier la présence du lien "Mon Compte" dans le burger menu.
- Dans la page "Mon Compte" l'affichage à été repensé, les infos de l'utilisateur passent sous leurs labels et le bouton modifier pour l'adresse e-mail doit être visible.