### PR TITLE
[FEATURE] Ajout de nouveaux champs à la bdd pour permettre des participations multiples à la même campagne (PIX-2445).

### DIFF
--- a/api/db/migrations/20210413170121_add-column-envoisMultiples-to-campaigns-and-add-isImproved-to-campaign-participations-and-update-constraint-campaign-participations-unique-userId-campaignId-isImproved.js
+++ b/api/db/migrations/20210413170121_add-column-envoisMultiples-to-campaigns-and-add-isImproved-to-campaign-participations-and-update-constraint-campaign-participations-unique-userId-campaignId-isImproved.js
@@ -1,0 +1,34 @@
+const CAMPAIGNS_TABLE = 'campaigns';
+const MULTIPLESENDINGS_COLUMN = 'multipleSendings';
+
+const CAMPAIGNPARTICIPATIONS_TABLE = 'campaign-participations';
+const ISIMPROVED_COLUMN = 'isImproved';
+const USERID_COLUMN = 'userId';
+const CAMPAIGNID_COLUMN = 'campaignId';
+const NEW_CONSTRAINT_NAME = 'campaign_participations_campaignid_userid_isimproved';
+
+exports.up = async (knex) => {
+  await knex.schema.table(CAMPAIGNS_TABLE, function(table) {
+    table.boolean(MULTIPLESENDINGS_COLUMN).defaultTo(false);
+  });
+  await knex.schema.table(CAMPAIGNPARTICIPATIONS_TABLE, function(table) {
+    table.boolean(ISIMPROVED_COLUMN).defaultTo(false);
+  });
+  await knex.schema.table(CAMPAIGNPARTICIPATIONS_TABLE, function(table) {
+    table.dropUnique([CAMPAIGNID_COLUMN, USERID_COLUMN ]);
+  });
+  return knex.raw(`CREATE UNIQUE INDEX ${NEW_CONSTRAINT_NAME} ON "${CAMPAIGNPARTICIPATIONS_TABLE}" ("${CAMPAIGNID_COLUMN}", "${USERID_COLUMN}" ) WHERE "${ISIMPROVED_COLUMN}" IS FALSE;`);
+};
+
+exports.down = async (knex) => {
+  await knex.raw(`DROP INDEX ${NEW_CONSTRAINT_NAME};`);
+  await knex.schema.table(CAMPAIGNPARTICIPATIONS_TABLE, (table) => {
+    table.dropColumn(ISIMPROVED_COLUMN);
+  });
+  await knex.schema.table(CAMPAIGNPARTICIPATIONS_TABLE, (table) => {
+    table.unique([CAMPAIGNID_COLUMN, USERID_COLUMN]);
+  });
+  await knex.schema.table(CAMPAIGNS_TABLE, (table) => {
+    table.dropColumn(MULTIPLESENDINGS_COLUMN);
+  });
+};


### PR DESCRIPTION

## :unicorn: Problème
Un participant ne peut actuellement pas participer et envoyer les résultats plusieurs fois avec le même code campagne, il y un nouveau besoin qui nécessite qu'un utilisateur participe plusieurs fois à la même campagne, ce qui n'est pas possible à cause de une contraint dans la base de données.

## :robot: Solution
Permettre à un participant de participer plus d'une fois à la même campagne, pour ce faire, de nouveaux champs doivent être ajoutés à la base de données dans les deux tables campaign et campaign-participations, puis remplacer l'ancienne contrainte qui empêche le participant de participer plus d'une fois à la même campagne par une nouvelle contrainte qui permettra aux participants de participer à nouveau sans changer le code ni le compte.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
