### PR TITLE
[FEATURE] Affiche les badgePartnerCompetences dans les critéres du badge

### DIFF
--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -47,6 +47,11 @@
           {{/each}}
         </tbody>
       </table>
+      <ul>
+      {{#each @badge.badgePartnerCompetences as |badgePartnerCompetence|}}
+        <li>{{badgePartnerCompetence.name}}</li>
+      {{/each}}
+      </ul>
     </div>
   </section>
 </main>

--- a/admin/app/components/badges/badge.hbs
+++ b/admin/app/components/badges/badge.hbs
@@ -41,17 +41,20 @@
         <tbody>
           {{#each @badge.badgeCriteria as |criterion|}}
             <tr>
-              <td>{{criterion.scope}}</td>
+              <td>{{criterion.scope}}
+                {{#if criterion.partnerCompetences}}
+                  <ul>
+                    {{#each criterion.partnerCompetences as |badgePartnerCompetence|}}
+                      <li>{{badgePartnerCompetence.name}}</li>
+                    {{/each}}
+                  </ul>
+                {{/if}}
+              </td>
               <td>{{criterion.threshold}}</td>
             </tr>
           {{/each}}
         </tbody>
       </table>
-      <ul>
-      {{#each @badge.badgePartnerCompetences as |badgePartnerCompetence|}}
-        <li>{{badgePartnerCompetence.name}}</li>
-      {{/each}}
-      </ul>
     </div>
   </section>
 </main>

--- a/admin/app/models/badge-criterion.js
+++ b/admin/app/models/badge-criterion.js
@@ -1,8 +1,9 @@
-import Model, { attr, belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class BadgeCriterion extends Model {
   @attr('string') scope;
   @attr('number') threshold;
 
   @belongsTo('badge') badge;
+  @hasMany('badgePartnerCompetence') partnerCompetences;
 }

--- a/admin/app/models/badge-partner-competence.js
+++ b/admin/app/models/badge-partner-competence.js
@@ -5,5 +5,5 @@ export default class BadgePartnerCompetence extends Model {
   @attr('string') name;
 
   @belongsTo('badge') badge;
-
+  @belongsTo('badge-criterion') criterion;
 }

--- a/admin/app/models/badge-partner-competence.js
+++ b/admin/app/models/badge-partner-competence.js
@@ -1,0 +1,9 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class BadgePartnerCompetence extends Model {
+
+  @attr('string') name;
+
+  @belongsTo('badge') badge;
+
+}

--- a/admin/app/models/badge.js
+++ b/admin/app/models/badge.js
@@ -10,4 +10,5 @@ export default class Badge extends Model {
 
   @belongsTo('target-profile') targetProfile;
   @hasMany('badge-criterion') badgeCriteria;
+  @hasMany('badge-partner-competence') badgePartnerCompetences;
 }

--- a/admin/mirage/handlers/badges.js
+++ b/admin/mirage/handlers/badges.js
@@ -1,5 +1,6 @@
 function getBadge(schema, request) {
   const id = request.params.id;
+  request.queryParams.include = 'badgeCriteria.partnerCompetences';
   return schema.badges.find(id);
 }
 

--- a/admin/mirage/serializers/badge.js
+++ b/admin/mirage/serializers/badge.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const include = ['badgeCriteria'];
+const include = ['badgeCriteria', 'badgePartnerCompetences'];
 
 export default ApplicationSerializer.extend({
   include,

--- a/admin/tests/acceptance/authenticated/badges/badges-test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges-test.js
@@ -16,22 +16,29 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     currentUser = server.create('user');
     await createAuthenticateSession({ userId: currentUser.id });
 
-    const criterion = this.server.create('badge-criterion', {
+    const badgePartnerCompetence = this.server.create('badge-partner-competence', {
+      id: 1,
+      name: 'Internet for dummies',
+    });
+
+    const criterionCampaignParticipation = this.server.create('badge-criterion', {
       id: 1,
       scope: 'CampaignParticipation',
       threshold: 20,
     });
-
-    const badgePartnerCompetence = this.server.create('badge-partner-competence', {
-      id: 1,
-      name: 'Internet for dummies',
+    const criterionEveryPartnerCompetence = this.server.create('badge-criterion', {
+      id: 2,
+      scope: 'EveryPartnerCompetence',
+      threshold: 40,
+      partnerCompetences: [badgePartnerCompetence],
     });
 
     badge = this.server.create('badge', {
       id: 1,
       title: 'My badge',
       badgeCriteria: [
-        criterion,
+        criterionCampaignParticipation,
+        criterionEveryPartnerCompetence,
       ],
       badgePartnerCompetences: [
         badgePartnerCompetence,
@@ -45,6 +52,8 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     const badgeElement = find('.page-section__details');
     assert.ok(badgeElement.textContent.match(badge.title));
     assert.contains('20');
+    assert.dom('.table-admin tbody tr:nth-child(1) ul').doesNotExist();
+    assert.dom('.table-admin tbody tr:nth-child(2) ul').exists();
     assert.contains('Internet for dummies');
   });
 

--- a/admin/tests/acceptance/authenticated/badges/badges-test.js
+++ b/admin/tests/acceptance/authenticated/badges/badges-test.js
@@ -21,11 +21,20 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
       scope: 'CampaignParticipation',
       threshold: 20,
     });
+
+    const badgePartnerCompetence = this.server.create('badge-partner-competence', {
+      id: 1,
+      name: 'Internet for dummies',
+    });
+
     badge = this.server.create('badge', {
       id: 1,
       title: 'My badge',
       badgeCriteria: [
         criterion,
+      ],
+      badgePartnerCompetences: [
+        badgePartnerCompetence,
       ],
     });
   });
@@ -36,5 +45,7 @@ module('Acceptance | authenticated/badges/badge', function(hooks) {
     const badgeElement = find('.page-section__details');
     assert.ok(badgeElement.textContent.match(badge.title));
     assert.contains('20');
+    assert.contains('Internet for dummies');
   });
+
 });

--- a/api/db/seeds/data/badges-builder.js
+++ b/api/db/seeds/data/badges-builder.js
@@ -6,14 +6,6 @@ const PRO_BASICS_BADGE_ID = 114;
 const PRO_TOOLS_BADGE_ID = 115;
 const PIX_DROIT_MAITRE_BADGE_ID = 116;
 const PIX_DROIT_EXPERT_BADGE_ID = 117;
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_M = '78954665';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_M = '13654984';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_M = '14089753';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_M = '09873856';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_E = '78954666';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_E = '13654985';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_E = '14089754';
-const PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_E = '09873857';
 
 const BadgeCriterion = require('../../../lib/domain/models/BadgeCriterion');
 const Badge = require('../../../lib/domain/models/Badge');
@@ -47,8 +39,8 @@ function _createPixEmploiCleaBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIX_EMPLOI_CLEA_ID,
   });
 
-  _associateBadgePartnerCompetences(databaseBuilder, skillIdsForBadgePartnerCompetences, badge);
-  _associateBadgeCriteria(databaseBuilder, badge);
+  const badgePartnerCompetencesIds = _associateBadgePartnerCompetences(databaseBuilder, skillIdsForBadgePartnerCompetences, badge);
+  _associateBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds);
 }
 
 function _createBasicsBadge(databaseBuilder) {
@@ -69,8 +61,8 @@ function _createBasicsBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_STAGES_BADGES_ID,
   });
 
-  _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForBasicsBadge, basicsBadge);
-  _associateBadgeCriteria(databaseBuilder, basicsBadge);
+  const badgePartnerCompetencesIds = _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForBasicsBadge, basicsBadge);
+  _associateBadgeCriteria(databaseBuilder, basicsBadge, badgePartnerCompetencesIds);
 }
 
 function _createToolsBadge(databaseBuilder) {
@@ -91,8 +83,8 @@ function _createToolsBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_STAGES_BADGES_ID,
   });
 
-  _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForToolsBadge, toolsBadge);
-  _associateBadgeCriteria(databaseBuilder, toolsBadge);
+  const badgePartnerCompetencesIds = _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForToolsBadge, toolsBadge);
+  _associateBadgeCriteria(databaseBuilder, toolsBadge, badgePartnerCompetencesIds);
 }
 
 function _createManipBadge(databaseBuilder) {
@@ -113,8 +105,8 @@ function _createManipBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_STAGES_BADGES_ID,
   });
 
