### PR TITLE
[FEATURE] L'arrondi à l'entier supérieur n'est pas correct pour filtrer les participants dans pixOrga (PIX-2456).

### DIFF
--- a/api/lib/domain/models/Stage.js
+++ b/api/lib/domain/models/Stage.js
@@ -19,7 +19,7 @@ class Stage {
   }
 
   getMinSkillsCountToReachStage(totalSkills) {
-    return Math.ceil(totalSkills * (this.threshold / 100));
+    return Math.floor(totalSkills * (this.threshold / 100));
   }
 }
 

--- a/api/tests/unit/domain/models/Stage_test.js
+++ b/api/tests/unit/domain/models/Stage_test.js
@@ -14,15 +14,26 @@ describe('Unit | Domain | Models | Stage', () => {
       expect(skillsToReach).to.be.equal(10);
     });
 
-    it('should always return an integer', () => {
+    it('should always return a floor integer 7.5 become 7 not 8', () => {
       // given
-      const stage = domainBuilder.buildStage({ threshold: 33 });
+      const stage = domainBuilder.buildStage({ threshold: 25 });
 
       // when
-      const skillsToReach = stage.getMinSkillsCountToReachStage(25);
+      const skillsToReach = stage.getMinSkillsCountToReachStage(30);
 
       // then
-      expect(skillsToReach).to.be.equal(9);
+      expect(skillsToReach).to.be.equal(7);
+    });
+
+    it('should always return a floor integer 7.25 become 7 not 8', () => {
+      // given
+      const stage = domainBuilder.buildStage({ threshold: 25 });
+
+      // when
+      const skillsToReach = stage.getMinSkillsCountToReachStage(29);
+
+      // then
+      expect(skillsToReach).to.be.equal(7);
     });
   });
 });

--- a/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
+++ b/api/tests/unit/domain/models/TargetProfileWithLearningContent_test.js
@@ -761,7 +761,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 3, to: 4 },
+        { from: 2, to: 3 },
       ]);
     });
 
@@ -788,8 +788,8 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 0, to: 2 },
-        { from: 3, to: 4 },
+        { from: 0, to: 1 },
+        { from: 2, to: 3 },
       ]);
     });
 
@@ -816,7 +816,7 @@ describe('Unit | Domain | Models | TargetProfileWithLearningContent', () => {
 
       // then
       expect(skillCountBoundaries).to.deep.equal([
-        { from: 5, to: 6 },
+        { from: 4, to: 6 },
       ]);
     });
 


### PR DESCRIPTION
## :unicorn: Problème
Un problème d'arrondi dans les filtres. nous arrondissions toujours à l'arrondi supérieur.
Or sur des cas à la marge. un palier à 9.09% devient 10%  `Math.ceil`.

Un participant avec un réusltat 9.2% =>` round = 9` ceil = 10 floor = 9
Le % d'un palier avec 9.4 => round = 9 `ceil = 10` floor = 9

Dans un cas comme celui-ci nous afffichons que l'utilisateur à atteinte le palier. mais lors du filtre nous l'excluons.

## :robot: Solution
Faire un `Math.floor` au lieu du `Math.ceil`

## :rainbow: Remarques
Je pense qu'un souci plus global se pose. ne devrait-on pas faire un `Math.floor` partout. ou `.ceil` ou `.round` en fonction de ce que l'on veut vraiment ? Et assurer une cohérence des arrondis dans toute l'application ? 


## :100: Pour tester
