### PR TITLE
[FEATURE] Affiche les critères d'un résultat thématique dans Pix Admin.

### DIFF
--- a/admin/app/app.js
+++ b/admin/app/app.js
@@ -2,12 +2,15 @@ import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'pix-admin/config/environment';
+import Inflector from 'ember-inflector';
 
 class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
 }
+
+Inflector.inflector.irregular('badge-criterion', 'badge-criteria');
 
 loadInitializers(App, config.modulePrefix);
 

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -30,12 +30,23 @@
     </div>
 
 
-    <div class="page-section__details">
-      <ul>
-      {{#each @badge.badgeCriteria as |criterion|}}
-        <li><span>{{criterion.scope}}</span> <span>{{criterion.threshold}}</span></li>
-      {{/each}}
-      </ul>
+    <div class="page-section__details table-admin">
+      <table>
+        <thead>
+          <tr>
+            <th>Périmètre</th>
+            <th>Seuil</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each @badge.badgeCriteria as |criterion|}}
+            <tr>
+              <td>{{criterion.scope}}</td>
+              <td>{{criterion.threshold}}</td>
+            </tr>
+          {{/each}}
+        </tbody>
+      </table>
     </div>
   </section>
 </main>

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -23,4 +23,19 @@
       </div>
     </div>
   </section>
+
+  <section class="page-section">
+    <div class="page-section__header">
+      <h2 class="page-section__title">Critères</h2>
+    </div>
+
+
+    <div class="page-section__details">
+      <ul>
+      {{#each @badge.badgeCriteria as |criterion|}}
+        <li><span>{{criterion.scope}}</span> <span>{{criterion.threshold}}</span></li>
+      {{/each}}
+      </ul>
+    </div>
+  </section>
 </main>

--- a/admin/app/models/badge-criterion.js
+++ b/admin/app/models/badge-criterion.js
@@ -1,0 +1,8 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class BadgeCriterion extends Model {
+  @attr('string') scope;
+  @attr('number') threshold;
+
+  @belongsTo('badge') badge;
+}

--- a/admin/app/models/badge.js
+++ b/admin/app/models/badge.js
@@ -1,12 +1,13 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class Badge extends Model {
-  @belongsTo('target-profile') targetProfile;
+  @attr('string') key;
+  @attr('string') title;
+  @attr('string') message;
+  @attr('string') imageUrl;
+  @attr('string') altMessage;
+  @attr('boolean') isCertifiable;
 
-  @attr() key;
-  @attr() title;
-  @attr() message;
-  @attr() imageUrl;
-  @attr() altMessage;
-  @attr() isCertifiable;
+  @belongsTo('target-profile') targetProfile;
+  @hasMany('badge-criterion') badgeCriteria;
 }

--- a/admin/mirage/serializers/application.js
+++ b/admin/mirage/serializers/application.js
@@ -4,5 +4,5 @@ import Inflector from 'ember-inflector';
 export default JSONAPISerializer.extend({
   typeKeyForModel(model) {
     return Inflector.inflector.singularize(model.modelName);
-  }
+  },
 });

--- a/admin/mirage/serializers/application.js
+++ b/admin/mirage/serializers/application.js
@@ -1,4 +1,8 @@
 import { JSONAPISerializer } from 'ember-cli-mirage';
+import Inflector from 'ember-inflector';
 
 export default JSONAPISerializer.extend({
+  typeKeyForModel(model) {
+    return Inflector.inflector.singularize(model.modelName);
+  }
 });

--- a/admin/mirage/serializers/badge.js
+++ b/admin/mirage/serializers/badge.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+const include = ['badgeCriteria'];
+
+export default ApplicationSerializer.extend({
+  include,
+});

--- a/admin/tests/acceptance/authenticated/badges/badges-test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges-test.js
@@ -16,7 +16,18 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
 
-    badge = this.server.create('badge', { id: 1, title: 'My badge' });
+    const criterion = this.server.create('badge-criterion', {
+      id: 1,
+      scope: 'CampaignParticipation',
+      threshold: 20,
+    });
+    badge = this.server.create('badge', {
+      id: 1,
+      title: 'My badge',
+      badgeCriteria: [
+        criterion,
+      ],
+    });
   });
 
   test('should display the badge', async function(assert) {
@@ -24,5 +35,6 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
 
     const badgeElement = find('.page-section__details');
     assert.ok(badgeElement.textContent.match(badge.title));
+    assert.contains('20');
   });
 });