-  _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForManipBadge, manipBadge);
-  _associateBadgeCriteria(databaseBuilder, manipBadge);
+  const badgePartnerCompetencesIds = _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForManipBadge, manipBadge);
+  _associateBadgeCriteria(databaseBuilder, manipBadge, badgePartnerCompetencesIds);
 }
 
 function _createProfessionalBasicsBadge(databaseBuilder) {
@@ -219,45 +211,51 @@ function _createPixDroitBadge(databaseBuilder) {
     targetProfileId: TARGET_PROFILE_PIX_DROIT_ID,
   });
 
-  _associatePixDroitMasterBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForPixDroitBadge, pixDroitMasterBadge);
-  _associatePixDroitMasterBadgeCriteria(databaseBuilder, pixDroitMasterBadge);
+  const badgePartnerCompetencesMasterIds = _associatePixDroitMasterBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForPixDroitBadge, pixDroitMasterBadge);
+  _associatePixDroitMasterBadgeCriteria(databaseBuilder, pixDroitMasterBadge, badgePartnerCompetencesMasterIds);
 
-  _associatePixDroitExpertBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForPixDroitBadge, pixDroitExpertBadge);
-  _associatePixDroitExpertBadgeCriteria(databaseBuilder, pixDroitExpertBadge);
+  const badgePartnerCompetencesExpertIds = _associatePixDroitExpertBadgePartnerCompetences(databaseBuilder, targetProfileSkillIdsForPixDroitBadge, pixDroitExpertBadge);
+  _associatePixDroitExpertBadgeCriteria(databaseBuilder, pixDroitExpertBadge, badgePartnerCompetencesExpertIds);
 
