### PR TITLE
[FEATURE] Affichage d'une documentation dans PIX ORGA pour les organisations ayant comme type SUP (PIX-2462).

### DIFF
--- a/orga/app/components/sidebar-menu.js
+++ b/orga/app/components/sidebar-menu.js
@@ -26,6 +26,10 @@ export default class SidebarMenu extends Component {
       return 'https://cloud.pix.fr/s/cwZN2GAbqSPGnw4';
     }
 
+    if (this.currentUser.organization.isSup) {
+      return 'https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo';
+    }
+
     return null;
   }
 

--- a/orga/tests/integration/components/sidebar-menu-test.js
+++ b/orga/tests/integration/components/sidebar-menu-test.js
@@ -86,9 +86,20 @@ module('Integration | Component | sidebar-menu', function(hooks) {
 
     // when
     await render(hbs`<SidebarMenu />`);
-
     // then
     assert.dom('a[href="https://view.genial.ly/5ffb6eed1ac90d0d0daf65d8"]').exists();
+  });
+
+  test('it should display documentation for a SUP organization', async function(assert) {
+    class CurrentUserStub extends Service {
+      organization = Object.create({ id: 1, isSup: true });
+    }
+    this.owner.register('service:current-user', CurrentUserStub);
+
+    // when
+    await render(hbs`<SidebarMenu />`);
+    // then
+    assert.dom('a[href="https://cloud.pix.fr/s/DTTo7Lp7p6Ktceo"]').exists();
   });
 
   test('it should not display documentation for a sco organization that does not managed students', async function(assert) {


### PR DESCRIPTION
## :unicorn: Problème
Les organisations de l'enseignement supérieur n'ont pas de documentation sur PixOrga.

## :robot: Solution
Ajouter une documentation pour les organisations de type SUP

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Se connecter sur PixOrga à une organisation SUP et vérifier que dans le menu il y a bien une entrée documentation 