--- a/admin/tests/integration/components/badges/badge-test.js
+++ b/admin/tests/integration/components/badges/badge-test.js
@@ -17,6 +17,10 @@ module('Integration | Component | Badges::Badge', function(hooks) {
       key: 'ma clef',
       altMessage: 'mon message alternatif',
       isCertifiable: true,
+      badgeCriteria: [
+        { id: 1, scope: 'CampaignParticipation', threshold: 85 },
+      ],
+      badgePartnerCompetences: [],
     };
 
     this.set('badge', badge);
@@ -36,6 +40,7 @@ module('Integration | Component | Badges::Badge', function(hooks) {
     assert.ok(detailsContent.match(badge.altMessage), 'altMessage');
     assert.ok(detailsContent.match('Certifiable'), 'Certifiable');
     assert.dom('.page-section__details img').exists();
-    assert.dom('.page-section__details img').hasAttribute('src', 'data:,');
+    assert.contains('85');
+    assert.contains('CampaignParticipation');
   });
 });

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -45,7 +45,9 @@ module.exports = {
   async get(id) {
     const bookshelfBadge = await BookshelfBadge
       .where('id', id)
-      .fetch();
+      .fetch({
+        withRelated: ['badgeCriteria'],
+      });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -4,7 +4,15 @@ module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable'],
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'badgeCriteria'],
+      badgeCriteria: {
+        include: true,
+        ref: 'id',
+        attributes: ['threshold', 'scope'],
+      },
+      typeForAttribute: (attribute) => {
+        if (attribute === 'badgeCriteria') return 'badge-criterion';
+      },
     }).serialize(badge);
   },
 };

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -3,7 +3,7 @@ const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insert
 
 describe('Acceptance | API | Badges', () => {
 
-  let server, options, userId, badge;
+  let server, options, userId, badge, badgeCriterion;
 
   beforeEach(async () => {
     server = await createServer();
@@ -23,6 +23,7 @@ describe('Acceptance | API | Badges', () => {
         key: 'clef du badge',
         isCertifiable: false,
       });
+      badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({ badgeId: badge.id });
 
       await databaseBuilder.commit();
     });
@@ -46,7 +47,23 @@ describe('Acceptance | API | Badges', () => {
             title: 'titre du badge',
             key: 'clef du badge',
           },
+          relationships: {
+            'badge-criteria': {
+              data: [{
+                id: badgeCriterion.id.toString(),
+                type: 'badge-criterion',
+              }],
+            },
+          },
         },
+        included: [{
+          type: 'badge-criterion',
+          id: badgeCriterion.id.toString(),
+          attributes: {
+            scope: 'CampaignParticipation',
+            threshold: 50,
+          },
+        }],
       };
 
       // when

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -302,6 +302,11 @@ describe('Acceptance | Controller | target-profile-controller', () => {
           'message': badge.message,
           'title': badge.title,
         },
+        relationships: {
+          'badge-criteria': {
+            data: [],
+          },
+        },
       }];
       expect(response.result.data).to.deep.equal(expectedData);
     });

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -30,7 +30,23 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
           },
           id: '1',
           type: 'badges',
+          relationships: {
+            'badge-criteria': {
+              'data': [{
+                id: '1',
+                type: 'badge-criterion',
+              }],
+            },
+          },
         },
+        included: [{
+          attributes: {
+            scope: 'CampaignParticipation',
+            threshold: 40,
+          },
+          id: '1',
+          type: 'badge-criterion',
+        }],
       };
 
       // when


### PR DESCRIPTION
## :unicorn: Problème
Il n'est pas possible de connaître les critères et périmètres paramétrés pour un résultat thématique donné.

## :robot: Solution
Afficher les critères et périmètres dans la page de détail d'un résultat thématique.

## :rainbow: Remarques
RAS

## :100: Pour tester
Se rendre sur Pix Admin.
Aller dans l'onglet `Profils cibles`.
Sélectionner un profil cible.
Sélectionner l'onglet `Clé de lecture`.
Cliquer sur le bouton `Voir détail` d'un résultat thématique.
Vérifier qu'un tableau `Critères` est affiché.


https://user-images.githubusercontent.com/86659/114370498-d6184a00-9b7f-11eb-9b85-8e2b9c1d15ef.mp4


