### PR TITLE
[FEATURE] Ajouter un statut Annulé aux certifications

### DIFF
--- a/api/db/database-builder/factory/build-certification-course.js
+++ b/api/db/database-builder/factory/build-certification-course.js
@@ -20,6 +20,7 @@ module.exports = function buildCertificationCourse({
   userId,
   sessionId,
   maxReachableLevelOnCertificationDate = 5,
+  isCancelled = false,
 } = {}) {
 
   userId = _.isUndefined(userId) ? buildUser().id : userId;
@@ -41,6 +42,7 @@ module.exports = function buildCertificationCourse({
     userId,
     sessionId,
     maxReachableLevelOnCertificationDate,
+    isCancelled,
   };
   return databaseBuffer.pushInsertable({
     tableName: 'certification-courses',

--- a/api/db/migrations/20210420154410_add-column-isCancelled-to-certification-course.js
+++ b/api/db/migrations/20210420154410_add-column-isCancelled-to-certification-course.js
@@ -1,0 +1,13 @@
+const TABLE_NAME = 'certification-courses';
+
+exports.up = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.boolean('isCancelled').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(TABLE_NAME, (table) => {
+    table.dropColumn('isCancelled');
+  });
+};

--- a/api/lib/domain/models/CertificationCourse.js
+++ b/api/lib/domain/models/CertificationCourse.js
@@ -19,6 +19,7 @@ class CertificationCourse {
       userId,
       sessionId,
       maxReachableLevelOnCertificationDate,
+      isCancelled = false,
     } = {}) {
     this.id = id;
     this.firstName = firstName;
@@ -38,6 +39,7 @@ class CertificationCourse {
     this.userId = userId;
     this.sessionId = sessionId;
     this.maxReachableLevelOnCertificationDate = maxReachableLevelOnCertificationDate;
+    this.isCancelled = isCancelled;
   }
 
   reportIssue(issueReport) {

--- a/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
+++ b/api/lib/infrastructure/repositories/certification-livret-scolaire-repository.js
@@ -36,6 +36,7 @@ module.exports = {
         .innerJoin('sessions', 'sessions.id', 'certification-courses.sessionId')
         .innerJoin('competence-marks', 'competence-marks.assessmentResultId', 'assessment-results.id')
         .modify(_filterMostRecentCertificationCourse)
+        .where('certification-courses.isCancelled', '=', false)
         .whereRaw('LOWER("organizations"."externalId") = LOWER(?)', uai),
     )
       .select(knex.ref('*').withSchema(withName))

--- a/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/certification-livret-scolaire-repository_test.js
@@ -9,6 +9,7 @@ const {
   buildCertificationDataWithNoCompetenceMarks,
   buildValidatedPublishedCertificationData,
   buildValidatedUnpublishedCertificationData,
+  buildCancelledCertificationData,
   buildRejectedPublishedCertificationData,
   buildErrorUnpublishedCertificationData,
 } = require('../../../../tests/tooling/domain-builder/factory/build-certifications-results-for-ls');
@@ -81,6 +82,28 @@ describe('Integration | Repository | Certification-ls ', () => {
 
       // then
       expect(certificationResults).to.deep.equal([expected]);
+    });
+
+    it('should not return cancelled certification for a given UAI', async () => {
+      // given
+      const organizationId = buildOrganization(uai).id;
+      const user = buildUser();
+      const schoolingRegistration = buildSchoolingRegistration({
+        userId: user.id, organizationId,
+      });
+      buildCancelledCertificationData(
+        {
+          user, schoolingRegistration, verificationCode, pixScore, competenceMarks,
+        },
+      );
+
+      await databaseBuilder.commit();
+
+      // when
+      const certificationResults = await certificationLsRepository.getCertificatesByOrganizationUAI(uai);
+
+      // then
+      expect(certificationResults).to.deep.equal([]);
     });
 
     it('should return rejected certification results for a given UAI', async () => {

--- a/api/tests/tooling/domain-builder/factory/build-certification-course.js
+++ b/api/tests/tooling/domain-builder/factory/build-certification-course.js
@@ -22,6 +22,7 @@ module.exports = function buildCertificationCourse({
   challenges = [],
   userId = 456,
   sessionId = 789,
+  isCancelled = false,
 } = {}) {
 
   const certificationIssueReports = [];
@@ -56,5 +57,6 @@ module.exports = function buildCertificationCourse({
     challenges,
     sessionId,
     userId,
+    isCancelled,
   });
 };

--- a/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
+++ b/api/tests/tooling/domain-builder/factory/build-certifications-results-for-ls.js
@@ -25,7 +25,7 @@ function _createCertificationCenter() {
   return { certificationCenterId: id, certificationCenter: name };
 }
 
-function _buildCertificationData({ user, schoolingRegistration, certificationCreatedDate, isPublished, verificationCode }) {
+function _buildCertificationData({ user, schoolingRegistration, certificationCreatedDate, isPublished, isCancelled, verificationCode }) {
   const {
     id: certificationCenterId,
     name: certificationCenter,
@@ -54,6 +54,7 @@ function _buildCertificationData({ user, schoolingRegistration, certificationCre
     isPublished,
     createdAt: certificationCreatedDate || new Date(),
     verificationCode,
+    isCancelled,
   });
 
   databaseBuilder.factory.buildCertificationCourse({
@@ -63,6 +64,7 @@ function _buildCertificationData({ user, schoolingRegistration, certificationCre
     birthdate: schoolingRegistration.birthdate,
     sessionId: session.id,
     isPublished: false,
+    isCancelled,
   });
 
   const assessment = databaseBuilder.factory.buildAssessment({
@@ -108,6 +110,10 @@ function buildOrganization(uai) {
   return databaseBuilder.factory.buildOrganization({ externalId: uai });
 }
 
+function buildCancelledCertificationData({ user, schoolingRegistration, verificationCode, pixScore, competenceMarks, certificationCreatedDate }) {
+  return _buildValidatedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, certificationCreatedDate, competenceMarks, isPublished: false, isCancelled: true });
+}
+
 function buildValidatedPublishedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, competenceMarks, certificationCreatedDate }) {
   return _buildValidatedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, certificationCreatedDate, competenceMarks, isPublished: true });
 }
@@ -116,7 +122,7 @@ function buildValidatedUnpublishedCertificationData({ user, schoolingRegistratio
   return _buildValidatedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, certificationCreatedDate, competenceMarks, isPublished: false });
 }
 
-function _buildValidatedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, competenceMarks, certificationCreatedDate, isPublished }) {
+function _buildValidatedCertificationData({ user, schoolingRegistration, verificationCode, pixScore, competenceMarks, certificationCreatedDate, isPublished, isCancelled = false }) {
   const certificationStatus = status.VALIDATED;
   const {
     session,
@@ -129,6 +135,7 @@ function _buildValidatedCertificationData({ user, schoolingRegistration, verific
     type,
     pixScore,
     isPublished,
+    isCancelled,
     certificationCreatedDate,
   });
 
@@ -274,6 +281,7 @@ function mockLearningContentCompetences() {
 module.exports = {
   buildValidatedPublishedCertificationData,
   buildValidatedUnpublishedCertificationData,
+  buildCancelledCertificationData,
   buildRejectedPublishedCertificationData,
   buildErrorUnpublishedCertificationData,
   buildCertificationDataWithNoCompetenceMarks,


### PR DESCRIPTION
## :unicorn: Problème
Les certifications qui ne se terminent pas suite à un problème passent en statut `rejected`. 
C'est le même statut que pour une certification non acquise (faute de réponses correctes). 
Il est alors difficile de determiner si une certification est rejetée parce que les réponses sont incorrectes ou à cause d'un problème annexe.

## :robot: Solution
Ajouter un statut `cancelled` pour une certification _annulée_
i.e. 
- problème technique l'élève ne peut démarrer la certification correctement

## :rainbow: Remarques
Pour cette US, le statut est placé "manuellement" 
Cette PR ne prends pas en compte l'affichage/la recuperation des infos par les autres services. 
Pas besoin de feature-flag tant qu'on laisse la valeur du champ par défaut

## :100: Pour tester
- [ ] Mettre un certif-course en `cancelled`
- [ ] Verifier qu'il ne ressort pas pour le livret-scolaire
