### PR TITLE
[FEATURE] À la fin de l'url donnée par l'organisation, ajouter le seuil du palier atteint par le participant (Pix-2329)

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -82,11 +82,28 @@ export default class SkillReview extends Component {
   }
 
   get customButtonUrl() {
-    return this.args.model.campaignParticipation.campaign.get('customResultPageButtonUrl');
+    const buttonUrl = this.args.model.campaignParticipation.campaign.get('customResultPageButtonUrl');
+    if (this.reachedStage && buttonUrl) {
+      return this._buildUrl(buttonUrl, { stage: this.reachedStage.get('threshold') });
+    } else {
+      return buttonUrl;
+    }
   }
 
   get customButtonText() {
     return this.args.model.campaignParticipation.campaign.get('customResultPageButtonText');
+  }
+
+  _buildUrl(baseUrl, params) {
+    const Url = new URL(baseUrl);
+    const urlParams = new URLSearchParams(Url.search);
+    for (const key in params) {
+      if (params[key] !== undefined) {
+        urlParams.set(key, params[key]);
+      }
+    }
+    Url.search = urlParams.toString();
+    return Url.toString();
   }
 
   @action

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -209,7 +209,7 @@
     text-decoration: none;
     display: inline-block;
     font-size: 0.875rem;
-    margin-top: 4px;
+    margin-top: 12px;
     cursor: pointer;
 
     svg {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -67,7 +67,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
       it('displays an error message and a resume button', async function() {
         // Given
-        const campaign = {
+        const model = {
           campaignParticipation: {
             id: 8654,
             save: sinon.stub().rejects(),
@@ -87,15 +87,15 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             },
           },
         };
-        campaign.campaignParticipation.get.withArgs('isShared').returns(false);
+        model.campaignParticipation.get.withArgs('isShared').returns(false);
 
-        this.set('campaign', campaign);
+        this.set('model', model);
         this.set('assessmentId', 'BADGES123');
         this.set('acquiredBadges', null);
 
         // When
         await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-          @model={{campaign}}
+          @model={{model}}
           @assessmentId={{assessmentId}}
           @acquiredBadges={{acquiredBadge}}
          />`);
@@ -112,7 +112,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
   context('When campaign is for Absolute Novice', function() {
     beforeEach(async function() {
       // Given
-      const campaignParticipation = {
+      const model = {
         campaignParticipation: {
           id: 8654,
           save: sinon.stub().rejects(),
@@ -134,15 +134,15 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         },
       };
 
-      campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(false);
+      model.campaignParticipation.get.withArgs('isShared').returns(false);
 
-      this.set('campaignParticipation', campaignParticipation);
+      this.set('model', model);
       this.set('assessmentId', 'BADGES123');
       this.set('acquiredBadges', null);
 
       // When
       await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-          @model={{campaignParticipation}}
+          @model={{model}}
           @assessmentId={{assessmentId}}
           @acquiredBadges={{acquiredBadge}}
          />`);
@@ -166,9 +166,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
     context('When the camapaign is shared', function() {
       context('when the organization has a message', function() {
         context('when the organization has a logo', function() {
-          beforeEach(async function() {
+          beforeEach(function() {
             // Given
-            const campaignParticipation = {
+            const model = {
               campaignParticipation: {
                 get: sinon.stub(),
                 campaignParticipationResult: {
@@ -182,29 +182,31 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 },
               },
             };
-            campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-            this.set('campaignParticipation', campaignParticipation);
-            // When
-            await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-                @model={{campaignParticipation}}/>`);
+            model.campaignParticipation.get.withArgs('isShared').returns(true);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+            model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            this.set('model', model);
           });
-          it('should display the block for the message', function() {
+
+          it('should display the block for the message', async function() {
+            // When
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}}/>`);
             // Then
             expect(contains('Message de votre organisation')).to.exist;
             expect(contains('Dragon & Co')).to.exist;
           });
 
-          it('should show the logo of the organization ', function() {
+          it('should show the logo of the organization ', async function() {
+            //when
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}}/>`);
             // Then
             expect(find('[src="www.logo-example.com"]')).to.exist;
           });
         });
 
         context('when the organization has no logo', function() {
-          beforeEach(async function() {
+          beforeEach(function() {
             // Given
             const campaignParticipation = {
               campaignParticipation: {
@@ -225,12 +227,13 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
             campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
             this.set('campaignParticipation', campaignParticipation);
+          });
+
+          it('should display the block for the message', async function() {
             // When
             await render(hbs`<Routes::Campaigns::Assessment::SkillReview
                 @model={{campaignParticipation}}/>`);
-          });
 
-          it('should display the block for the message', function() {
             // Then
             expect(contains('Dragon & Co')).to.exist;
             expect(contains('Message de votre organisation')).to.exist;
@@ -243,9 +246,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         });
       });
       context('when the organization has no message', function() {
-        beforeEach(async function() {
+        beforeEach(function() {
           // Given
-          const campaignParticipation = {
+          const model = {
             campaignParticipation: {
               get: sinon.stub(),
               campaignParticipationResult: {
@@ -259,61 +262,114 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               },
             },
           };
-          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-          this.set('campaignParticipation', campaignParticipation);
-          // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-              @model={{campaignParticipation}}/>`);
+          model.campaignParticipation.get.withArgs('isShared').returns(true);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('model', model);
         });
 
-        it('should not display the block for the message', function() {
+        it('should not display the block for the message', async function() {
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{model}}/>`);
+
           // Then
           expect(contains('Message de votre organisation')).to.not.exist;
         });
       });
 
       context('when the organization has a customResultPageButtonUrl and a customResultPageButtonText', function() {
-        beforeEach(async function() {
-          // Given
-          const campaignParticipation = {
-            campaignParticipation: {
+        context('when the participant has finished a campaign with stages', function() {
+          beforeEach(function() {
+            // Given
+            const reachedStage = {
+              id: 78890,
+              threshold: 75,
               get: sinon.stub(),
-              campaignParticipationResult: {
-                get: sinon.stub().returns([]),
-              },
-              campaign: {
-                organizationName: 'Dragon & Co',
-                customResultPageButtonUrl: 'www.my-url.net',
-                customResultPageButtonText: 'Next step',
+            };
+
+            const model = {
+              campaignParticipation: {
                 get: sinon.stub(),
+                campaignParticipationResult: {
+                  reachedStage: reachedStage,
+                  get: sinon.stub().returns([]),
+                },
+                campaign: {
+                  organizationName: 'Dragon & Co',
+                  customResultPageButtonUrl: 'http://www.my-url.net/resultats',
+                  customResultPageButtonText: 'Next step',
+                  get: sinon.stub(),
+                },
               },
-            },
-          };
-          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-          this.set('campaignParticipation', campaignParticipation);
-          // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-              @model={{campaignParticipation}}/>`);
+            };
+
+            model.campaignParticipation.get.withArgs('isShared').returns(true);
+            model.campaignParticipation.campaignParticipationResult.get.withArgs('reachedStage').returns(reachedStage);
+            model.campaignParticipation.campaignParticipationResult.reachedStage.get.withArgs('threshold').returns([75]);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['http://www.my-url.net/resultats']);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            this.set('model', model);
+          });
+
+          it('should display the button', async function() {
+            // When
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+                @model={{model}}/>`);
+
+            // Then
+            expect(find('[href="http://www.my-url.net/resultats?stage=75"]')).to.exist;
+            expect(find('[target="_blank"]')).to.exist;
+            expect(contains('Next step')).to.exist;
+          });
         });
 
-        it('should display the button', function() {
-          // Then
-          expect(find('[href="www.my-url.net"]')).to.exist;
-          expect(find('[target="_blank"]')).to.exist;
-          expect(contains('Next step')).to.exist;
+        context('when the participant has finished a campaign without stages', function() {
+          beforeEach(function() {
+            // Given
+            const model = {
+              campaignParticipation: {
+                get: sinon.stub(),
+                campaignParticipationResult: {
+                  get: sinon.stub().returns([]),
+                  reachedStage: null,
+                },
+                campaign: {
+                  organizationName: 'Dragon & Co',
+                  customResultPageButtonUrl: 'www.my-url.net',
+                  customResultPageButtonText: 'Next step',
+                  get: sinon.stub(),
+                },
+              },
+            };
+            model.campaignParticipation.get.withArgs('isShared').returns(true);
+            model.campaignParticipation.campaignParticipationResult.get.withArgs('reachedStage').returns(null);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            this.set('model', model);
+
+          });
+
+          it('should display the button', async function() {
+            // When
+            await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+                @model={{model}}/>`);
+
+            // Then
+            expect(find('[href="www.my-url.net"]')).to.exist;
+            expect(find('[target="_blank"]')).to.exist;
+            expect(contains('Next step')).to.exist;
+          });
         });
       });
 
       context('when the organization only has a customResultPageButtonUrl', function() {
-        beforeEach(async function() {
+        beforeEach(function() {
           // Given
-          const campaignParticipation = {
+          const model = {
             campaignParticipation: {
               get: sinon.stub(),
               campaignParticipationResult: {
@@ -327,16 +383,17 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               },
             },
           };
-          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-          this.set('campaignParticipation', campaignParticipation);
-          // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{campaignParticipation}}/>`);
+          model.campaignParticipation.get.withArgs('isShared').returns(true);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('model', model);
         });
 
-        it('should not display the button', function() {
+        it('should not display the button', async function() {
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview @model={{model}}/>`);
+
           // Then
           expect(find('[href="www.my-url.net"]')).to.not.exist;
           expect(contains('Next step')).to.not.exist;
@@ -344,9 +401,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
 
       context('when the organization has neither a message nor a button', function() {
-        beforeEach(async function() {
+        beforeEach(function() {
           // Given
-          const campaignParticipation = {
+          const model = {
             campaignParticipation: {
               get: sinon.stub(),
               campaignParticipationResult: {
@@ -362,28 +419,30 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               },
             },
           };
-          campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
-          campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-          this.set('campaignParticipation', campaignParticipation);
-          // When
-          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-              @model={{campaignParticipation}}/>`);
+          model.campaignParticipation.get.withArgs('isShared').returns(true);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          this.set('model', model);
+
         });
 
-        it('should not display the block for the message', function() {
+        it('should not display the block for the message', async function() {
+          // When
+          await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+              @model={{model}}/>`);
+
           // Then
           expect(contains('Message de votre organisation')).to.not.exist;
         });
       });
     });
     context('when the campaign is not shared and the organization has a message or a button', function() {
-      beforeEach(async function() {
+      beforeEach(function() {
         // Given
-        const campaignParticipation = {
+        const model = {
           campaignParticipation: {
             get: sinon.stub(),
             campaignParticipationResult: {
@@ -396,16 +455,16 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
             },
           },
         };
-        campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(false);
-        campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-        campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-        this.set('campaignParticipation', campaignParticipation);
-        // When
-        await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-            @model={{campaignParticipation}}/>`);
+        model.campaignParticipation.get.withArgs('isShared').returns(false);
+        model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
+        model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+        this.set('model', model);
       });
 
-      it('should not display the block for the message', function() {
+      it('should not display the block for the message', async function() {
+        // When
+        await render(hbs`<Routes::Campaigns::Assessment::SkillReview
+            @model={{model}}/>`);
 
         // Then
         expect(contains('J\'envoie mes résultats')).to.exist;

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -238,7 +238,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     it('should return true when the organization has a customResultPageButtonText and a customResultPageButtonUrl', async function() {
       // given
       component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Go to the next step';
-      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
 
       // when
       const result = await component.showOrganizationButton;
@@ -250,7 +250,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     it('should return false when the organization has no a customResultPageButtonText ', function() {
       // given
       component.args.model.campaignParticipation.campaign.customResultPageButtonText = null;
-      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
 
       // when
       const result = component.showOrganizationButton;
@@ -273,16 +273,48 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
   });
 
   describe('#customButtonUrl', function() {
+    context('when the participant has finished a campaign with stages', function() {
+      it('should add the stage to the url as the first query params when the url does not have one', function() {
+        // given
+        const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+        reachedStage.get.withArgs('threshold').returns(6);
+        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
 
-    it('should return the url of the custom button', function() {
-      // given
-      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+        // when
+        const url = component.customButtonUrl;
 
-      // when
-      const url = component.customButtonUrl;
+        // then
+        expect(url).to.equal('http://www.my-url.net/resultats?stage=6');
+      });
 
-      // then
-      expect(url).to.equal('www.my-url.net');
+      it('should add the stage to the other query params', function() {
+        // given
+        const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+        reachedStage.get.withArgs('threshold').returns(6);
+        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
+        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+
+        // when
+        const url = component.customButtonUrl;
+
+        // then
+        expect(url).to.equal('http://www.my-url.net/resultats?foo=bar&stage=6');
+      });
+    });
+
+    context('when the participant has finished a campaign without stages ', function() {
+      it('should return the url of the custom button', function() {
+        // given
+        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
+        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = null;
+
+        // when
+        const url = component.customButtonUrl;
+
+        // then
+        expect(url).to.equal('http://www.my-url.net');
+      });
     });
   });
 
@@ -319,7 +351,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     it('should return false when there are customResultPageButtonText and customResultPageButtonUrl', function() {
       // given
       component.args.model.campaignParticipation.campaign.customResultPageButtonText = 'Next step';
-      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
       // when
       const result = component.displayPixLink;
 
@@ -330,7 +362,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
     it('should return true when customResultPageButtonText or customResultPageButtonUrl is empty', function() {
       // given
       component.args.model.campaignParticipation.campaign.customResultPageButtonText = null;
-      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'www.my-url.net';
+      component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
       // when
       const result = component.displayPixLink;
 


### PR DESCRIPTION
## :unicorn: Problème
Pour la personnalisation de fin de parcours , les organisations peuvent fournir une url qui permettra aux participants d'être redirigés vers une autre page pour continuer leur apprentissage. Afin que cette suite soit la plus conforme au niveau du participant, on ajoute le seuil du palier atteint sur PIX à la fin de l'url fournie.

## :robot: Solution
Ajouter '?stage=**niveau_atteint**`

## :rainbow: Remarques


## :100: Pour tester
Aller sur Pix-App avec le compte de jaune.attend@example.net et allers dans "Mes Parcours" et aller voir le détail du parcours terminer avec des paliers.
