### PR TITLE
[FEATURE] Ajout de la section "Compétences à retenter" sur le TDB (PIX-2263).

### DIFF
--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -113,7 +113,7 @@
     {{/if}}
 
     {{#if this.hasImprovableCompetences}}
-      <section class="dashboard-content-main__section" data-test-improvable-competences>
+      <section class="dashboard-content-main__section">
         <div class="dashboard-content-main-section--with-button">
           <div>
             <h2 class="dashboard-content-main-section__title">{{t 'pages.dashboard.improvable-competences.title'}}</h2>

--- a/mon-pix/app/components/dashboard/content.hbs
+++ b/mon-pix/app/components/dashboard/content.hbs
@@ -111,6 +111,20 @@
         <CompetenceCard::List @scorecards={{this.recommendedScorecards}} />
       </section>
     {{/if}}
+
+    {{#if this.hasImprovableCompetences}}
+      <section class="dashboard-content-main__section" data-test-improvable-competences>
+        <div class="dashboard-content-main-section--with-button">
+          <div>
+            <h2 class="dashboard-content-main-section__title">{{t 'pages.dashboard.improvable-competences.title'}}</h2>
+            <p class="dashboard-content-main-section__subtitle">{{t 'pages.dashboard.improvable-competences.subtitle'}}</p>
+          </div>
+          <LinkTo @route="profile" class="dashboard-content-main-section__button">{{t 'pages.dashboard.improvable-competences.profile-link'}}</LinkTo>
+        </div>
+
+        <CompetenceCard::List @scorecards={{this.improvableScorecards}} />
+      </section>
+    {{/if}}
   </section>
 
   <section class="dashboard-content__section dashboard-content__certif">

--- a/mon-pix/app/components/dashboard/content.js
+++ b/mon-pix/app/components/dashboard/content.js
@@ -44,6 +44,10 @@ export default class Content extends Component {
     return this.startedCompetences.length > 0;
   }
 
+  get hasImprovableCompetences() {
+    return this.improvableScorecards.length > 0;
+  }
+
   get recommendedScorecards() {
     const isScorecardNotStarted = (scorecard) => scorecard.isNotStarted;
     return this._filterScorecardsByStateAndRetrieveTheFirstOnesByIndex(isScorecardNotStarted);
@@ -52,6 +56,11 @@ export default class Content extends Component {
   get startedCompetences() {
     const isScorecardStarted = (scorecard) => scorecard.isStarted;
     return this._filterScorecardsByStateAndRetrieveTheFirstOnesByIndex(isScorecardStarted);
+  }
+
+  get improvableScorecards() {
+    const isScorecardImprovable = (scorecard) => scorecard.isImprovable;
+    return this._filterScorecardsByStateAndRetrieveTheFirstOnesByIndex(isScorecardImprovable);
   }
 
   _filterScorecardsByStateAndRetrieveTheFirstOnesByIndex(state) {

--- a/mon-pix/app/models/scorecard.js
+++ b/mon-pix/app/models/scorecard.js
@@ -43,6 +43,10 @@ export default class Scorecard extends Model {
     return this.level >= ENV.APP.MAX_REACHABLE_LEVEL;
   }
 
+  get isImprovable() {
+    return this.isFinished && !this.isFinishedWithMaxLevel && this.remainingDaysBeforeImproving === 0;
+  }
+
   get hasNotEarnAnything() {
     return this.earnedPix === 0;
   }

--- a/mon-pix/tests/acceptance/user-dashboard-test.js
+++ b/mon-pix/tests/acceptance/user-dashboard-test.js
@@ -160,6 +160,19 @@ describe('Acceptance | User dashboard page', function() {
 
   });
 
+  describe('retryable-competences', function() {
+
+    beforeEach(async function() {
+      user = server.create('user', 'withEmail');
+      await authenticateByEmail(user);
+      await visit('/accueil');
+    });
+
+    it('should display the improvable-competences section', function() {
+      expect(find('section[data-test-improvable-competences]')).to.exist;
+    });
+  });
+
   describe('started-competences', function() {
 
     beforeEach(async function() {

--- a/mon-pix/tests/acceptance/user-dashboard-test.js
+++ b/mon-pix/tests/acceptance/user-dashboard-test.js
@@ -1,17 +1,21 @@
 import { currentURL, click, find } from '@ember/test-helpers';
-import { beforeEach, describe, it } from 'mocha';
-import { authenticateByEmail } from '../helpers/authentication';
-import { expect } from 'chai';
-import visit from '../helpers/visit';
-import { setupApplicationTest } from 'ember-mocha';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import { invalidateSession } from 'ember-simple-auth/test-support';
+import { setupApplicationTest } from 'ember-mocha';
+import { beforeEach, describe, it } from 'mocha';
+import { expect } from 'chai';
+import visit from '../helpers/visit';
+import { authenticateByEmail } from '../helpers/authentication';
+import { contains } from '../helpers/contains';
+import setupIntl from '../helpers/setup-intl';
 
 const ASSESSMENT = 'ASSESSMENT';
 
 describe('Acceptance | User dashboard page', function() {
   setupApplicationTest();
   setupMirage();
+  setupIntl();
+
   let user;
 
   describe('Visit the user dashboard page', function() {
@@ -169,7 +173,7 @@ describe('Acceptance | User dashboard page', function() {
     });
 
     it('should display the improvable-competences section', function() {
-      expect(find('section[data-test-improvable-competences]')).to.exist;
+      expect(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle'))).to.exist;
     });
   });
 

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -172,6 +172,66 @@ describe('Integration | Component | Dashboard | Content', function() {
     });
   });
 
+  describe('improvable competence-card rendering', function() {
+    beforeEach(function() {
+      this.owner.register('service:currentUser', CurrentUserStub);
+    });
+
+    it('should render competence-card when there is at least one competence-card not started', async function() {
+      // given
+      const scorecard = { isImprovable: true };
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards: [scorecard],
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+
+      // then
+      expect(find('section[data-test-improvable-competences]')).to.exist;
+    });
+
+    it('should not render competence-card when there is no competence-card', async function() {
+      // given
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards: [],
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+
+      // then
+      expect(find('section[data-test-improvable-competences]')).to.not.exist;
+    });
+
+    it('should render the four first non improvable competence cards from the received arguments', async function() {
+      // given
+      const scorecards = [
+        { id: 1, index: '1.1', isImprovable: true },
+        { id: 2, index: '1.2', isImprovable: true },
+        { id: 3, index: '3.1', isImprovable: true },
+        { id: 5, index: '1.3', isImprovable: false },
+        { id: 4, index: '2.4', isImprovable: true },
+        { id: 4, index: '1.4', isImprovable: true },
+      ];
+      this.set('model', {
+        campaignParticipationOverviews: [],
+        campaignParticipations: [],
+        scorecards,
+      });
+
+      // when
+      await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
+
+      // then
+      expect(findAll('.competence-card')).to.have.length(4);
+    });
+  });
+
   describe('started competence-card rendering', function() {
     beforeEach(function() {
       this.owner.register('service:currentUser', CurrentUserStub);

--- a/mon-pix/tests/integration/components/dashboard/content-test.js
+++ b/mon-pix/tests/integration/components/dashboard/content-test.js
@@ -190,7 +190,7 @@ describe('Integration | Component | Dashboard | Content', function() {
       await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      expect(find('section[data-test-improvable-competences]')).to.exist;
+      expect(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle'))).to.exist;
     });
 
     it('should not render competence-card when there is no competence-card', async function() {
@@ -205,7 +205,7 @@ describe('Integration | Component | Dashboard | Content', function() {
       await render(hbs`<Dashboard::Content @model={{this.model}} />}`);
 
       // then
-      expect(find('section[data-test-improvable-competences]')).to.not.exist;
+      expect(contains(this.intl.t('pages.dashboard.improvable-competences.subtitle'))).to.not.exist;
     });
 
     it('should render the four first non improvable competence cards from the received arguments', async function() {

--- a/mon-pix/tests/unit/components/dashboard/content-test.js
+++ b/mon-pix/tests/unit/components/dashboard/content-test.js
@@ -171,6 +171,80 @@ describe('Unit | Component | Dashboard | Content', function() {
     });
   });
 
+  describe('#improvableScorecards', function() {
+
+    it('should return improvable scorecards', function() {
+      // given
+      const scorecards = [
+        { id: 1, isImprovable: false },
+        { id: 2, isImprovable: false },
+        { id: 5, isImprovable: true },
+        { id: 3, isImprovable: false },
+      ];
+
+      const expectedScorecards = [
+        { id: 5, isImprovable: true },
+      ];
+
+      component.args.model = { scorecards };
+
+      // when
+      const result = component.improvableScorecards;
+
+      // then
+      expect(result).to.deep.equal(expectedScorecards);
+    });
+
+    it('should return scorecards ordered by index', function() {
+      // given
+      const scorecards = [
+        { id: 3, index: '3.1', isImprovable: true },
+        { id: 1, index: '1.1', isImprovable: true },
+        { id: 4, index: '2.4', isImprovable: true },
+      ];
+
+      const expectedScorecards = [
+        { id: 1, index: '1.1', isImprovable: true },
+        { id: 4, index: '2.4', isImprovable: true },
+        { id: 3, index: '3.1', isImprovable: true },
+      ];
+
+      component.args.model = { scorecards };
+
+      // when
+      const result = component.improvableScorecards;
+
+      // then
+      expect(result).to.deep.equal(expectedScorecards);
+    });
+
+    it('should return a maximum of four cards', function() {
+      // given
+      const scorecards = [
+        { id: 1, isImprovable: true },
+        { id: 2, isImprovable: true },
+        { id: 4, isImprovable: true },
+        { id: 5, isImprovable: true },
+        { id: 3, isImprovable: true },
+      ];
+
+      const expectedScorecards = [
+        { id: 1, isImprovable: true },
+        { id: 2, isImprovable: true },
+        { id: 4, isImprovable: true },
+        { id: 5, isImprovable: true },
+      ];
+
+      component.args.model = EmberObject.create({ scorecards });
+
+      // when
+      const result = component.improvableScorecards;
+
+      // then
+      expect(result).to.deep.equal(expectedScorecards);
+    });
+  });
+
   describe('#userFirstname', function() {
     it('should return userFirstname', function() {
       // given

--- a/mon-pix/tests/unit/models/scorecard-test.js
+++ b/mon-pix/tests/unit/models/scorecard-test.js
@@ -123,6 +123,68 @@ describe('Unit | Model | Scorecard model', function() {
     });
   });
 
+  describe('isImprovable', function() {
+    context('when the competence is finished with max level', function() {
+      it('should return false', function() {
+        // given
+        scorecard.set('level', 5);
+        scorecard.set('status', 'COMPLETED');
+        scorecard.set('remainingDaysBeforeImproving', 0);
+
+        // when
+        const isImprovable = scorecard.get('isImprovable');
+
+        // then
+        expect(isImprovable).to.be.false;
+      });
+    });
+
+    context('when the competence is not finished', function() {
+      it('should return false', function() {
+        // given
+        scorecard.set('level', 5);
+        scorecard.set('status', 'STARTED');
+        scorecard.set('remainingDaysBeforeImproving', 0);
+
+        // when
+        const isImprovable = scorecard.get('isImprovable');
+
+        // then
+        expect(isImprovable).to.be.false;
+      });
+    });
+
+    context('when there are remaining days before improving', function() {
+      it('should return false', function() {
+        // given
+        scorecard.set('level', 5);
+        scorecard.set('status', 'COMPLETED');
+        scorecard.set('remainingDaysBeforeImproving', 1);
+
+        // when
+        const isImprovable = scorecard.get('isImprovable');
+
+        // then
+        expect(isImprovable).to.be.false;
+      });
+    });
+
+    context('when the competence is finished without reaching the max level and there are no remaining days before improving', function() {
+      it('should return true', function() {
+        // given
+        scorecard.set('level', 3);
+        scorecard.set('status', 'COMPLETED');
+        scorecard.set('remainingDaysBeforeImproving', 0);
+
+        // when
+        const isImprovable = scorecard.get('isImprovable');
+
+        // then
+        expect(isImprovable).to.be.true;
+      });
+    });
+  });
+
   describe('hasNotEarnAnything', function() {
     it('should return true', function() {
       // given

--- a/mon-pix/tests/unit/models/scorecard-test.js
+++ b/mon-pix/tests/unit/models/scorecard-test.js
@@ -2,8 +2,10 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { setupTest } from 'ember-mocha';
 import { run } from '@ember/runloop';
+import ENV from 'mon-pix/config/environment';
 
 describe('Unit | Model | Scorecard model', function() {
+  const maxReachableLevel = ENV.APP.MAX_REACHABLE_LEVEL;
   let scorecard;
 
   setupTest();
@@ -48,7 +50,7 @@ describe('Unit | Model | Scorecard model', function() {
   describe('isMaxLevel', function() {
     it('should return true', function() {
       // given
-      scorecard.set('level', 5);
+      scorecard.set('level', maxReachableLevel);
 
       // when
       const isMaxLevel = scorecard.get('isMaxLevel');
@@ -73,7 +75,7 @@ describe('Unit | Model | Scorecard model', function() {
     context('when max level is reached', function() {
       it('should return true', function() {
         // given
-        scorecard.set('level', 5);
+        scorecard.set('level', maxReachableLevel);
         scorecard.set('status', 'COMPLETED');
 
         // when
@@ -85,7 +87,7 @@ describe('Unit | Model | Scorecard model', function() {
 
       it('should return false', function() {
         // given
-        scorecard.set('level', 5);
+        scorecard.set('level', maxReachableLevel);
         scorecard.set('status', 'STARTED');
 
         // when
@@ -127,7 +129,7 @@ describe('Unit | Model | Scorecard model', function() {
     context('when the competence is finished with max level', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', 5);
+        scorecard.set('level', maxReachableLevel);
         scorecard.set('status', 'COMPLETED');
         scorecard.set('remainingDaysBeforeImproving', 0);
 
@@ -142,7 +144,7 @@ describe('Unit | Model | Scorecard model', function() {
     context('when the competence is not finished', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', 5);
+        scorecard.set('level', maxReachableLevel);
         scorecard.set('status', 'STARTED');
         scorecard.set('remainingDaysBeforeImproving', 0);
 
@@ -157,7 +159,7 @@ describe('Unit | Model | Scorecard model', function() {
     context('when there are remaining days before improving', function() {
       it('should return false', function() {
         // given
-        scorecard.set('level', 5);
+        scorecard.set('level', maxReachableLevel);
         scorecard.set('status', 'COMPLETED');
         scorecard.set('remainingDaysBeforeImproving', 1);
 

--- a/mon-pix/translations/en.json
+++ b/mon-pix/translations/en.json
@@ -568,6 +568,11 @@
                 "subtitle": "Discover the skills recommended for you.",
                 "title": "Recommended skills"
             },
+            "improvable-competences": {
+                "profile-link": "See all",
+                "subtitle": "Ready to improve your score?",
+                "title": "Try again"
+            },
             "score": {
                 "profile-link": "See my skills"
             },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -568,6 +568,11 @@
                 "subtitle": "Explorez les compétences recommandées pour vous.",
                 "title": "Compétences recommandées"
             },
+            "improvable-competences": {
+                "profile-link": "Voir toutes",
+                "subtitle": "Prêt à faire passer votre compétence au niveau supérieur ?",
+                "title": "Retenter une compétence"
+            },
             "score": {
                 "profile-link": "Voir mes compétences"
             },

--- a/mon-pix/translations/fr.json
+++ b/mon-pix/translations/fr.json
@@ -569,7 +569,7 @@
                 "title": "Compétences recommandées"
             },
             "improvable-competences": {
-                "profile-link": "Voir toutes",
+                "profile-link": "Toutes les compétences",
                 "subtitle": "Prêt à faire passer votre compétence au niveau supérieur ?",
                 "title": "Retenter une compétence"
             },


### PR DESCRIPTION
## :unicorn: Problème

Il est possible pour les utilisateurs d'avoir accès aux compétences à reprendre et recommandées sur leur tableau de bord mais pas encore aux compétences à retenter.

## :robot: Solution

Ajout de la section des compétences à retenter qui s'appuie sur la même implémentation fonctionnelle et visuelle que les autres sections déjà en place. (4 cartes visibles au maximum, rangées par index et disparition de la section si absence de carte correspondant aux critères d'affichage)

## :rainbow: Remarques

Je suis ouvert à toute proposition si le terme `improvableCompetence` ne convient pas. Je le trouve explicite mais il ne me convainc pas entièrement. 🤔

La demande de traductions a été effectuée.
Edit 15/04 : Traductions rajoutées au fichier.

## :100: Pour tester

Le nombre de jours avant de pouvoir retenter une compétence a été passé à `1` sur la RA.

Terminer une des compétences visibles sur le TDB et s'assurer de son absence une fois finie.

Commencer une nouvelle compétence et s'assurer que celle-ci n'est pas disponible immédiatement sur le TDB une fois terminée.

Repasser la variable d'environnement à 0 et recommencer le processus pour constater de la présence de la nouvelle carte dans la section du TDB.