### PR TITLE
[TECH] Rendre l'email à utiliser pour les notifications JIRA explicite (PIX-2472). 

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,22 @@
+# =========
+# NOTIFICATION
+# =========
+
+# Email of JIRA account used to signal Pull request deployments to JIRA
+# presence: required
+#
+# If not present, the notification will fail.
+#
+# presence: required
+# type: email
+# default: none
+JIRA_NOTIFICATION_ACCOUNT_EMAIL
+
+# Token of JIRA account used to signal Pull request deployments to JIRA
+#
+# If not present, the notification will fail.
+#
+# presence: required
+# type: Secret
+# default: none
+JIRA_NOTIFICATION_ACCOUNT_TOKEN

--- a/scripts/jira/comment-with-review-app-url.js
+++ b/scripts/jira/comment-with-review-app-url.js
@@ -39,8 +39,8 @@ async function main() {
     method: 'get',
     url: `${JIRA_API_URL}/issue/${issueCode}/comment`,
     auth: {
-      username: process.env.JIRA_API_KEY,
-      password: process.env.JIRA_API_SECRET,
+      username: process.env.JIRA_NOTIFICATION_ACCOUNT_EMAIL,
+      password: process.env.JIRA_NOTIFICATION_ACCOUNT_TOKEN,
     },
   });
 
@@ -69,8 +69,8 @@ async function main() {
       url: `${JIRA_API_URL}/issue/${issueCode}/comment`,
       headers: { 'Content-Type': 'application/json' },
       auth: {
-        username: process.env.JIRA_API_KEY,
-        password: process.env.JIRA_API_SECRET,
+        username: process.env.JIRA_NOTIFICATION_ACCOUNT_EMAIL,
+        password: process.env.JIRA_NOTIFICATION_ACCOUNT_TOKEN,
       },
       data: {
         body: text,


### PR DESCRIPTION
## :unicorn: Problème
Voir [issue](https://github.com/1024pix/pix/issues/2848)

## :robot: Solution
Renommer les variables d'environnement 
*  `JIRA_API_KEY` en `JIRA_NOTIFICATION_ACCOUNT_EMAIL` 
*  `JIRA_API_SECRET` en `JIRA_NOTIFICATION_ACCOUNT_TOKEN` 

## :rainbow: Remarques
Ajout d'un `sample.env` à la racine du repository

## :100: Pour tester
Vérifier dans JIRA qu'un commentaire a bien été posté avec les liens suite au déploiement