### PR TITLE
[TECH] Améliorer les index sur les requêtes par email sur password-reset-demands et users (PIX-2474).

### DIFF
--- a/api/db/migrations/20210414154016_add-index-on-lower-email-column-table-users.js
+++ b/api/db/migrations/20210414154016_add-index-on-lower-email-column-table-users.js
@@ -1,0 +1,9 @@
+const INDEX_NAME = 'users_email_lower';
+
+exports.up = (knex) => {
+  return knex.raw(`CREATE INDEX "${INDEX_NAME}" ON "users"(LOWER("email"))`);
+};
+
+exports.down = (knex) => {
+  return knex.raw(`DROP INDEX "${INDEX_NAME}"`);
+};

--- a/api/db/migrations/20210414161434_add-index-lower-email-reset-password.js
+++ b/api/db/migrations/20210414161434_add-index-lower-email-reset-password.js
@@ -1,0 +1,16 @@
+const INDEX_NAME = 'reset-password-demands_email_lower';
+
+exports.up = async (knex) => {
+  await knex.raw(`CREATE INDEX "${INDEX_NAME}" ON "reset-password-demands"(LOWER("email"))`);
+  return knex.schema.table('reset-password-demands', function(table) {
+    table.dropIndex('email');
+  });
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('reset-password-demands', function(table) {
+    table.index('email');
+  });
+
+  return knex.raw(`DROP INDEX "${INDEX_NAME}"`);
+};

--- a/api/lib/infrastructure/repositories/reset-password-demands-repository.js
+++ b/api/lib/infrastructure/repositories/reset-password-demands-repository.js
@@ -28,7 +28,7 @@ module.exports = {
 
   findByUserEmail(email, temporaryKey) {
     return ResetPasswordDemand.query((qb) => {
-      qb.where('email', 'ILIKE', email);
+      qb.whereRaw('LOWER("email") = ?', email.toLowerCase());
       qb.where({ 'used': false });
       qb.where({ temporaryKey });
     })

--- a/api/lib/infrastructure/repositories/reset-password-demands-repository.js
+++ b/api/lib/infrastructure/repositories/reset-password-demands-repository.js
@@ -8,7 +8,7 @@ module.exports = {
 
   markAsBeingUsed(email) {
     return ResetPasswordDemand
-      .query((qb) => qb.where('email', 'ILIKE', email))
+      .query((qb) => qb.whereRaw('LOWER("email") = ?', email.toLowerCase()))
       .save({ used: true }, {
         patch: true,
         require: false,

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -29,7 +29,7 @@ module.exports = {
   getByEmail(email) {
     return BookshelfUser
       .query((qb) => {
-        qb.where('email', 'ILIKE', email);
+        qb.whereRaw('LOWER("email") = ?', email.toLowerCase());
       })
       .fetch()
       .then((bookshelfUser) => {

--- a/api/lib/infrastructure/repositories/user-repository.js
+++ b/api/lib/infrastructure/repositories/user-repository.js
@@ -183,7 +183,7 @@ module.exports = {
 
   isEmailAvailable(email) {
     return BookshelfUser
-      .query((qb) => qb.where('email', 'ILIKE', email))
+      .query((qb) => qb.whereRaw('LOWER("email") = ?', email.toLowerCase()))
       .fetch({ require: false })
       .then((user) => {
         if (user) {

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -46,6 +46,19 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
       expect(demand.used).to.be.true;
     });
 
+    it('should be case insensitive', async () => {
+      // when
+      const emailWithUppercase = email.toUpperCase();
+      await resetPasswordDemandsRepository.markAsBeingUsed(emailWithUppercase);
+
+      // then
+      const demand = await knex('reset-password-demands')
+        .select('used')
+        .where({ email })
+        .first();
+      expect(demand.used).to.be.true;
+    });
+
     context('when case is not identical', () => {
       it('should mark demand as used', async () => {
         // given

--- a/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
+++ b/api/tests/integration/infrastructure/repositories/reset-password-demands-repository_test.js
@@ -177,6 +177,18 @@ describe('Integration | Infrastructure | Repository | reset-password-demands-rep
           expect(demand.attributes.used).to.equal(false);
         });
 
+        it('should be case insensitive', async () => {
+          // when
+          const emailWithUppercase = email.toUpperCase();
+          const demand = await resetPasswordDemandsRepository.findByUserEmail(emailWithUppercase, temporaryKey);
+
+          // then
+          expect(demand.attributes.id).to.equal(demandId);
+          expect(demand.attributes.email).to.equal(email);
+          expect(demand.attributes.temporaryKey).to.equal(temporaryKey);
+          expect(demand.attributes.used).to.equal(false);
+        });
+
         context('when case is not identical', () => {
           it('should return the bookshelf demand', async () => {
             // given


### PR DESCRIPTION
## :unicorn: Problème
Certaines requêtes parmi les plus fréquemment effectuées ont un temps moyen d'exécution important :
![candidats_2](https://user-images.githubusercontent.com/48727874/114839084-a793ac80-9dd5-11eb-9c14-3144f143ee41.png)

En y regardant de plus près, on remarque que les deux requêtes lentes ont une structure commune : `WHERE email ILIKE $1`

En fait, le `ILIKE` est comme un `LIKE`, dans le sens où il permet de positionner des caractères Joker dans la recherche texte, sauf que la recherche est insensible à la casse. Du coup, malgré la présence d'un index sur la colonne `email` dans la table `users`, celui-ci ne peut être utilisé car le `ILIKE` force une recherche insensible à la casse. Il est donc obligé d'effectuer un scan séquentiel de la table afin de faire des comparaisons insensibles à la casse.

## :robot: Solution
Il existe une solution pour réaliser une recherche texte qui satisfait deux exigences : être efficace et être insensible à la casse sur une recherche stricte.
Il s'agit de positionner des index, non pas sur la colonne `email`, mais sur `LOWER(email)`. Ainsi, il suffit de modifier légèrement la requête pour avoir `WHERE LOWER(email) = $1` et de s'assurer que le binding a bien été mis en lowerCase, et le tour est joué.

Les deux requêtes candidates concernent deux tables : `users` et `reset-password-demands`.
La table `users` présente un index **unique** sur `email`, on ne pouvait donc pas le remplacer par un index unique sur `LOWER(email)` simplement (car la contrainte d'unicité ne serait pas satisfaite, il existe une poignée de cas dans la table `users` avec deux utilisateurs ayant le même mail avec une casse différente, comme laura.bergoens@pix.fr et Laura.Bergoens@pix.fr). Dans le cas de la table `users` on ajoute un index supplémentaire sur `email` via `LOWER(email)`.
La table `reset-password-demands` quant à elle présente déjà un index simple sur `email`, mais qui n'a jamais pu être utilisé à ce jour car la syntaxe des requêts ne le permettait pas. On l'a donc simplement remplacé par un index sur `LOWER(email)`

## :rainbow: Remarques


## :100: Pour tester
Tester non rég sur création de compte / connexion / demande de reset de password
