### PR TITLE
[INFRA] Renommage de deux méthodes statiques pour les faire ressembler aux autres

### DIFF
--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -93,7 +93,7 @@ async function _saveResult({
 }
 
 function _createAssessmentResult({ certificationAssessment, certificationAssessmentScore, assessmentResultRepository }) {
-  const assessmentResult = AssessmentResult.BuildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id);
+  const assessmentResult = AssessmentResult.buildStandardAssessmentResult(certificationAssessmentScore.nbPix, certificationAssessmentScore.status, certificationAssessment.id);
   return assessmentResultRepository.save(assessmentResult);
 }
 
@@ -103,7 +103,7 @@ async function _saveResultAfterCertificationComputeError({
   certificationCourseRepository,
   certificationComputeError,
 }) {
-  const assessmentResult = AssessmentResult.BuildAlgoErrorResult(certificationComputeError, certificationAssessment.id);
+  const assessmentResult = AssessmentResult.buildAlgoErrorResult(certificationComputeError, certificationAssessment.id);
   await assessmentResultRepository.save(assessmentResult);
   return certificationCourseRepository.changeCompletionDate(certificationAssessment.certificationCourseId, new Date());
 }

--- a/api/lib/domain/models/AssessmentResult.js
+++ b/api/lib/domain/models/AssessmentResult.js
@@ -34,7 +34,7 @@ class AssessmentResult {
     this.juryId = juryId;
   }
 
-  static BuildAlgoErrorResult(error, assessmentId) {
+  static buildAlgoErrorResult(error, assessmentId) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: error.message,
@@ -44,7 +44,7 @@ class AssessmentResult {
     });
   }
 
-  static BuildStandardAssessmentResult(pixScore, status, assessmentId) {
+  static buildStandardAssessmentResult(pixScore, status, assessmentId) {
     return new AssessmentResult({
       emitter: 'PIX-ALGO',
       commentForJury: 'Computed',

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -68,7 +68,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       const otherError = new Error();
       beforeEach(() => {
         sinon.stub(scoringCertificationService, 'calculateCertificationAssessmentScore').rejects(otherError);
-        sinon.stub(AssessmentResult, 'BuildAlgoErrorResult');
+        sinon.stub(AssessmentResult, 'buildAlgoErrorResult');
         sinon.stub(assessmentResultRepository, 'save');
         sinon.stub(certificationCourseRepository, 'changeCompletionDate');
       });
@@ -80,7 +80,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         });
 
         // then
-        expect(AssessmentResult.BuildAlgoErrorResult).to.not.have.been.called;
+        expect(AssessmentResult.buildAlgoErrorResult).to.not.have.been.called;
         expect(assessmentResultRepository.save).to.not.have.been.called;
         expect(certificationCourseRepository.changeCompletionDate).to.not.have.been.called;
       });
@@ -91,7 +91,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       const computeError = new CertificationComputeError();
       beforeEach(() => {
         sinon.stub(scoringCertificationService, 'calculateCertificationAssessmentScore').rejects(computeError);
-        sinon.stub(AssessmentResult, 'BuildAlgoErrorResult').returns(errorAssessmentResult);
+        sinon.stub(AssessmentResult, 'buildAlgoErrorResult').returns(errorAssessmentResult);
         sinon.stub(assessmentResultRepository, 'save').resolves();
         sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
       });
@@ -117,7 +117,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         });
 
         // then
-        expect(AssessmentResult.BuildAlgoErrorResult).to.have.been.calledWithExactly(
+        expect(AssessmentResult.buildAlgoErrorResult).to.have.been.calledWithExactly(
           computeError, certificationAssessment.id,
         );
         expect(assessmentResultRepository.save).to.have.been.calledWithExactly(
@@ -145,7 +145,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
       };
 
       beforeEach(() => {
-        sinon.stub(AssessmentResult, 'BuildStandardAssessmentResult').returns(assessmentResult);
+        sinon.stub(AssessmentResult, 'buildStandardAssessmentResult').returns(assessmentResult);
         sinon.stub(assessmentResultRepository, 'save').resolves(savedAssessmentResult);
         sinon.stub(competenceMarkRepository, 'save').resolves();
         sinon.stub(certificationCourseRepository, 'changeCompletionDate').resolves();
@@ -159,7 +159,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         });
 
         // then
-        expect(AssessmentResult.BuildStandardAssessmentResult).to.have.been.calledWithExactly(
+        expect(AssessmentResult.buildStandardAssessmentResult).to.have.been.calledWithExactly(
           certificationAssessmentScore.nbPix,
           certificationAssessmentScore.status,
           certificationAssessment.id,


### PR DESCRIPTION
## :unicorn: Problème

Les méthodes statiques `AssessmentResult.BuildStandardAssessmentResult` et `AssessmentResult.BuildAlgoErrorResult` sont les seules qui commencent par une majuscule. Il y a douze autres méthodes statiques `buildXXX` qui commencent par une minuscule, donc l'usage majoritaire est la minuscule.

## :robot: Solution

Renommer ces deux méthodes pour qu'elles commencent par une minuscule.

## :100: Pour tester

Finir un test de certification et voir que tout se passe bien, finir un test de certification qui génère une erreur de scoring (j'aurai besoin d'aide pour ça) et voir que tout se passe bien.