### PR TITLE
[TECH] Restaurer la domainTransaction sur la completion d'assessement (PIX-2458).

### DIFF
--- a/api/lib/application/assessments/assessment-controller.js
+++ b/api/lib/application/assessments/assessment-controller.js
@@ -7,6 +7,7 @@ const assessmentRepository = require('../../infrastructure/repositories/assessme
 const assessmentSerializer = require('../../infrastructure/serializers/jsonapi/assessment-serializer');
 const challengeSerializer = require('../../infrastructure/serializers/jsonapi/challenge-serializer');
 const competenceEvaluationSerializer = require('../../infrastructure/serializers/jsonapi/competence-evaluation-serializer');
+const DomainTransaction = require('../../infrastructure/DomainTransaction');
 const { extractParameters } = require('../../infrastructure/utils/query-params-utils');
 const { extractLocaleFromRequest, extractUserIdFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
@@ -75,8 +76,10 @@ module.exports = {
   async completeAssessment(request) {
     const assessmentId = parseInt(request.params.id);
 
-    const event = await usecases.completeAssessment({ assessmentId });
-    await events.eventDispatcher.dispatch(event);
+    await DomainTransaction.execute(async (domainTransaction) => {
+      const event = await usecases.completeAssessment({ assessmentId, domainTransaction });
+      await events.eventDispatcher.dispatch(event, domainTransaction);
+    });
 
     return null;
   },

--- a/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
+++ b/api/lib/application/campaign-participation-results/campaign-participation-result-controller.js
@@ -3,6 +3,7 @@ const serializer = require('../../infrastructure/serializers/jsonapi/participant
 const { extractLocaleFromRequest } = require('../../infrastructure/utils/request-response-utils');
 
 module.exports = {
+
   async get(request) {
     const locale = extractLocaleFromRequest(request);
     const campaignParticipationId = parseInt(request.params.id);

--- a/api/lib/domain/events/compute-validated-skills-count.js
+++ b/api/lib/domain/events/compute-validated-skills-count.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const CampaignParticipationResultShared = require('./CampaignParticipationResultsShared');
 
 module.exports = async function computeValidatedSkillsCount({ event, campaignParticipationRepository, knowledgeElementRepository, targetProfileWithLearningContentRepository }) {
-  const campaignParticipation = await campaignParticipationRepository.get(event.campaignParticipationId, { include: ['campaign'] });
+  const campaignParticipation = await campaignParticipationRepository.get({ id: event.campaignParticipationId, options: { include: ['campaign'] } });
   if (campaignParticipation.canComputeValidatedSkillsCount()) {
 
     campaignParticipation.validatedSkillsCount = await _countValidatedSkills(campaignParticipation, knowledgeElementRepository, targetProfileWithLearningContentRepository);

--- a/api/lib/domain/events/handle-badge-acquisition.js
+++ b/api/lib/domain/events/handle-badge-acquisition.js
@@ -6,6 +6,7 @@ const eventType = AssessmentCompleted;
 
 const handleBadgeAcquisition = async function({
   event,
+  domainTransaction,
   badgeCriteriaService,
   badgeAcquisitionRepository,
   badgeRepository,
@@ -27,7 +28,7 @@ const handleBadgeAcquisition = async function({
     });
 
     if (!_.isEmpty(badgesAcquisitionToCreate)) {
-      await badgeAcquisitionRepository.create(badgesAcquisitionToCreate);
+      await badgeAcquisitionRepository.create(badgesAcquisitionToCreate, domainTransaction);
     }
   }
 };

--- a/api/lib/domain/events/handle-certification-scoring.js
+++ b/api/lib/domain/events/handle-certification-scoring.js
@@ -24,7 +24,7 @@ async function handleCertificationScoring({
   checkEventType(event, eventType);
 
   if (event.isCertificationType) {
-    const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId);
+    const certificationAssessment = await certificationAssessmentRepository.get(event.assessmentId, domainTransaction);
     return _calculateCertificationScore({
       certificationAssessment,
       domainTransaction,

--- a/api/lib/domain/events/handle-pole-emploi-participation-finished.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-finished.js
@@ -7,6 +7,7 @@ const eventType = AssessmentCompleted;
 
 async function handlePoleEmploiParticipationFinished({
   event,
+  domainTransaction,
   assessmentRepository,
   campaignParticipationRepository,
   campaignRepository,
@@ -49,7 +50,7 @@ async function handlePoleEmploiParticipationFinished({
       responseCode: response.code,
     });
 
-    return poleEmploiSendingRepository.create({ poleEmploiSending });
+    return poleEmploiSendingRepository.create({ poleEmploiSending, domainTransaction });
   }
 }
 

--- a/api/lib/domain/events/handle-pole-emploi-participation-finished.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-finished.js
@@ -23,15 +23,15 @@ async function handlePoleEmploiParticipationFinished({
 
   if (!campaignParticipationId) return;
 
-  const participation = await campaignParticipationRepository.get(campaignParticipationId);
-  const campaign = await campaignRepository.get(participation.campaignId);
-  const organization = await organizationRepository.get(campaign.organizationId);
+  const participation = await campaignParticipationRepository.get({ id: campaignParticipationId, domainTransaction });
+  const campaign = await campaignRepository.get(participation.campaignId, domainTransaction);
+  const organization = await organizationRepository.get(campaign.organizationId, domainTransaction);
 
   if (campaign.isAssessment() && organization.isPoleEmploi) {
 
-    const user = await userRepository.get(participation.userId);
-    const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
-    const assessment = await assessmentRepository.get(participation.assessmentId);
+    const user = await userRepository.get(participation.userId, domainTransaction);
+    const targetProfile = await targetProfileRepository.get(campaign.targetProfileId, domainTransaction);
+    const assessment = await assessmentRepository.get(participation.assessmentId, domainTransaction);
 
     const payload = PoleEmploiPayload.buildForParticipationFinished({
       user,
@@ -41,7 +41,7 @@ async function handlePoleEmploiParticipationFinished({
       assessment,
     });
 
-    const response = await poleEmploiNotifier.notify(user.id, payload.toString());
+    const response = await poleEmploiNotifier.notify({ userId: user.id, payload: payload.toString(), domainTransaction });
 
     const poleEmploiSending = PoleEmploiSending.buildForParticipationFinished({
       campaignParticipationId,
@@ -55,4 +55,5 @@ async function handlePoleEmploiParticipationFinished({
 }
 
 handlePoleEmploiParticipationFinished.eventType = eventType;
+
 module.exports = handlePoleEmploiParticipationFinished;

--- a/api/lib/domain/events/handle-pole-emploi-participation-shared.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-shared.js
@@ -20,7 +20,7 @@ async function handlePoleEmploiParticipationShared({
 
   const { campaignParticipationId } = event;
 
-  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+  const participation = await campaignParticipationRepository.get({ id: campaignParticipationId });
   const campaign = await campaignRepository.get(participation.campaignId);
   const organization = await organizationRepository.get(campaign.organizationId);
 

--- a/api/lib/domain/events/handle-pole-emploi-participation-started.js
+++ b/api/lib/domain/events/handle-pole-emploi-participation-started.js
@@ -19,7 +19,7 @@ async function handlePoleEmploiParticipationStarted({
 
   const { campaignParticipationId } = event;
 
-  const participation = await campaignParticipationRepository.get(campaignParticipationId);
+  const participation = await campaignParticipationRepository.get({ id: campaignParticipationId });
   const campaign = await campaignRepository.get(participation.campaignId);
   const organization = await organizationRepository.get(campaign.organizationId);
 

--- a/api/lib/domain/usecases/begin-campaign-participation-improvement.js
+++ b/api/lib/domain/usecases/begin-campaign-participation-improvement.js
@@ -10,7 +10,7 @@ module.exports = async function beginCampaignParticipationImprovement({
   assessmentRepository,
   campaignParticipationRepository,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, {});
+  const campaignParticipation = await campaignParticipationRepository.get({ id: campaignParticipationId, options: {} });
   if (campaignParticipation.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntityError();
   }

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -9,7 +9,7 @@ module.exports = async function completeAssessment({
   domainTransaction,
   assessmentRepository,
 }) {
-  const assessment = await assessmentRepository.get(assessmentId);
+  const assessment = await assessmentRepository.get(assessmentId, domainTransaction);
 
   if (assessment.isCompleted()) {
     throw new AlreadyRatedAssessmentError();

--- a/api/lib/domain/usecases/complete-assessment.js
+++ b/api/lib/domain/usecases/complete-assessment.js
@@ -6,6 +6,7 @@ const {
 
 module.exports = async function completeAssessment({
   assessmentId,
+  domainTransaction,
   assessmentRepository,
 }) {
   const assessment = await assessmentRepository.get(assessmentId);
@@ -14,7 +15,7 @@ module.exports = async function completeAssessment({
     throw new AlreadyRatedAssessmentError();
   }
 
-  await assessmentRepository.completeByAssessmentId(assessmentId);
+  await assessmentRepository.completeByAssessmentId(assessmentId, domainTransaction);
 
   return new AssessmentCompleted({
     assessmentId: assessment.id,

--- a/api/lib/domain/usecases/compute-campaign-participation-analysis.js
+++ b/api/lib/domain/usecases/compute-campaign-participation-analysis.js
@@ -10,7 +10,7 @@ module.exports = async function computeCampaignParticipationAnalysis({
   tutorialRepository,
   locale,
 } = {}) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+  const campaignParticipation = await campaignParticipationRepository.get({ id: campaignParticipationId });
   const campaignId = campaignParticipation.campaignId;
   const hasUserAccessToResult = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignId, userId);
 

--- a/api/lib/domain/usecases/get-campaign-participation.js
+++ b/api/lib/domain/usecases/get-campaign-participation.js
@@ -7,7 +7,7 @@ module.exports = async function getCampaignParticipation({
   options,
   userId,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, options);
+  const campaignParticipation = await campaignParticipationRepository.get({ id: campaignParticipationId, options });
 
   const userIsCampaignOrganizationMember = await campaignRepository.checkIfUserOrganizationHasAccessToCampaign(campaignParticipation.campaignId, userId);
 

--- a/api/lib/domain/usecases/get-participant-result.js
+++ b/api/lib/domain/usecases/get-participant-result.js
@@ -14,7 +14,7 @@ module.exports = async function getParticipantResult({
 };
 
 async function _checkCampaignParticipationIsOwnedByUser(campaignParticipationRepository, campaignParticipationId, userId) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId);
+  const campaignParticipation = await campaignParticipationRepository.get({ id: campaignParticipationId });
   if (campaignParticipation.userId !== userId) {
     throw new UserNotAuthorizedToAccessEntityError();
   }

--- a/api/lib/domain/usecases/get-progression.js
+++ b/api/lib/domain/usecases/get-progression.js
@@ -1,17 +1,16 @@
 const Progression = require('../../../lib/domain/models/Progression');
 
-module.exports = async function getProgression(
-  {
-    progressionId,
-    userId,
-    assessmentRepository,
-    competenceEvaluationRepository,
-    campaignParticipationRepository,
-    knowledgeElementRepository,
-    skillRepository,
-    targetProfileRepository,
-    improvementService,
-  }) {
+module.exports = async function getProgression({
+  progressionId,
+  userId,
+  assessmentRepository,
+  competenceEvaluationRepository,
+  campaignParticipationRepository,
+  knowledgeElementRepository,
+  skillRepository,
+  targetProfileRepository,
+  improvementService,
+}) {
 
   const assessmentId = Progression.getAssessmentIdFromId(progressionId);
 
@@ -19,7 +18,7 @@ module.exports = async function getProgression(
   let progression;
 
   if (assessment.isForCampaign()) {
-    const campaignParticipation = await campaignParticipationRepository.get(assessment.campaignParticipationId);
+    const campaignParticipation = await campaignParticipationRepository.get({ id: assessment.campaignParticipationId });
     const targetProfile = await targetProfileRepository.getByCampaignId(campaignParticipation.campaignId);
     const knowledgeElementsBeforeSharedDate = await knowledgeElementRepository.findUniqByUserId({ userId, limitDate: campaignParticipation.sharedAt });
 

--- a/api/lib/domain/usecases/share-campaign-result.js
+++ b/api/lib/domain/usecases/share-campaign-result.js
@@ -6,7 +6,7 @@ module.exports = async function shareCampaignResult({
   campaignParticipationId,
   campaignParticipationRepository,
 }) {
-  const campaignParticipation = await campaignParticipationRepository.get(campaignParticipationId, { include: ['campaign'] });
+  const campaignParticipation = await campaignParticipationRepository.get({ id: campaignParticipationId, options: { include: ['campaign'] } });
 
   _checkUserIsOwnerOfCampaignParticipation(campaignParticipation, userId);
 

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -24,11 +24,11 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
-  async get(id) {
+  async get(id, domainTransaction = DomainTransaction.emptyTransaction()) {
     try {
       const bookshelfAssessment = await BookshelfAssessment
         .where({ id })
-        .fetch();
+        .fetch({ transacting: domainTransaction.knexTransaction });
 
       return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, bookshelfAssessment);
     } catch (err) {
@@ -119,8 +119,8 @@ module.exports = {
       .then((assessment) => bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment));
   },
 
-  abortByAssessmentId(assessmentId) {
-    return this._updateStateById({ id: assessmentId, state: Assessment.states.ABORTED });
+  abortByAssessmentId(assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
+    return this._updateStateById({ id: assessmentId, state: Assessment.states.ABORTED }, domainTransaction);
   },
 
   completeByAssessmentId(assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
@@ -141,11 +141,9 @@ module.exports = {
   },
 
   async _updateStateById({ id, state }, domainTransaction) {
-    const transacting = domainTransaction && domainTransaction.knexTransaction;
-
     const assessment = await BookshelfAssessment
       .where({ id })
-      .save({ state }, { require: true, patch: true, transacting });
+      .save({ state }, { require: true, patch: true, transacting: domainTransaction.knexTransaction });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment);
   },
 

--- a/api/lib/infrastructure/repositories/assessment-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-repository.js
@@ -124,7 +124,7 @@ module.exports = {
   },
 
   completeByAssessmentId(assessmentId, domainTransaction = DomainTransaction.emptyTransaction()) {
-    return this._updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }, domainTransaction.knexTransaction);
+    return this._updateStateById({ id: assessmentId, state: Assessment.states.COMPLETED }, domainTransaction);
   },
 
   async ownedByUser({ id, userId = null }) {
@@ -140,10 +140,12 @@ module.exports = {
     return assessment.userId === userId;
   },
 
-  async _updateStateById({ id, state }, knexTransaction) {
+  async _updateStateById({ id, state }, domainTransaction) {
+    const transacting = domainTransaction && domainTransaction.knexTransaction;
+
     const assessment = await BookshelfAssessment
       .where({ id })
-      .save({ state }, { require: true, patch: true, transacting: knexTransaction });
+      .save({ state }, { require: true, patch: true, transacting });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessment, assessment);
   },
 

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -44,7 +44,6 @@ module.exports = {
       throw new MissingAssessmentId();
     }
     try {
-      const transacting = domainTransaction && domainTransaction.knexTransaction;
       const savedAssessmentResultBookshelf = await new BookshelfAssessmentResult({
         pixScore,
         status,
@@ -56,7 +55,7 @@ module.exports = {
         juryId,
         assessmentId,
       })
-        .save(null, { require: true, transacting });
+        .save(null, { require: true, transacting: domainTransaction.knexTransaction });
 
       return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessmentResult, savedAssessmentResultBookshelf);
     } catch (error) {

--- a/api/lib/infrastructure/repositories/assessment-result-repository.js
+++ b/api/lib/infrastructure/repositories/assessment-result-repository.js
@@ -39,10 +39,12 @@ module.exports = {
     juryId,
     assessmentId,
   }, domainTransaction = DomainTransaction.emptyTransaction()) {
+
     if (_.isNil(assessmentId)) {
       throw new MissingAssessmentId();
     }
     try {
+      const transacting = domainTransaction && domainTransaction.knexTransaction;
       const savedAssessmentResultBookshelf = await new BookshelfAssessmentResult({
         pixScore,
         status,
@@ -54,7 +56,7 @@ module.exports = {
         juryId,
         assessmentId,
       })
-        .save(null, { require: true, transacting: domainTransaction.knexTransaction });
+        .save(null, { require: true, transacting });
 
       return bookshelfToDomainConverter.buildDomainObject(BookshelfAssessmentResult, savedAssessmentResultBookshelf);
     } catch (error) {

--- a/api/lib/infrastructure/repositories/authentication-method-repository.js
+++ b/api/lib/infrastructure/repositories/authentication-method-repository.js
@@ -156,10 +156,17 @@ module.exports = {
       });
   },
 
-  async findOneByUserIdAndIdentityProvider({ userId, identityProvider }) {
+  async findOneByUserIdAndIdentityProvider({
+    userId,
+    identityProvider,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
     const authenticationMethod = await BookshelfAuthenticationMethod
       .where({ userId, identityProvider })
-      .fetch({ require: false });
+      .fetch({
+        require: false,
+        domainTransaction,
+      });
 
     return authenticationMethod ? _toDomainEntity(authenticationMethod) : null;
   },
@@ -186,11 +193,23 @@ module.exports = {
     }
   },
 
-  async updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId }) {
+  async updatePoleEmploiAuthenticationComplementByUserId({
+    authenticationComplement,
+    userId,
+    domainTransaction = DomainTransaction.emptyTransaction(),
+  }) {
     try {
       const bookshelfAuthenticationMethod = await BookshelfAuthenticationMethod
         .where({ userId, identityProvider: AuthenticationMethod.identityProviders.POLE_EMPLOI })
-        .save({ authenticationComplement }, { method: 'update', patch: true, require: true });
+        .save(
+          { authenticationComplement },
+          {
+            method: 'update',
+            patch: true,
+            require: true,
+            transacting: domainTransaction.knexTransaction,
+          },
+        );
       return _toDomainEntity(bookshelfAuthenticationMethod);
     } catch (err) {
       if (err instanceof BookshelfAuthenticationMethod.NoRowsUpdatedError) {

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -1,5 +1,6 @@
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
 const BookshelfBadge = require('../../infrastructure/data/badge');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
 
@@ -27,7 +28,7 @@ module.exports = {
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },
 
-  findByCampaignParticipationId(campaignParticipationId) {
+  findByCampaignParticipationId(campaignParticipationId, domainTransaction = DomainTransaction.emptyTransaction()) {
     return BookshelfBadge
       .query((qb) => {
         qb.join('target-profiles', 'target-profiles.id', 'badges.targetProfileId');
@@ -38,6 +39,7 @@ module.exports = {
       .fetchAll({
         require: false,
         withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
+        transacting: domainTransaction.knexTransaction,
       })
       .then((results) => bookshelfToDomainConverter.buildDomainObjects(BookshelfBadge, results));
   },

--- a/api/lib/infrastructure/repositories/campaign-participation-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-participation-repository.js
@@ -43,7 +43,7 @@ function _toDomain(bookshelfCampaignParticipation) {
 
 module.exports = {
 
-  async get(id, options = {}) {
+  async get({ id, options = {}, domainTransaction = DomainTransaction.emptyTransaction() }) {
     if (options.include) {
       options.withRelated = _.union(options.include, ['assessments']);
     } else {
@@ -52,7 +52,11 @@ module.exports = {
 
     const campaignParticipation = await BookshelfCampaignParticipation
       .where({ id })
-      .fetch({ ...options, require: false });
+      .fetch({
+        ...options,
+        require: false,
+        transacting: domainTransaction.knexTransaction,
+      });
     return _toDomain(campaignParticipation);
   },
 

--- a/api/lib/infrastructure/repositories/campaign-repository.js
+++ b/api/lib/infrastructure/repositories/campaign-repository.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const BookshelfCampaign = require('../data/campaign');
 const { NotFoundError } = require('../../domain/errors');
 const bookshelfToDomainConverter = require('../utils/bookshelf-to-domain-converter');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
 
@@ -24,11 +25,12 @@ module.exports = {
     return bookshelfToDomainConverter.buildDomainObject(BookshelfCampaign, bookshelfCampaign);
   },
 
-  async get(id) {
+  async get(id, domainTransaction = DomainTransaction.emptyTransaction()) {
     const bookshelfCampaign = await BookshelfCampaign
       .where({ id })
       .fetch({
         withRelated: ['creator', 'organization', 'targetProfile'],
+        transacting: domainTransaction.knexTransaction,
       })
       .catch((err) => {
         if (err instanceof BookshelfCampaign.NotFoundError) {

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -29,8 +29,9 @@ module.exports = {
   },
 
   async changeCompletionDate(certificationCourseId, completedAt = null, domainTransaction = DomainTransaction.emptyTransaction()) {
+    const transacting = domainTransaction && domainTransaction.knexTransaction;
     const certificationCourseBookshelf = new CertificationCourseBookshelf({ id: certificationCourseId, completedAt });
-    const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting: domainTransaction.knexTransaction });
+    const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting });
     return _toDomain(savedCertificationCourse);
   },
 

--- a/api/lib/infrastructure/repositories/certification-course-repository.js
+++ b/api/lib/infrastructure/repositories/certification-course-repository.js
@@ -29,9 +29,8 @@ module.exports = {
   },
 
   async changeCompletionDate(certificationCourseId, completedAt = null, domainTransaction = DomainTransaction.emptyTransaction()) {
-    const transacting = domainTransaction && domainTransaction.knexTransaction;
     const certificationCourseBookshelf = new CertificationCourseBookshelf({ id: certificationCourseId, completedAt });
-    const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting });
+    const savedCertificationCourse = await certificationCourseBookshelf.save(null, { transacting: domainTransaction.knexTransaction });
     return _toDomain(savedCertificationCourse);
   },
 

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -9,9 +9,10 @@ function _toDomain(competenceMark) {
 
 module.exports = {
   async save(competenceMark, domainTransaction = DomainTransaction.emptyTransaction()) {
+    const transacting = domainTransaction && domainTransaction.knexTransaction;
     await competenceMark.validate();
     const savedCompetenceMark = await new BookshelfCompetenceMark(competenceMark)
-      .save(null, { transacting: domainTransaction.knexTransaction });
+      .save(null, { transacting });
     return savedCompetenceMark.toDomainEntity();
   },
 

--- a/api/lib/infrastructure/repositories/competence-mark-repository.js
+++ b/api/lib/infrastructure/repositories/competence-mark-repository.js
@@ -8,11 +8,11 @@ function _toDomain(competenceMark) {
 }
 
 module.exports = {
+
   async save(competenceMark, domainTransaction = DomainTransaction.emptyTransaction()) {
-    const transacting = domainTransaction && domainTransaction.knexTransaction;
     await competenceMark.validate();
     const savedCompetenceMark = await new BookshelfCompetenceMark(competenceMark)
-      .save(null, { transacting });
+      .save(null, { transacting: domainTransaction.knexTransaction });
     return savedCompetenceMark.toDomainEntity();
   },
 

--- a/api/lib/infrastructure/repositories/knowledge-element-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-repository.js
@@ -58,8 +58,8 @@ async function _filterValidatedKnowledgeElementsByCampaignId(knowledgeElements, 
   });
 }
 
-async function _findSnapshotsForUsers(userIdsAndDates) {
-  const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates);
+async function _findSnapshotsForUsers(userIdsAndDates, domainTransaction) {
+  const knowledgeElementsGroupedByUser = await knowledgeElementSnapshotRepository.findByUserIdsAndSnappedAtDates(userIdsAndDates, domainTransaction);
 
   for (const [userIdStr, knowledgeElementsFromSnapshot] of Object.entries(knowledgeElementsGroupedByUser)) {
     const userId = parseInt(userIdStr);
@@ -179,8 +179,8 @@ module.exports = {
     return targetProfileWithLearningContent.getValidatedKnowledgeElementsGroupedByTube(_.flatMap(knowledgeElementsGroupedByUser));
   },
 
-  async findSnapshotForUsers(userIdsAndDates) {
-    return _findSnapshotsForUsers(userIdsAndDates);
+  async findSnapshotForUsers(userIdsAndDates, domainTransaction = DomainTransaction.emptyTransaction()) {
+    return _findSnapshotsForUsers(userIdsAndDates, domainTransaction);
   },
 
 };

--- a/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
+++ b/api/lib/infrastructure/repositories/knowledge-element-snapshot-repository.js
@@ -4,6 +4,7 @@ const BookshelfKnowledgeElementSnapshot = require('../data/knowledge-element-sna
 const KnowledgeElement = require('../../domain/models/KnowledgeElement');
 const { AlreadyExistingEntityError } = require('../../domain/errors');
 const bookshelfUtils = require('../utils/knex-utils');
+const DomainTransaction = require('../DomainTransaction');
 
 function _toKnowledgeElementCollection({ snapshot } = {}) {
   if (!snapshot) return null;
@@ -28,9 +29,11 @@ module.exports = {
     }
   },
 
-  async findByUserIdsAndSnappedAtDates(userIdsAndSnappedAtDates = {}) {
+  async findByUserIdsAndSnappedAtDates(userIdsAndSnappedAtDates = {}, domainTransaction = DomainTransaction.emptyTransaction()) {
+    const knexConn = domainTransaction.knexTransaction || knex;
+
     const params = Object.entries(userIdsAndSnappedAtDates);
-    const results = await knex
+    const results = await knexConn
       .select('userId', 'snapshot')
       .from('knowledge-element-snapshots')
       .whereIn(['userId', 'snappedAt'], params);

--- a/api/lib/infrastructure/repositories/organization-repository.js
+++ b/api/lib/infrastructure/repositories/organization-repository.js
@@ -75,7 +75,7 @@ module.exports = {
       .then(_toDomain);
   },
 
-  get(id) {
+  get(id, domainTransaction = DomainTransaction.emptyTransaction()) {
     return BookshelfOrganization
       .where({ id })
       .fetch({
@@ -83,6 +83,7 @@ module.exports = {
           'targetProfileShares.targetProfile',
           'tags',
         ],
+        transacting: domainTransaction.knexTransaction,
       })
       .then(_toDomain)
       .catch((err) => {

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -3,7 +3,6 @@ const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
   create({ poleEmploiSending, domainTransaction = DomainTransaction.emptyTransaction() }) {
-    const transacting = domainTransaction && domainTransaction.knexTransaction;
-    return new BookshelfPoleEmploiSending(poleEmploiSending).save(null, { transacting });
+    return new BookshelfPoleEmploiSending(poleEmploiSending).save(null, { transacting: domainTransaction.knexTransaction });
   },
 };

--- a/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
+++ b/api/lib/infrastructure/repositories/pole-emploi-sending-repository.js
@@ -1,7 +1,9 @@
 const BookshelfPoleEmploiSending = require('../../infrastructure/data/pole-emploi-sending');
+const DomainTransaction = require('../DomainTransaction');
 
 module.exports = {
-  create({ poleEmploiSending }) {
-    return new BookshelfPoleEmploiSending(poleEmploiSending).save();
+  create({ poleEmploiSending, domainTransaction = DomainTransaction.emptyTransaction() }) {
+    const transacting = domainTransaction && domainTransaction.knexTransaction;
+    return new BookshelfPoleEmploiSending(poleEmploiSending).save(null, { transacting });
   },
 };

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -64,10 +64,10 @@ module.exports = {
       });
   },
 
-  get(userId) {
+  get(userId, domainTransaction = DomainTransaction.emptyTransaction()) {
     return BookshelfUser
       .where({ id: userId })
-      .fetch()
+      .fetch({ transacting: domainTransaction.knexTransaction })
       .then((user) => bookshelfToDomainConverter.buildDomainObject(BookshelfUser, user))
       .catch((err) => {
         if (err instanceof BookshelfUser.NotFoundError) {

--- a/api/scripts/prod/compute-pole-emploi-sendings.js
+++ b/api/scripts/prod/compute-pole-emploi-sendings.js
@@ -119,7 +119,7 @@ async function _computeSharedPoleEmploiSendings(participation) {
   const user = await userRepository.get(participation.userId);
   const campaign = await campaignRepository.get(participation.campaignId);
   const targetProfile = await targetProfileRepository.get(campaign.targetProfileId);
-  const participationResult = await campaignParticipationResultRepository.getByParticipationId(participation.id);
+  const participationResult = await campaignParticipationResultRepository.getByParticipationId({ campaignParticipationId: participation.id });
 
   const payload = PoleEmploiPayload.buildForParticipationShared({
     user,

--- a/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
+++ b/api/tests/acceptance/application/assessments/assessment-controller-complete-assessment_test.js
@@ -180,7 +180,7 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
 
     server = await createServer();
 
-    user = databaseBuilder.factory.buildUser({});
+    user = databaseBuilder.factory.buildUser();
     assessment = databaseBuilder.factory.buildAssessment({
       userId: user.id, state: Assessment.states.STARTED,
     });
@@ -230,14 +230,16 @@ describe('Acceptance | Controller | assessment-controller-complete-assessment', 
     });
 
     context('when assessment belongs to a campaign', () => {
+
       let user;
       let targetProfile;
       let badge;
 
-      beforeEach(() => {
-        user = databaseBuilder.factory.buildUser({});
+      beforeEach(async () => {
+        user = databaseBuilder.factory.buildUser();
         targetProfile = databaseBuilder.factory.buildTargetProfile();
         badge = databaseBuilder.factory.buildBadge({ targetProfileId: targetProfile.id });
+        await databaseBuilder.commit();
       });
 
       afterEach(async () => {

--- a/api/tests/acceptance/application/campaign-participation-result-controller_test.js
+++ b/api/tests/acceptance/application/campaign-participation-result-controller_test.js
@@ -165,6 +165,7 @@ describe('Acceptance | API | Campaign Participation Result', () => {
   });
 
   describe('GET /api/campaign-participations/{id}/campaign-participation-result', () => {
+
     let options;
 
     beforeEach(async () => {

--- a/api/tests/acceptance/application/progression-controller_test.js
+++ b/api/tests/acceptance/application/progression-controller_test.js
@@ -15,7 +15,6 @@ describe('Acceptance | API | Progressions', () => {
     let userId;
 
     beforeEach(async () => {
-
       const learningContent = [{
         id: 'recArea1',
         competences: [{
@@ -54,7 +53,7 @@ describe('Acceptance | API | Progressions', () => {
 
     context('without authorization token', () => {
 
-      it('should return 401 HTTP status code', () => {
+      it('should return 401 HTTP status code', async () => {
         // given
         const progressionId = assessmentId;
         const options = {
@@ -66,19 +65,18 @@ describe('Acceptance | API | Progressions', () => {
         };
 
         // when
-        const promise = server.inject(options);
+        const response = await server.inject(options);
 
         // then
-        return promise.then((response) => {
-          expect(response.statusCode).to.equal(401);
-        });
+        expect(response.statusCode).to.equal(401);
       });
     });
 
     context('with authorization token', () => {
 
       context('when the assessment does not exists', () => {
-        it('should respond with a 404', () => {
+
+        it('should respond with a 404', async () => {
           // given
           const progressionId = assessmentId + 1;
           const options = {
@@ -90,18 +88,16 @@ describe('Acceptance | API | Progressions', () => {
           };
 
           // when
-          const promise = server.inject(options);
+          const response = await server.inject(options);
 
           // then
-          return promise.then((response) => {
-            expect(response.statusCode).to.equal(404);
-          });
+          expect(response.statusCode).to.equal(404);
         });
       });
 
       context('allowed to access the progression', () => {
 
-        it('should respond with a 200', () => {
+        it('should respond with a 200', async () => {
           // given
           const progressionId = assessmentId;
           const options = {
@@ -113,12 +109,10 @@ describe('Acceptance | API | Progressions', () => {
           };
 
           // when
-          const promise = server.inject(options);
+          const response = await server.inject(options);
 
           // then
-          return promise.then((response) => {
-            expect(response.statusCode).to.equal(200);
-          });
+          expect(response.statusCode).to.equal(200);
         });
       });
     });

--- a/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/assessment-repository_test.js
@@ -58,6 +58,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
 
     context('when the assessment does not exist', () => {
+
       it('should return null', async () => {
         // when
         const assessment = await assessmentRepository.getWithAnswersAndCampaignParticipation(245);
@@ -81,7 +82,9 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
 
       it('should return the assessment', async () => {
         // when
-        const assessment = await assessmentRepository.get(assessmentId);
+        const assessment = await DomainTransaction.execute(async (domainTransaction) =>
+          assessmentRepository.get(assessmentId, domainTransaction),
+        );
 
         // then
         expect(assessment).to.be.an.instanceOf(Assessment);
@@ -91,9 +94,12 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
     });
 
     context('when the assessment does not exist', () => {
+
       it('should return null', async () => {
         // when
-        const error = await catchErr(assessmentRepository.get)(245);
+        const error = await DomainTransaction.execute(async (domainTransaction) =>
+          catchErr(assessmentRepository.get)(245, domainTransaction),
+        );
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);
@@ -104,6 +110,7 @@ describe('Integration | Infrastructure | Repositories | assessment-repository', 
   describe('#getByAssessmentIdAndUserId', () => {
 
     describe('when userId is provided,', () => {
+
       let userId;
       let assessmentId;
 

--- a/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/authentication-method-repository_test.js
@@ -13,6 +13,7 @@ const {
 
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const authenticationMethodRepository = require('../../../../lib/infrastructure/repositories/authentication-method-repository');
 
 describe('Integration | Repository | AuthenticationMethod', () => {
@@ -171,7 +172,9 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       await databaseBuilder.commit();
 
       // when
-      const authenticationMethodsByUserIdAndIdentityProvider = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider });
+      const authenticationMethodsByUserIdAndIdentityProvider = await DomainTransaction.execute(async (domainTransaction) =>
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider, domainTransaction }),
+      );
 
       // then
       expect(authenticationMethodsByUserIdAndIdentityProvider).to.be.instanceof(AuthenticationMethod);
@@ -185,7 +188,9 @@ describe('Integration | Repository | AuthenticationMethod', () => {
       const identityProvider = AuthenticationMethod.identityProviders.GAR;
 
       // when
-      const authenticationMethodsByUserIdAndIdentityProvider = await authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider });
+      const authenticationMethodsByUserIdAndIdentityProvider = await DomainTransaction.execute(async (domainTransaction) =>
+        authenticationMethodRepository.findOneByUserIdAndIdentityProvider({ userId, identityProvider, domainTransaction }),
+      );
 
       // then
       expect(authenticationMethodsByUserIdAndIdentityProvider).to.be.null;
@@ -449,7 +454,13 @@ describe('Integration | Repository | AuthenticationMethod', () => {
         });
 
         // when
-        const updatedAuthenticationMethod = await authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({ authenticationComplement, userId });
+        const updatedAuthenticationMethod = await DomainTransaction.execute(async (domainTransaction) =>
+          authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId({
+            authenticationComplement,
+            userId,
+            domainTransaction,
+          }),
+        );
 
         // then
         expect(updatedAuthenticationMethod.authenticationComplement).to.deep.equal(authenticationComplement);
@@ -464,7 +475,13 @@ describe('Integration | Repository | AuthenticationMethod', () => {
         const authenticationComplement = {};
 
         // when
-        const error = await catchErr(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId)({ authenticationComplement, userId });
+        const error = await DomainTransaction.execute(async (domainTransaction) =>
+          catchErr(authenticationMethodRepository.updatePoleEmploiAuthenticationComplementByUserId)({
+            authenticationComplement,
+            userId,
+            domainTransaction,
+          }),
+        );
 
         // then
         expect(error).to.be.instanceOf(AuthenticationMethodNotFoundError);

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -3,6 +3,7 @@ const badgeRepository = require('../../../../lib/infrastructure/repositories/bad
 const Badge = require('../../../../lib/domain/models/Badge');
 const BadgeCriterion = require('../../../../lib/domain/models/BadgeCriterion');
 const BadgePartnerCompetence = require('../../../../lib/domain/models/BadgePartnerCompetence');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
 describe('Integration | Repository | Badge', () => {
 
@@ -149,8 +150,8 @@ describe('Integration | Repository | Badge', () => {
       expect(badges[0].badgePartnerCompetences[0]).to.be.an.instanceOf(BadgePartnerCompetence);
       expect(badges[0]).to.deep.equal({
         ...badgeWithBadgePartnerCompetences,
-        badgeCriteria: [ badgeCriterionForBadgeWithPartnerCompetences ],
-        badgePartnerCompetences: [ badgePartnerCompetence_1, badgePartnerCompetence_2 ],
+        badgeCriteria: [badgeCriterionForBadgeWithPartnerCompetences],
+        badgePartnerCompetences: [badgePartnerCompetence_1, badgePartnerCompetence_2],
       });
     });
 
@@ -211,8 +212,8 @@ describe('Integration | Repository | Badge', () => {
       expect(badges[0].badgePartnerCompetences[0]).to.be.an.instanceOf(BadgePartnerCompetence);
       expect(badges[0]).to.deep.equal({
         ...badgeWithBadgePartnerCompetences,
-        badgeCriteria: [ badgeCriterionForBadgeWithPartnerCompetences ],
-        badgePartnerCompetences: [ badgePartnerCompetence_1, badgePartnerCompetence_2 ],
+        badgeCriteria: [badgeCriterionForBadgeWithPartnerCompetences],
+        badgePartnerCompetences: [badgePartnerCompetence_1, badgePartnerCompetence_2],
       });
     });
 
@@ -263,8 +264,11 @@ describe('Integration | Repository | Badge', () => {
       await databaseBuilder.commit();
 
       // when
-      const badges = await badgeRepository.findByCampaignParticipationId(campaignParticipationId);
+      const badges = await DomainTransaction.execute(async (domainTransaction) =>
+        badgeRepository.findByCampaignParticipationId(campaignParticipationId, domainTransaction),
+      );
 
+      // then
       expect(badges.length).to.equal(2);
 
       const firstBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_1.id);
@@ -275,13 +279,11 @@ describe('Integration | Repository | Badge', () => {
       });
 
       const secondBadge = badges.find(({ id }) => id === badgeWithSameTargetProfile_2.id);
-      expect(secondBadge).deep.equal(
-        {
-          ...badgeWithSameTargetProfile_2,
-          badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_2],
-          badgePartnerCompetences: [],
-        });
-
+      expect(secondBadge).deep.equal({
+        ...badgeWithSameTargetProfile_2,
+        badgeCriteria: [badgeCriterionForBadgeWithSameTargetProfile_2],
+        badgePartnerCompetences: [],
+      });
     });
 
     it('should return the badge linked to the target profile of the given campaign participation with related badge criteria and badge partner competences', async () => {
@@ -292,7 +294,9 @@ describe('Integration | Repository | Badge', () => {
       await databaseBuilder.commit();
 
       // when
-      const badges = await badgeRepository.findByCampaignParticipationId(campaignParticipationId);
+      const badges = await DomainTransaction.execute(async (domainTransaction) =>
+        badgeRepository.findByCampaignParticipationId(campaignParticipationId, domainTransaction),
+      );
 
       // then
       expect(badges.length).to.equal(1);
@@ -301,20 +305,9 @@ describe('Integration | Repository | Badge', () => {
       expect(badges[0].badgePartnerCompetences[0]).to.be.an.instanceOf(BadgePartnerCompetence);
       expect(badges[0]).to.deep.equal({
         ...badgeWithBadgePartnerCompetences,
-        badgeCriteria: [ badgeCriterionForBadgeWithPartnerCompetences ],
-        badgePartnerCompetences: [ badgePartnerCompetence_1, badgePartnerCompetence_2 ],
+        badgeCriteria: [badgeCriterionForBadgeWithPartnerCompetences],
+        badgePartnerCompetences: [badgePartnerCompetence_1, badgePartnerCompetence_2],
       });
-    });
-
-    it('should return an empty array when the given target profile has no badges', async function() {
-      // given
-      const targetProfileId = targetProfileWithoutBadge.id;
-
-      // when
-      const badges = await badgeRepository.findByTargetProfileId(targetProfileId);
-
-      // then
-      expect(badges.length).to.equal(0);
     });
   });
 

--- a/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-assessment-repository_test.js
@@ -3,6 +3,7 @@ const { NotFoundError } = require('../../../../lib/domain/errors');
 const certificationAssessmentRepository = require('../../../../lib/infrastructure/repositories/certification-assessment-repository');
 const CertificationAssessment = require('../../../../lib/domain/models/CertificationAssessment');
 const _ = require('lodash');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
 describe('Integration | Infrastructure | Repositories | certification-assessment-repository', () => {
 
@@ -41,7 +42,9 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
 
       it('should return the certification assessment with certification challenges and answers', async () => {
         // when
-        const certificationAssessment = await certificationAssessmentRepository.get(certificationAssessmentId);
+        const certificationAssessment = await DomainTransaction.execute(async (domainTransaction) =>
+          certificationAssessmentRepository.get(certificationAssessmentId, domainTransaction),
+        );
 
         // then
         expect(certificationAssessment).to.be.an.instanceOf(CertificationAssessment);
@@ -60,7 +63,9 @@ describe('Integration | Infrastructure | Repositories | certification-assessment
     context('when the assessment does not exist', () => {
       it('should throw a NotFoundError', async () => {
         // when
-        const error = await catchErr(certificationAssessmentRepository.get)(12345);
+        const error = await DomainTransaction.execute(async (domainTransaction) =>
+          catchErr(certificationAssessmentRepository.get)(12345, domainTransaction),
+        );
 
         // then
         expect(error).to.be.instanceOf(NotFoundError);

--- a/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-course-repository_test.js
@@ -2,6 +2,7 @@ const { catchErr, expect, databaseBuilder, domainBuilder, knex } = require('../.
 const certificationCourseRepository = require('../../../../lib/infrastructure/repositories/certification-course-repository');
 const BookshelfCertificationCourse = require('../../../../lib/infrastructure/data/certification-course');
 const { NotFoundError } = require('../../../../lib/domain/errors');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 
 const CertificationCourse = require('../../../../lib/domain/models/CertificationCourse');
 const _ = require('lodash');
@@ -9,6 +10,7 @@ const _ = require('lodash');
 describe('Integration | Repository | Certification Course', function() {
 
   describe('#save', () => {
+
     let certificationCourse;
 
     beforeEach(() => {
@@ -85,6 +87,7 @@ describe('Integration | Repository | Certification Course', function() {
   });
 
   describe('#changeCompletionDate', () => {
+
     let courseId;
 
     beforeEach(async () => {
@@ -93,9 +96,13 @@ describe('Integration | Repository | Certification Course', function() {
     });
 
     it('should update completedAt of the certificationCourse if one date is passed', async () => {
-      // when
+      // given
       const completionDate = new Date('2018-01-01T06:07:08Z');
-      const updatedCertificationCourse = await certificationCourseRepository.changeCompletionDate(courseId, completionDate);
+
+      // when
+      const updatedCertificationCourse = await DomainTransaction.execute(async (domainTransaction) =>
+        certificationCourseRepository.changeCompletionDate(courseId, completionDate, domainTransaction),
+      );
 
       // then
       expect(updatedCertificationCourse).to.be.instanceOf(CertificationCourse);

--- a/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/competence-mark-repository_test.js
@@ -2,13 +2,16 @@ const { expect, knex, domainBuilder, databaseBuilder } = require('../../../test-
 const _ = require('lodash');
 
 const CompetenceMark = require('../../../../lib/domain/models/CompetenceMark');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const competenceMarkRepository = require('../../../../lib/infrastructure/repositories/competence-mark-repository');
 
 describe('Integration | Repository | CompetenceMark', () => {
 
   describe('#save', () => {
+
     let assessmentResultId;
     let competenceMark;
+
     beforeEach(async () => {
       assessmentResultId = await databaseBuilder.factory.buildAssessmentResult().id;
       await databaseBuilder.commit();
@@ -29,7 +32,9 @@ describe('Integration | Repository | CompetenceMark', () => {
 
     it('should persist the mark in db', async () => {
       // when
-      await competenceMarkRepository.save(competenceMark);
+      await DomainTransaction.execute(async (domainTransaction) =>
+        competenceMarkRepository.save(competenceMark, domainTransaction),
+      );
 
       // then
       const marks = await knex('competence-marks').select();
@@ -48,7 +53,9 @@ describe('Integration | Repository | CompetenceMark', () => {
       });
 
       // when
-      const savedMark = await competenceMarkRepository.save(mark);
+      const savedMark = await DomainTransaction.execute(async (domainTransaction) =>
+        competenceMarkRepository.save(mark, domainTransaction),
+      );
 
       // then
       expect(savedMark).to.be.an.instanceOf(CompetenceMark);

--- a/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/pole-emploi-sending-repository_test.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const { expect, databaseBuilder, knex, domainBuilder } = require('../../../test-helper');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const poleEmploiSendingRepository = require('../../../../lib/infrastructure/repositories/pole-emploi-sending-repository');
 
 describe('Integration | Repository | PoleEmploiSending', () => {
@@ -17,7 +18,9 @@ describe('Integration | Repository | PoleEmploiSending', () => {
       const poleEmploiSending = domainBuilder.buildPoleEmploiSending({ campaignParticipationId });
 
       // when
-      await poleEmploiSendingRepository.create({ poleEmploiSending });
+      await DomainTransaction.execute(async (domainTransaction) =>
+        poleEmploiSendingRepository.create({ poleEmploiSending, domainTransaction }),
+      );
 
       // then
       const poleEmploiSendings = await knex('pole-emploi-sendings').select();

--- a/api/tests/integration/infrastructure/repositories/user-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/user-repository_test.js
@@ -22,6 +22,7 @@ const Organization = require('../../../../lib/domain/models/Organization');
 const SchoolingRegistrationForAdmin = require('../../../../lib/domain/read-models/SchoolingRegistrationForAdmin');
 const AuthenticationMethod = require('../../../../lib/domain/models/AuthenticationMethod');
 
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const userRepository = require('../../../../lib/infrastructure/repositories/user-repository');
 
 describe('Integration | Infrastructure | Repository | UserRepository', () => {
@@ -242,7 +243,9 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
 
       it('should return the found user', async () => {
         // when
-        const user = await userRepository.get(userInDb.id);
+        const user = await DomainTransaction.execute(async (domainTransaction) =>
+          userRepository.get(userInDb.id, domainTransaction),
+        );
 
         // then
         expect(user).to.be.an.instanceOf(User);
@@ -258,10 +261,12 @@ describe('Integration | Infrastructure | Repository | UserRepository', () => {
         const nonExistentUserId = 678;
 
         // when
-        const result = await catchErr(userRepository.get)(nonExistentUserId);
+        const error = await DomainTransaction.execute(async (domainTransaction) =>
+          catchErr(userRepository.get)(nonExistentUserId, domainTransaction),
+        );
 
         // then
-        expect(result).to.be.instanceOf(UserNotFoundError);
+        expect(error).to.be.instanceOf(UserNotFoundError);
       });
     });
 

--- a/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
+++ b/api/tests/integration/scripts/prod/compute-pole-emploi-sendings_test.js
@@ -196,6 +196,7 @@ describe('computePoleEmploiSendings', () => {
     });
 
     it('should create pole emploi sending', async () => {
+      // given
       const payload = {
         campagne: {
           nom: 'Campagne Pôle Emploi',
@@ -254,8 +255,10 @@ describe('computePoleEmploiSendings', () => {
         payload,
       };
 
+      // when
       await computePoleEmploiSendings(code, 1);
 
+      // then
       const [ poleEmploiSending ] = await knex('pole-emploi-sendings').where({ type: PoleEmploiSending.TYPES.CAMPAIGN_PARTICIPATION_SHARING });
       expect(_.omit(poleEmploiSending, ['id', 'createdAt'])).to.deep.equal(expectedResults);
     });

--- a/api/tests/unit/application/assessments/assessment-controller_test.js
+++ b/api/tests/unit/application/assessments/assessment-controller_test.js
@@ -3,6 +3,7 @@ const assessmentController = require('../../../../lib/application/assessments/as
 const usecases = require('../../../../lib/domain/usecases');
 const events = require('../../../../lib/domain/events');
 const assessmentSerializer = require('../../../../lib/infrastructure/serializers/jsonapi/assessment-serializer');
+const DomainTransaction = require('../../../../lib/infrastructure/DomainTransaction');
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
 describe('Unit | Controller | assessment-controller', function() {
@@ -139,27 +140,36 @@ describe('Unit | Controller | assessment-controller', function() {
   describe('#completeAssessment', () => {
     const assessmentId = 2;
     const assessmentCompletedEvent = new AssessmentCompleted();
+    const domainTransaction = Symbol('domain transaction');
+    let transactionToBeExecuted;
 
     beforeEach(() => {
       sinon.stub(usecases, 'completeAssessment');
       usecases.completeAssessment.resolves(assessmentCompletedEvent);
+
       sinon.stub(events.eventDispatcher, 'dispatch');
+      sinon.stub(DomainTransaction, 'execute').callsFake((lambda) => {
+        transactionToBeExecuted = lambda;
+      });
     });
 
     it('should call the completeAssessment use case', async () => {
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
+      await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ assessmentId });
+      expect(usecases.completeAssessment).to.have.been.calledWithExactly({ domainTransaction, assessmentId });
     });
 
     it('should dispatch the assessment completed event', async () => {
+
       // when
       await assessmentController.completeAssessment({ params: { id: assessmentId } });
+      await transactionToBeExecuted(domainTransaction);
 
       // then
-      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent);
+      expect(events.eventDispatcher.dispatch).to.have.been.calledWith(assessmentCompletedEvent, domainTransaction);
     });
   });
 

--- a/api/tests/unit/domain/events/compute-validated-skills-count_test.js
+++ b/api/tests/unit/domain/events/compute-validated-skills-count_test.js
@@ -5,6 +5,7 @@ const CampaignParticipationResultsShared = require('./../../../../lib/domain/eve
 describe('Unit | Domain | Events | compute-validated-skills-count', function() {
 
   describe('eventType', () => {
+
     it('returns the CampaignParticipationResultsShared', () => {
       const eventType = computeValidatedSkillsCount.eventType;
 
@@ -36,7 +37,7 @@ describe('Unit | Domain | Events | compute-validated-skills-count', function() {
         const validatedSkillsCount = 5;
 
         campaignParticipationRepository.get
-          .withArgs(event.campaignParticipationId, { include: ['campaign'] })
+          .withArgs({ id: event.campaignParticipationId, options: { include: ['campaign'] } })
           .resolves(campaignParticipation);
 
         targetProfileWithLearningContentRepository.getByCampaignId

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -6,6 +6,7 @@ const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCom
 describe('Unit | Domain | Events | handle-badge-acquisition', () => {
 
   describe('#handleBadgeAcquisition', () => {
+    const domainTransaction = Symbol('a DomainTransaction');
     const badgeRepository = {
       findByCampaignParticipationId: _.noop,
     };
@@ -75,14 +76,14 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
             badgeId,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
-          }]);
+          }], domainTransaction);
         });
 
         it('should not create a badge when badge requirements are not fulfilled', async () => {
@@ -90,8 +91,9 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           badgeCriteriaService.areBadgeCriteriaFulfilled
             .withArgs({ campaignParticipationResult, badge })
             .returns(false);
+
           // when
-          await handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
@@ -138,14 +140,14 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(false);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([{
             badgeId: badge1.id,
             userId: event.userId,
             campaignParticipationId: event.campaignParticipationId,
-          }]);
+          }], domainTransaction);
         });
 
         it('should create two badges when both badges requirements are fulfilled', async () => {
@@ -158,13 +160,13 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             .returns(true);
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.have.been.calledWithExactly([
             { badgeId: badge1.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
             { badgeId: badge2.id, userId: event.userId, campaignParticipationId: event.campaignParticipationId },
-          ]);
+          ], domainTransaction);
         });
       });
 
@@ -180,11 +182,10 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           // when
-          await handleBadgeAcquisition({ event, ...dependencies });
+          await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
           // then
           expect(badgeAcquisitionRepository.create).to.not.have.been.called;
-
         });
       });
     });
@@ -198,7 +199,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
         const event = new AssessmentCompleted({ userId });
 
         // when
-        await handleBadgeAcquisition({ event, ...dependencies });
+        await handleBadgeAcquisition({ event, ...dependencies, domainTransaction });
 
         // then
         expect(badgeAcquisitionRepository.create).to.not.have.been.called;

--- a/api/tests/unit/domain/events/handle-badge-acquisition_test.js
+++ b/api/tests/unit/domain/events/handle-badge-acquisition_test.js
@@ -32,7 +32,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
       const event = 'not an event of the correct type';
       // when / then
       const error = await catchErr(handleBadgeAcquisition)(
-        { event, ...dependencies },
+        { event, ...dependencies, domainTransaction },
       );
 
       // then
@@ -57,12 +57,17 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             id: badgeId,
             badgeCriteria: Symbol('badgeCriteria'),
           };
-          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([badge]);
+          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId, domainTransaction).resolves([badge]);
 
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           sinon.stub(campaignParticipationResultRepository, 'getByParticipationId');
-          campaignParticipationResultRepository.getByParticipationId.withArgs(event.campaignParticipationId, [badge], []).resolves(
+          campaignParticipationResultRepository.getByParticipationId.withArgs({
+            campaignParticipationId: event.campaignParticipationId,
+            campaignBadges: [badge],
+            acquiredBadgeIds: [],
+            domainTransaction,
+          }).resolves(
             campaignParticipationResult,
           );
 
@@ -118,12 +123,17 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
             id: badgeId_2,
             badgeCriteria: Symbol('badgeCriteria'),
           };
-          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([badge1, badge2]);
+          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId, domainTransaction).resolves([badge1, badge2]);
 
           sinon.stub(badgeAcquisitionRepository, 'create');
 
           sinon.stub(campaignParticipationResultRepository, 'getByParticipationId');
-          campaignParticipationResultRepository.getByParticipationId.withArgs(event.campaignParticipationId, [badge1, badge2], []).resolves(
+          campaignParticipationResultRepository.getByParticipationId.withArgs({
+            campaignParticipationId: event.campaignParticipationId,
+            campaignBadges: [badge1, badge2],
+            acquiredBadgeIds: [],
+            domainTransaction,
+          }).resolves(
             campaignParticipationResult,
           );
 
@@ -177,7 +187,7 @@ describe('Unit | Domain | Events | handle-badge-acquisition', () => {
           const campaignParticipationId = 78;
           const event = new AssessmentCompleted({ userId, campaignParticipationId });
           sinon.stub(badgeRepository, 'findByCampaignParticipationId');
-          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId).resolves([]);
+          badgeRepository.findByCampaignParticipationId.withArgs(event.campaignParticipationId, domainTransaction).resolves([]);
 
           sinon.stub(badgeAcquisitionRepository, 'create');
 

--- a/api/tests/unit/domain/events/handle-certification-scoring_test.js
+++ b/api/tests/unit/domain/events/handle-certification-scoring_test.js
@@ -54,7 +54,7 @@ describe('Unit | Domain | Events | handle-certification-scoring', () => {
         userId,
         createdAt: Symbol('someCreationDate'),
       };
-      sinon.stub(certificationAssessmentRepository, 'get').withArgs(assessmentId).resolves(certificationAssessment);
+      sinon.stub(certificationAssessmentRepository, 'get').withArgs(assessmentId, domainTransaction).resolves(certificationAssessment);
     });
 
     it('fails when event is not of correct type', async () => {

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-finished_test.js
@@ -123,6 +123,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         // given
 
         const expectedResponse = { isSuccessful: 'someValue', code: 'someCode' };
+        const domainTransaction = Symbol('domainTransaction');
         poleEmploiNotifier.notify.withArgs(userId, expectedResults).resolves(expectedResponse);
         const poleEmploiSending = Symbol('Pole emploi sending');
         sinon.stub(PoleEmploiSending, 'buildForParticipationFinished').withArgs({
@@ -135,11 +136,12 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-finished', (
         // when
         await handlePoleEmploiParticipationFinished({
           event,
+          domainTransaction,
           ...dependencies,
         });
 
         // then
-        expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending });
+        expect(poleEmploiSendingRepository.create).to.have.been.calledWith({ poleEmploiSending, domainTransaction });
       });
 
     });

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-shared_test.js
@@ -5,6 +5,7 @@ const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSendi
 const { handlePoleEmploiParticipationShared } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () => {
+
   let event;
 
   const campaignRepository = { get: _.noop() };
@@ -107,12 +108,14 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
   });
 
   context('#handlePoleEmploiParticipationShared', () => {
+
     const campaignParticipationId = 55667788;
     const campaignId = 11223344;
     const userId = 987654321;
     const organizationId = Symbol('organizationId');
 
     context('when campaign is of type ASSESSMENT and organization is Pole Emploi', () => {
+
       beforeEach(() => {
         event = new CampaignParticipationResultsShared({ campaignParticipationId });
 
@@ -131,7 +134,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
           }),
         );
         targetProfileRepository.get.withArgs('targetProfileId1').resolves({ name: 'Diagnostic initial' });
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(
           domainBuilder.buildCampaignParticipation({
             id: 55667788,
             campaignId,
@@ -190,7 +193,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
     context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {
       beforeEach(() => {
         event = new CampaignParticipationResultsShared({ campaignParticipationId });
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(
           domainBuilder.buildCampaignParticipation({
             id: 55667788,
             campaignId,
@@ -219,7 +222,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-shared', () 
       beforeEach(() => {
         event = new CampaignParticipationResultsShared({ campaignParticipationId });
 
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(
           domainBuilder.buildCampaignParticipation({
             id: 55667788,
             campaignId,

--- a/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
+++ b/api/tests/unit/domain/events/handle-pole-emploi-participation-started_test.js
@@ -5,6 +5,7 @@ const PoleEmploiSending = require('../../../../lib/domain/models/PoleEmploiSendi
 const { handlePoleEmploiParticipationStarted } = require('../../../../lib/domain/events')._forTestOnly.handlers;
 
 describe('Unit | Domain | Events | handle-pole-emploi-participation-started', () => {
+
   let event;
 
   const campaignRepository = { get: _.noop() };
@@ -89,7 +90,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
           createdAt: new Date('2020-01-02'),
         });
 
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: true });
         userRepository.get.withArgs(userId).resolves(domainBuilder.buildUser({ id: userId, firstName: 'Jean', lastName: 'Bonneau' }));
         campaignRepository.get.withArgs(campaignId).resolves(
@@ -133,6 +134,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
     });
 
     context('when campaign is of type ASSESSMENT but organization is not Pole Emploi', () => {
+
       beforeEach(() => {
         const campaignParticipation = domainBuilder.buildCampaignParticipation({
           id: campaignParticipationId,
@@ -141,7 +143,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
           createdAt: new Date('2020-01-02'),
         });
 
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
         campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'ASSESSMENT', organization: { id: organizationId } }));
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: false });
 
@@ -169,7 +171,7 @@ describe('Unit | Domain | Events | handle-pole-emploi-participation-started', ()
           createdAt: new Date('2020-01-02'),
         });
 
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
         campaignRepository.get.withArgs(campaignId).resolves(domainBuilder.buildCampaign({ type: 'PROFILES_COLLECTION', organization: { id: organizationId } }));
         organizationRepository.get.withArgs(organizationId).resolves({ isPoleEmploi: true });
 

--- a/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
+++ b/api/tests/unit/domain/usecases/begin-campaign-participation-improvement_test.js
@@ -21,7 +21,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     const campaignParticipationId = 2;
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId: userId + 1, id: campaignParticipationId });
     campaignParticipationRepository.get
-      .withArgs(campaignParticipationId, {})
+      .withArgs({ id: campaignParticipationId, options: {} })
       .resolves(campaignParticipation);
 
     // when
@@ -37,7 +37,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     const campaignParticipationId = 2;
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: true });
     campaignParticipationRepository.get
-      .withArgs(campaignParticipationId, {})
+      .withArgs({ id: campaignParticipationId, options: {} })
       .resolves(campaignParticipation);
 
     // when
@@ -53,7 +53,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     const campaignParticipationId = 2;
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: false });
     campaignParticipationRepository.get
-      .withArgs(campaignParticipationId, {})
+      .withArgs({ id: campaignParticipationId, options: {} })
       .resolves(campaignParticipation);
     const ongoingAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
     assessmentRepository.getLatestByCampaignParticipationId
@@ -73,7 +73,7 @@ describe('Unit | Usecase | begin-campaign-participation-improvement', () => {
     const campaignParticipationId = 2;
     const campaignParticipation = domainBuilder.buildCampaignParticipation({ userId, id: campaignParticipationId, isShared: false });
     campaignParticipationRepository.get
-      .withArgs(campaignParticipationId, {})
+      .withArgs({ id: campaignParticipationId, options: {} })
       .resolves(campaignParticipation);
     const latestAssessment = Assessment.createImprovingForCampaign({ userId, campaignParticipationId });
     latestAssessment.state = Assessment.states.COMPLETED;

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -14,6 +14,7 @@ describe('Unit | UseCase | complete-assessment', () => {
   const assessmentResultRepository = { save: _.noop };
   const certificationCourseRepository = { changeCompletionDate: _.noop };
   const competenceMarkRepository = { save: _.noop };
+  const domainTransaction = Symbol('domainTransaction');
   const now = new Date('2019-01-01T05:06:07Z');
   let clock;
 
@@ -71,6 +72,7 @@ describe('Unit | UseCase | complete-assessment', () => {
             // when
             await completeAssessment({
               assessmentId: assessment.id,
+              domainTransaction,
               assessmentRepository,
               assessmentResultRepository,
               certificationCourseRepository,
@@ -79,13 +81,14 @@ describe('Unit | UseCase | complete-assessment', () => {
             });
 
             // then
-            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id)).to.be.true;
+            expect(assessmentRepository.completeByAssessmentId.calledWithExactly(assessment.id, domainTransaction)).to.be.true;
           });
 
           it('should return a AssessmentCompleted event', async () => {
             // when
             const result = await completeAssessment({
               assessmentId: assessment.id,
+              domainTransaction,
               assessmentRepository,
               assessmentResultRepository,
               certificationCourseRepository,
@@ -110,6 +113,7 @@ describe('Unit | UseCase | complete-assessment', () => {
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
+          domainTransaction,
           assessmentRepository,
           assessmentResultRepository,
           certificationCourseRepository,
@@ -131,6 +135,7 @@ describe('Unit | UseCase | complete-assessment', () => {
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
+          domainTransaction,
           assessmentRepository,
           assessmentResultRepository,
           certificationCourseRepository,

--- a/api/tests/unit/domain/usecases/complete-assessment_test.js
+++ b/api/tests/unit/domain/usecases/complete-assessment_test.js
@@ -6,16 +6,14 @@ const { AlreadyRatedAssessmentError } = require('../../../../lib/domain/errors')
 const AssessmentCompleted = require('../../../../lib/domain/events/AssessmentCompleted');
 
 describe('Unit | UseCase | complete-assessment', () => {
-  const scoringCertificationService = { calculateCertificationAssessmentScore: _.noop };
+
   const assessmentRepository = {
     get: _.noop,
     completeByAssessmentId: _.noop,
   };
-  const assessmentResultRepository = { save: _.noop };
-  const certificationCourseRepository = { changeCompletionDate: _.noop };
-  const competenceMarkRepository = { save: _.noop };
   const domainTransaction = Symbol('domainTransaction');
   const now = new Date('2019-01-01T05:06:07Z');
+
   let clock;
 
   beforeEach(() => {
@@ -27,6 +25,7 @@ describe('Unit | UseCase | complete-assessment', () => {
   });
 
   context('when assessment is already completed', () => {
+
     const assessmentId = 'assessmentId';
 
     beforeEach(() => {
@@ -41,11 +40,8 @@ describe('Unit | UseCase | complete-assessment', () => {
       // when
       const err = await catchErr(completeAssessment)({
         assessmentId,
+        domainTransaction,
         assessmentRepository,
-        assessmentResultRepository,
-        certificationCourseRepository,
-        competenceMarkRepository,
-        scoringCertificationService,
       });
 
       // then
@@ -74,10 +70,6 @@ describe('Unit | UseCase | complete-assessment', () => {
               assessmentId: assessment.id,
               domainTransaction,
               assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
             });
 
             // then
@@ -90,10 +82,6 @@ describe('Unit | UseCase | complete-assessment', () => {
               assessmentId: assessment.id,
               domainTransaction,
               assessmentRepository,
-              assessmentResultRepository,
-              certificationCourseRepository,
-              competenceMarkRepository,
-              scoringCertificationService,
             });
 
             // then
@@ -105,20 +93,19 @@ describe('Unit | UseCase | complete-assessment', () => {
       });
 
     context('when assessment is of type CAMPAIGN', () => {
+
       it('should return a AssessmentCompleted event with a userId and targetProfileId', async () => {
+        // given
         const assessment = _buildCampaignAssessment();
 
         sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
+
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
           domainTransaction,
           assessmentRepository,
-          assessmentResultRepository,
-          certificationCourseRepository,
-          competenceMarkRepository,
-          scoringCertificationService,
         });
 
         // then
@@ -127,20 +114,19 @@ describe('Unit | UseCase | complete-assessment', () => {
     });
 
     context('when assessment is of type CERTIFICATION', () => {
+
       it('should return a AssessmentCompleted event with certification flag', async () => {
+        // given
         const assessment = _buildCertificationAssessment();
 
         sinon.stub(assessmentRepository, 'get').withArgs(assessment.id).resolves(assessment);
         sinon.stub(assessmentRepository, 'completeByAssessmentId').resolves();
+
         // when
         const result = await completeAssessment({
           assessmentId: assessment.id,
           domainTransaction,
           assessmentRepository,
-          assessmentResultRepository,
-          certificationCourseRepository,
-          competenceMarkRepository,
-          scoringCertificationService,
         });
 
         // then

--- a/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
+++ b/api/tests/unit/domain/usecases/compute-campaign-participation-analysis_test.js
@@ -35,7 +35,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
         const tutorials = Symbol('tutorials');
         const campaignParticipationAnalysis = Symbol('analysis');
         campaignParticipation.userId = userId;
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
         targetProfileWithLearningContentRepository.getByCampaignId.withArgs({ campaignId, locale }).resolves(targetProfile);
         tutorialRepository.list.withArgs({ locale }).resolves(tutorials);
@@ -64,7 +64,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
         // given
         campaignParticipation.userId = userId;
         campaignParticipation.isShared = false;
-        campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+        campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
         campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(true);
 
         // when
@@ -87,7 +87,7 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
 
   context('User does not have access to this result', () => {
     beforeEach(() => {
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignId, userId).resolves(false);
     });
 
@@ -108,5 +108,4 @@ describe('Unit | UseCase | compute-campaign-participation-analysis', () => {
       expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
-
 });

--- a/api/tests/unit/domain/usecases/get-campaign-participation_test.js
+++ b/api/tests/unit/domain/usecases/get-campaign-participation_test.js
@@ -18,12 +18,13 @@ describe('Unit | UseCase | get-campaign-participation', () => {
   });
 
   context('when user is the user of the campaignParticipation', () => {
+
     it('should get the campaignParticipation', async () => {
       // given
       const campaignParticipationId = 1;
       const userId = 1;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, options).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options }).resolves(campaignParticipation);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignParticipation.campaignId, userId).resolves(false);
 
       // when
@@ -35,12 +36,13 @@ describe('Unit | UseCase | get-campaign-participation', () => {
   });
 
   context('when user is a member of the organization which is related to requested campaignParticipation', () => {
+
     it('should get the campaignParticipation', async () => {
       // given
       const campaignParticipationId = 1;
       const userId = 2;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId: 1 });
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, options).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options }).resolves(campaignParticipation);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignParticipation.campaignId, userId).resolves(true);
 
       // when
@@ -52,12 +54,13 @@ describe('Unit | UseCase | get-campaign-participation', () => {
   });
 
   context('when user is neither the user of the campaignParticipation nor the organization', () => {
+
     it('should not get the campaignParticipation', async () => {
       // given
       const campaignParticipationId = 1;
       const userId = 2;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId: 1 });
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, options).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options }).resolves(campaignParticipation);
       campaignRepository.checkIfUserOrganizationHasAccessToCampaign.withArgs(campaignParticipation.campaignId, userId).resolves(false);
 
       // when
@@ -65,8 +68,6 @@ describe('Unit | UseCase | get-campaign-participation', () => {
 
       // then
       expect(result).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
-
     });
   });
-
 });

--- a/api/tests/unit/domain/usecases/get-participant-result_test.js
+++ b/api/tests/unit/domain/usecases/get-participant-result_test.js
@@ -7,6 +7,7 @@ describe('Unit | UseCase | get-participant-result', () => {
   let campaignParticipationRepository;
   let participantResultRepository;
   let dependencies;
+
   beforeEach(() => {
     campaignParticipationRepository = { get: sinon.stub() };
     participantResultRepository = { getByParticipationId: sinon.stub() };
@@ -14,6 +15,7 @@ describe('Unit | UseCase | get-participant-result', () => {
   });
 
   context('when user is the owner of the participation', () => {
+
     it('should get the participant result', async () => {
       const userId = 123;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: 12, userId });
@@ -21,7 +23,7 @@ describe('Unit | UseCase | get-participant-result', () => {
       const locale = 'FR';
       const participantResult = Symbol();
 
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
       participantResultRepository.getByParticipationId.withArgs(campaignParticipationId, locale).resolves(participantResult);
 
       const actualCampaignParticipationResult = await getParticipantResult({
@@ -36,12 +38,13 @@ describe('Unit | UseCase | get-participant-result', () => {
   });
 
   context('when user is not the owner of the campaignParticipation', () => {
+
     it('should throw an error', async () => {
       const userId = 123;
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: 12, userId: 456 });
       const { id: campaignParticipationId } = campaignParticipation;
       const locale = 'FR';
-      campaignParticipationRepository.get.withArgs(campaignParticipationId).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId }).resolves(campaignParticipation);
 
       const result = await catchErr(getParticipantResult)({
         userId,

--- a/api/tests/unit/domain/usecases/get-progression_test.js
+++ b/api/tests/unit/domain/usecases/get-progression_test.js
@@ -48,7 +48,7 @@ describe('Unit | Domain | Use Cases | get-progression', () => {
 
       beforeEach(() => {
         sandbox.stub(assessmentRepository, 'getByAssessmentIdAndUserId').withArgs(assessment.id, userId).resolves(assessment);
-        sandbox.stub(campaignParticipationRepository, 'get').withArgs(assessment.campaignParticipationId).resolves(campaignParticipation);
+        sandbox.stub(campaignParticipationRepository, 'get').withArgs({ id: assessment.campaignParticipationId }).resolves(campaignParticipation);
         sandbox.stub(targetProfileRepository, 'getByCampaignId').withArgs(campaignParticipation.campaignId).resolves(targetProfile);
       });
 
@@ -81,7 +81,9 @@ describe('Unit | Domain | Use Cases | get-progression', () => {
       });
 
       context('when the assessment is improving', () => {
+
         let knowledgeElements, knowledgeElementsFiltered;
+
         beforeEach(() => {
           assessment.state = 'improving';
           knowledgeElements = [

--- a/api/tests/unit/domain/usecases/share-campaign-result_test.js
+++ b/api/tests/unit/domain/usecases/share-campaign-result_test.js
@@ -4,6 +4,7 @@ const CampaignParticipationResultsShared = require('../../../../lib/domain/event
 const shareCampaignResult = require('../../../../lib/domain/usecases/share-campaign-result');
 
 describe('Unit | UseCase | share-campaign-result', () => {
+
   const campaignParticipationRepository = {
     get: sinon.stub(),
     updateWithSnapshot: sinon.stub(),
@@ -13,9 +14,10 @@ describe('Unit | UseCase | share-campaign-result', () => {
   const campaignParticipationId = 456;
 
   context('when user is not the owner of the campaign participation', () => {
+
     it('throws a UserNotAuthorizedToAccessEntityError error ', async () => {
       // given
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves({ userId: userId + 1 });
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options: { include: [ 'campaign' ] } }).resolves({ userId: userId + 1 });
 
       // when
       const error = await catchErr(shareCampaignResult)({ userId, campaignParticipationId, campaignParticipationRepository });
@@ -24,12 +26,14 @@ describe('Unit | UseCase | share-campaign-result', () => {
       expect(error).to.be.instanceOf(UserNotAuthorizedToAccessEntityError);
     });
   });
+
   context('when user is the owner of the campaign participation', () => {
+
     it('updates the campaign participation', async () => {
       // given
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
       sinon.stub(campaignParticipation, 'share');
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options: { include: [ 'campaign' ] } }).resolves(campaignParticipation);
 
       // when
       await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });
@@ -44,7 +48,7 @@ describe('Unit | UseCase | share-campaign-result', () => {
       const campaignParticipation = domainBuilder.buildCampaignParticipation({ id: campaignParticipationId, userId });
       sinon.stub(campaignParticipation, 'share');
 
-      campaignParticipationRepository.get.withArgs(campaignParticipationId, { include: [ 'campaign' ] }).resolves(campaignParticipation);
+      campaignParticipationRepository.get.withArgs({ id: campaignParticipationId, options: { include: [ 'campaign' ] } }).resolves(campaignParticipation);
 
       // when
       const actualEvent = await shareCampaignResult({ userId, campaignParticipationId, campaignParticipationRepository });


### PR DESCRIPTION
## :unicorn: Problème
Suite au problème de deadlock hier, la domainTransaction a été supprimée de la route de complétion d'un assessment #2825.
Toutes les requêtes d'écriture dans cette route utilisent donc la transaction Bookshelf/knex par défaut.
Si un problème survient sur l'une de ces requêtes en DB, cela peut entraîner une incohérence des données.

## :robot: Solution
Restaurer la domainTransaction dans la route de complétion d'un assessment et utiliser le domainTransaction sur toutes les requêtes d'écriture/lecture en DB.

## :rainbow: Remarques
A terme, il faudrait faire une passe dans le reste du code pour identifier tous les mésusages de domainTransaction créées et non utilisées qui pourraient engendrer de futur deadlock.

## :100: Pour tester
- Tests de non régression sur pix-app
- Tester la certification et la campagne