+}
+
+function _returnIds(...builders) {
+  return builders.map((builder) => builder.id);
 }
 
 function _associateBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    name: 'Rechercher des informations sur internet',
-    color: null,
-    skillIds: targetProfileSkillIds[0].map((id) => id),
-    badgeId: badge.id,
-  });
+  return _returnIds(
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Rechercher des informations sur internet',
+      color: null,
+      skillIds: targetProfileSkillIds[0].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    name: 'Utiliser des outils informatiques',
-    color: null,
-    skillIds: targetProfileSkillIds[1].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Utiliser des outils informatiques',
+      color: null,
+      skillIds: targetProfileSkillIds[1].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    name: 'Naviguer sur internet',
-    color: null,
-    skillIds: targetProfileSkillIds[2].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Naviguer sur internet',
+      color: null,
+      skillIds: targetProfileSkillIds[2].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    name: 'Partager sur les réseaux sociaux',
-    color: null,
-    skillIds: targetProfileSkillIds[3].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Partager sur les réseaux sociaux',
+      color: null,
+      skillIds: targetProfileSkillIds[3].map((id) => id),
+      badgeId: badge.id,
+    }),
+  );
 }
 
-function _associateBadgeCriteria(databaseBuilder, badge) {
+function _associateBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds = []) {
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.CAMPAIGN_PARTICIPATION,
     threshold: 85,
@@ -268,116 +266,114 @@ function _associateBadgeCriteria(databaseBuilder, badge) {
     scope: BadgeCriterion.SCOPES.EVERY_PARTNER_COMPETENCE,
     threshold: 75,
     badgeId: badge.id,
+    partnerCompetenceIds: badgePartnerCompetencesIds,
   });
 }
 
 function _associatePixDroitMasterBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_M,
