### PR TITLE
[TECH] Lancer les tests end to end en 1 commande

### DIFF
--- a/high-level-tests/e2e/Dockerfile
+++ b/high-level-tests/e2e/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:14.16.0
+
+# To run chrome headless with no-sandbox.
+ENV CI 1
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg --install google-chrome-stable_current_amd64.deb; apt-get update --yes && apt --fix-broken --yes install
+RUN apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb

--- a/high-level-tests/e2e/README.md
+++ b/high-level-tests/e2e/README.md
@@ -1,8 +1,19 @@
 ## Cypress
 
 Cypress est un framework de test end to end (back-end + front-end).
-Il est utilisé ici pour les tests de non-régression sur les chemins fonctionnels entiers. 
+Il est utilisé ici pour les tests de non-régression sur les chemins fonctionnels entiers.
 
+### Je veux lancer les tests rapidement, comment faire ?
+
+Si tu es sous Linux et que tu a `docker` et `docker-compose`, alors le plus simple est de lancer a la racine.
+
+    ./scripts/tests-e2e
+
+Pour lancer une session interactive de débugage avec cypress (avec forward de X11):
+
+    ./scripts/tests-e2e open
+
+Si tu n'aimes pas les scripts qui font tout, suit le reste de la procédure.
 
 ### Installer un navigateur
 

--- a/high-level-tests/e2e/docker-compose.yml
+++ b/high-level-tests/e2e/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres:12.5-alpine
+    environment:
+      POSTGRES_DB: pix
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+  redis:
+    image: redis:5.0.7-alpine
+
+  cypress:
+    user: node
+    build:
+      context: .
+    env_file: ./env-api
+    volumes:
+      - ../..:/code
+    working_dir: /code/high-level-tests/e2e
+    depends_on:
+      - orga
+      - monpix
+      - certif
+
+  orga:
+    user: node
+    image: node:14.16.0
+    command: npx ember serve --proxy http://api:3000
+    volumes:
+      - ../..:/code
+    working_dir: /code/orga
+    depends_on:
+      - api
+
+  certif:
+    user: node
+    image: node:14.16.0
+    command: npx ember serve --proxy http://api:3000
+    volumes:
+      - ../..:/code
+    working_dir: /code/certif
+    depends_on:
+      - api
+
+  monpix:
+    user: node
+    image: node:14.16.0
+    command: npx ember serve --proxy http://api:3000
+    volumes:
+      - ../..:/code
+    working_dir: /code/mon-pix
+    depends_on:
+      - api
+
+  api:
+    user: node
+    image: node:14.16.0
+    env_file: ./env-api
+    command: npm run start:watch
+    volumes:
+      - ../..:/code
+    working_dir: /code/api
+    depends_on:
+      - redis
+      - postgres

