### PR TITLE
[BUGFIX] Amélioration des erreurs lors d'un appel Pôle emploi avec Axios (PIX-2460).

### DIFF
--- a/api/lib/infrastructure/http/http-agent.js
+++ b/api/lib/infrastructure/http/http-agent.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const logger = require('../logger');
 
 class HttpResponse {
   constructor({
@@ -24,10 +25,24 @@ module.exports = {
         isSuccessful: true,
       });
     } catch (httpErr) {
+      const isSuccessful = false;
+
+      let code;
+      let data;
+
+      if (httpErr.response) {
+        code = httpErr.response.status;
+        data = httpErr.response.data;
+      } else {
+        code = '500';
+        data = null;
+      }
+
+      logger.error({ err: httpErr }, `Error while post ${url}`);
       return new HttpResponse({
-        code: httpErr.response.status,
-        data: httpErr.response.data,
-        isSuccessful: false,
+        code,
+        data,
+        isSuccessful,
       });
     }
   },


### PR DESCRIPTION
## :unicorn: Problème
cf. [Erreur Sentry](https://sentry.io/organizations/pix/issues/2326978774/?project=1398749&referrer=slack)

A la fin d’un parcours Pôle-emploi, les résultats sont transmis en utilisant Axios. Mais la gestion des erreurs est incomplète.

## :robot: Solution
* Améliorer la gestion des erreurs en se basant sur la documentation d'Axios : https://github.com/axios/axios#handling-errors
* Utiliser le `logger.error()`

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc._
