### PR TITLE
[FEATURE] Ajouter les params externalId et masteryPercentage à l'url donnée par une orga (PIX-2440).

### DIFF
--- a/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
+++ b/mon-pix/app/components/routes/campaigns/assessment/skill-review.js
@@ -1,6 +1,7 @@
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import isNil from 'lodash/isNil';
 
 import Component from '@glimmer/component';
 
@@ -81,12 +82,34 @@ export default class SkillReview extends Component {
     return Boolean(this.customButtonText && this.customButtonUrl);
   }
 
+  get masteryPercentage() {
+    return this.args.model.campaignParticipation.campaignParticipationResult.get('masteryPercentage');
+  }
+
+  get participantExternalId() {
+    return this.args.model.campaignParticipation.get('participantExternalId');
+  }
+
   get customButtonUrl() {
     const buttonUrl = this.args.model.campaignParticipation.campaign.get('customResultPageButtonUrl');
-    if (this.reachedStage && buttonUrl) {
-      return this._buildUrl(buttonUrl, { stage: this.reachedStage.get('threshold') });
+    if (buttonUrl) {
+      const params = {};
+
+      if (!isNil(this.masteryPercentage)) {
+        params.masteryPercentage = this.masteryPercentage;
+      }
+
+      if (!isNil(this.participantExternalId)) {
+        params.externalId = this.participantExternalId;
+      }
+
+      if (!isNil(this.reachedStage)) {
+        params.stage = this.reachedStage.get('threshold');
+      }
+
+      return this._buildUrl(buttonUrl, params);
     } else {
-      return buttonUrl;
+      return null;
     }
   }
 

--- a/mon-pix/app/styles/pages/_skill-review.scss
+++ b/mon-pix/app/styles/pages/_skill-review.scss
@@ -9,7 +9,6 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    padding-bottom: 48px;
     margin: auto;
 
     @include device-is('tablet') {

--- a/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
+++ b/mon-pix/tests/integration/components/routes/campaigns/assessment/skill-review-test.js
@@ -47,6 +47,9 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               stageCount: 2,
               get: sinon.stub().returns([]),
             },
+            campaign: {
+              get: sinon.stub().returns([]),
+            },
           },
         };
         campaign.campaignParticipation.get.withArgs('isShared').returns(false);
@@ -175,17 +178,14 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                   get: sinon.stub().returns([]),
                 },
                 campaign: {
-                  customResultPageText: 'Bravo !',
-                  organizationLogoUrl: 'www.logo-example.com',
-                  organizationName: 'Dragon & Co',
                   get: sinon.stub(),
                 },
               },
             };
             model.campaignParticipation.get.withArgs('isShared').returns(true);
-            model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-            model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(['www.logo-example.com']);
-            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns('Bravo !');
+            model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns('www.logo-example.com');
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
             this.set('model', model);
           });
 