--- a/high-level-tests/e2e/env-api
+++ b/high-level-tests/e2e/env-api
@@ -1,0 +1,230 @@
+# This file is the minimal confuguration file used by Dotenv to define the
+# environment variables on localhost.
+#
+# Instructions:
+#   1. copy this file as `.env`
+#   2. edit the `.env` file with working values
+#   3. uncomment the lines to activate or configure associated features
+#
+# Sections (displayed in sorted in alphabtic order):
+#   - caching
+#   - databases
+#   - emailing
+#   - learning content
+#   - logging
+#   - security
+#
+# Line size max: 80 characters.
+#
+
+# =======
+# CACHING
+# =======
+
+# URL of the Redis server used for caching learning content from LCMS.
+#
+# If not present, only the in-memory cache will be active and the learning
+# content will be re-fetched from LCMS at each restart of the API.
+#
+# presence: optionnal
+# type: Url
+# default: none
+REDIS_URL=redis://redis:6379
+
+# =========
+# DATABASES
+# =========
+
+# URL of the PostgreSQL databse used for storing users data (filled-in or
+# generated).
+#
+# If not present, the application will crash during API boostrap.
+#
+# presence: required
+# type: Url
+# default: none
+DATABASE_URL=postgresql://postgres@postgres/pix
+
+# URL of the PostgreSQL databse used for API local testing.
+#
+# If not present, the tests will fail.
+#
+# presence: required
+# type: Url
+# default: none
+TEST_DATABASE_URL=postgresql://postgres@postgres/pix_test
+
+# ========
+# EMAILING
+# ========
+
+# Enable or disable the sending of e-mails.
+#
+# presence: optionnal
+# type: Boolean
+# default: `false`
+# MAILING_ENABLED=true
+
+# Select the emailing service provider. Availaible providers supported  are
+# Sendinblue (value="sendinblue").
+#
+# presence: required only if emailing is enabled
+# type: String
+# default: "sendinblue"
+# MAILING_PROVIDER=sendinblue
+
+# Sendinblue
+# ----------
+
+## API key required to call the Sendinblue API.
+#
+# presence: required if emailing is enabled and provider is Sendinblue
+# type: String
+# default: none
+# SENDINBLUE_API_KEY=
+
+# ID of the template used for generating the e-mail when an account is created.
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_ACCOUNT_CREATION_TEMPLATE_ID=
+
+# ID of the template used for generating the e-mail when a user is invited to
+# join an organization.
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_ORGANIZATION_INVITATION_TEMPLATE_ID=
+
+# ID of the template used for generating the e-mail when a user want to
+# join a SCO organization.
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_ORGANIZATION_INVITATION_SCO_TEMPLATE_ID=
+
+# ID of the template used for generating the e-mail when a user want to
+# generate a new password.
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_PASSWORD_RESET_TEMPLATE_ID=
+
+# ID of the template used to notify the user its email has been changed
+#
+# If not present when required, the e-mail will not be sent and an error will
+# be thrown.
+#
+# presence: required only if emailing is enabled and provider is Sendinblue
+# type: Number
+# default: none
+# SENDINBLUE_EMAIL_CHANGE_TEMPLATE_ID=
+
+# String for links in emails redirect to a specific domain when user comes from french domain
+#
+# presence: optional
+# type: String
+# default: '.fr'
+# TLD_FR=
+
+# String for links in emails redirect to a specific domain when user comes from international domain
+#
+# presence: optional
+# type: String
+# default: '.org'
+# TLD_ORG=
+
+# String for links in emails to build url with Pix domain
+#
+# presence: optional
+# type: String
+# default: 'pix'
+# DOMAIN_PIX=
+
+# String for links in emails to build url with Pix App domain
+#
+# presence: optional
+# type: String
+# default: 'app.pix'
+# DOMAIN_PIX_APP=
+
+# String for links in emails to build url with Pix Orga domain
+#
+# presence: optional
+# type: String
+# default: 'orga.pix'
+# DOMAIN_PIX_ORGA=
+
+# ================
+# LEARNING CONTENT
+# ================
+
+# API key provided by learning content management system.
+#
+# If not present and if the Redis cache were not enabled/preloaded, the
+# application will crash during data fetching.
+#
+# presence: required
+# type: String
+# default: none
+LCMS_API_KEY=e5d7b101-d0bd-4a3b-86c9-61edd5d39e8d
+
+# Learning content API URL.
+#
+# If not present and if the Redis cache were not enabled/preloaded, the
+# application will crash during data fetching.
+#
+# presence: required
+# type: String
+# default: none
+LCMS_API_URL=https://lcms.minimal.pix.fr/api
+
+# =======
+# LOGGING
+# =======
+
+# Enable or disable the logging of the API.
+#
+# presence: optionnal
+# type: Boolean
+# default: `false`
+LOG_ENABLED=true
+
+# Enable or disable the logging of the API.
+#
+# presence: optionnal
+# type: String
+# default: "info"
+# LOG_LEVEL=debug
+
+# ========
+# SECURITY
+# ========
+
+# Secret salt value used in JWT token generation.
+#
+# If not present, the application will crash during bootstrap.
+#
+# presence: required
+# type: String
+# default: none
+AUTH_SECRET=Change me!
+
+# Allow email change in API
+

--- a/scripts/tests-e2e
+++ b/scripts/tests-e2e
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CYPRESS_ARGS="run --browser=chrome"
+DC_CYPRESS_ARGS=""
+if [ "$1" == "open" ]; then
+    CYPRESS_ARGS="open"
+    DC_CYPRESS_ARGS=" --volume /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix:0"
+fi
+
+npm run ci:all
+cd high-level-tests/e2e
+docker-compose stop
+docker-compose up -d postgres redis api monpix certif orga
+docker-compose run --rm api npm run db:prepare
+docker-compose exec redis redis-cli flushdb
+docker-compose run --rm cypress npx wait-on http://api:3000/api http://monpix:4200 http://orga:4201 http://certif:4203
+docker-compose run --rm $DC_CYPRESS_ARGS cypress bash -c "npm ci && npx cypress $CYPRESS_ARGS --config baseUrl=http://monpix:4200 --env API_URL=http://api:3000,ORGA_URL=http://orga:4201,CERTIF_URL=http://certif:4203"
+docker-compose down


### PR DESCRIPTION
## :unicorn: Problème
Faire tourner les tests e2e sur sa machine nécessite de lire de la documentation et de changer son environnement.

## :robot: Solution
Faire un script qui, grâce a docker et docker-compose permet de lancer les tests e2e en :one: commande

## :rainbow: Remarques
Annule et remplace #2818 

## :100: Pour tester

Il y a deux scénarios à tester

1. Lancer tout les tests e2e: `./scripts/tests-e2e`
2. Lancer les tests d'une manière interactive et sélective avec : `./scripts/tests-e2e open`