-    name: 'Acquis du référentiel Pix',
-    color: null,
-    skillIds: targetProfileSkillIds[0].map((id) => id),
-    badgeId: badge.id,
-  });
+  return _returnIds(
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_M,
-    name: 'Acquis Pix+ Droit',
-    color: null,
-    skillIds: targetProfileSkillIds[1].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Acquis du référentiel Pix',
+      color: null,
+      skillIds: targetProfileSkillIds[0].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_M,
-    name: 'Domaine Pix+ Droit Domaine 7',
-    color: null,
-    skillIds: targetProfileSkillIds[2].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Acquis Pix+ Droit',
+      color: null,
+      skillIds: targetProfileSkillIds[1].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_M,
-    name: 'Domaine Pix+ Droit Domaine 10',
-    color: null,
-    skillIds: targetProfileSkillIds[3].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Domaine Pix+ Droit Domaine 7',
+      color: null,
+      skillIds: targetProfileSkillIds[2].map((id) => id),
+      badgeId: badge.id,
+    }),
+
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Domaine Pix+ Droit Domaine 10',
+      color: null,
+      skillIds: targetProfileSkillIds[3].map((id) => id),
+      badgeId: badge.id,
+    }),
+  );
 }
 
 function _associatePixDroitExpertBadgePartnerCompetences(databaseBuilder, targetProfileSkillIds, badge) {
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_E,
-    name: 'Acquis du référentiel Pix',
-    color: null,
-    skillIds: targetProfileSkillIds[0].map((id) => id),
-    badgeId: badge.id,
-  });
+  return _returnIds(
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Acquis du référentiel Pix',
+      color: null,
+      skillIds: targetProfileSkillIds[0].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_E,
-    name: 'Acquis Pix+ Droit',
-    color: null,
-    skillIds: targetProfileSkillIds[1].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Acquis Pix+ Droit',
+      color: null,
+      skillIds: targetProfileSkillIds[1].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_E,
-    name: 'Domaine Pix+ Droit Domaine 7',
-    color: null,
-    skillIds: targetProfileSkillIds[2].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Domaine Pix+ Droit Domaine 7',
+      color: null,
+      skillIds: targetProfileSkillIds[2].map((id) => id),
+      badgeId: badge.id,
+    }),
 
-  databaseBuilder.factory.buildBadgePartnerCompetence({
-    id: PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_E,
-    name: 'Domaine Pix+ Droit Domaine 10',
-    color: null,
-    skillIds: targetProfileSkillIds[3].map((id) => id),
-    badgeId: badge.id,
-  });
+    databaseBuilder.factory.buildBadgePartnerCompetence({
+      name: 'Domaine Pix+ Droit Domaine 10',
+      color: null,
+      skillIds: targetProfileSkillIds[3].map((id) => id),
+      badgeId: badge.id,
+    }),
+  );
 }
 
-function _associatePixDroitMasterBadgeCriteria(databaseBuilder, badge) {
+function _associatePixDroitMasterBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds) {
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 70,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_M],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[0]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 60,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_M],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[1]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 40,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_M, PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_M],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[2], badgePartnerCompetencesIds[3]],
   });
 }
 
-function _associatePixDroitExpertBadgeCriteria(databaseBuilder, badge) {
+function _associatePixDroitExpertBadgeCriteria(databaseBuilder, badge, badgePartnerCompetencesIds) {
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 70,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_PIX_E],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[0]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 80,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_E],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[1]],
   });
   databaseBuilder.factory.buildBadgeCriterion({
     scope: BadgeCriterion.SCOPES.SOME_PARTNER_COMPETENCES,
     threshold: 40,
     badgeId: badge.id,
-    partnerCompetenceIds: [PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_7_E, PIX_DROIT_BADGE_PARTNER_COMPETENCE_DROIT_10_E],
+    partnerCompetenceIds: [badgePartnerCompetencesIds[2], badgePartnerCompetencesIds[3]],
   });
 }
 

--- a/api/lib/infrastructure/repositories/badge-repository.js
+++ b/api/lib/infrastructure/repositories/badge-repository.js
@@ -46,7 +46,7 @@ module.exports = {
     const bookshelfBadge = await BookshelfBadge
       .where('id', id)
       .fetch({
-        withRelated: ['badgeCriteria'],
+        withRelated: ['badgeCriteria', 'badgePartnerCompetences'],
       });
     return bookshelfToDomainConverter.buildDomainObject(BookshelfBadge, bookshelfBadge);
   },

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -3,6 +3,7 @@ const { Serializer } = require('jsonapi-serializer');
 const mapType = {
   badgeCriteria: 'badge-criterion',
   badgePartnerCompetences: 'badge-partner-competence',
+  partnerCompetences: 'badge-partner-competence',
 };
 
 module.exports = {
@@ -13,16 +14,29 @@ module.exports = {
       badgeCriteria: {
         include: true,
         ref: 'id',
-        attributes: ['threshold', 'scope'],
+        attributes: ['threshold', 'scope', 'partnerCompetences'],
+        partnerCompetences: {
+          include: false,
+          ref: 'id',
+        },
       },
       badgePartnerCompetences: {
         include: true,
         ref: 'id',
         attributes: ['name'],
       },
-      typeForAttribute: (attribute) => {
+      typeForAttribute(attribute) {
         return mapType[attribute];
       },
+      transform(record) {
+        record.badgeCriteria.forEach((badgeCriterion) => {
+          badgeCriterion.partnerCompetences = badgeCriterion.partnerCompetenceIds.map((partnerCompetenceId) => {
+            return { id: partnerCompetenceId };
+          });
+        });
+        return record;
+      },
+
     }).serialize(badge);
   },
 };