@@ -208,31 +208,28 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
         context('when the organization has no logo', function() {
           beforeEach(function() {
             // Given
-            const campaignParticipation = {
+            const model = {
               campaignParticipation: {
                 get: sinon.stub(),
                 campaignParticipationResult: {
                   get: sinon.stub().returns([]),
                 },
                 campaign: {
-                  customResultPageText: 'Bravo !',
-                  organizationLogoUrl: null,
-                  organizationName: 'Dragon & Co',
                   get: sinon.stub(),
                 },
               },
             };
-            campaignParticipation.campaignParticipation.get.withArgs('isShared').returns(true);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
-            campaignParticipation.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
-            this.set('campaignParticipation', campaignParticipation);
+            model.campaignParticipation.get.withArgs('isShared').returns(true);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns('Bravo !');
+            model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
+            this.set('model', model);
           });
 
           it('should display the block for the message', async function() {
             // When
             await render(hbs`<Routes::Campaigns::Assessment::SkillReview
-                @model={{campaignParticipation}}/>`);
+                @model={{model}}/>`);
 
             // Then
             expect(contains('Dragon & Co')).to.exist;
@@ -245,6 +242,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           });
         });
       });
+
       context('when the organization has no message', function() {
         beforeEach(function() {
           // Given
@@ -255,9 +253,6 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 get: sinon.stub().returns([]),
               },
               campaign: {
-                customResultPageText: null,
-                organizationLogoUrl: null,
-                organizationName: 'Dragon & Co',
                 get: sinon.stub(),
               },
             },
@@ -265,7 +260,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           model.campaignParticipation.get.withArgs('isShared').returns(true);
           model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(null);
           model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
-          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
           this.set('model', model);
         });
 
@@ -280,12 +275,10 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
       });
 
       context('when the organization has a customResultPageButtonUrl and a customResultPageButtonText', function() {
-        context('when the participant has finished a campaign with stages', function() {
+        context('when the participant has finished a campaign with stages and has a masteryPercentage and a participantExternalId', function() {
           beforeEach(function() {
             // Given
             const reachedStage = {
-              id: 78890,
-              threshold: 75,
               get: sinon.stub(),
             };
 
@@ -297,9 +290,6 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                   get: sinon.stub().returns([]),
                 },
                 campaign: {
-                  organizationName: 'Dragon & Co',
-                  customResultPageButtonUrl: 'http://www.my-url.net/resultats',
-                  customResultPageButtonText: 'Next step',
                   get: sinon.stub(),
                 },
               },
@@ -307,26 +297,28 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
 
             model.campaignParticipation.get.withArgs('isShared').returns(true);
             model.campaignParticipation.campaignParticipationResult.get.withArgs('reachedStage').returns(reachedStage);
+            model.campaignParticipation.campaignParticipationResult.get.withArgs('masteryPercentage').returns(50);
             model.campaignParticipation.campaignParticipationResult.reachedStage.get.withArgs('threshold').returns([75]);
-            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['http://www.my-url.net/resultats']);
-            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
-            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns('http://www.my-url.net/resultats');
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns('Next step');
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
+            model.campaignParticipation.get.withArgs('participantExternalId').returns('1234G56');
             this.set('model', model);
           });
 
-          it('should display the button', async function() {
+          it('should display the button with all params', async function() {
             // When
             await render(hbs`<Routes::Campaigns::Assessment::SkillReview
                 @model={{model}}/>`);
 
             // Then
-            expect(find('[href="http://www.my-url.net/resultats?stage=75"]')).to.exist;
+            expect(find('[href="http://www.my-url.net/resultats?masteryPercentage=50&externalId=1234G56&stage=75"]')).to.exist;
             expect(find('[target="_blank"]')).to.exist;
             expect(contains('Next step')).to.exist;
           });
         });
 
-        context('when the participant has finished a campaign without stages', function() {
+        context('when the participant has finished a campaign with neither stages and he has neither masteryPercentage nor participantExternalId', function() {
           beforeEach(function() {
             // Given
             const model = {
@@ -334,21 +326,19 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 get: sinon.stub(),
                 campaignParticipationResult: {
                   get: sinon.stub().returns([]),
-                  reachedStage: null,
                 },
                 campaign: {
-                  organizationName: 'Dragon & Co',
-                  customResultPageButtonUrl: 'www.my-url.net',
-                  customResultPageButtonText: 'Next step',
                   get: sinon.stub(),
                 },
               },
             };
             model.campaignParticipation.get.withArgs('isShared').returns(true);
             model.campaignParticipation.campaignParticipationResult.get.withArgs('reachedStage').returns(null);
-            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
-            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(['Next step']);
-            model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+            model.campaignParticipation.campaignParticipationResult.get.withArgs('masteryPercentage').returns(null);
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns('http://www.my-url.net');
+            model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns('Next step');
+            model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
+            model.campaignParticipation.get.withArgs('participantExternalId').returns(null);
             this.set('model', model);
 
           });
@@ -359,7 +349,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 @model={{model}}/>`);
 
             // Then
-            expect(find('[href="www.my-url.net"]')).to.exist;
+            expect(find('[href="http://www.my-url.net/"]')).to.exist;
             expect(find('[target="_blank"]')).to.exist;
             expect(contains('Next step')).to.exist;
           });
@@ -376,17 +366,14 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 get: sinon.stub().returns([]),
               },
               campaign: {
-                organizationName: 'Dragon & Co',
-                customResultPageButtonUrl: 'www.my-url.net',
-                customResultPageButtonText: null,
                 get: sinon.stub(),
               },
             },
           };
           model.campaignParticipation.get.withArgs('isShared').returns(true);
-          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(['www.my-url.net']);
+          model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns('www.my-url.net');
           model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
-          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
           this.set('model', model);
         });
 
@@ -410,11 +397,6 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
                 get: sinon.stub().returns([]),
               },
               campaign: {
-                customResultPageText: null,
-                organizationLogoUrl: null,
-                customResultPageButtonUrl: null,
-                customResultPageButtonText: null,
-                organizationName: 'Dragon & Co',
                 get: sinon.stub(),
               },
             },
@@ -424,7 +406,7 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
           model.campaignParticipation.campaign.get.withArgs('organizationLogoUrl').returns(null);
           model.campaignParticipation.campaign.get.withArgs('customResultPageButtonUrl').returns(null);
           model.campaignParticipation.campaign.get.withArgs('customResultPageButtonText').returns(null);
-          model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+          model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
           this.set('model', model);
 
         });
@@ -449,15 +431,13 @@ describe('Integration | Component | routes/campaigns/assessment/skill-review', f
               get: sinon.stub().returns([]),
             },
             campaign: {
-              customResultPageText: 'Bravo !',
-              organizationName: 'Dragon & Co',
               get: sinon.stub(),
             },
           },
         };
         model.campaignParticipation.get.withArgs('isShared').returns(false);
-        model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns(['Bravo !']);
-        model.campaignParticipation.campaign.get.withArgs('organizationName').returns(['Dragon & Co']);
+        model.campaignParticipation.campaign.get.withArgs('customResultPageText').returns('Bravo !');
+        model.campaignParticipation.campaign.get.withArgs('organizationName').returns('Dragon & Co');
         this.set('model', model);
       });
 