--- a/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
+++ b/api/lib/infrastructure/serializers/jsonapi/badge-serializer.js
@@ -1,17 +1,27 @@
 const { Serializer } = require('jsonapi-serializer');
 
+const mapType = {
+  badgeCriteria: 'badge-criterion',
+  badgePartnerCompetences: 'badge-partner-competence',
+};
+
 module.exports = {
   serialize(badge = {}) {
     return new Serializer('badge', {
       ref: 'id',
-      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'badgeCriteria'],
+      attributes: ['altMessage', 'imageUrl', 'message', 'key', 'title', 'isCertifiable', 'badgeCriteria', 'badgePartnerCompetences'],
       badgeCriteria: {
         include: true,
         ref: 'id',
         attributes: ['threshold', 'scope'],
       },
+      badgePartnerCompetences: {
+        include: true,
+        ref: 'id',
+        attributes: ['name'],
+      },
       typeForAttribute: (attribute) => {
-        if (attribute === 'badgeCriteria') return 'badge-criterion';
+        return mapType[attribute];
       },
     }).serialize(badge);
   },

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -70,6 +70,11 @@ describe('Acceptance | API | Badges', () => {
             scope: 'CampaignParticipation',
             threshold: 50,
           },
+          relationships: {
+            'partner-competences': {
+              data: [],
+            },
+          },
         }, {
           type: 'badge-partner-competence',
           id: badgePartnerCompetence.id.toString(),

--- a/api/tests/acceptance/application/badges/badge-controller_test.js
+++ b/api/tests/acceptance/application/badges/badge-controller_test.js
@@ -3,7 +3,7 @@ const { expect, databaseBuilder, generateValidRequestAuthorizationHeader, insert
 
 describe('Acceptance | API | Badges', () => {
 
-  let server, options, userId, badge, badgeCriterion;
+  let server, options, userId, badge, badgeCriterion, badgePartnerCompetence;
 
   beforeEach(async () => {
     server = await createServer();
@@ -24,6 +24,7 @@ describe('Acceptance | API | Badges', () => {
         isCertifiable: false,
       });
       badgeCriterion = databaseBuilder.factory.buildBadgeCriterion({ badgeId: badge.id });
+      badgePartnerCompetence = databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id });
 
       await databaseBuilder.commit();
     });
@@ -54,6 +55,12 @@ describe('Acceptance | API | Badges', () => {
                 type: 'badge-criterion',
               }],
             },
+            'badge-partner-competences': {
+              data: [{
+                id: badgePartnerCompetence.id.toString(),
+                type: 'badge-partner-competence',
+              }],
+            },
           },
         },
         included: [{
@@ -62,6 +69,12 @@ describe('Acceptance | API | Badges', () => {
           attributes: {
             scope: 'CampaignParticipation',
             threshold: 50,
+          },
+        }, {
+          type: 'badge-partner-competence',
+          id: badgePartnerCompetence.id.toString(),
+          attributes: {
+            name: 'name',
           },
         }],
       };

--- a/api/tests/acceptance/application/target-profile-controller_test.js
+++ b/api/tests/acceptance/application/target-profile-controller_test.js
@@ -306,6 +306,9 @@ describe('Acceptance | Controller | target-profile-controller', () => {
           'badge-criteria': {
             data: [],
           },
+          'badge-partner-competences': {
+            data: [],
+          },
         },
       }];
       expect(response.result.data).to.deep.equal(expectedData);

--- a/api/tests/integration/infrastructure/repositories/badge-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/badge-repository_test.js
@@ -329,6 +329,8 @@ describe('Integration | Repository | Badge', () => {
         message: 'Congrats, you won the Toto badge!',
         key: 'TOTO2',
       });
+      databaseBuilder.factory.buildBadgeCriterion({ badgeId: badge.id });
+      databaseBuilder.factory.buildBadgePartnerCompetence({ badgeId: badge.id });
       await databaseBuilder.commit();
     });
 
@@ -336,6 +338,13 @@ describe('Integration | Repository | Badge', () => {
       const myBadge = await badgeRepository.get(badge.id);
 
       expect(myBadge.id).to.equal(1);
+    });
+
+    it('should return a badge with badgeCriteria and badgePartnerCompetences', async () => {
+      const myBadge = await badgeRepository.get(badge.id);
+
+      expect(myBadge.badgeCriteria.length).to.equal(1);
+      expect(myBadge.badgePartnerCompetences.length).to.equal(1);
     });
   });
 });

--- a/api/tests/tooling/domain-builder/factory/build-badge.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge.js
@@ -13,6 +13,7 @@ module.exports = function buildBadge({
   targetProfileId = 456,
   badgeCriteria = [
     buildBadgeCriterion(),
+    buildBadgeCriterion({ id: 2, partnerCompetenceIds: [1, 2] }),
   ],
   badgePartnerCompetences = [
     buildBadgePartnerCompetence(),

--- a/api/tests/tooling/domain-builder/factory/build-badge.js
+++ b/api/tests/tooling/domain-builder/factory/build-badge.js
@@ -16,7 +16,7 @@ module.exports = function buildBadge({
   ],
   badgePartnerCompetences = [
     buildBadgePartnerCompetence(),
-    buildBadgePartnerCompetence(),
+    buildBadgePartnerCompetence({ id: 2 }),
   ],
 } = {}) {
   return new Badge({

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -37,16 +37,41 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
                 type: 'badge-criterion',
               }],
             },
+            'badge-partner-competences': {
+              'data': [{
+                id: '1',
+                type: 'badge-partner-competence',
+              }, {
+                id: '2',
+                type: 'badge-partner-competence',
+              }],
+            },
           },
         },
-        included: [{
-          attributes: {
-            scope: 'CampaignParticipation',
-            threshold: 40,
+        included: [
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            id: '1',
+            type: 'badge-criterion',
           },
-          id: '1',
-          type: 'badge-criterion',
-        }],
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '1',
+            type: 'badge-partner-competence',
+          },
+          {
+            attributes: {
+              name: 'name',
+            },
+            id: '2',
+            type: 'badge-partner-competence',
+          },
+        ],
       };
 
       // when

--- a/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
+++ b/api/tests/unit/infrastructure/serializers/jsonapi/badge-serializer_test.js
@@ -35,6 +35,9 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
               'data': [{
                 id: '1',
                 type: 'badge-criterion',
+              }, {
+                id: '2',
+                type: 'badge-criterion',
               }],
             },
             'badge-partner-competences': {
@@ -54,7 +57,31 @@ describe('Unit | Serializer | JSONAPI | badge-serializer', function() {
               scope: 'CampaignParticipation',
               threshold: 40,
             },
+            relationships: {
+              'partner-competences': {
+                data: [],
+              },
+            },
             id: '1',
+            type: 'badge-criterion',
+          },
+          {
+            attributes: {
+              scope: 'CampaignParticipation',
+              threshold: 40,
+            },
+            relationships: {
+              'partner-competences': {
+                data: [{
+                  id: '1',
+                  type: 'badge-partner-competence',
+                }, {
+                  id: '2',
+                  type: 'badge-partner-competence',
+                }],
+              },
+            },
+            id: '2',
             type: 'badge-criterion',
           },
           {


### PR DESCRIPTION
## :unicorn: Problème
Nous n'avons aucun détail sur les compétences évalués de chaque critère du badge.

## :robot: Solution
Afficher le nom des groupes de critère pour chaque critère du badge.

## :rainbow: Remarques
Nous avons mis à jour les seeds qui ne représentaient pas la réalité (oublie d'associer les critères au partner competence).

## :100: Pour tester
1. Se rendre sur Pix Admin.
2. Aller dans l'onglet Profils cibles.
3. Sélectionner un profil cible.
4. Sélectionner l'onglet Clé de lecture.
5. Cliquer sur le bouton Voir détail d’un résultat thématique.
6. Vérifier que que les noms du groupe de critères associé est affiché dans le tableau

https://user-images.githubusercontent.com/86659/114585947-6fc91f80-9c84-11eb-9e54-89ffbe9f8c66.mp4