--- a/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
+++ b/mon-pix/tests/unit/components/routes/campaigns/skill-review-test.js
@@ -19,7 +19,7 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
         set: sinon.stub().resolves({}),
         save: sinon.stub().resolves({}),
         campaignParticipationResult: EmberObject.create({
-          masteryPercentage: 50,
+          id: 3,
         }),
         campaign: EmberObject.create({
           isSimplifiedAccess: false,
@@ -273,47 +273,145 @@ describe('Unit | component | Campaigns | Evaluation | Skill Review', function() 
   });
 
   describe('#customButtonUrl', function() {
-    context('when the participant has finished a campaign with stages', function() {
-      it('should add the stage to the url as the first query params when the url does not have one', function() {
-        // given
-        const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-        reachedStage.get.withArgs('threshold').returns(6);
-        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
-        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+    context('when there is a customResultPageButtonUrl', function() {
+      context('when the participant has finished a campaign with stages', function() {
+        it('should add the stage to the url ', function() {
+          // given
+          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+          reachedStage.get.withArgs('threshold').returns(6);
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+          component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
 
-        // when
-        const url = component.customButtonUrl;
+          // when
+          const url = component.customButtonUrl;
 
-        // then
-        expect(url).to.equal('http://www.my-url.net/resultats?stage=6');
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?stage=6');
+        });
       });
 
-      it('should add the stage to the other query params', function() {
-        // given
-        const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
-        reachedStage.get.withArgs('threshold').returns(6);
-        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
-        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+      context('when the participant has a mastery percentage', function() {
+        it('should add the masteryPercentage to the url', function() {
+          // given
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+          component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
 
-        // when
-        const url = component.customButtonUrl;
+          // when
+          const url = component.customButtonUrl;
 
-        // then
-        expect(url).to.equal('http://www.my-url.net/resultats?foo=bar&stage=6');
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?masteryPercentage=56');
+        });
+      });
+
+      context('when the participant has a mastery percentage equals to 0', function() {
+        it('should add the masteryPercentage to the url', function() {
+          // given
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+          component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 0;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?masteryPercentage=0');
+        });
+      });
+
+      context('when the participant has a participantExternalId', function() {
+        it('should add the externalId to the url', function() {
+          // given
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+          component.args.model.campaignParticipation.participantExternalId = '1234F56';
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?externalId=1234F56');
+        });
+      });
+
+      context('when the participant has a participantExternalId, a mastery percentage and stages ', function() {
+        it('should add all params to the url', function() {
+          // given
+          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+          reachedStage.get.withArgs('threshold').returns(6);
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats';
+          component.args.model.campaignParticipation.participantExternalId = '1234F56';
+          component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+          component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?masteryPercentage=56&externalId=1234F56&stage=6');
+        });
+      });
+
+      context('when the url already has query params', function() {
+        it('should add the new parameters to the other query params', function() {
+          // given
+          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+          reachedStage.get.withArgs('threshold').returns(6);
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/resultats?foo=bar';
+          component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+          component.args.model.campaignParticipation.participantExternalId = '1234F56';
+          component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/resultats?foo=bar&masteryPercentage=56&externalId=1234F56&stage=6');
+        });
+      });
+
+      context('when the url has an ancor', function() {
+        it('should add the new parameters before the ancor', function() {
+          // given
+          const reachedStage = { id: 123, threshold: 6, get: sinon.stub() };
+          reachedStage.get.withArgs('threshold').returns(6);
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net/#page1';
+          component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = reachedStage;
+          component.args.model.campaignParticipation.participantExternalId = '1234F56';
+          component.args.model.campaignParticipation.campaignParticipationResult.masteryPercentage = 56;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/?masteryPercentage=56&externalId=1234F56&stage=6#page1');
+        });
+      });
+
+      context('when there is no params', function() {
+        it('should return the url of the custom button', function() {
+          // given
+          component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
+          component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = null;
+
+          // when
+          const url = component.customButtonUrl;
+
+          // then
+          expect(url).to.equal('http://www.my-url.net/');
+        });
       });
     });
 
-    context('when the participant has finished a campaign without stages ', function() {
-      it('should return the url of the custom button', function() {
+    context('when there is no customResultPageButtonUrl', function() {
+      it('should return nothing', function() {
         // given
-        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = 'http://www.my-url.net';
-        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = null;
+        component.args.model.campaignParticipation.campaign.customResultPageButtonUrl = null;
+        component.args.model.campaignParticipation.campaignParticipationResult.reachedStage = 80;
 
         // when
         const url = component.customButtonUrl;
 
         // then
-        expect(url).to.equal('http://www.my-url.net');
+        expect(url).to.equal(null);
       });
     });
   });


### PR DESCRIPTION
## :unicorn: Problème
Dans le cadre de la personnalisation de fin de parcours, on souhaite pouvoir envoyer des infos du participant dans l'url du bouton

## :robot: Solution
Ajouter à l'url fournie par l'organisation, le mastertyPercentage et l'externalId.

## :rainbow: Remarques

## :100: Pour tester
Toujours avec notre bon vieux jaune.attend@example.net
